### PR TITLE
Add a rendered version of the documentation to Read the Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Another source of documentation is the standard library itself, located at
 (including `Int`), and the standard library gives some examples of what can be
 expressed today.
 
+You can see the rendered documentation on 
+[Read the Docs](http://apple-swift.readthedocs.org/en/latest/contents.html)
+
 
 ## Getting Started
 


### PR DESCRIPTION
This allows folks to browse the contents in a nicer way,
including with navigation and search.

I made the project, but would be happy to hand over the keys
to folks on the Swift team if you're interested.

You could also CNAME `docs.swift.org` to this,
and use that as a canonical source if you were interested.

You can see the rendered version here: http://apple-swift.readthedocs.org/en/latest/contents.html

I also added a branch that renders it using our own theme, which I find to be more useful. We could help add some swift branding to it, if you're interested in using it: http://apple-swift.readthedocs.org/en/readthedocs-theme/index.html -- It makes the contents much more readable on mobile as well.
