### PR TITLE
Fixing typo in TypeChecker.rst

### DIFF
--- a/docs/TypeChecker.rst
+++ b/docs/TypeChecker.rst
@@ -486,7 +486,7 @@ down to only simple constraints that are trivially satisfied.
 The simplification process breaks down constraints into simpler
 constraints, and each different kind of constraint is handled by
 different rules based on the Swift type system. The constraints fall
-intofive categories: relational constraints, member constraints,
+into five categories: relational constraints, member constraints,
 type properties, conjunctions, and disjunctions. Only the first three
 kinds of constraints have interesting simplification rules, and are
 discussed in the following sections.


### PR DESCRIPTION
fixing typo of "into five" to "into five"
