### PR TITLE
Alias analysis cleanups

### DIFF
--- a/include/swift/SILAnalysis/AliasAnalysis.h
+++ b/include/swift/SILAnalysis/AliasAnalysis.h
@@ -113,7 +113,8 @@ public:
   MemoryBehavior getMemoryBehavior(SILInstruction *Inst, SILValue V,
                                    RetainObserveKind);
 
-  /// Returns true if Inst may read from memory in a manner that affects V.
+  /// Returns true if \p Inst may read from memory in a manner that
+  /// affects V.
   bool mayReadFromMemory(SILInstruction *Inst, SILValue V) {
     MemoryBehavior B = getMemoryBehavior(Inst, V,
                                          RetainObserveKind::IgnoreRetains);
@@ -122,7 +123,8 @@ public:
       B == MemoryBehavior::MayHaveSideEffects;
   }
 
-  /// Returns true if Inst may write to memory in a manner that affects V.
+  /// Returns true if \p Inst may write to memory in a manner that
+  /// affects V.
   bool mayWriteToMemory(SILInstruction *Inst, SILValue V) {
     MemoryBehavior B = getMemoryBehavior(Inst, V,
                                          RetainObserveKind::IgnoreRetains);
@@ -131,8 +133,8 @@ public:
       B == MemoryBehavior::MayHaveSideEffects;
   }
 
-  /// Returns true if Inst may read or write to memory in a manner that affects
-  /// V.
+  /// Returns true if \p Inst may read or write to memory in a manner that
+  /// affects V.
   bool mayReadOrWriteMemory(SILInstruction *Inst, SILValue V) {
     auto B = getMemoryBehavior(Inst, V, RetainObserveKind::IgnoreRetains);
     return B != MemoryBehavior::None;
@@ -169,7 +171,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 /// Otherwise, return an empty type.
 SILType computeTBAAType(SILValue V);
 
-/// Check if V points to a let-variable.
+/// Check if \p V points to a let-member.
+/// Nobody can write into let members.
 bool isLetPointer(SILValue V);
 
 } // end namespace swift

--- a/include/swift/SILAnalysis/AliasAnalysis.h
+++ b/include/swift/SILAnalysis/AliasAnalysis.h
@@ -111,8 +111,7 @@ public:
   /// TODO: When ref count behavior is separated from generic memory behavior,
   /// the IgnoreRefCountIncrements flag will be unnecessary.
   MemoryBehavior getMemoryBehavior(SILInstruction *Inst, SILValue V,
-                                   RetainObserveKind =
-                                   RetainObserveKind::ObserveRetains);
+                                   RetainObserveKind);
 
   /// Returns true if Inst may read from memory in a manner that affects V.
   bool mayReadFromMemory(SILInstruction *Inst, SILValue V) {
@@ -141,7 +140,8 @@ public:
 
   /// Returns true if Inst may have side effects in a manner that affects V.
   bool mayHaveSideEffects(SILInstruction *Inst, SILValue V) {
-    MemoryBehavior B = getMemoryBehavior(Inst, V);
+    MemoryBehavior B = getMemoryBehavior(Inst, V,
+                                         RetainObserveKind::ObserveRetains);
     return B == MemoryBehavior::MayWrite ||
       B == MemoryBehavior::MayReadWrite ||
       B == MemoryBehavior::MayHaveSideEffects;
@@ -151,7 +151,8 @@ public:
   /// V. This is independent of whether or not Inst may write to V and is meant
   /// to encode notions such as ref count modifications.
   bool mayHavePureSideEffects(SILInstruction *Inst, SILValue V) {
-    return getMemoryBehavior(Inst, V) == MemoryBehavior::MayHaveSideEffects;
+    return getMemoryBehavior(Inst, V, RetainObserveKind::ObserveRetains) ==
+           MemoryBehavior::MayHaveSideEffects;
   }
 
   virtual void invalidate(SILAnalysis::InvalidationKind K) { AliasCache.clear(); }

--- a/include/swift/SILAnalysis/AliasAnalysis.h
+++ b/include/swift/SILAnalysis/AliasAnalysis.h
@@ -28,10 +28,24 @@ class SideEffectAnalysis;
 /// needed since we do not have an "analysis" infrastructure.
 class AliasAnalysis : public SILAnalysis {
 public:
-  /// The result of an alias query. This is based off of LLVM's alias
-  /// analysis so see LLVM's documentation for more information.
+
+  /// This enum describes the different kinds of aliasing relations between
+  /// pointers.
   ///
-  /// FIXME: PartialAlias?
+  /// NoAlias: There is never dependence between memory referenced by the two
+  ///          pointers. Example: Two pointers pointing to non-overlapping
+  ///          memory ranges.
+  ///
+  /// MayAlias: Two pointers might refer to the same memory location.
+  ///
+  ///
+  /// PartialAlias: The two memory locations are known to be overlapping
+  ///               but do not start at the same address.
+  ///
+  ///
+  /// MustAlias: The two memory locations always start at exactly the same
+  ///            location. The pointers are equal.
+  ///
   enum class AliasResult : unsigned {
     NoAlias=0,      ///< The two values have no dependencies on each
                     ///  other.

--- a/include/swift/SILAnalysis/AliasAnalysis.h
+++ b/include/swift/SILAnalysis/AliasAnalysis.h
@@ -56,14 +56,10 @@ public:
   };
 
 private:
-  using AliasCacheKey = std::pair<SILValue, SILValue>;
-  llvm::DenseMap<AliasCacheKey, AliasResult> AliasCache;
   SILModule *Mod;
   SideEffectAnalysis *SEA;
 
   using MemoryBehavior = SILInstruction::MemoryBehavior;
-
-  AliasResult cacheValue(AliasCacheKey Key, AliasResult Result);
 
   AliasResult aliasAddressProjection(SILValue V1, SILValue V2,
                                      SILValue O1, SILValue O2);
@@ -154,7 +150,7 @@ public:
     return MemoryBehavior::MayHaveSideEffects == B;
   }
 
-  virtual void invalidate(SILAnalysis::InvalidationKind K) { AliasCache.clear(); }
+  virtual void invalidate(SILAnalysis::InvalidationKind K) { }
 
   virtual void invalidate(SILFunction *, SILAnalysis::InvalidationKind K) {
     invalidate(K);

--- a/include/swift/SILAnalysis/AliasAnalysis.h
+++ b/include/swift/SILAnalysis/AliasAnalysis.h
@@ -84,33 +84,26 @@ public:
   
   SideEffectAnalysis *getSideEffectAnalysis() const { return SEA; }
 
-  /// Perform an alias query to see if V1, V2 refer to the same values.
-  AliasResult alias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
+  /// Compute the alias properties of the pointers \p V1 and \p V2.
+  /// The optional arguments \pTBAAType1 and \p TBAAType2 specify the exact
+  /// types that the pointers access.
+  AliasResult alias(SILValue V1, SILValue V2,
+                    SILType TBAAType1 = SILType(),
                     SILType TBAAType2 = SILType());
 
-  /// Convenience method that returns true if V1 and V2 must alias.
-  bool isMustAlias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
-                   SILType TBAAType2 = SILType()) {
-    return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::MustAlias;
+#define ALIAS_PROPERTY_CONVENIENCE_METHOD(KIND)   \
+  bool is##KIND(SILValue V1, SILValue V2,         \
+                SILType TBAAType1 = SILType(),    \
+                SILType TBAAType2 = SILType()) {  \
+    return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::KIND; \
   }
 
-  /// Convenience method that returns true if V1 and V2 partially alias.
-  bool isPartialAlias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
-                      SILType TBAAType2 = SILType()) {
-    return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::PartialAlias;
-  }
+  ALIAS_PROPERTY_CONVENIENCE_METHOD(MustAlias)
+  ALIAS_PROPERTY_CONVENIENCE_METHOD(PartialAlias)
+  ALIAS_PROPERTY_CONVENIENCE_METHOD(NoAlias)
+  ALIAS_PROPERTY_CONVENIENCE_METHOD(MayAlias)
 
-  /// Convenience method that returns true if V1, V2 can not alias.
-  bool isNoAlias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
-                 SILType TBAAType2 = SILType()) {
-    return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::NoAlias;
-  }
-
-  /// Convenience method that returns true if V1, V2 may alias.
-  bool isMayAlias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
-                  SILType TBAAType2 = SILType()) {
-    return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::MayAlias;
-  }
+#undef ALIAS_PROPERTY_CONVENIENCE_METHOD
 
   /// Use the alias analysis to determine the memory behavior of Inst with
   /// respect to V.

--- a/include/swift/SILAnalysis/AliasAnalysis.h
+++ b/include/swift/SILAnalysis/AliasAnalysis.h
@@ -110,51 +110,48 @@ public:
   ///
   /// TODO: When ref count behavior is separated from generic memory behavior,
   /// the IgnoreRefCountIncrements flag will be unnecessary.
-  MemoryBehavior getMemoryBehavior(SILInstruction *Inst, SILValue V,
-                                   RetainObserveKind);
+  MemoryBehavior computeMemoryBehavior(SILInstruction *Inst, SILValue V,
+                                       RetainObserveKind);
 
   /// Returns true if \p Inst may read from memory in a manner that
   /// affects V.
   bool mayReadFromMemory(SILInstruction *Inst, SILValue V) {
-    MemoryBehavior B = getMemoryBehavior(Inst, V,
-                                         RetainObserveKind::IgnoreRetains);
+    auto B = computeMemoryBehavior(Inst, V, RetainObserveKind::IgnoreRetains);
     return B == MemoryBehavior::MayRead ||
-      B == MemoryBehavior::MayReadWrite ||
-      B == MemoryBehavior::MayHaveSideEffects;
+           B == MemoryBehavior::MayReadWrite ||
+           B == MemoryBehavior::MayHaveSideEffects;
   }
 
   /// Returns true if \p Inst may write to memory in a manner that
   /// affects V.
   bool mayWriteToMemory(SILInstruction *Inst, SILValue V) {
-    MemoryBehavior B = getMemoryBehavior(Inst, V,
-                                         RetainObserveKind::IgnoreRetains);
+    auto B = computeMemoryBehavior(Inst, V, RetainObserveKind::IgnoreRetains);
     return B == MemoryBehavior::MayWrite ||
-      B == MemoryBehavior::MayReadWrite ||
-      B == MemoryBehavior::MayHaveSideEffects;
+           B == MemoryBehavior::MayReadWrite ||
+           B == MemoryBehavior::MayHaveSideEffects;
   }
 
   /// Returns true if \p Inst may read or write to memory in a manner that
   /// affects V.
   bool mayReadOrWriteMemory(SILInstruction *Inst, SILValue V) {
-    auto B = getMemoryBehavior(Inst, V, RetainObserveKind::IgnoreRetains);
-    return B != MemoryBehavior::None;
+    auto B = computeMemoryBehavior(Inst, V, RetainObserveKind::IgnoreRetains);
+    return MemoryBehavior::None != B;
   }
 
   /// Returns true if Inst may have side effects in a manner that affects V.
   bool mayHaveSideEffects(SILInstruction *Inst, SILValue V) {
-    MemoryBehavior B = getMemoryBehavior(Inst, V,
-                                         RetainObserveKind::ObserveRetains);
+    auto B = computeMemoryBehavior(Inst, V, RetainObserveKind::ObserveRetains);
     return B == MemoryBehavior::MayWrite ||
-      B == MemoryBehavior::MayReadWrite ||
-      B == MemoryBehavior::MayHaveSideEffects;
+           B == MemoryBehavior::MayReadWrite ||
+           B == MemoryBehavior::MayHaveSideEffects;
   }
 
   /// Returns true if Inst may have side effects in a manner that affects
   /// V. This is independent of whether or not Inst may write to V and is meant
   /// to encode notions such as ref count modifications.
   bool mayHavePureSideEffects(SILInstruction *Inst, SILValue V) {
-    return getMemoryBehavior(Inst, V, RetainObserveKind::ObserveRetains) ==
-           MemoryBehavior::MayHaveSideEffects;
+    auto B = computeMemoryBehavior(Inst, V, RetainObserveKind::ObserveRetains);
+    return MemoryBehavior::MayHaveSideEffects == B;
   }
 
   virtual void invalidate(SILAnalysis::InvalidationKind K) { AliasCache.clear(); }

--- a/lib/SILAnalysis/AliasAnalysis.cpp
+++ b/lib/SILAnalysis/AliasAnalysis.cpp
@@ -699,10 +699,8 @@ AliasResult AliasAnalysis::aliasInner(SILValue V1, SILValue V2,
   return AliasResult::MayAlias;
 }
 
-/// Check if this is the address of a "let" member.
-/// Nobody can write into let members.
 bool swift::isLetPointer(SILValue V) {
-  // Traverse the "access" path for V and check that starts with "let"
+  // Traverse the "access" path for V and check that it starts with "let"
   // and everything along this path is a value-type (i.e. struct or tuple).
 
   // Is this an address of a "let" class member?

--- a/lib/SILAnalysis/MemoryBehavior.cpp
+++ b/lib/SILAnalysis/MemoryBehavior.cpp
@@ -66,18 +66,20 @@ public:
     // If we do not have any more information, just use the general memory
     // behavior implementation.
     auto Behavior = Inst->getMemoryBehavior();
-    if (!isLetPointer(V))
+    bool ReadOnlyAccess = isLetPointer(V);
+
+    // If this is a regular read-write access then return the computed memory
+    // behavior.
+    if (!ReadOnlyAccess)
       return Behavior;
 
+    // If this is a read-only access to 'let variable' then we can strip away
+    // the write access.
     switch (Behavior) {
-    case MemBehavior::MayHaveSideEffects:
-      return MemBehavior::MayRead;
-    case MemBehavior::MayReadWrite:
-      return MemBehavior::MayRead;
-    case MemBehavior::MayWrite:
-      return MemBehavior::None;
-    default:
-      return Behavior;
+    case MemBehavior::MayHaveSideEffects: return MemBehavior::MayRead;
+    case MemBehavior::MayReadWrite:       return MemBehavior::MayRead;
+    case MemBehavior::MayWrite:           return MemBehavior::None;
+    default: return Behavior;
     }
   }
 

--- a/lib/SILAnalysis/MemoryBehavior.cpp
+++ b/lib/SILAnalysis/MemoryBehavior.cpp
@@ -305,8 +305,8 @@ MemBehavior MemoryBehaviorVisitor::visitReleaseValueInst(ReleaseValueInst *SI) {
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
-SILInstruction::MemoryBehavior
-AliasAnalysis::getMemoryBehavior(SILInstruction *Inst, SILValue V,
+MemBehavior
+AliasAnalysis::computeMemoryBehavior(SILInstruction *Inst, SILValue V,
                                  RetainObserveKind IgnoreRefCountIncrements) {
   DEBUG(llvm::dbgs() << "GET MEMORY BEHAVIOR FOR:\n    " << *Inst << "    "
                      << *V.getDef());

--- a/lib/SILAnalysis/ValueTracking.cpp
+++ b/lib/SILAnalysis/ValueTracking.cpp
@@ -185,7 +185,7 @@ static bool isTransitiveEscapeInst(SILInstruction *Inst) {
 }
 
 /// Maximum amount of ValueCapture queries.
-static unsigned const Threshold = 32;
+static unsigned const ValueCaptureSearchThreshold = 32;
 
 namespace {
 
@@ -205,8 +205,8 @@ enum CaptureException : unsigned {
 /// case to be conservative, we must assume it is captured.
 /// FIXME: Maybe put this on SILValue?
 static bool valueMayBeCaptured(SILValue V, CaptureException Exception) {
-  llvm::SmallVector<Operand *, Threshold> Worklist;
-  llvm::SmallPtrSet<Operand *, Threshold> Visited;
+  llvm::SmallVector<Operand *, ValueCaptureSearchThreshold> Worklist;
+  llvm::SmallPtrSet<Operand *, ValueCaptureSearchThreshold> Visited;
   unsigned Count = 0;
 
   DEBUG(llvm::dbgs() << "        Checking for capture.\n");
@@ -216,7 +216,7 @@ static bool valueMayBeCaptured(SILValue V, CaptureException Exception) {
   for (auto *UI : V.getUses()) {
     // If we have more uses than the threshold, be conservative and bail so we
     // don't use too much compile time.
-    if (Count++ >= Threshold)
+    if (Count++ >= ValueCaptureSearchThreshold)
       return true;
     Visited.insert(UI);
     Worklist.push_back(UI);
@@ -238,7 +238,7 @@ static bool valueMayBeCaptured(SILValue V, CaptureException Exception) {
       for (auto *UI : Inst->getUses()) {
         // If we have more uses than the threshold, be conservative and bail
         // so we don't use too much compile time.
-        if (Count++ >= Threshold)
+        if (Count++ >= ValueCaptureSearchThreshold)
           return true;
 
         if (Visited.insert(UI).second) {


### PR DESCRIPTION
This pull request contains a bunch of cleanups to AliasAnalysis.  Changes:

Removing the cache from AliasAnalysis.
Renaming getMemoryBehavior to computeMemoryBehavior.
Documenting stuff, and removing the default argument form a method.

@trentxintong @gottesmm @atrick 
