### PR TITLE
Replace let/nil-check patterns with `guard let`

### DIFF
--- a/lib/Markup/Markup.cpp
+++ b/lib/Markup/Markup.cpp
@@ -16,7 +16,6 @@
 #include "swift/Markup/LineList.h"
 #include "swift/Markup/Markup.h"
 #include "cmark.h"
-#include "node.h"
 
 using namespace llvm;
 using namespace markup;
@@ -60,15 +59,7 @@ StringRef getLiteralContent(MarkupContext &MC, LineList &LL, cmark_node *Node) {
   // its parent.
   auto Literal = cmark_node_get_literal(Node);
   assert(Literal != nullptr);
-  size_t Length = 0;
-  switch (cmark_node_get_type(Node)) {
-  case CMARK_NODE_CODE_BLOCK:
-    Length = Node->as.code.literal.len;
-    break;
-  default:
-    Length = Node->as.literal.len;
-  }
-  return MC.allocateCopy(StringRef(Literal, Length));
+  return MC.allocateCopy(StringRef(Literal));
 }
 
 ParseResult<MarkupASTNode>

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -247,29 +247,26 @@ extension _ArrayBuffer {
       // Look for contiguous storage in the NSArray
       let nonNative = self._nonNative
       let cocoa = _CocoaArrayWrapper(nonNative)
-      let cocoaStorageBaseAddress = cocoa.contiguousStorage(self.indices)
+      guard let cocoaStorageBaseAddress = cocoa.contiguousStorage(self.indices) else {
+        // No contiguous storage found; we must allocate
+        let subRangeCount = subRange.count
+        let result = _ContiguousArrayBuffer<Element>(
+          count: subRangeCount, minimumCapacity: 0)
 
-      if cocoaStorageBaseAddress != nil {
-        return _SliceBuffer(
-          owner: nonNative,
-          subscriptBaseAddress: UnsafeMutablePointer(cocoaStorageBaseAddress),
-          indices: subRange,
-          hasNativeBuffer: false)
+        // Tell Cocoa to copy the objects into our storage
+        cocoa.buffer.getObjects(
+          UnsafeMutablePointer(result.firstElementAddress),
+          range: _SwiftNSRange(
+            location: subRange.startIndex,
+            length: subRangeCount))
+
+        return _SliceBuffer(result, shiftedToStartIndex: subRange.startIndex)
       }
-
-      // No contiguous storage found; we must allocate
-      let subRangeCount = subRange.count
-      let result = _ContiguousArrayBuffer<Element>(
-        count: subRangeCount, minimumCapacity: 0)
-
-      // Tell Cocoa to copy the objects into our storage
-      cocoa.buffer.getObjects(
-        UnsafeMutablePointer(result.firstElementAddress),
-        range: _SwiftNSRange(
-          location: subRange.startIndex,
-          length: subRangeCount))
-
-      return _SliceBuffer(result, shiftedToStartIndex: subRange.startIndex)
+      return _SliceBuffer(
+        owner: nonNative,
+        subscriptBaseAddress: UnsafeMutablePointer(cocoaStorageBaseAddress),
+        indices: subRange,
+        hasNativeBuffer: false)
     }
     set {
       fatalError("not implemented")

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -584,17 +584,18 @@ extension SequenceType
   // A fast implementation for when you are backed by a contiguous array.
   public func _initializeTo(ptr: UnsafeMutablePointer<Generator.Element>)
     -> UnsafeMutablePointer<Generator.Element> {
-    guard let s = self._baseAddressIfContiguous else {
-      var p = ptr
-      for x in self {
-        p++.initialize(x)
+      if let s = self._baseAddressIfContiguous {
+        let count = self.count
+        ptr.initializeFrom(s, count: count)
+        _fixLifetime(self._owner)
+        return ptr + count
+      } else {
+        var p = ptr
+        for x in self {
+          p++.initialize(x)
+        }
+        return p
       }
-      return p
-    }
-    let count = self.count
-    ptr.initializeFrom(s, count: count)
-    _fixLifetime(self._owner)
-    return ptr + count
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -584,19 +584,17 @@ extension SequenceType
   // A fast implementation for when you are backed by a contiguous array.
   public func _initializeTo(ptr: UnsafeMutablePointer<Generator.Element>)
     -> UnsafeMutablePointer<Generator.Element> {
-    let s = self._baseAddressIfContiguous
-    if s != nil {
-      let count = self.count
-      ptr.initializeFrom(s, count: count)
-      _fixLifetime(self._owner)
-      return ptr + count
-    } else {
+    guard let s = self._baseAddressIfContiguous else {
       var p = ptr
       for x in self {
         p++.initialize(x)
       }
       return p
     }
+    let count = self.count
+    ptr.initializeFrom(s, count: count)
+    _fixLifetime(self._owner)
+    return ptr + count
   }
 }
 

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -26,11 +26,10 @@ public struct LazyMapGenerator<
   ///   since the copy was made, and no preceding call to `self.next()`
   ///   has returned `nil`.
   public mutating func next() -> Element? {
-    let x = _base.next()
-    if x != nil {
-      return _transform(x!)
+    guard let x = _base.next() else {
+          return nil
     }
-    return nil
+    return _transform(x)
   }
 
   public var base: Base { return _base }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -83,6 +83,30 @@ func _typeName(type: Any.Type, qualified: Bool = true) -> String {
     input: UnsafeBufferPointer(start: stringPtr, count: count))
 }
 
+@warn_unused_result
+@_silgen_name("swift_stdlib_demangleName")
+func _stdlib_demangleNameImpl(
+  mangledName: UnsafePointer<UInt8>,
+  _ mangledNameLength: UInt,
+  _ demangledName: UnsafeMutablePointer<String>)
+
+// NB: This function is not used directly in the Swift codebase, but is
+// exported for Xcode support. Please coordinate before changing.
+@warn_unused_result
+public // @testable
+func _stdlib_demangleName(mangledName: String) -> String {
+  let mangledNameUTF8 = Array(mangledName.utf8)
+  return mangledNameUTF8.withUnsafeBufferPointer {
+    (mangledNameUTF8) in
+    let (_, demangledName) = _withUninitializedString {
+      _stdlib_demangleNameImpl(
+        mangledNameUTF8.baseAddress, UInt(mangledNameUTF8.endIndex),
+        $0)
+    }
+    return demangledName
+  }
+}
+
 /// Returns `floor(log(x))`.  This equals to the position of the most
 /// significant non-zero bit, or 63 - number-of-zeros before it.
 ///

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -247,12 +247,11 @@ public // @testable
 func _stdlib_atomicLoadARCRef(
   object target: UnsafeMutablePointer<AnyObject?>
 ) -> AnyObject? {
-  let result = _swift_stdlib_atomicLoadPtrImpl(
-    object: UnsafeMutablePointer(target))
-  if result != nil {
-    return Unmanaged<AnyObject>.fromOpaque(result).takeUnretainedValue()
+  guard let result = _swift_stdlib_atomicLoadPtrImpl(
+    object: UnsafeMutablePointer(target)) {
+    return nil
   }
-  return nil
+  return Unmanaged<AnyObject>.fromOpaque(result).takeUnretainedValue()
 }
 
 % for operation in [ 'Add', 'And', 'Or', 'Xor' ]:

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -1264,3 +1264,17 @@ MirrorReturn swift::swift_reflectAny(OpaqueValue *value, const Metadata *T) {
     T->vw_destroy(value);
   return MirrorReturn(result);
 }
+
+// NB: This function is not used directly in the Swift codebase, but is
+// exported for Xcode support. Please coordinate before changing.
+extern "C" void swift_stdlib_demangleName(const char *mangledName,
+                                          size_t mangledNameLength,
+                                          String *demangledName) {
+  auto options = Demangle::DemangleOptions();
+  options.DisplayDebuggerGeneratedModule = false;
+  auto result =
+      Demangle::demangleSymbolAsString(mangledName,
+                                       mangledNameLength,
+                                       options);
+  new (demangledName) String(result.data(), result.size());
+}

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -665,6 +665,16 @@ Runtime.test("typeName") {
   expectEqual("protocol<>.Protocol", _typeName(a.dynamicType))
 }
 
+Runtime.test("demangleName") {
+  expectEqual("", _stdlib_demangleName(""))
+  expectEqual("abc", _stdlib_demangleName("abc"))
+  expectEqual("\0", _stdlib_demangleName("\0"))
+  expectEqual("Swift.Double", _stdlib_demangleName("_TtSd"))
+  expectEqual("x.a : x.Foo<x.Foo<x.Foo<Swift.Int, Swift.Int>, x.Foo<Swift.Int, Swift.Int>>, x.Foo<x.Foo<Swift.Int, Swift.Int>, x.Foo<Swift.Int, Swift.Int>>>",
+      _stdlib_demangleName("_Tv1x1aGCS_3FooGS0_GS0_SiSi_GS0_SiSi__GS0_GS0_SiSi_GS0_SiSi___"))
+  expectEqual("Foobar", _stdlib_demangleName("_TtC13__lldb_expr_46Foobar"))
+}
+
 Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
   typealias IntPtr = UnsafeMutablePointer<Int>
   var origP1 = IntPtr(bitPattern: 0x10101010)

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -1,4 +1,5 @@
 // FIXME: This is failing on some of Apple's internal CI.
+// FIXME: <rdar://problem/23771412> Fix test/Driver/{environment.swift,options-interpreter.swift}
 // REQUIRES: disabled
 
 // RUN: %swift_driver -target x86_64-apple-macosx10.9 -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s DYLD_LIBRARY_PATH | FileCheck %s

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -1,4 +1,5 @@
 // FIXME: This is failing on some of Apple's internal CI.
+// FIXME: <rdar://problem/23771412> Fix test/Driver/{environment.swift,options-interpreter.swift}
 // REQUIRES: disabled
 
 // RUN: not %swift_driver -deprecated-integrated-repl -emit-module 2>&1 | FileCheck -check-prefix=IMMEDIATE_NO_MODULE %s


### PR DESCRIPTION
The let/nil-check pattern is more expensive and less elegant than
`guard let`.
- The elegance goes without reasoning.
- I confirmed, after some experiments with the Swift complier, that it `guard let` is also less expensive. 

The change on  `LazyMapGenerator` should increase performance negligibly of `map()`.
