### PR TITLE
[WIP] Modify Python scripts to run on Python 2 and 3

### DIFF
--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -17,4 +17,4 @@ if os.path.basename(primaryFile) == 'bad.swift':
     exit(1)
 
 dir = os.path.dirname(os.path.abspath(__file__))
-execfile(os.path.join(dir, "update-dependencies.py"))
+exec(compile(open(os.path.join(dir, "update-dependencies.py")).read(), os.path.join(dir, "update-dependencies.py"), 'exec'))

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -12,6 +12,14 @@
 
 from ctypes import *
 
+# Python 3 has just one integer type, which mostly behaves like the `long`
+# type from Python 2.  There's an `isinstance(obj, (int,long,bool))` in this
+# file; this fudge is to make that work on Python 3.  See PEP 237.
+try:
+    long
+except NameError:
+    long = int
+
 # ctypes doesn't implicitly convert c_void_p to the appropriate wrapper
 # object. This is a problem, because it means that from_parameter will see an
 # integer and pass the wrong value on platforms where int != void*. Work around

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -156,7 +156,7 @@ class ErrorKind(object):
         if value >= len(ErrorKind._kinds):
             ErrorKind._kinds += [None] * (value - len(ErrorKind._kinds) + 1)
         if ErrorKind._kinds[value] is not None:
-            raise ValueError,'ErrorKind already loaded'
+            raise ValueError('ErrorKind already loaded')
         self.value = value
         ErrorKind._kinds[value] = self
         ErrorKind._name_map = None
@@ -177,7 +177,7 @@ class ErrorKind(object):
     @staticmethod
     def from_id(id):
         if id >= len(ErrorKind._kinds) or ErrorKind._kinds[id] is None:
-            raise ValueError,'Unknown type kind %d' % id
+            raise ValueError('Unknown type kind %d' % id)
         return ErrorKind._kinds[id]
 
     def __repr__(self):
@@ -239,7 +239,7 @@ class VariantType(object):
         if value >= len(VariantType._kinds):
             VariantType._kinds += [None] * (value - len(VariantType._kinds) + 1)
         if VariantType._kinds[value] is not None:
-            raise ValueError,'VariantType already loaded'
+            raise ValueError('VariantType already loaded')
         self.value = value
         VariantType._kinds[value] = self
         VariantType._name_map = None
@@ -260,7 +260,7 @@ class VariantType(object):
     @staticmethod
     def from_id(id):
         if id >= len(VariantType._kinds) or VariantType._kinds[id] is None:
-            raise ValueError,'Unknown type kind %d' % id
+            raise ValueError('Unknown type kind %d' % id)
         return VariantType._kinds[id]
 
     def __repr__(self):

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -529,7 +529,7 @@ def register_functions(lib, ignore_errors):
     def register(item):
         return register_function(lib, item, ignore_errors)
 
-    map(register, functionList)
+    list(map(register, functionList))
 
 class Config:
     library_path = None

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -64,7 +64,7 @@ class GraphemeClusterBreakPropertyTable(UnicodeProperty):
         # values to symbolic values.
         self.symbolic_values = \
             [ None ] * (max(self.numeric_value_table.values()) + 1)
-        for k,v in self.numeric_value_table.iteritems():
+        for k,v in self.numeric_value_table.items():
             self.symbolic_values[v] = k
 
         # Load the data file.
@@ -329,7 +329,7 @@ class UnicodeTrieGenerator(object):
                 else:
                     return idx
 
-            return map(map_index, indexes)
+            return list(map(map_index, indexes))
 
         # If self.BMP_data contains identical data blocks, keep the first one,
         # remove duplicates and change the indexes in self.BMP_lookup to point to

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -12,7 +12,11 @@
 
 from __future__ import print_function
 
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:  # Python 3
+    import configparser as ConfigParser
+
 import os
 import pipes
 import subprocess

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -139,7 +139,7 @@ def _get_preset_options_impl(config, substitutions, preset_name):
     for o in config.options(section_name):
         try:
             a = config.get(section_name, o)
-        except ConfigParser.InterpolationMissingOptionError, e:
+        except configparser.InterpolationMissingOptionError as e:
             # e.reference contains the correctly formatted option
             missing_opts.append(e.reference)
             continue

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -49,11 +49,11 @@ def apply_edits(path):
     edits_per_file = {}
     for ed in edits_set:
         fname = ed[0]
-        if not edits_per_file.has_key(fname):
+        if fname not in edits_per_file:
             edits_per_file[fname] = []
         edits_per_file[fname].append((ed[1], ed[2], ed[3]))
     
-    for fname, edits in edits_per_file.iteritems():
+    for fname, edits in edits_per_file.items():
         print('Updating', fname)
         edits.sort(reverse=True)
         file_data = open(fname).read()

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -168,7 +168,7 @@ How to specify files:
             sizes = collections.defaultdict(int)
             for file in oldFiles:
                 readSizes(sizes, file, True, False)
-            print(listFunctionSizes(sizes.items()))
+            print(listFunctionSizes(list(sizes.items())))
         else:
             compareFunctionSizes(oldFiles, newFiles)
     else:

--- a/utils/demo-tool
+++ b/utils/demo-tool
@@ -9,6 +9,13 @@ import time
 import random
 import sys
 
+# In Python 3, raw_input() was renamed to input() and the original
+# input() was removed.
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
 def send_to_screen(screen_name, arg0=None, command='stuff'):
     args = ['screen', '-S', screen_name, '-p', '0',
             '-X', command]

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -135,7 +135,7 @@ def tokenizePythonToUnmatchedCloseCurly(sourceText, start, lineStarts):
                 if nesting < 0:
                     return tokenPosToIndex(tokenStart, start, lineStarts)
 
-    except tokenize.TokenError, (message, errorPos):
+    except tokenize.TokenError as (message, errorPos):
         return tokenPosToIndex(errorPos, start, lineStarts)
 
     return len(sourceText)
@@ -324,7 +324,7 @@ def splitGybLines(sourceLines):
                 
             lastTokenText,lastTokenKind = tokenText,tokenKind
 
-    except tokenize.TokenError, (message, errorPos):
+    except tokenize.TokenError as (message, errorPos):
         return [] # Let the later compile() call report the error
 
     if lastTokenText == ':':

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -5,11 +5,15 @@
 from __future__ import print_function
 
 import re
-from cStringIO import StringIO
 import tokenize
 import textwrap
 from bisect import bisect
 import os
+
+try:
+    from cStringIO import StringIO
+except ImportError
+    from io import StringIO
 
 def getLineStarts(s):
     """Return a list containing the start index of each line in s.

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -41,7 +41,7 @@ def run_build_script_with_data_file(build_script, data_file, verbose=False):
             sys.stdout.write(" Failure:\n")
 
 def build_disable_slice_pipelines(**kwargs):
-    pipeline_range = range(len(PIPELINES))
+    pipeline_range = list(range(len(PIPELINES)))
 
     def get_pipeline_args(script, iter):
         result = [script]

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -22,10 +22,10 @@ def merge_file_lists(src_root_dirs, skip_files, skip_subpaths):
             rel_dir = os.path.relpath(src_dir, src_root_dir)
             rel_files = [os.path.join(rel_dir, file) for file in files+dirs
                         if file not in skip_files]
-            file_list.extend(filter(lambda file:
-                                    file not in file_list, rel_files))
-            dirs[:] = filter(lambda dir:
-                             os.path.join(rel_dir, dir) not in skip_subpaths, dirs)
+            file_list.extend([file for file in rel_files
+                                   if file not in file_list])
+            dirs[:] = [dir for dir in dirs
+                       if os.path.join(rel_dir, dir) not in skip_subpaths]
     return file_list
 
 

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -12,8 +12,13 @@ import json
 import optparse
 import subprocess
 import sys
-import urllib
-import urllib2
+
+try:
+    from urllib import urlencode
+    from urllib2 import urlopen, Request
+except ImportError:  # Python 3
+    from urllib.parse import urlencode
+    from urllib.request import urlopen, Request
 
 # Test status codes.
 PASS = 0
@@ -52,9 +57,9 @@ def timestamp():
 
 def submit_results_to_server(results_data, submit_url):
     # Submit the URL encoded data.
-    data = urllib.urlencode({ 'input_data' : results_data,
-                              'commit' : '1' })
-    response = urllib2.urlopen(urllib2.Request(submit_url, data))
+    data = urlencode({'input_data': results_data,
+                      'commit': '1'})
+    response = urlopen(Request(submit_url, data))
     result_data = response.read()
 
     # The result is expected to be a JSON object.
@@ -113,7 +118,7 @@ def main():
    utcnow = datetime.datetime.utcnow()
    start_time = utcnow - datetime.timedelta(seconds=data['elapsed'])
    end_time = utcnow
-   
+
    # Create the LNT report format.
    lnt_results = {}
    lnt_results['Machine'] = {
@@ -186,6 +191,6 @@ def main():
    # Submit the results to an LNT server, if requested.
    if opts.submit_url:
       submit_results_to_server(lnt_result_data, opts.submit_url)
-      
+
 if __name__ == '__main__':
    main()

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -32,7 +32,7 @@ def capture_with_result(args, include_stderr=False):
         stderr = subprocess.STDOUT
     try:
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=stderr)
-    except OSError,e:
+    except OSError as e:
         if e.errno == errno.ENOENT:
             sys.exit('no such file or directory: %r when running %s.' % (
                   args[0], ' '.join(args)))

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -270,7 +270,7 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
         spent = int(execTime) / 1000000 # Convert ns to ms
         if spent <= self.minIterTime:
           scale *= 2
-        if scale > sys.maxint:
+        if scale > sys.maxsize:
           return (0, 0)
       except subprocess.CalledProcessError as e:
         r = e.output

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -64,7 +64,7 @@ def obtain_additional_swift_sources(opts = {'with_ssh': False}):
         'swift-corelibs-foundation': 'apple/swift-corelibs-foundation',
         'swift-integration-tests': 'apple/swift-integration-tests',
     }
-    for dir_name, repo in additional_repos.iteritems():
+    for dir_name, repo in additional_repos.items():
         with WorkingDirectory(SWIFT_SOURCE_ROOT):
             if not os.path.isdir(os.path.join(dir_name, ".git")):
                 print("--- Cloning '" + dir_name + "' ---")

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -119,17 +119,17 @@ def main():
     # Add empty blocks which we didn't see, but which are referenced.
 
     newBlocks = { }
-    for name, block in blocks.iteritems():
+    for name, block in blocks.items():
         for adjName in (block.preds + block.getSuccs()):
             if not adjName in blocks:
                 newBlocks[adjName] = Block(adjName, None)
 
-    blocks = dict(blocks.items() + newBlocks.items())
+    blocks = dict(list(blocks.items()) + list(newBlocks.items()))
 
     # Add missing edges if we didn't see a successor in the terminator
     # but the block is mentioned in the pred list of the successor.
 
-    for name, block in blocks.iteritems():
+    for name, block in blocks.items():
         for predName in block.preds:
             predBlock = blocks[predName]
             if not name in predBlock.getSuccs():
@@ -141,7 +141,7 @@ def main():
     outFile = open(fileName, "w")
 
     outFile.write('digraph "CFG" {\n')
-    for name, block in blocks.iteritems():
+    for name, block in blocks.items():
         if block.content is not None:
             outFile.write("\tNode" + str(block.index) + \
                 " [shape=record,label=\"{" + block.content + "}\"];\n")


### PR DESCRIPTION
Some systems use Python 3 as their default interpreter (e.g. #83).

This is a collection of fixes that should get these scripts much closer to running on both Python 2 and 3. Obtained by running the [six module](http://pythonhosted.org/six/) over every .py file in the repo, and going through the proposed changes by hand.

There are probably still a few gotchas that will break in Python 3 – but this gets substantially closer to a fully working set.
