### PR TITLE
Remove needless equal symbol in `max` func

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -92,7 +92,7 @@ public func max<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
     r = z
   }
   for t in rest {
-    if t >= r {
+    if t > r {
       r = t
     }
   }


### PR DESCRIPTION
I think that this equal symbol is not necessary like `min` func.
