### PR TITLE
[Clang importer] Refactor and centralize name mapping

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -438,34 +438,6 @@ public:
   /// \param scratch Scratch space to use.
   StringRef getString(llvm::SmallVectorImpl<char> &scratch) const;
 
-  /// Ask whether this selector is a nullary selector (taking no
-  /// arguments) whose name matches the given piece.
-  bool isNullarySelector(StringRef piece) const {
-    if (Storage.isSimpleName()) {
-      return Storage.getBaseName().str() == piece;
-    } else {
-      return false;
-    }
-  }
-
-  /// Ask whether this selector is a non-nullary selector matching the
-  /// given literal pieces.
-  bool isNonNullarySelector(ArrayRef<StringRef> pieces) const {
-    if (Storage.isSimpleName()) {
-      return false;
-    }
-
-    ArrayRef<Identifier> args = Storage.getArgumentNames();
-    if (args.size() != pieces.size())
-      return false;
-
-    for (size_t i = 0, e = args.size(); i != e; ++i) {
-      if (args[i].str() != pieces[i])
-        return false;
-    }
-    return true;
-  }
-
   void *getOpaqueValue() const { return Storage.getOpaqueValue(); }
   static ObjCSelector getFromOpaqueValue(void *p) {
     return ObjCSelector(DeclName::getFromOpaqueValue(p));

--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -51,6 +51,14 @@ namespace swift {
   /// Determine the part of speech for the given word.
   PartOfSpeech getPartOfSpeech(StringRef word);
 
+  /// Scratch space used for returning a set of StringRefs.
+  class StringScratchSpace {
+    llvm::BumpPtrAllocator Allocator;
+
+  public:
+    StringRef copyString(StringRef string);
+  };
+
   namespace camel_case {
     class WordIterator;
 
@@ -219,6 +227,16 @@ namespace swift {
     /// unchanged.
     StringRef toLowercaseWord(StringRef string, SmallVectorImpl<char> &scratch);
 
+    /// Lowercase the first word within the given camelCase string.
+    ///
+    /// \param string The string to lowercase.
+    /// \param scratch Scratch buffer used to form the resulting string.
+    ///
+    /// \returns the string with the first word lowercased. When the
+    /// first word is an acronym, the string will be returned
+    /// unchanged.
+    StringRef toLowercaseWord(StringRef string, StringScratchSpace &scratch);
+
     /// Sentence-case the given camelCase string by turning the first
     /// letter into an uppercase letter.
     ///
@@ -357,14 +375,6 @@ struct OmissionTypeName {
 /// For example, matching "stringByAppendingString" to the type "NSString"
 /// would produce "ByAppendingString".
 StringRef matchLeadingTypeName(StringRef name, OmissionTypeName typeName);
-
-/// Scratch space used for returning a set of StringRefs.
-class StringScratchSpace {
-  llvm::BumpPtrAllocator Allocator;
-
-public:
-  StringRef copyString(StringRef string);
-};
 
 /// Describes a set of names with an inheritance relationship.
 class InheritedNameSet {

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -259,6 +259,9 @@ public:
   // Print statistics from the Clang AST reader.
   void printStatistics() const override;
 
+  /// Dump Swift lookup tables.
+  void dumpSwiftLookupTables();
+  
   /// Given the path of a Clang module, collect the names of all its submodules
   /// and their corresponding visibility. Calling this function does not load the
   /// module.

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -73,6 +73,10 @@ public:
   // If true, infer default arguments for nullable pointers (nil) and
   // option sets ([]).
   bool InferDefaultArguments = false;
+
+  /// If true, we should use the Swift name lookup tables rather than
+  /// Clang's name lookup facilities.
+  bool UseSwiftLookupTables = false;
 };
 
 } // end namespace swift

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -442,9 +442,10 @@ bool InheritedNameSet::contains(StringRef name) const {
 }
 
 /// Wrapper for camel_case::toLowercaseWord that uses string scratch space.
-static StringRef toLowercaseWord(StringRef string, StringScratchSpace &scratch){
+StringRef camel_case::toLowercaseWord(StringRef string,
+                                      StringScratchSpace &scratch){
   llvm::SmallString<32> scratchStr;
-  StringRef result = camel_case::toLowercaseWord(string, scratchStr);
+  StringRef result = toLowercaseWord(string, scratchStr);
   if (string == result)
     return string;
 

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -309,10 +309,16 @@ static bool isKeyword(StringRef identifier) {
 static Optional<StringRef> skipTypeSuffix(StringRef typeName) {
   if (typeName.empty()) return None;
 
+  auto lastWord = camel_case::getLastWord(typeName);
+
   // "Type" suffix.
-  if (camel_case::getLastWord(typeName) == "Type" &&
-      typeName.size() > 4) {
+  if (lastWord == "Type" && typeName.size() > 4) {
     return typeName.drop_back(4);
+  }
+
+  // "Ref" suffix.
+  if (lastWord == "Ref" && typeName.size() > 3) {
+    return typeName.drop_back(3);
   }
 
   // \d+D for dimensionality.

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_library(swiftClangImporter
   ImportDecl.cpp
   ImportMacro.cpp
   ImportType.cpp
+  SwiftLookupTable.cpp
   LINK_LIBRARIES
     swiftAST
 )

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1579,6 +1579,10 @@ DeclName ClangImporter::Implementation::importFullName(
            const clang::NamedDecl *D,
            bool *hasCustomName,
            clang::DeclContext **effectiveContext) {
+  // Objective-C categories and extensions don't have names.
+  if (isa<clang::ObjCCategoryDecl>(D))
+    return { };
+
   // Compute the effective context, if requested.
   if (effectiveContext) {
     auto dc = const_cast<clang::DeclContext *>(D->getDeclContext());
@@ -1604,6 +1608,12 @@ DeclName ClangImporter::Implementation::importFullName(
     } else {
       // Everything else goes into its redeclaration context.
       *effectiveContext = dc->getRedeclContext();
+    }
+
+    // Anything in an Objective-C category or extension is adjusted to the
+    // class context.
+    if (auto category = dyn_cast<clang::ObjCCategoryDecl>(*effectiveContext)) {
+      *effectiveContext = category->getClassInterface();
     }
   }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -743,8 +743,7 @@ bool ClangImporter::Implementation::importHeader(
 
         if (UseSwiftLookupTables) {
           if (auto named = dyn_cast<clang::NamedDecl>(D)) {
-            bool hasCustomName;
-            if (DeclName name = importFullName(named, hasCustomName))
+            if (DeclName name = importFullName(named))
               BridgingHeaderLookupTable.addEntry(name, named);
           }
         }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1349,6 +1349,232 @@ static DeclName parseDeclName(ASTContext &ctx, StringRef Name) {
   return DeclName(ctx, BaseID, ParamIDs);
 }
 
+/// \brief Returns the common prefix of two strings at camel-case word
+/// granularity.
+///
+/// For example, given "NSFooBar" and "NSFooBas", returns "NSFoo"
+/// (not "NSFooBa"). The returned StringRef is a slice of the "a" argument.
+///
+/// If either string has a non-identifier character immediately after the
+/// prefix, \p followedByNonIdentifier will be set to \c true. If both strings
+/// have identifier characters after the prefix, \p followedByNonIdentifier will
+/// be set to \c false. Otherwise, \p followedByNonIdentifier will not be
+/// changed from its initial value.
+///
+/// This is used to derive the common prefix of enum constants so we can elide
+/// it from the Swift interface.
+static StringRef getCommonWordPrefix(StringRef a, StringRef b,
+                                     bool &followedByNonIdentifier) {
+  auto aWords = camel_case::getWords(a), bWords = camel_case::getWords(b);
+  auto aI = aWords.begin(), aE = aWords.end(),
+       bI = bWords.begin(), bE = bWords.end();
+
+  unsigned prevLength = 0;
+  unsigned prefixLength = 0;
+  for ( ; aI != aE && bI != bE; ++aI, ++bI) {
+    if (*aI != *bI) {
+      followedByNonIdentifier = false;
+      break;
+    }
+
+    prevLength = prefixLength;
+    prefixLength = aI.getPosition() + aI->size();
+  }
+
+  // Avoid creating a prefix where the rest of the string starts with a number.
+  if ((aI != aE && !Lexer::isIdentifier(*aI)) ||
+      (bI != bE && !Lexer::isIdentifier(*bI))) {
+    followedByNonIdentifier = true;
+    prefixLength = prevLength;
+  }
+
+  return a.slice(0, prefixLength);
+}
+
+/// Returns the common word-prefix of two strings, allowing the second string
+/// to be a common English plural form of the first.
+///
+/// For example, given "NSProperty" and "NSProperties", the full "NSProperty"
+/// is returned. Given "NSMagicArmor" and "NSMagicArmory", only
+/// "NSMagic" is returned.
+///
+/// The "-s", "-es", and "-ies" patterns cover every plural NS_OPTIONS name
+/// in Cocoa and Cocoa Touch.
+///
+/// \see getCommonWordPrefix
+static StringRef getCommonPluralPrefix(StringRef singular, StringRef plural) {
+  assert(!plural.empty());
+
+  if (singular.empty())
+    return singular;
+
+  bool ignored;
+  StringRef commonPrefix = getCommonWordPrefix(singular, plural, ignored);
+  if (commonPrefix.size() == singular.size() || plural.back() != 's')
+    return commonPrefix;
+
+  StringRef leftover = singular.substr(commonPrefix.size());
+  StringRef firstLeftoverWord = camel_case::getFirstWord(leftover);
+  StringRef commonPrefixPlusWord =
+      singular.substr(0, commonPrefix.size() + firstLeftoverWord.size());
+
+  // Is the plural string just "[singular]s"?
+  plural = plural.drop_back();
+  if (plural.endswith(firstLeftoverWord))
+    return commonPrefixPlusWord;
+
+  if (plural.empty() || plural.back() != 'e')
+    return commonPrefix;
+
+  // Is the plural string "[singular]es"?
+  plural = plural.drop_back();
+  if (plural.endswith(firstLeftoverWord))
+    return commonPrefixPlusWord;
+
+  if (plural.empty() || !(plural.back() == 'i' && singular.back() == 'y'))
+    return commonPrefix;
+
+  // Is the plural string "[prefix]ies" and the singular "[prefix]y"?
+  plural = plural.drop_back();
+  firstLeftoverWord = firstLeftoverWord.drop_back();
+  if (plural.endswith(firstLeftoverWord))
+    return commonPrefixPlusWord;
+
+  return commonPrefix;
+}
+
+StringRef ClangImporter::Implementation::getEnumConstantNamePrefix(
+            const clang::EnumDecl *decl) {
+  switch (classifyEnum(decl)) {
+  case EnumKind::Enum:
+  case EnumKind::Options:
+    // Enums are mapped to Swift enums, Options to Swift option sets, both
+    // of which attempt prefix-stripping.
+    break;
+
+  case EnumKind::Constants:
+  case EnumKind::Unknown:
+    // Nothing to do.
+    return StringRef();
+  }
+
+  // If there are no enumers, there is no prefix to compute.
+  auto ec = decl->enumerator_begin(), ecEnd = decl->enumerator_end();
+  if (ec == ecEnd)
+    return StringRef();
+
+  // If we've already computed the prefix, return it.
+  auto known = EnumConstantNamePrefixes.find(decl);
+  if (known != EnumConstantNamePrefixes.end())
+    return known->second;
+
+  // Determine whether the given enumerator is non-deprecated and has no
+  // specifically-provided name.
+  auto isNonDeprecatedWithoutCustomName =
+    [](const clang::EnumConstantDecl *elem) -> bool {
+      if (elem->hasAttr<clang::SwiftNameAttr>())
+        return false;
+
+      clang::VersionTuple maxVersion{~0U, ~0U, ~0U};
+      switch (elem->getAvailability(nullptr, maxVersion)) {
+      case clang::AR_Available:
+      case clang::AR_NotYetIntroduced:
+        for (auto attr : elem->attrs()) {
+          if (auto annotate = dyn_cast<clang::AnnotateAttr>(attr)) {
+            if (annotate->getAnnotation() == "swift1_unavailable")
+              return false;
+          }
+          if (auto avail = dyn_cast<clang::AvailabilityAttr>(attr)) {
+            if (avail->getPlatform()->getName() == "swift")
+              return false;
+          }
+        }
+        return true;
+
+      case clang::AR_Deprecated:
+      case clang::AR_Unavailable:
+        return false;
+      }
+    };
+
+  // Move to the first non-deprecated enumerator, or non-swift_name'd
+  // enumerator, if present.
+  auto firstNonDeprecated = std::find_if(ec, ecEnd,
+                                         isNonDeprecatedWithoutCustomName);
+  bool hasNonDeprecated = (firstNonDeprecated != ecEnd);
+  if (hasNonDeprecated) {
+    ec = firstNonDeprecated;
+  } else {
+    // Advance to the first case without a custom name, deprecated or not.
+    while (ec != ecEnd && (*ec)->hasAttr<clang::SwiftNameAttr>())
+      ++ec;
+    if (ec == ecEnd) {
+      EnumConstantNamePrefixes.insert({decl, StringRef()});
+      return StringRef();
+    }
+  }
+
+  // Compute th e common prefix.
+  StringRef commonPrefix = (*ec)->getName();
+  bool followedByNonIdentifier = false;
+  for (++ec; ec != ecEnd; ++ec) {
+    // Skip deprecated or swift_name'd enumerators.
+    const clang::EnumConstantDecl *elem = *ec;
+    if (hasNonDeprecated) {
+      if (!isNonDeprecatedWithoutCustomName(elem))
+        continue;
+    } else {
+      if (elem->hasAttr<clang::SwiftNameAttr>())
+        continue;
+    }
+
+    commonPrefix = getCommonWordPrefix(commonPrefix, elem->getName(),
+                                       followedByNonIdentifier);
+    if (commonPrefix.empty())
+      break;
+  }
+
+  if (!commonPrefix.empty()) {
+    StringRef checkPrefix = commonPrefix;
+
+    // Account for the 'kConstant' naming convention on enumerators.
+    if (checkPrefix[0] == 'k') {
+      bool canDropK;
+      if (checkPrefix.size() >= 2)
+        canDropK = clang::isUppercase(checkPrefix[1]);
+      else
+        canDropK = !followedByNonIdentifier;
+
+      if (canDropK)
+        checkPrefix = checkPrefix.drop_front();
+    }
+
+    // Account for the enum being imported using
+    // __attribute__((swift_private)). This is a little ad hoc, but it's a
+    // rare case anyway.
+    Identifier enumName = importFullName(decl).getBaseName();
+    StringRef enumNameStr = enumName.str();
+    if (enumNameStr.startswith("__") && !checkPrefix.startswith("__"))
+      enumNameStr = enumNameStr.drop_front(2);
+
+    StringRef commonWithEnum = getCommonPluralPrefix(checkPrefix,
+                                                     enumNameStr);
+    size_t delta = commonPrefix.size() - checkPrefix.size();
+
+    // Account for the 'EnumName_Constant' convention on enumerators.
+    if (commonWithEnum.size() < checkPrefix.size() &&
+        checkPrefix[commonWithEnum.size()] == '_' &&
+        !followedByNonIdentifier) {
+      delta += 1;
+    }
+
+    commonPrefix = commonPrefix.slice(0, commonWithEnum.size() + delta);
+  }
+
+  EnumConstantNamePrefixes.insert({decl, commonPrefix});
+  return commonPrefix;
+}
+
 DeclName ClangImporter::Implementation::importFullName(
            const clang::NamedDecl *D,
            bool *hasCustomName,
@@ -1431,6 +1657,16 @@ DeclName ClangImporter::Implementation::importFullName(
     isFunction = true;
     break;
   }
+  }
+
+  // Perform automatic name transformations.
+
+  // Enumeration constants may have common prefixes stripped.
+  if (isa<clang::EnumConstantDecl>(D)) {
+    auto enumDecl = cast<clang::EnumDecl>(D->getDeclContext());
+    StringRef removePrefix = getEnumConstantNamePrefix(enumDecl);
+    if (baseName.startswith(removePrefix))
+      baseName = baseName.substr(removePrefix.size());
   }
 
   // Local function to determine whether the given declaration is subject to
@@ -1556,87 +1792,6 @@ ClangImporter::Implementation::importIdentifier(
 
   // Get the Swift identifier.
   return SwiftContext.getIdentifier(name);
-}
-
-Identifier
-ClangImporter::Implementation::importName(const clang::NamedDecl *D,
-                                          StringRef removePrefix) {
-  if (auto *nameAttr = D->getAttr<clang::SwiftNameAttr>()) {
-    StringRef customName = nameAttr->getName();
-    if (Lexer::isIdentifier(customName))
-      return SwiftContext.getIdentifier(customName);
-
-    return Identifier();
-  }
-
-  Identifier result = importIdentifier(D->getIdentifier(), removePrefix);
-  if (result.empty())
-    return result;
-
-  auto hasSwiftPrivate = [this](const clang::NamedDecl *D) {
-    if (D->hasAttr<clang::SwiftPrivateAttr>())
-      return true;
-
-    // Enum constants that are not imported as members should be considered
-    // private if the parent enum is marked private.
-    if (auto *ECD = dyn_cast<clang::EnumConstantDecl>(D)) {
-      auto *ED = cast<clang::EnumDecl>(ECD->getDeclContext());
-      switch (classifyEnum(ED)) {
-      case EnumKind::Constants:
-      case EnumKind::Unknown:
-        if (ED->hasAttr<clang::SwiftPrivateAttr>())
-          return true;
-        if (auto *enumTypedef = ED->getTypedefNameForAnonDecl())
-          if (enumTypedef->hasAttr<clang::SwiftPrivateAttr>())
-            return true;
-        break;
-
-      case EnumKind::Enum:
-      case EnumKind::Options:
-        break;
-      }
-    }
-
-    return false;
-  };
-
-  if (hasSwiftPrivate(D) && D->getDeclName().isIdentifier()) {
-    SmallString<64> name{"__"};
-    name += result.str();
-    result = SwiftContext.getIdentifier(name.str());
-  }
-
-  // Omit needless words from properties.
-  if (OmitNeedlessWords) {
-    if (auto objcProperty = dyn_cast<clang::ObjCPropertyDecl>(D)) {
-      auto contextType = getClangDeclContextType(D->getDeclContext());
-      if (!contextType.isNull()) {
-        auto contextTypeName = getClangTypeNameForOmission(contextType);
-        auto propertyTypeName = getClangTypeNameForOmission(
-                                  objcProperty->getType());
-        StringScratchSpace scratch;
-        StringRef name = result.str();
-
-        // Find the property names.
-        const InheritedNameSet *allPropertyNames = nullptr;
-        if (!contextType.isNull()) {
-          if (auto objcPtrType = contextType->getAsObjCInterfacePointerType())
-            if (auto objcClassDecl = objcPtrType->getInterfaceDecl())
-              allPropertyNames = SwiftContext.getAllPropertyNames(
-                                   objcClassDecl,
-                                   /*forInstance=*/true);
-        }
-
-        if (omitNeedlessWords(name, { }, "", propertyTypeName, contextTypeName,
-                              { }, /*returnsSelf=*/false, /*isProperty=*/true,
-                              allPropertyNames, scratch)) {
-          result = SwiftContext.getIdentifier(name);
-        }
-      }
-    }
-  }
-
-  return result;
 }
 
 /// Import an argument name.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2150,6 +2150,7 @@ auto ClangImporter::Implementation::importFullName(
   StringRef baseName;
   SmallVector<StringRef, 4> argumentNames;
   SmallString<16> selectorSplitScratch;
+  StringScratchSpace stringScratch;
   ArrayRef<const clang::ParmVarDecl *> params;
   switch (D->getDeclName().getNameKind()) {
   case clang::DeclarationName::CXXConstructorName:
@@ -2205,7 +2206,15 @@ auto ClangImporter::Implementation::importFullName(
       if (index == 0) {
         argumentNames.push_back(StringRef());
       } else {
-        argumentNames.push_back(selector.getNameForSlot(index));
+        StringRef argName = selector.getNameForSlot(index);
+
+        // Swift 2 lowercased all subsequent argument names.
+        // Swift 3 may handle this as part of omitting needless words, below,
+        // but don't preempt that here.
+        if (!OmitNeedlessWords)
+          argName = camel_case::toLowercaseWord(argName, stringScratch);
+
+        argumentNames.push_back(argName);
       }
     }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2198,7 +2198,7 @@ auto ClangImporter::Implementation::importFullName(
     if (objcMethod->isVariadic() && shouldMakeSelectorNonVariadic(selector)) {
       --numArgs;
       result.DroppedVariadic = true;
-      params = params.slice(1);
+      params = params.drop_back(1);
     }
 
     for (unsigned index = 0; index != numArgs; ++index) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3162,7 +3162,7 @@ namespace {
 
       // If we dropped the variadic, handle it now.
       if (importedName.DroppedVariadic) {
-        params = params.slice(1);
+        params = params.drop_back(1);
         variadic = false;
       }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5108,7 +5108,7 @@ namespace {
                                    name,
                                    None);
       result->computeType();
-      addObjCAttribute(result, Impl.importDeclName(decl->getDeclName()));
+      addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
       if (declaredNative)
         markMissingSwiftDecl(result);
@@ -5193,7 +5193,7 @@ namespace {
         result->setSuperclass(Type());
         result->setCheckedInheritanceClause();
         result->setAddedImplicitInitializers(); // suppress all initializers
-        addObjCAttribute(result, Impl.importDeclName(decl->getDeclName()));
+        addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
         Impl.registerExternalDecl(result);
         return result;
       };
@@ -5262,7 +5262,7 @@ namespace {
       Impl.ImportedDecls[decl->getCanonicalDecl()] = result;
       result->setCircularityCheck(CircularityCheck::Checked);
       result->setAddedImplicitInitializers();
-      addObjCAttribute(result, Impl.importDeclName(decl->getDeclName()));
+      addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
       if (declaredNative)
         markMissingSwiftDecl(result);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2720,7 +2720,7 @@ namespace {
 
       // Determine the name of the function.
       bool hasCustomName;
-      DeclName name = Impl.importFullName(decl, hasCustomName);
+      DeclName name = Impl.importFullName(decl, &hasCustomName);
       if (!name)
         return nullptr;
 
@@ -3014,7 +3014,7 @@ namespace {
       switch (Impl.getFactoryAsInit(objcClass, decl)) {
       case FactoryAsInitKind::AsInitializer:
         if (decl->hasAttr<clang::SwiftNameAttr>()) {
-          initName = Impl.importFullName(decl, hasCustomName);
+          initName = Impl.importFullName(decl, &hasCustomName);
           break;
         }
         // FIXME: We probably should stop using this codepath. It won't ever
@@ -3126,7 +3126,7 @@ namespace {
       bool hasCustomName;
       if (auto *customNameAttr = decl->getAttr<clang::SwiftNameAttr>()) {
         if (!customNameAttr->getName().startswith("init(")) {
-          name = Impl.importFullName(decl, hasCustomName);
+          name = Impl.importFullName(decl, &hasCustomName);
         }
       }
       if (!name) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1425,7 +1425,7 @@ Type ClangImporter::Implementation::importFunctionType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importName(param);
+    Identifier bodyName = importFullName(param).getBaseName();
 
     // Retrieve the argument name.
     Identifier name;
@@ -2427,7 +2427,7 @@ Type ClangImporter::Implementation::importMethodType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importName(param);
+    Identifier bodyName = importFullName(param).getBaseName();
 
     // Figure out the name for this argument, which comes from the method name.
     Identifier name;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1425,7 +1425,7 @@ Type ClangImporter::Implementation::importFunctionType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importFullName(param).getBaseName();
+    Identifier bodyName = importFullName(param).Imported.getBaseName();
 
     // Retrieve the argument name.
     Identifier name;
@@ -2427,7 +2427,7 @@ Type ClangImporter::Implementation::importMethodType(
     }
 
     // Figure out the name for this parameter.
-    Identifier bodyName = importFullName(param).getBaseName();
+    Identifier bodyName = importFullName(param).Imported.getBaseName();
 
     // Figure out the name for this argument, which comes from the method name.
     Identifier name;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -151,6 +151,7 @@ namespace {
   };
 
   bool canImportAsOptional(ImportHint hint) {
+    // See also ClangImporter.cpp's canImportAsOptional.
     switch (hint) {
     case ImportHint::None:
     case ImportHint::BOOL:
@@ -1543,330 +1544,6 @@ namespace {
   };
 }
 
-static bool isBlockParameter(const clang::ParmVarDecl *param) {
-  return param->getType()->isBlockPointerType();
-}
-
-static bool isErrorOutParameter(const clang::ParmVarDecl *param,
-                         ForeignErrorConvention::IsOwned_t &isErrorOwned) {
-  clang::QualType type = param->getType();
-
-  // Must be a pointer.
-  auto ptrType = type->getAs<clang::PointerType>();
-  if (!ptrType) return false;
-  type = ptrType->getPointeeType();
-
-  // For NSError**, take ownership from the qualifier.
-  if (auto objcPtrType = type->getAs<clang::ObjCObjectPointerType>()) {
-    auto iface = objcPtrType->getInterfaceDecl();
-    if (iface && iface->getName() == "NSError") {
-      switch (type.getObjCLifetime()) {
-      case clang::Qualifiers::OCL_None:
-        llvm_unreachable("not in ARC?");
-
-      case clang::Qualifiers::OCL_ExplicitNone:
-      case clang::Qualifiers::OCL_Autoreleasing:
-        isErrorOwned = ForeignErrorConvention::IsNotOwned;
-        return true;
-
-      case clang::Qualifiers::OCL_Weak:
-        // We just don't know how to handle this.
-        return false;
-
-      case clang::Qualifiers::OCL_Strong:
-        isErrorOwned = ForeignErrorConvention::IsOwned;
-        return false;
-      }
-      llvm_unreachable("bad error ownership");
-    }
-  }
-  return false;
-}
-
-static bool isBoolType(ClangImporter::Implementation &importer, Type type) {
-  if (auto nominalType = type->getAs<NominalType>()) {
-    return nominalType->getDecl() == importer.SwiftContext.getBoolDecl();
-  }
-  return false;
-}
-
-static bool isIntegerType(Type type) {
-  // Look through arbitrarily many struct abstractions.
-  while (auto structDecl = type->getStructOrBoundGenericStruct()) {
-    // Require the struct to have exactly one stored property.
-    auto properties = structDecl->getStoredProperties();
-    auto i = properties.begin(), e = properties.end();
-    if (i == e) return false;
-
-    VarDecl *property = *i;
-    if (++i != e) return false;
-    type = property->getType();
-  }
-
-  return type->is<BuiltinIntegerType>();
-}
-
-static Optional<ForeignErrorConvention::Kind>
-classifyMethodErrorHandling(ClangImporter::Implementation &importer,
-                            const clang::ObjCMethodDecl *clangDecl,
-                            Type importedResultType) {
-  // TODO: opt out any non-standard methods here?
-
-  // Check for an explicit attribute.
-  if (auto attr = clangDecl->getAttr<clang::SwiftErrorAttr>()) {
-    switch (attr->getConvention()) {
-    case clang::SwiftErrorAttr::None:
-      return None;
-
-    case clang::SwiftErrorAttr::NonNullError:
-      return ForeignErrorConvention::NonNilError;
-
-    // Only honor null_result if we actually imported as a
-    // non-optional type.
-    case clang::SwiftErrorAttr::NullResult:
-      if (importedResultType->getAnyOptionalObjectType())
-        return ForeignErrorConvention::NilResult;
-      return None;
-
-    // Preserve the original result type on a zero_result unless we
-    // imported it as Bool.
-    case clang::SwiftErrorAttr::ZeroResult:
-      if (isBoolType(importer, importedResultType)) {
-        return ForeignErrorConvention::ZeroResult;
-      } else if (isIntegerType(importedResultType)) {
-        return ForeignErrorConvention::ZeroPreservedResult;
-      }
-      return None;
-
-    // There's no reason to do the same for nonzero_result because the
-    // only meaningful value remaining would be zero.
-    case clang::SwiftErrorAttr::NonZeroResult:
-      if (isIntegerType(importedResultType))
-        return ForeignErrorConvention::NonZeroResult;
-      return None;
-    }
-    llvm_unreachable("bad swift_error kind");
-  }
-
-  // Otherwise, apply the default rules.
-
-  // For bool results, a zero value is an error.
-  if (isBoolType(importer, importedResultType)) {
-    return ForeignErrorConvention::ZeroResult;
-  }
-
-  // For optional reference results, a nil value is normally an error.
-  if (importedResultType->getAnyOptionalObjectType()) {
-    return ForeignErrorConvention::NilResult;
-  }
-
-  return None;
-}
-
-static const char ErrorSuffix[] = "AndReturnError";
-static const char AltErrorSuffix[] = "WithError";
-
-/// Look for a method that will import to have the same name as the
-/// given method after importing the Nth parameter as an elided error
-/// parameter.
-static bool hasErrorMethodNameCollision(ClangImporter::Implementation &importer,
-                                        const clang::ObjCMethodDecl *method,
-                                        unsigned paramIndex,
-                                        StringRef suffixToStrip) {
-  // Copy the existing selector pieces into an array.
-  auto selector = method->getSelector();
-  unsigned numArgs = selector.getNumArgs();
-  assert(numArgs > 0);
-
-  SmallVector<clang::IdentifierInfo *, 4> chunks;
-  for (unsigned i = 0, e = selector.getNumArgs(); i != e; ++i) {
-    chunks.push_back(selector.getIdentifierInfoForSlot(i));
-  }
-
-  auto &ctx = method->getASTContext();
-  if (paramIndex == 0 && !suffixToStrip.empty()) {
-    StringRef name = chunks[0]->getName();
-    assert(name.endswith(suffixToStrip));
-    name = name.drop_back(suffixToStrip.size());
-    chunks[0] = &ctx.Idents.get(name);
-  } else if (paramIndex != 0) {
-    chunks.erase(chunks.begin() + paramIndex);
-  }
-
-  auto newSelector = ctx.Selectors.getSelector(numArgs - 1, chunks.data());
-  const clang::ObjCMethodDecl *conflict;
-  if (auto iface = method->getClassInterface()) {
-    conflict = iface->lookupMethod(newSelector, method->isInstanceMethod());
-  } else {
-    auto protocol = cast<clang::ObjCProtocolDecl>(method->getDeclContext());
-    conflict = protocol->getMethod(newSelector, method->isInstanceMethod());
-  }
-
-  if (conflict == nullptr)
-    return false;
-
-  // Look to see if the conflicting decl is unavailable, either because it's
-  // been marked NS_SWIFT_UNAVAILABLE, because it's actually marked unavailable,
-  // or because it was deprecated before our API sunset. We can handle
-  // "conflicts" where one form is unavailable.
-  // FIXME: Somewhat duplicated from Implementation::importAttributes.
-  clang::AvailabilityResult availability = conflict->getAvailability();
-  if (availability != clang::AR_Unavailable &&
-      importer.DeprecatedAsUnavailableFilter) {
-    for (auto *attr : conflict->specific_attrs<clang::AvailabilityAttr>()) {
-      if (attr->getPlatform()->getName() == "swift") {
-        availability = clang::AR_Unavailable;
-        break;
-      }
-      if (importer.PlatformAvailabilityFilter &&
-          !importer.PlatformAvailabilityFilter(attr->getPlatform()->getName())){
-        continue;
-      }
-      clang::VersionTuple version = attr->getDeprecated();
-      if (version.empty())
-        continue;
-      if (importer.DeprecatedAsUnavailableFilter(version.getMajor(),
-                                                 version.getMinor())) {
-        availability = clang::AR_Unavailable;
-        break;
-      }
-    }
-  }
-  return availability != clang::AR_Unavailable;
-}
-
-
-static Optional<ErrorImportInfo>
-considerErrorImport(ClangImporter::Implementation &importer,
-                    const clang::ObjCMethodDecl *clangDecl,
-                    DeclName &methodName,
-                    ArrayRef<const clang::ParmVarDecl *> params,
-                    Type &importedResultType,
-                    SpecialMethodKind methodKind,
-                    bool hasCustomName) {
-  // If the declaration name isn't parallel to the actual parameter
-  // list (e.g. if the method has C-style parameter declarations),
-  // don't try to apply error conventions.
-  auto paramNames = methodName.getArgumentNames();
-  bool expectsToRemoveError =
-      hasCustomName && paramNames.size() + 1 == params.size();
-  if (!expectsToRemoveError && paramNames.size() != params.size())
-    return None;
-
-  for (unsigned index = params.size(); index-- != 0; ) {
-    // Allow an arbitrary number of trailing blocks.
-    if (isBlockParameter(params[index]))
-      continue;
-
-    // Otherwise, require the last parameter to be an out-parameter.
-    auto isErrorOwned = ForeignErrorConvention::IsNotOwned;
-    if (!isErrorOutParameter(params[index], isErrorOwned))
-      break;
-
-    auto errorKind =
-      classifyMethodErrorHandling(importer, clangDecl, importedResultType);
-    if (!errorKind) return None;
-
-    // Consider adjusting the imported declaration name to remove the
-    // parameter.
-    bool adjustName = !hasCustomName;
-
-    // Never do this if it's the first parameter of a constructor.
-    if (methodKind == SpecialMethodKind::Constructor && index == 0) {
-      adjustName = false;
-    }
-
-    // If the error parameter is the first parameter, try removing the
-    // standard error suffix from the base name.
-    StringRef suffixToStrip;
-    Identifier newBaseName = methodName.getBaseName();
-    if (adjustName && index == 0 && paramNames[0].empty()) {
-      StringRef baseNameStr = newBaseName.str();
-      if (baseNameStr.endswith(ErrorSuffix))
-        suffixToStrip = ErrorSuffix;
-      else if (baseNameStr.endswith(AltErrorSuffix))
-        suffixToStrip = AltErrorSuffix;
-
-      if (!suffixToStrip.empty()) {
-        baseNameStr = baseNameStr.drop_back(suffixToStrip.size());
-        if (baseNameStr.empty() || importer.isSwiftReservedName(baseNameStr)) {
-          adjustName = false;
-          suffixToStrip = {};
-        } else {
-          newBaseName = importer.SwiftContext.getIdentifier(baseNameStr);
-        }
-      }
-    }
-
-    // Also suppress name changes if there's a collision.
-    // TODO: this logic doesn't really work with init methods
-    // TODO: this privileges the old API over the new one
-    if (adjustName &&
-        hasErrorMethodNameCollision(importer, clangDecl, index,
-                                    suffixToStrip)) {
-      // If there was a conflict on the first argument, and this was
-      // the first argument and we're not stripping error suffixes, just
-      // give up completely on error import.
-      if (index == 0 && suffixToStrip.empty()) {
-        return None;
-
-      // If there was a conflict stripping an error suffix, adjust the
-      // name but don't change the base name.  This avoids creating a
-      // spurious _: () argument.
-      } else if (index == 0 && !suffixToStrip.empty()) {
-        suffixToStrip = {};
-        newBaseName = methodName.getBaseName();
-
-      // Otherwise, give up on adjusting the name.
-      } else {
-        adjustName = false;
-      }
-    }
-
-    auto replaceWithVoid = ForeignErrorConvention::IsNotReplaced;
-    if (!adjustName && !expectsToRemoveError)
-      replaceWithVoid = ForeignErrorConvention::IsReplaced;
-    ErrorImportInfo errorInfo = {
-      *errorKind, isErrorOwned, replaceWithVoid, index, CanType(),
-      importedResultType->getCanonicalType()
-    };
-    
-    // Adjust the return type.
-    switch (*errorKind) {
-    case ForeignErrorConvention::ZeroResult:
-    case ForeignErrorConvention::NonZeroResult:
-      importedResultType = TupleType::getEmpty(importer.SwiftContext);
-      break;
-
-    case ForeignErrorConvention::NilResult:
-      importedResultType = importedResultType->getAnyOptionalObjectType();
-      assert(importedResultType &&
-             "result type of NilResult convention was not imported as optional");
-      break;
-
-    case ForeignErrorConvention::ZeroPreservedResult:
-    case ForeignErrorConvention::NonNilError:
-      break;
-    }
-
-    if (!adjustName)
-      return errorInfo;
-
-    // Build the new declaration name.
-    SmallVector<Identifier, 8> newParamNames;
-    newParamNames.append(paramNames.begin(),
-                         paramNames.begin() + index);
-    newParamNames.append(paramNames.begin() + index + 1,
-                         paramNames.end());
-    methodName = DeclName(importer.SwiftContext, newBaseName, newParamNames);
-
-    return errorInfo;
-  }
-
-  // Didn't find an error parameter.
-  return None;
-}
-
 /// Determine whether this is the name of an Objective-C collection
 /// with a single element type.
 static bool isObjCCollectionName(StringRef typeName) {
@@ -2190,13 +1867,68 @@ bool ClangImporter::Implementation::canInferDefaultArgument(
   return false;
 }
 
+/// Adjust the result type of a throwing function based on the
+/// imported error information.
+static Type adjustResultTypeForThrowingFunction(
+              const ClangImporter::Implementation::ImportedErrorInfo &errorInfo,
+              Type resultTy) {
+  switch (errorInfo.Kind) {
+  case ForeignErrorConvention::ZeroResult:
+  case ForeignErrorConvention::NonZeroResult:
+    return TupleType::getEmpty(resultTy->getASTContext());
+
+  case ForeignErrorConvention::NilResult:
+    resultTy = resultTy->getAnyOptionalObjectType();
+    assert(resultTy &&
+           "result type of NilResult convention was not imported as optional");
+    return resultTy;
+
+  case ForeignErrorConvention::ZeroPreservedResult:
+  case ForeignErrorConvention::NonNilError:
+    return resultTy;
+  }
+}
+                                     
+/// Produce the foreign error convention from the imported error info,
+/// error parameter type, and original result type.
+static ForeignErrorConvention
+getForeignErrorInfo(
+    const ClangImporter::Implementation::ImportedErrorInfo &errorInfo,
+    CanType errorParamTy, CanType origResultTy) {
+  assert(errorParamTy && "not fully initialized!");
+  using FEC = ForeignErrorConvention;
+  auto ReplaceParamWithVoid = errorInfo.ReplaceParamWithVoid
+                                ? FEC::IsReplaced
+                                : FEC::IsNotReplaced;
+  switch (errorInfo.Kind) {
+  case FEC::ZeroResult:
+    return FEC::getZeroResult(errorInfo.ParamIndex, errorInfo.IsOwned,
+                              ReplaceParamWithVoid, errorParamTy, origResultTy);
+  case FEC::NonZeroResult:
+    return FEC::getNonZeroResult(errorInfo.ParamIndex, errorInfo.IsOwned,
+                                 ReplaceParamWithVoid, errorParamTy,
+                                 origResultTy);
+  case FEC::ZeroPreservedResult:
+    return FEC::getZeroPreservedResult(errorInfo.ParamIndex, errorInfo.IsOwned,
+                                       ReplaceParamWithVoid, errorParamTy);
+  case FEC::NilResult:
+    return FEC::getNilResult(errorInfo.ParamIndex, errorInfo.IsOwned,
+                             ReplaceParamWithVoid, errorParamTy);
+  case FEC::NonNilError:
+    return FEC::getNonNilError(errorInfo.ParamIndex, errorInfo.IsOwned,
+                               ReplaceParamWithVoid, errorParamTy);
+  }
+  llvm_unreachable("bad error convention");
+}
+
 Type ClangImporter::Implementation::importMethodType(
        const clang::ObjCMethodDecl *clangDecl,
        clang::QualType resultType,
        ArrayRef<const clang::ParmVarDecl *> params,
        bool isVariadic, bool isNoReturn,
-       bool isFromSystemModule, bool isCustomName,
+       bool isFromSystemModule,
        SmallVectorImpl<Pattern*> &bodyPatterns,
+       ImportedName importedName,
        DeclName &methodName,
        Optional<ForeignErrorConvention> &foreignErrorInfo,
        SpecialMethodKind kind) {
@@ -2244,7 +1976,9 @@ Type ClangImporter::Implementation::importMethodType(
   }
 
   // Import the result type.
+  CanType origSwiftResultTy;
   Type swiftResultTy;
+  auto errorInfo = importedName.ErrorInfo;
   if (isPropertyGetter) {
     swiftResultTy = importPropertyType(property, isFromSystemModule);
   } else {
@@ -2271,6 +2005,13 @@ Type ClangImporter::Implementation::importMethodType(
                                /*isFullyBridgeable*/true,
                                OptionalityOfReturn);
 
+    // Adjust the result type for a throwing function.
+    if (errorInfo) {
+      origSwiftResultTy = swiftResultTy->getCanonicalType();
+      swiftResultTy = adjustResultTypeForThrowingFunction(*errorInfo,
+                                                          swiftResultTy);
+    }
+
     if (swiftResultTy &&
         clangDecl->getMethodFamily() == clang::OMF_performSelector) {
       // performSelector methods that return 'id' should be imported into Swift
@@ -2290,13 +2031,12 @@ Type ClangImporter::Implementation::importMethodType(
   if (!swiftResultTy)
     return Type();
 
-  auto errorInfo = considerErrorImport(*this, clangDecl, methodName, params,
-                                       swiftResultTy, kind, isCustomName);
+  CanType errorParamType;
 
   llvm::SmallBitVector nonNullArgs = getNonNullArgs(clangDecl, params);
 
   // If we should omit needless words and don't have a custom name, do so.
-  if (OmitNeedlessWords && !isCustomName && clangDecl &&
+  if (OmitNeedlessWords && !importedName.HasCustomName && clangDecl &&
       (kind == SpecialMethodKind::Regular ||
        kind == SpecialMethodKind::Constructor)) {
     methodName = omitNeedlessWordsInFunctionName(
@@ -2406,7 +2146,7 @@ Type ClangImporter::Implementation::importMethodType(
     // If this is the error parameter, remember it, but don't build it
     // into the parameter type.
     if (errorInfo && paramIndex == errorInfo->ParamIndex) {
-      errorInfo->ParamType = swiftParamTy->getCanonicalType();
+      errorParamType = swiftParamTy->getCanonicalType();
 
       // ...unless we're supposed to replace it with ().
       if (errorInfo->ReplaceParamWithVoid) {
@@ -2492,7 +2232,7 @@ Type ClangImporter::Implementation::importMethodType(
     addEmptyTupleParameter(argNames[0]);
   }
 
-  if (isCustomName && argNames.size() != swiftBodyParams.size()) {
+  if (importedName.HasCustomName && argNames.size() != swiftBodyParams.size()) {
     // Note carefully: we're emitting a warning in the /Clang/ buffer.
     auto &srcMgr = getClangASTContext().getSourceManager();
     auto &rawDiagClient = Instance->getDiagnosticClient();
@@ -2519,7 +2259,8 @@ Type ClangImporter::Implementation::importMethodType(
   extInfo = extInfo.withIsNoReturn(isNoReturn);
 
   if (errorInfo) {
-    foreignErrorInfo = errorInfo->asForeignErrorConvention();
+    foreignErrorInfo = getForeignErrorInfo(*errorInfo, errorParamType,
+                                           origSwiftResultTy);
 
     // Mark that the function type throws.
     extInfo = extInfo.withThrows(true);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1967,9 +1967,8 @@ Type ClangImporter::Implementation::importMethodType(
                                allowNSUIntegerAsIntInResult,
                                /*isFullyBridgeable*/true,
                                OptionalityOfReturn);
-
     // Adjust the result type for a throwing function.
-    if (errorInfo) {
+    if (swiftResultTy && errorInfo) {
       origSwiftResultTy = swiftResultTy->getCanonicalType();
       swiftResultTy = adjustResultTypeForThrowingFunction(*errorInfo,
                                                           swiftResultTy);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -724,7 +724,8 @@ public:
 
   /// Determine the imported CF type for the given typedef-name, or the empty
   /// string if this is not an imported CF type name.
-  StringRef getCFTypeName(const clang::TypedefNameDecl *decl);
+  StringRef getCFTypeName(const clang::TypedefNameDecl *decl,
+                          StringRef *secondaryName = nullptr);
 
   /// Retrieve the type name of a Clang type for the purposes of
   /// omitting unneeded words.
@@ -765,6 +766,10 @@ public:
     /// The imported name.
     DeclName Imported;
 
+    /// An additional alias to the imported name, which should be
+    /// recorded in name lookup tables as well.
+    DeclName Alias;
+
     /// Whether this name was explicitly specified via a Clang
     /// swift_name attribute.
     bool HasCustomName = false;
@@ -775,7 +780,7 @@ public:
     bool DroppedVariadic = false;
 
     /// For an initializer, the kind of initializer to import.
-    CtorInitializerKind InitKind;
+    CtorInitializerKind InitKind = CtorInitializerKind::Designated;
 
     /// For names that map Objective-C error handling conventions into
     /// throwing Swift methods, describes how the mapping is performed.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -426,6 +426,10 @@ public:
   /// imported as methods into Swift.
   bool isAccessibilityDecl(const clang::Decl *objCMethodOrProp);
 
+  /// Determine whether this method is an Objective-C "init" method
+  /// that will be imported as a Swift initializer.
+  bool isInitMethod(const clang::ObjCMethodDecl *method);
+
 private:
   /// \brief Generation number that is used for crude versioning.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -625,6 +625,10 @@ public:
   void addBridgeHeaderTopLevelDecls(clang::Decl *D);
   bool shouldIgnoreBridgeHeaderTopLevelDecl(clang::Decl *D);
 
+  /// Add the given named declaration as an entry to the given Swift name
+  /// lookup table, including any of its child entries.
+  void addEntryToLookupTable(SwiftLookupTable &table, clang::NamedDecl *named);
+
 public:
   void registerExternalDecl(Decl *D) {
     RegisteredExternalDecls.push_back(D);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -32,6 +32,7 @@
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include <set>
@@ -730,16 +731,18 @@ public:
   OmissionTypeName getClangTypeNameForOmission(clang::QualType type);
 
   /// Omit needless words in a function name.
-  DeclName omitNeedlessWordsInFunctionName(
-             DeclName name,
-             ArrayRef<const clang::ParmVarDecl *> params,
-             clang::QualType resultType,
-             const clang::DeclContext *dc,
-             const llvm::SmallBitVector &nonNullArgs,
-             const Optional<api_notes::ObjCMethodInfo> &knownMethod,
-             Optional<unsigned> errorParamIndex,
-             bool returnsSelf,
-             bool isInstanceMethod);
+  bool omitNeedlessWordsInFunctionName(
+         StringRef &baseName,
+         SmallVectorImpl<StringRef> &argumentNames,
+         ArrayRef<const clang::ParmVarDecl *> params,
+         clang::QualType resultType,
+         const clang::DeclContext *dc,
+         const llvm::SmallBitVector &nonNullArgs,
+         const Optional<api_notes::ObjCMethodInfo> &knownMethod,
+         Optional<unsigned> errorParamIndex,
+         bool returnsSelf,
+         bool isInstanceMethod,
+         StringScratchSpace &scratch);
 
   /// \brief Converts the given Swift identifier for Clang.
   clang::DeclarationName exportName(Identifier name);
@@ -1107,6 +1110,12 @@ public:
                                Identifier baseName,
                                unsigned numParams,
                                bool isLastParameter);
+
+  /// Retrieve a bit vector containing the non-null argument
+  /// annotations for the given declaration.
+  llvm::SmallBitVector getNonNullArgs(
+                         const clang::Decl *decl,
+                         ArrayRef<const clang::ParmVarDecl *> params);
 
   /// \brief Import the type of an Objective-C method.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -430,6 +430,20 @@ public:
   /// that will be imported as a Swift initializer.
   bool isInitMethod(const clang::ObjCMethodDecl *method);
 
+  /// Determine whether this Objective-C method should be imported as
+  /// an initializer.
+  ///
+  /// \param prefixLength Will be set to the length of the prefix that
+  /// should be stripped from the first selector piece, e.g., "init"
+  /// or the restated name of the class in a factory method.
+  ///
+  ///  \param kind Will be set to the kind of initializer being
+  ///  imported. Note that this does not distinguish designated
+  ///  vs. convenience; both will be classified as "designated".
+  bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
+                                 unsigned &prefixLength,
+                                 CtorInitializerKind &kind);
+
 private:
   /// \brief Generation number that is used for crude versioning.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -744,6 +744,26 @@ public:
   /// \brief Converts the given Swift identifier for Clang.
   clang::DeclarationName exportName(Identifier name);
 
+  /// Describes a name that was imported from Clang.
+  struct ImportedName {
+    /// The imported name.
+    DeclName Imported;
+
+    /// Whether this name was explicitly specified via a Clang
+    /// swift_name attribute.
+    bool HasCustomName = false;
+
+    /// For an initializer, the kind of initializer to import.
+    CtorInitializerKind InitKind;
+
+    /// Produce just the imported name, for clients that don't care
+    /// about the details.
+    operator DeclName() const { return Imported; }
+
+    /// Whether any name was imported.
+    explicit operator bool() const { return static_cast<bool>(Imported); }
+  };
+
   /// Imports the full name of the given Clang declaration into Swift.
   ///
   /// Note that this may result in a name very different from the Clang name,
@@ -751,16 +771,12 @@ public:
   ///
   /// \param D The Clang declaration whose name should be imported.
   ///
-  /// \param hasCustomName If non-null, will be set to indicate whether the
-  /// name was provided directly via a C swift_name attribute.
-  ///
   /// \param effectiveContext If non-null, will be set to the effective
   /// Clang declaration context in which the declaration will be imported.
   /// This can differ from D's redeclaration context when the Clang importer
   /// introduces nesting, e.g., for enumerators within an NS_ENUM.
-  DeclName importFullName(const clang::NamedDecl *D,
-                          bool *hasCustomName = nullptr,
-                          clang::DeclContext **effectiveContext = nullptr);
+  ImportedName importFullName(const clang::NamedDecl *D,
+                              clang::DeclContext **effectiveContext = nullptr);
 
   /// \brief Import the given Clang identifier into Swift.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -734,15 +734,15 @@ public:
   /// \sa importName(clang::DeclarationName, StringRef)
   Identifier importName(const clang::NamedDecl *D, StringRef removePrefix = "");
   
-  /// \brief Import the given Clang name into Swift.
+  /// \brief Import the given Clang identifier into Swift.
   ///
-  /// \param name The Clang name to map into Swift.
+  /// \param identifier The Clang identifier to map into Swift.
   ///
   /// \param removePrefix The prefix to remove from the Clang name to produce
   /// the Swift name. If the Clang name does not start with this prefix,
   /// nothing is removed.
-  Identifier importDeclName(clang::DeclarationName name,
-                            StringRef removePrefix = "");
+  Identifier importIdentifier(const clang::IdentifierInfo *identifier,
+                              StringRef removePrefix = "");
 
   /// Import an Objective-C selector.
   ObjCSelector importSelector(clang::Selector selector);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -722,6 +722,15 @@ public:
   ///
   /// Note that this may result in a name very different from the Clang name,
   /// so it should not be used when referencing Clang symbols.
+  DeclName importFullName(const clang::NamedDecl *D) {
+    bool hasCustomName;
+    return importFullName(D, hasCustomName);
+  }
+
+  /// Imports the full name of the given Clang declaration into Swift.
+  ///
+  /// Note that this may result in a name very different from the Clang name,
+  /// so it should not be used when referencing Clang symbols.
   DeclName importFullName(const clang::NamedDecl *D,
                           bool &hasCustomName);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -726,17 +726,19 @@ public:
   ///
   /// Note that this may result in a name very different from the Clang name,
   /// so it should not be used when referencing Clang symbols.
-  DeclName importFullName(const clang::NamedDecl *D) {
-    bool hasCustomName;
-    return importFullName(D, hasCustomName);
-  }
-
-  /// Imports the full name of the given Clang declaration into Swift.
   ///
-  /// Note that this may result in a name very different from the Clang name,
-  /// so it should not be used when referencing Clang symbols.
+  /// \param D The Clang declaration whose name should be imported.
+  ///
+  /// \param hasCustomName If non-null, will be set to indicate whether the
+  /// name was provided directly via a C swift_name attribute.
+  ///
+  /// \param effectiveContext If non-null, will be set to the effective
+  /// Clang declaration context in which the declaration will be imported.
+  /// This can differ from D's redeclaration context when the Clang importer
+  /// introduces nesting, e.g., for enumerators within an NS_ENUM.
   DeclName importFullName(const clang::NamedDecl *D,
-                          bool &hasCustomName);
+                          bool *hasCustomName = nullptr,
+                          clang::DeclContext **effectiveContext = nullptr);
 
   /// Imports the name of the given Clang decl into Swift.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -310,9 +310,6 @@ public:
   llvm::SmallDenseMap<const clang::TypedefNameDecl *, MappedTypeNameKind, 16>
     SpecialTypedefNames;
 
-  /// Mapping from Objective-C selectors to method names.
-  llvm::DenseMap<std::pair<ObjCSelector, char>, DeclName> SelectorMappings;
-
   /// Is the given identifier a reserved name in Swift?
   static bool isSwiftReservedName(StringRef name);
 
@@ -769,6 +766,15 @@ public:
     explicit operator bool() const { return static_cast<bool>(Imported); }
   };
 
+  /// Flags that control the import of names in importFullName.
+  enum class ImportNameFlags {
+    /// Suppress the factory-method-as-initializer transformation.
+    SuppressFactoryMethodAsInit = 0x01,
+  };
+
+  /// Options that control the import of names in importFullName.
+  typedef OptionSet<ImportNameFlags> ImportNameOptions;
+
   /// Imports the full name of the given Clang declaration into Swift.
   ///
   /// Note that this may result in a name very different from the Clang name,
@@ -781,6 +787,7 @@ public:
   /// This can differ from D's redeclaration context when the Clang importer
   /// introduces nesting, e.g., for enumerators within an NS_ENUM.
   ImportedName importFullName(const clang::NamedDecl *D,
+                              ImportNameOptions options = None,
                               clang::DeclContext **effectiveContext = nullptr);
 
   /// \brief Import the given Clang identifier into Swift.
@@ -801,18 +808,6 @@ public:
 
   /// Export a Swift Objective-C selector as a Clang Objective-C selector.
   clang::Selector exportSelector(ObjCSelector selector);
-
-  /// Map the given selector to a declaration name.
-  ///
-  /// \param selector The selector to map.
-  ///
-  /// \param isInitializer Whether this name should be mapped as an
-  /// initializer.
-  ///
-  /// \param isSwiftPrivate Whether this name is for a declaration marked with
-  /// the 'swift_private' attribute.
-  DeclName mapSelectorToDeclName(ObjCSelector selector, bool isInitializer,
-                                 bool isSwiftPrivate);
 
   /// \brief Import the given Swift source location into Clang.
   clang::SourceLocation exportSourceLoc(SourceLoc loc);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -503,6 +503,10 @@ private:
     }
   };
 
+  /// Retrieve the prefix to be stripped from the names of the enum constants
+  /// within the given enum.
+  StringRef getEnumConstantNamePrefix(const clang::EnumDecl *enumDecl);
+
 public:
   /// \brief Keep track of enum constant values that have been imported.
   llvm::DenseMap<std::pair<const clang::EnumDecl *, llvm::APSInt>,
@@ -740,15 +744,6 @@ public:
                           bool *hasCustomName = nullptr,
                           clang::DeclContext **effectiveContext = nullptr);
 
-  /// Imports the name of the given Clang decl into Swift.
-  ///
-  /// Note that this may result in a name different from the Clang name, so it
-  /// should not be used when referencing Clang symbols. (In particular, it
-  /// should not be put into \c \@objc attributes.)
-  ///
-  /// \sa importName(clang::DeclarationName, StringRef)
-  Identifier importName(const clang::NamedDecl *D, StringRef removePrefix = "");
-  
   /// \brief Import the given Clang identifier into Swift.
   ///
   /// \param identifier The Clang identifier to map into Swift.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -809,22 +809,6 @@ public:
   DeclName mapSelectorToDeclName(ObjCSelector selector, bool isInitializer,
                                  bool isSwiftPrivate);
 
-  /// Try to map the given selector, which may be the name of a factory method,
-  /// to the name of an initializer.
-  ///
-  /// \param selector The selector to map.
-  ///
-  /// \param className The name of the class in which the method occurs.
-  ///
-  /// \param isSwiftPrivate Whether this name is for a declaration marked with
-  /// the 'swift_private' attribute.
-  ///
-  /// \returns the initializer name for this factory method, or an empty
-  /// name if this selector does not fit the pattern.
-  DeclName mapFactorySelectorToInitializerName(ObjCSelector selector,
-                                               StringRef className,
-                                               bool isSwiftPrivate);
-
   /// \brief Import the given Swift source location into Clang.
   clang::SourceLocation exportSourceLoc(SourceLoc loc);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -753,6 +753,11 @@ public:
     /// swift_name attribute.
     bool HasCustomName = false;
 
+    /// Whether this was one of a special class of Objective-C
+    /// initializers for which we drop the variadic argument rather
+    /// than refuse to import the initializer.
+    bool DroppedVariadic = false;
+
     /// For an initializer, the kind of initializer to import.
     CtorInitializerKind InitKind;
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_CLANG_IMPORTER_IMPL_H
 #define SWIFT_CLANG_IMPORTER_IMPL_H
 
+#include "SwiftLookupTable.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/LazyResolver.h"
@@ -251,6 +252,7 @@ public:
   const bool ImportForwardDeclarations;
   const bool OmitNeedlessWords;
   const bool InferDefaultArguments;
+  const bool UseSwiftLookupTables;
 
   constexpr static const char * const moduleImportBufferName =
     "<swift-imported-modules>";
@@ -288,6 +290,9 @@ private:
   /// The flag is \c true if there has ever been a type resolver assigned, i.e.
   /// if type checking has begun.
   llvm::PointerIntPair<LazyResolver *, 1, bool> typeResolver;
+
+  /// The Swift lookup table for the bridging header.
+  SwiftLookupTable BridgingHeaderLookupTable;
 
 public:
   /// \brief Mapping of already-imported declarations.
@@ -1177,6 +1182,9 @@ public:
       ASD->setSetterAccessibility(Accessibility::Public);
     return D;
   }
+
+  /// Dump the Swift-specific name lookup tables we generate.
+  void dumpSwiftLookupTables();
 };
 
 }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -718,6 +718,13 @@ public:
   /// \brief Converts the given Swift identifier for Clang.
   clang::DeclarationName exportName(Identifier name);
 
+  /// Imports the full name of the given Clang declaration into Swift.
+  ///
+  /// Note that this may result in a name very different from the Clang name,
+  /// so it should not be used when referencing Clang symbols.
+  DeclName importFullName(const clang::NamedDecl *D,
+                          bool &hasCustomName);
+
   /// Imports the name of the given Clang decl into Swift.
   ///
   /// Note that this may result in a name different from the Clang name, so it

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -53,8 +53,7 @@ static bool matchesExistingDecl(clang::Decl *decl, clang::Decl *existingDecl) {
 
 void SwiftLookupTable::addEntry(DeclName name, clang::NamedDecl *decl,
                                 clang::DeclContext *effectiveContext) {
-  clang::DeclContext *context
-    = decl->getDeclContext()->getRedeclContext()->getPrimaryContext();
+  clang::DeclContext *context = effectiveContext->getPrimaryContext();
 
   // First, check whether there is already a full name entry.
   auto knownFull = FullNameTable.find(name);

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -71,7 +71,9 @@ public:
   ///
   /// \param name The Swift name of the entry.
   /// \param decl The Clang declaration to add.
-  void addEntry(DeclName name, clang::NamedDecl *decl);
+  /// \param effectiveContext The effective context in which name lookup occurs.
+  void addEntry(DeclName name, clang::NamedDecl *decl,
+                clang::DeclContext *effectiveContext);
 
   /// Lookup the set of declarations with the given base name.
   ///

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -1,0 +1,108 @@
+//===--- SwiftLookupTable.h - Swift Lookup Table ----------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements support for Swift name lookup tables stored in Clang
+// modules.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_CLANGIMPORTER_SWIFTLOOKUPTABLE_H
+#define SWIFT_CLANGIMPORTER_SWIFTLOOKUPTABLE_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/AST/Identifier.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
+
+namespace clang {
+class NamedDecl;
+class DeclContext;
+}
+
+namespace swift {
+
+/// A lookup table that maps Swift names to the set of Clang
+/// declarations with that particular name.
+///
+/// The names of C entities can undergo significant transformations
+/// when they are mapped into Swift, which makes Clang's name lookup
+/// mechanisms useless when searching for the Swift name of
+/// entities. This lookup table provides efficient access to the C
+/// entities based on their Swift names, and is used by the Clang
+/// importer to satisfy the Swift compiler's queries.
+class SwiftLookupTable {
+  /// An entry in the table of C entities indexed by full Swift name.
+  struct FullTableEntry {
+    /// The context in which the entities with the given name occur, e.g.,
+    /// a class, struct, translation unit, etc.
+    ///
+    /// Many Clang DeclContexts can have redeclarations, so this entry
+    /// is always the canonical DeclContext for the entity.
+    clang::DeclContext *Context;
+
+    /// The set of Clang declarations with this name and in this
+    /// context.
+    llvm::TinyPtrVector<clang::NamedDecl *> Decls;
+  };
+
+  /// A table mapping from the full name of Swift entities to all of
+  /// the C entities that have that name, in all contexts.
+  llvm::DenseMap<DeclName, SmallVector<FullTableEntry, 2>> FullNameTable;
+
+  /// A table mapping from the base name of a Swift name to all of the
+  /// full Swift names based on that identifier.
+  llvm::DenseMap<Identifier, SmallVector<DeclName, 2>> BaseNameTable;
+
+  /// Determine whether the given context we found matches the
+  /// requested context.
+  bool matchesContext(clang::DeclContext *foundContext,
+                      clang::DeclContext *requestedContext);
+public:
+  /// Add an entry to the lookup table.
+  ///
+  /// \param name The Swift name of the entry.
+  /// \param decl The Clang declaration to add.
+  void addEntry(DeclName name, clang::NamedDecl *decl);
+
+  /// Lookup the set of declarations with the given base name.
+  ///
+  /// \param baseName The base name to search for. All results will
+  /// have this base name.
+  ///
+  /// \param context The context in which the resulting set of
+  /// declarations should reside. This may be null to indicate that
+  /// all results from all contexts should be produced.
+  ArrayRef<clang::NamedDecl *>
+  lookup(Identifier baseName,
+         clang::DeclContext *context,
+         SmallVectorImpl<clang::NamedDecl *> &scratch);
+
+  /// Lookup the set of declarations with the given full name.
+  ///
+  /// \param name The full name to search for. All results will have
+  /// this full name.
+  ///
+  /// \param context The context in which the resulting set of
+  /// declarations should reside. This may be null to indicate that
+  /// all results from all contexts should be produced.
+  ArrayRef<clang::NamedDecl *>
+  lookup(DeclName name,
+         clang::DeclContext *context,
+         SmallVectorImpl<clang::NamedDecl *> &scratch);
+
+  /// Dump the internal representation of this lookup table.
+  void dump() const;
+};
+
+}
+
+#endif // SWIFT_CLANGIMPORTER_SWIFTLOOKUPTABLE_H

--- a/test/ClangModules/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangModules/Inputs/SwiftPrivateAttr.txt
@@ -25,7 +25,7 @@ class Foo : NSObject, __PrivProto {
   init()
 }
 class Bar : NSObject {
-  init!()
+  init!(__: ())
   init!(__noArgs: ())
   init!(__oneArg arg: Int32)
   init!(__twoArgs arg: Int32, other arg2: Int32)

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -13,5 +13,12 @@ struct SNSomeStruct SNMakeSomeStruct(double X, double Y) SWIFT_NAME(makeSomeStru
 
 struct SNSomeStruct SNMakeSomeStructForX(double X) SWIFT_NAME(makeSomeStruct(x:));
 
+// Renaming typedefs.
+typedef int SNIntegerType SWIFT_NAME(MyInt);
+
 // swift_private attribute
 void SNTransposeInPlace(struct SNSomeStruct *value) __attribute__((swift_private));
+
+typedef struct {
+  double x, y, z;
+} SNPoint SWIFT_NAME(Point);

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -1,0 +1,7 @@
+#define SWIFT_NAME(X) __attribute__((swift_name(#X)))
+
+int SNFoo SWIFT_NAME(Bar);
+
+struct SWIFT_NAME(SomeStruct) SNSomeStruct {
+  double X SWIFT_NAME(x);
+};

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -1,7 +1,17 @@
 #define SWIFT_NAME(X) __attribute__((swift_name(#X)))
 
+// Renaming global variables.
 int SNFoo SWIFT_NAME(Bar);
 
+// Renaming tags and fields.
 struct SWIFT_NAME(SomeStruct) SNSomeStruct {
   double X SWIFT_NAME(x);
 };
+
+// Renaming C functions
+struct SNSomeStruct SNMakeSomeStruct(double X, double Y) SWIFT_NAME(makeSomeStruct(x:y:));
+
+struct SNSomeStruct SNMakeSomeStructForX(double X) SWIFT_NAME(makeSomeStruct(x:));
+
+// swift_private attribute
+void SNTransposeInPlace(struct SNSomeStruct *value) __attribute__((swift_private));

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -28,7 +28,7 @@ typedef int SNIntegerType SWIFT_NAME(MyInt);
 
 // Renaming enumerations.
 SWIFT_ENUM(unsigned char, SNColorChoice) {
-  SNColorRed,
+  SNColorRed SWIFT_NAME(Rouge),
   SNColorGreen,
   SNColorBlue
 };

--- a/test/IDE/Inputs/swift_name.h
+++ b/test/IDE/Inputs/swift_name.h
@@ -1,5 +1,15 @@
 #define SWIFT_NAME(X) __attribute__((swift_name(#X)))
 
+#ifndef SWIFT_ENUM_EXTRA
+#  define SWIFT_ENUM_EXTRA
+#endif
+
+#ifndef SWIFT_ENUM
+#  define SWIFT_ENUM(_type, _name)    \
+  enum _name : _type _name;           \
+  enum SWIFT_ENUM_EXTRA _name : _type
+#endif
+
 // Renaming global variables.
 int SNFoo SWIFT_NAME(Bar);
 
@@ -15,6 +25,13 @@ struct SNSomeStruct SNMakeSomeStructForX(double X) SWIFT_NAME(makeSomeStruct(x:)
 
 // Renaming typedefs.
 typedef int SNIntegerType SWIFT_NAME(MyInt);
+
+// Renaming enumerations.
+SWIFT_ENUM(unsigned char, SNColorChoice) {
+  SNColorRed,
+  SNColorGreen,
+  SNColorBlue
+};
 
 // swift_private attribute
 void SNTransposeInPlace(struct SNSomeStruct *value) __attribute__((swift_private));

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -1,0 +1,45 @@
+@import ObjectiveC;
+
+#define SWIFT_NAME(X) __attribute__((swift_name(#X)))
+
+#ifndef SWIFT_ENUM_EXTRA
+#  define SWIFT_ENUM_EXTRA
+#endif
+
+#ifndef SWIFT_ENUM
+#  define SWIFT_ENUM(_type, _name)    \
+  enum _name : _type _name;           \
+  enum SWIFT_ENUM_EXTRA _name : _type
+#endif
+
+// Renaming classes
+SWIFT_NAME(SomeClass)
+@interface SNSomeClass : NSObject
+- (instancetype)initWithFloat:(float)f;
+- (void)instanceMethodWithX:(float)x y:(float)y z:(float)z;
++ (instancetype)someClassWithDouble:(double)d;
+
+@property (readonly,nonatomic) float floatProperty;
+@property (readwrite,nonatomic) double doubleProperty;
+@end
+
+SWIFT_NAME(SomeProtocol)
+@protocol SNSomeProtocol
+- (void)protoInstanceMethodWithX:(float)x y:(float)y;
+@end
+
+@interface SNSomeClass ()
+- (void)extensionMethodWithX:(float)x y:(float)y;
+@end
+
+@interface SNSomeClass (Category1) <SNSomeProtocol>
+- (void)categoryMethodWithX:(float)x y:(float)y;
+- (void)categoryMethodWithX:(float)x y:(float)y z:(float)z;
+@end
+
+@interface SNCollision
+@end
+
+@protocol SNCollision
+@end
+

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -63,3 +63,6 @@ SWIFT_NAME(SomeProtocol)
 - (nullable instancetype)initAndReturnError:(NSError **)error;
 - (nullable instancetype)initWithFloat:(float)value error:(NSError **)error;
 @end
+
+typedef const void *CFTypeRef __attribute__((objc_bridge(id)));
+typedef const struct __attribute__((objc_bridge(id))) __CCItem *CCItemRef;

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -16,6 +16,7 @@
 SWIFT_NAME(SomeClass)
 @interface SNSomeClass : NSObject
 - (instancetype)initWithFloat:(float)f;
+- (instancetype)initWithDefault;
 - (void)instanceMethodWithX:(float)x y:(float)y z:(float)z;
 + (instancetype)someClassWithDouble:(double)d;
 

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -17,7 +17,7 @@ SWIFT_NAME(SomeClass)
 @interface SNSomeClass : NSObject
 - (instancetype)initWithFloat:(float)f;
 - (instancetype)initWithDefault;
-- (void)instanceMethodWithX:(float)x y:(float)y z:(float)z;
+- (void)instanceMethodWithX:(float)x Y:(float)y Z:(float)z;
 + (instancetype)someClassWithDouble:(double)d;
 + (instancetype)someClassWithTry:(BOOL)shouldTry;
 + (NSObject *)buildWithObject:(NSObject *)object SWIFT_NAME(init(object:));

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -19,6 +19,8 @@ SWIFT_NAME(SomeClass)
 - (instancetype)initWithDefault;
 - (void)instanceMethodWithX:(float)x y:(float)y z:(float)z;
 + (instancetype)someClassWithDouble:(double)d;
++ (instancetype)someClassWithTry:(BOOL)shouldTry;
++ (NSObject *)buildWithObject:(NSObject *)object SWIFT_NAME(init(object:));
 
 @property (readonly,nonatomic) float floatProperty;
 @property (readwrite,nonatomic) double doubleProperty;

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -43,3 +43,6 @@ SWIFT_NAME(SomeProtocol)
 @protocol SNCollision
 @end
 
+@protocol NSAccessibility
+@property (nonatomic) float accessibilityFloat;
+@end

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -53,3 +53,13 @@ SWIFT_NAME(SomeProtocol)
 @interface UIActionSheet : NSObject
 -(instancetype)initWithTitle:(const char *)title delegate:(id)delegate cancelButtonTitle:(const char *)cancelButtonTitle destructiveButtonTitle:(const char *)destructiveButtonTitle otherButtonTitles:(const char *)otherButtonTitles, ...;
 @end
+
+@interface NSError : NSObject
+@end
+
+@interface NSErrorImports : NSObject
+- (nullable NSObject *)methodAndReturnError:(NSError **)error;
+- (BOOL)methodWithFloat:(float)value error:(NSError **)error;
+- (nullable instancetype)initAndReturnError:(NSError **)error;
+- (nullable instancetype)initWithFloat:(float)value error:(NSError **)error;
+@end

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -49,3 +49,7 @@ SWIFT_NAME(SomeProtocol)
 @protocol NSAccessibility
 @property (nonatomic) float accessibilityFloat;
 @end
+
+@interface UIActionSheet : NSObject
+-(instancetype)initWithTitle:(const char *)title delegate:(id)delegate cancelButtonTitle:(const char *)cancelButtonTitle destructiveButtonTitle:(const char *)destructiveButtonTitle otherButtonTitles:(const char *)otherButtonTitles, ...;
+@end

--- a/test/IDE/Inputs/swift_name_objc.h
+++ b/test/IDE/Inputs/swift_name_objc.h
@@ -21,7 +21,7 @@ SWIFT_NAME(SomeClass)
 + (instancetype)someClassWithDouble:(double)d;
 + (instancetype)someClassWithTry:(BOOL)shouldTry;
 + (NSObject *)buildWithObject:(NSObject *)object SWIFT_NAME(init(object:));
-
++ (instancetype)buildWithUnsignedChar:(unsigned char)uint8 SWIFT_NAME(init(uint8:));
 @property (readonly,nonatomic) float floatProperty;
 @property (readwrite,nonatomic) double doubleProperty;
 @end

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -3,12 +3,12 @@
 
 // CHECK:      Base -> full name mappings:
 // CHECK-NEXT:   Bar --> Bar
+// CHECK-NEXT:   Blue --> Blue
+// CHECK-NEXT:   Green --> Green
 // CHECK-NEXT:   MyInt --> MyInt
 // CHECK-NEXT:   Point --> Point
 // CHECK-NEXT:   Rouge --> Rouge
-// CHECK-NEXT:   SNColorBlue --> SNColorBlue
 // CHECK-NEXT:   SNColorChoice --> SNColorChoice
-// CHECK-NEXT:   SNColorGreen --> SNColorGreen
 // CHECK-NEXT:   SomeStruct --> SomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace --> __SNTransposeInPlace
 // CHECK-NEXT:   makeSomeStruct --> makeSomeStruct(x:y:), makeSomeStruct(x:)
@@ -19,18 +19,18 @@
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   Bar:
 // CHECK-NEXT:     TU: SNFoo
+// CHECK-NEXT:   Blue:
+// CHECK-NEXT:     SNColorChoice: SNColorBlue
+// CHECK-NEXT:   Green:
+// CHECK-NEXT:     SNColorChoice: SNColorGreen
 // CHECK-NEXT:   MyInt:
 // CHECK-NEXT:     TU: SNIntegerType
 // CHECK-NEXT:   Point:
 // CHECK-NEXT:     TU: SNPoint
 // CHECK-NEXT:   Rouge:
 // CHECK-NEXT:     SNColorChoice: SNColorRed
-// CHECK-NEXT:   SNColorBlue:
-// CHECK-NEXT:     SNColorChoice: SNColorBlue
 // CHECK-NEXT:   SNColorChoice:
 // CHECK-NEXT:     TU: SNColorChoice, SNColorChoice
-// CHECK-NEXT:   SNColorGreen:
-// CHECK-NEXT:     SNColorChoice: SNColorGreen
 // CHECK-NEXT:   SomeStruct:
 // CHECK-NEXT:     TU: SNSomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace:

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -5,10 +5,16 @@
 // CHECK-NEXT:   Bar --> Bar
 // CHECK-NEXT:   MyInt --> MyInt
 // CHECK-NEXT:   Point --> Point
+// CHECK-NEXT:   Rouge --> Rouge
+// CHECK-NEXT:   SNColorBlue --> SNColorBlue
 // CHECK-NEXT:   SNColorChoice --> SNColorChoice
+// CHECK-NEXT:   SNColorGreen --> SNColorGreen
 // CHECK-NEXT:   SomeStruct --> SomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace --> __SNTransposeInPlace
 // CHECK-NEXT:   makeSomeStruct --> makeSomeStruct(x:y:), makeSomeStruct(x:)
+// CHECK-NEXT:   x --> x
+// CHECK-NEXT:   y --> y
+// CHECK-NEXT:   z --> z
 
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   Bar:
@@ -17,8 +23,14 @@
 // CHECK-NEXT:     TU: SNIntegerType
 // CHECK-NEXT:   Point:
 // CHECK-NEXT:     TU: SNPoint
+// CHECK-NEXT:   Rouge:
+// CHECK-NEXT:     TU: SNColorRed
+// CHECK-NEXT:   SNColorBlue:
+// CHECK-NEXT:     TU: SNColorBlue
 // CHECK-NEXT:   SNColorChoice:
-// CHECK-NEXT:     TU: SNColorChoice, SNColorChoice{{$}}
+// CHECK-NEXT:     TU: SNColorChoice, SNColorChoice
+// CHECK-NEXT:   SNColorGreen:
+// CHECK-NEXT:     TU: SNColorGreen
 // CHECK-NEXT:   SomeStruct:
 // CHECK-NEXT:     TU: SNSomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace:
@@ -27,3 +39,10 @@
 // CHECK-NEXT:     TU: SNMakeSomeStructForX
 // CHECK-NEXT:   makeSomeStruct(x:y:):
 // CHECK-NEXT:     TU: SNMakeSomeStruct
+// CHECK-NEXT:   x:
+// CHECK-NEXT:     SNSomeStruct: X
+// CHECK-NEXT:     SNPoint: x
+// CHECK-NEXT:   y:
+// CHECK-NEXT:     SNPoint: y
+// CHECK-NEXT:   z:
+// CHECK-NEXT:     SNPoint: z

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -5,6 +5,7 @@
 // CHECK-NEXT:   Bar --> Bar
 // CHECK-NEXT:   MyInt --> MyInt
 // CHECK-NEXT:   Point --> Point
+// CHECK-NEXT:   SNColorChoice --> SNColorChoice
 // CHECK-NEXT:   SomeStruct --> SomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace --> __SNTransposeInPlace
 // CHECK-NEXT:   makeSomeStruct --> makeSomeStruct(x:y:), makeSomeStruct(x:)
@@ -16,6 +17,8 @@
 // CHECK-NEXT:     TU: SNIntegerType
 // CHECK-NEXT:   Point:
 // CHECK-NEXT:     TU: SNPoint
+// CHECK-NEXT:   SNColorChoice:
+// CHECK-NEXT:     TU: SNColorChoice, SNColorChoice{{$}}
 // CHECK-NEXT:   SomeStruct:
 // CHECK-NEXT:     TU: SNSomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace:

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -3,6 +3,8 @@
 
 // CHECK:      Base -> full name mappings:
 // CHECK-NEXT:   Bar --> Bar
+// CHECK-NEXT:   MyInt --> MyInt
+// CHECK-NEXT:   Point --> Point
 // CHECK-NEXT:   SomeStruct --> SomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace --> __SNTransposeInPlace
 // CHECK-NEXT:   makeSomeStruct --> makeSomeStruct(x:y:), makeSomeStruct(x:)
@@ -10,6 +12,10 @@
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   Bar:
 // CHECK-NEXT:     TU: SNFoo
+// CHECK-NEXT:   MyInt:
+// CHECK-NEXT:     TU: SNIntegerType
+// CHECK-NEXT:   Point:
+// CHECK-NEXT:     TU: SNPoint
 // CHECK-NEXT:   SomeStruct:
 // CHECK-NEXT:     TU: SNSomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace:

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -4,9 +4,17 @@
 // CHECK:      Base -> full name mappings:
 // CHECK-NEXT:   Bar --> Bar
 // CHECK-NEXT:   SomeStruct --> SomeStruct
+// CHECK-NEXT:   __SNTransposeInPlace --> __SNTransposeInPlace
+// CHECK-NEXT:   makeSomeStruct --> makeSomeStruct(x:y:), makeSomeStruct(x:)
 
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   Bar:
 // CHECK-NEXT:     TU: SNFoo
 // CHECK-NEXT:   SomeStruct:
 // CHECK-NEXT:     TU: SNSomeStruct
+// CHECK-NEXT:   __SNTransposeInPlace:
+// CHECK-NEXT:     TU: SNTransposeInPlace
+// CHECK-NEXT:   makeSomeStruct(x:):
+// CHECK-NEXT:     TU: SNMakeSomeStructForX
+// CHECK-NEXT:   makeSomeStruct(x:y:):
+// CHECK-NEXT:     TU: SNMakeSomeStruct

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -24,13 +24,13 @@
 // CHECK-NEXT:   Point:
 // CHECK-NEXT:     TU: SNPoint
 // CHECK-NEXT:   Rouge:
-// CHECK-NEXT:     TU: SNColorRed
+// CHECK-NEXT:     SNColorChoice: SNColorRed
 // CHECK-NEXT:   SNColorBlue:
-// CHECK-NEXT:     TU: SNColorBlue
+// CHECK-NEXT:     SNColorChoice: SNColorBlue
 // CHECK-NEXT:   SNColorChoice:
 // CHECK-NEXT:     TU: SNColorChoice, SNColorChoice
 // CHECK-NEXT:   SNColorGreen:
-// CHECK-NEXT:     TU: SNColorGreen
+// CHECK-NEXT:     SNColorChoice: SNColorGreen
 // CHECK-NEXT:   SomeStruct:
 // CHECK-NEXT:     TU: SNSomeStruct
 // CHECK-NEXT:   __SNTransposeInPlace:

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name.h > %t.log 2>&1
+// RUN: FileCheck %s < %t.log
+
+// CHECK:      Base -> full name mappings:
+// CHECK-NEXT:   Bar --> Bar
+// CHECK-NEXT:   SomeStruct --> SomeStruct
+
+// CHECK:      Full name -> entry mappings:
+// CHECK-NEXT:   Bar:
+// CHECK-NEXT:     TU: SNFoo
+// CHECK-NEXT:   SomeStruct:
+// CHECK-NEXT:     TU: SNSomeStruct

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -14,7 +14,7 @@
 // CHECK-NEXT:   doubleProperty --> doubleProperty{{$}}
 // CHECK-NEXT:   extensionMethodWithX --> extensionMethodWithX(_:y:)
 // CHECK-NEXT:   floatProperty --> floatProperty{{$}}
-// CHECK-NEXT:   init --> init(float:), init(withDefault:), init(double:), init(withTry:){{$}}
+// CHECK-NEXT:   init --> init(float:), init(withDefault:), init(double:), init(withTry:), init(uint8:){{$}}
 // CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
 // CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
 // CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
@@ -46,6 +46,8 @@
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]
 // CHECK-NEXT:   init(float:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
+// CHECK-NEXT:   init(uint8:):
+// CHECK-NEXT:     SNSomeClass: +[SNSomeClass buildWithUnsignedChar:]
 // CHECK-NEXT:   init(withDefault:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithDefault]
 // CHECK-NEXT:   init(withTry:):

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -84,7 +84,7 @@
 // CHECK-NEXT:   init(withTry:):
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithTry:]
 // CHECK-NEXT:   instanceMethodWithX(_:y:z:):
-// CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:y:z:]
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:Y:Z:]
 // CHECK-NEXT:   method():
 // CHECK-NEXT:     NSErrorImports: -[NSErrorImports methodAndReturnError:]
 // CHECK-NEXT:   methodWithFloat(_:):
@@ -95,6 +95,7 @@
 // CHECK-NEXT:     NSAccessibility: -[NSAccessibility setAccessibilityFloat:]
 
 // CHECK-OMIT-NEEDLESS-WORDS: Base -> full name mappings:
+// CHECK-OMIT-NEEDLESS-WORDS:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
 // CHECK-OMIT-NEEDLESS-WORDS:   methodWith --> methodWith(_:)
 
 // CHECK-OMIT-NEEDLESS-WORDS: Full name -> entry mappings:

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -4,21 +4,25 @@
 // REQUIRES: objc_interop
 
 // CHECK:      Base -> full name mappings:
+// CHECK-NEXT:   NSAccessibility --> NSAccessibility
 // CHECK-NEXT:   SNCollision --> SNCollision
 // CHECK-NEXT:   SNCollisionProtocol --> SNCollisionProtocol
 // CHECK-NEXT:   SomeClass --> SomeClass
 // CHECK-NEXT:   SomeProtocol --> SomeProtocol
+// CHECK-NEXT:   accessibilityFloat --> accessibilityFloat()
 // CHECK-NEXT:   categoryMethodWithX --> categoryMethodWithX(_:y:), categoryMethodWithX(_:y:z:)
-// CHECK-NEXT:   doubleProperty --> doubleProperty, doubleProperty()
+// CHECK-NEXT:   doubleProperty --> doubleProperty{{$}}
 // CHECK-NEXT:   extensionMethodWithX --> extensionMethodWithX(_:y:)
-// CHECK-NEXT:   floatProperty --> floatProperty, floatProperty()
+// CHECK-NEXT:   floatProperty --> floatProperty{{$}}
 // CHECK-NEXT:   initWithFloat --> initWithFloat(_:)
 // CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
 // CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
-// CHECK-NEXT:   setDoubleProperty --> setDoubleProperty(_:)
+// CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
 // CHECK-NEXT:   someClassWithDouble --> someClassWithDouble(_:)
 
 // CHECK:      Full name -> entry mappings:
+// CHECK-NEXT:   NSAccessibility:
+// CHECK-NEXT:     TU: NSAccessibility{{$}}
 // CHECK-NEXT:   SNCollision:
 // CHECK-NEXT:     TU: SNCollision{{$}}
 // CHECK-NEXT:   SNCollisionProtocol:
@@ -27,27 +31,25 @@
 // CHECK-NEXT:     TU: SNSomeClass
 // CHECK-NEXT:   SomeProtocol:
 // CHECK-NEXT:     TU: SNSomeProtocol
+// CHECK-NEXT:   accessibilityFloat():
+// CHECK-NEXT:     NSAccessibility: -[NSAccessibility accessibilityFloat]
 // CHECK-NEXT:   categoryMethodWithX(_:y:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass categoryMethodWithX:y:]
 // CHECK-NEXT:   categoryMethodWithX(_:y:z:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass categoryMethodWithX:y:z:]
 // CHECK-NEXT:   doubleProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.doubleProperty
-// CHECK-NEXT:   doubleProperty():
-// CHECK-NEXT:     SNSomeClass: -[SNSomeClass doubleProperty]
 // CHECK-NEXT:   extensionMethodWithX(_:y:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
 // CHECK-NEXT:   floatProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.floatProperty
-// CHECK-NEXT:   floatProperty():
-// CHECK-NEXT:     SNSomeClass: -[SNSomeClass floatProperty]
 // CHECK-NEXT:   initWithFloat(_:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
 // CHECK-NEXT:   instanceMethodWithX(_:y:z:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:y:z:]
 // CHECK-NEXT:   protoInstanceMethodWithX(_:y:):
 // CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
-// CHECK-NEXT:   setDoubleProperty(_:):
-// CHECK-NEXT:     SNSomeClass: -[SNSomeClass setDoubleProperty:]
+// CHECK-NEXT:   setAccessibilityFloat(_:):
+// CHECK-NEXT:     NSAccessibility: -[NSAccessibility setAccessibilityFloat:]
 // CHECK-NEXT:   someClassWithDouble(_:):
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -14,7 +14,7 @@
 // CHECK-NEXT:   doubleProperty --> doubleProperty{{$}}
 // CHECK-NEXT:   extensionMethodWithX --> extensionMethodWithX(_:y:)
 // CHECK-NEXT:   floatProperty --> floatProperty{{$}}
-// CHECK-NEXT:   initWithFloat --> initWithFloat(_:)
+// CHECK-NEXT:   init --> init(float:), init(withDefault:)
 // CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
 // CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
 // CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
@@ -43,8 +43,10 @@
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
 // CHECK-NEXT:   floatProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.floatProperty
-// CHECK-NEXT:   initWithFloat(_:):
+// CHECK-NEXT:   init(float:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
+// CHECK-NEXT:   init(withDefault:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithDefault]
 // CHECK-NEXT:   instanceMethodWithX(_:y:z:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:y:z:]
 // CHECK-NEXT:   protoInstanceMethodWithX(_:y:):

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -5,6 +5,8 @@
 
 // CHECK:      Base -> full name mappings:
 // CHECK-NEXT:   NSAccessibility --> NSAccessibility
+// CHECK-NEXT:   NSError --> NSError
+// CHECK-NEXT:   NSErrorImports --> NSErrorImports
 // CHECK-NEXT:   SNCollision --> SNCollision
 // CHECK-NEXT:   SNCollisionProtocol --> SNCollisionProtocol
 // CHECK-NEXT:   SomeClass --> SomeClass
@@ -17,12 +19,18 @@
 // CHECK-NEXT:   floatProperty --> floatProperty{{$}}
 // CHECK-NEXT:   init --> init(float:), init(withDefault:), init(double:), init(withTry:), init(uint8:), init(title:delegate:cancelButtonTitle:destructiveButtonTitle:)
 // CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
+// CHECK-NEXT:   method --> method()
+// CHECK-NEXT:   methodWithFloat --> methodWithFloat(_:)
 // CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
 // CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
 
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   NSAccessibility:
 // CHECK-NEXT:     TU: NSAccessibility{{$}}
+// CHECK-NEXT:   NSError:
+// CHECK-NEXT:     TU: NSError
+// CHECK-NEXT:   NSErrorImports:
+// CHECK-NEXT:     TU: NSErrorImports
 // CHECK-NEXT:   SNCollision:
 // CHECK-NEXT:     TU: SNCollision{{$}}
 // CHECK-NEXT:   SNCollisionProtocol:
@@ -45,10 +53,13 @@
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
 // CHECK-NEXT:   floatProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.floatProperty
+// CHECK-NEXT:   init(andReturnError:):
+// CHECK-NEXT:     NSErrorImports: -[NSErrorImports initAndReturnError:]
 // CHECK-NEXT:   init(double:):
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]
 // CHECK-NEXT:   init(float:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
+// CHECK-NEXT:     NSErrorImports: -[NSErrorImports initWithFloat:error:]
 // CHECK-NEXT:   init(title:delegate:cancelButtonTitle:destructiveButtonTitle:):
 // CHECK-NEXT:     UIActionSheet: -[UIActionSheet initWithTitle:delegate:cancelButtonTitle:destructiveButtonTitle:otherButtonTitles:]
 // CHECK-NEXT:   init(uint8:):
@@ -59,6 +70,10 @@
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithTry:]
 // CHECK-NEXT:   instanceMethodWithX(_:y:z:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:y:z:]
+// CHECK-NEXT:   method():
+// CHECK-NEXT:     NSErrorImports: -[NSErrorImports methodAndReturnError:]
+// CHECK-NEXT:   methodWithFloat(_:):
+// CHECK-NEXT:     NSErrorImports: -[NSErrorImports methodWithFloat:error:]
 // CHECK-NEXT:   protoInstanceMethodWithX(_:y:):
 // CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
 // CHECK-NEXT:   setAccessibilityFloat(_:):

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -5,6 +5,7 @@
 
 // CHECK:      Base -> full name mappings:
 // CHECK-NEXT:   SNCollision --> SNCollision
+// CHECK-NEXT:   SNCollisionProtocol --> SNCollisionProtocol
 // CHECK-NEXT:   SomeClass --> SomeClass
 // CHECK-NEXT:   SomeProtocol --> SomeProtocol
 // CHECK-NEXT:   categoryMethodWithX --> categoryMethodWithX(_:y:), categoryMethodWithX(_:y:z:)
@@ -19,7 +20,9 @@
 
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   SNCollision:
-// CHECK-NEXT:     TU: SNCollision, SNCollision
+// CHECK-NEXT:     TU: SNCollision{{$}}
+// CHECK-NEXT:   SNCollisionProtocol:
+// CHECK-NEXT:     TU: SNCollision{{$}}
 // CHECK-NEXT:   SomeClass:
 // CHECK-NEXT:     TU: SNSomeClass
 // CHECK-NEXT:   SomeProtocol:

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name_objc.h > %t.log 2>&1
 // RUN: FileCheck %s < %t.log
 
+// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name_objc.h -enable-omit-needless-words > %t-omit-needless-words.log 2>&1
+// RUN: FileCheck -check-prefix=CHECK-OMIT-NEEDLESS-WORDS %s < %t-omit-needless-words.log
+
 // REQUIRES: objc_interop
 
 // CHECK:      Base -> full name mappings:
@@ -78,3 +81,10 @@
 // CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
 // CHECK-NEXT:   setAccessibilityFloat(_:):
 // CHECK-NEXT:     NSAccessibility: -[NSAccessibility setAccessibilityFloat:]
+
+// CHECK-OMIT-NEEDLESS-WORDS: Base -> full name mappings:
+// CHECK-OMIT-NEEDLESS-WORDS:   methodWith --> methodWith(_:)
+
+// CHECK-OMIT-NEEDLESS-WORDS: Full name -> entry mappings:
+// CHECK-OMIT-NEEDLESS-WORDS:   methodWith(_:):
+// CHECK-OMIT-NEEDLESS-WORDS:     NSErrorImports: -[NSErrorImports methodWithFloat:error:]

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -7,6 +7,9 @@
 // REQUIRES: objc_interop
 
 // CHECK:      Base -> full name mappings:
+// CHECK-NEXT:   CCItem --> CCItem
+// CHECK-NEXT:   CCItemRef --> CCItemRef
+// CHECK-NEXT:   CFTypeRef --> CFTypeRef
 // CHECK-NEXT:   NSAccessibility --> NSAccessibility
 // CHECK-NEXT:   NSError --> NSError
 // CHECK-NEXT:   NSErrorImports --> NSErrorImports
@@ -15,6 +18,7 @@
 // CHECK-NEXT:   SomeClass --> SomeClass
 // CHECK-NEXT:   SomeProtocol --> SomeProtocol
 // CHECK-NEXT:   UIActionSheet --> UIActionSheet
+// CHECK-NEXT:   __CCItem --> __CCItem
 // CHECK-NEXT:   accessibilityFloat --> accessibilityFloat()
 // CHECK-NEXT:   categoryMethodWithX --> categoryMethodWithX(_:y:), categoryMethodWithX(_:y:z:)
 // CHECK-NEXT:   doubleProperty --> doubleProperty{{$}}
@@ -28,6 +32,12 @@
 // CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
 
 // CHECK:      Full name -> entry mappings:
+// CHECK-NEXT:   CCItem:
+// CHECK-NEXT:     TU: CCItemRef
+// CHECK-NEXT:   CCItemRef:
+// CHECK-NEXT:     TU: CCItemRef
+// CHECK-NEXT:   CFTypeRef:
+// CHECK-NEXT:     TU: CFTypeRef
 // CHECK-NEXT:   NSAccessibility:
 // CHECK-NEXT:     TU: NSAccessibility{{$}}
 // CHECK-NEXT:   NSError:
@@ -44,6 +54,8 @@
 // CHECK-NEXT:     TU: SNSomeProtocol
 // CHECK-NEXT:   UIActionSheet:
 // CHECK-NEXT:     TU: UIActionSheet
+// CHECK-NEXT:   __CCItem:
+// CHECK-NEXT:     TU: __CCItem
 // CHECK-NEXT:   accessibilityFloat():
 // CHECK-NEXT:     NSAccessibility: -[NSAccessibility accessibilityFloat]
 // CHECK-NEXT:   categoryMethodWithX(_:y:):

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name_objc.h > %t.log 2>&1
+// RUN: FileCheck %s < %t.log
+
+// REQUIRES: objc_interop
+
+// CHECK:      Base -> full name mappings:
+// CHECK-NEXT:   SNCollision --> SNCollision
+// CHECK-NEXT:   SomeClass --> SomeClass
+// CHECK-NEXT:   SomeProtocol --> SomeProtocol
+// CHECK-NEXT:   categoryMethodWithX --> categoryMethodWithX(_:y:), categoryMethodWithX(_:y:z:)
+// CHECK-NEXT:   doubleProperty --> doubleProperty, doubleProperty()
+// CHECK-NEXT:   extensionMethodWithX --> extensionMethodWithX(_:y:)
+// CHECK-NEXT:   floatProperty --> floatProperty, floatProperty()
+// CHECK-NEXT:   initWithFloat --> initWithFloat(_:)
+// CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
+// CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
+// CHECK-NEXT:   setDoubleProperty --> setDoubleProperty(_:)
+// CHECK-NEXT:   someClassWithDouble --> someClassWithDouble(_:)
+
+// CHECK:      Full name -> entry mappings:
+// CHECK-NEXT:   SNCollision:
+// CHECK-NEXT:     TU: SNCollision, SNCollision
+// CHECK-NEXT:   SomeClass:
+// CHECK-NEXT:     TU: SNSomeClass
+// CHECK-NEXT:   SomeProtocol:
+// CHECK-NEXT:     TU: SNSomeProtocol
+// CHECK-NEXT:   categoryMethodWithX(_:y:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass categoryMethodWithX:y:]
+// CHECK-NEXT:   categoryMethodWithX(_:y:z:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass categoryMethodWithX:y:z:]
+// CHECK-NEXT:   doubleProperty:
+// CHECK-NEXT:     SNSomeClass: SNSomeClass.doubleProperty
+// CHECK-NEXT:   doubleProperty():
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass doubleProperty]
+// CHECK-NEXT:   extensionMethodWithX(_:y:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
+// CHECK-NEXT:   floatProperty:
+// CHECK-NEXT:     SNSomeClass: SNSomeClass.floatProperty
+// CHECK-NEXT:   floatProperty():
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass floatProperty]
+// CHECK-NEXT:   initWithFloat(_:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
+// CHECK-NEXT:   instanceMethodWithX(_:y:z:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:y:z:]
+// CHECK-NEXT:   protoInstanceMethodWithX(_:y:):
+// CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
+// CHECK-NEXT:   setDoubleProperty(_:):
+// CHECK-NEXT:     SNSomeClass: -[SNSomeClass setDoubleProperty:]
+// CHECK-NEXT:   someClassWithDouble(_:):
+// CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -14,11 +14,10 @@
 // CHECK-NEXT:   doubleProperty --> doubleProperty{{$}}
 // CHECK-NEXT:   extensionMethodWithX --> extensionMethodWithX(_:y:)
 // CHECK-NEXT:   floatProperty --> floatProperty{{$}}
-// CHECK-NEXT:   init --> init(float:), init(withDefault:)
+// CHECK-NEXT:   init --> init(float:), init(withDefault:), init(double:), init(withTry:){{$}}
 // CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
 // CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
 // CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
-// CHECK-NEXT:   someClassWithDouble --> someClassWithDouble(_:)
 
 // CHECK:      Full name -> entry mappings:
 // CHECK-NEXT:   NSAccessibility:
@@ -43,15 +42,17 @@
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass extensionMethodWithX:y:]
 // CHECK-NEXT:   floatProperty:
 // CHECK-NEXT:     SNSomeClass: SNSomeClass.floatProperty
+// CHECK-NEXT:   init(double:):
+// CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]
 // CHECK-NEXT:   init(float:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
 // CHECK-NEXT:   init(withDefault:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithDefault]
+// CHECK-NEXT:   init(withTry:):
+// CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithTry:]
 // CHECK-NEXT:   instanceMethodWithX(_:y:z:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass instanceMethodWithX:y:z:]
 // CHECK-NEXT:   protoInstanceMethodWithX(_:y:):
 // CHECK-NEXT:     SNSomeProtocol: -[SNSomeProtocol protoInstanceMethodWithX:y:]
 // CHECK-NEXT:   setAccessibilityFloat(_:):
 // CHECK-NEXT:     NSAccessibility: -[NSAccessibility setAccessibilityFloat:]
-// CHECK-NEXT:   someClassWithDouble(_:):
-// CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -9,12 +9,13 @@
 // CHECK-NEXT:   SNCollisionProtocol --> SNCollisionProtocol
 // CHECK-NEXT:   SomeClass --> SomeClass
 // CHECK-NEXT:   SomeProtocol --> SomeProtocol
+// CHECK-NEXT:   UIActionSheet --> UIActionSheet
 // CHECK-NEXT:   accessibilityFloat --> accessibilityFloat()
 // CHECK-NEXT:   categoryMethodWithX --> categoryMethodWithX(_:y:), categoryMethodWithX(_:y:z:)
 // CHECK-NEXT:   doubleProperty --> doubleProperty{{$}}
 // CHECK-NEXT:   extensionMethodWithX --> extensionMethodWithX(_:y:)
 // CHECK-NEXT:   floatProperty --> floatProperty{{$}}
-// CHECK-NEXT:   init --> init(float:), init(withDefault:), init(double:), init(withTry:), init(uint8:){{$}}
+// CHECK-NEXT:   init --> init(float:), init(withDefault:), init(double:), init(withTry:), init(uint8:), init(title:delegate:cancelButtonTitle:destructiveButtonTitle:)
 // CHECK-NEXT:   instanceMethodWithX --> instanceMethodWithX(_:y:z:)
 // CHECK-NEXT:   protoInstanceMethodWithX --> protoInstanceMethodWithX(_:y:)
 // CHECK-NEXT:   setAccessibilityFloat --> setAccessibilityFloat(_:)
@@ -30,6 +31,8 @@
 // CHECK-NEXT:     TU: SNSomeClass
 // CHECK-NEXT:   SomeProtocol:
 // CHECK-NEXT:     TU: SNSomeProtocol
+// CHECK-NEXT:   UIActionSheet:
+// CHECK-NEXT:     TU: UIActionSheet
 // CHECK-NEXT:   accessibilityFloat():
 // CHECK-NEXT:     NSAccessibility: -[NSAccessibility accessibilityFloat]
 // CHECK-NEXT:   categoryMethodWithX(_:y:):
@@ -46,6 +49,8 @@
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass someClassWithDouble:]
 // CHECK-NEXT:   init(float:):
 // CHECK-NEXT:     SNSomeClass: -[SNSomeClass initWithFloat:]
+// CHECK-NEXT:   init(title:delegate:cancelButtonTitle:destructiveButtonTitle:):
+// CHECK-NEXT:     UIActionSheet: -[UIActionSheet initWithTitle:delegate:cancelButtonTitle:destructiveButtonTitle:otherButtonTitles:]
 // CHECK-NEXT:   init(uint8:):
 // CHECK-NEXT:     SNSomeClass: +[SNSomeClass buildWithUnsignedChar:]
 // CHECK-NEXT:   init(withDefault:):

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -69,6 +69,7 @@ enum class ActionType {
   CodeCompletion,
   REPLCodeCompletion,
   DumpCompletionCache,
+  DumpImporterLookupTable,
   SyntaxColoring,
   DumpAPI,
   DumpComments,
@@ -144,6 +145,8 @@ Action(llvm::cl::desc("Mode:"), llvm::cl::init(ActionType::None),
                       "repl-code-completion", "Perform REPL-style code completion"),
            clEnumValN(ActionType::DumpCompletionCache,
                       "dump-completion-cache", "Dump a code completion cache file"),
+           clEnumValN(ActionType::DumpImporterLookupTable,
+                      "dump-importer-lookup-table", "Dump the Clang importer's lookup tables"),
            clEnumValN(ActionType::SyntaxColoring,
                       "syntax-coloring", "Perform syntax coloring"),
            clEnumValN(ActionType::DumpAPI,
@@ -277,6 +280,12 @@ static llvm::cl::opt<bool>
 InferDefaultArguments(
   "enable-infer-default-arguments",
   llvm::cl::desc("Infer default arguments for imported parameters"),
+  llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
+UseSwiftLookupTables(
+  "enable-swift-name-lookup-tables",
+  llvm::cl::desc("Use Swift-specific name lookup tables in the importer"),
   llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
@@ -938,6 +947,38 @@ static int doDumpAPI(const CompilerInvocation &InitInvok,
 
   // Write the edited buffer to stdout
   RewriteBuf.write(llvm::outs());
+
+  return 0;
+}
+
+static int doDumpImporterLookupTables(const CompilerInvocation &InitInvok,
+                                      StringRef SourceFilename) {
+  auto &FEOpts = InitInvok.getFrontendOptions();
+  if (options::ImportObjCHeader.empty()) {
+    llvm::errs() << "implicit header required\n";
+    llvm::cl::PrintHelpMessage();
+    return 1;
+  }
+
+  CompilerInvocation Invocation(InitInvok);
+  Invocation.addInputFilename(SourceFilename);
+
+  // We must use the Swift lookup tables.
+  Invocation.getClangImporterOptions().UseSwiftLookupTables = true;
+
+  CompilerInstance CI;
+
+  // Display diagnostics to stderr.
+  PrintingDiagnosticConsumer PrintDiags;
+  CI.addDiagnosticConsumer(&PrintDiags);
+  if (CI.setup(Invocation))
+    return 1;
+  CI.performSema();
+
+  auto &Context = CI.getASTContext();
+  auto &Importer = static_cast<ClangImporter &>(
+                     *Context.getClangModuleLoader());
+  Importer.dumpSwiftLookupTables();
 
   return 0;
 }
@@ -2515,6 +2556,8 @@ int main(int argc, char *argv[]) {
     options::OmitNeedlessWords;
   InitInvok.getClangImporterOptions().InferDefaultArguments |=
     options::InferDefaultArguments;
+  InitInvok.getClangImporterOptions().UseSwiftLookupTables |=
+    options::UseSwiftLookupTables;
 
   if (!options::ResourceDir.empty()) {
     InitInvok.setRuntimeResourcePath(options::ResourceDir);
@@ -2616,6 +2659,10 @@ int main(int argc, char *argv[]) {
 
   case ActionType::DumpAPI:
     ExitCode = doDumpAPI(InitInvok, options::SourceFilename);
+    break;
+
+  case ActionType::DumpImporterLookupTable:
+    ExitCode = doDumpImporterLookupTables(InitInvok, options::SourceFilename);
     break;
 
   case ActionType::Structure:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -953,7 +953,6 @@ static int doDumpAPI(const CompilerInvocation &InitInvok,
 
 static int doDumpImporterLookupTables(const CompilerInvocation &InitInvok,
                                       StringRef SourceFilename) {
-  auto &FEOpts = InitInvok.getFrontendOptions();
   if (options::ImportObjCHeader.empty()) {
     llvm::errs() << "implicit header required\n";
     llvm::cl::PrintHelpMessage();


### PR DESCRIPTION
The Clang importer performs a number of translations from the names of (Objective-)C APIs into their Swift counterparts, but the logic was scattered across various places---Objective-C mapping in one place, factory methods being imported as initializers in another, enums in a third place, CF types elsewhere. Refactor and centralize the logic that performs name mapping into a single function, ClangImporter::Implementation::importFullName. This part is almost entirely NFC, which I've verified by comparing the imported APIs for all of Cocoa[Touch] before/after. The only difference is that we stop generating a handful of weird typealiases when dealing with typedefs of CF types, e.g.,

```
-typealias ODPolicyType = ODPolicyType
+typealias ODPolicyType = CFStringRef
```

Also, optionally start building a table that maps from the Swift names of entities back to the (Objective-)C entities that generate those names, using the new importFullName(). Do this as a result of parsing the (Objective-)C, without importing anything. At present, this is being used as a debugging aid for the refactoring in this pull request. In the future, we'll continue building out this table so we can start using it for name lookup rather than falling back to Clang's name lookup.
