### PR TITLE
Fix typo in String.swift documentation

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -95,7 +95,7 @@ import SwiftShims
 ///
 /// `String` is bridged to Objective-C as `NSString`, and a `String`
 /// that originated in Objective-C may store its characters in an
-/// `NSString`.  Since any arbitrary subclass of `NSSString` can
+/// `NSString`.  Since any arbitrary subclass of `NSString` can
 /// become a `String`, there are no guarantees about representation or
 /// efficiency in this case.  Since `NSString` is immutable, it is
 /// just as though the storage was shared by some copy: the first in


### PR DESCRIPTION
`NSSString` -> `NSString`
