### PR TITLE
Fix grammar in Shims.swift: "value that is be used" -> "value to be used"

### DIFF
--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -25,7 +25,7 @@ internal func _makeSwiftNSFastEnumerationState()
     extra: (0, 0, 0, 0, 0))
 }
 
-/// A dummy value that is be used as the target for `mutationsPtr` in fast
+/// A dummy value to be used as the target for `mutationsPtr` in fast
 /// enumeration implementations.
 var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 


### PR DESCRIPTION
Typo fix
