### PR TITLE
Make c++ defer looks like a swift one

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3643,7 +3643,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
 
   // No matter what error path we take, make sure the
   // PatternBindingDecl/TopLevel code block are added.
-  defer([&]{
+  defer {
     // If we didn't parse any patterns, don't create the pattern binding decl.
     if (PBDEntries.empty())
       return;
@@ -3683,7 +3683,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
     // specific spot to get it in before any accessors, which SILGen seems to
     // want.
     Decls.insert(Decls.begin()+NumDeclsInResult, PBD);
-  });
+  };
 
   do {
     Pattern *pattern;

--- a/lib/Sema/IterativeTypeChecker.cpp
+++ b/lib/Sema/IterativeTypeChecker.cpp
@@ -84,7 +84,7 @@ void IterativeTypeChecker::satisfy(TypeCheckRequest request) {
 
   // Add this request to the stack of active requests.
   ActiveRequests.push_back(request);
-  defer([&] { ActiveRequests.pop_back(); });
+  defer { ActiveRequests.pop_back(); };
 
   while (true) {
     // Process this requirement, enumerating dependencies if anything else needs

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -356,7 +356,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     {
       bool iBTC = decl->isBeingTypeChecked();
       decl->setIsBeingTypeChecked();
-      defer([&]{decl->setIsBeingTypeChecked(iBTC); });
+      defer {decl->setIsBeingTypeChecked(iBTC); };
 
       // Validate the type.
       if (validateType(inherited, DC, options, resolver)) {
@@ -1219,9 +1219,9 @@ static void validatePatternBindingDecl(TypeChecker &tc,
 
   // On any path out of this function, make sure to mark the binding as done
   // being type checked.
-  defer([&]{
+  defer {
     binding->setIsBeingTypeChecked(false);
-  });
+  };
 
   // Resolve the pattern.
   auto *pattern = tc.resolvePattern(binding->getPattern(entryNumber),
@@ -6239,7 +6239,7 @@ static Type checkExtensionGenericParams(
   };
 
   ext->setIsBeingTypeChecked(true);
-  defer([ext] { ext->setIsBeingTypeChecked(false); });
+  defer { ext->setIsBeingTypeChecked(false); };
 
   // Validate the generic type signature.
   bool invalid = false;

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -890,7 +890,7 @@ namespace {
           }
           // Recursively check the transitive captures.
           capturePath.push_back(func);
-          defer([&]{ capturePath.pop_back(); });
+          defer { capturePath.pop_back(); };
           for (auto capture : func->getCaptureInfo().getCaptures())
             if (!validateForwardCapture(capture.getDecl()))
               return false;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2922,9 +2922,9 @@ void ConformanceChecker::resolveTypeWitnesses() {
   // Track when we are checking type witnesses.
   ProtocolConformanceState initialState = Conformance->getState();
   Conformance->setState(ProtocolConformanceState::CheckingTypeWitnesses);
-  defer([&] {
+  defer {
     Conformance->setState(initialState);
-  });
+  };
 
   for (auto member : Proto->getMembers()) {
     auto assocType = dyn_cast<AssociatedTypeDecl>(member);
@@ -3251,11 +3251,11 @@ void ConformanceChecker::resolveTypeWitnesses() {
       valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
       if (witnessReq.Witness->getDeclContext()->isProtocolExtensionContext())
         ++numValueWitnessesInProtocolExtensions;
-      defer([&]{
+      defer {
         if (witnessReq.Witness->getDeclContext()->isProtocolExtensionContext())
           --numValueWitnessesInProtocolExtensions;
         valueWitnesses.pop_back();
-      });
+      };
 
       // Introduce each of the type witnesses into the hash table.
       bool failed = false;
@@ -3635,7 +3635,7 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
   // Note that we're resolving this witness.
   assert(ResolvingWitnesses.count(requirement) == 0 && "Currently resolving");
   ResolvingWitnesses.insert(requirement);
-  defer([&]{ ResolvingWitnesses.erase(requirement); });
+  defer { ResolvingWitnesses.erase(requirement); };
 
   // Make sure we've validated the requirement.
   if (!requirement->hasType())
@@ -3934,7 +3934,7 @@ checkConformsToProtocol(TypeChecker &TC,
 
   // Note that we are checking this conformance now.
   conformance->setState(ProtocolConformanceState::Checking);
-  defer([&] { conformance->setState(ProtocolConformanceState::Complete); });
+  defer { conformance->setState(ProtocolConformanceState::Complete); };
 
   // If the protocol requires a class, non-classes are a non-starter.
   if (Proto->requiresClass() && !canT->getClassOrBoundGenericClass()) {


### PR DESCRIPTION
This code uses some c++ trickery to make defer macro looks almost like defer keyword in swift.

Instad of:

```
defer([&]() {
  /* cleanup code */
});
```

coders can now drop some boilerplate and do this:

```
defer {
  /* cleanup code */
};
```

But this changes capture list to all values by reference
