### PR TITLE
Change shebangs to specify python2 instead of system default

### DIFF
--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, re, subprocess
 
 def run():

--- a/test/Driver/Dependencies/Inputs/fail.py
+++ b/test/Driver/Dependencies/Inputs/fail.py
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 exit(1)

--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Emulates the frontend of an -embed-bitcode job. That means we have to handle
 # -emit-bc and -c actions.

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Emulates the frontend of a -whole-module-optimization compilation.
 

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # modify-non-primary-files.py simulates a build where the user is modifying the
 # source files during compilation.

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Fails if the input file is named "bad.swift"; otherwise dispatches to
 # update-dependencies.py.

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # update-dependencies.py simulates a Swift compilation for the purposes of
 # dependency analysis. That means it has two tasks:

--- a/test/Inputs/getmtime.py
+++ b/test/Inputs/getmtime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/test/Serialization/Inputs/binary_sub.py
+++ b/test/Serialization/Inputs/binary_sub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #===--- apply-fixit-edits.py - Tool for applying edits from .remap files ---===#
 #

--- a/utils/benchmark/BST/bst.py
+++ b/utils/benchmark/BST/bst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # A binary search tree.
 class BST:

--- a/utils/build-script
+++ b/utils/build-script
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #===--- build-script - The ultimate tool for building Swift ----------------===#
 #
 ## This source file is part of the Swift.org open source project

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import re
 import sys

--- a/utils/create-filecheck-test.py
+++ b/utils/create-filecheck-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # The following script takes as input a SIL fragment and changes all
 # SSA variables into FileCheck variables. This significantly reduces

--- a/utils/demo-tool
+++ b/utils/demo-tool
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import optparse

--- a/utils/gyb
+++ b/utils/gyb
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import gyb
 gyb.main()

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #convert line numbers in error messages according to "line directive" comments
 import os
 import sys

--- a/utils/omit-needless-words.py
+++ b/utils/omit-needless-words.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # This tool helps assess the impact of automatically applying
 # heuristics that omit 'needless' words from APIs imported from Clang

--- a/utils/pass-pipeline/scripts/pipeline_generator.py
+++ b/utils/pass-pipeline/scripts/pipeline_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Note: it doesn't matter what directory you invoke this in; it uses
 # your SWIFT_BUILD_ROOT and SWIFT_SOURCE_ROOT settings, just like

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import re
 

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import argparse
 import os.path

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # A small utility to take the output of a Swift validation test run
 # where some compiler crashers have been fixed, and move them into the

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #===------------------------------------------------------------------------===#
 #
 # This source file is part of the Swift.org open source project

--- a/utils/split_file.py
+++ b/utils/split_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 split_file.py [-o <dir>] <path>

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Utility script for submitting benchmark results to an LNT server.

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 ##===--- swift-bench.py -------------------------------*- coding: utf-8 -*-===##
 ##
 ## This source file is part of the Swift.org open source project

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #===--- update-checkout - Utility to update your local checkouts -----------===#
 #
 # This source file is part of the Swift.org open source project

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # A script for viewing the CFG of SIL and llvm IR.
 

--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import itertools
 


### PR DESCRIPTION
This replaces all shebangs in the python scripts to use python2 instead of system default. This is because not all of the python scripts support running in python3. The new shebangs use `#!/usr/bin/env python2` 
