### PR TITLE
Add link to swift.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Welcome to Swift!**
 
-Swift is a high-performance system programming language.  It has a clean
+[Swift](https://swift.org/) is a high-performance system programming language.  It has a clean
 and modern syntax, and offers seamless access to existing C and Objective-C code
 and frameworks, and is memory safe (by default).
 
@@ -162,7 +162,7 @@ See [docs/Testing.rst](docs/Testing.rst).
 
 Contributions to Swift are welcomed and encouraged! Please see the [Contributing to Swift guide](https://swift.org/contributing/).
 
-To be a truly great community, Swift.org needs to welcome developers from all
+To be a truly great community, [Swift.org](https://swift.org/) needs to welcome developers from all
 walks of life, with different backgrounds, and with a wide range of experience.
 A diverse and friendly community will have more great ideas, more unique
 perspectives, and produce more great code. We will work diligently to make the


### PR DESCRIPTION
Added a link in the README that points to https://swift.org/, the official website of the project.

I also suggest that the owner of the repository add a link to https://swift.org/ next to the description at the top of the page, where GitHub allows the owner to provide a project website.
