### PR TITLE
Only run bindings-build-record on OS X due to test flakiness on Liunx…

### DIFF
--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -1,5 +1,6 @@
 // XFAIL: linux
 // rdar://problem/21515673
+// REQUIRES: OS=macosx
 
 // RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
 // RUN: touch -t 201401240005 %t/*

--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -1,5 +1,3 @@
-// XFAIL: linux
-// rdar://problem/21515673
 // REQUIRES: OS=macosx
 
 // RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t

--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -1,3 +1,4 @@
+// rdar://problem/21515673
 // REQUIRES: OS=macosx
 
 // RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t


### PR DESCRIPTION
… system rdar://21515673
