### PR TITLE
Remove instances of duplicated words

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -237,7 +237,7 @@ To complete the semantics understood by the optimizer, we define these relations
 
 interferes-with
   
-  Given idempotent ``OpA``, the the sequence "``OpA, OpB, OpA``" is
+  Given idempotent ``OpA``, the sequence "``OpA, OpB, OpA``" is
   semantically equivalent to the sequence "``OpA, OpB``" *iff* ``OpB``
   does not interfere with ``OpA``.
 

--- a/docs/ObjectInitialization.rst
+++ b/docs/ObjectInitialization.rst
@@ -515,7 +515,7 @@ make use of ``self``. This is important uses of ``self``---say,
 calling a method on ``self``---could end up referring to stored
 properties before they are initialized. Consider the following
 Objective-C code, where instance variables are initialized *after* the
-call to the the superclass initializer::
+call to the superclass initializer::
 
   @interface A : NSObject
   - (instancetype)init;

--- a/docs/archive/LangRef.html
+++ b/docs/archive/LangRef.html
@@ -106,8 +106,8 @@
   
   <p>An import without an explicit import-kind names a module; all of the 
   module's members are imported into the current scope. The module's name is
-  also imported into the the current scope in order to allow qualified access
-  to the module's members, which can be useful for disambiguation.</p>
+  also imported into the current scope in order to allow qualified access to
+  the module's members, which can be useful for disambiguation.</p>
   
   <p>If an import-kind is provided, the last element of the import path is
   taken to be the name of a decl <em>within</em> the module named by the rest of

--- a/docs/proposals/OptimizerEffects.rst
+++ b/docs/proposals/OptimizerEffects.rst
@@ -492,7 +492,7 @@ elt2's destructor can't change the uniqueness state of the arrays.::
    setElement(&a.array, elt2, i)
  }
 
-In the the following loop it is not safe to hoist the makeUnique(&a)
+In the following loop it is not safe to hoist the makeUnique(&a)
 call even for trivial types. 'appendAssumingUnique' captures its argument 'a'
 which forces a copy on 'a' on every iteration of the loop.::
 

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -96,7 +96,7 @@ public:
 /// deployment target. This specification is designed to ease porting
 /// to new platforms. Because new platforms typically branch from
 /// existing platforms, the wildcard allows an #available() check to do the
-/// "right" thing (executing the the guarded branch) on the new platform without
+/// "right" thing (executing the guarded branch) on the new platform without
 /// requiring a modification to every availablity guard in the program. Note
 /// that we still do compile-time availability checking with '*', so the
 /// compiler will still catch references to potentially unavailable symbols.

--- a/include/swift/ASTSectionImporter/ASTSectionImporter.h
+++ b/include/swift/ASTSectionImporter/ASTSectionImporter.h
@@ -27,8 +27,8 @@ namespace swift {
   /// section, this function makes memory buffer copies of all swift
   /// modules found in it and registers them using
   /// registerMemoryBuffer() so they can be found by loadModule(). The
-  /// the access path of all modules found in the section is appended
-  /// to the vector foundModules.
+  /// access path of all modules found in the section is appended to
+  /// the vector foundModules.
   /// \return true if successful.
   bool parseASTSection(SerializedModuleLoader* SML, StringRef Data,
                        SmallVectorImpl<std::string> &foundModules);

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -99,7 +99,7 @@ class ClusteredBitVector {
   ///
   ///  c) 0 < LengthInBits < ChunkSizeInBits.  In this case, Data contains
   ///     a single chunk, with its unused high bits zeroed like in the
-  ///     the out-of-line case.
+  ///     out-of-line case.
   ///
   /// Therefore, an efficient way to test whether all bits are zero:
   /// Data != 0.  (isInlineAndAllClear())  Not *guaranteed* to find

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -55,7 +55,7 @@ typedef struct objc_image_info {
 
 // Class and metaclass construction from a compiler-generated memory image.
 // cls and cls->isa must each be OBJC_MAX_CLASS_SIZE bytes.·
-// Extra bytes not used the the metadata must be zero.
+// Extra bytes not used the metadata must be zero.
 // info is the same objc_image_info that would be emitted by a static compiler.
 // Returns nil if a class with the same name already exists.
 // Returns nil if the superclass is nil and the class is not marked as a root.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4332,7 +4332,7 @@ namespace {
       return subscript;
     }
 
-    /// Import the the accessor and its attributes.
+    /// Import the accessor and its attributes.
     FuncDecl *importAccessor(clang::ObjCMethodDecl *clangAccessor,
                              DeclContext *dc) {
       auto *accessor =
@@ -4711,7 +4711,7 @@ namespace {
 
     /// \brief Import the members of all of the protocols to which the given
     /// Objective-C class, category, or extension explicitly conforms into
-    /// the given list of members, so long as the the method was not already
+    /// the given list of members, so long as the method was not already
     /// declared in the class.
     ///
     /// FIXME: This whole thing is a hack, because name lookup should really

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -957,7 +957,7 @@ public:
   /// \returns The named type, or null if the type could not be found.
   Type getNamedSwiftType(Module *module, StringRef name);
 
-  /// \brief Retrieve a specialization of the the named Swift type, e.g.,
+  /// \brief Retrieve a specialization of the named Swift type, e.g.,
   /// UnsafeMutablePointer<T>.
   ///
   /// \param module The name of the module in which the type should occur.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2709,7 +2709,7 @@ public:
     // Ignore the internal members of Optional, like getLogicValue() and
     // _getMirror().
     // These are not commonly used and cause noise and confusion when showing
-    // among the the members of the underlying type. If someone really wants to
+    // among the members of the underlying type. If someone really wants to
     // use them they can write them directly.
 
     return true;

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -64,7 +64,7 @@ namespace irgen {
     llvm::Value *casted;
   };
 
-  /// \brief Convert the given value to the the exact destination type.
+  /// \brief Convert the given value to the exact destination type.
   FailableCastResult emitClassIdenticalCast(IRGenFunction &IGF,
                                                   llvm::Value *from,
                                                   SILType fromType,

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -80,8 +80,7 @@ public:
 
   /// A stable insertion point in the function.  "Stable" means that
   /// it will point to the same location in the function, even if
-  /// instructions are subsequently added to the the current basic
-  /// block.
+  /// instructions are subsequently added to the current basic block.
   class StableIP {
     /// Either an instruction that we're inserting after or the basic
     /// block that we're inserting at the beginning of.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -397,7 +397,7 @@ public:
   ///
   /// Unlike \c setLoweredObjCMethod, which finds the method in the actual
   /// runtime type of the object, this routine starts at the static type of the
-  /// object and searches up the the class hierarchy (toward superclasses).
+  /// object and searches up the class hierarchy (toward superclasses).
   ///
   /// \param searchType The class from which the Objective-C runtime will start
   /// its search for a method.
@@ -1571,8 +1571,8 @@ void IRGenSILFunction::visitSILBasicBlock(SILBasicBlock *BB) {
       auto DS = I.getDebugScope();
       // Handle cleanup locations.
       if (ILoc.getKind() == SILLocation::CleanupKind) {
-        // Cleanup locations point to the decl of the the value that
-        // is being destroyed (for diagnostic generation). As far as
+        // Cleanup locations point to the decl of the value that is
+        // being destroyed (for diagnostic generation). As far as
         // the linetable is concerned, cleanups at the end of a
         // lexical scope should point to the cleanup location, which
         // is the location of the last instruction in the basic block.
@@ -2686,7 +2686,7 @@ mapTriviallyToInt(IRGenSILFunction &IGF, const EnumImplStrategy &EIS, SelectEnum
   // Cast to the result type.
   result = IGF.Builder.CreateIntCast(result, resultType, false);
   if (commonOffset != 0) {
-    // The the offset, if any.
+    // The offset, if any.
     auto *offsetConst = llvm::ConstantInt::get(resultType, commonOffset);
     result = IGF.Builder.CreateAdd(result, offsetConst);
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4305,7 +4305,7 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       }
     }
     
-    // For recovery, again make sure the the user didn't try to spell a switch
+    // For recovery, again make sure the user didn't try to spell a switch
     // case label:
     // 'case Identifier:' or
     // 'case Identifier where ...:'

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2022,7 +2022,7 @@ static BraceStmt *ConvertClosureToBraceStmt(Expr *E, ASTContext &Ctx) {
   CE->setExplicitResultType(CE->getStartLoc(), empty);
   
   // The trick here is that the ClosureExpr provides a DeclContext for stuff
-  // inside of it, so it isn't safe to just drop it and rip the the BraceStmt
+  // inside of it, so it isn't safe to just drop it and rip the BraceStmt
   // from inside of it.  While we could try to walk the body and update any
   // Decls, ClosureExprs, etc within the body of the ClosureExpr, it is easier
   // to just turn it into BraceStmt(CallExpr(TheClosure, VoidTuple)).  This also

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -230,7 +230,7 @@ emitBridgeReturnValueForForeignError(SILLocation loc,
     return emitIntValue(*this, loc, bridgedType, 0);
 
   // If an error is signalled by a zero result, but we've preserved
-  // the rest of the return value, then just return the the normal
+  // the rest of the return value, then just return the normal
   // result, assuming (hoping!) that it isn't zero.
   case ForeignErrorConvention::ZeroPreservedResult:
     return result;

--- a/lib/SILPasses/IPO/FunctionSignatureOpts.cpp
+++ b/lib/SILPasses/IPO/FunctionSignatureOpts.cpp
@@ -397,7 +397,7 @@ updateOptimizedBBArgs(SILBuilder &Builder, SILBasicBlock *BB,
   ProjTree.replaceValueUsesWithLeafUses(Builder, BB->getParent()->getLocation(),
                                         LeafValues);
 
-  // Replace all uses of the the original arg with undef so it does not have any
+  // Replace all uses of the original arg with undef so it does not have any
   // uses.
   SILValue OrigArg = SILValue(BB->getBBArg(OldArgOffset));
   OrigArg.replaceAllUsesWith(SILUndef::get(OrigArg.getType(),

--- a/lib/SILPasses/Loop/LoopRotate.cpp
+++ b/lib/SILPasses/Loop/LoopRotate.cpp
@@ -391,7 +391,7 @@ bool swift::rotateLoop(SILLoop *L, DominanceInfo *DT, SILLoopInfo *LI,
   // the latch.
   Header->moveAfter(Latch);
 
-  // Merge the the old latch with the old header if possible.
+  // Merge the old latch with the old header if possible.
   mergeBasicBlockWithSuccessor(Latch, DT, LI);
 
   // Create a new preheader.

--- a/lib/SILPasses/Scalar/RedundantLoadElimination.cpp
+++ b/lib/SILPasses/Scalar/RedundantLoadElimination.cpp
@@ -63,7 +63,7 @@
 /// value) and then aggregate them.
 ///
 /// However, this may introduce a lot of extraction and aggregation which may
-/// not be necessary. i.e. a store the the struct followed by a load from the
+/// not be necessary. i.e. a store the struct followed by a load from the
 /// struct. To solve this problem, when RLE detects that an load instruction
 /// can be replaced by forwarded value, it will try to find minimum # of
 /// extraction necessary to form the forwarded value. It will group the

--- a/lib/SILPasses/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILPasses/Utils/CheckedCastBrJumpThreading.cpp
@@ -614,15 +614,15 @@ bool CheckedCastBrJumpThreading::trySimplify(TermInst *Term) {
     // TODO:
     // If the dominating checked_cast_br is non-exact, then
     // it is in general not safe to assume that current exact cast
-    // would have the same outcome. But if the the dominating
-    // non-exact checked_cast_br fails, then the current exact cast
-    // would always fail as well.
+    // would have the same outcome. But if the dominating non-exact
+    // checked_cast_br fails, then the current exact cast would
+    // always fail as well.
     //
     // If the dominating checked_cast_br is exact then then
     // it is in general not safe to assume that the current non-exact
-    // cast would have the same outcome. But if the the dominating
-    // exact checked_cast_br succeeds, then the current non-exact
-    // cast would always succeed as well.
+    // cast would have the same outcome. But if the dominating exact
+    // checked_cast_br succeeds, then the current non-exact cast
+    // would always succeed as well.
     //
     // TODO: In some specific cases, it is possible to prove that
     // success or failure of the dominating cast is equivalent to

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1075,7 +1075,7 @@ private:
     walkInContext(E->getBase(), MemberAccessContext::Getter);
 
     ValueDecl *D = E->getMember().getDecl();
-    // Diagnose for the the member declaration itself.
+    // Diagnose for the member declaration itself.
     if (diagAvailability(TC, D, E->getNameLoc(), DC)) {
       return;
     }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -354,7 +354,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       }
     }
 
-    // Substitute the the base into the member's type.
+    // Substitute the base into the member's type.
     if (Type memberType = substMemberTypeWithBase(dc->getParentModule(),
                                                   typeDecl, type,
                                                   /*isTypeReference=*/true)) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -1273,7 +1273,7 @@ private:
 
     // If the starting version range is not completely contained in the
     // false flow version range then it must be the case that false flow range
-    // is strictly smaller than the the starting range (because the false flow
+    // is strictly smaller than the starting range (because the false flow
     // range *is* contained in the starting range), so we should introduce a
     // new refinement for the false flow.
     if (!StartingTRC->getPotentialVersions().isContainedIn(FalseFlow)) {
@@ -1487,7 +1487,7 @@ void TypeChecker::diagnosePotentialUnavailability(
 /// This class finds the innermost nodes of interest by walking
 /// down the root until it has found the target range (in a Pre-visitor)
 /// and then recording the innermost node on the way back up in the
-/// the Post-visitors. It does its best to not search unnecessary subtrees,
+/// Post-visitors. It does its best to not search unnecessary subtrees,
 /// although this is complicated by the fact that not all nodes have
 /// source range information.
 class InnermostAncestorFinder : private ASTWalker {
@@ -1911,8 +1911,8 @@ static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
   SourceLoc InsertLoc;
 
   // To avoid exposing the pattern binding declaration to the user, get the
-  // descriptive kind from one of the VarDecls. We get the the Fix-It
-  // location from the PatternBindingDecl unless the VarDecl has attributes,
+  // descriptive kind from one of the VarDecls. We get the Fix-It location
+  // from the PatternBindingDecl unless the VarDecl has attributes,
   // in which case we get the start location of the VarDecl attributes.
   DeclAttributes AttrsForLoc;
   if (KindForDiagnostic == DescriptiveDeclKind::PatternBinding) {

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -118,7 +118,7 @@ public func split<S : CollectionType, R : BooleanType>(
   fatalError("unavailable function can't be called")
 }
 
-/// Returns `true` iff the the initial elements of `s` are equal to `prefix`.
+/// Returns `true` iff the initial elements of `s` are equal to `prefix`.
 @available(*, unavailable, message="call the 'startsWith()' method on the sequence")
 public func startsWith<
   S0 : SequenceType, S1 : SequenceType

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -95,7 +95,7 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
   return Int8(Builtin.canBeClass(T.self))
 }
 
-/// Returns the the bits of `x`, interpreted as having type `U`.
+/// Returns the bits of `x`, interpreted as having type `U`.
 ///
 /// - Warning: Breaks the guarantees of Swift's type system; use
 ///   with extreme care.  There's almost always a better way to do

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -140,7 +140,7 @@ if preds:
   rethrows_ = "rethrows "
 else:
   comment = """
-  /// Return true iff the the initial elements of `self` are equal to `prefix`.
+  /// Return true iff the initial elements of `self` are equal to `prefix`.
   /// Return true if `other` is empty."""
   rethrows_ = ""
 }%

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -1,7 +1,7 @@
 // This file is used by Sema/availability_versions_multi.swift to
 // test that we build enough of the type refinement context as needed to
 // validate declarations when resolving declaration signatures.
-// This file relies on the the minimum deployment target for OS X being 10.9.
+// This file relies on the minimum deployment target for OS X being 10.9.
 
 @available(OSX, introduced=10.11)
 private class PrivateIntroduced10_11 { }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -298,7 +298,7 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueDeclLoc) {
   StringRef TextToReplace = "0";
   replaceText(DocName, findOffset(TextToReplace, Contents), TextToReplace.size(),
               ExpensiveInit);
-  // Edit over the the 'foo' decl.
+  // Edit over the 'foo' decl.
   replaceText(DocName, FooOffs, strlen("foo"), "foo");
 
   // Should wait for the new AST, because the declaration location for the 'foo'
@@ -328,7 +328,7 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueOffset) {
   StringRef TextToReplace = "0";
   replaceText(DocName, findOffset(TextToReplace, Contents), TextToReplace.size(),
               ExpensiveInit);
-  // Edit over the the 'foo' reference.
+  // Edit over the 'foo' reference.
   replaceText(DocName, FooRefOffs, strlen("foo"), "foo");
 
   // Should wait for the new AST, because the cursor location has been edited

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -506,7 +506,7 @@ class ParseContext:
 
 
     def nextToken(self):
-        """Move to the the next token"""
+        """Move to the next token"""
         for kind in self.tokens:
             return self.tokenKind
 


### PR DESCRIPTION
It removes instances of `the the` as well as an instance of a `would would`. Some on same line, some split on two lines.
