### PR TITLE
Fix tiny typo

### DIFF
--- a/test/SILPasses/sil_combine.sil
+++ b/test/SILPasses/sil_combine.sil
@@ -2838,7 +2838,7 @@ sil @closure_with_in_guaranteed_owened_in_args : $@convention(method) (@in CC2, 
 // Test the peephole performing apply{partial_apply(x,y,z)}(a) -> apply(a,x,y,z)
 // We need to check the following:
 // - all arguments of a partial_apply, which are either results of a stack_alloc or consumed indirect arguments
-//  should be copied into temporaries. This should happen just before tha partial_apply instruction.
+//  should be copied into temporaries. This should happen just before that partial_apply instruction.
 // - The temporaries are allocated at the beginning of the function and deallocated at the end.
 // - Before each apply of the partial_apply, we retain values of any arguments which are of non-address type.
 //   This is required because they could be consumed (i.e. relased by the callee).


### PR DESCRIPTION
I found the typo in sil_combine.sil.
