### PR TITLE
Simplify configure pass for Foundation to use a defined variable for XCTest's build directory

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1696,7 +1696,7 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 set -x
                 pushd "${FOUNDATION_SOURCE_DIR}"
                 SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
-                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="${INSTALL_DESTDIR}" PREFIX="${INSTALL_PREFIX}" SWIFTCFLAGS="-I${XCTEST_BUILD_DIR}" LDFLAGS="-L${XCTEST_BUILD_DIR}" ./configure "${FOUNDATION_BUILD_TYPE}"
+                      SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="${INSTALL_DESTDIR}" PREFIX="${INSTALL_PREFIX}" ./configure "${FOUNDATION_BUILD_TYPE}" -DXCTEST_BUILD_DIR=${XCTEST_BUILD_DIR}
                 $NINJA_BIN
                 popd
                 { set +x; } 2>/dev/null


### PR DESCRIPTION
This is required for emitting useful information during build and iteration for Foundation.

When Foundation is re-built in it's own context it allows for the build scripts to emit useful information such as:

***\* RUNNING TESTS ****
execute:
LD_LIBRARY_PATH=../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/:/mnt/Develop/Sandbox2/swift/build/Ninja-ReleaseAssert/xctest-linux-x86_64 ../build/Ninja-ReleaseAssert/foundation-linux-x86_64/TestFoundation/TestFoundation
***\* DEBUGGING TESTS ****
execute:
LD_LIBRARY_PATH=../build/Ninja-ReleaseAssert/foundation-linux-x86_64/Foundation/:/mnt/Develop/Sandbox2/swift/build/Ninja-ReleaseAssert/xctest-linux-x86_64 lldb ../build/Ninja-ReleaseAssert/foundation-linux-x86_64/TestFoundation/TestFoundation

Which avoids the potentially error prone manual invocation of the correct LD_LIBRARY_PATH and executable.
