### PR TITLE
Grammatical Fix in Introduction of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Welcome to Swift!**
 
 Swift is a high-performance system programming language.  It has a clean
-and modern syntax, and offers seamless access to existing C and Objective-C code
+and modern syntax, offers seamless access to existing C and Objective-C code
 and frameworks, and is memory safe (by default).
 
 Although inspired by Objective-C and many other languages, Swift is not itself a


### PR DESCRIPTION
There is no need for the first "and" because it is a list of 3 items. This change improves the readability of the introduction.
