### PR TITLE
Copy code of conduct from website to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,14 @@ See [docs/Testing.rst](docs/Testing.rst).
 ## Contributing to Swift
 
 Contributions to Swift are welcomed and encouraged! Please see the [Contributing to Swift guide](https://swift.org/contributing/).
+
+To be a truly great community, Swift.org needs to welcome developers from all
+walks of life, with different backgrounds, and with a wide range of experience.
+A diverse and friendly community will have more great ideas, more unique
+perspectives, and produce more great code. We will work diligently to make the
+Swift community welcoming to everyone.
+
+To give clarity of what is expected of our members, Swift has adopted the
+code of conduct defined by the Contributor Covenant. This document is used
+across many open source communities, and we think it articulates our values
+well. For more, see [the website](https://swift.org/community/#code-of-conduct).


### PR DESCRIPTION
Just as including the licence in the repository is important, including
the text of the code of conduct is important.

This is copied directly from https://swift.org/community/#code-of-conduct
