### PR TITLE
Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Welcome to Swift!**
 
-Swift is a high performance systems programming language.  It has a clean
+Swift is a high-performance systems programming language.  It has a clean
 and modern syntax, and offers seamless access to existing C and Objective-C code
 and frameworks, and is memory safe (by default).
 
@@ -18,20 +18,20 @@ modules, eliminating the need for headers and the code duplication they entail.
 To read the documentation, start by installing the Sphinx documentation
 generator tool (http://sphinx-doc.org, just run `easy_install -U Sphinx` from
 the command line and you're good to go).  Once you have that, you can build the
-swift documentation by going into `swift/docs` and typing `make`.  This compiles
-the 'rst' files in the docs directory into HTML in the `swift/docs/_build/html`
+Swift documentation by going into `docs` and typing `make`.  This compiles
+the `.rst` files in the `docs` directory into HTML in the `docs/_build/html`
 directory.
 
-Once built, the best place to start is with the swift whitepaper, which gives a
-tour of the language (in `swift/docs/_build/html/whitepaper/index.html`).
+Once built, the best place to start is with the Swift white paper, which gives a
+tour of the language (in `docs/_build/html/whitepaper/index.html`).
 Another potentially useful document is `docs/LangRef`, which gives a low level
 tour of how the language works from the implementation perspective.
 
 Many of the docs are out of date, but you can see some historical design
 documents in the `docs` directory.
 
-Another source of documentation is the standard library itself, located at
-`swift/stdlib`.  Much of the language is actually implemented in the library
+Another source of documentation is the standard library itself, located in
+`stdlib`.  Much of the language is actually implemented in the library
 (including `Int`), and the standard library gives some examples of what can be
 expressed today.
 
@@ -107,14 +107,14 @@ supports presets which you can define for common combinations of build options.
 
 To find out more:
 
-    swift/utils/build-script -h
+    utils/build-script -h
 
 Note: Arguments after "--" above are forwarded to `build-script-impl`, which is
 the ultimate shell script that invokes the actual build and test commands.
 
 A basic command to build Swift and run basic tests with Ninja:
 
-    swift/utils/build-script -t
+    utils/build-script -t
 
 ## Develop Swift in Xcode
 
@@ -124,13 +124,13 @@ to build for other SDKs but still use Xcode, once you've built Swift using Ninja
 or one of the other supported CMake generators, you can set up an IDE-only Xcode
 environment using the build-script's `-X` flag:
 
-    swift/utils/build-script -X --skip-build -- --reconfigure
+    utils/build-script -X --skip-build -- --reconfigure
 
-The `--skip-build` flag tells build-script to only generate the project,
+The `--skip-build` flag tells `build-script` to only generate the project,
 not build it in its entirety. A bare minimum of LLVM tools will build in order
 to configure the Xcode projects.
 
-The `--reconfigure` flag tells build-script-impl to run the CMake configuration
+The `--reconfigure` flag tells `build-script-impl` to run the CMake configuration
 step even if there is a cached configuration. As you develop in Xcode, you may
 need to rerun this from time to time to refresh your generated Xcode project,
 picking up new targets, file removals, or file additions.


### PR DESCRIPTION
- Fix capitalization of "Swift".
- Use monospaced font for names of scripts.
- Omit root `swift` directory from paths.
- Split "whitepaper" into two words.
- Hyphenate "high-performance".
