### PR TITLE
Fixed typo : failable -> fallible

### DIFF
--- a/docs/ErrorHandling.rst
+++ b/docs/ErrorHandling.rst
@@ -570,11 +570,11 @@ the NSError back like they do today, and have to throw the result
 manually.
 
 For initializers, importing an initializer as throwing takes
-precedence over importing it as failable.  That is, an imported
+precedence over importing it as fallible.  That is, an imported
 initializer with a nullable result and an error parameter would be
 imported as throwing.  Throwing initializers have very similar
-constraints to failable initializers; in a way, it's just a new axis
-of failability.
+constraints to fallible initializers; in a way, it's just a new axis
+of fallibility.
 
 One limitation of this approach is that we need to be able to reconstruct
 the selector to use when an overload of a method is introduced.  For this


### PR DESCRIPTION
the word "failable" doesn't exist.
Its a common spelling error.

fallible

adjective
1. (of persons) liable to err, especially in being deceived or mistaken.
2. liable to be erroneous or false; not accurate:
ex) fallible information.

from 
http://dictionary.reference.com/browse/fallible
