### PR TITLE
Provide clarity around the dependencies of running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ A basic command to build Swift and run basic tests with Ninja:
 
     utils/build-script -t
 
+Note: To build and run the tests for the swift project, you'll need the
+swift-clang, swift-llvm and swift-cmark projects cloned from GitHub.
+
 ## Develop Swift in Xcode
 
 The Xcode IDE can be used to edit the Swift source code, but it is not currently


### PR DESCRIPTION
This makes it clear to people getting started what projects they need cloned as well as swift in order to build and run the tests.

I've determined this using OSX though haven't determined if the dependencies are the same on Linux. Is anyone able to clarify whether the swift-corelibs-xctest and swift-corelibs-foundation libraries are required in that situation? 
