### PR TITLE
Remove trailing semicolons from files in stdlib

### DIFF
--- a/stdlib/public/SDK/AppKit/NSError.swift
+++ b/stdlib/public/SDK/AppKit/NSError.swift
@@ -28,14 +28,14 @@ public extension NSCocoaError {
   }
 
   public var isServiceError: Bool {
-    return rawValue >= 66560 && rawValue <= 66817;
+    return rawValue >= 66560 && rawValue <= 66817
   }
 
   public var isSharingServiceError: Bool {
-    return rawValue >= 67072 && rawValue <= 67327;
+    return rawValue >= 67072 && rawValue <= 67327
   }
 
   public var isTextReadWriteError: Bool {
-    return rawValue >= 65792 && rawValue <= 66303;
+    return rawValue >= 65792 && rawValue <= 66303
   }
 }

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -67,7 +67,7 @@ public var DISPATCH_QUEUE_PRIORITY_BACKGROUND: dispatch_queue_priority_t {
 @warn_unused_result
 public func dispatch_get_global_queue(identifier: qos_class_t,
                                       _ flags: UInt) -> dispatch_queue_t {
-  return dispatch_get_global_queue(Int(identifier.rawValue), flags);
+  return dispatch_get_global_queue(Int(identifier.rawValue), flags)
 }
 
 public var DISPATCH_QUEUE_CONCURRENT : dispatch_queue_attr_t {

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -363,44 +363,44 @@ public extension NSCocoaError {
 
   @available(OSX, introduced=10.11) @available(iOS, introduced=9.0)
   public var isCoderError: Bool {
-    return rawValue >= 4864 && rawValue <= 4991;
+    return rawValue >= 4864 && rawValue <= 4991
   }
 
   @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
   public var isExecutableError: Bool {
-    return rawValue >= 3584 && rawValue <= 3839;
+    return rawValue >= 3584 && rawValue <= 3839
   }
 
   public var isFileError: Bool {
-    return rawValue >= 0 && rawValue <= 1023;
+    return rawValue >= 0 && rawValue <= 1023
   }
 
   public var isFormattingError: Bool {
-    return rawValue >= 2048 && rawValue <= 2559;
+    return rawValue >= 2048 && rawValue <= 2559
   }
 
   @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
   public var isPropertyListError: Bool {
-    return rawValue >= 3840 && rawValue <= 4095;
+    return rawValue >= 3840 && rawValue <= 4095
   }
 
   @available(OSX, introduced=10.9) @available(iOS, introduced=7.0)
   public var isUbiquitousFileError: Bool {
-    return rawValue >= 4352 && rawValue <= 4607;
+    return rawValue >= 4352 && rawValue <= 4607
   }
 
   @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
   public var isUserActivityError: Bool {
-    return rawValue >= 4608 && rawValue <= 4863;
+    return rawValue >= 4608 && rawValue <= 4863
   }
 
   public var isValidationError: Bool {
-    return rawValue >= 1024 && rawValue <= 2047;
+    return rawValue >= 1024 && rawValue <= 2047
   }
 
   @available(OSX, introduced=10.8) @available(iOS, introduced=6.0)
   public var isXPCConnectionError: Bool {
-    return rawValue >= 4096 && rawValue <= 4224;
+    return rawValue >= 4096 && rawValue <= 4224
   }
 }
 

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -153,7 +153,7 @@ public func XCTAssertNotNil(@autoclosure expression: () -> Any?, _ message: Stri
 
 public func XCTAssert( @autoclosure expression: () -> BooleanType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__)  -> Void {
   // XCTAssert is just a cover for XCTAssertTrue.
-  XCTAssertTrue(expression, message, file: file, line: line);
+  XCTAssertTrue(expression, message, file: file, line: line)
 }
 
 public func XCTAssertTrue(@autoclosure expression: () -> BooleanType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> Void {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -615,7 +615,7 @@ internal func _copyCollectionToNativeArrayBuffer<
     (p++).initialize(source[i++])
   }
   _expectEnd(i, source)
-  return result;
+  return result
 }
 
 /// A "builder" interface for initializing array buffers.


### PR DESCRIPTION
This commit removes trailing semicolons from files in stdlib 
