### PR TITLE
Fix cmark checkout path

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -833,8 +833,8 @@ FOUNDATION_SOURCE_DIR="$WORKSPACE/swift-corelibs-foundation"
 
 if [[ ! -d $CMARK_SOURCE_DIR ]]; then
   echo "$CMARK_SOURCE_DIR not found. Attempting to clone ..."
-  git clone git@github.com/apple/swift-cmark.git "$CMARK_SOURCE_DIR" || \
-    (echo "Couldn't clone cmark. Please check README.md and visit https:/github.com/apple/swift-cmark for details." && \
+  git clone https://github.com/apple/swift-cmark.git "$CMARK_SOURCE_DIR" || \
+    (echo "Couldn't clone cmark. Please check README.md and visit https://github.com/apple/swift-cmark for details." && \
     exit 1)
 fi
 


### PR DESCRIPTION
git@github links only work if you've got write permissions to the repository. This changes it to the https version
