### PR TITLE
Remove the FunctionEnumeration data structure from CalleeAnalysis

### DIFF
--- a/lib/SILAnalysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILAnalysis/BasicCalleeAnalysis.cpp
@@ -22,29 +22,14 @@
 using namespace swift;
 
 void CalleeCache::sortAndUniqueCallees() {
-  llvm::DenseMap<SILFunction *, unsigned int> FunctionEnumeration;
-
-  // Enumerate the functions in the module to use as keys in sorting.
-  unsigned int count = 0;
-  for (auto &F : M)
-    FunctionEnumeration[&F] = count++;
-
-  auto Lookup = [&FunctionEnumeration](SILFunction *F) -> unsigned int {
-    auto It = FunctionEnumeration.find(F);
-    assert(It != FunctionEnumeration.end() &&
-           "Function unexpectedly not found in enumeration!");
-
-    return It->second;
-  };
-
   // Sort the callees for each decl and remove duplicates.
   for (auto &Pair : TheCache) {
     auto &Callees = *Pair.second.getPointer();
 
     // Sort by enumeration number so that clients get a stable order.
     std::sort(Callees.begin(), Callees.end(),
-              [&Lookup](SILFunction *Left, SILFunction *Right) {
-                return Lookup(Left) < Lookup(Right);
+              [](SILFunction *Left, SILFunction *Right) {
+                return Left->getName().compare(Right->getName());
               });
 
     // Remove duplicates.

--- a/lib/SILAnalysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILAnalysis/BasicCalleeAnalysis.cpp
@@ -29,7 +29,8 @@ void CalleeCache::sortAndUniqueCallees() {
     // Sort by enumeration number so that clients get a stable order.
     std::sort(Callees.begin(), Callees.end(),
               [](SILFunction *Left, SILFunction *Right) {
-                return Left->getName().compare(Right->getName());
+                // Check if Right's lexicographical order is greater than Left.
+                return 1 == Right->getName().compare(Left->getName());
               });
 
     // Remove duplicates.

--- a/test/SILAnalysis/function-order.sil
+++ b/test/SILAnalysis/function-order.sil
@@ -14,8 +14,8 @@ import Builtin
 // CHECK-NEXT: public_bottom
 // CHECK-NEXT: public_middle
 // CHECK-NEXT: public_top
-// CHECK-NEXT: private_derived_foo
 // CHECK-NEXT: private_base_foo
+// CHECK-NEXT: private_derived_foo
 // CHECK-NEXT: call_private
 // CHECK-NEXT: internal_base_foo
 // CHECK-NEXT: internal_derived_foo


### PR DESCRIPTION
This pull request removes the FunctionEnumeration data structure that's needed for sorting the methods in the callee cache. Instead of creating a data structure that holds the mapping between the functions in the module and a unique integer, and accessing the map every time we sort, this patch implements the sort by comparing the name of the methods. This allows us to remove the scan of the whole module and delete the data structure. 

@rudkx 
