### PR TITLE
Fix code block formatting in OptimizationTips.rst

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -557,6 +557,7 @@ If it makes sense to limit the adoption of protocols to classes then mark
 protocols as class-only protocols to get better runtime performance.
 
 ::
+
   protocol Pingable : class { func ping() -> Int }
 
 .. https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Protocols.html


### PR DESCRIPTION
The code would not originally display as code, but rather as normal text with "::" above it. This change allows the code to appear in a code block, as all the other code does in the file.
