### PR TITLE
Use Optional's built-in map

### DIFF
--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -26,11 +26,7 @@ public struct LazyMapGenerator<
   ///   since the copy was made, and no preceding call to `self.next()`
   ///   has returned `nil`.
   public mutating func next() -> Element? {
-    let x = _base.next()
-    if x != nil {
-      return _transform(x!)
-    }
-    return nil
+    return _base.next().map(_transform)
   }
 
   public var base: Base { return _base }


### PR DESCRIPTION
I was reading through the source and saw this usage of force-casting an optional. I think the code reads cleaner using the built-in `map` on Optional. I can also imagine an `if let` would be a good alternative, in case using the built-in `map` has a performance overhead (not sure if this is the case for generic/rethrows functions, or if that gets compiled away).
