### PR TITLE
Initial implementation of a @_cdecl attribute to export top-level functions to C

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -245,6 +245,10 @@ SIMPLE_DECL_ATTR(warn_unqualified_access, WarnUnqualifiedAccess,
 SIMPLE_DECL_ATTR(_show_in_interface, ShowInInterface,
                  OnProtocol | UserInaccessible, 62)
 
+DECL_ATTR(_cdecl, CDecl,
+          OnFunc | LongAttribute | UserInaccessible, 63)
+
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -516,6 +516,24 @@ public:
   }
 };
 
+/// Defines the @_cdecl attribute.
+class CDeclAttr : public DeclAttribute {
+public:
+  CDeclAttr(StringRef Name, SourceLoc AtLoc, SourceRange Range, bool Implicit)
+    : DeclAttribute(DAK_CDecl, AtLoc, Range, Implicit),
+      Name(Name) {}
+
+  CDeclAttr(StringRef Name, bool Implicit)
+    : CDeclAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+
+  /// The symbol name.
+  const StringRef Name;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_CDecl;
+  }
+};
+
 /// Defines the @_semantics attribute.
 class SemanticsAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -836,6 +836,14 @@ ERROR(no_objc_tagged_pointer_not_class_protocol,none,
 ERROR(swift_native_objc_runtime_base_not_on_root_class,none,
       "@_swift_native_objc_runtime_base_not_on_root_class can only be applied "
       "to root classes", ())
+
+ERROR(cdecl_not_at_top_level,none,
+      "@_cdecl can only be applied to global functions", ())
+ERROR(cdecl_empty_name,none,
+      "@_cdecl symbol name cannot be empty", ())
+ERROR(cdecl_throws,none,
+      "raising errors from @_cdecl functions is not supported", ())
+
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))
 ERROR(access_control_in_protocol,none,
@@ -2487,7 +2495,7 @@ ERROR(objc_enum_case_multi,none,
       "'@objc' enum case declaration defines multiple enum cases with the same Objective-C name", ())
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked dynamic|marked @objc|marked @IBOutlet|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override}"
 
 ERROR(objc_invalid_on_var,none,
       "property cannot be %" OBJC_ATTR_SELECT "0 "

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -43,7 +43,7 @@ const unsigned char MODULE_DOC_SIGNATURE[] = { 0xE2, 0x9C, 0xA8, 0x07 };
 
 /// Serialized module format major version number.
 ///
-/// Always 0 for Swift 1.0.
+/// Always 0 for Swift 1.x and 2.x.
 const uint16_t VERSION_MAJOR = 0;
 
 /// Serialized module format minor version number.
@@ -53,7 +53,8 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 239; // multiple results for SILFunctionType
+/// describe what change you made.
+const uint16_t VERSION_MINOR = 240; // Last change: @_cdecl
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -1223,6 +1224,13 @@ namespace decls_block {
     BCFixed<1>, // implicit flag
     BCBlob      // _silgen_name
   >;
+
+  using CDeclDeclAttrLayout = BCRecordLayout<
+    CDecl_DECL_ATTR,
+    BCFixed<1>, // implicit flag
+    BCBlob      // _silgen_name
+  >;
+
   
   using AlignmentDeclAttrLayout = BCRecordLayout<
     Alignment_DECL_ATTR,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1908,7 +1908,10 @@ void AbstractFunctionDecl::setForeignErrorConvention(
 
 Optional<ForeignErrorConvention>
 AbstractFunctionDecl::getForeignErrorConvention() const {
-  if (!isObjC() || !isBodyThrowing()) return None;
+  if (!isObjC() && !getAttrs().hasAttribute<CDeclAttr>())
+    return None;
+  if (!isBodyThrowing())
+    return None;
   auto &conventionsMap = getASTContext().Impl.ForeignErrorConventions;
   auto it = conventionsMap.find(this);
   if (it == conventionsMap.end()) return None;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2200,8 +2200,9 @@ struct ASTNodeBase {};
         abort();
       }
 
-      if (AFD->getForeignErrorConvention() && !AFD->isObjC()) {
-        Out << "foreign error convention on non-@objc function\n";
+      if (AFD->getForeignErrorConvention()
+          && !AFD->isObjC() && !AFD->getAttrs().hasAttribute<CDeclAttr>()) {
+        Out << "foreign error convention on non-@objc, non-@_cdecl function\n";
         AFD->dump(Out);
         abort();
       }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -372,6 +372,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
     if (cast<AutoClosureAttr>(this)->isEscaping())
       Printer << "(escaping)";
     break;
+      
+  case DAK_CDecl:
+    Printer << "@_cdecl(\"" << cast<CDeclAttr>(this)->Name << "\")";
+    break;
+
   case DAK_ObjC: {
     Printer.printAttrName("@objc");
     llvm::SmallString<32> scratch;
@@ -487,6 +492,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_silgen_name";
   case DAK_Alignment:
     return "_alignment";
+  case DAK_CDecl:
+    return "_cdecl";
   case DAK_SwiftNativeObjCRuntimeBase:
     return "_swift_native_objc_runtime_base";
   case DAK_Semantics:

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -232,7 +232,7 @@ void LinkEntity::mangle(raw_ostream &buffer) const {
 
   //   entity ::= declaration                     // other declaration
   case Kind::Function:
-    // As a special case, functions can have external asm names.
+    // As a special case, functions can have manually mangled names.
     if (auto AsmA = getDecl()->getAttrs().getAttribute<SILGenNameAttr>()) {
       mangler.append(AsmA->Name);
       return mangler.finalize(buffer);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -565,6 +565,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
   }
 
+  case DAK_CDecl:
   case DAK_SILGenName: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
@@ -601,9 +602,16 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       diagnose(Loc, diag::attr_only_at_non_local_scope, AttrName);
     }
 
-    if (!DiscardAttribute)
-      Attributes.add(new (Context) SILGenNameAttr(AsmName.getValue(), AtLoc,
+    if (!DiscardAttribute) {
+      if (DK == DAK_SILGenName)
+        Attributes.add(new (Context) SILGenNameAttr(AsmName.getValue(), AtLoc,
+                                                AttrRange, /*Implicit=*/false));
+      else if (DK == DAK_CDecl)
+        Attributes.add(new (Context) CDeclAttr(AsmName.getValue(), AtLoc,
                                                AttrRange, /*Implicit=*/false));
+      else
+        llvm_unreachable("out of sync with switch");
+    }
 
     break;
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -435,6 +435,14 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
     if (!Captures.empty())
       TopLevelSGF->B.createMarkFunctionEscape(AFD, Captures);
   }
+  
+  // If the declaration is exported as a C function, emit its native-to-foreign
+  // thunk too, if it wasn't already forced.
+  if (AFD->getAttrs().hasAttribute<CDeclAttr>()) {
+    auto thunk = SILDeclRef(AFD).asForeign();
+    if (!hasFunction(thunk))
+      emitNativeToForeignThunk(thunk);
+  }
 }
 
 static bool hasSILBody(FuncDecl *fd) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -47,6 +47,7 @@ public:
   bool visitDeclAttribute(DeclAttribute *A) = delete;
 
 #define IGNORED_ATTR(X) void visit##X##Attr(X##Attr *) {}
+  IGNORED_ATTR(CDecl)
   IGNORED_ATTR(SILGenName)
   IGNORED_ATTR(Available)
   IGNORED_ATTR(Convenience)
@@ -652,6 +653,8 @@ public:
 #undef IGNORED_ATTR
 
   void visitAvailableAttr(AvailableAttr *attr);
+  
+  void visitCDeclAttr(CDeclAttr *attr);
 
   void visitFinalAttr(FinalAttr *attr);
   void visitIBActionAttr(IBActionAttr *attr);
@@ -851,6 +854,18 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
     TC.diagnose(EnclosingDecl->getLoc(),
                 diag::availability_decl_more_than_enclosing_enclosing_here);
   }
+}
+
+void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
+  // Only top-level func decls are currently supported.
+  if (D->getDeclContext()->isTypeContext())
+    TC.diagnose(attr->getLocation(),
+                diag::cdecl_not_at_top_level);
+  
+  // The name must not be empty.
+  if (attr->Name.empty())
+    TC.diagnose(attr->getLocation(),
+                diag::cdecl_empty_name);
 }
 
 void AttributeChecker::visitUnsafeNoObjCTaggedPointerAttr(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4414,6 +4414,18 @@ public:
       markAsObjC(TC, FD, isObjC, errorConvention);
     }
     
+    // If the function is exported to C, it must be representable in (Obj-)C.
+    if (auto CDeclAttr = FD->getAttrs().getAttribute<swift::CDeclAttr>()) {
+      Optional<ForeignErrorConvention> errorConvention;
+      if (TC.isRepresentableInObjC(FD, ObjCReason::ExplicitlyCDecl,
+                                   errorConvention)) {
+        if (FD->isBodyThrowing()) {
+          FD->setForeignErrorConvention(*errorConvention);
+          TC.diagnose(CDeclAttr->getLocation(), diag::cdecl_throws);
+        }
+      }
+    }
+    
     inferDynamic(TC.Context, FD);
 
     TC.checkDeclAttributes(FD);
@@ -5056,6 +5068,7 @@ public:
 
     UNINTERESTING_ATTR(Accessibility)
     UNINTERESTING_ATTR(Alignment)
+    UNINTERESTING_ATTR(CDecl)
     UNINTERESTING_ATTR(SILGenName)
     UNINTERESTING_ATTR(Exported)
     UNINTERESTING_ATTR(IBAction)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -399,6 +399,7 @@ withoutContext(TypeResolutionOptions options) {
 /// the OBJC_ATTR_SELECT macro in DiagnosticsSema.def.
 enum class ObjCReason {
   DoNotDiagnose,
+  ExplicitlyCDecl,
   ExplicitlyDynamic,
   ExplicitlyObjC,
   ExplicitlyIBOutlet,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1884,6 +1884,14 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
         break;
       }
 
+      case decls_block::CDecl_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::CDeclDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) CDeclAttr(blobData, isImplicit);
+        break;
+      }
+
       case decls_block::Alignment_DECL_ATTR: {
         bool isImplicit;
         unsigned alignment;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1621,7 +1621,16 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
                                       theAttr->Name);
     return;
   }
-  
+
+  case DAK_CDecl: {
+    auto *theAttr = cast<CDeclAttr>(DA);
+    auto abbrCode = DeclTypeAbbrCodes[CDeclDeclAttrLayout::Code];
+    CDeclDeclAttrLayout::emitRecord(Out, ScratchRecord, abbrCode,
+                                    theAttr->isImplicit(),
+                                    theAttr->Name);
+    return;
+  }
+
   case DAK_Alignment: {
     auto *theAlignment = cast<AlignmentAttr>(DA);
     auto abbrCode = DeclTypeAbbrCodes[AlignmentDeclAttrLayout::Code];

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/cdecl.swiftmodule -parse -emit-objc-header-path %t/cdecl.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: FileCheck %s < %t/cdecl.h
+// RUN: %check-in-clang %t/cdecl.h
+// RUN: %check-in-clang -fno-modules %t/cdecl.h -include Foundation.h -include ctypes.h -include CoreFoundation.h
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: /// What a nightmare!
+// CHECK-LABEL: double (^ _Nonnull block_nightmare(float (^ _Nonnull x)(NSInteger)))(char);
+
+/// What a nightmare!
+@_cdecl("block_nightmare")
+func block_nightmare(x: @convention(block) Int -> Float)
+  -> @convention(block) CChar -> Double { return { _ in 0 } }
+
+// CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y);
+@_cdecl("foo_bar")
+func foo(x: Int, bar y: Int) {}
+
+// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(float (* _Nonnull x)(NSInteger)))(char);
+@_cdecl("function_pointer_nightmare")
+func function_pointer_nightmare(x: @convention(c) Int -> Float)
+  -> @convention(c) CChar -> Double { return { _ in 0 } }
+  
+// CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
+@_cdecl("has_keyword_arg_names")
+func keywordArgNames(auto: Int, union: Int) {}

--- a/test/SILGen/cdecl.swift
+++ b/test/SILGen/cdecl.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
+
+// CHECK-LABEL: sil hidden @pear : $@convention(c)
+// CHECK:         function_ref @_TF5cdecl5apple
+// CHECK-LABEL: sil hidden @_TF5cdecl5apple
+@_cdecl("pear")
+func apple(f: @convention(c) Int -> Int) {
+}
+
+// CHECK-LABEL: sil hidden @_TF5cdecl16forceCEntryPoint
+// CHECK:         function_ref @grapefruit
+func forceCEntryPoint() {
+  apple(orange)
+}
+
+// CHECK-LABEL: sil hidden @grapefruit : $@convention(c)
+// CHECK:         function_ref @_TF5cdecl6orange
+// CHECK-LABEL: sil hidden @_TF5cdecl6orange
+@_cdecl("grapefruit")
+func orange(x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil @cauliflower : $@convention(c)
+// CHECK:         function_ref @_TF5cdecl8broccoli
+// CHECK-LABEL: sil @_TF5cdecl8broccoli
+@_cdecl("cauliflower")
+public func broccoli(x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil private @collard_greens : $@convention(c)
+// CHECK:         function_ref @_TF5cdeclP[[PRIVATE:.*]]4kale
+// CHECK:       sil private @_TF5cdeclP[[PRIVATE:.*]]4kale
+@_cdecl("collard_greens")
+private func kale(x: Int) -> Int {
+  return x
+}
+
+/* TODO: Handle error conventions
+@_cdecl("vomits")
+func barfs() throws {}
+ */

--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -1,0 +1,55 @@
+// RUN: %target-parse-verify-swift
+
+@_cdecl("cdecl_foo") func foo(x: Int) -> Int { return x }
+
+@_cdecl("") // expected-error{{symbol name cannot be empty}}
+func emptyName(x: Int) -> Int { return x }
+
+@_cdecl("noBody")
+func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
+
+@_cdecl("property") // expected-error{{may only be used on 'func' declarations}}
+var property: Int
+
+var computed: Int {
+  @_cdecl("get_computed") get { return 0 }
+  @_cdecl("set_computed") set { return }
+}
+
+struct SwiftStruct { var x, y: Int }
+enum SwiftEnum { case A, B }
+@objc enum CEnum: Int { case A, B }
+
+@_cdecl("swiftStruct")
+func swiftStruct(x: SwiftStruct) {} // expected-error{{cannot be represented}} expected-note{{Swift struct}}
+
+@_cdecl("swiftEnum")
+func swiftEnum(x: SwiftEnum) {} // expected-error{{cannot be represented}} expected-note{{non-'@objc' enum}}
+
+@_cdecl("cEnum")
+func cEnum(x: CEnum) {}
+
+class Foo {
+  @_cdecl("Foo_foo") // expected-error{{can only be applied to global functions}}
+  func foo(x: Int) -> Int { return x }
+
+  @_cdecl("Foo_foo_2") // expected-error{{can only be applied to global functions}}
+  static func foo(x: Int) -> Int { return x }
+
+  @_cdecl("Foo_init") // expected-error{{may only be used on 'func'}}
+  init() {}
+
+  @_cdecl("Foo_deinit") // expected-error{{may only be used on 'func'}}
+  deinit {}
+}
+
+func hasNested() {
+  @_cdecl("nested") // expected-error{{can only be used in a non-local scope}}
+  func nested() { }
+}
+
+// TODO: Handle error conventions in SILGen for toplevel functions.
+@_cdecl("throwing") // expected-error{{raising errors from @_cdecl functions is not supported}}
+func throwing() throws { }
+
+// TODO: cdecl name collisions


### PR DESCRIPTION
There's an immediate need for this in the core libs, and we have most of the necessary pieces on hand to make it easy to implement. This is an unpolished initial implementation, with the following limitations, among others:
- It doesn't support bridging error conventions,
- It relies on ObjC interop,
- It doesn't check for symbol name collisions,
- It has an underscored name with required symbol name `@cdecl("symbol_name")`, awaiting official bikeshed painting.
