### PR TITLE
Add a way to specify the number of build jobs

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -477,6 +477,13 @@ also build for Apple watchos, but disallow tests that require an watchOS device"
 name of the directory under $SWIFT_BUILD_ROOT where the build products will be
 placed""",
         metavar="PATH")
+
+    parser.add_argument("-j", "--jobs",
+        help="""
+the number of parallel build jobs to use""",
+        type=int,
+        dest="build_jobs")
+
     parser.add_argument("--extra-swift-args", help=textwrap.dedent("""
     Pass through extra flags to swift in the form of a cmake list 'module_regexp;flag'. Can
     be called multiple times to add multiple such module_regexp flag pairs. All semicolons
@@ -700,6 +707,8 @@ placed""",
         "--cmake-generator", args.cmake_generator,
         "--workspace", SWIFT_SOURCE_ROOT
     ]
+    if args.build_jobs:
+        build_script_impl_args += ["--build-jobs", str(args.build_jobs)]
     if args.build_foundation:
         build_script_impl_args += [
             "--foundation-build-type", args.foundation_build_variant

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -182,6 +182,7 @@ KNOWN_SETTINGS=(
     darwin-toolchain-application-cert  ""        "Application Cert name to codesign xctoolchain"
     darwin-toolchain-installer-cert    ""        "Installer Cert name to create installer pkg"
     darwin-toolchain-installer-package ""        "The path to installer pkg"
+    build-jobs ""                                "The number of parallel build jobs to use"
 
 )
 
@@ -1049,9 +1050,16 @@ case "${CMAKE_GENERATOR}" in
         if [[ "${VERBOSE_BUILD}" ]] ; then
             BUILD_ARGS="${BUILD_ARGS} -v"
         fi
+        if [[ "${BUILD_JOBS}" ]] ; then
+            BUILD_ARGS="${BUILD_ARGS} -j${BUILD_JOBS}"
+        fi
         ;;
     'Unix Makefiles')
-        BUILD_ARGS="${BUILD_ARGS:--j$(get_make_parallelism)}"
+        if [[ "${BUILD_JOBS}" ]] ; then
+            BUILD_ARGS="${BUILD_ARGS} -j${BUILD_JOBS}"
+        else
+            BUILD_ARGS="${BUILD_ARGS:--j$(get_make_parallelism)}"
+        fi
         if [[ "${VERBOSE_BUILD}" ]] ; then
             BUILD_ARGS="${BUILD_ARGS} VERBOSE=1"
         fi
@@ -1061,6 +1069,9 @@ case "${CMAKE_GENERATOR}" in
         # but since we're not using proper Xcode 4 schemes, this is the
         # only way to get target-level parallelism.
         BUILD_ARGS="${BUILD_ARGS} -parallelizeTargets"
+        if [[ "${BUILD_JOBS}" ]] ; then
+            BUILD_ARGS="${BUILD_ARGS} -jobs ${BUILD_JOBS}"
+        fi
         BUILD_TARGET_FLAG="-target"
         COMMON_CMAKE_OPTIONS=(
             "${COMMON_CMAKE_OPTIONS[@]}"


### PR DESCRIPTION
This change adds a '-j' option to the top-level
build script.  The computed defaults may not
always be suitable.

Tested by building for Ninja (default), Make (-m), and XCode (-x).
I also verified the jobs count via a process monitor.
