### PR TITLE
Add suggested directory names for XCTest and Foundation repositories

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -138,11 +138,11 @@ SWIFT_SOURCE_ROOT: a directory containing the source for LLVM, Clang, Swift.
    $SWIFT_SOURCE_ROOT/llvm
                      /clang
                      /swift
-                     /lldb       (optional)
-                     /llbuild    (optional)
-                     /swiftpm    (optional, requires llbuild)
-                     /XCTest     (optional)
-                     /Foundation (optional)
+                     /lldb                      (optional)
+                     /llbuild                   (optional)
+                     /swiftpm                   (optional, requires llbuild)
+                     /swift-corelibs-xctest     (optional)
+                     /swift-corelibs-foundation (optional)
 
 SWIFT_BUILD_ROOT: a directory in which to create out-of-tree builds.
                   Defaults to "$SWIFT_SOURCE_ROOT/build/".


### PR DESCRIPTION
in the manner expected by the build-script
