### PR TITLE
Fix crash when considering invalid binary operator function for resolution <rdar://23719809&23720006>

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -752,7 +752,10 @@ namespace {
       }
       
       Type paramTy = fnTy->getInput();
-      auto paramTupleTy = paramTy->castTo<TupleType>();
+      auto paramTupleTy = paramTy->getAs<TupleType>();
+      if (!paramTupleTy || paramTupleTy->getNumElements() != 2)
+        return false;
+      
       auto firstParamTy = paramTupleTy->getElement(0).getType();
       auto secondParamTy = paramTupleTy->getElement(1).getType();
       

--- a/validation-test/compiler_crashers_2_fixed/0036-rdar23719809.swift
+++ b/validation-test/compiler_crashers_2_fixed/0036-rdar23719809.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend %s -parse
+
+// rdar://problem/23719809&23720006
+
+func ~=() {}
+func ~=(_: Int) {}
+func ~=(_: () -> ()) {}
+
+switch 0 {
+case 0:
+    break
+}


### PR DESCRIPTION
This fixes compiler crashes resulting from an invalid FuncDecl which is later considered while resolving a binary application. &lt;rdar://23719809&23720006>

Examples:
- `func ~=(){}` (empty tuple)
- `func ~=(_:Int){}` (one argument which cannot be cast to a tuple)

These are considered when type-checking something like `switch 0 { case 0: ... }`.

Some questions I had while poking around to figure out this patch:
- I've already submitted test cases at practicalswift/swift-compiler-crashes#98, so presumably, they will eventually be pulled into `validation-test`. Should I still add a test in `test/decl/operators.swift`, or perhaps somewhere under `test/Sema`?
- Should `DeclChecker::bindFuncDeclToOperator` have called `FD->setInvalid(true)` when it emits error diagnostics for the function definitions, which happens earlier, to avoid getting this far into operator resolution with a bad operator function? I'm not familiar enough with the code to understand who's expected to call `setInvalid`, and who's expected to check `isInvalid`.
- As of f00e5bc6, `FuncDecl::isBinaryOperator()` returns true if the argument tuple has 1 element with an ellipsis. I'm concerned that `favorMatchingBinaryOperators` (the function being modified here) doesn't support this case properly. Should it?
