### PR TITLE
[IRGen] Add assertion to `emitPHINodesForBBArgs`

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -828,9 +828,7 @@ emitPHINodesForBBArgs(IRGenSILFunction &IGF,
     if (!silBB->empty()) {
       SILInstruction &I = *silBB->begin();
       auto DS = I.getDebugScope();
-      // FIXME: This should be an assertion.
-      if (!DS || (DS->SILFn != IGF.CurSILFn && !DS->InlinedCallSite))
-        DS = IGF.CurSILFn->getDebugScope();
+      assert(DS && (DS->SILFn == IGF.CurSILFn || DS->InlinedCallSite));
       IGF.IGM.DebugInfo->setCurrentLoc(IGF.Builder, DS, I.getLoc());
     }
   }


### PR DESCRIPTION
Converted the check that the DebugScope `DS` exists and that the
DebugScope's `SILFn` is the same as the `IGF`'s to an assertion
based on the FIXME's suggestion on line 831.
