### PR TITLE
Fixing wrong method documentation for SetAlgebra

### DIFF
--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -108,7 +108,7 @@ public protocol SetAlgebraType : Equatable, ArrayLiteralConvertible {
   mutating func exclusiveOrInPlace(other: Self)  
 
   //===--- Requirements with default implementations ----------------------===//
-  /// Return true iff `self.intersect(other).isEmpty`.
+  /// Returns the set of elements contained in `self` but not in `other`.
   @warn_unused_result
   func subtract(other: Self) -> Self
 


### PR DESCRIPTION
Spot the error:

```
/// Return true iff `self.intersect(other).isEmpty`.
@warn_unused_result
func subtract(other: Self) -> Self

…

/// Return true iff `self.intersect(other).isEmpty`.
@warn_unused_result
func isDisjointWith(other: Self) -> Bool
```

:wink:

I had reported a bug on this on Aug 4th 2015 (rdar://22031133).  
Radar screening staff however deemed it not even worthy reading, apparently.

> This issue behaves as intended based on the following:  
> Your suggested rewrite is isn’t accurate—‘subtract’ doesn’t return a Boolean at all.  
> We are now closing this bug report.

It does indeed not return a boolean. That was the whole point of my radar. Sigh.

So here I am, fixing the damn thing myself. :sunglasses: 

Ps: Thanks @lattner & Team! You made my day with this release! :bow:
Your attitude of friendliness and openness really makes a difference at Apple!
