### PR TITLE
Update License to include copyright information and remove instructions on how to apply the license that are not meant for production

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -175,18 +175,7 @@
 
     END OF TERMS AND CONDITIONS
 
-    APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2015 Apple Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
The license now includes the proper year of copyright (2015) as well as the name of the company (Apple Inc.) in their proper position in the license. It also removes the information that tells you how to use the license, as that information is not to be used in a final license release.
