### PR TITLE
Diagnose Circular Typealiases in Protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -577,7 +577,7 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether or not this declaration is currently being type-checked.
     unsigned BeingTypeChecked : 1;
   };
-  enum { NumAssociatedTypeDeclBits = NumTypeDeclBits + 1 };
+  enum { NumAssociatedTypeDeclBits = NumTypeDeclBits + 2 };
   static_assert(NumAssociatedTypeDeclBits <= 32, "fits in an unsigned");
 
   class ImportDeclBitfields {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -573,6 +573,9 @@ class alignas(1 << DeclAlignInBits) Decl {
     unsigned : NumTypeDeclBits;
 
     unsigned Recursive : 1;
+
+    /// Whether or not this declaration is currently being type-checked.
+    unsigned BeingTypeChecked : 1;
   };
   enum { NumAssociatedTypeDeclBits = NumTypeDeclBits + 1 };
   static_assert(NumAssociatedTypeDeclBits <= 32, "fits in an unsigned");
@@ -2604,6 +2607,14 @@ public:
 
   void setIsRecursive() { AssociatedTypeDeclBits.Recursive = true; }
   bool isRecursive() { return AssociatedTypeDeclBits.Recursive; }
+
+  /// Whether the declaration is currently being validated.
+  bool isBeingTypeChecked() { return AssociatedTypeDeclBits.BeingTypeChecked; }
+
+  /// Toggle whether or not the declaration is being validated.
+  void setIsBeingTypeChecked(bool ibt = true) {
+    AssociatedTypeDeclBits.BeingTypeChecked = ibt;
+  }
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::AssociatedType;

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -16,3 +16,7 @@ public struct S<A: P where A.T == S<A>> {}
 class X<T where T == X> { // expected-error{{same-type requirement makes generic parameter 'T' non-generic}}
     var type: T { return self.dynamicType } // expected-error{{use of undeclared type 'T'}}
 }
+
+protocol Y {
+  typealias Z = Z // expected-error{{type alias 'Z' circularly references itself}}
+}


### PR DESCRIPTION
Fixes a longstanding issue where declarations of the form

``` swift
protocol Foo {
    typealias X = X
}
```

would accidentally crash the compiler by sending the AST visitor into a loop with the typechecker.

The error `type alias 'X' circularly references itself` is now emitted at the declaration site.
