### PR TITLE
install Foundation via the ninja script and add the test phase for Foundation

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -349,6 +349,11 @@ build the Debug variant of the Swift standard library and SDK overlay""",
         action="store_const",
         const="Debug",
         dest="cmark_build_variant")
+    build_variant_override_group.add_argument("--debug-foundation",
+        help="build the Debug variant of Foundation",
+        action="store_const",
+        const="Debug",
+        dest="foundation_build_variant")
 
     assertions_group = parser.add_mutually_exclusive_group(required=False)
     assertions_group.add_argument("--assertions",
@@ -512,6 +517,9 @@ placed""",
 
     if args.lldb_build_variant is None:
         args.lldb_build_variant = args.build_variant
+
+    if args.foundation_build_variant is None:
+        args.foundation_build_variant = args.build_variant
 
     # Assertions are enabled by default.
     if args.assertions is None:
@@ -692,6 +700,10 @@ placed""",
         "--cmake-generator", args.cmake_generator,
         "--workspace", SWIFT_SOURCE_ROOT
     ]
+    if args.build_foundation:
+        build_script_impl_args += [
+            "--foundation-build-type", args.foundation_build_variant
+        ]   
     build_script_impl_args += build_script_impl_inferred_args
 
     # If we have extra_swift_args, combine all of them together and then add

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -73,6 +73,7 @@ KNOWN_SETTINGS=(
     swift-stdlib-enable-assertions "1"           "enable assertions in Swift"
     lldb-build-type             "Debug"          "the CMake build variant for LLDB"
     llbuild-build-type          "Debug"          "the CMake build variant for llbuild"
+    foundation-build-type       "Debug"          "the build variant for Foundation"
     llbuild-enable-assertions   "1"              "enable assertions in llbuild"
     enable-asan                 ""               "enable AddressSanitizer"
     cmake                       ""               "path to the cmake binary"
@@ -1706,6 +1707,8 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 continue
                 ;;
             foundation)
+                # the configuration script requires knowing about XCTest's location for building and running the tests
+                XCTEST_BUILD_DIR=$(build_directory $deployment_target xctest)
                 SWIFTC_BIN="$(build_directory_bin $deployment_target swift)/swiftc"
                 SWIFT_BIN="$(build_directory_bin $deployment_target swift)/swift"
                 SWIFT_BUILD_PATH="$(build_directory $deployment_target swift)"
@@ -1720,7 +1723,7 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 set -x
                 pushd "${FOUNDATION_SOURCE_DIR}"
                 SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
-                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" ./configure
+                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="${INSTALL_DESTDIR}" PREFIX="${INSTALL_PREFIX}" LDFLAGS="-L${XCTEST_BUILD_DIR}" ./configure "${FOUNDATION_BUILD_TYPE}"
                 $NINJA_BIN
                 popd
                 { set +x; } 2>/dev/null
@@ -1900,7 +1903,12 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 if [[ "$SKIP_TEST_FOUNDATION" ]]; then
                     continue
                 fi
-                # FIXME: We don't test foundation, yet...
+                build_dir=$(build_directory $deployment_target $product)
+                XCTEST_BUILD_DIR=$(build_directory $deployment_target xctest)
+                pushd "${FOUNDATION_SOURCE_DIR}"
+                $NINJA_BIN TestFoundation
+                LD_LIBRARY_PATH="${INSTALL_DESTDIR}"/"${INSTALL_PREFIX}"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}":$LD_LIBRARY_PATH "${build_dir}"/TestFoundation/TestFoundation
+                popd
                 continue
                 ;;
             *)
@@ -2048,7 +2056,7 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
 								build_dir=$(build_directory $deployment_target $product)
                 set -x
                 pushd "${FOUNDATION_SOURCE_DIR}"
-                DSTROOT="${INSTALL_DESTDIR}" BUILD_DIR="${build_dir}" ./install
+                $NINJA_BIN install
                 popd
                 { set +x; } 2>/dev/null
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1723,7 +1723,7 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 set -x
                 pushd "${FOUNDATION_SOURCE_DIR}"
                 SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
-                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="${INSTALL_DESTDIR}" PREFIX="${INSTALL_PREFIX}" LDFLAGS="-L${XCTEST_BUILD_DIR}" ./configure "${FOUNDATION_BUILD_TYPE}"
+                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="${INSTALL_DESTDIR}" PREFIX="${INSTALL_PREFIX}" SWIFTCFLAGS="-I${XCTEST_BUILD_DIR}" LDFLAGS="-L${XCTEST_BUILD_DIR}" ./configure "${FOUNDATION_BUILD_TYPE}"
                 $NINJA_BIN
                 popd
                 { set +x; } 2>/dev/null


### PR DESCRIPTION
The configuration script for Foundation respects debug and release builds so a new option for foundation-build-type has been added to control the build variant of Foundation.
Resolve the FIXME for adding a mechanism for a custom invocation of running the Foundation unit tests
Foundation now has an install target provided from the generated ninja script such that the potentially error prone install script is dramatically simplified into a single encapsulation of a ninja phony target of "install"; so adopt this new target for installation
