### PR TITLE
update related projects list to include Foundation and XCTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For OS X, you need [the latest Xcode](https://developer.apple.com/xcode/download
 
 For Ubuntu, you'll need the following development dependencies:
 
-    sudo apt-get install git cmake ninja-build clang uuid-dev libicu-dev libbsd-dev libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config
+    sudo apt-get install git cmake ninja-build clang uuid-dev libicu-dev icu-devtools libbsd-dev libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config
 
 Note: LLDB currently requires at least swig-1.3.40 but will successfully build
 with version 2 shipped with Ubuntu.
@@ -73,6 +73,8 @@ compiler for C++14 support and create a symlink:
      git clone git@github.com:/apple/swift-cmark.git cmark
      git clone git@github.com:/apple/swift-llbuild.git llbuild
      git clone git@github.com:/apple/swift-package-manager.git swiftpm
+     git clone git@github.com:/apple/swift-corelibs-xctest.git XCTest
+     git clone git@github.com:/apple/swift-corelibs-foundation.git Foundation
 
 
 [CMake](http://cmake.org) is the core infrastructure used to configure builds of


### PR DESCRIPTION
This ensures proper naming when initial clones are made
Also ensure the list of required packages from apt-get include icu-devtools which is required for building CF on linux
