### PR TITLE
[stdlib] Make comparison operator choices consistent

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -92,7 +92,7 @@ public func max<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
     r = z
   }
   for t in rest {
-    if t >= r {
+    if r < t {
       r = t
     }
   }


### PR DESCRIPTION
Since all other comparisons in the `min` and `max` functions use the less-than operator, this line should use the same operator as well.
