### PR TITLE
Consistently use env(1) to resolve bash and python paths

### DIFF
--- a/test/1_stdlib/timeout.sh
+++ b/test/1_stdlib/timeout.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # timeout.sh <seconds> <command...>
 

--- a/utils/benchmark/build.sh
+++ b/utils/benchmark/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -n "$LLVM_DIR" ]]; then
     BUILD_DIR="$LLVM_DIR/build"

--- a/utils/build-script
+++ b/utils/build-script
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #===--- build-script - The ultimate tool for building Swift ----------------===#
 #
 ## This source file is part of the Swift.org open source project

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #===--- build-script-impl - Implementation details of build-script ---------===#
 #
 ## This source file is part of the Swift.org open source project

--- a/utils/darwin-installer-scripts/postinstall
+++ b/utils/darwin-installer-scripts/postinstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #===--- postinstall - Creates symlink after installing xctoolchain ----------===#
 #
 ## This source file is part of the Swift.org open source project

--- a/utils/omit-needless-words.py
+++ b/utils/omit-needless-words.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This tool helps assess the impact of automatically applying
 # heuristics that omit 'needless' words from APIs imported from Clang

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import re
 

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse
 import os.path

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # A small utility to take the output of a Swift validation test run
 # where some compiler crashers have been fixed, and move them into the

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #===------------------------------------------------------------------------===#
 #
 # This source file is part of the Swift.org open source project

--- a/utils/swift-stdlib-tool-substitute
+++ b/utils/swift-stdlib-tool-substitute
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #===--- swift-stdlib-tool - stand-in for the real swift-stdlib-tool --------===#
 #

--- a/utils/toolchain-codesign
+++ b/utils/toolchain-codesign
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #===--- toolchain-codesign - Creates code signed xctoolchain ---------------===#
 #
 ## This source file is part of the Swift.org open source project

--- a/utils/toolchain-installer
+++ b/utils/toolchain-installer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #===--- toolchain-installer - Creates installer pkg for OS X ---------------===#
 #
 ## This source file is part of the Swift.org open source project

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #===--- update-checkout - Utility to update your local checkouts -----------===#
 #
 # This source file is part of the Swift.org open source project

--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 process_count=17
 process_id_max=$(($process_count - 1))


### PR DESCRIPTION
The paths of bash and python in hashbangs sometimes use e.g. `#!/usr/bin/env python`, but sometimes hardcode to e.g. `/usr/bin/python`.  This PR consolidates all hashbangs to use env, which is important on operating systems such as FreeBSD where python and bash are more likely to be in `/usr/local/`.
