### PR TITLE
QuickLook Project to navigate sources

### DIFF
--- a/QuickLook.xcodeproj/project.pbxproj
+++ b/QuickLook.xcodeproj/project.pbxproj
@@ -1,0 +1,4151 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BB32C32E1C124CFE00BEA123 /* ErrorObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A41C124A0C00C91975 /* ErrorObject.cpp */; };
+		BB32C32F1C124D6000BEA123 /* ErrorObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A61C124A0C00C91975 /* ErrorObject.mm */; };
+		BB32C3301C124D6500BEA123 /* SwiftObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B81C124A0C00C91975 /* SwiftObject.mm */; };
+		BB8B28291C1233F800C91975 /* libclangAnalysis.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D21C1233F600C91975 /* libclangAnalysis.a */; };
+		BB8B282A1C1233F800C91975 /* libclangAPINotes.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D31C1233F600C91975 /* libclangAPINotes.a */; };
+		BB8B282B1C1233F800C91975 /* libclangARCMigrate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D41C1233F600C91975 /* libclangARCMigrate.a */; };
+		BB8B282C1C1233F800C91975 /* libclangAST.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D51C1233F600C91975 /* libclangAST.a */; };
+		BB8B282D1C1233F800C91975 /* libclangASTMatchers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D61C1233F700C91975 /* libclangASTMatchers.a */; };
+		BB8B282E1C1233F800C91975 /* libclangBasic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D71C1233F700C91975 /* libclangBasic.a */; };
+		BB8B282F1C1233F800C91975 /* libclangCodeGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D81C1233F700C91975 /* libclangCodeGen.a */; };
+		BB8B28301C1233F800C91975 /* libclangDriver.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27D91C1233F700C91975 /* libclangDriver.a */; };
+		BB8B28311C1233F800C91975 /* libclangDynamicASTMatchers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27DA1C1233F700C91975 /* libclangDynamicASTMatchers.a */; };
+		BB8B28321C1233F800C91975 /* libclangEdit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27DB1C1233F700C91975 /* libclangEdit.a */; };
+		BB8B28331C1233F800C91975 /* libclangFormat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27DC1C1233F700C91975 /* libclangFormat.a */; };
+		BB8B28341C1233F800C91975 /* libclangFrontend.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27DD1C1233F700C91975 /* libclangFrontend.a */; };
+		BB8B28351C1233F800C91975 /* libclangFrontendTool.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27DE1C1233F700C91975 /* libclangFrontendTool.a */; };
+		BB8B28361C1233F800C91975 /* libclangIndex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27DF1C1233F700C91975 /* libclangIndex.a */; };
+		BB8B28371C1233F800C91975 /* libclangLex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E01C1233F700C91975 /* libclangLex.a */; };
+		BB8B28381C1233F800C91975 /* libclangParse.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E11C1233F700C91975 /* libclangParse.a */; };
+		BB8B28391C1233F800C91975 /* libclangRewrite.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E21C1233F700C91975 /* libclangRewrite.a */; };
+		BB8B283A1C1233F800C91975 /* libclangRewriteFrontend.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E31C1233F700C91975 /* libclangRewriteFrontend.a */; };
+		BB8B283B1C1233F800C91975 /* libclangSema.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E41C1233F700C91975 /* libclangSema.a */; };
+		BB8B283C1C1233F800C91975 /* libclangSerialization.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E51C1233F700C91975 /* libclangSerialization.a */; };
+		BB8B283D1C1233F800C91975 /* libclangStaticAnalyzerCheckers.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E61C1233F700C91975 /* libclangStaticAnalyzerCheckers.a */; };
+		BB8B283E1C1233F800C91975 /* libclangStaticAnalyzerCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E71C1233F700C91975 /* libclangStaticAnalyzerCore.a */; };
+		BB8B283F1C1233F800C91975 /* libclangStaticAnalyzerFrontend.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E81C1233F700C91975 /* libclangStaticAnalyzerFrontend.a */; };
+		BB8B28401C1233F800C91975 /* libclangTooling.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27E91C1233F700C91975 /* libclangTooling.a */; };
+		BB8B28411C1233F800C91975 /* libclangToolingCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27EA1C1233F700C91975 /* libclangToolingCore.a */; };
+		BB8B28431C1233F800C91975 /* libgtest_main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27EC1C1233F700C91975 /* libgtest_main.a */; };
+		BB8B28441C1233F800C91975 /* libgtest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27ED1C1233F700C91975 /* libgtest.a */; };
+		BB8B28451C1233F800C91975 /* libLLVMAArch64AsmParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27EE1C1233F700C91975 /* libLLVMAArch64AsmParser.a */; };
+		BB8B28461C1233F800C91975 /* libLLVMAArch64AsmPrinter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27EF1C1233F700C91975 /* libLLVMAArch64AsmPrinter.a */; };
+		BB8B28471C1233F800C91975 /* libLLVMAArch64CodeGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F01C1233F700C91975 /* libLLVMAArch64CodeGen.a */; };
+		BB8B28481C1233F800C91975 /* libLLVMAArch64Desc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F11C1233F700C91975 /* libLLVMAArch64Desc.a */; };
+		BB8B28491C1233F800C91975 /* libLLVMAArch64Disassembler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F21C1233F700C91975 /* libLLVMAArch64Disassembler.a */; };
+		BB8B284A1C1233F800C91975 /* libLLVMAArch64Info.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F31C1233F700C91975 /* libLLVMAArch64Info.a */; };
+		BB8B284B1C1233F800C91975 /* libLLVMAArch64Utils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F41C1233F700C91975 /* libLLVMAArch64Utils.a */; };
+		BB8B284C1C1233F800C91975 /* libLLVMAnalysis.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F51C1233F700C91975 /* libLLVMAnalysis.a */; };
+		BB8B284D1C1233F800C91975 /* libLLVMARMAsmParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F61C1233F700C91975 /* libLLVMARMAsmParser.a */; };
+		BB8B284E1C1233F800C91975 /* libLLVMARMAsmPrinter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F71C1233F700C91975 /* libLLVMARMAsmPrinter.a */; };
+		BB8B284F1C1233F800C91975 /* libLLVMARMCodeGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F81C1233F700C91975 /* libLLVMARMCodeGen.a */; };
+		BB8B28501C1233F800C91975 /* libLLVMARMDesc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27F91C1233F700C91975 /* libLLVMARMDesc.a */; };
+		BB8B28511C1233F800C91975 /* libLLVMARMDisassembler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27FA1C1233F700C91975 /* libLLVMARMDisassembler.a */; };
+		BB8B28521C1233F800C91975 /* libLLVMARMInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27FB1C1233F700C91975 /* libLLVMARMInfo.a */; };
+		BB8B28531C1233F800C91975 /* libLLVMAsmParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27FC1C1233F700C91975 /* libLLVMAsmParser.a */; };
+		BB8B28541C1233F800C91975 /* libLLVMAsmPrinter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27FD1C1233F700C91975 /* libLLVMAsmPrinter.a */; };
+		BB8B28551C1233F800C91975 /* libLLVMBitReader.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27FE1C1233F700C91975 /* libLLVMBitReader.a */; };
+		BB8B28561C1233F800C91975 /* libLLVMBitWriter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B27FF1C1233F700C91975 /* libLLVMBitWriter.a */; };
+		BB8B28571C1233F800C91975 /* libLLVMCodeGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28001C1233F700C91975 /* libLLVMCodeGen.a */; };
+		BB8B28581C1233F800C91975 /* libLLVMCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28011C1233F700C91975 /* libLLVMCore.a */; };
+		BB8B28591C1233F800C91975 /* libLLVMDebugInfoDWARF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28021C1233F700C91975 /* libLLVMDebugInfoDWARF.a */; };
+		BB8B285A1C1233F800C91975 /* libLLVMDebugInfoPDB.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28031C1233F700C91975 /* libLLVMDebugInfoPDB.a */; };
+		BB8B285B1C1233F800C91975 /* libLLVMExecutionEngine.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28041C1233F700C91975 /* libLLVMExecutionEngine.a */; };
+		BB8B285C1C1233F800C91975 /* libLLVMInstCombine.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28051C1233F700C91975 /* libLLVMInstCombine.a */; };
+		BB8B285D1C1233F800C91975 /* libLLVMInstrumentation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28061C1233F700C91975 /* libLLVMInstrumentation.a */; };
+		BB8B285E1C1233F800C91975 /* libLLVMInterpreter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28071C1233F700C91975 /* libLLVMInterpreter.a */; };
+		BB8B285F1C1233F800C91975 /* libLLVMipo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28081C1233F700C91975 /* libLLVMipo.a */; };
+		BB8B28601C1233F800C91975 /* libLLVMIRReader.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28091C1233F700C91975 /* libLLVMIRReader.a */; };
+		BB8B28611C1233F800C91975 /* libLLVMLibDriver.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B280A1C1233F700C91975 /* libLLVMLibDriver.a */; };
+		BB8B28621C1233F800C91975 /* libLLVMLineEditor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B280B1C1233F700C91975 /* libLLVMLineEditor.a */; };
+		BB8B28631C1233F800C91975 /* libLLVMLinker.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B280C1C1233F700C91975 /* libLLVMLinker.a */; };
+		BB8B28641C1233F800C91975 /* libLLVMLTO.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B280D1C1233F700C91975 /* libLLVMLTO.a */; };
+		BB8B28651C1233F800C91975 /* libLLVMMC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B280E1C1233F700C91975 /* libLLVMMC.a */; };
+		BB8B28661C1233F800C91975 /* libLLVMMCDisassembler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B280F1C1233F700C91975 /* libLLVMMCDisassembler.a */; };
+		BB8B28671C1233F800C91975 /* libLLVMMCJIT.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28101C1233F700C91975 /* libLLVMMCJIT.a */; };
+		BB8B28681C1233F800C91975 /* libLLVMMCParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28111C1233F700C91975 /* libLLVMMCParser.a */; };
+		BB8B28691C1233F800C91975 /* libLLVMMIRParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28121C1233F700C91975 /* libLLVMMIRParser.a */; };
+		BB8B286A1C1233F800C91975 /* libLLVMObjCARCOpts.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28131C1233F700C91975 /* libLLVMObjCARCOpts.a */; };
+		BB8B286B1C1233F800C91975 /* libLLVMObject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28141C1233F700C91975 /* libLLVMObject.a */; };
+		BB8B286C1C1233F800C91975 /* libLLVMOption.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28151C1233F700C91975 /* libLLVMOption.a */; };
+		BB8B286D1C1233F800C91975 /* libLLVMOrcJIT.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28161C1233F700C91975 /* libLLVMOrcJIT.a */; };
+		BB8B286E1C1233F800C91975 /* libLLVMPasses.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28171C1233F700C91975 /* libLLVMPasses.a */; };
+		BB8B286F1C1233F800C91975 /* libLLVMProfileData.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28181C1233F700C91975 /* libLLVMProfileData.a */; };
+		BB8B28701C1233F800C91975 /* libLLVMRuntimeDyld.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28191C1233F700C91975 /* libLLVMRuntimeDyld.a */; };
+		BB8B28711C1233F800C91975 /* libLLVMScalarOpts.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B281A1C1233F700C91975 /* libLLVMScalarOpts.a */; };
+		BB8B28721C1233F800C91975 /* libLLVMSelectionDAG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B281B1C1233F700C91975 /* libLLVMSelectionDAG.a */; };
+		BB8B28731C1233F800C91975 /* libLLVMSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B281C1C1233F700C91975 /* libLLVMSupport.a */; };
+		BB8B28741C1233F800C91975 /* libLLVMSymbolize.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B281D1C1233F700C91975 /* libLLVMSymbolize.a */; };
+		BB8B28751C1233F800C91975 /* libLLVMTableGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B281E1C1233F700C91975 /* libLLVMTableGen.a */; };
+		BB8B28761C1233F800C91975 /* libLLVMTarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B281F1C1233F700C91975 /* libLLVMTarget.a */; };
+		BB8B28771C1233F800C91975 /* libLLVMTransformUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28201C1233F700C91975 /* libLLVMTransformUtils.a */; };
+		BB8B28781C1233F800C91975 /* libLLVMVectorize.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28211C1233F700C91975 /* libLLVMVectorize.a */; };
+		BB8B28791C1233F800C91975 /* libLLVMX86AsmParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28221C1233F700C91975 /* libLLVMX86AsmParser.a */; };
+		BB8B287A1C1233F800C91975 /* libLLVMX86AsmPrinter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28231C1233F700C91975 /* libLLVMX86AsmPrinter.a */; };
+		BB8B287B1C1233F800C91975 /* libLLVMX86CodeGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28241C1233F700C91975 /* libLLVMX86CodeGen.a */; };
+		BB8B287C1C1233F800C91975 /* libLLVMX86Desc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28251C1233F800C91975 /* libLLVMX86Desc.a */; };
+		BB8B287D1C1233F800C91975 /* libLLVMX86Disassembler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28261C1233F800C91975 /* libLLVMX86Disassembler.a */; };
+		BB8B287E1C1233F800C91975 /* libLLVMX86Info.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28271C1233F800C91975 /* libLLVMX86Info.a */; };
+		BB8B287F1C1233F800C91975 /* libLLVMX86Utils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28281C1233F800C91975 /* libLLVMX86Utils.a */; };
+		BB8B28811C12352E00C91975 /* libcmark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28801C12352E00C91975 /* libcmark.a */; };
+		BB8B28831C12357300C91975 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28821C12357300C91975 /* libz.tbd */; };
+		BB8B28881C1236D400C91975 /* libedit.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28871C1236D400C91975 /* libedit.tbd */; };
+		BB8B288B1C1238B100C91975 /* libLLVMSupport.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B28891C1238B100C91975 /* libLLVMSupport.a */; };
+		BB8B288C1C1238B100C91975 /* libLLVMTableGen.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB8B288A1C1238B100C91975 /* libLLVMTableGen.a */; };
+		BB8B28B01C1248CE00C91975 /* InterceptTraps.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B28A01C1248CE00C91975 /* InterceptTraps.cpp */; };
+		BB8B28B21C1248CE00C91975 /* OpaqueIdentityFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B28A31C1248CE00C91975 /* OpaqueIdentityFunctions.cpp */; };
+		BB8B299E1C1249E500C91975 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = BB8B299C1C1249E500C91975 /* README.md */; };
+		BB8B29BC1C124A0C00C91975 /* Casting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A01C124A0C00C91975 /* Casting.cpp */; };
+		BB8B29BD1C124A0C00C91975 /* Demangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A21C124A0C00C91975 /* Demangle.cpp */; };
+		BB8B29BE1C124A0C00C91975 /* Enum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A31C124A0C00C91975 /* Enum.cpp */; };
+		BB8B29C11C124A0C00C91975 /* Errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A71C124A0C00C91975 /* Errors.cpp */; };
+		BB8B29C21C124A0C00C91975 /* Heap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29A91C124A0C00C91975 /* Heap.cpp */; };
+		BB8B29C31C124A0C00C91975 /* HeapObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29AA1C124A0C00C91975 /* HeapObject.cpp */; };
+		BB8B29C41C124A0C00C91975 /* KnownMetadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29AB1C124A0C00C91975 /* KnownMetadata.cpp */; };
+		BB8B29C61C124A0C00C91975 /* Metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29AE1C124A0C00C91975 /* Metadata.cpp */; };
+		BB8B29C71C124A0C00C91975 /* Once.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B11C124A0C00C91975 /* Once.cpp */; };
+		BB8B29C81C124A0C00C91975 /* Reflection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B31C124A0C00C91975 /* Reflection.cpp */; };
+		BB8B29C91C124A0C00C91975 /* Reflection.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B41C124A0C00C91975 /* Reflection.mm */; };
+		BB8B29CA1C124A0C00C91975 /* Remangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B51C124A0C00C91975 /* Remangle.cpp */; };
+		BB8B29CB1C124A0C00C91975 /* SwiftObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B71C124A0C00C91975 /* SwiftObject.cpp */; };
+		BB8B29CD1C124A0C00C91975 /* SwiftRuntimeDTraceProbes.d in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29B91C124A0C00C91975 /* SwiftRuntimeDTraceProbes.d */; };
+		BB8B29FA1C124A6500C91975 /* Availability.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29F31C124A6500C91975 /* Availability.mm */; };
+		BB8B29FB1C124A6500C91975 /* FoundationHelpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29F51C124A6500C91975 /* FoundationHelpers.mm */; };
+		BB8B29FC1C124A6500C91975 /* GlobalObjects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29F61C124A6500C91975 /* GlobalObjects.cpp */; };
+		BB8B29FD1C124A6500C91975 /* LibcShims.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29F71C124A6500C91975 /* LibcShims.cpp */; };
+		BB8B29FE1C124A6500C91975 /* Stubs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB8B29F81C124A6500C91975 /* Stubs.cpp */; };
+		BB9FD7C41C10F3CD0008A1EA /* ArchetypeBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD79A1C10F3CD0008A1EA /* ArchetypeBuilder.cpp */; };
+		BB9FD7C51C10F3CD0008A1EA /* ASTContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD79B1C10F3CD0008A1EA /* ASTContext.cpp */; };
+		BB9FD7C61C10F3CD0008A1EA /* ASTDumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD79C1C10F3CD0008A1EA /* ASTDumper.cpp */; };
+		BB9FD7C71C10F3CD0008A1EA /* ASTNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD79D1C10F3CD0008A1EA /* ASTNode.cpp */; };
+		BB9FD7C81C10F3CD0008A1EA /* ASTPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD79E1C10F3CD0008A1EA /* ASTPrinter.cpp */; };
+		BB9FD7C91C10F3CD0008A1EA /* ASTWalker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD79F1C10F3CD0008A1EA /* ASTWalker.cpp */; };
+		BB9FD7CA1C10F3CD0008A1EA /* Attr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A01C10F3CD0008A1EA /* Attr.cpp */; };
+		BB9FD7CB1C10F3CD0008A1EA /* Availability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A11C10F3CD0008A1EA /* Availability.cpp */; };
+		BB9FD7CC1C10F3CD0008A1EA /* AvailabilitySpec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A21C10F3CD0008A1EA /* AvailabilitySpec.cpp */; };
+		BB9FD7CD1C10F3CD0008A1EA /* Builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A31C10F3CD0008A1EA /* Builtins.cpp */; };
+		BB9FD7CE1C10F3CD0008A1EA /* CaptureInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A41C10F3CD0008A1EA /* CaptureInfo.cpp */; };
+		BB9FD7CF1C10F3CD0008A1EA /* ConcreteDeclRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A61C10F3CD0008A1EA /* ConcreteDeclRef.cpp */; };
+		BB9FD7D01C10F3CD0008A1EA /* ConformanceLookupTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A71C10F3CD0008A1EA /* ConformanceLookupTable.cpp */; };
+		BB9FD7D11C10F3CD0008A1EA /* Decl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7A91C10F3CD0008A1EA /* Decl.cpp */; };
+		BB9FD7D21C10F3CD0008A1EA /* DeclContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7AA1C10F3CD0008A1EA /* DeclContext.cpp */; };
+		BB9FD7D31C10F3CD0008A1EA /* DiagnosticEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7AB1C10F3CD0008A1EA /* DiagnosticEngine.cpp */; };
+		BB9FD7D41C10F3CD0008A1EA /* DiagnosticList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7AC1C10F3CD0008A1EA /* DiagnosticList.cpp */; };
+		BB9FD7D51C10F3CD0008A1EA /* DocComment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7AD1C10F3CD0008A1EA /* DocComment.cpp */; };
+		BB9FD7D61C10F3CD0008A1EA /* Expr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7AE1C10F3CD0008A1EA /* Expr.cpp */; };
+		BB9FD7D71C10F3CD0008A1EA /* GenericSignature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7AF1C10F3CD0008A1EA /* GenericSignature.cpp */; };
+		BB9FD7D81C10F3CD0008A1EA /* Identifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B01C10F3CD0008A1EA /* Identifier.cpp */; };
+		BB9FD7D91C10F3CD0008A1EA /* LookupVisibleDecls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B11C10F3CD0008A1EA /* LookupVisibleDecls.cpp */; };
+		BB9FD7DA1C10F3CD0008A1EA /* Mangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B21C10F3CD0008A1EA /* Mangle.cpp */; };
+		BB9FD7DB1C10F3CD0008A1EA /* Module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B31C10F3CD0008A1EA /* Module.cpp */; };
+		BB9FD7DC1C10F3CD0008A1EA /* ModuleNameLookup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B41C10F3CD0008A1EA /* ModuleNameLookup.cpp */; };
+		BB9FD7DD1C10F3CD0008A1EA /* NameLookup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B51C10F3CD0008A1EA /* NameLookup.cpp */; };
+		BB9FD7DE1C10F3CD0008A1EA /* Pattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B71C10F3CD0008A1EA /* Pattern.cpp */; };
+		BB9FD7DF1C10F3CD0008A1EA /* PlatformKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B81C10F3CD0008A1EA /* PlatformKind.cpp */; };
+		BB9FD7E01C10F3CD0008A1EA /* PrettyStackTrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7B91C10F3CD0008A1EA /* PrettyStackTrace.cpp */; };
+		BB9FD7E11C10F3CD0008A1EA /* ProtocolConformance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7BA1C10F3CD0008A1EA /* ProtocolConformance.cpp */; };
+		BB9FD7E21C10F3CD0008A1EA /* RawComment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7BB1C10F3CD0008A1EA /* RawComment.cpp */; };
+		BB9FD7E31C10F3CD0008A1EA /* Stmt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7BC1C10F3CD0008A1EA /* Stmt.cpp */; };
+		BB9FD7E41C10F3CD0008A1EA /* Substitution.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7BD1C10F3CD0008A1EA /* Substitution.cpp */; };
+		BB9FD7E51C10F3CD0008A1EA /* Type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7BE1C10F3CD0008A1EA /* Type.cpp */; };
+		BB9FD7E61C10F3CD0008A1EA /* TypeRefinementContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7BF1C10F3CD0008A1EA /* TypeRefinementContext.cpp */; };
+		BB9FD7E71C10F3CD0008A1EA /* TypeRepr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7C01C10F3CD0008A1EA /* TypeRepr.cpp */; };
+		BB9FD7E81C10F3CD0008A1EA /* TypeWalker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7C11C10F3CD0008A1EA /* TypeWalker.cpp */; };
+		BB9FD7E91C10F3CD0008A1EA /* USRGeneration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7C21C10F3CD0008A1EA /* USRGeneration.cpp */; };
+		BB9FD7EA1C10F3CD0008A1EA /* Verifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7C31C10F3CD0008A1EA /* Verifier.cpp */; };
+		BB9FD7EE1C10F4500008A1EA /* ASTSectionImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7EC1C10F4500008A1EA /* ASTSectionImporter.cpp */; };
+		BB9FD80D1C10F4770008A1EA /* Cache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F01C10F4770008A1EA /* Cache.cpp */; };
+		BB9FD80E1C10F4770008A1EA /* ClusteredBitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F11C10F4770008A1EA /* ClusteredBitVector.cpp */; };
+		BB9FD80F1C10F4770008A1EA /* Demangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F31C10F4770008A1EA /* Demangle.cpp */; };
+		BB9FD8101C10F4770008A1EA /* DemangleWrappers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F41C10F4770008A1EA /* DemangleWrappers.cpp */; };
+		BB9FD8111C10F4770008A1EA /* DiagnosticConsumer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F51C10F4770008A1EA /* DiagnosticConsumer.cpp */; };
+		BB9FD8121C10F4770008A1EA /* DiverseStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F61C10F4770008A1EA /* DiverseStack.cpp */; };
+		BB9FD8131C10F4770008A1EA /* EditorPlaceholder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F71C10F4770008A1EA /* EditorPlaceholder.cpp */; };
+		BB9FD8141C10F4770008A1EA /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F81C10F4770008A1EA /* FileSystem.cpp */; };
+		BB9FD8151C10F4770008A1EA /* JSONSerialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7F91C10F4770008A1EA /* JSONSerialization.cpp */; };
+		BB9FD8161C10F4770008A1EA /* LangOptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7FA1C10F4770008A1EA /* LangOptions.cpp */; };
+		BB9FD8171C10F4770008A1EA /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7FC1C10F4770008A1EA /* Platform.cpp */; };
+		BB9FD8181C10F4770008A1EA /* PrefixMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7FD1C10F4770008A1EA /* PrefixMap.cpp */; };
+		BB9FD8191C10F4770008A1EA /* PrettyStackTrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7FE1C10F4770008A1EA /* PrettyStackTrace.cpp */; };
+		BB9FD81A1C10F4770008A1EA /* PrimitiveParsing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD7FF1C10F4770008A1EA /* PrimitiveParsing.cpp */; };
+		BB9FD81B1C10F4770008A1EA /* Program.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8001C10F4770008A1EA /* Program.cpp */; };
+		BB9FD81C1C10F4770008A1EA /* Punycode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8011C10F4770008A1EA /* Punycode.cpp */; };
+		BB9FD81D1C10F4770008A1EA /* PunycodeUTF8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8021C10F4770008A1EA /* PunycodeUTF8.cpp */; };
+		BB9FD81E1C10F4770008A1EA /* QuotedString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8031C10F4770008A1EA /* QuotedString.cpp */; };
+		BB9FD81F1C10F4770008A1EA /* Remangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8041C10F4770008A1EA /* Remangle.cpp */; };
+		BB9FD8201C10F4770008A1EA /* SourceLoc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8051C10F4770008A1EA /* SourceLoc.cpp */; };
+		BB9FD8211C10F4770008A1EA /* StringExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8061C10F4770008A1EA /* StringExtras.cpp */; };
+		BB9FD8221C10F4770008A1EA /* TaskQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8071C10F4770008A1EA /* TaskQueue.cpp */; };
+		BB9FD8231C10F4770008A1EA /* ThreadSafeRefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8081C10F4770008A1EA /* ThreadSafeRefCounted.cpp */; };
+		BB9FD8241C10F4770008A1EA /* Unicode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8091C10F4770008A1EA /* Unicode.cpp */; };
+		BB9FD8251C10F4770008A1EA /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD80B1C10F4770008A1EA /* UUID.cpp */; };
+		BB9FD8261C10F4770008A1EA /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD80C1C10F4770008A1EA /* Version.cpp */; };
+		BB9FD82B1C10F4CA0008A1EA /* Cache-Mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD82A1C10F4CA0008A1EA /* Cache-Mac.cpp */; };
+		BB9FD83E1C10F50E0008A1EA /* ClangDiagnosticConsumer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8321C10F50E0008A1EA /* ClangDiagnosticConsumer.cpp */; };
+		BB9FD83F1C10F50E0008A1EA /* ClangImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8341C10F50E0008A1EA /* ClangImporter.cpp */; };
+		BB9FD8401C10F50E0008A1EA /* ImportDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8361C10F50E0008A1EA /* ImportDecl.cpp */; };
+		BB9FD8411C10F50E0008A1EA /* ImportMacro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8381C10F50E0008A1EA /* ImportMacro.cpp */; };
+		BB9FD8421C10F50E0008A1EA /* ImportType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8391C10F50E0008A1EA /* ImportType.cpp */; };
+		BB9FD8521C10F54E0008A1EA /* Action.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8451C10F54E0008A1EA /* Action.cpp */; };
+		BB9FD8531C10F54E0008A1EA /* Compilation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8471C10F54E0008A1EA /* Compilation.cpp */; };
+		BB9FD8541C10F54E0008A1EA /* DependencyGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8481C10F54E0008A1EA /* DependencyGraph.cpp */; };
+		BB9FD8551C10F54E0008A1EA /* Driver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8491C10F54E0008A1EA /* Driver.cpp */; };
+		BB9FD8561C10F54E0008A1EA /* FrontendUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD84A1C10F54E0008A1EA /* FrontendUtil.cpp */; };
+		BB9FD8571C10F54E0008A1EA /* Job.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD84B1C10F54E0008A1EA /* Job.cpp */; };
+		BB9FD8581C10F54E0008A1EA /* OutputFileMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD84C1C10F54E0008A1EA /* OutputFileMap.cpp */; };
+		BB9FD8591C10F54E0008A1EA /* ParseableOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD84D1C10F54E0008A1EA /* ParseableOutput.cpp */; };
+		BB9FD85A1C10F54E0008A1EA /* ToolChain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD84E1C10F54E0008A1EA /* ToolChain.cpp */; };
+		BB9FD85B1C10F54E0008A1EA /* ToolChains.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD84F1C10F54E0008A1EA /* ToolChains.cpp */; };
+		BB9FD85C1C10F54E0008A1EA /* Types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8511C10F54E0008A1EA /* Types.cpp */; };
+		BB9FD8651C10F5790008A1EA /* CompilerInvocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD85F1C10F5790008A1EA /* CompilerInvocation.cpp */; };
+		BB9FD8661C10F5790008A1EA /* DiagnosticVerifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8601C10F5790008A1EA /* DiagnosticVerifier.cpp */; };
+		BB9FD8671C10F5790008A1EA /* Frontend.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8611C10F5790008A1EA /* Frontend.cpp */; };
+		BB9FD8681C10F5790008A1EA /* FrontendOptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8621C10F5790008A1EA /* FrontendOptions.cpp */; };
+		BB9FD8691C10F5790008A1EA /* PrintingDiagnosticConsumer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8631C10F5790008A1EA /* PrintingDiagnosticConsumer.cpp */; };
+		BB9FD86A1C10F5790008A1EA /* SerializedDiagnosticConsumer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8641C10F5790008A1EA /* SerializedDiagnosticConsumer.cpp */; };
+		BB9FD8771C10F5A40008A1EA /* CodeCompletion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD86D1C10F5A40008A1EA /* CodeCompletion.cpp */; };
+		BB9FD8781C10F5A40008A1EA /* CodeCompletionCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD86E1C10F5A40008A1EA /* CodeCompletionCache.cpp */; };
+		BB9FD8791C10F5A40008A1EA /* CommentConversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8701C10F5A40008A1EA /* CommentConversion.cpp */; };
+		BB9FD87A1C10F5A40008A1EA /* ModuleInterfacePrinting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8711C10F5A40008A1EA /* ModuleInterfacePrinting.cpp */; };
+		BB9FD87B1C10F5A40008A1EA /* REPLCodeCompletion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8721C10F5A40008A1EA /* REPLCodeCompletion.cpp */; };
+		BB9FD87C1C10F5A40008A1EA /* SourceEntityWalker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8731C10F5A40008A1EA /* SourceEntityWalker.cpp */; };
+		BB9FD87D1C10F5A40008A1EA /* SwiftSourceDocInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8741C10F5A40008A1EA /* SwiftSourceDocInfo.cpp */; };
+		BB9FD87E1C10F5A40008A1EA /* SyntaxModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8751C10F5A40008A1EA /* SyntaxModel.cpp */; };
+		BB9FD87F1C10F5A40008A1EA /* Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8761C10F5A40008A1EA /* Utils.cpp */; };
+		BB9FD8851C10F5C40008A1EA /* Immediate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8821C10F5C40008A1EA /* Immediate.cpp */; };
+		BB9FD8861C10F5C40008A1EA /* REPL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8841C10F5C40008A1EA /* REPL.cpp */; };
+		BB9FD8E11C10F5F20008A1EA /* DebugTypeInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD88E1C10F5F10008A1EA /* DebugTypeInfo.cpp */; };
+		BB9FD8E21C10F5F20008A1EA /* EnumPayload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8911C10F5F10008A1EA /* EnumPayload.cpp */; };
+		BB9FD8E31C10F5F20008A1EA /* ExtraInhabitants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8941C10F5F10008A1EA /* ExtraInhabitants.cpp */; };
+		BB9FD8E41C10F5F20008A1EA /* GenArchetype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8971C10F5F10008A1EA /* GenArchetype.cpp */; };
+		BB9FD8E51C10F5F20008A1EA /* GenCast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8991C10F5F10008A1EA /* GenCast.cpp */; };
+		BB9FD8E61C10F5F20008A1EA /* GenClangDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD89B1C10F5F10008A1EA /* GenClangDecl.cpp */; };
+		BB9FD8E71C10F5F20008A1EA /* GenClangType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD89C1C10F5F10008A1EA /* GenClangType.cpp */; };
+		BB9FD8E81C10F5F20008A1EA /* GenClass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD89D1C10F5F10008A1EA /* GenClass.cpp */; };
+		BB9FD8E91C10F5F20008A1EA /* GenControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD89F1C10F5F10008A1EA /* GenControl.cpp */; };
+		BB9FD8EA1C10F5F20008A1EA /* GenCoverage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8A01C10F5F10008A1EA /* GenCoverage.cpp */; };
+		BB9FD8EB1C10F5F20008A1EA /* GenDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8A11C10F5F10008A1EA /* GenDecl.cpp */; };
+		BB9FD8EC1C10F5F20008A1EA /* GenEnum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8A21C10F5F10008A1EA /* GenEnum.cpp */; };
+		BB9FD8ED1C10F5F20008A1EA /* GenExistential.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8A41C10F5F10008A1EA /* GenExistential.cpp */; };
+		BB9FD8EE1C10F5F20008A1EA /* GenFunc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8A61C10F5F10008A1EA /* GenFunc.cpp */; };
+		BB9FD8EF1C10F5F20008A1EA /* GenHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8A81C10F5F10008A1EA /* GenHeap.cpp */; };
+		BB9FD8F01C10F5F20008A1EA /* GenInit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8AA1C10F5F10008A1EA /* GenInit.cpp */; };
+		BB9FD8F11C10F5F20008A1EA /* GenMeta.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8AB1C10F5F10008A1EA /* GenMeta.cpp */; };
+		BB9FD8F21C10F5F20008A1EA /* GenObjC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8AD1C10F5F10008A1EA /* GenObjC.cpp */; };
+		BB9FD8F31C10F5F20008A1EA /* GenOpaque.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8AF1C10F5F10008A1EA /* GenOpaque.cpp */; };
+		BB9FD8F41C10F5F20008A1EA /* GenPoly.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8B11C10F5F10008A1EA /* GenPoly.cpp */; };
+		BB9FD8F51C10F5F20008A1EA /* GenProto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8B31C10F5F10008A1EA /* GenProto.cpp */; };
+		BB9FD8F61C10F5F20008A1EA /* GenStruct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8B61C10F5F10008A1EA /* GenStruct.cpp */; };
+		BB9FD8F71C10F5F20008A1EA /* GenTuple.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8B81C10F5F10008A1EA /* GenTuple.cpp */; };
+		BB9FD8F81C10F5F20008A1EA /* GenType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8BA1C10F5F10008A1EA /* GenType.cpp */; };
+		BB9FD8F91C10F5F20008A1EA /* IRGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8BF1C10F5F10008A1EA /* IRGen.cpp */; };
+		BB9FD8FA1C10F5F20008A1EA /* IRGenDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8C11C10F5F10008A1EA /* IRGenDebugInfo.cpp */; };
+		BB9FD8FB1C10F5F20008A1EA /* IRGenFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8C31C10F5F10008A1EA /* IRGenFunction.cpp */; };
+		BB9FD8FC1C10F5F20008A1EA /* IRGenModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8C51C10F5F10008A1EA /* IRGenModule.cpp */; };
+		BB9FD8FD1C10F5F20008A1EA /* IRGenSIL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8C71C10F5F10008A1EA /* IRGenSIL.cpp */; };
+		BB9FD8FE1C10F5F20008A1EA /* Linking.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8C81C10F5F10008A1EA /* Linking.cpp */; };
+		BB9FD8FF1C10F5F20008A1EA /* StructLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8D41C10F5F10008A1EA /* StructLayout.cpp */; };
+		BB9FD9001C10F5F20008A1EA /* SwiftTargetInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8D71C10F5F10008A1EA /* SwiftTargetInfo.cpp */; };
+		BB9FD9011C10F5F20008A1EA /* TypeLayoutVerifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8DA1C10F5F10008A1EA /* TypeLayoutVerifier.cpp */; };
+		BB9FD9021C10F5F20008A1EA /* UnimplementedTypeInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD8DC1C10F5F20008A1EA /* UnimplementedTypeInfo.cpp */; };
+		BB9FD90C1C10F60D0008A1EA /* LLVMARCContract.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9061C10F60D0008A1EA /* LLVMARCContract.cpp */; };
+		BB9FD90D1C10F60D0008A1EA /* LLVMARCOpts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9071C10F60D0008A1EA /* LLVMARCOpts.cpp */; };
+		BB9FD90E1C10F60D0008A1EA /* LLVMStackPromotion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9091C10F60D0008A1EA /* LLVMStackPromotion.cpp */; };
+		BB9FD90F1C10F60D0008A1EA /* LLVMSwiftAA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD90A1C10F60D0008A1EA /* LLVMSwiftAA.cpp */; };
+		BB9FD9101C10F60D0008A1EA /* LLVMSwiftRCIdentity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD90B1C10F60D0008A1EA /* LLVMSwiftRCIdentity.cpp */; };
+		BB9FD9161C10F6360008A1EA /* AST.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9121C10F6360008A1EA /* AST.cpp */; };
+		BB9FD9171C10F6360008A1EA /* LineList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9141C10F6360008A1EA /* LineList.cpp */; };
+		BB9FD9181C10F6360008A1EA /* Markup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9151C10F6360008A1EA /* Markup.cpp */; };
+		BB9FD91C1C10F6580008A1EA /* Options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD91B1C10F6580008A1EA /* Options.cpp */; };
+		BB9FD92A1C10F67C0008A1EA /* Lexer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD91F1C10F67C0008A1EA /* Lexer.cpp */; };
+		BB9FD92B1C10F67C0008A1EA /* ParseDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9201C10F67C0008A1EA /* ParseDecl.cpp */; };
+		BB9FD92C1C10F67C0008A1EA /* ParseExpr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9211C10F67C0008A1EA /* ParseExpr.cpp */; };
+		BB9FD92D1C10F67C0008A1EA /* ParseGeneric.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9221C10F67C0008A1EA /* ParseGeneric.cpp */; };
+		BB9FD92E1C10F67C0008A1EA /* ParsePattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9231C10F67C0008A1EA /* ParsePattern.cpp */; };
+		BB9FD92F1C10F67C0008A1EA /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9241C10F67C0008A1EA /* Parser.cpp */; };
+		BB9FD9301C10F67C0008A1EA /* ParseSIL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9251C10F67C0008A1EA /* ParseSIL.cpp */; };
+		BB9FD9311C10F67C0008A1EA /* ParseStmt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9261C10F67C0008A1EA /* ParseStmt.cpp */; };
+		BB9FD9321C10F67C0008A1EA /* ParseType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9271C10F67C0008A1EA /* ParseType.cpp */; };
+		BB9FD9331C10F67C0008A1EA /* PersistentParserState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9281C10F67C0008A1EA /* PersistentParserState.cpp */; };
+		BB9FD9341C10F67C0008A1EA /* Scope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9291C10F67C0008A1EA /* Scope.cpp */; };
+		BB9FD9381C10F6A50008A1EA /* PrintAsObjC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9371C10F6A50008A1EA /* PrintAsObjC.cpp */; };
+		BB9FD96D1C10F6CE0008A1EA /* CodeSynthesis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD93B1C10F6CE0008A1EA /* CodeSynthesis.cpp */; };
+		BB9FD96E1C10F6CE0008A1EA /* Constraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD93D1C10F6CE0008A1EA /* Constraint.cpp */; };
+		BB9FD96F1C10F6CE0008A1EA /* ConstraintGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD93F1C10F6CE0008A1EA /* ConstraintGraph.cpp */; };
+		BB9FD9701C10F6CE0008A1EA /* ConstraintLocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9421C10F6CE0008A1EA /* ConstraintLocator.cpp */; };
+		BB9FD9711C10F6CE0008A1EA /* ConstraintSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9451C10F6CE0008A1EA /* ConstraintSystem.cpp */; };
+		BB9FD9721C10F6CE0008A1EA /* CSApply.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9471C10F6CE0008A1EA /* CSApply.cpp */; };
+		BB9FD9731C10F6CE0008A1EA /* CSDiag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9481C10F6CE0008A1EA /* CSDiag.cpp */; };
+		BB9FD9741C10F6CE0008A1EA /* CSGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9491C10F6CE0008A1EA /* CSGen.cpp */; };
+		BB9FD9751C10F6CE0008A1EA /* CSRanking.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD94A1C10F6CE0008A1EA /* CSRanking.cpp */; };
+		BB9FD9761C10F6CE0008A1EA /* CSSimplify.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD94B1C10F6CE0008A1EA /* CSSimplify.cpp */; };
+		BB9FD9771C10F6CE0008A1EA /* CSSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD94C1C10F6CE0008A1EA /* CSSolver.cpp */; };
+		BB9FD9781C10F6CE0008A1EA /* DerivedConformanceEquatableHashable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD94D1C10F6CE0008A1EA /* DerivedConformanceEquatableHashable.cpp */; };
+		BB9FD9791C10F6CE0008A1EA /* DerivedConformanceErrorType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD94E1C10F6CE0008A1EA /* DerivedConformanceErrorType.cpp */; };
+		BB9FD97A1C10F6CE0008A1EA /* DerivedConformanceRawRepresentable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD94F1C10F6CE0008A1EA /* DerivedConformanceRawRepresentable.cpp */; };
+		BB9FD97B1C10F6CE0008A1EA /* DerivedConformances.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9501C10F6CE0008A1EA /* DerivedConformances.cpp */; };
+		BB9FD97C1C10F6CE0008A1EA /* ITCDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9531C10F6CE0008A1EA /* ITCDecl.cpp */; };
+		BB9FD97D1C10F6CE0008A1EA /* ITCNameLookup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9541C10F6CE0008A1EA /* ITCNameLookup.cpp */; };
+		BB9FD97E1C10F6CE0008A1EA /* ITCType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9551C10F6CE0008A1EA /* ITCType.cpp */; };
+		BB9FD97F1C10F6CE0008A1EA /* IterativeTypeChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9561C10F6CE0008A1EA /* IterativeTypeChecker.cpp */; };
+		BB9FD9801C10F6CE0008A1EA /* MiscDiagnostics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9571C10F6CE0008A1EA /* MiscDiagnostics.cpp */; };
+		BB9FD9811C10F6CE0008A1EA /* NameBinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9591C10F6CE0008A1EA /* NameBinding.cpp */; };
+		BB9FD9821C10F6CE0008A1EA /* OverloadChoice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD95A1C10F6CE0008A1EA /* OverloadChoice.cpp */; };
+		BB9FD9831C10F6CE0008A1EA /* PlaygroundTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD95C1C10F6CE0008A1EA /* PlaygroundTransform.cpp */; };
+		BB9FD9841C10F6CE0008A1EA /* SourceLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD95D1C10F6CE0008A1EA /* SourceLoader.cpp */; };
+		BB9FD9851C10F6CE0008A1EA /* TypeCheckAttr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD95E1C10F6CE0008A1EA /* TypeCheckAttr.cpp */; };
+		BB9FD9861C10F6CE0008A1EA /* TypeCheckConstraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD95F1C10F6CE0008A1EA /* TypeCheckConstraints.cpp */; };
+		BB9FD9871C10F6CE0008A1EA /* TypeCheckDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9601C10F6CE0008A1EA /* TypeCheckDecl.cpp */; };
+		BB9FD9881C10F6CE0008A1EA /* TypeChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9611C10F6CE0008A1EA /* TypeChecker.cpp */; };
+		BB9FD9891C10F6CE0008A1EA /* TypeCheckError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9631C10F6CE0008A1EA /* TypeCheckError.cpp */; };
+		BB9FD98A1C10F6CE0008A1EA /* TypeCheckExpr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9641C10F6CE0008A1EA /* TypeCheckExpr.cpp */; };
+		BB9FD98B1C10F6CE0008A1EA /* TypeCheckGeneric.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9651C10F6CE0008A1EA /* TypeCheckGeneric.cpp */; };
+		BB9FD98C1C10F6CE0008A1EA /* TypeCheckNameLookup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9661C10F6CE0008A1EA /* TypeCheckNameLookup.cpp */; };
+		BB9FD98D1C10F6CE0008A1EA /* TypeCheckPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9671C10F6CE0008A1EA /* TypeCheckPattern.cpp */; };
+		BB9FD98E1C10F6CE0008A1EA /* TypeCheckProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9681C10F6CE0008A1EA /* TypeCheckProtocol.cpp */; };
+		BB9FD98F1C10F6CE0008A1EA /* TypeCheckREPL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9691C10F6CE0008A1EA /* TypeCheckREPL.cpp */; };
+		BB9FD9901C10F6CE0008A1EA /* TypeCheckRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD96A1C10F6CE0008A1EA /* TypeCheckRequest.cpp */; };
+		BB9FD9911C10F6CE0008A1EA /* TypeCheckStmt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD96B1C10F6CE0008A1EA /* TypeCheckStmt.cpp */; };
+		BB9FD9921C10F6CE0008A1EA /* TypeCheckType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD96C1C10F6CE0008A1EA /* TypeCheckType.cpp */; };
+		BB9FD99F1C10F6F10008A1EA /* Deserialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9951C10F6F10008A1EA /* Deserialization.cpp */; };
+		BB9FD9A01C10F6F10008A1EA /* DeserializeSIL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9961C10F6F10008A1EA /* DeserializeSIL.cpp */; };
+		BB9FD9A11C10F6F10008A1EA /* ModuleFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9981C10F6F10008A1EA /* ModuleFile.cpp */; };
+		BB9FD9A21C10F6F10008A1EA /* Serialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9991C10F6F10008A1EA /* Serialization.cpp */; };
+		BB9FD9A31C10F6F10008A1EA /* SerializedModuleLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD99B1C10F6F10008A1EA /* SerializedModuleLoader.cpp */; };
+		BB9FD9A41C10F6F10008A1EA /* SerializedSILLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD99C1C10F6F10008A1EA /* SerializedSILLoader.cpp */; };
+		BB9FD9A51C10F6F10008A1EA /* SerializeSIL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD99D1C10F6F10008A1EA /* SerializeSIL.cpp */; };
+		BB9FD9C81C10F7110008A1EA /* AbstractionPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9A71C10F7110008A1EA /* AbstractionPattern.cpp */; };
+		BB9FD9C91C10F7110008A1EA /* Bridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9A81C10F7110008A1EA /* Bridging.cpp */; };
+		BB9FD9CA1C10F7110008A1EA /* Dominance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9AA1C10F7110008A1EA /* Dominance.cpp */; };
+		BB9FD9CB1C10F7110008A1EA /* DynamicCasts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9AB1C10F7110008A1EA /* DynamicCasts.cpp */; };
+		BB9FD9CC1C10F7110008A1EA /* Linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9AC1C10F7110008A1EA /* Linker.cpp */; };
+		BB9FD9CD1C10F7110008A1EA /* LoopInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9AE1C10F7110008A1EA /* LoopInfo.cpp */; };
+		BB9FD9CE1C10F7110008A1EA /* Mangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9AF1C10F7110008A1EA /* Mangle.cpp */; };
+		BB9FD9CF1C10F7110008A1EA /* MemLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B01C10F7110008A1EA /* MemLocation.cpp */; };
+		BB9FD9D01C10F7110008A1EA /* PrettyStackTrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B11C10F7110008A1EA /* PrettyStackTrace.cpp */; };
+		BB9FD9D11C10F7110008A1EA /* Projection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B21C10F7110008A1EA /* Projection.cpp */; };
+		BB9FD9D21C10F7110008A1EA /* SIL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B31C10F7110008A1EA /* SIL.cpp */; };
+		BB9FD9D31C10F7110008A1EA /* SILArgument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B41C10F7110008A1EA /* SILArgument.cpp */; };
+		BB9FD9D41C10F7110008A1EA /* SILBasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B51C10F7110008A1EA /* SILBasicBlock.cpp */; };
+		BB9FD9D51C10F7110008A1EA /* SILBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B61C10F7110008A1EA /* SILBuilder.cpp */; };
+		BB9FD9D61C10F7110008A1EA /* SILCoverageMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B71C10F7110008A1EA /* SILCoverageMap.cpp */; };
+		BB9FD9D71C10F7110008A1EA /* SILDeclRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B81C10F7110008A1EA /* SILDeclRef.cpp */; };
+		BB9FD9D81C10F7110008A1EA /* SILFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9B91C10F7110008A1EA /* SILFunction.cpp */; };
+		BB9FD9D91C10F7110008A1EA /* SILFunctionType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9BA1C10F7110008A1EA /* SILFunctionType.cpp */; };
+		BB9FD9DA1C10F7110008A1EA /* SILGlobalVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9BB1C10F7110008A1EA /* SILGlobalVariable.cpp */; };
+		BB9FD9DB1C10F7110008A1EA /* SILInstruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9BC1C10F7110008A1EA /* SILInstruction.cpp */; };
+		BB9FD9DC1C10F7110008A1EA /* SILInstructions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9BD1C10F7110008A1EA /* SILInstructions.cpp */; };
+		BB9FD9DD1C10F7110008A1EA /* SILLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9BE1C10F7110008A1EA /* SILLocation.cpp */; };
+		BB9FD9DE1C10F7110008A1EA /* SILModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9BF1C10F7110008A1EA /* SILModule.cpp */; };
+		BB9FD9DF1C10F7110008A1EA /* SILPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C01C10F7110008A1EA /* SILPrinter.cpp */; };
+		BB9FD9E01C10F7110008A1EA /* SILSuccessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C11C10F7110008A1EA /* SILSuccessor.cpp */; };
+		BB9FD9E11C10F7110008A1EA /* SILType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C21C10F7110008A1EA /* SILType.cpp */; };
+		BB9FD9E21C10F7110008A1EA /* SILValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C31C10F7110008A1EA /* SILValue.cpp */; };
+		BB9FD9E31C10F7110008A1EA /* SILVTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C41C10F7110008A1EA /* SILVTable.cpp */; };
+		BB9FD9E41C10F7110008A1EA /* SILWitnessTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C51C10F7110008A1EA /* SILWitnessTable.cpp */; };
+		BB9FD9E51C10F7110008A1EA /* TypeLowering.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C61C10F7110008A1EA /* TypeLowering.cpp */; };
+		BB9FD9E61C10F7110008A1EA /* Verifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9C71C10F7110008A1EA /* Verifier.cpp */; };
+		BB9FD9FD1C10F7490008A1EA /* AliasAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9E81C10F7490008A1EA /* AliasAnalysis.cpp */; };
+		BB9FD9FE1C10F7490008A1EA /* Analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9E91C10F7490008A1EA /* Analysis.cpp */; };
+		BB9FD9FF1C10F7490008A1EA /* ARCAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9EA1C10F7490008A1EA /* ARCAnalysis.cpp */; };
+		BB9FDA001C10F7490008A1EA /* ArraySemantic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9EB1C10F7490008A1EA /* ArraySemantic.cpp */; };
+		BB9FDA011C10F7490008A1EA /* BasicCalleeAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9EC1C10F7490008A1EA /* BasicCalleeAnalysis.cpp */; };
+		BB9FDA021C10F7490008A1EA /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9ED1C10F7490008A1EA /* CallGraph.cpp */; };
+		BB9FDA031C10F7490008A1EA /* CFG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9EE1C10F7490008A1EA /* CFG.cpp */; };
+		BB9FDA041C10F7490008A1EA /* ClassHierarchyAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9EF1C10F7490008A1EA /* ClassHierarchyAnalysis.cpp */; };
+		BB9FDA051C10F7490008A1EA /* ColdBlockInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F11C10F7490008A1EA /* ColdBlockInfo.cpp */; };
+		BB9FDA061C10F7490008A1EA /* DestructorAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F21C10F7490008A1EA /* DestructorAnalysis.cpp */; };
+		BB9FDA071C10F7490008A1EA /* EscapeAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F31C10F7490008A1EA /* EscapeAnalysis.cpp */; };
+		BB9FDA081C10F7490008A1EA /* FunctionOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F41C10F7490008A1EA /* FunctionOrder.cpp */; };
+		BB9FDA091C10F7490008A1EA /* IVAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F51C10F7490008A1EA /* IVAnalysis.cpp */; };
+		BB9FDA0A1C10F7490008A1EA /* LoopAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F61C10F7490008A1EA /* LoopAnalysis.cpp */; };
+		BB9FDA0B1C10F7490008A1EA /* LoopRegionAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F71C10F7490008A1EA /* LoopRegionAnalysis.cpp */; };
+		BB9FDA0C1C10F7490008A1EA /* MemoryBehavior.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F81C10F7490008A1EA /* MemoryBehavior.cpp */; };
+		BB9FDA0D1C10F7490008A1EA /* RCIdentityAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9F91C10F7490008A1EA /* RCIdentityAnalysis.cpp */; };
+		BB9FDA0E1C10F7490008A1EA /* SideEffectAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9FA1C10F7490008A1EA /* SideEffectAnalysis.cpp */; };
+		BB9FDA0F1C10F7490008A1EA /* SimplifyInstruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9FB1C10F7490008A1EA /* SimplifyInstruction.cpp */; };
+		BB9FDA101C10F7490008A1EA /* ValueTracking.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FD9FC1C10F7490008A1EA /* ValueTracking.cpp */; };
+		BB9FDA3E1C10F76B0008A1EA /* ArgumentSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA121C10F76B0008A1EA /* ArgumentSource.cpp */; };
+		BB9FDA3F1C10F76B0008A1EA /* Cleanup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA151C10F76B0008A1EA /* Cleanup.cpp */; };
+		BB9FDA401C10F76B0008A1EA /* Condition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA181C10F76B0008A1EA /* Condition.cpp */; };
+		BB9FDA411C10F76B0008A1EA /* ManagedValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA1E1C10F76B0008A1EA /* ManagedValue.cpp */; };
+		BB9FDA421C10F76B0008A1EA /* RValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA201C10F76B0008A1EA /* RValue.cpp */; };
+		BB9FDA431C10F76B0008A1EA /* SILGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA231C10F76B0008A1EA /* SILGen.cpp */; };
+		BB9FDA441C10F76B0008A1EA /* SILGenApply.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA251C10F76B0008A1EA /* SILGenApply.cpp */; };
+		BB9FDA451C10F76B0008A1EA /* SILGenBridging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA261C10F76B0008A1EA /* SILGenBridging.cpp */; };
+		BB9FDA461C10F76B0008A1EA /* SILGenBuiltin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA271C10F76B0008A1EA /* SILGenBuiltin.cpp */; };
+		BB9FDA471C10F76B0008A1EA /* SILGenConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA281C10F76B0008A1EA /* SILGenConstructor.cpp */; };
+		BB9FDA481C10F76B0008A1EA /* SILGenConvert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA291C10F76B0008A1EA /* SILGenConvert.cpp */; };
+		BB9FDA491C10F76B0008A1EA /* SILGenDecl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA2A1C10F76B0008A1EA /* SILGenDecl.cpp */; };
+		BB9FDA4A1C10F76B0008A1EA /* SILGenDestructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA2B1C10F76B0008A1EA /* SILGenDestructor.cpp */; };
+		BB9FDA4B1C10F76B0008A1EA /* SILGenDynamicCast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA2C1C10F76B0008A1EA /* SILGenDynamicCast.cpp */; };
+		BB9FDA4C1C10F76B0008A1EA /* SILGenEpilog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA2E1C10F76B0008A1EA /* SILGenEpilog.cpp */; };
+		BB9FDA4D1C10F76B0008A1EA /* SILGenExpr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA2F1C10F76B0008A1EA /* SILGenExpr.cpp */; };
+		BB9FDA4E1C10F76B0008A1EA /* SILGenForeignError.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA301C10F76B0008A1EA /* SILGenForeignError.cpp */; };
+		BB9FDA4F1C10F76B0008A1EA /* SILGenFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA311C10F76B0008A1EA /* SILGenFunction.cpp */; };
+		BB9FDA501C10F76B0008A1EA /* SILGenGlobalVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA331C10F76B0008A1EA /* SILGenGlobalVariable.cpp */; };
+		BB9FDA511C10F76B0008A1EA /* SILGenLValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA341C10F76B0008A1EA /* SILGenLValue.cpp */; };
+		BB9FDA521C10F76B0008A1EA /* SILGenPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA351C10F76B0008A1EA /* SILGenPattern.cpp */; };
+		BB9FDA531C10F76B0008A1EA /* SILGenPoly.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA361C10F76B0008A1EA /* SILGenPoly.cpp */; };
+		BB9FDA541C10F76B0008A1EA /* SILGenProfiling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA371C10F76B0008A1EA /* SILGenProfiling.cpp */; };
+		BB9FDA551C10F76B0008A1EA /* SILGenProlog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA391C10F76B0008A1EA /* SILGenProlog.cpp */; };
+		BB9FDA561C10F76B0008A1EA /* SILGenStmt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA3A1C10F76B0008A1EA /* SILGenStmt.cpp */; };
+		BB9FDA571C10F76B0008A1EA /* SILGenType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA3B1C10F76B0008A1EA /* SILGenType.cpp */; };
+		BB9FDA5C1C10F7B90008A1EA /* MangleHack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA5A1C10F7B90008A1EA /* MangleHack.cpp */; };
+		BB9FDA5D1C10F7B90008A1EA /* SwiftDemangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA5B1C10F7B90008A1EA /* SwiftDemangle.cpp */; };
+		BB9FDA731C10F7F00008A1EA /* ARCBBState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA601C10F7F00008A1EA /* ARCBBState.cpp */; };
+		BB9FDA741C10F7F00008A1EA /* ARCRegionState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA621C10F7F00008A1EA /* ARCRegionState.cpp */; };
+		BB9FDA751C10F7F00008A1EA /* ARCSequenceOpts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA641C10F7F00008A1EA /* ARCSequenceOpts.cpp */; };
+		BB9FDA761C10F7F00008A1EA /* GlobalARCPairingAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA661C10F7F00008A1EA /* GlobalARCPairingAnalysis.cpp */; };
+		BB9FDA771C10F7F00008A1EA /* GlobalARCSequenceDataflow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA681C10F7F00008A1EA /* GlobalARCSequenceDataflow.cpp */; };
+		BB9FDA781C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA6A1C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.cpp */; };
+		BB9FDA791C10F7F00008A1EA /* RCStateTransition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA6C1C10F7F00008A1EA /* RCStateTransition.cpp */; };
+		BB9FDA7A1C10F7F00008A1EA /* RCStateTransitionVisitors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA6F1C10F7F00008A1EA /* RCStateTransitionVisitors.cpp */; };
+		BB9FDA7B1C10F7F00008A1EA /* RefCountState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA711C10F7F00008A1EA /* RefCountState.cpp */; };
+		BB9FDA871C10F8110008A1EA /* ConstantPropagation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA7E1C10F8110008A1EA /* ConstantPropagation.cpp */; };
+		BB9FDA881C10F8110008A1EA /* DataflowDiagnostics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA7F1C10F8110008A1EA /* DataflowDiagnostics.cpp */; };
+		BB9FDA891C10F8110008A1EA /* DefiniteInitialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA801C10F8110008A1EA /* DefiniteInitialization.cpp */; };
+		BB9FDA8A1C10F8110008A1EA /* DiagnoseUnreachable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA811C10F8110008A1EA /* DiagnoseUnreachable.cpp */; };
+		BB9FDA8B1C10F8110008A1EA /* DIMemoryUseCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA821C10F8110008A1EA /* DIMemoryUseCollector.cpp */; };
+		BB9FDA8C1C10F8110008A1EA /* InOutDeshadowing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA841C10F8110008A1EA /* InOutDeshadowing.cpp */; };
+		BB9FDA8D1C10F8110008A1EA /* MandatoryInlining.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA851C10F8110008A1EA /* MandatoryInlining.cpp */; };
+		BB9FDA8E1C10F8110008A1EA /* PredictableMemOpt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA861C10F8110008A1EA /* PredictableMemOpt.cpp */; };
+		BB9FDA9D1C10F84F0008A1EA /* CapturePromotion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA911C10F84F0008A1EA /* CapturePromotion.cpp */; };
+		BB9FDA9E1C10F84F0008A1EA /* CapturePropagation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA921C10F84F0008A1EA /* CapturePropagation.cpp */; };
+		BB9FDA9F1C10F84F0008A1EA /* ClosureSpecializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA931C10F84F0008A1EA /* ClosureSpecializer.cpp */; };
+		BB9FDAA01C10F84F0008A1EA /* DeadFunctionElimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA951C10F84F0008A1EA /* DeadFunctionElimination.cpp */; };
+		BB9FDAA11C10F84F0008A1EA /* ExternalDefsToDecls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA961C10F84F0008A1EA /* ExternalDefsToDecls.cpp */; };
+		BB9FDAA21C10F84F0008A1EA /* FunctionSignatureOpts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA971C10F84F0008A1EA /* FunctionSignatureOpts.cpp */; };
+		BB9FDAA31C10F84F0008A1EA /* GlobalOpt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA981C10F84F0008A1EA /* GlobalOpt.cpp */; };
+		BB9FDAA41C10F84F0008A1EA /* GlobalPropertyOpt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA991C10F84F0008A1EA /* GlobalPropertyOpt.cpp */; };
+		BB9FDAA51C10F84F0008A1EA /* LetPropertiesOpts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA9A1C10F84F0008A1EA /* LetPropertiesOpts.cpp */; };
+		BB9FDAA61C10F84F0008A1EA /* PerformanceInliner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA9B1C10F84F0008A1EA /* PerformanceInliner.cpp */; };
+		BB9FDAA71C10F84F0008A1EA /* UsePrespecialized.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDA9C1C10F84F0008A1EA /* UsePrespecialized.cpp */; };
+		BB9FDAAE1C10F86C0008A1EA /* ArrayBoundsCheckOpts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAA91C10F86C0008A1EA /* ArrayBoundsCheckOpts.cpp */; };
+		BB9FDAAF1C10F86C0008A1EA /* COWArrayOpt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAAB1C10F86C0008A1EA /* COWArrayOpt.cpp */; };
+		BB9FDAB01C10F86C0008A1EA /* LICM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAAC1C10F86C0008A1EA /* LICM.cpp */; };
+		BB9FDAB11C10F86C0008A1EA /* LoopRotate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAAD1C10F86C0008A1EA /* LoopRotate.cpp */; };
+		BB9FDAB71C10F8980008A1EA /* Passes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAB41C10F8980008A1EA /* Passes.cpp */; };
+		BB9FDAB81C10F8980008A1EA /* PassManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAB51C10F8980008A1EA /* PassManager.cpp */; };
+		BB9FDAB91C10F8980008A1EA /* PrettyStackTrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAB61C10F8980008A1EA /* PrettyStackTrace.cpp */; };
+		BB9FDAD11C10F8B40008A1EA /* AllocBoxToStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDABB1C10F8B40008A1EA /* AllocBoxToStack.cpp */; };
+		BB9FDAD21C10F8B40008A1EA /* ArrayCountPropagation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDABC1C10F8B40008A1EA /* ArrayCountPropagation.cpp */; };
+		BB9FDAD31C10F8B40008A1EA /* CopyForwarding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDABE1C10F8B40008A1EA /* CopyForwarding.cpp */; };
+		BB9FDAD41C10F8B40008A1EA /* CSE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDABF1C10F8B40008A1EA /* CSE.cpp */; };
+		BB9FDAD51C10F8B40008A1EA /* DeadCodeElimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC01C10F8B40008A1EA /* DeadCodeElimination.cpp */; };
+		BB9FDAD61C10F8B40008A1EA /* DeadObjectElimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC11C10F8B40008A1EA /* DeadObjectElimination.cpp */; };
+		BB9FDAD71C10F8B40008A1EA /* DeadStoreElimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC21C10F8B40008A1EA /* DeadStoreElimination.cpp */; };
+		BB9FDAD81C10F8B40008A1EA /* MergeCondFail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC31C10F8B40008A1EA /* MergeCondFail.cpp */; };
+		BB9FDAD91C10F8B40008A1EA /* RedundantLoadElimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC41C10F8B40008A1EA /* RedundantLoadElimination.cpp */; };
+		BB9FDADA1C10F8B40008A1EA /* RedundantOverflowCheckRemoval.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC51C10F8B40008A1EA /* RedundantOverflowCheckRemoval.cpp */; };
+		BB9FDADB1C10F8B40008A1EA /* ReleaseDevirtualizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC61C10F8B40008A1EA /* ReleaseDevirtualizer.cpp */; };
+		BB9FDADC1C10F8B40008A1EA /* RemovePin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC71C10F8B40008A1EA /* RemovePin.cpp */; };
+		BB9FDADD1C10F8B40008A1EA /* SILCleanup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC81C10F8B40008A1EA /* SILCleanup.cpp */; };
+		BB9FDADE1C10F8B40008A1EA /* SILCodeMotion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAC91C10F8B40008A1EA /* SILCodeMotion.cpp */; };
+		BB9FDADF1C10F8B40008A1EA /* SILLowerAggregateInstrs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDACA1C10F8B40008A1EA /* SILLowerAggregateInstrs.cpp */; };
+		BB9FDAE01C10F8B40008A1EA /* SILMem2Reg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDACB1C10F8B40008A1EA /* SILMem2Reg.cpp */; };
+		BB9FDAE11C10F8B40008A1EA /* SILSROA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDACC1C10F8B40008A1EA /* SILSROA.cpp */; };
+		BB9FDAE21C10F8B40008A1EA /* SimplifyCFG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDACD1C10F8B40008A1EA /* SimplifyCFG.cpp */; };
+		BB9FDAE31C10F8B40008A1EA /* Sink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDACE1C10F8B40008A1EA /* Sink.cpp */; };
+		BB9FDAE41C10F8B40008A1EA /* SpeculativeDevirtualizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDACF1C10F8B40008A1EA /* SpeculativeDevirtualizer.cpp */; };
+		BB9FDAE51C10F8B40008A1EA /* StackPromotion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAD01C10F8B40008A1EA /* StackPromotion.cpp */; };
+		BB9FDAEE1C10F8D90008A1EA /* SILCombine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAE81C10F8D90008A1EA /* SILCombine.cpp */; };
+		BB9FDAEF1C10F8D90008A1EA /* SILCombinerApplyVisitors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAEA1C10F8D90008A1EA /* SILCombinerApplyVisitors.cpp */; };
+		BB9FDAF01C10F8D90008A1EA /* SILCombinerBuiltinVisitors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAEB1C10F8D90008A1EA /* SILCombinerBuiltinVisitors.cpp */; };
+		BB9FDAF11C10F8D90008A1EA /* SILCombinerCastVisitors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAEC1C10F8D90008A1EA /* SILCombinerCastVisitors.cpp */; };
+		BB9FDAF21C10F8D90008A1EA /* SILCombinerMiscVisitors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAED1C10F8D90008A1EA /* SILCombinerMiscVisitors.cpp */; };
+		BB9FDB041C10F8FC0008A1EA /* AADumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAF41C10F8FC0008A1EA /* AADumper.cpp */; };
+		BB9FDB051C10F8FC0008A1EA /* BasicCalleePrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAF51C10F8FC0008A1EA /* BasicCalleePrinter.cpp */; };
+		BB9FDB061C10F8FC0008A1EA /* CallGraphPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAF61C10F8FC0008A1EA /* CallGraphPrinter.cpp */; };
+		BB9FDB071C10F8FC0008A1EA /* CFGPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAF71C10F8FC0008A1EA /* CFGPrinter.cpp */; };
+		BB9FDB081C10F8FC0008A1EA /* FunctionOrderPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAF91C10F8FC0008A1EA /* FunctionOrderPrinter.cpp */; };
+		BB9FDB091C10F8FC0008A1EA /* InstCount.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAFA1C10F8FC0008A1EA /* InstCount.cpp */; };
+		BB9FDB0A1C10F8FC0008A1EA /* IVInfoPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAFB1C10F8FC0008A1EA /* IVInfoPrinter.cpp */; };
+		BB9FDB0B1C10F8FC0008A1EA /* Link.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAFC1C10F8FC0008A1EA /* Link.cpp */; };
+		BB9FDB0C1C10F8FC0008A1EA /* LoopCanonicalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAFD1C10F8FC0008A1EA /* LoopCanonicalizer.cpp */; };
+		BB9FDB0D1C10F8FC0008A1EA /* LoopInfoPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAFE1C10F8FC0008A1EA /* LoopInfoPrinter.cpp */; };
+		BB9FDB0E1C10F8FC0008A1EA /* LoopRegionPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDAFF1C10F8FC0008A1EA /* LoopRegionPrinter.cpp */; };
+		BB9FDB0F1C10F8FC0008A1EA /* MemLocationPrinter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB001C10F8FC0008A1EA /* MemLocationPrinter.cpp */; };
+		BB9FDB101C10F8FC0008A1EA /* StripDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB011C10F8FC0008A1EA /* StripDebugInfo.cpp */; };
+		BB9FDB111C10F8FC0008A1EA /* UpdateEscapeAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB021C10F8FC0008A1EA /* UpdateEscapeAnalysis.cpp */; };
+		BB9FDB121C10F8FC0008A1EA /* UpdateSideEffects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB031C10F8FC0008A1EA /* UpdateSideEffects.cpp */; };
+		BB9FDB1F1C10F9200008A1EA /* CFG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB141C10F9200008A1EA /* CFG.cpp */; };
+		BB9FDB201C10F9200008A1EA /* CheckedCastBrJumpThreading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB151C10F9200008A1EA /* CheckedCastBrJumpThreading.cpp */; };
+		BB9FDB211C10F9200008A1EA /* ConstantFolding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB171C10F9200008A1EA /* ConstantFolding.cpp */; };
+		BB9FDB221C10F9200008A1EA /* Devirtualize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB181C10F9200008A1EA /* Devirtualize.cpp */; };
+		BB9FDB231C10F9200008A1EA /* GenericCloner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB191C10F9200008A1EA /* GenericCloner.cpp */; };
+		BB9FDB241C10F9200008A1EA /* Generics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB1A1C10F9200008A1EA /* Generics.cpp */; };
+		BB9FDB251C10F9200008A1EA /* Local.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB1B1C10F9200008A1EA /* Local.cpp */; };
+		BB9FDB261C10F9200008A1EA /* LoopUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB1C1C10F9200008A1EA /* LoopUtils.cpp */; };
+		BB9FDB271C10F9200008A1EA /* SILInliner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB1D1C10F9200008A1EA /* SILInliner.cpp */; };
+		BB9FDB281C10F9200008A1EA /* SILSSAUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB9FDB1E1C10F9200008A1EA /* SILSSAUpdater.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		BB9FD63E1C10EF850008A1EA /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		BB8B27D21C1233F600C91975 /* libclangAnalysis.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangAnalysis.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangAnalysis.a"; sourceTree = "<group>"; };
+		BB8B27D31C1233F600C91975 /* libclangAPINotes.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangAPINotes.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangAPINotes.a"; sourceTree = "<group>"; };
+		BB8B27D41C1233F600C91975 /* libclangARCMigrate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangARCMigrate.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangARCMigrate.a"; sourceTree = "<group>"; };
+		BB8B27D51C1233F600C91975 /* libclangAST.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangAST.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangAST.a"; sourceTree = "<group>"; };
+		BB8B27D61C1233F700C91975 /* libclangASTMatchers.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangASTMatchers.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangASTMatchers.a"; sourceTree = "<group>"; };
+		BB8B27D71C1233F700C91975 /* libclangBasic.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangBasic.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangBasic.a"; sourceTree = "<group>"; };
+		BB8B27D81C1233F700C91975 /* libclangCodeGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangCodeGen.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangCodeGen.a"; sourceTree = "<group>"; };
+		BB8B27D91C1233F700C91975 /* libclangDriver.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangDriver.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangDriver.a"; sourceTree = "<group>"; };
+		BB8B27DA1C1233F700C91975 /* libclangDynamicASTMatchers.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangDynamicASTMatchers.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangDynamicASTMatchers.a"; sourceTree = "<group>"; };
+		BB8B27DB1C1233F700C91975 /* libclangEdit.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangEdit.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangEdit.a"; sourceTree = "<group>"; };
+		BB8B27DC1C1233F700C91975 /* libclangFormat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangFormat.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangFormat.a"; sourceTree = "<group>"; };
+		BB8B27DD1C1233F700C91975 /* libclangFrontend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangFrontend.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangFrontend.a"; sourceTree = "<group>"; };
+		BB8B27DE1C1233F700C91975 /* libclangFrontendTool.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangFrontendTool.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangFrontendTool.a"; sourceTree = "<group>"; };
+		BB8B27DF1C1233F700C91975 /* libclangIndex.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangIndex.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangIndex.a"; sourceTree = "<group>"; };
+		BB8B27E01C1233F700C91975 /* libclangLex.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangLex.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangLex.a"; sourceTree = "<group>"; };
+		BB8B27E11C1233F700C91975 /* libclangParse.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangParse.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangParse.a"; sourceTree = "<group>"; };
+		BB8B27E21C1233F700C91975 /* libclangRewrite.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangRewrite.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangRewrite.a"; sourceTree = "<group>"; };
+		BB8B27E31C1233F700C91975 /* libclangRewriteFrontend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangRewriteFrontend.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangRewriteFrontend.a"; sourceTree = "<group>"; };
+		BB8B27E41C1233F700C91975 /* libclangSema.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangSema.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangSema.a"; sourceTree = "<group>"; };
+		BB8B27E51C1233F700C91975 /* libclangSerialization.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangSerialization.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangSerialization.a"; sourceTree = "<group>"; };
+		BB8B27E61C1233F700C91975 /* libclangStaticAnalyzerCheckers.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangStaticAnalyzerCheckers.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangStaticAnalyzerCheckers.a"; sourceTree = "<group>"; };
+		BB8B27E71C1233F700C91975 /* libclangStaticAnalyzerCore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangStaticAnalyzerCore.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangStaticAnalyzerCore.a"; sourceTree = "<group>"; };
+		BB8B27E81C1233F700C91975 /* libclangStaticAnalyzerFrontend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangStaticAnalyzerFrontend.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangStaticAnalyzerFrontend.a"; sourceTree = "<group>"; };
+		BB8B27E91C1233F700C91975 /* libclangTooling.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangTooling.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangTooling.a"; sourceTree = "<group>"; };
+		BB8B27EA1C1233F700C91975 /* libclangToolingCore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangToolingCore.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libclangToolingCore.a"; sourceTree = "<group>"; };
+		BB8B27EC1C1233F700C91975 /* libgtest_main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgtest_main.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libgtest_main.a"; sourceTree = "<group>"; };
+		BB8B27ED1C1233F700C91975 /* libgtest.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgtest.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libgtest.a"; sourceTree = "<group>"; };
+		BB8B27EE1C1233F700C91975 /* libLLVMAArch64AsmParser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64AsmParser.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64AsmParser.a"; sourceTree = "<group>"; };
+		BB8B27EF1C1233F700C91975 /* libLLVMAArch64AsmPrinter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64AsmPrinter.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64AsmPrinter.a"; sourceTree = "<group>"; };
+		BB8B27F01C1233F700C91975 /* libLLVMAArch64CodeGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64CodeGen.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64CodeGen.a"; sourceTree = "<group>"; };
+		BB8B27F11C1233F700C91975 /* libLLVMAArch64Desc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64Desc.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64Desc.a"; sourceTree = "<group>"; };
+		BB8B27F21C1233F700C91975 /* libLLVMAArch64Disassembler.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64Disassembler.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64Disassembler.a"; sourceTree = "<group>"; };
+		BB8B27F31C1233F700C91975 /* libLLVMAArch64Info.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64Info.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64Info.a"; sourceTree = "<group>"; };
+		BB8B27F41C1233F700C91975 /* libLLVMAArch64Utils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAArch64Utils.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAArch64Utils.a"; sourceTree = "<group>"; };
+		BB8B27F51C1233F700C91975 /* libLLVMAnalysis.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAnalysis.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAnalysis.a"; sourceTree = "<group>"; };
+		BB8B27F61C1233F700C91975 /* libLLVMARMAsmParser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMARMAsmParser.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMARMAsmParser.a"; sourceTree = "<group>"; };
+		BB8B27F71C1233F700C91975 /* libLLVMARMAsmPrinter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMARMAsmPrinter.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMARMAsmPrinter.a"; sourceTree = "<group>"; };
+		BB8B27F81C1233F700C91975 /* libLLVMARMCodeGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMARMCodeGen.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMARMCodeGen.a"; sourceTree = "<group>"; };
+		BB8B27F91C1233F700C91975 /* libLLVMARMDesc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMARMDesc.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMARMDesc.a"; sourceTree = "<group>"; };
+		BB8B27FA1C1233F700C91975 /* libLLVMARMDisassembler.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMARMDisassembler.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMARMDisassembler.a"; sourceTree = "<group>"; };
+		BB8B27FB1C1233F700C91975 /* libLLVMARMInfo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMARMInfo.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMARMInfo.a"; sourceTree = "<group>"; };
+		BB8B27FC1C1233F700C91975 /* libLLVMAsmParser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAsmParser.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAsmParser.a"; sourceTree = "<group>"; };
+		BB8B27FD1C1233F700C91975 /* libLLVMAsmPrinter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMAsmPrinter.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMAsmPrinter.a"; sourceTree = "<group>"; };
+		BB8B27FE1C1233F700C91975 /* libLLVMBitReader.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMBitReader.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMBitReader.a"; sourceTree = "<group>"; };
+		BB8B27FF1C1233F700C91975 /* libLLVMBitWriter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMBitWriter.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMBitWriter.a"; sourceTree = "<group>"; };
+		BB8B28001C1233F700C91975 /* libLLVMCodeGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMCodeGen.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMCodeGen.a"; sourceTree = "<group>"; };
+		BB8B28011C1233F700C91975 /* libLLVMCore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMCore.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMCore.a"; sourceTree = "<group>"; };
+		BB8B28021C1233F700C91975 /* libLLVMDebugInfoDWARF.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMDebugInfoDWARF.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMDebugInfoDWARF.a"; sourceTree = "<group>"; };
+		BB8B28031C1233F700C91975 /* libLLVMDebugInfoPDB.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMDebugInfoPDB.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMDebugInfoPDB.a"; sourceTree = "<group>"; };
+		BB8B28041C1233F700C91975 /* libLLVMExecutionEngine.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMExecutionEngine.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMExecutionEngine.a"; sourceTree = "<group>"; };
+		BB8B28051C1233F700C91975 /* libLLVMInstCombine.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMInstCombine.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMInstCombine.a"; sourceTree = "<group>"; };
+		BB8B28061C1233F700C91975 /* libLLVMInstrumentation.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMInstrumentation.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMInstrumentation.a"; sourceTree = "<group>"; };
+		BB8B28071C1233F700C91975 /* libLLVMInterpreter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMInterpreter.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMInterpreter.a"; sourceTree = "<group>"; };
+		BB8B28081C1233F700C91975 /* libLLVMipo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMipo.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMipo.a"; sourceTree = "<group>"; };
+		BB8B28091C1233F700C91975 /* libLLVMIRReader.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMIRReader.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMIRReader.a"; sourceTree = "<group>"; };
+		BB8B280A1C1233F700C91975 /* libLLVMLibDriver.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMLibDriver.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMLibDriver.a"; sourceTree = "<group>"; };
+		BB8B280B1C1233F700C91975 /* libLLVMLineEditor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMLineEditor.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMLineEditor.a"; sourceTree = "<group>"; };
+		BB8B280C1C1233F700C91975 /* libLLVMLinker.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMLinker.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMLinker.a"; sourceTree = "<group>"; };
+		BB8B280D1C1233F700C91975 /* libLLVMLTO.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMLTO.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMLTO.a"; sourceTree = "<group>"; };
+		BB8B280E1C1233F700C91975 /* libLLVMMC.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMMC.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMMC.a"; sourceTree = "<group>"; };
+		BB8B280F1C1233F700C91975 /* libLLVMMCDisassembler.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMMCDisassembler.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMMCDisassembler.a"; sourceTree = "<group>"; };
+		BB8B28101C1233F700C91975 /* libLLVMMCJIT.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMMCJIT.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMMCJIT.a"; sourceTree = "<group>"; };
+		BB8B28111C1233F700C91975 /* libLLVMMCParser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMMCParser.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMMCParser.a"; sourceTree = "<group>"; };
+		BB8B28121C1233F700C91975 /* libLLVMMIRParser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMMIRParser.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMMIRParser.a"; sourceTree = "<group>"; };
+		BB8B28131C1233F700C91975 /* libLLVMObjCARCOpts.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMObjCARCOpts.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMObjCARCOpts.a"; sourceTree = "<group>"; };
+		BB8B28141C1233F700C91975 /* libLLVMObject.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMObject.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMObject.a"; sourceTree = "<group>"; };
+		BB8B28151C1233F700C91975 /* libLLVMOption.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMOption.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMOption.a"; sourceTree = "<group>"; };
+		BB8B28161C1233F700C91975 /* libLLVMOrcJIT.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMOrcJIT.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMOrcJIT.a"; sourceTree = "<group>"; };
+		BB8B28171C1233F700C91975 /* libLLVMPasses.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMPasses.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMPasses.a"; sourceTree = "<group>"; };
+		BB8B28181C1233F700C91975 /* libLLVMProfileData.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMProfileData.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMProfileData.a"; sourceTree = "<group>"; };
+		BB8B28191C1233F700C91975 /* libLLVMRuntimeDyld.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMRuntimeDyld.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMRuntimeDyld.a"; sourceTree = "<group>"; };
+		BB8B281A1C1233F700C91975 /* libLLVMScalarOpts.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMScalarOpts.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMScalarOpts.a"; sourceTree = "<group>"; };
+		BB8B281B1C1233F700C91975 /* libLLVMSelectionDAG.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMSelectionDAG.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMSelectionDAG.a"; sourceTree = "<group>"; };
+		BB8B281C1C1233F700C91975 /* libLLVMSupport.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMSupport.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMSupport.a"; sourceTree = "<group>"; };
+		BB8B281D1C1233F700C91975 /* libLLVMSymbolize.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMSymbolize.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMSymbolize.a"; sourceTree = "<group>"; };
+		BB8B281E1C1233F700C91975 /* libLLVMTableGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMTableGen.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMTableGen.a"; sourceTree = "<group>"; };
+		BB8B281F1C1233F700C91975 /* libLLVMTarget.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMTarget.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMTarget.a"; sourceTree = "<group>"; };
+		BB8B28201C1233F700C91975 /* libLLVMTransformUtils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMTransformUtils.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMTransformUtils.a"; sourceTree = "<group>"; };
+		BB8B28211C1233F700C91975 /* libLLVMVectorize.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMVectorize.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMVectorize.a"; sourceTree = "<group>"; };
+		BB8B28221C1233F700C91975 /* libLLVMX86AsmParser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86AsmParser.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86AsmParser.a"; sourceTree = "<group>"; };
+		BB8B28231C1233F700C91975 /* libLLVMX86AsmPrinter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86AsmPrinter.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86AsmPrinter.a"; sourceTree = "<group>"; };
+		BB8B28241C1233F700C91975 /* libLLVMX86CodeGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86CodeGen.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86CodeGen.a"; sourceTree = "<group>"; };
+		BB8B28251C1233F800C91975 /* libLLVMX86Desc.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86Desc.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86Desc.a"; sourceTree = "<group>"; };
+		BB8B28261C1233F800C91975 /* libLLVMX86Disassembler.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86Disassembler.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86Disassembler.a"; sourceTree = "<group>"; };
+		BB8B28271C1233F800C91975 /* libLLVMX86Info.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86Info.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86Info.a"; sourceTree = "<group>"; };
+		BB8B28281C1233F800C91975 /* libLLVMX86Utils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMX86Utils.a; path = "../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib/libLLVMX86Utils.a"; sourceTree = "<group>"; };
+		BB8B28801C12352E00C91975 /* libcmark.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcmark.a; path = "../build/Ninja-DebugAssert/cmark-macosx-x86_64/src/libcmark.a"; sourceTree = "<group>"; };
+		BB8B28821C12357300C91975 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		BB8B28871C1236D400C91975 /* libedit.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libedit.tbd; path = usr/lib/libedit.tbd; sourceTree = SDKROOT; };
+		BB8B28891C1238B100C91975 /* libLLVMSupport.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMSupport.a; path = "../build/Xcode-DebugAssert/llvm-macosx-x86_64/Debug/lib/libLLVMSupport.a"; sourceTree = "<group>"; };
+		BB8B288A1C1238B100C91975 /* libLLVMTableGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMTableGen.a; path = "../build/Xcode-DebugAssert/llvm-macosx-x86_64/Debug/lib/libLLVMTableGen.a"; sourceTree = "<group>"; };
+		BB8B28931C12489800C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/internal/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28941C12489800C91975 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.txt; path = stdlib/internal/README.txt; sourceTree = "<group>"; };
+		BB8B28951C1248AA00C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/internal/SwiftExperimental/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28961C1248AA00C91975 /* SwiftExperimental.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftExperimental.swift; path = stdlib/internal/SwiftExperimental/SwiftExperimental.swift; sourceTree = "<group>"; };
+		BB8B28991C1248CE00C91975 /* CheckCollectionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CheckCollectionType.swift; path = stdlib/private/StdlibUnittest/CheckCollectionType.swift; sourceTree = "<group>"; };
+		BB8B289A1C1248CE00C91975 /* CheckMutableCollectionType.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CheckMutableCollectionType.swift.gyb; path = stdlib/private/StdlibUnittest/CheckMutableCollectionType.swift.gyb; sourceTree = "<group>"; };
+		BB8B289B1C1248CE00C91975 /* CheckRangeReplaceableCollectionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CheckRangeReplaceableCollectionType.swift; path = stdlib/private/StdlibUnittest/CheckRangeReplaceableCollectionType.swift; sourceTree = "<group>"; };
+		BB8B289C1C1248CE00C91975 /* CheckRangeReplaceableSliceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CheckRangeReplaceableSliceType.swift; path = stdlib/private/StdlibUnittest/CheckRangeReplaceableSliceType.swift; sourceTree = "<group>"; };
+		BB8B289D1C1248CE00C91975 /* CheckSequenceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CheckSequenceType.swift; path = stdlib/private/StdlibUnittest/CheckSequenceType.swift; sourceTree = "<group>"; };
+		BB8B289E1C1248CE00C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/private/StdlibUnittest/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B289F1C1248CE00C91975 /* GetOSVersion.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = GetOSVersion.mm; path = stdlib/private/StdlibUnittest/GetOSVersion.mm; sourceTree = "<group>"; };
+		BB8B28A01C1248CE00C91975 /* InterceptTraps.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InterceptTraps.cpp; path = stdlib/private/StdlibUnittest/InterceptTraps.cpp; sourceTree = "<group>"; };
+		BB8B28A11C1248CE00C91975 /* LifetimeTracked.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LifetimeTracked.swift; path = stdlib/private/StdlibUnittest/LifetimeTracked.swift; sourceTree = "<group>"; };
+		BB8B28A21C1248CE00C91975 /* LoggingWrappers.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = LoggingWrappers.swift.gyb; path = stdlib/private/StdlibUnittest/LoggingWrappers.swift.gyb; sourceTree = "<group>"; };
+		BB8B28A31C1248CE00C91975 /* OpaqueIdentityFunctions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OpaqueIdentityFunctions.cpp; path = stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp; sourceTree = "<group>"; };
+		BB8B28A41C1248CE00C91975 /* OpaqueIdentityFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OpaqueIdentityFunctions.swift; path = stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift; sourceTree = "<group>"; };
+		BB8B28A51C1248CE00C91975 /* RaceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RaceTest.swift; path = stdlib/private/StdlibUnittest/RaceTest.swift; sourceTree = "<group>"; };
+		BB8B28A61C1248CE00C91975 /* Statistics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Statistics.swift; path = stdlib/private/StdlibUnittest/Statistics.swift; sourceTree = "<group>"; };
+		BB8B28A71C1248CE00C91975 /* StdlibCoreExtras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StdlibCoreExtras.swift; path = stdlib/private/StdlibUnittest/StdlibCoreExtras.swift; sourceTree = "<group>"; };
+		BB8B28A81C1248CE00C91975 /* StdlibUnittest.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = StdlibUnittest.swift.gyb; path = stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb; sourceTree = "<group>"; };
+		BB8B28A91C1248CE00C91975 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestHelpers.swift; path = stdlib/private/StdlibUnittest/TestHelpers.swift; sourceTree = "<group>"; };
+		BB8B28AA1C1248CE00C91975 /* TypeIndexed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TypeIndexed.swift; path = stdlib/private/StdlibUnittest/TypeIndexed.swift; sourceTree = "<group>"; };
+		BB8B28B91C1248DE00C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/private/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28BA1C1248DE00C91975 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.txt; path = stdlib/private/README.txt; sourceTree = "<group>"; };
+		BB8B28BC1C1248FD00C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/private/StdlibUnittestFoundationExtras/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28BD1C1248FD00C91975 /* StdlibUnittestFoundationExtras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StdlibUnittestFoundationExtras.swift; path = stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift; sourceTree = "<group>"; };
+		BB8B28C01C12492100C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/private/SwiftPrivate/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28C11C12492100C91975 /* IO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IO.swift; path = stdlib/private/SwiftPrivate/IO.swift; sourceTree = "<group>"; };
+		BB8B28C21C12492100C91975 /* PRNG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PRNG.swift; path = stdlib/private/SwiftPrivate/PRNG.swift; sourceTree = "<group>"; };
+		BB8B28C31C12492100C91975 /* ShardedAtomicCounter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShardedAtomicCounter.swift; path = stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift; sourceTree = "<group>"; };
+		BB8B28C41C12492100C91975 /* SwiftPrivate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftPrivate.swift; path = stdlib/private/SwiftPrivate/SwiftPrivate.swift; sourceTree = "<group>"; };
+		BB8B28CA1C12494700C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/private/SwiftPrivateDarwinExtras/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28CB1C12494700C91975 /* Subprocess.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Subprocess.swift; path = stdlib/private/SwiftPrivateDarwinExtras/Subprocess.swift; sourceTree = "<group>"; };
+		BB8B28CC1C12494700C91975 /* SwiftPrivateDarwinExtras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftPrivateDarwinExtras.swift; path = stdlib/private/SwiftPrivateDarwinExtras/SwiftPrivateDarwinExtras.swift; sourceTree = "<group>"; };
+		BB8B28D01C12496900C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/private/SwiftPrivatePthreadExtras/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28D11C12496900C91975 /* PthreadBarriers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PthreadBarriers.swift; path = stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift; sourceTree = "<group>"; };
+		BB8B28D21C12496900C91975 /* SwiftPrivatePthreadExtras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftPrivatePthreadExtras.swift; path = stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift; sourceTree = "<group>"; };
+		BB8B28D61C12499300C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28D71C12499300C91975 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.txt; path = stdlib/public/README.txt; sourceTree = "<group>"; };
+		BB8B28D81C1249A200C91975 /* MirrorBoilerplate.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MirrorBoilerplate.gyb; path = stdlib/public/common/MirrorBoilerplate.gyb; sourceTree = "<group>"; };
+		BB8B28D91C1249A200C91975 /* MirrorCommon.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = MirrorCommon.py; path = stdlib/public/common/MirrorCommon.py; sourceTree = "<group>"; };
+		BB8B28DA1C1249A200C91975 /* MirrorCommon.pyc */ = {isa = PBXFileReference; lastKnownFileType = file; name = MirrorCommon.pyc; path = stdlib/public/common/MirrorCommon.pyc; sourceTree = "<group>"; };
+		BB8B28DB1C1249A200C91975 /* MirrorConformance.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MirrorConformance.gyb; path = stdlib/public/common/MirrorConformance.gyb; sourceTree = "<group>"; };
+		BB8B28DC1C1249A200C91975 /* MirrorDecl.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MirrorDecl.gyb; path = stdlib/public/common/MirrorDecl.gyb; sourceTree = "<group>"; };
+		BB8B28DE1C1249C800C91975 /* Algorithm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Algorithm.swift; path = stdlib/public/core/Algorithm.swift; sourceTree = "<group>"; };
+		BB8B28DF1C1249C800C91975 /* ArrayBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayBody.swift; path = stdlib/public/core/ArrayBody.swift; sourceTree = "<group>"; };
+		BB8B28E01C1249C800C91975 /* ArrayBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayBuffer.swift; path = stdlib/public/core/ArrayBuffer.swift; sourceTree = "<group>"; };
+		BB8B28E11C1249C800C91975 /* ArrayBufferType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayBufferType.swift; path = stdlib/public/core/ArrayBufferType.swift; sourceTree = "<group>"; };
+		BB8B28E21C1249C800C91975 /* ArrayCast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayCast.swift; path = stdlib/public/core/ArrayCast.swift; sourceTree = "<group>"; };
+		BB8B28E31C1249C800C91975 /* Arrays.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Arrays.swift.gyb; path = stdlib/public/core/Arrays.swift.gyb; sourceTree = "<group>"; };
+		BB8B28E41C1249C800C91975 /* ArrayType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayType.swift; path = stdlib/public/core/ArrayType.swift; sourceTree = "<group>"; };
+		BB8B28E51C1249C800C91975 /* Assert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Assert.swift; path = stdlib/public/core/Assert.swift; sourceTree = "<group>"; };
+		BB8B28E61C1249C800C91975 /* AssertCommon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AssertCommon.swift; path = stdlib/public/core/AssertCommon.swift; sourceTree = "<group>"; };
+		BB8B28E71C1249C800C91975 /* Availability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Availability.swift; path = stdlib/public/core/Availability.swift; sourceTree = "<group>"; };
+		BB8B28E81C1249C800C91975 /* Bit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bit.swift; path = stdlib/public/core/Bit.swift; sourceTree = "<group>"; };
+		BB8B28E91C1249C800C91975 /* Bool.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bool.swift; path = stdlib/public/core/Bool.swift; sourceTree = "<group>"; };
+		BB8B28EA1C1249C800C91975 /* BooleanType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BooleanType.swift; path = stdlib/public/core/BooleanType.swift; sourceTree = "<group>"; };
+		BB8B28EB1C1249C800C91975 /* BridgeObjectiveC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BridgeObjectiveC.swift; path = stdlib/public/core/BridgeObjectiveC.swift; sourceTree = "<group>"; };
+		BB8B28EC1C1249C800C91975 /* BridgeStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BridgeStorage.swift; path = stdlib/public/core/BridgeStorage.swift; sourceTree = "<group>"; };
+		BB8B28ED1C1249C800C91975 /* Builtin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Builtin.swift; path = stdlib/public/core/Builtin.swift; sourceTree = "<group>"; };
+		BB8B28EE1C1249C800C91975 /* BuiltinMath.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = BuiltinMath.swift.gyb; path = stdlib/public/core/BuiltinMath.swift.gyb; sourceTree = "<group>"; };
+		BB8B28EF1C1249C800C91975 /* Character.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Character.swift; path = stdlib/public/core/Character.swift; sourceTree = "<group>"; };
+		BB8B28F01C1249C800C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/core/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B28F11C1249C800C91975 /* CocoaArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CocoaArray.swift; path = stdlib/public/core/CocoaArray.swift; sourceTree = "<group>"; };
+		BB8B28F21C1249C800C91975 /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Collection.swift; path = stdlib/public/core/Collection.swift; sourceTree = "<group>"; };
+		BB8B28F31C1249C800C91975 /* CollectionAlgorithms.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CollectionAlgorithms.swift.gyb; path = stdlib/public/core/CollectionAlgorithms.swift.gyb; sourceTree = "<group>"; };
+		BB8B28F41C1249C800C91975 /* CollectionMirrors.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CollectionMirrors.swift.gyb; path = stdlib/public/core/CollectionMirrors.swift.gyb; sourceTree = "<group>"; };
+		BB8B28F51C1249C800C91975 /* CollectionOfOne.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CollectionOfOne.swift; path = stdlib/public/core/CollectionOfOne.swift; sourceTree = "<group>"; };
+		BB8B28F61C1249C800C91975 /* CompilerProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CompilerProtocols.swift; path = stdlib/public/core/CompilerProtocols.swift; sourceTree = "<group>"; };
+		BB8B28F71C1249C800C91975 /* ContiguousArrayBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContiguousArrayBuffer.swift; path = stdlib/public/core/ContiguousArrayBuffer.swift; sourceTree = "<group>"; };
+		BB8B28F81C1249C800C91975 /* CString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CString.swift; path = stdlib/public/core/CString.swift; sourceTree = "<group>"; };
+		BB8B28F91C1249C800C91975 /* CTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CTypes.swift; path = stdlib/public/core/CTypes.swift; sourceTree = "<group>"; };
+		BB8B28FA1C1249C800C91975 /* EmptyCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EmptyCollection.swift; path = stdlib/public/core/EmptyCollection.swift; sourceTree = "<group>"; };
+		BB8B28FB1C1249C800C91975 /* ErrorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ErrorType.swift; path = stdlib/public/core/ErrorType.swift; sourceTree = "<group>"; };
+		BB8B28FC1C1249C800C91975 /* Existential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Existential.swift; path = stdlib/public/core/Existential.swift; sourceTree = "<group>"; };
+		BB8B28FD1C1249C800C91975 /* ExistentialCollection.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ExistentialCollection.swift.gyb; path = stdlib/public/core/ExistentialCollection.swift.gyb; sourceTree = "<group>"; };
+		BB8B28FE1C1249C800C91975 /* Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = stdlib/public/core/Filter.swift; sourceTree = "<group>"; };
+		BB8B28FF1C1249C800C91975 /* FixedPoint.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FixedPoint.swift.gyb; path = stdlib/public/core/FixedPoint.swift.gyb; sourceTree = "<group>"; };
+		BB8B29001C1249C800C91975 /* FlatMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatMap.swift; path = stdlib/public/core/FlatMap.swift; sourceTree = "<group>"; };
+		BB8B29011C1249C800C91975 /* Flatten.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Flatten.swift.gyb; path = stdlib/public/core/Flatten.swift.gyb; sourceTree = "<group>"; };
+		BB8B29021C1249C800C91975 /* FloatingPoint.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FloatingPoint.swift.gyb; path = stdlib/public/core/FloatingPoint.swift.gyb; sourceTree = "<group>"; };
+		BB8B29031C1249C800C91975 /* FloatingPointOperations.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FloatingPointOperations.swift.gyb; path = stdlib/public/core/FloatingPointOperations.swift.gyb; sourceTree = "<group>"; };
+		BB8B29041C1249C800C91975 /* FloatingPointParsing.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FloatingPointParsing.swift.gyb; path = stdlib/public/core/FloatingPointParsing.swift.gyb; sourceTree = "<group>"; };
+		BB8B29051C1249C800C91975 /* HashedCollections.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = HashedCollections.swift.gyb; path = stdlib/public/core/HashedCollections.swift.gyb; sourceTree = "<group>"; };
+		BB8B29061C1249C800C91975 /* Hashing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Hashing.swift; path = stdlib/public/core/Hashing.swift; sourceTree = "<group>"; };
+		BB8B29071C1249C800C91975 /* HeapBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeapBuffer.swift; path = stdlib/public/core/HeapBuffer.swift; sourceTree = "<group>"; };
+		BB8B29081C1249C800C91975 /* ImplicitlyUnwrappedOptional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImplicitlyUnwrappedOptional.swift; path = stdlib/public/core/ImplicitlyUnwrappedOptional.swift; sourceTree = "<group>"; };
+		BB8B29091C1249C800C91975 /* Index.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Index.swift; path = stdlib/public/core/Index.swift; sourceTree = "<group>"; };
+		BB8B290A1C1249C800C91975 /* InputStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InputStream.swift; path = stdlib/public/core/InputStream.swift; sourceTree = "<group>"; };
+		BB8B290B1C1249C800C91975 /* IntegerArithmetic.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = IntegerArithmetic.swift.gyb; path = stdlib/public/core/IntegerArithmetic.swift.gyb; sourceTree = "<group>"; };
+		BB8B290C1C1249C800C91975 /* IntegerParsing.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = IntegerParsing.swift.gyb; path = stdlib/public/core/IntegerParsing.swift.gyb; sourceTree = "<group>"; };
+		BB8B290D1C1249C800C91975 /* Interval.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Interval.swift.gyb; path = stdlib/public/core/Interval.swift.gyb; sourceTree = "<group>"; };
+		BB8B290E1C1249C800C91975 /* Join.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Join.swift; path = stdlib/public/core/Join.swift; sourceTree = "<group>"; };
+		BB8B290F1C1249C800C91975 /* LazyCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LazyCollection.swift; path = stdlib/public/core/LazyCollection.swift; sourceTree = "<group>"; };
+		BB8B29101C1249C800C91975 /* LazySequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LazySequence.swift; path = stdlib/public/core/LazySequence.swift; sourceTree = "<group>"; };
+		BB8B29111C1249C800C91975 /* LifetimeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LifetimeManager.swift; path = stdlib/public/core/LifetimeManager.swift; sourceTree = "<group>"; };
+		BB8B29121C1249C800C91975 /* ManagedBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ManagedBuffer.swift; path = stdlib/public/core/ManagedBuffer.swift; sourceTree = "<group>"; };
+		BB8B29131C1249C800C91975 /* Map.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Map.swift; path = stdlib/public/core/Map.swift; sourceTree = "<group>"; };
+		BB8B29141C1249C800C91975 /* Mirror.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Mirror.swift; path = stdlib/public/core/Mirror.swift; sourceTree = "<group>"; };
+		BB8B29151C1249C800C91975 /* Mirrors.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Mirrors.swift.gyb; path = stdlib/public/core/Mirrors.swift.gyb; sourceTree = "<group>"; };
+		BB8B29161C1249C800C91975 /* Misc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Misc.swift; path = stdlib/public/core/Misc.swift; sourceTree = "<group>"; };
+		BB8B29171C1249C800C91975 /* ObjCMirrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjCMirrors.swift; path = stdlib/public/core/ObjCMirrors.swift; sourceTree = "<group>"; };
+		BB8B29181C1249C800C91975 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = stdlib/public/core/Optional.swift; sourceTree = "<group>"; };
+		BB8B29191C1249C800C91975 /* OptionSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OptionSet.swift; path = stdlib/public/core/OptionSet.swift; sourceTree = "<group>"; };
+		BB8B291A1C1249C800C91975 /* OutputStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OutputStream.swift; path = stdlib/public/core/OutputStream.swift; sourceTree = "<group>"; };
+		BB8B291B1C1249C800C91975 /* Pointer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Pointer.swift; path = stdlib/public/core/Pointer.swift; sourceTree = "<group>"; };
+		BB8B291C1C1249C800C91975 /* Policy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Policy.swift; path = stdlib/public/core/Policy.swift; sourceTree = "<group>"; };
+		BB8B291D1C1249C800C91975 /* Prespecialized.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Prespecialized.swift; path = stdlib/public/core/Prespecialized.swift; sourceTree = "<group>"; };
+		BB8B291E1C1249C800C91975 /* Print.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Print.swift; path = stdlib/public/core/Print.swift; sourceTree = "<group>"; };
+		BB8B291F1C1249C800C91975 /* Process.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Process.swift; path = stdlib/public/core/Process.swift; sourceTree = "<group>"; };
+		BB8B29201C1249C800C91975 /* Range.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Range.swift; path = stdlib/public/core/Range.swift; sourceTree = "<group>"; };
+		BB8B29211C1249C800C91975 /* RangeMirrors.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = RangeMirrors.swift.gyb; path = stdlib/public/core/RangeMirrors.swift.gyb; sourceTree = "<group>"; };
+		BB8B29221C1249C800C91975 /* RangeReplaceableCollectionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RangeReplaceableCollectionType.swift; path = stdlib/public/core/RangeReplaceableCollectionType.swift; sourceTree = "<group>"; };
+		BB8B29231C1249C800C91975 /* Reflection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reflection.swift; path = stdlib/public/core/Reflection.swift; sourceTree = "<group>"; };
+		BB8B29241C1249C800C91975 /* Repeat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Repeat.swift; path = stdlib/public/core/Repeat.swift; sourceTree = "<group>"; };
+		BB8B29251C1249C800C91975 /* REPL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = REPL.swift; path = stdlib/public/core/REPL.swift; sourceTree = "<group>"; };
+		BB8B29261C1249C800C91975 /* Reverse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reverse.swift; path = stdlib/public/core/Reverse.swift; sourceTree = "<group>"; };
+		BB8B29271C1249C800C91975 /* Runtime.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Runtime.swift.gyb; path = stdlib/public/core/Runtime.swift.gyb; sourceTree = "<group>"; };
+		BB8B29281C1249C800C91975 /* Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sequence.swift; path = stdlib/public/core/Sequence.swift; sourceTree = "<group>"; };
+		BB8B29291C1249C800C91975 /* SequenceAlgorithms.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = SequenceAlgorithms.swift.gyb; path = stdlib/public/core/SequenceAlgorithms.swift.gyb; sourceTree = "<group>"; };
+		BB8B292A1C1249C800C91975 /* SequenceWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SequenceWrapper.swift; path = stdlib/public/core/SequenceWrapper.swift; sourceTree = "<group>"; };
+		BB8B292B1C1249C800C91975 /* SetAlgebra.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SetAlgebra.swift; path = stdlib/public/core/SetAlgebra.swift; sourceTree = "<group>"; };
+		BB8B292C1C1249C800C91975 /* ShadowProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShadowProtocols.swift; path = stdlib/public/core/ShadowProtocols.swift; sourceTree = "<group>"; };
+		BB8B292D1C1249C800C91975 /* Shims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Shims.swift; path = stdlib/public/core/Shims.swift; sourceTree = "<group>"; };
+		BB8B292E1C1249C800C91975 /* Slice.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Slice.swift.gyb; path = stdlib/public/core/Slice.swift.gyb; sourceTree = "<group>"; };
+		BB8B292F1C1249C800C91975 /* SliceBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SliceBuffer.swift; path = stdlib/public/core/SliceBuffer.swift; sourceTree = "<group>"; };
+		BB8B29301C1249C800C91975 /* Sort.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Sort.swift.gyb; path = stdlib/public/core/Sort.swift.gyb; sourceTree = "<group>"; };
+		BB8B29311C1249C800C91975 /* StaticString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StaticString.swift; path = stdlib/public/core/StaticString.swift; sourceTree = "<group>"; };
+		BB8B29321C1249C800C91975 /* Stride.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Stride.swift; path = stdlib/public/core/Stride.swift; sourceTree = "<group>"; };
+		BB8B29331C1249C800C91975 /* StrideMirrors.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = StrideMirrors.swift.gyb; path = stdlib/public/core/StrideMirrors.swift.gyb; sourceTree = "<group>"; };
+		BB8B29341C1249C800C91975 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = String.swift; path = stdlib/public/core/String.swift; sourceTree = "<group>"; };
+		BB8B29351C1249C800C91975 /* StringBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringBridge.swift; path = stdlib/public/core/StringBridge.swift; sourceTree = "<group>"; };
+		BB8B29361C1249C800C91975 /* StringBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringBuffer.swift; path = stdlib/public/core/StringBuffer.swift; sourceTree = "<group>"; };
+		BB8B29371C1249C800C91975 /* StringCharacterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringCharacterView.swift; path = stdlib/public/core/StringCharacterView.swift; sourceTree = "<group>"; };
+		BB8B29381C1249C800C91975 /* StringCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringCore.swift; path = stdlib/public/core/StringCore.swift; sourceTree = "<group>"; };
+		BB8B29391C1249C800C91975 /* StringInterpolation.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = StringInterpolation.swift.gyb; path = stdlib/public/core/StringInterpolation.swift.gyb; sourceTree = "<group>"; };
+		BB8B293A1C1249C800C91975 /* StringLegacy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringLegacy.swift; path = stdlib/public/core/StringLegacy.swift; sourceTree = "<group>"; };
+		BB8B293B1C1249C800C91975 /* StringUnicodeScalarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringUnicodeScalarView.swift; path = stdlib/public/core/StringUnicodeScalarView.swift; sourceTree = "<group>"; };
+		BB8B293C1C1249C800C91975 /* StringUTF8.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringUTF8.swift; path = stdlib/public/core/StringUTF8.swift; sourceTree = "<group>"; };
+		BB8B293D1C1249C800C91975 /* StringUTF16.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringUTF16.swift; path = stdlib/public/core/StringUTF16.swift; sourceTree = "<group>"; };
+		BB8B293E1C1249C800C91975 /* StringUTFViewsMirrors.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = StringUTFViewsMirrors.swift.gyb; path = stdlib/public/core/StringUTFViewsMirrors.swift.gyb; sourceTree = "<group>"; };
+		BB8B293F1C1249C800C91975 /* SwiftNativeNSArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftNativeNSArray.swift; path = stdlib/public/core/SwiftNativeNSArray.swift; sourceTree = "<group>"; };
+		BB8B29401C1249C800C91975 /* UnavailableStringAPIs.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnavailableStringAPIs.swift.gyb; path = stdlib/public/core/UnavailableStringAPIs.swift.gyb; sourceTree = "<group>"; };
+		BB8B29411C1249C800C91975 /* Unicode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Unicode.swift; path = stdlib/public/core/Unicode.swift; sourceTree = "<group>"; };
+		BB8B29421C1249C800C91975 /* UnicodeScalar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnicodeScalar.swift; path = stdlib/public/core/UnicodeScalar.swift; sourceTree = "<group>"; };
+		BB8B29431C1249C800C91975 /* UnicodeTrie.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnicodeTrie.swift.gyb; path = stdlib/public/core/UnicodeTrie.swift.gyb; sourceTree = "<group>"; };
+		BB8B29441C1249C800C91975 /* Unmanaged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Unmanaged.swift; path = stdlib/public/core/Unmanaged.swift; sourceTree = "<group>"; };
+		BB8B29451C1249C800C91975 /* UnsafeBufferPointer.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnsafeBufferPointer.swift.gyb; path = stdlib/public/core/UnsafeBufferPointer.swift.gyb; sourceTree = "<group>"; };
+		BB8B29461C1249C800C91975 /* UnsafePointer.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnsafePointer.swift.gyb; path = stdlib/public/core/UnsafePointer.swift.gyb; sourceTree = "<group>"; };
+		BB8B29471C1249C800C91975 /* VarArgs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = VarArgs.swift; path = stdlib/public/core/VarArgs.swift; sourceTree = "<group>"; };
+		BB8B29481C1249C800C91975 /* Zip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Zip.swift; path = stdlib/public/core/Zip.swift; sourceTree = "<group>"; };
+		BB8B29991C1249E500C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/Glibc/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B299A1C1249E500C91975 /* Glibc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Glibc.swift; path = stdlib/public/Glibc/Glibc.swift; sourceTree = "<group>"; };
+		BB8B299B1C1249E500C91975 /* module.map */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.map; path = stdlib/public/Glibc/module.map; sourceTree = "<group>"; };
+		BB8B299C1C1249E500C91975 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = stdlib/public/Glibc/README.md; sourceTree = "<group>"; };
+		BB8B29A01C124A0C00C91975 /* Casting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Casting.cpp; path = stdlib/public/runtime/Casting.cpp; sourceTree = "<group>"; };
+		BB8B29A11C124A0C00C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/runtime/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B29A21C124A0C00C91975 /* Demangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Demangle.cpp; path = stdlib/public/runtime/Demangle.cpp; sourceTree = "<group>"; };
+		BB8B29A31C124A0C00C91975 /* Enum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Enum.cpp; path = stdlib/public/runtime/Enum.cpp; sourceTree = "<group>"; };
+		BB8B29A41C124A0C00C91975 /* ErrorObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ErrorObject.cpp; path = stdlib/public/runtime/ErrorObject.cpp; sourceTree = "<group>"; };
+		BB8B29A51C124A0C00C91975 /* ErrorObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ErrorObject.h; path = stdlib/public/runtime/ErrorObject.h; sourceTree = "<group>"; };
+		BB8B29A61C124A0C00C91975 /* ErrorObject.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ErrorObject.mm; path = stdlib/public/runtime/ErrorObject.mm; sourceTree = "<group>"; };
+		BB8B29A71C124A0C00C91975 /* Errors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Errors.cpp; path = stdlib/public/runtime/Errors.cpp; sourceTree = "<group>"; };
+		BB8B29A81C124A0C00C91975 /* ExistentialMetadataImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExistentialMetadataImpl.h; path = stdlib/public/runtime/ExistentialMetadataImpl.h; sourceTree = "<group>"; };
+		BB8B29A91C124A0C00C91975 /* Heap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Heap.cpp; path = stdlib/public/runtime/Heap.cpp; sourceTree = "<group>"; };
+		BB8B29AA1C124A0C00C91975 /* HeapObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HeapObject.cpp; path = stdlib/public/runtime/HeapObject.cpp; sourceTree = "<group>"; };
+		BB8B29AB1C124A0C00C91975 /* KnownMetadata.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = KnownMetadata.cpp; path = stdlib/public/runtime/KnownMetadata.cpp; sourceTree = "<group>"; };
+		BB8B29AC1C124A0C00C91975 /* Leaks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Leaks.h; path = stdlib/public/runtime/Leaks.h; sourceTree = "<group>"; };
+		BB8B29AD1C124A0C00C91975 /* Leaks.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = Leaks.mm; path = stdlib/public/runtime/Leaks.mm; sourceTree = "<group>"; };
+		BB8B29AE1C124A0C00C91975 /* Metadata.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Metadata.cpp; path = stdlib/public/runtime/Metadata.cpp; sourceTree = "<group>"; };
+		BB8B29AF1C124A0C00C91975 /* MetadataCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MetadataCache.h; path = stdlib/public/runtime/MetadataCache.h; sourceTree = "<group>"; };
+		BB8B29B01C124A0C00C91975 /* MetadataImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MetadataImpl.h; path = stdlib/public/runtime/MetadataImpl.h; sourceTree = "<group>"; };
+		BB8B29B11C124A0C00C91975 /* Once.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Once.cpp; path = stdlib/public/runtime/Once.cpp; sourceTree = "<group>"; };
+		BB8B29B21C124A0C00C91975 /* Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Private.h; path = stdlib/public/runtime/Private.h; sourceTree = "<group>"; };
+		BB8B29B31C124A0C00C91975 /* Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Reflection.cpp; path = stdlib/public/runtime/Reflection.cpp; sourceTree = "<group>"; };
+		BB8B29B41C124A0C00C91975 /* Reflection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = Reflection.mm; path = stdlib/public/runtime/Reflection.mm; sourceTree = "<group>"; };
+		BB8B29B51C124A0C00C91975 /* Remangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Remangle.cpp; path = stdlib/public/runtime/Remangle.cpp; sourceTree = "<group>"; };
+		BB8B29B61C124A0C00C91975 /* swift.ld */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = swift.ld; path = stdlib/public/runtime/swift.ld; sourceTree = "<group>"; };
+		BB8B29B71C124A0C00C91975 /* SwiftObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftObject.cpp; path = stdlib/public/runtime/SwiftObject.cpp; sourceTree = "<group>"; };
+		BB8B29B81C124A0C00C91975 /* SwiftObject.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SwiftObject.mm; path = stdlib/public/runtime/SwiftObject.mm; sourceTree = "<group>"; };
+		BB8B29B91C124A0C00C91975 /* SwiftRuntimeDTraceProbes.d */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.dtrace; name = SwiftRuntimeDTraceProbes.d; path = stdlib/public/runtime/SwiftRuntimeDTraceProbes.d; sourceTree = "<group>"; };
+		BB8B29BA1C124A0C00C91975 /* UnicodeExtendedGraphemeClusters.cpp.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnicodeExtendedGraphemeClusters.cpp.gyb; path = stdlib/public/runtime/UnicodeExtendedGraphemeClusters.cpp.gyb; sourceTree = "<group>"; };
+		BB8B29BB1C124A0C00C91975 /* UnicodeNormalization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnicodeNormalization.cpp; path = stdlib/public/runtime/UnicodeNormalization.cpp; sourceTree = "<group>"; };
+		BB8B29D01C124A3700C91975 /* AppKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AppKit; path = stdlib/public/SDK/AppKit; sourceTree = "<group>"; };
+		BB8B29D11C124A3800C91975 /* AssetsLibrary */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AssetsLibrary; path = stdlib/public/SDK/AssetsLibrary; sourceTree = "<group>"; };
+		BB8B29D21C124A3800C91975 /* AVFoundation */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AVFoundation; path = stdlib/public/SDK/AVFoundation; sourceTree = "<group>"; };
+		BB8B29D31C124A3800C91975 /* CloudKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CloudKit; path = stdlib/public/SDK/CloudKit; sourceTree = "<group>"; };
+		BB8B29D41C124A3800C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/SDK/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B29D51C124A3800C91975 /* Contacts */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Contacts; path = stdlib/public/SDK/Contacts; sourceTree = "<group>"; };
+		BB8B29D61C124A3800C91975 /* CoreAudio */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreAudio; path = stdlib/public/SDK/CoreAudio; sourceTree = "<group>"; };
+		BB8B29D71C124A3800C91975 /* CoreBluetooth */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreBluetooth; path = stdlib/public/SDK/CoreBluetooth; sourceTree = "<group>"; };
+		BB8B29D81C124A3800C91975 /* CoreData */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreData; path = stdlib/public/SDK/CoreData; sourceTree = "<group>"; };
+		BB8B29D91C124A3800C91975 /* CoreGraphics */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreGraphics; path = stdlib/public/SDK/CoreGraphics; sourceTree = "<group>"; };
+		BB8B29DA1C124A3800C91975 /* CoreImage */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreImage; path = stdlib/public/SDK/CoreImage; sourceTree = "<group>"; };
+		BB8B29DB1C124A3800C91975 /* CoreLocation */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreLocation; path = stdlib/public/SDK/CoreLocation; sourceTree = "<group>"; };
+		BB8B29DC1C124A3800C91975 /* CoreMedia */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CoreMedia; path = stdlib/public/SDK/CoreMedia; sourceTree = "<group>"; };
+		BB8B29DD1C124A3800C91975 /* Darwin */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Darwin; path = stdlib/public/SDK/Darwin; sourceTree = "<group>"; };
+		BB8B29DE1C124A3800C91975 /* Dispatch */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Dispatch; path = stdlib/public/SDK/Dispatch; sourceTree = "<group>"; };
+		BB8B29DF1C124A3800C91975 /* EventKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = EventKit; path = stdlib/public/SDK/EventKit; sourceTree = "<group>"; };
+		BB8B29E01C124A3800C91975 /* Foundation */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Foundation; path = stdlib/public/SDK/Foundation; sourceTree = "<group>"; };
+		BB8B29E11C124A3800C91975 /* GameKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GameKit; path = stdlib/public/SDK/GameKit; sourceTree = "<group>"; };
+		BB8B29E21C124A3800C91975 /* GameplayKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GameplayKit; path = stdlib/public/SDK/GameplayKit; sourceTree = "<group>"; };
+		BB8B29E31C124A3800C91975 /* GLKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GLKit; path = stdlib/public/SDK/GLKit; sourceTree = "<group>"; };
+		BB8B29E41C124A3800C91975 /* HomeKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HomeKit; path = stdlib/public/SDK/HomeKit; sourceTree = "<group>"; };
+		BB8B29E51C124A3800C91975 /* LocalAuthentication */ = {isa = PBXFileReference; lastKnownFileType = folder; name = LocalAuthentication; path = stdlib/public/SDK/LocalAuthentication; sourceTree = "<group>"; };
+		BB8B29E61C124A3800C91975 /* MultipeerConnectivity */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MultipeerConnectivity; path = stdlib/public/SDK/MultipeerConnectivity; sourceTree = "<group>"; };
+		BB8B29E71C124A3800C91975 /* ObjectiveC */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ObjectiveC; path = stdlib/public/SDK/ObjectiveC; sourceTree = "<group>"; };
+		BB8B29E81C124A3800C91975 /* OpenCL */ = {isa = PBXFileReference; lastKnownFileType = folder; name = OpenCL; path = stdlib/public/SDK/OpenCL; sourceTree = "<group>"; };
+		BB8B29E91C124A3800C91975 /* PassKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PassKit; path = stdlib/public/SDK/PassKit; sourceTree = "<group>"; };
+		BB8B29EA1C124A3800C91975 /* SceneKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SceneKit; path = stdlib/public/SDK/SceneKit; sourceTree = "<group>"; };
+		BB8B29EB1C124A3800C91975 /* simd */ = {isa = PBXFileReference; lastKnownFileType = folder; name = simd; path = stdlib/public/SDK/simd; sourceTree = "<group>"; };
+		BB8B29EC1C124A3800C91975 /* SpriteKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SpriteKit; path = stdlib/public/SDK/SpriteKit; sourceTree = "<group>"; };
+		BB8B29ED1C124A3800C91975 /* UIKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = UIKit; path = stdlib/public/SDK/UIKit; sourceTree = "<group>"; };
+		BB8B29EE1C124A3800C91975 /* WatchConnectivity */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WatchConnectivity; path = stdlib/public/SDK/WatchConnectivity; sourceTree = "<group>"; };
+		BB8B29EF1C124A3800C91975 /* WatchKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WatchKit; path = stdlib/public/SDK/WatchKit; sourceTree = "<group>"; };
+		BB8B29F01C124A3800C91975 /* WebKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WebKit; path = stdlib/public/SDK/WebKit; sourceTree = "<group>"; };
+		BB8B29F11C124A3800C91975 /* XCTest */ = {isa = PBXFileReference; lastKnownFileType = folder; name = XCTest; path = stdlib/public/SDK/XCTest; sourceTree = "<group>"; };
+		BB8B29F31C124A6500C91975 /* Availability.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = Availability.mm; path = stdlib/public/stubs/Availability.mm; sourceTree = "<group>"; };
+		BB8B29F41C124A6500C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/stubs/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B29F51C124A6500C91975 /* FoundationHelpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = FoundationHelpers.mm; path = stdlib/public/stubs/FoundationHelpers.mm; sourceTree = "<group>"; };
+		BB8B29F61C124A6500C91975 /* GlobalObjects.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GlobalObjects.cpp; path = stdlib/public/stubs/GlobalObjects.cpp; sourceTree = "<group>"; };
+		BB8B29F71C124A6500C91975 /* LibcShims.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LibcShims.cpp; path = stdlib/public/stubs/LibcShims.cpp; sourceTree = "<group>"; };
+		BB8B29F81C124A6500C91975 /* Stubs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Stubs.cpp; path = stdlib/public/stubs/Stubs.cpp; sourceTree = "<group>"; };
+		BB8B29F91C124A6500C91975 /* SwiftNativeNSXXXBase.mm.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = SwiftNativeNSXXXBase.mm.gyb; path = stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb; sourceTree = "<group>"; };
+		BB8B2A001C124A8A00C91975 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = stdlib/public/SwiftShims/CMakeLists.txt; sourceTree = "<group>"; };
+		BB8B2A011C124A8A00C91975 /* CoreFoundationShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CoreFoundationShims.h; path = stdlib/public/SwiftShims/CoreFoundationShims.h; sourceTree = "<group>"; };
+		BB8B2A021C124A8A00C91975 /* FoundationShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FoundationShims.h; path = stdlib/public/SwiftShims/FoundationShims.h; sourceTree = "<group>"; };
+		BB8B2A031C124A8A00C91975 /* GlobalObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GlobalObjects.h; path = stdlib/public/SwiftShims/GlobalObjects.h; sourceTree = "<group>"; };
+		BB8B2A041C124A8A00C91975 /* HeapObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HeapObject.h; path = stdlib/public/SwiftShims/HeapObject.h; sourceTree = "<group>"; };
+		BB8B2A051C124A8A00C91975 /* LibcShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibcShims.h; path = stdlib/public/SwiftShims/LibcShims.h; sourceTree = "<group>"; };
+		BB8B2A061C124A8A00C91975 /* module.map */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = module.map; path = stdlib/public/SwiftShims/module.map; sourceTree = "<group>"; };
+		BB8B2A071C124A8A00C91975 /* RefCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RefCount.h; path = stdlib/public/SwiftShims/RefCount.h; sourceTree = "<group>"; };
+		BB8B2A081C124A8A00C91975 /* RuntimeShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RuntimeShims.h; path = stdlib/public/SwiftShims/RuntimeShims.h; sourceTree = "<group>"; };
+		BB8B2A091C124A8A00C91975 /* RuntimeStubs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RuntimeStubs.h; path = stdlib/public/SwiftShims/RuntimeStubs.h; sourceTree = "<group>"; };
+		BB8B2A0A1C124A8A00C91975 /* SwiftStddef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwiftStddef.h; path = stdlib/public/SwiftShims/SwiftStddef.h; sourceTree = "<group>"; };
+		BB8B2A0B1C124A8A00C91975 /* SwiftStdint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwiftStdint.h; path = stdlib/public/SwiftShims/SwiftStdint.h; sourceTree = "<group>"; };
+		BB8B2A0C1C124A8A00C91975 /* UnicodeShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnicodeShims.h; path = stdlib/public/SwiftShims/UnicodeShims.h; sourceTree = "<group>"; };
+		BB9FD6401C10EF850008A1EA /* swift */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = swift; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB9FD64D1C10F0280008A1EA /* Class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Class.h; path = include/swift/ABI/Class.h; sourceTree = "<group>"; };
+		BB9FD64E1C10F0280008A1EA /* MetadataKind.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MetadataKind.def; path = include/swift/ABI/MetadataKind.def; sourceTree = "<group>"; };
+		BB9FD64F1C10F0280008A1EA /* MetadataValues.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MetadataValues.h; path = include/swift/ABI/MetadataValues.h; sourceTree = "<group>"; };
+		BB9FD6501C10F0280008A1EA /* System.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = System.h; path = include/swift/ABI/System.h; sourceTree = "<group>"; };
+		BB9FD6521C10F0460008A1EA /* AnyFunctionRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnyFunctionRef.h; path = include/swift/AST/AnyFunctionRef.h; sourceTree = "<group>"; };
+		BB9FD6531C10F0460008A1EA /* ArchetypeBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArchetypeBuilder.h; path = include/swift/AST/ArchetypeBuilder.h; sourceTree = "<group>"; };
+		BB9FD6541C10F0460008A1EA /* AST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AST.h; path = include/swift/AST/AST.h; sourceTree = "<group>"; };
+		BB9FD6551C10F0460008A1EA /* ASTContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTContext.h; path = include/swift/AST/ASTContext.h; sourceTree = "<group>"; };
+		BB9FD6561C10F0460008A1EA /* ASTNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTNode.h; path = include/swift/AST/ASTNode.h; sourceTree = "<group>"; };
+		BB9FD6571C10F0460008A1EA /* ASTPrinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTPrinter.h; path = include/swift/AST/ASTPrinter.h; sourceTree = "<group>"; };
+		BB9FD6581C10F0460008A1EA /* ASTVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTVisitor.h; path = include/swift/AST/ASTVisitor.h; sourceTree = "<group>"; };
+		BB9FD6591C10F0460008A1EA /* ASTWalker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTWalker.h; path = include/swift/AST/ASTWalker.h; sourceTree = "<group>"; };
+		BB9FD65A1C10F0460008A1EA /* Attr.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Attr.def; path = include/swift/AST/Attr.def; sourceTree = "<group>"; };
+		BB9FD65B1C10F0460008A1EA /* Attr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Attr.h; path = include/swift/AST/Attr.h; sourceTree = "<group>"; };
+		BB9FD65C1C10F0460008A1EA /* Availability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Availability.h; path = include/swift/AST/Availability.h; sourceTree = "<group>"; };
+		BB9FD65D1C10F0460008A1EA /* AvailabilitySpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AvailabilitySpec.h; path = include/swift/AST/AvailabilitySpec.h; sourceTree = "<group>"; };
+		BB9FD65E1C10F0460008A1EA /* Builtins.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Builtins.def; path = include/swift/AST/Builtins.def; sourceTree = "<group>"; };
+		BB9FD65F1C10F0460008A1EA /* Builtins.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Builtins.h; path = include/swift/AST/Builtins.h; sourceTree = "<group>"; };
+		BB9FD6601C10F0460008A1EA /* CanTypeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CanTypeVisitor.h; path = include/swift/AST/CanTypeVisitor.h; sourceTree = "<group>"; };
+		BB9FD6611C10F0460008A1EA /* CaptureInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CaptureInfo.h; path = include/swift/AST/CaptureInfo.h; sourceTree = "<group>"; };
+		BB9FD6621C10F0460008A1EA /* ClangModuleLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClangModuleLoader.h; path = include/swift/AST/ClangModuleLoader.h; sourceTree = "<group>"; };
+		BB9FD6631C10F0460008A1EA /* Comment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Comment.h; path = include/swift/AST/Comment.h; sourceTree = "<group>"; };
+		BB9FD6641C10F0460008A1EA /* ConcreteDeclRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConcreteDeclRef.h; path = include/swift/AST/ConcreteDeclRef.h; sourceTree = "<group>"; };
+		BB9FD6651C10F0460008A1EA /* DebuggerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DebuggerClient.h; path = include/swift/AST/DebuggerClient.h; sourceTree = "<group>"; };
+		BB9FD6661C10F0460008A1EA /* Decl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Decl.h; path = include/swift/AST/Decl.h; sourceTree = "<group>"; };
+		BB9FD6671C10F0460008A1EA /* DeclContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeclContext.h; path = include/swift/AST/DeclContext.h; sourceTree = "<group>"; };
+		BB9FD6681C10F0460008A1EA /* DeclNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DeclNodes.def; path = include/swift/AST/DeclNodes.def; sourceTree = "<group>"; };
+		BB9FD6691C10F0460008A1EA /* DefaultArgumentKind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DefaultArgumentKind.h; path = include/swift/AST/DefaultArgumentKind.h; sourceTree = "<group>"; };
+		BB9FD66A1C10F0460008A1EA /* DiagnosticEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticEngine.h; path = include/swift/AST/DiagnosticEngine.h; sourceTree = "<group>"; };
+		BB9FD66B1C10F0460008A1EA /* DiagnosticsAll.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsAll.def; path = include/swift/AST/DiagnosticsAll.def; sourceTree = "<group>"; };
+		BB9FD66C1C10F0460008A1EA /* DiagnosticsClangImporter.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsClangImporter.def; path = include/swift/AST/DiagnosticsClangImporter.def; sourceTree = "<group>"; };
+		BB9FD66D1C10F0460008A1EA /* DiagnosticsClangImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsClangImporter.h; path = include/swift/AST/DiagnosticsClangImporter.h; sourceTree = "<group>"; };
+		BB9FD66E1C10F0460008A1EA /* DiagnosticsCommon.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsCommon.def; path = include/swift/AST/DiagnosticsCommon.def; sourceTree = "<group>"; };
+		BB9FD66F1C10F0460008A1EA /* DiagnosticsCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsCommon.h; path = include/swift/AST/DiagnosticsCommon.h; sourceTree = "<group>"; };
+		BB9FD6701C10F0460008A1EA /* DiagnosticsDriver.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsDriver.def; path = include/swift/AST/DiagnosticsDriver.def; sourceTree = "<group>"; };
+		BB9FD6711C10F0460008A1EA /* DiagnosticsDriver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsDriver.h; path = include/swift/AST/DiagnosticsDriver.h; sourceTree = "<group>"; };
+		BB9FD6721C10F0460008A1EA /* DiagnosticsFrontend.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsFrontend.def; path = include/swift/AST/DiagnosticsFrontend.def; sourceTree = "<group>"; };
+		BB9FD6731C10F0460008A1EA /* DiagnosticsFrontend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsFrontend.h; path = include/swift/AST/DiagnosticsFrontend.h; sourceTree = "<group>"; };
+		BB9FD6741C10F0460008A1EA /* DiagnosticsIRGen.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsIRGen.def; path = include/swift/AST/DiagnosticsIRGen.def; sourceTree = "<group>"; };
+		BB9FD6751C10F0460008A1EA /* DiagnosticsIRGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsIRGen.h; path = include/swift/AST/DiagnosticsIRGen.h; sourceTree = "<group>"; };
+		BB9FD6761C10F0460008A1EA /* DiagnosticsParse.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsParse.def; path = include/swift/AST/DiagnosticsParse.def; sourceTree = "<group>"; };
+		BB9FD6771C10F0460008A1EA /* DiagnosticsParse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsParse.h; path = include/swift/AST/DiagnosticsParse.h; sourceTree = "<group>"; };
+		BB9FD6781C10F0460008A1EA /* DiagnosticsSema.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsSema.def; path = include/swift/AST/DiagnosticsSema.def; sourceTree = "<group>"; };
+		BB9FD6791C10F0460008A1EA /* DiagnosticsSema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsSema.h; path = include/swift/AST/DiagnosticsSema.h; sourceTree = "<group>"; };
+		BB9FD67A1C10F0460008A1EA /* DiagnosticsSIL.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DiagnosticsSIL.def; path = include/swift/AST/DiagnosticsSIL.def; sourceTree = "<group>"; };
+		BB9FD67B1C10F0460008A1EA /* DiagnosticsSIL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticsSIL.h; path = include/swift/AST/DiagnosticsSIL.h; sourceTree = "<group>"; };
+		BB9FD67C1C10F0460008A1EA /* Expr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Expr.h; path = include/swift/AST/Expr.h; sourceTree = "<group>"; };
+		BB9FD67D1C10F0460008A1EA /* ExprHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExprHandle.h; path = include/swift/AST/ExprHandle.h; sourceTree = "<group>"; };
+		BB9FD67E1C10F0460008A1EA /* ExprNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ExprNodes.def; path = include/swift/AST/ExprNodes.def; sourceTree = "<group>"; };
+		BB9FD67F1C10F0460008A1EA /* ForeignErrorConvention.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ForeignErrorConvention.h; path = include/swift/AST/ForeignErrorConvention.h; sourceTree = "<group>"; };
+		BB9FD6801C10F0460008A1EA /* GenericSignature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenericSignature.h; path = include/swift/AST/GenericSignature.h; sourceTree = "<group>"; };
+		BB9FD6811C10F0460008A1EA /* Identifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Identifier.h; path = include/swift/AST/Identifier.h; sourceTree = "<group>"; };
+		BB9FD6821C10F0460008A1EA /* Initializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Initializer.h; path = include/swift/AST/Initializer.h; sourceTree = "<group>"; };
+		BB9FD6831C10F0460008A1EA /* IRGenOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IRGenOptions.h; path = include/swift/AST/IRGenOptions.h; sourceTree = "<group>"; };
+		BB9FD6841C10F0460008A1EA /* KnownDecls.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = KnownDecls.def; path = include/swift/AST/KnownDecls.def; sourceTree = "<group>"; };
+		BB9FD6851C10F0460008A1EA /* KnownIdentifiers.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = KnownIdentifiers.def; path = include/swift/AST/KnownIdentifiers.def; sourceTree = "<group>"; };
+		BB9FD6861C10F0460008A1EA /* KnownProtocols.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = KnownProtocols.def; path = include/swift/AST/KnownProtocols.def; sourceTree = "<group>"; };
+		BB9FD6871C10F0460008A1EA /* KnownProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KnownProtocols.h; path = include/swift/AST/KnownProtocols.h; sourceTree = "<group>"; };
+		BB9FD6881C10F0460008A1EA /* LazyResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LazyResolver.h; path = include/swift/AST/LazyResolver.h; sourceTree = "<group>"; };
+		BB9FD6891C10F0460008A1EA /* LinkLibrary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LinkLibrary.h; path = include/swift/AST/LinkLibrary.h; sourceTree = "<group>"; };
+		BB9FD68A1C10F0460008A1EA /* Mangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Mangle.h; path = include/swift/AST/Mangle.h; sourceTree = "<group>"; };
+		BB9FD68B1C10F0460008A1EA /* Module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Module.h; path = include/swift/AST/Module.h; sourceTree = "<group>"; };
+		BB9FD68C1C10F0460008A1EA /* ModuleLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModuleLoader.h; path = include/swift/AST/ModuleLoader.h; sourceTree = "<group>"; };
+		BB9FD68D1C10F0460008A1EA /* NameLookup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NameLookup.h; path = include/swift/AST/NameLookup.h; sourceTree = "<group>"; };
+		BB9FD68E1C10F0460008A1EA /* Ownership.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ownership.h; path = include/swift/AST/Ownership.h; sourceTree = "<group>"; };
+		BB9FD68F1C10F0460008A1EA /* Pattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Pattern.h; path = include/swift/AST/Pattern.h; sourceTree = "<group>"; };
+		BB9FD6901C10F0460008A1EA /* PatternNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = PatternNodes.def; path = include/swift/AST/PatternNodes.def; sourceTree = "<group>"; };
+		BB9FD6911C10F0460008A1EA /* PlatformKind.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlatformKind.h; path = include/swift/AST/PlatformKind.h; sourceTree = "<group>"; };
+		BB9FD6921C10F0460008A1EA /* PlatformKinds.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = PlatformKinds.def; path = include/swift/AST/PlatformKinds.def; sourceTree = "<group>"; };
+		BB9FD6931C10F0460008A1EA /* PrettyStackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrettyStackTrace.h; path = include/swift/AST/PrettyStackTrace.h; sourceTree = "<group>"; };
+		BB9FD6941C10F0460008A1EA /* PrintOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrintOptions.h; path = include/swift/AST/PrintOptions.h; sourceTree = "<group>"; };
+		BB9FD6951C10F0460008A1EA /* ProtocolConformance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProtocolConformance.h; path = include/swift/AST/ProtocolConformance.h; sourceTree = "<group>"; };
+		BB9FD6961C10F0460008A1EA /* RawComment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RawComment.h; path = include/swift/AST/RawComment.h; sourceTree = "<group>"; };
+		BB9FD6971C10F0460008A1EA /* ReferencedNameTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ReferencedNameTracker.h; path = include/swift/AST/ReferencedNameTracker.h; sourceTree = "<group>"; };
+		BB9FD6981C10F0460008A1EA /* Requirement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Requirement.h; path = include/swift/AST/Requirement.h; sourceTree = "<group>"; };
+		BB9FD6991C10F0460008A1EA /* ResilienceExpansion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ResilienceExpansion.h; path = include/swift/AST/ResilienceExpansion.h; sourceTree = "<group>"; };
+		BB9FD69A1C10F0460008A1EA /* SearchPathOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SearchPathOptions.h; path = include/swift/AST/SearchPathOptions.h; sourceTree = "<group>"; };
+		BB9FD69B1C10F0460008A1EA /* SILOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILOptions.h; path = include/swift/AST/SILOptions.h; sourceTree = "<group>"; };
+		BB9FD69C1C10F0460008A1EA /* Stmt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Stmt.h; path = include/swift/AST/Stmt.h; sourceTree = "<group>"; };
+		BB9FD69D1C10F0460008A1EA /* StmtNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = StmtNodes.def; path = include/swift/AST/StmtNodes.def; sourceTree = "<group>"; };
+		BB9FD69E1C10F0460008A1EA /* Substitution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Substitution.h; path = include/swift/AST/Substitution.h; sourceTree = "<group>"; };
+		BB9FD69F1C10F0460008A1EA /* SubstTypeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SubstTypeVisitor.h; path = include/swift/AST/SubstTypeVisitor.h; sourceTree = "<group>"; };
+		BB9FD6A01C10F0460008A1EA /* Type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Type.h; path = include/swift/AST/Type.h; sourceTree = "<group>"; };
+		BB9FD6A11C10F0460008A1EA /* TypeAlignments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeAlignments.h; path = include/swift/AST/TypeAlignments.h; sourceTree = "<group>"; };
+		BB9FD6A21C10F0460008A1EA /* TypeCheckerDebugConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeCheckerDebugConsumer.h; path = include/swift/AST/TypeCheckerDebugConsumer.h; sourceTree = "<group>"; };
+		BB9FD6A31C10F0460008A1EA /* TypeLoc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeLoc.h; path = include/swift/AST/TypeLoc.h; sourceTree = "<group>"; };
+		BB9FD6A41C10F0460008A1EA /* TypeMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeMatcher.h; path = include/swift/AST/TypeMatcher.h; sourceTree = "<group>"; };
+		BB9FD6A51C10F0460008A1EA /* TypeMemberVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeMemberVisitor.h; path = include/swift/AST/TypeMemberVisitor.h; sourceTree = "<group>"; };
+		BB9FD6A61C10F0460008A1EA /* TypeNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TypeNodes.def; path = include/swift/AST/TypeNodes.def; sourceTree = "<group>"; };
+		BB9FD6A71C10F0460008A1EA /* TypeRefinementContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeRefinementContext.h; path = include/swift/AST/TypeRefinementContext.h; sourceTree = "<group>"; };
+		BB9FD6A81C10F0460008A1EA /* TypeRepr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeRepr.h; path = include/swift/AST/TypeRepr.h; sourceTree = "<group>"; };
+		BB9FD6A91C10F0460008A1EA /* TypeReprNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TypeReprNodes.def; path = include/swift/AST/TypeReprNodes.def; sourceTree = "<group>"; };
+		BB9FD6AA1C10F0460008A1EA /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Types.h; path = include/swift/AST/Types.h; sourceTree = "<group>"; };
+		BB9FD6AB1C10F0460008A1EA /* TypeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeVisitor.h; path = include/swift/AST/TypeVisitor.h; sourceTree = "<group>"; };
+		BB9FD6AC1C10F0460008A1EA /* TypeWalker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeWalker.h; path = include/swift/AST/TypeWalker.h; sourceTree = "<group>"; };
+		BB9FD6AD1C10F0460008A1EA /* USRGeneration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = USRGeneration.h; path = include/swift/AST/USRGeneration.h; sourceTree = "<group>"; };
+		BB9FD6AF1C10F0660008A1EA /* ASTSectionImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTSectionImporter.h; path = include/swift/ASTSectionImporter/ASTSectionImporter.h; sourceTree = "<group>"; };
+		BB9FD6B11C10F0930008A1EA /* Algorithm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Algorithm.h; path = include/swift/Basic/Algorithm.h; sourceTree = "<group>"; };
+		BB9FD6B21C10F0930008A1EA /* ArrayRefView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArrayRefView.h; path = include/swift/Basic/ArrayRefView.h; sourceTree = "<group>"; };
+		BB9FD6B31C10F0930008A1EA /* AssertImplements.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssertImplements.h; path = include/swift/Basic/AssertImplements.h; sourceTree = "<group>"; };
+		BB9FD6B41C10F0930008A1EA /* BlotMapVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlotMapVector.h; path = include/swift/Basic/BlotMapVector.h; sourceTree = "<group>"; };
+		BB9FD6B51C10F0930008A1EA /* BlotSetVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlotSetVector.h; path = include/swift/Basic/BlotSetVector.h; sourceTree = "<group>"; };
+		BB9FD6B61C10F0930008A1EA /* Cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Cache.h; path = include/swift/Basic/Cache.h; sourceTree = "<group>"; };
+		BB9FD6B71C10F0930008A1EA /* ClusteredBitVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClusteredBitVector.h; path = include/swift/Basic/ClusteredBitVector.h; sourceTree = "<group>"; };
+		BB9FD6B81C10F0930008A1EA /* Defer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Defer.h; path = include/swift/Basic/Defer.h; sourceTree = "<group>"; };
+		BB9FD6B91C10F0930008A1EA /* Demangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Demangle.h; path = include/swift/Basic/Demangle.h; sourceTree = "<group>"; };
+		BB9FD6BA1C10F0930008A1EA /* DemangleNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DemangleNodes.def; path = include/swift/Basic/DemangleNodes.def; sourceTree = "<group>"; };
+		BB9FD6BB1C10F0930008A1EA /* DemangleWrappers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DemangleWrappers.h; path = include/swift/Basic/DemangleWrappers.h; sourceTree = "<group>"; };
+		BB9FD6BC1C10F0930008A1EA /* DiagnosticConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticConsumer.h; path = include/swift/Basic/DiagnosticConsumer.h; sourceTree = "<group>"; };
+		BB9FD6BD1C10F0930008A1EA /* DiagnosticOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticOptions.h; path = include/swift/Basic/DiagnosticOptions.h; sourceTree = "<group>"; };
+		BB9FD6BE1C10F0930008A1EA /* DiverseList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiverseList.h; path = include/swift/Basic/DiverseList.h; sourceTree = "<group>"; };
+		BB9FD6BF1C10F0930008A1EA /* DiverseStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiverseStack.h; path = include/swift/Basic/DiverseStack.h; sourceTree = "<group>"; };
+		BB9FD6C01C10F0930008A1EA /* Dwarf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Dwarf.h; path = include/swift/Basic/Dwarf.h; sourceTree = "<group>"; };
+		BB9FD6C11C10F0930008A1EA /* EditorPlaceholder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EditorPlaceholder.h; path = include/swift/Basic/EditorPlaceholder.h; sourceTree = "<group>"; };
+		BB9FD6C21C10F0930008A1EA /* EncodedSequence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EncodedSequence.h; path = include/swift/Basic/EncodedSequence.h; sourceTree = "<group>"; };
+		BB9FD6C31C10F0930008A1EA /* Fallthrough.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Fallthrough.h; path = include/swift/Basic/Fallthrough.h; sourceTree = "<group>"; };
+		BB9FD6C41C10F0930008A1EA /* FileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileSystem.h; path = include/swift/Basic/FileSystem.h; sourceTree = "<group>"; };
+		BB9FD6C51C10F0930008A1EA /* FlaggedPointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FlaggedPointer.h; path = include/swift/Basic/FlaggedPointer.h; sourceTree = "<group>"; };
+		BB9FD6C61C10F0930008A1EA /* JSONSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSONSerialization.h; path = include/swift/Basic/JSONSerialization.h; sourceTree = "<group>"; };
+		BB9FD6C71C10F0940008A1EA /* LangOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LangOptions.h; path = include/swift/Basic/LangOptions.h; sourceTree = "<group>"; };
+		BB9FD6C81C10F0940008A1EA /* Lazy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lazy.h; path = include/swift/Basic/Lazy.h; sourceTree = "<group>"; };
+		BB9FD6C91C10F0940008A1EA /* LLVM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LLVM.h; path = include/swift/Basic/LLVM.h; sourceTree = "<group>"; };
+		BB9FD6CA1C10F0940008A1EA /* LLVMInitialize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LLVMInitialize.h; path = include/swift/Basic/LLVMInitialize.h; sourceTree = "<group>"; };
+		BB9FD6CB1C10F0940008A1EA /* Malloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Malloc.h; path = include/swift/Basic/Malloc.h; sourceTree = "<group>"; };
+		BB9FD6CC1C10F0940008A1EA /* NullablePtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NullablePtr.h; path = include/swift/Basic/NullablePtr.h; sourceTree = "<group>"; };
+		BB9FD6CD1C10F0940008A1EA /* OptionalEnum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OptionalEnum.h; path = include/swift/Basic/OptionalEnum.h; sourceTree = "<group>"; };
+		BB9FD6CE1C10F0940008A1EA /* OptionSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OptionSet.h; path = include/swift/Basic/OptionSet.h; sourceTree = "<group>"; };
+		BB9FD6CF1C10F0940008A1EA /* Platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Platform.h; path = include/swift/Basic/Platform.h; sourceTree = "<group>"; };
+		BB9FD6D01C10F0940008A1EA /* PrefixMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrefixMap.h; path = include/swift/Basic/PrefixMap.h; sourceTree = "<group>"; };
+		BB9FD6D11C10F0940008A1EA /* PrettyStackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrettyStackTrace.h; path = include/swift/Basic/PrettyStackTrace.h; sourceTree = "<group>"; };
+		BB9FD6D21C10F0940008A1EA /* PrimitiveParsing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrimitiveParsing.h; path = include/swift/Basic/PrimitiveParsing.h; sourceTree = "<group>"; };
+		BB9FD6D31C10F0940008A1EA /* Program.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Program.h; path = include/swift/Basic/Program.h; sourceTree = "<group>"; };
+		BB9FD6D41C10F0940008A1EA /* Punycode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Punycode.h; path = include/swift/Basic/Punycode.h; sourceTree = "<group>"; };
+		BB9FD6D51C10F0940008A1EA /* QuotedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QuotedString.h; path = include/swift/Basic/QuotedString.h; sourceTree = "<group>"; };
+		BB9FD6D61C10F0940008A1EA /* Range.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Range.h; path = include/swift/Basic/Range.h; sourceTree = "<group>"; };
+		BB9FD6D71C10F0940008A1EA /* RelativePointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RelativePointer.h; path = include/swift/Basic/RelativePointer.h; sourceTree = "<group>"; };
+		BB9FD6D81C10F0940008A1EA /* SourceLoc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourceLoc.h; path = include/swift/Basic/SourceLoc.h; sourceTree = "<group>"; };
+		BB9FD6D91C10F0940008A1EA /* SourceManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourceManager.h; path = include/swift/Basic/SourceManager.h; sourceTree = "<group>"; };
+		BB9FD6DA1C10F0940008A1EA /* STLExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STLExtras.h; path = include/swift/Basic/STLExtras.h; sourceTree = "<group>"; };
+		BB9FD6DB1C10F0940008A1EA /* StringExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StringExtras.h; path = include/swift/Basic/StringExtras.h; sourceTree = "<group>"; };
+		BB9FD6DC1C10F0940008A1EA /* SuccessorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SuccessorMap.h; path = include/swift/Basic/SuccessorMap.h; sourceTree = "<group>"; };
+		BB9FD6DD1C10F0940008A1EA /* TaskQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TaskQueue.h; path = include/swift/Basic/TaskQueue.h; sourceTree = "<group>"; };
+		BB9FD6DE1C10F0940008A1EA /* ThreadSafeRefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ThreadSafeRefCounted.h; path = include/swift/Basic/ThreadSafeRefCounted.h; sourceTree = "<group>"; };
+		BB9FD6DF1C10F0940008A1EA /* TreeScopedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TreeScopedHashTable.h; path = include/swift/Basic/TreeScopedHashTable.h; sourceTree = "<group>"; };
+		BB9FD6E01C10F0940008A1EA /* type_traits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = type_traits.h; path = include/swift/Basic/type_traits.h; sourceTree = "<group>"; };
+		BB9FD6E11C10F0940008A1EA /* Unicode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Unicode.h; path = include/swift/Basic/Unicode.h; sourceTree = "<group>"; };
+		BB9FD6E21C10F0940008A1EA /* UUID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UUID.h; path = include/swift/Basic/UUID.h; sourceTree = "<group>"; };
+		BB9FD6E31C10F0940008A1EA /* Version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Version.h; path = include/swift/Basic/Version.h; sourceTree = "<group>"; };
+		BB9FD6E51C10F0B40008A1EA /* BuiltinMappedTypes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = BuiltinMappedTypes.def; path = include/swift/ClangImporter/BuiltinMappedTypes.def; sourceTree = "<group>"; };
+		BB9FD6E61C10F0B40008A1EA /* ClangImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClangImporter.h; path = include/swift/ClangImporter/ClangImporter.h; sourceTree = "<group>"; };
+		BB9FD6E71C10F0B40008A1EA /* ClangImporterOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClangImporterOptions.h; path = include/swift/ClangImporter/ClangImporterOptions.h; sourceTree = "<group>"; };
+		BB9FD6E81C10F0B40008A1EA /* ClangModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClangModule.h; path = include/swift/ClangImporter/ClangModule.h; sourceTree = "<group>"; };
+		BB9FD6E91C10F0B40008A1EA /* SIMDMappedTypes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = SIMDMappedTypes.def; path = include/swift/ClangImporter/SIMDMappedTypes.def; sourceTree = "<group>"; };
+		BB9FD6EA1C10F0CF0008A1EA /* Strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Strings.h; path = include/swift/Strings.h; sourceTree = "<group>"; };
+		BB9FD6EB1C10F0CF0008A1EA /* Subsystems.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Subsystems.h; path = include/swift/Subsystems.h; sourceTree = "<group>"; };
+		BB9FD6ED1C10F0F20008A1EA /* Action.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Action.h; path = include/swift/Driver/Action.h; sourceTree = "<group>"; };
+		BB9FD6EE1C10F0F20008A1EA /* Compilation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Compilation.h; path = include/swift/Driver/Compilation.h; sourceTree = "<group>"; };
+		BB9FD6EF1C10F0F20008A1EA /* DependencyGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DependencyGraph.h; path = include/swift/Driver/DependencyGraph.h; sourceTree = "<group>"; };
+		BB9FD6F01C10F0F20008A1EA /* Driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Driver.h; path = include/swift/Driver/Driver.h; sourceTree = "<group>"; };
+		BB9FD6F11C10F0F20008A1EA /* FrontendUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FrontendUtil.h; path = include/swift/Driver/FrontendUtil.h; sourceTree = "<group>"; };
+		BB9FD6F21C10F0F20008A1EA /* Job.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Job.h; path = include/swift/Driver/Job.h; sourceTree = "<group>"; };
+		BB9FD6F31C10F0F20008A1EA /* OutputFileMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OutputFileMap.h; path = include/swift/Driver/OutputFileMap.h; sourceTree = "<group>"; };
+		BB9FD6F41C10F0F20008A1EA /* ParseableOutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ParseableOutput.h; path = include/swift/Driver/ParseableOutput.h; sourceTree = "<group>"; };
+		BB9FD6F51C10F0F20008A1EA /* ToolChain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ToolChain.h; path = include/swift/Driver/ToolChain.h; sourceTree = "<group>"; };
+		BB9FD6F61C10F0F20008A1EA /* Types.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Types.def; path = include/swift/Driver/Types.def; sourceTree = "<group>"; };
+		BB9FD6F71C10F0F20008A1EA /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Types.h; path = include/swift/Driver/Types.h; sourceTree = "<group>"; };
+		BB9FD6F81C10F0F20008A1EA /* Util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Util.h; path = include/swift/Driver/Util.h; sourceTree = "<group>"; };
+		BB9FD6F91C10F1070008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = include/swift/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD6FA1C10F1070008A1EA /* Config.h.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Config.h.in; path = include/swift/Config.h.in; sourceTree = "<group>"; };
+		BB9FD6FB1C10F11A0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = include/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD6FC1C10F12F0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD6FD1C10F12F0008A1EA /* CODE_OWNERS.TXT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CODE_OWNERS.TXT; sourceTree = "<group>"; };
+		BB9FD6FE1C10F12F0008A1EA /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		BB9FD6FF1C10F12F0008A1EA /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		BB9FD7021C10F1520008A1EA /* DiagnosticVerifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiagnosticVerifier.h; path = include/swift/Frontend/DiagnosticVerifier.h; sourceTree = "<group>"; };
+		BB9FD7031C10F1520008A1EA /* Frontend.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Frontend.h; path = include/swift/Frontend/Frontend.h; sourceTree = "<group>"; };
+		BB9FD7041C10F1520008A1EA /* FrontendOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FrontendOptions.h; path = include/swift/Frontend/FrontendOptions.h; sourceTree = "<group>"; };
+		BB9FD7051C10F1520008A1EA /* PrintingDiagnosticConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrintingDiagnosticConsumer.h; path = include/swift/Frontend/PrintingDiagnosticConsumer.h; sourceTree = "<group>"; };
+		BB9FD7061C10F1520008A1EA /* SerializedDiagnosticConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SerializedDiagnosticConsumer.h; path = include/swift/Frontend/SerializedDiagnosticConsumer.h; sourceTree = "<group>"; };
+		BB9FD7081C10F1700008A1EA /* CodeCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodeCompletion.h; path = include/swift/IDE/CodeCompletion.h; sourceTree = "<group>"; };
+		BB9FD7091C10F1700008A1EA /* CodeCompletionCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodeCompletionCache.h; path = include/swift/IDE/CodeCompletionCache.h; sourceTree = "<group>"; };
+		BB9FD70A1C10F1700008A1EA /* CommentConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CommentConversion.h; path = include/swift/IDE/CommentConversion.h; sourceTree = "<group>"; };
+		BB9FD70B1C10F1700008A1EA /* ModuleInterfacePrinting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModuleInterfacePrinting.h; path = include/swift/IDE/ModuleInterfacePrinting.h; sourceTree = "<group>"; };
+		BB9FD70C1C10F1700008A1EA /* REPLCodeCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = REPLCodeCompletion.h; path = include/swift/IDE/REPLCodeCompletion.h; sourceTree = "<group>"; };
+		BB9FD70D1C10F1700008A1EA /* SourceEntityWalker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourceEntityWalker.h; path = include/swift/IDE/SourceEntityWalker.h; sourceTree = "<group>"; };
+		BB9FD70E1C10F1700008A1EA /* SyntaxModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyntaxModel.h; path = include/swift/IDE/SyntaxModel.h; sourceTree = "<group>"; };
+		BB9FD70F1C10F1700008A1EA /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Utils.h; path = include/swift/IDE/Utils.h; sourceTree = "<group>"; };
+		BB9FD7111C10F1970008A1EA /* Immediate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Immediate.h; path = include/swift/Immediate/Immediate.h; sourceTree = "<group>"; };
+		BB9FD7131C10F1BD0008A1EA /* Passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Passes.h; path = include/swift/LLVMPasses/Passes.h; sourceTree = "<group>"; };
+		BB9FD7141C10F1BD0008A1EA /* PassesFwd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PassesFwd.h; path = include/swift/LLVMPasses/PassesFwd.h; sourceTree = "<group>"; };
+		BB9FD7161C10F1E10008A1EA /* AST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AST.h; path = include/swift/Markup/AST.h; sourceTree = "<group>"; };
+		BB9FD7171C10F1E10008A1EA /* ASTNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ASTNodes.def; path = include/swift/Markup/ASTNodes.def; sourceTree = "<group>"; };
+		BB9FD7181C10F1E10008A1EA /* LineList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LineList.h; path = include/swift/Markup/LineList.h; sourceTree = "<group>"; };
+		BB9FD7191C10F1E20008A1EA /* Markup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Markup.h; path = include/swift/Markup/Markup.h; sourceTree = "<group>"; };
+		BB9FD71A1C10F1E20008A1EA /* SimpleFields.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = SimpleFields.def; path = include/swift/Markup/SimpleFields.def; sourceTree = "<group>"; };
+		BB9FD71B1C10F1E20008A1EA /* SourceLoc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourceLoc.h; path = include/swift/Markup/SourceLoc.h; sourceTree = "<group>"; };
+		BB9FD71C1C10F1E20008A1EA /* XMLUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMLUtils.h; path = include/swift/Markup/XMLUtils.h; sourceTree = "<group>"; };
+		BB9FD71E1C10F1FC0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = include/swift/Option/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD71F1C10F1FC0008A1EA /* FrontendOptions.td */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FrontendOptions.td; path = include/swift/Option/FrontendOptions.td; sourceTree = "<group>"; };
+		BB9FD7201C10F1FC0008A1EA /* Options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Options.h; path = include/swift/Option/Options.h; sourceTree = "<group>"; };
+		BB9FD7211C10F1FC0008A1EA /* Options.td */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Options.td; path = include/swift/Option/Options.td; sourceTree = "<group>"; };
+		BB9FD7231C10F2230008A1EA /* CodeCompletionCallbacks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodeCompletionCallbacks.h; path = include/swift/Parse/CodeCompletionCallbacks.h; sourceTree = "<group>"; };
+		BB9FD7241C10F2230008A1EA /* DelayedParsingCallbacks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DelayedParsingCallbacks.h; path = include/swift/Parse/DelayedParsingCallbacks.h; sourceTree = "<group>"; };
+		BB9FD7251C10F2230008A1EA /* Lexer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lexer.h; path = include/swift/Parse/Lexer.h; sourceTree = "<group>"; };
+		BB9FD7261C10F2230008A1EA /* LocalContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LocalContext.h; path = include/swift/Parse/LocalContext.h; sourceTree = "<group>"; };
+		BB9FD7271C10F2230008A1EA /* Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Parser.h; path = include/swift/Parse/Parser.h; sourceTree = "<group>"; };
+		BB9FD7281C10F2230008A1EA /* ParserResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ParserResult.h; path = include/swift/Parse/ParserResult.h; sourceTree = "<group>"; };
+		BB9FD7291C10F2230008A1EA /* PersistentParserState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PersistentParserState.h; path = include/swift/Parse/PersistentParserState.h; sourceTree = "<group>"; };
+		BB9FD72A1C10F2230008A1EA /* Scope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Scope.h; path = include/swift/Parse/Scope.h; sourceTree = "<group>"; };
+		BB9FD72B1C10F2230008A1EA /* Token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Token.h; path = include/swift/Parse/Token.h; sourceTree = "<group>"; };
+		BB9FD72C1C10F2230008A1EA /* Tokens.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Tokens.def; path = include/swift/Parse/Tokens.def; sourceTree = "<group>"; };
+		BB9FD72E1C10F2400008A1EA /* PrintAsObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrintAsObjC.h; path = include/swift/PrintAsObjC/PrintAsObjC.h; sourceTree = "<group>"; };
+		BB9FD7301C10F2660008A1EA /* Concurrent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Concurrent.h; path = include/swift/Runtime/Concurrent.h; sourceTree = "<group>"; };
+		BB9FD7311C10F2660008A1EA /* Config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Config.h; path = include/swift/Runtime/Config.h; sourceTree = "<group>"; };
+		BB9FD7321C10F2660008A1EA /* Debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Debug.h; path = include/swift/Runtime/Debug.h; sourceTree = "<group>"; };
+		BB9FD7331C10F2660008A1EA /* Enum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Enum.h; path = include/swift/Runtime/Enum.h; sourceTree = "<group>"; };
+		BB9FD7341C10F2660008A1EA /* Heap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Heap.h; path = include/swift/Runtime/Heap.h; sourceTree = "<group>"; };
+		BB9FD7351C10F2660008A1EA /* HeapObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HeapObject.h; path = include/swift/Runtime/HeapObject.h; sourceTree = "<group>"; };
+		BB9FD7361C10F2660008A1EA /* InstrumentsSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InstrumentsSupport.h; path = include/swift/Runtime/InstrumentsSupport.h; sourceTree = "<group>"; };
+		BB9FD7371C10F2660008A1EA /* Metadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Metadata.h; path = include/swift/Runtime/Metadata.h; sourceTree = "<group>"; };
+		BB9FD7381C10F2660008A1EA /* ObjCBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ObjCBridge.h; path = include/swift/Runtime/ObjCBridge.h; sourceTree = "<group>"; };
+		BB9FD7391C10F2660008A1EA /* Once.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Once.h; path = include/swift/Runtime/Once.h; sourceTree = "<group>"; };
+		BB9FD73A1C10F2660008A1EA /* Reflection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Reflection.h; path = include/swift/Runtime/Reflection.h; sourceTree = "<group>"; };
+		BB9FD73C1C10F28D0008A1EA /* CodeCompletionTypeChecking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodeCompletionTypeChecking.h; path = include/swift/Sema/CodeCompletionTypeChecking.h; sourceTree = "<group>"; };
+		BB9FD73D1C10F28D0008A1EA /* IterativeTypeChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IterativeTypeChecker.h; path = include/swift/Sema/IterativeTypeChecker.h; sourceTree = "<group>"; };
+		BB9FD73E1C10F28D0008A1EA /* SourceLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourceLoader.h; path = include/swift/Sema/SourceLoader.h; sourceTree = "<group>"; };
+		BB9FD73F1C10F28D0008A1EA /* TypeCheckRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeCheckRequest.h; path = include/swift/Sema/TypeCheckRequest.h; sourceTree = "<group>"; };
+		BB9FD7401C10F28D0008A1EA /* TypeCheckRequestKinds.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TypeCheckRequestKinds.def; path = include/swift/Sema/TypeCheckRequestKinds.def; sourceTree = "<group>"; };
+		BB9FD7411C10F28D0008A1EA /* TypeCheckRequestPayloads.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TypeCheckRequestPayloads.def; path = include/swift/Sema/TypeCheckRequestPayloads.def; sourceTree = "<group>"; };
+		BB9FD7431C10F2C00008A1EA /* BCReadingExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BCReadingExtras.h; path = include/swift/Serialization/BCReadingExtras.h; sourceTree = "<group>"; };
+		BB9FD7441C10F2C00008A1EA /* DeclTypeRecordNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DeclTypeRecordNodes.def; path = include/swift/Serialization/DeclTypeRecordNodes.def; sourceTree = "<group>"; };
+		BB9FD7451C10F2C00008A1EA /* ModuleFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModuleFile.h; path = include/swift/Serialization/ModuleFile.h; sourceTree = "<group>"; };
+		BB9FD7461C10F2C00008A1EA /* ModuleFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModuleFormat.h; path = include/swift/Serialization/ModuleFormat.h; sourceTree = "<group>"; };
+		BB9FD7471C10F2C00008A1EA /* SerializationOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SerializationOptions.h; path = include/swift/Serialization/SerializationOptions.h; sourceTree = "<group>"; };
+		BB9FD7481C10F2C00008A1EA /* SerializedModuleLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SerializedModuleLoader.h; path = include/swift/Serialization/SerializedModuleLoader.h; sourceTree = "<group>"; };
+		BB9FD7491C10F2C00008A1EA /* SerializedSILLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SerializedSILLoader.h; path = include/swift/Serialization/SerializedSILLoader.h; sourceTree = "<group>"; };
+		BB9FD74A1C10F2C00008A1EA /* Validation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Validation.h; path = include/swift/Serialization/Validation.h; sourceTree = "<group>"; };
+		BB9FD74C1C10F2E70008A1EA /* AbstractionPattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AbstractionPattern.h; path = include/swift/SIL/AbstractionPattern.h; sourceTree = "<group>"; };
+		BB9FD74D1C10F2E70008A1EA /* BridgedTypes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = BridgedTypes.def; path = include/swift/SIL/BridgedTypes.def; sourceTree = "<group>"; };
+		BB9FD74E1C10F2E70008A1EA /* CFG.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CFG.h; path = include/swift/SIL/CFG.h; sourceTree = "<group>"; };
+		BB9FD74F1C10F2E70008A1EA /* Consumption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Consumption.h; path = include/swift/SIL/Consumption.h; sourceTree = "<group>"; };
+		BB9FD7501C10F2E70008A1EA /* DebugUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DebugUtils.h; path = include/swift/SIL/DebugUtils.h; sourceTree = "<group>"; };
+		BB9FD7511C10F2E70008A1EA /* Dominance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Dominance.h; path = include/swift/SIL/Dominance.h; sourceTree = "<group>"; };
+		BB9FD7521C10F2E70008A1EA /* DynamicCasts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamicCasts.h; path = include/swift/SIL/DynamicCasts.h; sourceTree = "<group>"; };
+		BB9FD7531C10F2E70008A1EA /* FormalLinkage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FormalLinkage.h; path = include/swift/SIL/FormalLinkage.h; sourceTree = "<group>"; };
+		BB9FD7541C10F2E70008A1EA /* LoopInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoopInfo.h; path = include/swift/SIL/LoopInfo.h; sourceTree = "<group>"; };
+		BB9FD7551C10F2E70008A1EA /* Mangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Mangle.h; path = include/swift/SIL/Mangle.h; sourceTree = "<group>"; };
+		BB9FD7561C10F2E70008A1EA /* MemLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MemLocation.h; path = include/swift/SIL/MemLocation.h; sourceTree = "<group>"; };
+		BB9FD7571C10F2E70008A1EA /* PatternMatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PatternMatch.h; path = include/swift/SIL/PatternMatch.h; sourceTree = "<group>"; };
+		BB9FD7581C10F2E70008A1EA /* PrettyStackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrettyStackTrace.h; path = include/swift/SIL/PrettyStackTrace.h; sourceTree = "<group>"; };
+		BB9FD7591C10F2E70008A1EA /* Projection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Projection.h; path = include/swift/SIL/Projection.h; sourceTree = "<group>"; };
+		BB9FD75A1C10F2E70008A1EA /* SILAllocated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILAllocated.h; path = include/swift/SIL/SILAllocated.h; sourceTree = "<group>"; };
+		BB9FD75B1C10F2E70008A1EA /* SILArgument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILArgument.h; path = include/swift/SIL/SILArgument.h; sourceTree = "<group>"; };
+		BB9FD75C1C10F2E70008A1EA /* SILBasicBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILBasicBlock.h; path = include/swift/SIL/SILBasicBlock.h; sourceTree = "<group>"; };
+		BB9FD75D1C10F2E70008A1EA /* SILBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILBuilder.h; path = include/swift/SIL/SILBuilder.h; sourceTree = "<group>"; };
+		BB9FD75E1C10F2E70008A1EA /* SILCloner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILCloner.h; path = include/swift/SIL/SILCloner.h; sourceTree = "<group>"; };
+		BB9FD75F1C10F2E70008A1EA /* SILCoverageMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILCoverageMap.h; path = include/swift/SIL/SILCoverageMap.h; sourceTree = "<group>"; };
+		BB9FD7601C10F2E70008A1EA /* SILDebuggerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILDebuggerClient.h; path = include/swift/SIL/SILDebuggerClient.h; sourceTree = "<group>"; };
+		BB9FD7611C10F2E70008A1EA /* SILDebugScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILDebugScope.h; path = include/swift/SIL/SILDebugScope.h; sourceTree = "<group>"; };
+		BB9FD7621C10F2E70008A1EA /* SILDeclRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILDeclRef.h; path = include/swift/SIL/SILDeclRef.h; sourceTree = "<group>"; };
+		BB9FD7631C10F2E70008A1EA /* SILExternalSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILExternalSource.h; path = include/swift/SIL/SILExternalSource.h; sourceTree = "<group>"; };
+		BB9FD7641C10F2E70008A1EA /* SILFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILFunction.h; path = include/swift/SIL/SILFunction.h; sourceTree = "<group>"; };
+		BB9FD7651C10F2E70008A1EA /* SILGlobalVariable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILGlobalVariable.h; path = include/swift/SIL/SILGlobalVariable.h; sourceTree = "<group>"; };
+		BB9FD7661C10F2E70008A1EA /* SILInstruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILInstruction.h; path = include/swift/SIL/SILInstruction.h; sourceTree = "<group>"; };
+		BB9FD7671C10F2E70008A1EA /* SILLinkage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILLinkage.h; path = include/swift/SIL/SILLinkage.h; sourceTree = "<group>"; };
+		BB9FD7681C10F2E70008A1EA /* SILLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILLocation.h; path = include/swift/SIL/SILLocation.h; sourceTree = "<group>"; };
+		BB9FD7691C10F2E70008A1EA /* SILModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILModule.h; path = include/swift/SIL/SILModule.h; sourceTree = "<group>"; };
+		BB9FD76A1C10F2E70008A1EA /* SILNodes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = SILNodes.def; path = include/swift/SIL/SILNodes.def; sourceTree = "<group>"; };
+		BB9FD76B1C10F2E70008A1EA /* SILSuccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILSuccessor.h; path = include/swift/SIL/SILSuccessor.h; sourceTree = "<group>"; };
+		BB9FD76C1C10F2E70008A1EA /* SILType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILType.h; path = include/swift/SIL/SILType.h; sourceTree = "<group>"; };
+		BB9FD76D1C10F2E70008A1EA /* SILUndef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILUndef.h; path = include/swift/SIL/SILUndef.h; sourceTree = "<group>"; };
+		BB9FD76E1C10F2E70008A1EA /* SILValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILValue.h; path = include/swift/SIL/SILValue.h; sourceTree = "<group>"; };
+		BB9FD76F1C10F2E70008A1EA /* SILVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILVisitor.h; path = include/swift/SIL/SILVisitor.h; sourceTree = "<group>"; };
+		BB9FD7701C10F2E70008A1EA /* SILVTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILVTable.h; path = include/swift/SIL/SILVTable.h; sourceTree = "<group>"; };
+		BB9FD7711C10F2E70008A1EA /* SILWitnessTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILWitnessTable.h; path = include/swift/SIL/SILWitnessTable.h; sourceTree = "<group>"; };
+		BB9FD7721C10F2E70008A1EA /* SILWitnessVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILWitnessVisitor.h; path = include/swift/SIL/SILWitnessVisitor.h; sourceTree = "<group>"; };
+		BB9FD7731C10F2E70008A1EA /* TypeLowering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeLowering.h; path = include/swift/SIL/TypeLowering.h; sourceTree = "<group>"; };
+		BB9FD7741C10F2E70008A1EA /* TypeSubstCloner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeSubstCloner.h; path = include/swift/SIL/TypeSubstCloner.h; sourceTree = "<group>"; };
+		BB9FD7761C10F3120008A1EA /* AliasAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AliasAnalysis.h; path = include/swift/SILAnalysis/AliasAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7771C10F3120008A1EA /* Analysis.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Analysis.def; path = include/swift/SILAnalysis/Analysis.def; sourceTree = "<group>"; };
+		BB9FD7781C10F3120008A1EA /* Analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Analysis.h; path = include/swift/SILAnalysis/Analysis.h; sourceTree = "<group>"; };
+		BB9FD7791C10F3120008A1EA /* ARCAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARCAnalysis.h; path = include/swift/SILAnalysis/ARCAnalysis.h; sourceTree = "<group>"; };
+		BB9FD77A1C10F3120008A1EA /* ArraySemantic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArraySemantic.h; path = include/swift/SILAnalysis/ArraySemantic.h; sourceTree = "<group>"; };
+		BB9FD77B1C10F3120008A1EA /* BasicCalleeAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BasicCalleeAnalysis.h; path = include/swift/SILAnalysis/BasicCalleeAnalysis.h; sourceTree = "<group>"; };
+		BB9FD77C1C10F3120008A1EA /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CallGraph.h; path = include/swift/SILAnalysis/CallGraph.h; sourceTree = "<group>"; };
+		BB9FD77D1C10F3120008A1EA /* CallGraphAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CallGraphAnalysis.h; path = include/swift/SILAnalysis/CallGraphAnalysis.h; sourceTree = "<group>"; };
+		BB9FD77E1C10F3120008A1EA /* CFG.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CFG.h; path = include/swift/SILAnalysis/CFG.h; sourceTree = "<group>"; };
+		BB9FD77F1C10F3120008A1EA /* ClassHierarchyAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClassHierarchyAnalysis.h; path = include/swift/SILAnalysis/ClassHierarchyAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7801C10F3120008A1EA /* ColdBlockInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ColdBlockInfo.h; path = include/swift/SILAnalysis/ColdBlockInfo.h; sourceTree = "<group>"; };
+		BB9FD7811C10F3120008A1EA /* DestructorAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DestructorAnalysis.h; path = include/swift/SILAnalysis/DestructorAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7821C10F3120008A1EA /* DominanceAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DominanceAnalysis.h; path = include/swift/SILAnalysis/DominanceAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7831C10F3120008A1EA /* EscapeAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EscapeAnalysis.h; path = include/swift/SILAnalysis/EscapeAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7841C10F3120008A1EA /* FunctionOrder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FunctionOrder.h; path = include/swift/SILAnalysis/FunctionOrder.h; sourceTree = "<group>"; };
+		BB9FD7851C10F3120008A1EA /* IVAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IVAnalysis.h; path = include/swift/SILAnalysis/IVAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7861C10F3120008A1EA /* LoopAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoopAnalysis.h; path = include/swift/SILAnalysis/LoopAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7871C10F3120008A1EA /* LoopRegionAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoopRegionAnalysis.h; path = include/swift/SILAnalysis/LoopRegionAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7881C10F3120008A1EA /* PostOrderAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PostOrderAnalysis.h; path = include/swift/SILAnalysis/PostOrderAnalysis.h; sourceTree = "<group>"; };
+		BB9FD7891C10F3120008A1EA /* RCIdentityAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCIdentityAnalysis.h; path = include/swift/SILAnalysis/RCIdentityAnalysis.h; sourceTree = "<group>"; };
+		BB9FD78A1C10F3120008A1EA /* SideEffectAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SideEffectAnalysis.h; path = include/swift/SILAnalysis/SideEffectAnalysis.h; sourceTree = "<group>"; };
+		BB9FD78B1C10F3120008A1EA /* SimplifyInstruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SimplifyInstruction.h; path = include/swift/SILAnalysis/SimplifyInstruction.h; sourceTree = "<group>"; };
+		BB9FD78C1C10F3120008A1EA /* ValueTracking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ValueTracking.h; path = include/swift/SILAnalysis/ValueTracking.h; sourceTree = "<group>"; };
+		BB9FD78F1C10F3500008A1EA /* Passes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Passes.def; path = include/swift/SILPasses/Passes.def; sourceTree = "<group>"; };
+		BB9FD7901C10F3500008A1EA /* Passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Passes.h; path = include/swift/SILPasses/Passes.h; sourceTree = "<group>"; };
+		BB9FD7911C10F3500008A1EA /* PassManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PassManager.h; path = include/swift/SILPasses/PassManager.h; sourceTree = "<group>"; };
+		BB9FD7921C10F3500008A1EA /* PrettyStackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrettyStackTrace.h; path = include/swift/SILPasses/PrettyStackTrace.h; sourceTree = "<group>"; };
+		BB9FD7931C10F3500008A1EA /* Transforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Transforms.h; path = include/swift/SILPasses/Transforms.h; sourceTree = "<group>"; };
+		BB9FD7941C10F3500008A1EA /* Utils */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Utils; path = include/swift/SILPasses/Utils; sourceTree = "<group>"; };
+		BB9FD7961C10F3780008A1EA /* MangleHack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MangleHack.h; path = include/swift/SwiftDemangle/MangleHack.h; sourceTree = "<group>"; };
+		BB9FD7971C10F3780008A1EA /* SwiftDemangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwiftDemangle.h; path = include/swift/SwiftDemangle/SwiftDemangle.h; sourceTree = "<group>"; };
+		BB9FD79A1C10F3CD0008A1EA /* ArchetypeBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArchetypeBuilder.cpp; path = lib/AST/ArchetypeBuilder.cpp; sourceTree = "<group>"; };
+		BB9FD79B1C10F3CD0008A1EA /* ASTContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ASTContext.cpp; path = lib/AST/ASTContext.cpp; sourceTree = "<group>"; };
+		BB9FD79C1C10F3CD0008A1EA /* ASTDumper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ASTDumper.cpp; path = lib/AST/ASTDumper.cpp; sourceTree = "<group>"; };
+		BB9FD79D1C10F3CD0008A1EA /* ASTNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ASTNode.cpp; path = lib/AST/ASTNode.cpp; sourceTree = "<group>"; };
+		BB9FD79E1C10F3CD0008A1EA /* ASTPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ASTPrinter.cpp; path = lib/AST/ASTPrinter.cpp; sourceTree = "<group>"; };
+		BB9FD79F1C10F3CD0008A1EA /* ASTWalker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ASTWalker.cpp; path = lib/AST/ASTWalker.cpp; sourceTree = "<group>"; };
+		BB9FD7A01C10F3CD0008A1EA /* Attr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Attr.cpp; path = lib/AST/Attr.cpp; sourceTree = "<group>"; };
+		BB9FD7A11C10F3CD0008A1EA /* Availability.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Availability.cpp; path = lib/AST/Availability.cpp; sourceTree = "<group>"; };
+		BB9FD7A21C10F3CD0008A1EA /* AvailabilitySpec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AvailabilitySpec.cpp; path = lib/AST/AvailabilitySpec.cpp; sourceTree = "<group>"; };
+		BB9FD7A31C10F3CD0008A1EA /* Builtins.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Builtins.cpp; path = lib/AST/Builtins.cpp; sourceTree = "<group>"; };
+		BB9FD7A41C10F3CD0008A1EA /* CaptureInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CaptureInfo.cpp; path = lib/AST/CaptureInfo.cpp; sourceTree = "<group>"; };
+		BB9FD7A51C10F3CD0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/AST/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD7A61C10F3CD0008A1EA /* ConcreteDeclRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConcreteDeclRef.cpp; path = lib/AST/ConcreteDeclRef.cpp; sourceTree = "<group>"; };
+		BB9FD7A71C10F3CD0008A1EA /* ConformanceLookupTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConformanceLookupTable.cpp; path = lib/AST/ConformanceLookupTable.cpp; sourceTree = "<group>"; };
+		BB9FD7A81C10F3CD0008A1EA /* ConformanceLookupTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConformanceLookupTable.h; path = lib/AST/ConformanceLookupTable.h; sourceTree = "<group>"; };
+		BB9FD7A91C10F3CD0008A1EA /* Decl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Decl.cpp; path = lib/AST/Decl.cpp; sourceTree = "<group>"; };
+		BB9FD7AA1C10F3CD0008A1EA /* DeclContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeclContext.cpp; path = lib/AST/DeclContext.cpp; sourceTree = "<group>"; };
+		BB9FD7AB1C10F3CD0008A1EA /* DiagnosticEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiagnosticEngine.cpp; path = lib/AST/DiagnosticEngine.cpp; sourceTree = "<group>"; };
+		BB9FD7AC1C10F3CD0008A1EA /* DiagnosticList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiagnosticList.cpp; path = lib/AST/DiagnosticList.cpp; sourceTree = "<group>"; };
+		BB9FD7AD1C10F3CD0008A1EA /* DocComment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DocComment.cpp; path = lib/AST/DocComment.cpp; sourceTree = "<group>"; };
+		BB9FD7AE1C10F3CD0008A1EA /* Expr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Expr.cpp; path = lib/AST/Expr.cpp; sourceTree = "<group>"; };
+		BB9FD7AF1C10F3CD0008A1EA /* GenericSignature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenericSignature.cpp; path = lib/AST/GenericSignature.cpp; sourceTree = "<group>"; };
+		BB9FD7B01C10F3CD0008A1EA /* Identifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Identifier.cpp; path = lib/AST/Identifier.cpp; sourceTree = "<group>"; };
+		BB9FD7B11C10F3CD0008A1EA /* LookupVisibleDecls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LookupVisibleDecls.cpp; path = lib/AST/LookupVisibleDecls.cpp; sourceTree = "<group>"; };
+		BB9FD7B21C10F3CD0008A1EA /* Mangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Mangle.cpp; path = lib/AST/Mangle.cpp; sourceTree = "<group>"; };
+		BB9FD7B31C10F3CD0008A1EA /* Module.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Module.cpp; path = lib/AST/Module.cpp; sourceTree = "<group>"; };
+		BB9FD7B41C10F3CD0008A1EA /* ModuleNameLookup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModuleNameLookup.cpp; path = lib/AST/ModuleNameLookup.cpp; sourceTree = "<group>"; };
+		BB9FD7B51C10F3CD0008A1EA /* NameLookup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NameLookup.cpp; path = lib/AST/NameLookup.cpp; sourceTree = "<group>"; };
+		BB9FD7B61C10F3CD0008A1EA /* NameLookupImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NameLookupImpl.h; path = lib/AST/NameLookupImpl.h; sourceTree = "<group>"; };
+		BB9FD7B71C10F3CD0008A1EA /* Pattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Pattern.cpp; path = lib/AST/Pattern.cpp; sourceTree = "<group>"; };
+		BB9FD7B81C10F3CD0008A1EA /* PlatformKind.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PlatformKind.cpp; path = lib/AST/PlatformKind.cpp; sourceTree = "<group>"; };
+		BB9FD7B91C10F3CD0008A1EA /* PrettyStackTrace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrettyStackTrace.cpp; path = lib/AST/PrettyStackTrace.cpp; sourceTree = "<group>"; };
+		BB9FD7BA1C10F3CD0008A1EA /* ProtocolConformance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ProtocolConformance.cpp; path = lib/AST/ProtocolConformance.cpp; sourceTree = "<group>"; };
+		BB9FD7BB1C10F3CD0008A1EA /* RawComment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RawComment.cpp; path = lib/AST/RawComment.cpp; sourceTree = "<group>"; };
+		BB9FD7BC1C10F3CD0008A1EA /* Stmt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Stmt.cpp; path = lib/AST/Stmt.cpp; sourceTree = "<group>"; };
+		BB9FD7BD1C10F3CD0008A1EA /* Substitution.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Substitution.cpp; path = lib/AST/Substitution.cpp; sourceTree = "<group>"; };
+		BB9FD7BE1C10F3CD0008A1EA /* Type.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Type.cpp; path = lib/AST/Type.cpp; sourceTree = "<group>"; };
+		BB9FD7BF1C10F3CD0008A1EA /* TypeRefinementContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeRefinementContext.cpp; path = lib/AST/TypeRefinementContext.cpp; sourceTree = "<group>"; };
+		BB9FD7C01C10F3CD0008A1EA /* TypeRepr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeRepr.cpp; path = lib/AST/TypeRepr.cpp; sourceTree = "<group>"; };
+		BB9FD7C11C10F3CD0008A1EA /* TypeWalker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeWalker.cpp; path = lib/AST/TypeWalker.cpp; sourceTree = "<group>"; };
+		BB9FD7C21C10F3CD0008A1EA /* USRGeneration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = USRGeneration.cpp; path = lib/AST/USRGeneration.cpp; sourceTree = "<group>"; };
+		BB9FD7C31C10F3CD0008A1EA /* Verifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Verifier.cpp; path = lib/AST/Verifier.cpp; sourceTree = "<group>"; };
+		BB9FD7EC1C10F4500008A1EA /* ASTSectionImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ASTSectionImporter.cpp; path = lib/ASTSectionImporter/ASTSectionImporter.cpp; sourceTree = "<group>"; };
+		BB9FD7ED1C10F4500008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/ASTSectionImporter/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD7F01C10F4770008A1EA /* Cache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Cache.cpp; path = lib/Basic/Cache.cpp; sourceTree = "<group>"; };
+		BB9FD7F11C10F4770008A1EA /* ClusteredBitVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClusteredBitVector.cpp; path = lib/Basic/ClusteredBitVector.cpp; sourceTree = "<group>"; };
+		BB9FD7F21C10F4770008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Basic/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD7F31C10F4770008A1EA /* Demangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Demangle.cpp; path = lib/Basic/Demangle.cpp; sourceTree = "<group>"; };
+		BB9FD7F41C10F4770008A1EA /* DemangleWrappers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DemangleWrappers.cpp; path = lib/Basic/DemangleWrappers.cpp; sourceTree = "<group>"; };
+		BB9FD7F51C10F4770008A1EA /* DiagnosticConsumer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiagnosticConsumer.cpp; path = lib/Basic/DiagnosticConsumer.cpp; sourceTree = "<group>"; };
+		BB9FD7F61C10F4770008A1EA /* DiverseStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiverseStack.cpp; path = lib/Basic/DiverseStack.cpp; sourceTree = "<group>"; };
+		BB9FD7F71C10F4770008A1EA /* EditorPlaceholder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EditorPlaceholder.cpp; path = lib/Basic/EditorPlaceholder.cpp; sourceTree = "<group>"; };
+		BB9FD7F81C10F4770008A1EA /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSystem.cpp; path = lib/Basic/FileSystem.cpp; sourceTree = "<group>"; };
+		BB9FD7F91C10F4770008A1EA /* JSONSerialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = JSONSerialization.cpp; path = lib/Basic/JSONSerialization.cpp; sourceTree = "<group>"; };
+		BB9FD7FA1C10F4770008A1EA /* LangOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LangOptions.cpp; path = lib/Basic/LangOptions.cpp; sourceTree = "<group>"; };
+		BB9FD7FB1C10F4770008A1EA /* PartsOfSpeech.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = PartsOfSpeech.def; path = lib/Basic/PartsOfSpeech.def; sourceTree = "<group>"; };
+		BB9FD7FC1C10F4770008A1EA /* Platform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Platform.cpp; path = lib/Basic/Platform.cpp; sourceTree = "<group>"; };
+		BB9FD7FD1C10F4770008A1EA /* PrefixMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrefixMap.cpp; path = lib/Basic/PrefixMap.cpp; sourceTree = "<group>"; };
+		BB9FD7FE1C10F4770008A1EA /* PrettyStackTrace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrettyStackTrace.cpp; path = lib/Basic/PrettyStackTrace.cpp; sourceTree = "<group>"; };
+		BB9FD7FF1C10F4770008A1EA /* PrimitiveParsing.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrimitiveParsing.cpp; path = lib/Basic/PrimitiveParsing.cpp; sourceTree = "<group>"; };
+		BB9FD8001C10F4770008A1EA /* Program.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Program.cpp; path = lib/Basic/Program.cpp; sourceTree = "<group>"; };
+		BB9FD8011C10F4770008A1EA /* Punycode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Punycode.cpp; path = lib/Basic/Punycode.cpp; sourceTree = "<group>"; };
+		BB9FD8021C10F4770008A1EA /* PunycodeUTF8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PunycodeUTF8.cpp; path = lib/Basic/PunycodeUTF8.cpp; sourceTree = "<group>"; };
+		BB9FD8031C10F4770008A1EA /* QuotedString.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = QuotedString.cpp; path = lib/Basic/QuotedString.cpp; sourceTree = "<group>"; };
+		BB9FD8041C10F4770008A1EA /* Remangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Remangle.cpp; path = lib/Basic/Remangle.cpp; sourceTree = "<group>"; };
+		BB9FD8051C10F4770008A1EA /* SourceLoc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SourceLoc.cpp; path = lib/Basic/SourceLoc.cpp; sourceTree = "<group>"; };
+		BB9FD8061C10F4770008A1EA /* StringExtras.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StringExtras.cpp; path = lib/Basic/StringExtras.cpp; sourceTree = "<group>"; };
+		BB9FD8071C10F4770008A1EA /* TaskQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TaskQueue.cpp; path = lib/Basic/TaskQueue.cpp; sourceTree = "<group>"; };
+		BB9FD8081C10F4770008A1EA /* ThreadSafeRefCounted.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ThreadSafeRefCounted.cpp; path = lib/Basic/ThreadSafeRefCounted.cpp; sourceTree = "<group>"; };
+		BB9FD8091C10F4770008A1EA /* Unicode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Unicode.cpp; path = lib/Basic/Unicode.cpp; sourceTree = "<group>"; };
+		BB9FD80A1C10F4770008A1EA /* UnicodeExtendedGraphemeClusters.cpp.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnicodeExtendedGraphemeClusters.cpp.gyb; path = lib/Basic/UnicodeExtendedGraphemeClusters.cpp.gyb; sourceTree = "<group>"; };
+		BB9FD80B1C10F4770008A1EA /* UUID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UUID.cpp; path = lib/Basic/UUID.cpp; sourceTree = "<group>"; };
+		BB9FD80C1C10F4770008A1EA /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Version.cpp; path = lib/Basic/Version.cpp; sourceTree = "<group>"; };
+		BB9FD82A1C10F4CA0008A1EA /* Cache-Mac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "Cache-Mac.cpp"; path = "lib/Basic/Darwin/Cache-Mac.cpp"; sourceTree = "<group>"; };
+		BB9FD82C1C10F4D70008A1EA /* TaskQueue.inc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.pascal; name = TaskQueue.inc; path = lib/Basic/Default/TaskQueue.inc; sourceTree = "<group>"; };
+		BB9FD82E1C10F4E50008A1EA /* TaskQueue.inc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.pascal; name = TaskQueue.inc; path = lib/Basic/Unix/TaskQueue.inc; sourceTree = "<group>"; };
+		BB9FD8311C10F50E0008A1EA /* CFDatabase.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CFDatabase.def; path = lib/ClangImporter/CFDatabase.def; sourceTree = "<group>"; };
+		BB9FD8321C10F50E0008A1EA /* ClangDiagnosticConsumer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClangDiagnosticConsumer.cpp; path = lib/ClangImporter/ClangDiagnosticConsumer.cpp; sourceTree = "<group>"; };
+		BB9FD8331C10F50E0008A1EA /* ClangDiagnosticConsumer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClangDiagnosticConsumer.h; path = lib/ClangImporter/ClangDiagnosticConsumer.h; sourceTree = "<group>"; };
+		BB9FD8341C10F50E0008A1EA /* ClangImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClangImporter.cpp; path = lib/ClangImporter/ClangImporter.cpp; sourceTree = "<group>"; };
+		BB9FD8351C10F50E0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/ClangImporter/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD8361C10F50E0008A1EA /* ImportDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ImportDecl.cpp; path = lib/ClangImporter/ImportDecl.cpp; sourceTree = "<group>"; };
+		BB9FD8371C10F50E0008A1EA /* ImporterImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImporterImpl.h; path = lib/ClangImporter/ImporterImpl.h; sourceTree = "<group>"; };
+		BB9FD8381C10F50E0008A1EA /* ImportMacro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ImportMacro.cpp; path = lib/ClangImporter/ImportMacro.cpp; sourceTree = "<group>"; };
+		BB9FD8391C10F50E0008A1EA /* ImportType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ImportType.cpp; path = lib/ClangImporter/ImportType.cpp; sourceTree = "<group>"; };
+		BB9FD83A1C10F50E0008A1EA /* InferredAttributes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = InferredAttributes.def; path = lib/ClangImporter/InferredAttributes.def; sourceTree = "<group>"; };
+		BB9FD83B1C10F50E0008A1EA /* MacroTable.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MacroTable.def; path = lib/ClangImporter/MacroTable.def; sourceTree = "<group>"; };
+		BB9FD83C1C10F50E0008A1EA /* MappedTypes.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MappedTypes.def; path = lib/ClangImporter/MappedTypes.def; sourceTree = "<group>"; };
+		BB9FD83D1C10F50E0008A1EA /* SortedCFDatabase.def.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = SortedCFDatabase.def.gyb; path = lib/ClangImporter/SortedCFDatabase.def.gyb; sourceTree = "<group>"; };
+		BB9FD8431C10F5250008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD8451C10F54E0008A1EA /* Action.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Action.cpp; path = lib/Driver/Action.cpp; sourceTree = "<group>"; };
+		BB9FD8461C10F54E0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Driver/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD8471C10F54E0008A1EA /* Compilation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Compilation.cpp; path = lib/Driver/Compilation.cpp; sourceTree = "<group>"; };
+		BB9FD8481C10F54E0008A1EA /* DependencyGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DependencyGraph.cpp; path = lib/Driver/DependencyGraph.cpp; sourceTree = "<group>"; };
+		BB9FD8491C10F54E0008A1EA /* Driver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Driver.cpp; path = lib/Driver/Driver.cpp; sourceTree = "<group>"; };
+		BB9FD84A1C10F54E0008A1EA /* FrontendUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FrontendUtil.cpp; path = lib/Driver/FrontendUtil.cpp; sourceTree = "<group>"; };
+		BB9FD84B1C10F54E0008A1EA /* Job.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Job.cpp; path = lib/Driver/Job.cpp; sourceTree = "<group>"; };
+		BB9FD84C1C10F54E0008A1EA /* OutputFileMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OutputFileMap.cpp; path = lib/Driver/OutputFileMap.cpp; sourceTree = "<group>"; };
+		BB9FD84D1C10F54E0008A1EA /* ParseableOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseableOutput.cpp; path = lib/Driver/ParseableOutput.cpp; sourceTree = "<group>"; };
+		BB9FD84E1C10F54E0008A1EA /* ToolChain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ToolChain.cpp; path = lib/Driver/ToolChain.cpp; sourceTree = "<group>"; };
+		BB9FD84F1C10F54E0008A1EA /* ToolChains.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ToolChains.cpp; path = lib/Driver/ToolChains.cpp; sourceTree = "<group>"; };
+		BB9FD8501C10F54E0008A1EA /* ToolChains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ToolChains.h; path = lib/Driver/ToolChains.h; sourceTree = "<group>"; };
+		BB9FD8511C10F54E0008A1EA /* Types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Types.cpp; path = lib/Driver/Types.cpp; sourceTree = "<group>"; };
+		BB9FD85E1C10F5790008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Frontend/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD85F1C10F5790008A1EA /* CompilerInvocation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CompilerInvocation.cpp; path = lib/Frontend/CompilerInvocation.cpp; sourceTree = "<group>"; };
+		BB9FD8601C10F5790008A1EA /* DiagnosticVerifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiagnosticVerifier.cpp; path = lib/Frontend/DiagnosticVerifier.cpp; sourceTree = "<group>"; };
+		BB9FD8611C10F5790008A1EA /* Frontend.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Frontend.cpp; path = lib/Frontend/Frontend.cpp; sourceTree = "<group>"; };
+		BB9FD8621C10F5790008A1EA /* FrontendOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FrontendOptions.cpp; path = lib/Frontend/FrontendOptions.cpp; sourceTree = "<group>"; };
+		BB9FD8631C10F5790008A1EA /* PrintingDiagnosticConsumer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrintingDiagnosticConsumer.cpp; path = lib/Frontend/PrintingDiagnosticConsumer.cpp; sourceTree = "<group>"; };
+		BB9FD8641C10F5790008A1EA /* SerializedDiagnosticConsumer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SerializedDiagnosticConsumer.cpp; path = lib/Frontend/SerializedDiagnosticConsumer.cpp; sourceTree = "<group>"; };
+		BB9FD86C1C10F5A40008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/IDE/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD86D1C10F5A40008A1EA /* CodeCompletion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CodeCompletion.cpp; path = lib/IDE/CodeCompletion.cpp; sourceTree = "<group>"; };
+		BB9FD86E1C10F5A40008A1EA /* CodeCompletionCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CodeCompletionCache.cpp; path = lib/IDE/CodeCompletionCache.cpp; sourceTree = "<group>"; };
+		BB9FD86F1C10F5A40008A1EA /* CodeCompletionResultBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodeCompletionResultBuilder.h; path = lib/IDE/CodeCompletionResultBuilder.h; sourceTree = "<group>"; };
+		BB9FD8701C10F5A40008A1EA /* CommentConversion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CommentConversion.cpp; path = lib/IDE/CommentConversion.cpp; sourceTree = "<group>"; };
+		BB9FD8711C10F5A40008A1EA /* ModuleInterfacePrinting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModuleInterfacePrinting.cpp; path = lib/IDE/ModuleInterfacePrinting.cpp; sourceTree = "<group>"; };
+		BB9FD8721C10F5A40008A1EA /* REPLCodeCompletion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = REPLCodeCompletion.cpp; path = lib/IDE/REPLCodeCompletion.cpp; sourceTree = "<group>"; };
+		BB9FD8731C10F5A40008A1EA /* SourceEntityWalker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SourceEntityWalker.cpp; path = lib/IDE/SourceEntityWalker.cpp; sourceTree = "<group>"; };
+		BB9FD8741C10F5A40008A1EA /* SwiftSourceDocInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftSourceDocInfo.cpp; path = lib/IDE/SwiftSourceDocInfo.cpp; sourceTree = "<group>"; };
+		BB9FD8751C10F5A40008A1EA /* SyntaxModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SyntaxModel.cpp; path = lib/IDE/SyntaxModel.cpp; sourceTree = "<group>"; };
+		BB9FD8761C10F5A40008A1EA /* Utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Utils.cpp; path = lib/IDE/Utils.cpp; sourceTree = "<group>"; };
+		BB9FD8811C10F5C40008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Immediate/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD8821C10F5C40008A1EA /* Immediate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Immediate.cpp; path = lib/Immediate/Immediate.cpp; sourceTree = "<group>"; };
+		BB9FD8831C10F5C40008A1EA /* ImmediateImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImmediateImpl.h; path = lib/Immediate/ImmediateImpl.h; sourceTree = "<group>"; };
+		BB9FD8841C10F5C40008A1EA /* REPL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = REPL.cpp; path = lib/Immediate/REPL.cpp; sourceTree = "<group>"; };
+		BB9FD8881C10F5F10008A1EA /* Address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Address.h; path = lib/IRGen/Address.h; sourceTree = "<group>"; };
+		BB9FD8891C10F5F10008A1EA /* Callee.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Callee.h; path = lib/IRGen/Callee.h; sourceTree = "<group>"; };
+		BB9FD88A1C10F5F10008A1EA /* CallEmission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CallEmission.h; path = lib/IRGen/CallEmission.h; sourceTree = "<group>"; };
+		BB9FD88B1C10F5F10008A1EA /* CallingConvention.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CallingConvention.h; path = lib/IRGen/CallingConvention.h; sourceTree = "<group>"; };
+		BB9FD88C1C10F5F10008A1EA /* ClassMetadataLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClassMetadataLayout.h; path = lib/IRGen/ClassMetadataLayout.h; sourceTree = "<group>"; };
+		BB9FD88D1C10F5F10008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/IRGen/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD88E1C10F5F10008A1EA /* DebugTypeInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DebugTypeInfo.cpp; path = lib/IRGen/DebugTypeInfo.cpp; sourceTree = "<group>"; };
+		BB9FD88F1C10F5F10008A1EA /* DebugTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DebugTypeInfo.h; path = lib/IRGen/DebugTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8901C10F5F10008A1EA /* EnumMetadataLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnumMetadataLayout.h; path = lib/IRGen/EnumMetadataLayout.h; sourceTree = "<group>"; };
+		BB9FD8911C10F5F10008A1EA /* EnumPayload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EnumPayload.cpp; path = lib/IRGen/EnumPayload.cpp; sourceTree = "<group>"; };
+		BB9FD8921C10F5F10008A1EA /* EnumPayload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnumPayload.h; path = lib/IRGen/EnumPayload.h; sourceTree = "<group>"; };
+		BB9FD8931C10F5F10008A1EA /* Explosion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Explosion.h; path = lib/IRGen/Explosion.h; sourceTree = "<group>"; };
+		BB9FD8941C10F5F10008A1EA /* ExtraInhabitants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ExtraInhabitants.cpp; path = lib/IRGen/ExtraInhabitants.cpp; sourceTree = "<group>"; };
+		BB9FD8951C10F5F10008A1EA /* ExtraInhabitants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExtraInhabitants.h; path = lib/IRGen/ExtraInhabitants.h; sourceTree = "<group>"; };
+		BB9FD8961C10F5F10008A1EA /* FixedTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FixedTypeInfo.h; path = lib/IRGen/FixedTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8971C10F5F10008A1EA /* GenArchetype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenArchetype.cpp; path = lib/IRGen/GenArchetype.cpp; sourceTree = "<group>"; };
+		BB9FD8981C10F5F10008A1EA /* GenArchetype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenArchetype.h; path = lib/IRGen/GenArchetype.h; sourceTree = "<group>"; };
+		BB9FD8991C10F5F10008A1EA /* GenCast.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenCast.cpp; path = lib/IRGen/GenCast.cpp; sourceTree = "<group>"; };
+		BB9FD89A1C10F5F10008A1EA /* GenCast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenCast.h; path = lib/IRGen/GenCast.h; sourceTree = "<group>"; };
+		BB9FD89B1C10F5F10008A1EA /* GenClangDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenClangDecl.cpp; path = lib/IRGen/GenClangDecl.cpp; sourceTree = "<group>"; };
+		BB9FD89C1C10F5F10008A1EA /* GenClangType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenClangType.cpp; path = lib/IRGen/GenClangType.cpp; sourceTree = "<group>"; };
+		BB9FD89D1C10F5F10008A1EA /* GenClass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenClass.cpp; path = lib/IRGen/GenClass.cpp; sourceTree = "<group>"; };
+		BB9FD89E1C10F5F10008A1EA /* GenClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenClass.h; path = lib/IRGen/GenClass.h; sourceTree = "<group>"; };
+		BB9FD89F1C10F5F10008A1EA /* GenControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenControl.cpp; path = lib/IRGen/GenControl.cpp; sourceTree = "<group>"; };
+		BB9FD8A01C10F5F10008A1EA /* GenCoverage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenCoverage.cpp; path = lib/IRGen/GenCoverage.cpp; sourceTree = "<group>"; };
+		BB9FD8A11C10F5F10008A1EA /* GenDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenDecl.cpp; path = lib/IRGen/GenDecl.cpp; sourceTree = "<group>"; };
+		BB9FD8A21C10F5F10008A1EA /* GenEnum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenEnum.cpp; path = lib/IRGen/GenEnum.cpp; sourceTree = "<group>"; };
+		BB9FD8A31C10F5F10008A1EA /* GenEnum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenEnum.h; path = lib/IRGen/GenEnum.h; sourceTree = "<group>"; };
+		BB9FD8A41C10F5F10008A1EA /* GenExistential.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenExistential.cpp; path = lib/IRGen/GenExistential.cpp; sourceTree = "<group>"; };
+		BB9FD8A51C10F5F10008A1EA /* GenExistential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenExistential.h; path = lib/IRGen/GenExistential.h; sourceTree = "<group>"; };
+		BB9FD8A61C10F5F10008A1EA /* GenFunc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenFunc.cpp; path = lib/IRGen/GenFunc.cpp; sourceTree = "<group>"; };
+		BB9FD8A71C10F5F10008A1EA /* GenFunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenFunc.h; path = lib/IRGen/GenFunc.h; sourceTree = "<group>"; };
+		BB9FD8A81C10F5F10008A1EA /* GenHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenHeap.cpp; path = lib/IRGen/GenHeap.cpp; sourceTree = "<group>"; };
+		BB9FD8A91C10F5F10008A1EA /* GenHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenHeap.h; path = lib/IRGen/GenHeap.h; sourceTree = "<group>"; };
+		BB9FD8AA1C10F5F10008A1EA /* GenInit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenInit.cpp; path = lib/IRGen/GenInit.cpp; sourceTree = "<group>"; };
+		BB9FD8AB1C10F5F10008A1EA /* GenMeta.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenMeta.cpp; path = lib/IRGen/GenMeta.cpp; sourceTree = "<group>"; };
+		BB9FD8AC1C10F5F10008A1EA /* GenMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenMeta.h; path = lib/IRGen/GenMeta.h; sourceTree = "<group>"; };
+		BB9FD8AD1C10F5F10008A1EA /* GenObjC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenObjC.cpp; path = lib/IRGen/GenObjC.cpp; sourceTree = "<group>"; };
+		BB9FD8AE1C10F5F10008A1EA /* GenObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenObjC.h; path = lib/IRGen/GenObjC.h; sourceTree = "<group>"; };
+		BB9FD8AF1C10F5F10008A1EA /* GenOpaque.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenOpaque.cpp; path = lib/IRGen/GenOpaque.cpp; sourceTree = "<group>"; };
+		BB9FD8B01C10F5F10008A1EA /* GenOpaque.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenOpaque.h; path = lib/IRGen/GenOpaque.h; sourceTree = "<group>"; };
+		BB9FD8B11C10F5F10008A1EA /* GenPoly.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenPoly.cpp; path = lib/IRGen/GenPoly.cpp; sourceTree = "<group>"; };
+		BB9FD8B21C10F5F10008A1EA /* GenPoly.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenPoly.h; path = lib/IRGen/GenPoly.h; sourceTree = "<group>"; };
+		BB9FD8B31C10F5F10008A1EA /* GenProto.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenProto.cpp; path = lib/IRGen/GenProto.cpp; sourceTree = "<group>"; };
+		BB9FD8B41C10F5F10008A1EA /* GenProto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenProto.h; path = lib/IRGen/GenProto.h; sourceTree = "<group>"; };
+		BB9FD8B51C10F5F10008A1EA /* GenSequential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenSequential.h; path = lib/IRGen/GenSequential.h; sourceTree = "<group>"; };
+		BB9FD8B61C10F5F10008A1EA /* GenStruct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenStruct.cpp; path = lib/IRGen/GenStruct.cpp; sourceTree = "<group>"; };
+		BB9FD8B71C10F5F10008A1EA /* GenStruct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenStruct.h; path = lib/IRGen/GenStruct.h; sourceTree = "<group>"; };
+		BB9FD8B81C10F5F10008A1EA /* GenTuple.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenTuple.cpp; path = lib/IRGen/GenTuple.cpp; sourceTree = "<group>"; };
+		BB9FD8B91C10F5F10008A1EA /* GenTuple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenTuple.h; path = lib/IRGen/GenTuple.h; sourceTree = "<group>"; };
+		BB9FD8BA1C10F5F10008A1EA /* GenType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenType.cpp; path = lib/IRGen/GenType.cpp; sourceTree = "<group>"; };
+		BB9FD8BB1C10F5F10008A1EA /* GenType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenType.h; path = lib/IRGen/GenType.h; sourceTree = "<group>"; };
+		BB9FD8BC1C10F5F10008A1EA /* HeapTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HeapTypeInfo.h; path = lib/IRGen/HeapTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8BD1C10F5F10008A1EA /* IndirectTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IndirectTypeInfo.h; path = lib/IRGen/IndirectTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8BE1C10F5F10008A1EA /* IRBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IRBuilder.h; path = lib/IRGen/IRBuilder.h; sourceTree = "<group>"; };
+		BB9FD8BF1C10F5F10008A1EA /* IRGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IRGen.cpp; path = lib/IRGen/IRGen.cpp; sourceTree = "<group>"; };
+		BB9FD8C01C10F5F10008A1EA /* IRGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IRGen.h; path = lib/IRGen/IRGen.h; sourceTree = "<group>"; };
+		BB9FD8C11C10F5F10008A1EA /* IRGenDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IRGenDebugInfo.cpp; path = lib/IRGen/IRGenDebugInfo.cpp; sourceTree = "<group>"; };
+		BB9FD8C21C10F5F10008A1EA /* IRGenDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IRGenDebugInfo.h; path = lib/IRGen/IRGenDebugInfo.h; sourceTree = "<group>"; };
+		BB9FD8C31C10F5F10008A1EA /* IRGenFunction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IRGenFunction.cpp; path = lib/IRGen/IRGenFunction.cpp; sourceTree = "<group>"; };
+		BB9FD8C41C10F5F10008A1EA /* IRGenFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IRGenFunction.h; path = lib/IRGen/IRGenFunction.h; sourceTree = "<group>"; };
+		BB9FD8C51C10F5F10008A1EA /* IRGenModule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IRGenModule.cpp; path = lib/IRGen/IRGenModule.cpp; sourceTree = "<group>"; };
+		BB9FD8C61C10F5F10008A1EA /* IRGenModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IRGenModule.h; path = lib/IRGen/IRGenModule.h; sourceTree = "<group>"; };
+		BB9FD8C71C10F5F10008A1EA /* IRGenSIL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IRGenSIL.cpp; path = lib/IRGen/IRGenSIL.cpp; sourceTree = "<group>"; };
+		BB9FD8C81C10F5F10008A1EA /* Linking.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Linking.cpp; path = lib/IRGen/Linking.cpp; sourceTree = "<group>"; };
+		BB9FD8C91C10F5F10008A1EA /* Linking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Linking.h; path = lib/IRGen/Linking.h; sourceTree = "<group>"; };
+		BB9FD8CA1C10F5F10008A1EA /* LoadableTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoadableTypeInfo.h; path = lib/IRGen/LoadableTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8CB1C10F5F10008A1EA /* MetadataLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MetadataLayout.h; path = lib/IRGen/MetadataLayout.h; sourceTree = "<group>"; };
+		BB9FD8CC1C10F5F10008A1EA /* MetadataPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MetadataPath.h; path = lib/IRGen/MetadataPath.h; sourceTree = "<group>"; };
+		BB9FD8CD1C10F5F10008A1EA /* NecessaryBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NecessaryBindings.h; path = lib/IRGen/NecessaryBindings.h; sourceTree = "<group>"; };
+		BB9FD8CE1C10F5F10008A1EA /* NonFixedTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NonFixedTypeInfo.h; path = lib/IRGen/NonFixedTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8CF1C10F5F10008A1EA /* ProtocolInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProtocolInfo.h; path = lib/IRGen/ProtocolInfo.h; sourceTree = "<group>"; };
+		BB9FD8D01C10F5F10008A1EA /* ReferenceTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ReferenceTypeInfo.h; path = lib/IRGen/ReferenceTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8D11C10F5F10008A1EA /* ResilientTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ResilientTypeInfo.h; path = lib/IRGen/ResilientTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8D21C10F5F10008A1EA /* RuntimeFunctions.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = RuntimeFunctions.def; path = lib/IRGen/RuntimeFunctions.def; sourceTree = "<group>"; };
+		BB9FD8D31C10F5F10008A1EA /* ScalarTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScalarTypeInfo.h; path = lib/IRGen/ScalarTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8D41C10F5F10008A1EA /* StructLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StructLayout.cpp; path = lib/IRGen/StructLayout.cpp; sourceTree = "<group>"; };
+		BB9FD8D51C10F5F10008A1EA /* StructLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StructLayout.h; path = lib/IRGen/StructLayout.h; sourceTree = "<group>"; };
+		BB9FD8D61C10F5F10008A1EA /* StructMetadataLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StructMetadataLayout.h; path = lib/IRGen/StructMetadataLayout.h; sourceTree = "<group>"; };
+		BB9FD8D71C10F5F10008A1EA /* SwiftTargetInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftTargetInfo.cpp; path = lib/IRGen/SwiftTargetInfo.cpp; sourceTree = "<group>"; };
+		BB9FD8D81C10F5F10008A1EA /* SwiftTargetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwiftTargetInfo.h; path = lib/IRGen/SwiftTargetInfo.h; sourceTree = "<group>"; };
+		BB9FD8D91C10F5F10008A1EA /* TypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeInfo.h; path = lib/IRGen/TypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8DA1C10F5F10008A1EA /* TypeLayoutVerifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeLayoutVerifier.cpp; path = lib/IRGen/TypeLayoutVerifier.cpp; sourceTree = "<group>"; };
+		BB9FD8DB1C10F5F10008A1EA /* TypeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeVisitor.h; path = lib/IRGen/TypeVisitor.h; sourceTree = "<group>"; };
+		BB9FD8DC1C10F5F20008A1EA /* UnimplementedTypeInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnimplementedTypeInfo.cpp; path = lib/IRGen/UnimplementedTypeInfo.cpp; sourceTree = "<group>"; };
+		BB9FD8DD1C10F5F20008A1EA /* UnimplementedTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnimplementedTypeInfo.h; path = lib/IRGen/UnimplementedTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8DE1C10F5F20008A1EA /* UnownedTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnownedTypeInfo.h; path = lib/IRGen/UnownedTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD8DF1C10F5F20008A1EA /* ValueWitness.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ValueWitness.h; path = lib/IRGen/ValueWitness.h; sourceTree = "<group>"; };
+		BB9FD8E01C10F5F20008A1EA /* WeakTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WeakTypeInfo.h; path = lib/IRGen/WeakTypeInfo.h; sourceTree = "<group>"; };
+		BB9FD9041C10F60D0008A1EA /* ARCEntryPointBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARCEntryPointBuilder.h; path = lib/LLVMPasses/ARCEntryPointBuilder.h; sourceTree = "<group>"; };
+		BB9FD9051C10F60D0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/LLVMPasses/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD9061C10F60D0008A1EA /* LLVMARCContract.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LLVMARCContract.cpp; path = lib/LLVMPasses/LLVMARCContract.cpp; sourceTree = "<group>"; };
+		BB9FD9071C10F60D0008A1EA /* LLVMARCOpts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LLVMARCOpts.cpp; path = lib/LLVMPasses/LLVMARCOpts.cpp; sourceTree = "<group>"; };
+		BB9FD9081C10F60D0008A1EA /* LLVMARCOpts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LLVMARCOpts.h; path = lib/LLVMPasses/LLVMARCOpts.h; sourceTree = "<group>"; };
+		BB9FD9091C10F60D0008A1EA /* LLVMStackPromotion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LLVMStackPromotion.cpp; path = lib/LLVMPasses/LLVMStackPromotion.cpp; sourceTree = "<group>"; };
+		BB9FD90A1C10F60D0008A1EA /* LLVMSwiftAA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LLVMSwiftAA.cpp; path = lib/LLVMPasses/LLVMSwiftAA.cpp; sourceTree = "<group>"; };
+		BB9FD90B1C10F60D0008A1EA /* LLVMSwiftRCIdentity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LLVMSwiftRCIdentity.cpp; path = lib/LLVMPasses/LLVMSwiftRCIdentity.cpp; sourceTree = "<group>"; };
+		BB9FD9121C10F6360008A1EA /* AST.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AST.cpp; path = lib/Markup/AST.cpp; sourceTree = "<group>"; };
+		BB9FD9131C10F6360008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Markup/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD9141C10F6360008A1EA /* LineList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LineList.cpp; path = lib/Markup/LineList.cpp; sourceTree = "<group>"; };
+		BB9FD9151C10F6360008A1EA /* Markup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Markup.cpp; path = lib/Markup/Markup.cpp; sourceTree = "<group>"; };
+		BB9FD91A1C10F6580008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Option/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD91B1C10F6580008A1EA /* Options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Options.cpp; path = lib/Option/Options.cpp; sourceTree = "<group>"; };
+		BB9FD91E1C10F67C0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Parse/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD91F1C10F67C0008A1EA /* Lexer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lexer.cpp; path = lib/Parse/Lexer.cpp; sourceTree = "<group>"; };
+		BB9FD9201C10F67C0008A1EA /* ParseDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseDecl.cpp; path = lib/Parse/ParseDecl.cpp; sourceTree = "<group>"; };
+		BB9FD9211C10F67C0008A1EA /* ParseExpr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseExpr.cpp; path = lib/Parse/ParseExpr.cpp; sourceTree = "<group>"; };
+		BB9FD9221C10F67C0008A1EA /* ParseGeneric.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseGeneric.cpp; path = lib/Parse/ParseGeneric.cpp; sourceTree = "<group>"; };
+		BB9FD9231C10F67C0008A1EA /* ParsePattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParsePattern.cpp; path = lib/Parse/ParsePattern.cpp; sourceTree = "<group>"; };
+		BB9FD9241C10F67C0008A1EA /* Parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Parser.cpp; path = lib/Parse/Parser.cpp; sourceTree = "<group>"; };
+		BB9FD9251C10F67C0008A1EA /* ParseSIL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseSIL.cpp; path = lib/Parse/ParseSIL.cpp; sourceTree = "<group>"; };
+		BB9FD9261C10F67C0008A1EA /* ParseStmt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseStmt.cpp; path = lib/Parse/ParseStmt.cpp; sourceTree = "<group>"; };
+		BB9FD9271C10F67C0008A1EA /* ParseType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ParseType.cpp; path = lib/Parse/ParseType.cpp; sourceTree = "<group>"; };
+		BB9FD9281C10F67C0008A1EA /* PersistentParserState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PersistentParserState.cpp; path = lib/Parse/PersistentParserState.cpp; sourceTree = "<group>"; };
+		BB9FD9291C10F67C0008A1EA /* Scope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Scope.cpp; path = lib/Parse/Scope.cpp; sourceTree = "<group>"; };
+		BB9FD9361C10F6A50008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/PrintAsObjC/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD9371C10F6A50008A1EA /* PrintAsObjC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrintAsObjC.cpp; path = lib/PrintAsObjC/PrintAsObjC.cpp; sourceTree = "<group>"; };
+		BB9FD93A1C10F6CE0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Sema/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD93B1C10F6CE0008A1EA /* CodeSynthesis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CodeSynthesis.cpp; path = lib/Sema/CodeSynthesis.cpp; sourceTree = "<group>"; };
+		BB9FD93C1C10F6CE0008A1EA /* CodeSynthesis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodeSynthesis.h; path = lib/Sema/CodeSynthesis.h; sourceTree = "<group>"; };
+		BB9FD93D1C10F6CE0008A1EA /* Constraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Constraint.cpp; path = lib/Sema/Constraint.cpp; sourceTree = "<group>"; };
+		BB9FD93E1C10F6CE0008A1EA /* Constraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Constraint.h; path = lib/Sema/Constraint.h; sourceTree = "<group>"; };
+		BB9FD93F1C10F6CE0008A1EA /* ConstraintGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConstraintGraph.cpp; path = lib/Sema/ConstraintGraph.cpp; sourceTree = "<group>"; };
+		BB9FD9401C10F6CE0008A1EA /* ConstraintGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConstraintGraph.h; path = lib/Sema/ConstraintGraph.h; sourceTree = "<group>"; };
+		BB9FD9411C10F6CE0008A1EA /* ConstraintGraphScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConstraintGraphScope.h; path = lib/Sema/ConstraintGraphScope.h; sourceTree = "<group>"; };
+		BB9FD9421C10F6CE0008A1EA /* ConstraintLocator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConstraintLocator.cpp; path = lib/Sema/ConstraintLocator.cpp; sourceTree = "<group>"; };
+		BB9FD9431C10F6CE0008A1EA /* ConstraintLocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConstraintLocator.h; path = lib/Sema/ConstraintLocator.h; sourceTree = "<group>"; };
+		BB9FD9441C10F6CE0008A1EA /* ConstraintSolverStats.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ConstraintSolverStats.def; path = lib/Sema/ConstraintSolverStats.def; sourceTree = "<group>"; };
+		BB9FD9451C10F6CE0008A1EA /* ConstraintSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConstraintSystem.cpp; path = lib/Sema/ConstraintSystem.cpp; sourceTree = "<group>"; };
+		BB9FD9461C10F6CE0008A1EA /* ConstraintSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConstraintSystem.h; path = lib/Sema/ConstraintSystem.h; sourceTree = "<group>"; };
+		BB9FD9471C10F6CE0008A1EA /* CSApply.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSApply.cpp; path = lib/Sema/CSApply.cpp; sourceTree = "<group>"; };
+		BB9FD9481C10F6CE0008A1EA /* CSDiag.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSDiag.cpp; path = lib/Sema/CSDiag.cpp; sourceTree = "<group>"; };
+		BB9FD9491C10F6CE0008A1EA /* CSGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSGen.cpp; path = lib/Sema/CSGen.cpp; sourceTree = "<group>"; };
+		BB9FD94A1C10F6CE0008A1EA /* CSRanking.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSRanking.cpp; path = lib/Sema/CSRanking.cpp; sourceTree = "<group>"; };
+		BB9FD94B1C10F6CE0008A1EA /* CSSimplify.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSSimplify.cpp; path = lib/Sema/CSSimplify.cpp; sourceTree = "<group>"; };
+		BB9FD94C1C10F6CE0008A1EA /* CSSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSSolver.cpp; path = lib/Sema/CSSolver.cpp; sourceTree = "<group>"; };
+		BB9FD94D1C10F6CE0008A1EA /* DerivedConformanceEquatableHashable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DerivedConformanceEquatableHashable.cpp; path = lib/Sema/DerivedConformanceEquatableHashable.cpp; sourceTree = "<group>"; };
+		BB9FD94E1C10F6CE0008A1EA /* DerivedConformanceErrorType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DerivedConformanceErrorType.cpp; path = lib/Sema/DerivedConformanceErrorType.cpp; sourceTree = "<group>"; };
+		BB9FD94F1C10F6CE0008A1EA /* DerivedConformanceRawRepresentable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DerivedConformanceRawRepresentable.cpp; path = lib/Sema/DerivedConformanceRawRepresentable.cpp; sourceTree = "<group>"; };
+		BB9FD9501C10F6CE0008A1EA /* DerivedConformances.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DerivedConformances.cpp; path = lib/Sema/DerivedConformances.cpp; sourceTree = "<group>"; };
+		BB9FD9511C10F6CE0008A1EA /* DerivedConformances.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DerivedConformances.h; path = lib/Sema/DerivedConformances.h; sourceTree = "<group>"; };
+		BB9FD9521C10F6CE0008A1EA /* GenericTypeResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenericTypeResolver.h; path = lib/Sema/GenericTypeResolver.h; sourceTree = "<group>"; };
+		BB9FD9531C10F6CE0008A1EA /* ITCDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ITCDecl.cpp; path = lib/Sema/ITCDecl.cpp; sourceTree = "<group>"; };
+		BB9FD9541C10F6CE0008A1EA /* ITCNameLookup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ITCNameLookup.cpp; path = lib/Sema/ITCNameLookup.cpp; sourceTree = "<group>"; };
+		BB9FD9551C10F6CE0008A1EA /* ITCType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ITCType.cpp; path = lib/Sema/ITCType.cpp; sourceTree = "<group>"; };
+		BB9FD9561C10F6CE0008A1EA /* IterativeTypeChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IterativeTypeChecker.cpp; path = lib/Sema/IterativeTypeChecker.cpp; sourceTree = "<group>"; };
+		BB9FD9571C10F6CE0008A1EA /* MiscDiagnostics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MiscDiagnostics.cpp; path = lib/Sema/MiscDiagnostics.cpp; sourceTree = "<group>"; };
+		BB9FD9581C10F6CE0008A1EA /* MiscDiagnostics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MiscDiagnostics.h; path = lib/Sema/MiscDiagnostics.h; sourceTree = "<group>"; };
+		BB9FD9591C10F6CE0008A1EA /* NameBinding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NameBinding.cpp; path = lib/Sema/NameBinding.cpp; sourceTree = "<group>"; };
+		BB9FD95A1C10F6CE0008A1EA /* OverloadChoice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OverloadChoice.cpp; path = lib/Sema/OverloadChoice.cpp; sourceTree = "<group>"; };
+		BB9FD95B1C10F6CE0008A1EA /* OverloadChoice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OverloadChoice.h; path = lib/Sema/OverloadChoice.h; sourceTree = "<group>"; };
+		BB9FD95C1C10F6CE0008A1EA /* PlaygroundTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PlaygroundTransform.cpp; path = lib/Sema/PlaygroundTransform.cpp; sourceTree = "<group>"; };
+		BB9FD95D1C10F6CE0008A1EA /* SourceLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SourceLoader.cpp; path = lib/Sema/SourceLoader.cpp; sourceTree = "<group>"; };
+		BB9FD95E1C10F6CE0008A1EA /* TypeCheckAttr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckAttr.cpp; path = lib/Sema/TypeCheckAttr.cpp; sourceTree = "<group>"; };
+		BB9FD95F1C10F6CE0008A1EA /* TypeCheckConstraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckConstraints.cpp; path = lib/Sema/TypeCheckConstraints.cpp; sourceTree = "<group>"; };
+		BB9FD9601C10F6CE0008A1EA /* TypeCheckDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckDecl.cpp; path = lib/Sema/TypeCheckDecl.cpp; sourceTree = "<group>"; };
+		BB9FD9611C10F6CE0008A1EA /* TypeChecker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeChecker.cpp; path = lib/Sema/TypeChecker.cpp; sourceTree = "<group>"; };
+		BB9FD9621C10F6CE0008A1EA /* TypeChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypeChecker.h; path = lib/Sema/TypeChecker.h; sourceTree = "<group>"; };
+		BB9FD9631C10F6CE0008A1EA /* TypeCheckError.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckError.cpp; path = lib/Sema/TypeCheckError.cpp; sourceTree = "<group>"; };
+		BB9FD9641C10F6CE0008A1EA /* TypeCheckExpr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckExpr.cpp; path = lib/Sema/TypeCheckExpr.cpp; sourceTree = "<group>"; };
+		BB9FD9651C10F6CE0008A1EA /* TypeCheckGeneric.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckGeneric.cpp; path = lib/Sema/TypeCheckGeneric.cpp; sourceTree = "<group>"; };
+		BB9FD9661C10F6CE0008A1EA /* TypeCheckNameLookup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckNameLookup.cpp; path = lib/Sema/TypeCheckNameLookup.cpp; sourceTree = "<group>"; };
+		BB9FD9671C10F6CE0008A1EA /* TypeCheckPattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckPattern.cpp; path = lib/Sema/TypeCheckPattern.cpp; sourceTree = "<group>"; };
+		BB9FD9681C10F6CE0008A1EA /* TypeCheckProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckProtocol.cpp; path = lib/Sema/TypeCheckProtocol.cpp; sourceTree = "<group>"; };
+		BB9FD9691C10F6CE0008A1EA /* TypeCheckREPL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckREPL.cpp; path = lib/Sema/TypeCheckREPL.cpp; sourceTree = "<group>"; };
+		BB9FD96A1C10F6CE0008A1EA /* TypeCheckRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckRequest.cpp; path = lib/Sema/TypeCheckRequest.cpp; sourceTree = "<group>"; };
+		BB9FD96B1C10F6CE0008A1EA /* TypeCheckStmt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckStmt.cpp; path = lib/Sema/TypeCheckStmt.cpp; sourceTree = "<group>"; };
+		BB9FD96C1C10F6CE0008A1EA /* TypeCheckType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeCheckType.cpp; path = lib/Sema/TypeCheckType.cpp; sourceTree = "<group>"; };
+		BB9FD9941C10F6F10008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/Serialization/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD9951C10F6F10008A1EA /* Deserialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Deserialization.cpp; path = lib/Serialization/Deserialization.cpp; sourceTree = "<group>"; };
+		BB9FD9961C10F6F10008A1EA /* DeserializeSIL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeserializeSIL.cpp; path = lib/Serialization/DeserializeSIL.cpp; sourceTree = "<group>"; };
+		BB9FD9971C10F6F10008A1EA /* DeserializeSIL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeserializeSIL.h; path = lib/Serialization/DeserializeSIL.h; sourceTree = "<group>"; };
+		BB9FD9981C10F6F10008A1EA /* ModuleFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModuleFile.cpp; path = lib/Serialization/ModuleFile.cpp; sourceTree = "<group>"; };
+		BB9FD9991C10F6F10008A1EA /* Serialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Serialization.cpp; path = lib/Serialization/Serialization.cpp; sourceTree = "<group>"; };
+		BB9FD99A1C10F6F10008A1EA /* Serialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Serialization.h; path = lib/Serialization/Serialization.h; sourceTree = "<group>"; };
+		BB9FD99B1C10F6F10008A1EA /* SerializedModuleLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SerializedModuleLoader.cpp; path = lib/Serialization/SerializedModuleLoader.cpp; sourceTree = "<group>"; };
+		BB9FD99C1C10F6F10008A1EA /* SerializedSILLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SerializedSILLoader.cpp; path = lib/Serialization/SerializedSILLoader.cpp; sourceTree = "<group>"; };
+		BB9FD99D1C10F6F10008A1EA /* SerializeSIL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SerializeSIL.cpp; path = lib/Serialization/SerializeSIL.cpp; sourceTree = "<group>"; };
+		BB9FD99E1C10F6F10008A1EA /* SILFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILFormat.h; path = lib/Serialization/SILFormat.h; sourceTree = "<group>"; };
+		BB9FD9A71C10F7110008A1EA /* AbstractionPattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AbstractionPattern.cpp; path = lib/SIL/AbstractionPattern.cpp; sourceTree = "<group>"; };
+		BB9FD9A81C10F7110008A1EA /* Bridging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Bridging.cpp; path = lib/SIL/Bridging.cpp; sourceTree = "<group>"; };
+		BB9FD9A91C10F7110008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SIL/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD9AA1C10F7110008A1EA /* Dominance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Dominance.cpp; path = lib/SIL/Dominance.cpp; sourceTree = "<group>"; };
+		BB9FD9AB1C10F7110008A1EA /* DynamicCasts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DynamicCasts.cpp; path = lib/SIL/DynamicCasts.cpp; sourceTree = "<group>"; };
+		BB9FD9AC1C10F7110008A1EA /* Linker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Linker.cpp; path = lib/SIL/Linker.cpp; sourceTree = "<group>"; };
+		BB9FD9AD1C10F7110008A1EA /* Linker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Linker.h; path = lib/SIL/Linker.h; sourceTree = "<group>"; };
+		BB9FD9AE1C10F7110008A1EA /* LoopInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopInfo.cpp; path = lib/SIL/LoopInfo.cpp; sourceTree = "<group>"; };
+		BB9FD9AF1C10F7110008A1EA /* Mangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Mangle.cpp; path = lib/SIL/Mangle.cpp; sourceTree = "<group>"; };
+		BB9FD9B01C10F7110008A1EA /* MemLocation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MemLocation.cpp; path = lib/SIL/MemLocation.cpp; sourceTree = "<group>"; };
+		BB9FD9B11C10F7110008A1EA /* PrettyStackTrace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrettyStackTrace.cpp; path = lib/SIL/PrettyStackTrace.cpp; sourceTree = "<group>"; };
+		BB9FD9B21C10F7110008A1EA /* Projection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Projection.cpp; path = lib/SIL/Projection.cpp; sourceTree = "<group>"; };
+		BB9FD9B31C10F7110008A1EA /* SIL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SIL.cpp; path = lib/SIL/SIL.cpp; sourceTree = "<group>"; };
+		BB9FD9B41C10F7110008A1EA /* SILArgument.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILArgument.cpp; path = lib/SIL/SILArgument.cpp; sourceTree = "<group>"; };
+		BB9FD9B51C10F7110008A1EA /* SILBasicBlock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILBasicBlock.cpp; path = lib/SIL/SILBasicBlock.cpp; sourceTree = "<group>"; };
+		BB9FD9B61C10F7110008A1EA /* SILBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILBuilder.cpp; path = lib/SIL/SILBuilder.cpp; sourceTree = "<group>"; };
+		BB9FD9B71C10F7110008A1EA /* SILCoverageMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCoverageMap.cpp; path = lib/SIL/SILCoverageMap.cpp; sourceTree = "<group>"; };
+		BB9FD9B81C10F7110008A1EA /* SILDeclRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILDeclRef.cpp; path = lib/SIL/SILDeclRef.cpp; sourceTree = "<group>"; };
+		BB9FD9B91C10F7110008A1EA /* SILFunction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILFunction.cpp; path = lib/SIL/SILFunction.cpp; sourceTree = "<group>"; };
+		BB9FD9BA1C10F7110008A1EA /* SILFunctionType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILFunctionType.cpp; path = lib/SIL/SILFunctionType.cpp; sourceTree = "<group>"; };
+		BB9FD9BB1C10F7110008A1EA /* SILGlobalVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGlobalVariable.cpp; path = lib/SIL/SILGlobalVariable.cpp; sourceTree = "<group>"; };
+		BB9FD9BC1C10F7110008A1EA /* SILInstruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILInstruction.cpp; path = lib/SIL/SILInstruction.cpp; sourceTree = "<group>"; };
+		BB9FD9BD1C10F7110008A1EA /* SILInstructions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILInstructions.cpp; path = lib/SIL/SILInstructions.cpp; sourceTree = "<group>"; };
+		BB9FD9BE1C10F7110008A1EA /* SILLocation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILLocation.cpp; path = lib/SIL/SILLocation.cpp; sourceTree = "<group>"; };
+		BB9FD9BF1C10F7110008A1EA /* SILModule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILModule.cpp; path = lib/SIL/SILModule.cpp; sourceTree = "<group>"; };
+		BB9FD9C01C10F7110008A1EA /* SILPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILPrinter.cpp; path = lib/SIL/SILPrinter.cpp; sourceTree = "<group>"; };
+		BB9FD9C11C10F7110008A1EA /* SILSuccessor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILSuccessor.cpp; path = lib/SIL/SILSuccessor.cpp; sourceTree = "<group>"; };
+		BB9FD9C21C10F7110008A1EA /* SILType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILType.cpp; path = lib/SIL/SILType.cpp; sourceTree = "<group>"; };
+		BB9FD9C31C10F7110008A1EA /* SILValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILValue.cpp; path = lib/SIL/SILValue.cpp; sourceTree = "<group>"; };
+		BB9FD9C41C10F7110008A1EA /* SILVTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILVTable.cpp; path = lib/SIL/SILVTable.cpp; sourceTree = "<group>"; };
+		BB9FD9C51C10F7110008A1EA /* SILWitnessTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILWitnessTable.cpp; path = lib/SIL/SILWitnessTable.cpp; sourceTree = "<group>"; };
+		BB9FD9C61C10F7110008A1EA /* TypeLowering.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeLowering.cpp; path = lib/SIL/TypeLowering.cpp; sourceTree = "<group>"; };
+		BB9FD9C71C10F7110008A1EA /* Verifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Verifier.cpp; path = lib/SIL/Verifier.cpp; sourceTree = "<group>"; };
+		BB9FD9E81C10F7490008A1EA /* AliasAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AliasAnalysis.cpp; path = lib/SILAnalysis/AliasAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9E91C10F7490008A1EA /* Analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Analysis.cpp; path = lib/SILAnalysis/Analysis.cpp; sourceTree = "<group>"; };
+		BB9FD9EA1C10F7490008A1EA /* ARCAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ARCAnalysis.cpp; path = lib/SILAnalysis/ARCAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9EB1C10F7490008A1EA /* ArraySemantic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArraySemantic.cpp; path = lib/SILAnalysis/ArraySemantic.cpp; sourceTree = "<group>"; };
+		BB9FD9EC1C10F7490008A1EA /* BasicCalleeAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BasicCalleeAnalysis.cpp; path = lib/SILAnalysis/BasicCalleeAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9ED1C10F7490008A1EA /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CallGraph.cpp; path = lib/SILAnalysis/CallGraph.cpp; sourceTree = "<group>"; };
+		BB9FD9EE1C10F7490008A1EA /* CFG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFG.cpp; path = lib/SILAnalysis/CFG.cpp; sourceTree = "<group>"; };
+		BB9FD9EF1C10F7490008A1EA /* ClassHierarchyAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClassHierarchyAnalysis.cpp; path = lib/SILAnalysis/ClassHierarchyAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9F01C10F7490008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILAnalysis/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FD9F11C10F7490008A1EA /* ColdBlockInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ColdBlockInfo.cpp; path = lib/SILAnalysis/ColdBlockInfo.cpp; sourceTree = "<group>"; };
+		BB9FD9F21C10F7490008A1EA /* DestructorAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DestructorAnalysis.cpp; path = lib/SILAnalysis/DestructorAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9F31C10F7490008A1EA /* EscapeAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EscapeAnalysis.cpp; path = lib/SILAnalysis/EscapeAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9F41C10F7490008A1EA /* FunctionOrder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FunctionOrder.cpp; path = lib/SILAnalysis/FunctionOrder.cpp; sourceTree = "<group>"; };
+		BB9FD9F51C10F7490008A1EA /* IVAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IVAnalysis.cpp; path = lib/SILAnalysis/IVAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9F61C10F7490008A1EA /* LoopAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopAnalysis.cpp; path = lib/SILAnalysis/LoopAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9F71C10F7490008A1EA /* LoopRegionAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopRegionAnalysis.cpp; path = lib/SILAnalysis/LoopRegionAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9F81C10F7490008A1EA /* MemoryBehavior.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MemoryBehavior.cpp; path = lib/SILAnalysis/MemoryBehavior.cpp; sourceTree = "<group>"; };
+		BB9FD9F91C10F7490008A1EA /* RCIdentityAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RCIdentityAnalysis.cpp; path = lib/SILAnalysis/RCIdentityAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9FA1C10F7490008A1EA /* SideEffectAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SideEffectAnalysis.cpp; path = lib/SILAnalysis/SideEffectAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FD9FB1C10F7490008A1EA /* SimplifyInstruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SimplifyInstruction.cpp; path = lib/SILAnalysis/SimplifyInstruction.cpp; sourceTree = "<group>"; };
+		BB9FD9FC1C10F7490008A1EA /* ValueTracking.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ValueTracking.cpp; path = lib/SILAnalysis/ValueTracking.cpp; sourceTree = "<group>"; };
+		BB9FDA121C10F76B0008A1EA /* ArgumentSource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArgumentSource.cpp; path = lib/SILGen/ArgumentSource.cpp; sourceTree = "<group>"; };
+		BB9FDA131C10F76B0008A1EA /* ArgumentSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArgumentSource.h; path = lib/SILGen/ArgumentSource.h; sourceTree = "<group>"; };
+		BB9FDA141C10F76B0008A1EA /* ASTVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASTVisitor.h; path = lib/SILGen/ASTVisitor.h; sourceTree = "<group>"; };
+		BB9FDA151C10F76B0008A1EA /* Cleanup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Cleanup.cpp; path = lib/SILGen/Cleanup.cpp; sourceTree = "<group>"; };
+		BB9FDA161C10F76B0008A1EA /* Cleanup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Cleanup.h; path = lib/SILGen/Cleanup.h; sourceTree = "<group>"; };
+		BB9FDA171C10F76B0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILGen/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDA181C10F76B0008A1EA /* Condition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Condition.cpp; path = lib/SILGen/Condition.cpp; sourceTree = "<group>"; };
+		BB9FDA191C10F76B0008A1EA /* Condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Condition.h; path = lib/SILGen/Condition.h; sourceTree = "<group>"; };
+		BB9FDA1A1C10F76B0008A1EA /* ExitableFullExpr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExitableFullExpr.h; path = lib/SILGen/ExitableFullExpr.h; sourceTree = "<group>"; };
+		BB9FDA1B1C10F76B0008A1EA /* Initialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Initialization.h; path = lib/SILGen/Initialization.h; sourceTree = "<group>"; };
+		BB9FDA1C1C10F76B0008A1EA /* JumpDest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JumpDest.h; path = lib/SILGen/JumpDest.h; sourceTree = "<group>"; };
+		BB9FDA1D1C10F76B0008A1EA /* LValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LValue.h; path = lib/SILGen/LValue.h; sourceTree = "<group>"; };
+		BB9FDA1E1C10F76B0008A1EA /* ManagedValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ManagedValue.cpp; path = lib/SILGen/ManagedValue.cpp; sourceTree = "<group>"; };
+		BB9FDA1F1C10F76B0008A1EA /* ManagedValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ManagedValue.h; path = lib/SILGen/ManagedValue.h; sourceTree = "<group>"; };
+		BB9FDA201C10F76B0008A1EA /* RValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RValue.cpp; path = lib/SILGen/RValue.cpp; sourceTree = "<group>"; };
+		BB9FDA211C10F76B0008A1EA /* RValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RValue.h; path = lib/SILGen/RValue.h; sourceTree = "<group>"; };
+		BB9FDA221C10F76B0008A1EA /* Scope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Scope.h; path = lib/SILGen/Scope.h; sourceTree = "<group>"; };
+		BB9FDA231C10F76B0008A1EA /* SILGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGen.cpp; path = lib/SILGen/SILGen.cpp; sourceTree = "<group>"; };
+		BB9FDA241C10F76B0008A1EA /* SILGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILGen.h; path = lib/SILGen/SILGen.h; sourceTree = "<group>"; };
+		BB9FDA251C10F76B0008A1EA /* SILGenApply.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenApply.cpp; path = lib/SILGen/SILGenApply.cpp; sourceTree = "<group>"; };
+		BB9FDA261C10F76B0008A1EA /* SILGenBridging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenBridging.cpp; path = lib/SILGen/SILGenBridging.cpp; sourceTree = "<group>"; };
+		BB9FDA271C10F76B0008A1EA /* SILGenBuiltin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenBuiltin.cpp; path = lib/SILGen/SILGenBuiltin.cpp; sourceTree = "<group>"; };
+		BB9FDA281C10F76B0008A1EA /* SILGenConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenConstructor.cpp; path = lib/SILGen/SILGenConstructor.cpp; sourceTree = "<group>"; };
+		BB9FDA291C10F76B0008A1EA /* SILGenConvert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenConvert.cpp; path = lib/SILGen/SILGenConvert.cpp; sourceTree = "<group>"; };
+		BB9FDA2A1C10F76B0008A1EA /* SILGenDecl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenDecl.cpp; path = lib/SILGen/SILGenDecl.cpp; sourceTree = "<group>"; };
+		BB9FDA2B1C10F76B0008A1EA /* SILGenDestructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenDestructor.cpp; path = lib/SILGen/SILGenDestructor.cpp; sourceTree = "<group>"; };
+		BB9FDA2C1C10F76B0008A1EA /* SILGenDynamicCast.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenDynamicCast.cpp; path = lib/SILGen/SILGenDynamicCast.cpp; sourceTree = "<group>"; };
+		BB9FDA2D1C10F76B0008A1EA /* SILGenDynamicCast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILGenDynamicCast.h; path = lib/SILGen/SILGenDynamicCast.h; sourceTree = "<group>"; };
+		BB9FDA2E1C10F76B0008A1EA /* SILGenEpilog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenEpilog.cpp; path = lib/SILGen/SILGenEpilog.cpp; sourceTree = "<group>"; };
+		BB9FDA2F1C10F76B0008A1EA /* SILGenExpr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenExpr.cpp; path = lib/SILGen/SILGenExpr.cpp; sourceTree = "<group>"; };
+		BB9FDA301C10F76B0008A1EA /* SILGenForeignError.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenForeignError.cpp; path = lib/SILGen/SILGenForeignError.cpp; sourceTree = "<group>"; };
+		BB9FDA311C10F76B0008A1EA /* SILGenFunction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenFunction.cpp; path = lib/SILGen/SILGenFunction.cpp; sourceTree = "<group>"; };
+		BB9FDA321C10F76B0008A1EA /* SILGenFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILGenFunction.h; path = lib/SILGen/SILGenFunction.h; sourceTree = "<group>"; };
+		BB9FDA331C10F76B0008A1EA /* SILGenGlobalVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenGlobalVariable.cpp; path = lib/SILGen/SILGenGlobalVariable.cpp; sourceTree = "<group>"; };
+		BB9FDA341C10F76B0008A1EA /* SILGenLValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenLValue.cpp; path = lib/SILGen/SILGenLValue.cpp; sourceTree = "<group>"; };
+		BB9FDA351C10F76B0008A1EA /* SILGenPattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenPattern.cpp; path = lib/SILGen/SILGenPattern.cpp; sourceTree = "<group>"; };
+		BB9FDA361C10F76B0008A1EA /* SILGenPoly.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenPoly.cpp; path = lib/SILGen/SILGenPoly.cpp; sourceTree = "<group>"; };
+		BB9FDA371C10F76B0008A1EA /* SILGenProfiling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenProfiling.cpp; path = lib/SILGen/SILGenProfiling.cpp; sourceTree = "<group>"; };
+		BB9FDA381C10F76B0008A1EA /* SILGenProfiling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILGenProfiling.h; path = lib/SILGen/SILGenProfiling.h; sourceTree = "<group>"; };
+		BB9FDA391C10F76B0008A1EA /* SILGenProlog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenProlog.cpp; path = lib/SILGen/SILGenProlog.cpp; sourceTree = "<group>"; };
+		BB9FDA3A1C10F76B0008A1EA /* SILGenStmt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenStmt.cpp; path = lib/SILGen/SILGenStmt.cpp; sourceTree = "<group>"; };
+		BB9FDA3B1C10F76B0008A1EA /* SILGenType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILGenType.cpp; path = lib/SILGen/SILGenType.cpp; sourceTree = "<group>"; };
+		BB9FDA3C1C10F76B0008A1EA /* SpecializedEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpecializedEmitter.h; path = lib/SILGen/SpecializedEmitter.h; sourceTree = "<group>"; };
+		BB9FDA3D1C10F76B0008A1EA /* Varargs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Varargs.h; path = lib/SILGen/Varargs.h; sourceTree = "<group>"; };
+		BB9FDA591C10F7B90008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SwiftDemangle/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDA5A1C10F7B90008A1EA /* MangleHack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MangleHack.cpp; path = lib/SwiftDemangle/MangleHack.cpp; sourceTree = "<group>"; };
+		BB9FDA5B1C10F7B90008A1EA /* SwiftDemangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SwiftDemangle.cpp; path = lib/SwiftDemangle/SwiftDemangle.cpp; sourceTree = "<group>"; };
+		BB9FDA601C10F7F00008A1EA /* ARCBBState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ARCBBState.cpp; path = lib/SILPasses/ARC/ARCBBState.cpp; sourceTree = "<group>"; };
+		BB9FDA611C10F7F00008A1EA /* ARCBBState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARCBBState.h; path = lib/SILPasses/ARC/ARCBBState.h; sourceTree = "<group>"; };
+		BB9FDA621C10F7F00008A1EA /* ARCRegionState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ARCRegionState.cpp; path = lib/SILPasses/ARC/ARCRegionState.cpp; sourceTree = "<group>"; };
+		BB9FDA631C10F7F00008A1EA /* ARCRegionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARCRegionState.h; path = lib/SILPasses/ARC/ARCRegionState.h; sourceTree = "<group>"; };
+		BB9FDA641C10F7F00008A1EA /* ARCSequenceOpts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ARCSequenceOpts.cpp; path = lib/SILPasses/ARC/ARCSequenceOpts.cpp; sourceTree = "<group>"; };
+		BB9FDA651C10F7F00008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/ARC/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDA661C10F7F00008A1EA /* GlobalARCPairingAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GlobalARCPairingAnalysis.cpp; path = lib/SILPasses/ARC/GlobalARCPairingAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FDA671C10F7F00008A1EA /* GlobalARCPairingAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GlobalARCPairingAnalysis.h; path = lib/SILPasses/ARC/GlobalARCPairingAnalysis.h; sourceTree = "<group>"; };
+		BB9FDA681C10F7F00008A1EA /* GlobalARCSequenceDataflow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GlobalARCSequenceDataflow.cpp; path = lib/SILPasses/ARC/GlobalARCSequenceDataflow.cpp; sourceTree = "<group>"; };
+		BB9FDA691C10F7F00008A1EA /* GlobalARCSequenceDataflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GlobalARCSequenceDataflow.h; path = lib/SILPasses/ARC/GlobalARCSequenceDataflow.h; sourceTree = "<group>"; };
+		BB9FDA6A1C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GlobalLoopARCSequenceDataflow.cpp; path = lib/SILPasses/ARC/GlobalLoopARCSequenceDataflow.cpp; sourceTree = "<group>"; };
+		BB9FDA6B1C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GlobalLoopARCSequenceDataflow.h; path = lib/SILPasses/ARC/GlobalLoopARCSequenceDataflow.h; sourceTree = "<group>"; };
+		BB9FDA6C1C10F7F00008A1EA /* RCStateTransition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RCStateTransition.cpp; path = lib/SILPasses/ARC/RCStateTransition.cpp; sourceTree = "<group>"; };
+		BB9FDA6D1C10F7F00008A1EA /* RCStateTransition.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = RCStateTransition.def; path = lib/SILPasses/ARC/RCStateTransition.def; sourceTree = "<group>"; };
+		BB9FDA6E1C10F7F00008A1EA /* RCStateTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCStateTransition.h; path = lib/SILPasses/ARC/RCStateTransition.h; sourceTree = "<group>"; };
+		BB9FDA6F1C10F7F00008A1EA /* RCStateTransitionVisitors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RCStateTransitionVisitors.cpp; path = lib/SILPasses/ARC/RCStateTransitionVisitors.cpp; sourceTree = "<group>"; };
+		BB9FDA701C10F7F00008A1EA /* RCStateTransitionVisitors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCStateTransitionVisitors.h; path = lib/SILPasses/ARC/RCStateTransitionVisitors.h; sourceTree = "<group>"; };
+		BB9FDA711C10F7F00008A1EA /* RefCountState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RefCountState.cpp; path = lib/SILPasses/ARC/RefCountState.cpp; sourceTree = "<group>"; };
+		BB9FDA721C10F7F00008A1EA /* RefCountState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RefCountState.h; path = lib/SILPasses/ARC/RefCountState.h; sourceTree = "<group>"; };
+		BB9FDA7D1C10F8110008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/EarlySIL/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDA7E1C10F8110008A1EA /* ConstantPropagation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConstantPropagation.cpp; path = lib/SILPasses/EarlySIL/ConstantPropagation.cpp; sourceTree = "<group>"; };
+		BB9FDA7F1C10F8110008A1EA /* DataflowDiagnostics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DataflowDiagnostics.cpp; path = lib/SILPasses/EarlySIL/DataflowDiagnostics.cpp; sourceTree = "<group>"; };
+		BB9FDA801C10F8110008A1EA /* DefiniteInitialization.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DefiniteInitialization.cpp; path = lib/SILPasses/EarlySIL/DefiniteInitialization.cpp; sourceTree = "<group>"; };
+		BB9FDA811C10F8110008A1EA /* DiagnoseUnreachable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiagnoseUnreachable.cpp; path = lib/SILPasses/EarlySIL/DiagnoseUnreachable.cpp; sourceTree = "<group>"; };
+		BB9FDA821C10F8110008A1EA /* DIMemoryUseCollector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DIMemoryUseCollector.cpp; path = lib/SILPasses/EarlySIL/DIMemoryUseCollector.cpp; sourceTree = "<group>"; };
+		BB9FDA831C10F8110008A1EA /* DIMemoryUseCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DIMemoryUseCollector.h; path = lib/SILPasses/EarlySIL/DIMemoryUseCollector.h; sourceTree = "<group>"; };
+		BB9FDA841C10F8110008A1EA /* InOutDeshadowing.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InOutDeshadowing.cpp; path = lib/SILPasses/EarlySIL/InOutDeshadowing.cpp; sourceTree = "<group>"; };
+		BB9FDA851C10F8110008A1EA /* MandatoryInlining.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MandatoryInlining.cpp; path = lib/SILPasses/EarlySIL/MandatoryInlining.cpp; sourceTree = "<group>"; };
+		BB9FDA861C10F8110008A1EA /* PredictableMemOpt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PredictableMemOpt.cpp; path = lib/SILPasses/EarlySIL/PredictableMemOpt.cpp; sourceTree = "<group>"; };
+		BB9FDA8F1C10F81E0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDA911C10F84F0008A1EA /* CapturePromotion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CapturePromotion.cpp; path = lib/SILPasses/IPO/CapturePromotion.cpp; sourceTree = "<group>"; };
+		BB9FDA921C10F84F0008A1EA /* CapturePropagation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CapturePropagation.cpp; path = lib/SILPasses/IPO/CapturePropagation.cpp; sourceTree = "<group>"; };
+		BB9FDA931C10F84F0008A1EA /* ClosureSpecializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClosureSpecializer.cpp; path = lib/SILPasses/IPO/ClosureSpecializer.cpp; sourceTree = "<group>"; };
+		BB9FDA941C10F84F0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/IPO/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDA951C10F84F0008A1EA /* DeadFunctionElimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeadFunctionElimination.cpp; path = lib/SILPasses/IPO/DeadFunctionElimination.cpp; sourceTree = "<group>"; };
+		BB9FDA961C10F84F0008A1EA /* ExternalDefsToDecls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ExternalDefsToDecls.cpp; path = lib/SILPasses/IPO/ExternalDefsToDecls.cpp; sourceTree = "<group>"; };
+		BB9FDA971C10F84F0008A1EA /* FunctionSignatureOpts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FunctionSignatureOpts.cpp; path = lib/SILPasses/IPO/FunctionSignatureOpts.cpp; sourceTree = "<group>"; };
+		BB9FDA981C10F84F0008A1EA /* GlobalOpt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GlobalOpt.cpp; path = lib/SILPasses/IPO/GlobalOpt.cpp; sourceTree = "<group>"; };
+		BB9FDA991C10F84F0008A1EA /* GlobalPropertyOpt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GlobalPropertyOpt.cpp; path = lib/SILPasses/IPO/GlobalPropertyOpt.cpp; sourceTree = "<group>"; };
+		BB9FDA9A1C10F84F0008A1EA /* LetPropertiesOpts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LetPropertiesOpts.cpp; path = lib/SILPasses/IPO/LetPropertiesOpts.cpp; sourceTree = "<group>"; };
+		BB9FDA9B1C10F84F0008A1EA /* PerformanceInliner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PerformanceInliner.cpp; path = lib/SILPasses/IPO/PerformanceInliner.cpp; sourceTree = "<group>"; };
+		BB9FDA9C1C10F84F0008A1EA /* UsePrespecialized.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UsePrespecialized.cpp; path = lib/SILPasses/IPO/UsePrespecialized.cpp; sourceTree = "<group>"; };
+		BB9FDAA91C10F86C0008A1EA /* ArrayBoundsCheckOpts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArrayBoundsCheckOpts.cpp; path = lib/SILPasses/Loop/ArrayBoundsCheckOpts.cpp; sourceTree = "<group>"; };
+		BB9FDAAA1C10F86C0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/Loop/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDAAB1C10F86C0008A1EA /* COWArrayOpt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COWArrayOpt.cpp; path = lib/SILPasses/Loop/COWArrayOpt.cpp; sourceTree = "<group>"; };
+		BB9FDAAC1C10F86C0008A1EA /* LICM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LICM.cpp; path = lib/SILPasses/Loop/LICM.cpp; sourceTree = "<group>"; };
+		BB9FDAAD1C10F86C0008A1EA /* LoopRotate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopRotate.cpp; path = lib/SILPasses/Loop/LoopRotate.cpp; sourceTree = "<group>"; };
+		BB9FDAB31C10F8980008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/PassManager/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDAB41C10F8980008A1EA /* Passes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Passes.cpp; path = lib/SILPasses/PassManager/Passes.cpp; sourceTree = "<group>"; };
+		BB9FDAB51C10F8980008A1EA /* PassManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PassManager.cpp; path = lib/SILPasses/PassManager/PassManager.cpp; sourceTree = "<group>"; };
+		BB9FDAB61C10F8980008A1EA /* PrettyStackTrace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PrettyStackTrace.cpp; path = lib/SILPasses/PassManager/PrettyStackTrace.cpp; sourceTree = "<group>"; };
+		BB9FDABB1C10F8B40008A1EA /* AllocBoxToStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AllocBoxToStack.cpp; path = lib/SILPasses/Scalar/AllocBoxToStack.cpp; sourceTree = "<group>"; };
+		BB9FDABC1C10F8B40008A1EA /* ArrayCountPropagation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArrayCountPropagation.cpp; path = lib/SILPasses/Scalar/ArrayCountPropagation.cpp; sourceTree = "<group>"; };
+		BB9FDABD1C10F8B40008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/Scalar/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDABE1C10F8B40008A1EA /* CopyForwarding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CopyForwarding.cpp; path = lib/SILPasses/Scalar/CopyForwarding.cpp; sourceTree = "<group>"; };
+		BB9FDABF1C10F8B40008A1EA /* CSE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSE.cpp; path = lib/SILPasses/Scalar/CSE.cpp; sourceTree = "<group>"; };
+		BB9FDAC01C10F8B40008A1EA /* DeadCodeElimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeadCodeElimination.cpp; path = lib/SILPasses/Scalar/DeadCodeElimination.cpp; sourceTree = "<group>"; };
+		BB9FDAC11C10F8B40008A1EA /* DeadObjectElimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeadObjectElimination.cpp; path = lib/SILPasses/Scalar/DeadObjectElimination.cpp; sourceTree = "<group>"; };
+		BB9FDAC21C10F8B40008A1EA /* DeadStoreElimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeadStoreElimination.cpp; path = lib/SILPasses/Scalar/DeadStoreElimination.cpp; sourceTree = "<group>"; };
+		BB9FDAC31C10F8B40008A1EA /* MergeCondFail.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MergeCondFail.cpp; path = lib/SILPasses/Scalar/MergeCondFail.cpp; sourceTree = "<group>"; };
+		BB9FDAC41C10F8B40008A1EA /* RedundantLoadElimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RedundantLoadElimination.cpp; path = lib/SILPasses/Scalar/RedundantLoadElimination.cpp; sourceTree = "<group>"; };
+		BB9FDAC51C10F8B40008A1EA /* RedundantOverflowCheckRemoval.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RedundantOverflowCheckRemoval.cpp; path = lib/SILPasses/Scalar/RedundantOverflowCheckRemoval.cpp; sourceTree = "<group>"; };
+		BB9FDAC61C10F8B40008A1EA /* ReleaseDevirtualizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ReleaseDevirtualizer.cpp; path = lib/SILPasses/Scalar/ReleaseDevirtualizer.cpp; sourceTree = "<group>"; };
+		BB9FDAC71C10F8B40008A1EA /* RemovePin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RemovePin.cpp; path = lib/SILPasses/Scalar/RemovePin.cpp; sourceTree = "<group>"; };
+		BB9FDAC81C10F8B40008A1EA /* SILCleanup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCleanup.cpp; path = lib/SILPasses/Scalar/SILCleanup.cpp; sourceTree = "<group>"; };
+		BB9FDAC91C10F8B40008A1EA /* SILCodeMotion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCodeMotion.cpp; path = lib/SILPasses/Scalar/SILCodeMotion.cpp; sourceTree = "<group>"; };
+		BB9FDACA1C10F8B40008A1EA /* SILLowerAggregateInstrs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILLowerAggregateInstrs.cpp; path = lib/SILPasses/Scalar/SILLowerAggregateInstrs.cpp; sourceTree = "<group>"; };
+		BB9FDACB1C10F8B40008A1EA /* SILMem2Reg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILMem2Reg.cpp; path = lib/SILPasses/Scalar/SILMem2Reg.cpp; sourceTree = "<group>"; };
+		BB9FDACC1C10F8B40008A1EA /* SILSROA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILSROA.cpp; path = lib/SILPasses/Scalar/SILSROA.cpp; sourceTree = "<group>"; };
+		BB9FDACD1C10F8B40008A1EA /* SimplifyCFG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SimplifyCFG.cpp; path = lib/SILPasses/Scalar/SimplifyCFG.cpp; sourceTree = "<group>"; };
+		BB9FDACE1C10F8B40008A1EA /* Sink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sink.cpp; path = lib/SILPasses/Scalar/Sink.cpp; sourceTree = "<group>"; };
+		BB9FDACF1C10F8B40008A1EA /* SpeculativeDevirtualizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpeculativeDevirtualizer.cpp; path = lib/SILPasses/Scalar/SpeculativeDevirtualizer.cpp; sourceTree = "<group>"; };
+		BB9FDAD01C10F8B40008A1EA /* StackPromotion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StackPromotion.cpp; path = lib/SILPasses/Scalar/StackPromotion.cpp; sourceTree = "<group>"; };
+		BB9FDAE71C10F8D90008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/SILCombiner/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDAE81C10F8D90008A1EA /* SILCombine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCombine.cpp; path = lib/SILPasses/SILCombiner/SILCombine.cpp; sourceTree = "<group>"; };
+		BB9FDAE91C10F8D90008A1EA /* SILCombiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SILCombiner.h; path = lib/SILPasses/SILCombiner/SILCombiner.h; sourceTree = "<group>"; };
+		BB9FDAEA1C10F8D90008A1EA /* SILCombinerApplyVisitors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCombinerApplyVisitors.cpp; path = lib/SILPasses/SILCombiner/SILCombinerApplyVisitors.cpp; sourceTree = "<group>"; };
+		BB9FDAEB1C10F8D90008A1EA /* SILCombinerBuiltinVisitors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCombinerBuiltinVisitors.cpp; path = lib/SILPasses/SILCombiner/SILCombinerBuiltinVisitors.cpp; sourceTree = "<group>"; };
+		BB9FDAEC1C10F8D90008A1EA /* SILCombinerCastVisitors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCombinerCastVisitors.cpp; path = lib/SILPasses/SILCombiner/SILCombinerCastVisitors.cpp; sourceTree = "<group>"; };
+		BB9FDAED1C10F8D90008A1EA /* SILCombinerMiscVisitors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILCombinerMiscVisitors.cpp; path = lib/SILPasses/SILCombiner/SILCombinerMiscVisitors.cpp; sourceTree = "<group>"; };
+		BB9FDAF41C10F8FC0008A1EA /* AADumper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AADumper.cpp; path = lib/SILPasses/UtilityPasses/AADumper.cpp; sourceTree = "<group>"; };
+		BB9FDAF51C10F8FC0008A1EA /* BasicCalleePrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BasicCalleePrinter.cpp; path = lib/SILPasses/UtilityPasses/BasicCalleePrinter.cpp; sourceTree = "<group>"; };
+		BB9FDAF61C10F8FC0008A1EA /* CallGraphPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CallGraphPrinter.cpp; path = lib/SILPasses/UtilityPasses/CallGraphPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDAF71C10F8FC0008A1EA /* CFGPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFGPrinter.cpp; path = lib/SILPasses/UtilityPasses/CFGPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDAF81C10F8FC0008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/UtilityPasses/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDAF91C10F8FC0008A1EA /* FunctionOrderPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FunctionOrderPrinter.cpp; path = lib/SILPasses/UtilityPasses/FunctionOrderPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDAFA1C10F8FC0008A1EA /* InstCount.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = InstCount.cpp; path = lib/SILPasses/UtilityPasses/InstCount.cpp; sourceTree = "<group>"; };
+		BB9FDAFB1C10F8FC0008A1EA /* IVInfoPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IVInfoPrinter.cpp; path = lib/SILPasses/UtilityPasses/IVInfoPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDAFC1C10F8FC0008A1EA /* Link.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Link.cpp; path = lib/SILPasses/UtilityPasses/Link.cpp; sourceTree = "<group>"; };
+		BB9FDAFD1C10F8FC0008A1EA /* LoopCanonicalizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopCanonicalizer.cpp; path = lib/SILPasses/UtilityPasses/LoopCanonicalizer.cpp; sourceTree = "<group>"; };
+		BB9FDAFE1C10F8FC0008A1EA /* LoopInfoPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopInfoPrinter.cpp; path = lib/SILPasses/UtilityPasses/LoopInfoPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDAFF1C10F8FC0008A1EA /* LoopRegionPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopRegionPrinter.cpp; path = lib/SILPasses/UtilityPasses/LoopRegionPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDB001C10F8FC0008A1EA /* MemLocationPrinter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MemLocationPrinter.cpp; path = lib/SILPasses/UtilityPasses/MemLocationPrinter.cpp; sourceTree = "<group>"; };
+		BB9FDB011C10F8FC0008A1EA /* StripDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StripDebugInfo.cpp; path = lib/SILPasses/UtilityPasses/StripDebugInfo.cpp; sourceTree = "<group>"; };
+		BB9FDB021C10F8FC0008A1EA /* UpdateEscapeAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UpdateEscapeAnalysis.cpp; path = lib/SILPasses/UtilityPasses/UpdateEscapeAnalysis.cpp; sourceTree = "<group>"; };
+		BB9FDB031C10F8FC0008A1EA /* UpdateSideEffects.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UpdateSideEffects.cpp; path = lib/SILPasses/UtilityPasses/UpdateSideEffects.cpp; sourceTree = "<group>"; };
+		BB9FDB141C10F9200008A1EA /* CFG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFG.cpp; path = lib/SILPasses/Utils/CFG.cpp; sourceTree = "<group>"; };
+		BB9FDB151C10F9200008A1EA /* CheckedCastBrJumpThreading.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CheckedCastBrJumpThreading.cpp; path = lib/SILPasses/Utils/CheckedCastBrJumpThreading.cpp; sourceTree = "<group>"; };
+		BB9FDB161C10F9200008A1EA /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CMakeLists.txt; path = lib/SILPasses/Utils/CMakeLists.txt; sourceTree = "<group>"; };
+		BB9FDB171C10F9200008A1EA /* ConstantFolding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConstantFolding.cpp; path = lib/SILPasses/Utils/ConstantFolding.cpp; sourceTree = "<group>"; };
+		BB9FDB181C10F9200008A1EA /* Devirtualize.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Devirtualize.cpp; path = lib/SILPasses/Utils/Devirtualize.cpp; sourceTree = "<group>"; };
+		BB9FDB191C10F9200008A1EA /* GenericCloner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GenericCloner.cpp; path = lib/SILPasses/Utils/GenericCloner.cpp; sourceTree = "<group>"; };
+		BB9FDB1A1C10F9200008A1EA /* Generics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Generics.cpp; path = lib/SILPasses/Utils/Generics.cpp; sourceTree = "<group>"; };
+		BB9FDB1B1C10F9200008A1EA /* Local.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Local.cpp; path = lib/SILPasses/Utils/Local.cpp; sourceTree = "<group>"; };
+		BB9FDB1C1C10F9200008A1EA /* LoopUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LoopUtils.cpp; path = lib/SILPasses/Utils/LoopUtils.cpp; sourceTree = "<group>"; };
+		BB9FDB1D1C10F9200008A1EA /* SILInliner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILInliner.cpp; path = lib/SILPasses/Utils/SILInliner.cpp; sourceTree = "<group>"; };
+		BB9FDB1E1C10F9200008A1EA /* SILSSAUpdater.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SILSSAUpdater.cpp; path = lib/SILPasses/Utils/SILSSAUpdater.cpp; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BB9FD63D1C10EF850008A1EA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB8B28881C1236D400C91975 /* libedit.tbd in Frameworks */,
+				BB8B28831C12357300C91975 /* libz.tbd in Frameworks */,
+				BB8B288B1C1238B100C91975 /* libLLVMSupport.a in Frameworks */,
+				BB8B288C1C1238B100C91975 /* libLLVMTableGen.a in Frameworks */,
+				BB8B28811C12352E00C91975 /* libcmark.a in Frameworks */,
+				BB8B28291C1233F800C91975 /* libclangAnalysis.a in Frameworks */,
+				BB8B282A1C1233F800C91975 /* libclangAPINotes.a in Frameworks */,
+				BB8B282B1C1233F800C91975 /* libclangARCMigrate.a in Frameworks */,
+				BB8B282C1C1233F800C91975 /* libclangAST.a in Frameworks */,
+				BB8B282D1C1233F800C91975 /* libclangASTMatchers.a in Frameworks */,
+				BB8B282E1C1233F800C91975 /* libclangBasic.a in Frameworks */,
+				BB8B282F1C1233F800C91975 /* libclangCodeGen.a in Frameworks */,
+				BB8B28301C1233F800C91975 /* libclangDriver.a in Frameworks */,
+				BB8B28311C1233F800C91975 /* libclangDynamicASTMatchers.a in Frameworks */,
+				BB8B28321C1233F800C91975 /* libclangEdit.a in Frameworks */,
+				BB8B28331C1233F800C91975 /* libclangFormat.a in Frameworks */,
+				BB8B28341C1233F800C91975 /* libclangFrontend.a in Frameworks */,
+				BB8B28351C1233F800C91975 /* libclangFrontendTool.a in Frameworks */,
+				BB8B28361C1233F800C91975 /* libclangIndex.a in Frameworks */,
+				BB8B28371C1233F800C91975 /* libclangLex.a in Frameworks */,
+				BB8B28381C1233F800C91975 /* libclangParse.a in Frameworks */,
+				BB8B28391C1233F800C91975 /* libclangRewrite.a in Frameworks */,
+				BB8B283A1C1233F800C91975 /* libclangRewriteFrontend.a in Frameworks */,
+				BB8B283B1C1233F800C91975 /* libclangSema.a in Frameworks */,
+				BB8B283C1C1233F800C91975 /* libclangSerialization.a in Frameworks */,
+				BB8B283D1C1233F800C91975 /* libclangStaticAnalyzerCheckers.a in Frameworks */,
+				BB8B283E1C1233F800C91975 /* libclangStaticAnalyzerCore.a in Frameworks */,
+				BB8B283F1C1233F800C91975 /* libclangStaticAnalyzerFrontend.a in Frameworks */,
+				BB8B28401C1233F800C91975 /* libclangTooling.a in Frameworks */,
+				BB8B28411C1233F800C91975 /* libclangToolingCore.a in Frameworks */,
+				BB8B28431C1233F800C91975 /* libgtest_main.a in Frameworks */,
+				BB8B28441C1233F800C91975 /* libgtest.a in Frameworks */,
+				BB8B28451C1233F800C91975 /* libLLVMAArch64AsmParser.a in Frameworks */,
+				BB8B28461C1233F800C91975 /* libLLVMAArch64AsmPrinter.a in Frameworks */,
+				BB8B28471C1233F800C91975 /* libLLVMAArch64CodeGen.a in Frameworks */,
+				BB8B28481C1233F800C91975 /* libLLVMAArch64Desc.a in Frameworks */,
+				BB8B28491C1233F800C91975 /* libLLVMAArch64Disassembler.a in Frameworks */,
+				BB8B284A1C1233F800C91975 /* libLLVMAArch64Info.a in Frameworks */,
+				BB8B284B1C1233F800C91975 /* libLLVMAArch64Utils.a in Frameworks */,
+				BB8B284C1C1233F800C91975 /* libLLVMAnalysis.a in Frameworks */,
+				BB8B284D1C1233F800C91975 /* libLLVMARMAsmParser.a in Frameworks */,
+				BB8B284E1C1233F800C91975 /* libLLVMARMAsmPrinter.a in Frameworks */,
+				BB8B284F1C1233F800C91975 /* libLLVMARMCodeGen.a in Frameworks */,
+				BB8B28501C1233F800C91975 /* libLLVMARMDesc.a in Frameworks */,
+				BB8B28511C1233F800C91975 /* libLLVMARMDisassembler.a in Frameworks */,
+				BB8B28521C1233F800C91975 /* libLLVMARMInfo.a in Frameworks */,
+				BB8B28531C1233F800C91975 /* libLLVMAsmParser.a in Frameworks */,
+				BB8B28541C1233F800C91975 /* libLLVMAsmPrinter.a in Frameworks */,
+				BB8B28551C1233F800C91975 /* libLLVMBitReader.a in Frameworks */,
+				BB8B28561C1233F800C91975 /* libLLVMBitWriter.a in Frameworks */,
+				BB8B28571C1233F800C91975 /* libLLVMCodeGen.a in Frameworks */,
+				BB8B28581C1233F800C91975 /* libLLVMCore.a in Frameworks */,
+				BB8B28591C1233F800C91975 /* libLLVMDebugInfoDWARF.a in Frameworks */,
+				BB8B285A1C1233F800C91975 /* libLLVMDebugInfoPDB.a in Frameworks */,
+				BB8B285B1C1233F800C91975 /* libLLVMExecutionEngine.a in Frameworks */,
+				BB8B285C1C1233F800C91975 /* libLLVMInstCombine.a in Frameworks */,
+				BB8B285D1C1233F800C91975 /* libLLVMInstrumentation.a in Frameworks */,
+				BB8B285E1C1233F800C91975 /* libLLVMInterpreter.a in Frameworks */,
+				BB8B285F1C1233F800C91975 /* libLLVMipo.a in Frameworks */,
+				BB8B28601C1233F800C91975 /* libLLVMIRReader.a in Frameworks */,
+				BB8B28611C1233F800C91975 /* libLLVMLibDriver.a in Frameworks */,
+				BB8B28621C1233F800C91975 /* libLLVMLineEditor.a in Frameworks */,
+				BB8B28631C1233F800C91975 /* libLLVMLinker.a in Frameworks */,
+				BB8B28641C1233F800C91975 /* libLLVMLTO.a in Frameworks */,
+				BB8B28651C1233F800C91975 /* libLLVMMC.a in Frameworks */,
+				BB8B28661C1233F800C91975 /* libLLVMMCDisassembler.a in Frameworks */,
+				BB8B28671C1233F800C91975 /* libLLVMMCJIT.a in Frameworks */,
+				BB8B28681C1233F800C91975 /* libLLVMMCParser.a in Frameworks */,
+				BB8B28691C1233F800C91975 /* libLLVMMIRParser.a in Frameworks */,
+				BB8B286A1C1233F800C91975 /* libLLVMObjCARCOpts.a in Frameworks */,
+				BB8B286B1C1233F800C91975 /* libLLVMObject.a in Frameworks */,
+				BB8B286C1C1233F800C91975 /* libLLVMOption.a in Frameworks */,
+				BB8B286D1C1233F800C91975 /* libLLVMOrcJIT.a in Frameworks */,
+				BB8B286E1C1233F800C91975 /* libLLVMPasses.a in Frameworks */,
+				BB8B286F1C1233F800C91975 /* libLLVMProfileData.a in Frameworks */,
+				BB8B28701C1233F800C91975 /* libLLVMRuntimeDyld.a in Frameworks */,
+				BB8B28711C1233F800C91975 /* libLLVMScalarOpts.a in Frameworks */,
+				BB8B28721C1233F800C91975 /* libLLVMSelectionDAG.a in Frameworks */,
+				BB8B28731C1233F800C91975 /* libLLVMSupport.a in Frameworks */,
+				BB8B28741C1233F800C91975 /* libLLVMSymbolize.a in Frameworks */,
+				BB8B28751C1233F800C91975 /* libLLVMTableGen.a in Frameworks */,
+				BB8B28761C1233F800C91975 /* libLLVMTarget.a in Frameworks */,
+				BB8B28771C1233F800C91975 /* libLLVMTransformUtils.a in Frameworks */,
+				BB8B28781C1233F800C91975 /* libLLVMVectorize.a in Frameworks */,
+				BB8B28791C1233F800C91975 /* libLLVMX86AsmParser.a in Frameworks */,
+				BB8B287A1C1233F800C91975 /* libLLVMX86AsmPrinter.a in Frameworks */,
+				BB8B287B1C1233F800C91975 /* libLLVMX86CodeGen.a in Frameworks */,
+				BB8B287C1C1233F800C91975 /* libLLVMX86Desc.a in Frameworks */,
+				BB8B287D1C1233F800C91975 /* libLLVMX86Disassembler.a in Frameworks */,
+				BB8B287E1C1233F800C91975 /* libLLVMX86Info.a in Frameworks */,
+				BB8B287F1C1233F800C91975 /* libLLVMX86Utils.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		BB8B288D1C12400700C91975 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28891C1238B100C91975 /* libLLVMSupport.a */,
+				BB8B288A1C1238B100C91975 /* libLLVMTableGen.a */,
+				BB8B28871C1236D400C91975 /* libedit.tbd */,
+				BB8B28821C12357300C91975 /* libz.tbd */,
+				BB8B28801C12352E00C91975 /* libcmark.a */,
+				BB8B27D21C1233F600C91975 /* libclangAnalysis.a */,
+				BB8B27D31C1233F600C91975 /* libclangAPINotes.a */,
+				BB8B27D41C1233F600C91975 /* libclangARCMigrate.a */,
+				BB8B27D51C1233F600C91975 /* libclangAST.a */,
+				BB8B27D61C1233F700C91975 /* libclangASTMatchers.a */,
+				BB8B27D71C1233F700C91975 /* libclangBasic.a */,
+				BB8B27D81C1233F700C91975 /* libclangCodeGen.a */,
+				BB8B27D91C1233F700C91975 /* libclangDriver.a */,
+				BB8B27DA1C1233F700C91975 /* libclangDynamicASTMatchers.a */,
+				BB8B27DB1C1233F700C91975 /* libclangEdit.a */,
+				BB8B27DC1C1233F700C91975 /* libclangFormat.a */,
+				BB8B27DD1C1233F700C91975 /* libclangFrontend.a */,
+				BB8B27DE1C1233F700C91975 /* libclangFrontendTool.a */,
+				BB8B27DF1C1233F700C91975 /* libclangIndex.a */,
+				BB8B27E01C1233F700C91975 /* libclangLex.a */,
+				BB8B27E11C1233F700C91975 /* libclangParse.a */,
+				BB8B27E21C1233F700C91975 /* libclangRewrite.a */,
+				BB8B27E31C1233F700C91975 /* libclangRewriteFrontend.a */,
+				BB8B27E41C1233F700C91975 /* libclangSema.a */,
+				BB8B27E51C1233F700C91975 /* libclangSerialization.a */,
+				BB8B27E61C1233F700C91975 /* libclangStaticAnalyzerCheckers.a */,
+				BB8B27E71C1233F700C91975 /* libclangStaticAnalyzerCore.a */,
+				BB8B27E81C1233F700C91975 /* libclangStaticAnalyzerFrontend.a */,
+				BB8B27E91C1233F700C91975 /* libclangTooling.a */,
+				BB8B27EA1C1233F700C91975 /* libclangToolingCore.a */,
+				BB8B27EC1C1233F700C91975 /* libgtest_main.a */,
+				BB8B27ED1C1233F700C91975 /* libgtest.a */,
+				BB8B27EE1C1233F700C91975 /* libLLVMAArch64AsmParser.a */,
+				BB8B27EF1C1233F700C91975 /* libLLVMAArch64AsmPrinter.a */,
+				BB8B27F01C1233F700C91975 /* libLLVMAArch64CodeGen.a */,
+				BB8B27F11C1233F700C91975 /* libLLVMAArch64Desc.a */,
+				BB8B27F21C1233F700C91975 /* libLLVMAArch64Disassembler.a */,
+				BB8B27F31C1233F700C91975 /* libLLVMAArch64Info.a */,
+				BB8B27F41C1233F700C91975 /* libLLVMAArch64Utils.a */,
+				BB8B27F51C1233F700C91975 /* libLLVMAnalysis.a */,
+				BB8B27F61C1233F700C91975 /* libLLVMARMAsmParser.a */,
+				BB8B27F71C1233F700C91975 /* libLLVMARMAsmPrinter.a */,
+				BB8B27F81C1233F700C91975 /* libLLVMARMCodeGen.a */,
+				BB8B27F91C1233F700C91975 /* libLLVMARMDesc.a */,
+				BB8B27FA1C1233F700C91975 /* libLLVMARMDisassembler.a */,
+				BB8B27FB1C1233F700C91975 /* libLLVMARMInfo.a */,
+				BB8B27FC1C1233F700C91975 /* libLLVMAsmParser.a */,
+				BB8B27FD1C1233F700C91975 /* libLLVMAsmPrinter.a */,
+				BB8B27FE1C1233F700C91975 /* libLLVMBitReader.a */,
+				BB8B27FF1C1233F700C91975 /* libLLVMBitWriter.a */,
+				BB8B28001C1233F700C91975 /* libLLVMCodeGen.a */,
+				BB8B28011C1233F700C91975 /* libLLVMCore.a */,
+				BB8B28021C1233F700C91975 /* libLLVMDebugInfoDWARF.a */,
+				BB8B28031C1233F700C91975 /* libLLVMDebugInfoPDB.a */,
+				BB8B28041C1233F700C91975 /* libLLVMExecutionEngine.a */,
+				BB8B28051C1233F700C91975 /* libLLVMInstCombine.a */,
+				BB8B28061C1233F700C91975 /* libLLVMInstrumentation.a */,
+				BB8B28071C1233F700C91975 /* libLLVMInterpreter.a */,
+				BB8B28081C1233F700C91975 /* libLLVMipo.a */,
+				BB8B28091C1233F700C91975 /* libLLVMIRReader.a */,
+				BB8B280A1C1233F700C91975 /* libLLVMLibDriver.a */,
+				BB8B280B1C1233F700C91975 /* libLLVMLineEditor.a */,
+				BB8B280C1C1233F700C91975 /* libLLVMLinker.a */,
+				BB8B280D1C1233F700C91975 /* libLLVMLTO.a */,
+				BB8B280E1C1233F700C91975 /* libLLVMMC.a */,
+				BB8B280F1C1233F700C91975 /* libLLVMMCDisassembler.a */,
+				BB8B28101C1233F700C91975 /* libLLVMMCJIT.a */,
+				BB8B28111C1233F700C91975 /* libLLVMMCParser.a */,
+				BB8B28121C1233F700C91975 /* libLLVMMIRParser.a */,
+				BB8B28131C1233F700C91975 /* libLLVMObjCARCOpts.a */,
+				BB8B28141C1233F700C91975 /* libLLVMObject.a */,
+				BB8B28151C1233F700C91975 /* libLLVMOption.a */,
+				BB8B28161C1233F700C91975 /* libLLVMOrcJIT.a */,
+				BB8B28171C1233F700C91975 /* libLLVMPasses.a */,
+				BB8B28181C1233F700C91975 /* libLLVMProfileData.a */,
+				BB8B28191C1233F700C91975 /* libLLVMRuntimeDyld.a */,
+				BB8B281A1C1233F700C91975 /* libLLVMScalarOpts.a */,
+				BB8B281B1C1233F700C91975 /* libLLVMSelectionDAG.a */,
+				BB8B281C1C1233F700C91975 /* libLLVMSupport.a */,
+				BB8B281D1C1233F700C91975 /* libLLVMSymbolize.a */,
+				BB8B281E1C1233F700C91975 /* libLLVMTableGen.a */,
+				BB8B281F1C1233F700C91975 /* libLLVMTarget.a */,
+				BB8B28201C1233F700C91975 /* libLLVMTransformUtils.a */,
+				BB8B28211C1233F700C91975 /* libLLVMVectorize.a */,
+				BB8B28221C1233F700C91975 /* libLLVMX86AsmParser.a */,
+				BB8B28231C1233F700C91975 /* libLLVMX86AsmPrinter.a */,
+				BB8B28241C1233F700C91975 /* libLLVMX86CodeGen.a */,
+				BB8B28251C1233F800C91975 /* libLLVMX86Desc.a */,
+				BB8B28261C1233F800C91975 /* libLLVMX86Disassembler.a */,
+				BB8B28271C1233F800C91975 /* libLLVMX86Info.a */,
+				BB8B28281C1233F800C91975 /* libLLVMX86Utils.a */,
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		BB8B288E1C12481F00C91975 /* stdlib */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B288F1C12484500C91975 /* internal */,
+				BB8B28901C12484D00C91975 /* private */,
+				BB8B28911C12486000C91975 /* public */,
+			);
+			name = stdlib;
+			sourceTree = "<group>";
+		};
+		BB8B288F1C12484500C91975 /* internal */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28931C12489800C91975 /* CMakeLists.txt */,
+				BB8B28941C12489800C91975 /* README.txt */,
+				BB8B28921C12488500C91975 /* SwiftExperimental */,
+			);
+			name = internal;
+			sourceTree = "<group>";
+		};
+		BB8B28901C12484D00C91975 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28B91C1248DE00C91975 /* CMakeLists.txt */,
+				BB8B28BA1C1248DE00C91975 /* README.txt */,
+				BB8B28981C1248B000C91975 /* StdlibUnittest */,
+				BB8B28BB1C1248E200C91975 /* StdlibUnittestFoundationExtras */,
+				BB8B28BF1C12490600C91975 /* SwiftPrivate */,
+				BB8B28C91C12492B00C91975 /* SwiftPrivateDarwinExtras */,
+				BB8B28CF1C12495100C91975 /* SwiftPrivatePthreadExtras */,
+			);
+			name = private;
+			sourceTree = "<group>";
+		};
+		BB8B28911C12486000C91975 /* public */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28D61C12499300C91975 /* CMakeLists.txt */,
+				BB8B28D71C12499300C91975 /* README.txt */,
+				BB8B28D51C12497200C91975 /* common */,
+				BB8B28DD1C1249B000C91975 /* core */,
+				BB8B29981C1249D000C91975 /* Glibc */,
+				BB8B299F1C1249EE00C91975 /* runtime */,
+				BB8B29CF1C124A1800C91975 /* SDK */,
+				BB8B29F21C124A5000C91975 /* stubs */,
+				BB8B29FF1C124A6F00C91975 /* SwiftShims */,
+			);
+			name = public;
+			sourceTree = "<group>";
+		};
+		BB8B28921C12488500C91975 /* SwiftExperimental */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28951C1248AA00C91975 /* CMakeLists.txt */,
+				BB8B28961C1248AA00C91975 /* SwiftExperimental.swift */,
+			);
+			name = SwiftExperimental;
+			sourceTree = "<group>";
+		};
+		BB8B28981C1248B000C91975 /* StdlibUnittest */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28991C1248CE00C91975 /* CheckCollectionType.swift */,
+				BB8B289A1C1248CE00C91975 /* CheckMutableCollectionType.swift.gyb */,
+				BB8B289B1C1248CE00C91975 /* CheckRangeReplaceableCollectionType.swift */,
+				BB8B289C1C1248CE00C91975 /* CheckRangeReplaceableSliceType.swift */,
+				BB8B289D1C1248CE00C91975 /* CheckSequenceType.swift */,
+				BB8B289E1C1248CE00C91975 /* CMakeLists.txt */,
+				BB8B289F1C1248CE00C91975 /* GetOSVersion.mm */,
+				BB8B28A01C1248CE00C91975 /* InterceptTraps.cpp */,
+				BB8B28A11C1248CE00C91975 /* LifetimeTracked.swift */,
+				BB8B28A21C1248CE00C91975 /* LoggingWrappers.swift.gyb */,
+				BB8B28A31C1248CE00C91975 /* OpaqueIdentityFunctions.cpp */,
+				BB8B28A41C1248CE00C91975 /* OpaqueIdentityFunctions.swift */,
+				BB8B28A51C1248CE00C91975 /* RaceTest.swift */,
+				BB8B28A61C1248CE00C91975 /* Statistics.swift */,
+				BB8B28A71C1248CE00C91975 /* StdlibCoreExtras.swift */,
+				BB8B28A81C1248CE00C91975 /* StdlibUnittest.swift.gyb */,
+				BB8B28A91C1248CE00C91975 /* TestHelpers.swift */,
+				BB8B28AA1C1248CE00C91975 /* TypeIndexed.swift */,
+			);
+			name = StdlibUnittest;
+			sourceTree = "<group>";
+		};
+		BB8B28BB1C1248E200C91975 /* StdlibUnittestFoundationExtras */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28BC1C1248FD00C91975 /* CMakeLists.txt */,
+				BB8B28BD1C1248FD00C91975 /* StdlibUnittestFoundationExtras.swift */,
+			);
+			name = StdlibUnittestFoundationExtras;
+			sourceTree = "<group>";
+		};
+		BB8B28BF1C12490600C91975 /* SwiftPrivate */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28C01C12492100C91975 /* CMakeLists.txt */,
+				BB8B28C11C12492100C91975 /* IO.swift */,
+				BB8B28C21C12492100C91975 /* PRNG.swift */,
+				BB8B28C31C12492100C91975 /* ShardedAtomicCounter.swift */,
+				BB8B28C41C12492100C91975 /* SwiftPrivate.swift */,
+			);
+			name = SwiftPrivate;
+			sourceTree = "<group>";
+		};
+		BB8B28C91C12492B00C91975 /* SwiftPrivateDarwinExtras */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28CA1C12494700C91975 /* CMakeLists.txt */,
+				BB8B28CB1C12494700C91975 /* Subprocess.swift */,
+				BB8B28CC1C12494700C91975 /* SwiftPrivateDarwinExtras.swift */,
+			);
+			name = SwiftPrivateDarwinExtras;
+			sourceTree = "<group>";
+		};
+		BB8B28CF1C12495100C91975 /* SwiftPrivatePthreadExtras */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28D01C12496900C91975 /* CMakeLists.txt */,
+				BB8B28D11C12496900C91975 /* PthreadBarriers.swift */,
+				BB8B28D21C12496900C91975 /* SwiftPrivatePthreadExtras.swift */,
+			);
+			name = SwiftPrivatePthreadExtras;
+			sourceTree = "<group>";
+		};
+		BB8B28D51C12497200C91975 /* common */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28D81C1249A200C91975 /* MirrorBoilerplate.gyb */,
+				BB8B28D91C1249A200C91975 /* MirrorCommon.py */,
+				BB8B28DA1C1249A200C91975 /* MirrorCommon.pyc */,
+				BB8B28DB1C1249A200C91975 /* MirrorConformance.gyb */,
+				BB8B28DC1C1249A200C91975 /* MirrorDecl.gyb */,
+			);
+			name = common;
+			sourceTree = "<group>";
+		};
+		BB8B28DD1C1249B000C91975 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B28DE1C1249C800C91975 /* Algorithm.swift */,
+				BB8B28DF1C1249C800C91975 /* ArrayBody.swift */,
+				BB8B28E01C1249C800C91975 /* ArrayBuffer.swift */,
+				BB8B28E11C1249C800C91975 /* ArrayBufferType.swift */,
+				BB8B28E21C1249C800C91975 /* ArrayCast.swift */,
+				BB8B28E31C1249C800C91975 /* Arrays.swift.gyb */,
+				BB8B28E41C1249C800C91975 /* ArrayType.swift */,
+				BB8B28E51C1249C800C91975 /* Assert.swift */,
+				BB8B28E61C1249C800C91975 /* AssertCommon.swift */,
+				BB8B28E71C1249C800C91975 /* Availability.swift */,
+				BB8B28E81C1249C800C91975 /* Bit.swift */,
+				BB8B28E91C1249C800C91975 /* Bool.swift */,
+				BB8B28EA1C1249C800C91975 /* BooleanType.swift */,
+				BB8B28EB1C1249C800C91975 /* BridgeObjectiveC.swift */,
+				BB8B28EC1C1249C800C91975 /* BridgeStorage.swift */,
+				BB8B28ED1C1249C800C91975 /* Builtin.swift */,
+				BB8B28EE1C1249C800C91975 /* BuiltinMath.swift.gyb */,
+				BB8B28EF1C1249C800C91975 /* Character.swift */,
+				BB8B28F01C1249C800C91975 /* CMakeLists.txt */,
+				BB8B28F11C1249C800C91975 /* CocoaArray.swift */,
+				BB8B28F21C1249C800C91975 /* Collection.swift */,
+				BB8B28F31C1249C800C91975 /* CollectionAlgorithms.swift.gyb */,
+				BB8B28F41C1249C800C91975 /* CollectionMirrors.swift.gyb */,
+				BB8B28F51C1249C800C91975 /* CollectionOfOne.swift */,
+				BB8B28F61C1249C800C91975 /* CompilerProtocols.swift */,
+				BB8B28F71C1249C800C91975 /* ContiguousArrayBuffer.swift */,
+				BB8B28F81C1249C800C91975 /* CString.swift */,
+				BB8B28F91C1249C800C91975 /* CTypes.swift */,
+				BB8B28FA1C1249C800C91975 /* EmptyCollection.swift */,
+				BB8B28FB1C1249C800C91975 /* ErrorType.swift */,
+				BB8B28FC1C1249C800C91975 /* Existential.swift */,
+				BB8B28FD1C1249C800C91975 /* ExistentialCollection.swift.gyb */,
+				BB8B28FE1C1249C800C91975 /* Filter.swift */,
+				BB8B28FF1C1249C800C91975 /* FixedPoint.swift.gyb */,
+				BB8B29001C1249C800C91975 /* FlatMap.swift */,
+				BB8B29011C1249C800C91975 /* Flatten.swift.gyb */,
+				BB8B29021C1249C800C91975 /* FloatingPoint.swift.gyb */,
+				BB8B29031C1249C800C91975 /* FloatingPointOperations.swift.gyb */,
+				BB8B29041C1249C800C91975 /* FloatingPointParsing.swift.gyb */,
+				BB8B29051C1249C800C91975 /* HashedCollections.swift.gyb */,
+				BB8B29061C1249C800C91975 /* Hashing.swift */,
+				BB8B29071C1249C800C91975 /* HeapBuffer.swift */,
+				BB8B29081C1249C800C91975 /* ImplicitlyUnwrappedOptional.swift */,
+				BB8B29091C1249C800C91975 /* Index.swift */,
+				BB8B290A1C1249C800C91975 /* InputStream.swift */,
+				BB8B290B1C1249C800C91975 /* IntegerArithmetic.swift.gyb */,
+				BB8B290C1C1249C800C91975 /* IntegerParsing.swift.gyb */,
+				BB8B290D1C1249C800C91975 /* Interval.swift.gyb */,
+				BB8B290E1C1249C800C91975 /* Join.swift */,
+				BB8B290F1C1249C800C91975 /* LazyCollection.swift */,
+				BB8B29101C1249C800C91975 /* LazySequence.swift */,
+				BB8B29111C1249C800C91975 /* LifetimeManager.swift */,
+				BB8B29121C1249C800C91975 /* ManagedBuffer.swift */,
+				BB8B29131C1249C800C91975 /* Map.swift */,
+				BB8B29141C1249C800C91975 /* Mirror.swift */,
+				BB8B29151C1249C800C91975 /* Mirrors.swift.gyb */,
+				BB8B29161C1249C800C91975 /* Misc.swift */,
+				BB8B29171C1249C800C91975 /* ObjCMirrors.swift */,
+				BB8B29181C1249C800C91975 /* Optional.swift */,
+				BB8B29191C1249C800C91975 /* OptionSet.swift */,
+				BB8B291A1C1249C800C91975 /* OutputStream.swift */,
+				BB8B291B1C1249C800C91975 /* Pointer.swift */,
+				BB8B291C1C1249C800C91975 /* Policy.swift */,
+				BB8B291D1C1249C800C91975 /* Prespecialized.swift */,
+				BB8B291E1C1249C800C91975 /* Print.swift */,
+				BB8B291F1C1249C800C91975 /* Process.swift */,
+				BB8B29201C1249C800C91975 /* Range.swift */,
+				BB8B29211C1249C800C91975 /* RangeMirrors.swift.gyb */,
+				BB8B29221C1249C800C91975 /* RangeReplaceableCollectionType.swift */,
+				BB8B29231C1249C800C91975 /* Reflection.swift */,
+				BB8B29241C1249C800C91975 /* Repeat.swift */,
+				BB8B29251C1249C800C91975 /* REPL.swift */,
+				BB8B29261C1249C800C91975 /* Reverse.swift */,
+				BB8B29271C1249C800C91975 /* Runtime.swift.gyb */,
+				BB8B29281C1249C800C91975 /* Sequence.swift */,
+				BB8B29291C1249C800C91975 /* SequenceAlgorithms.swift.gyb */,
+				BB8B292A1C1249C800C91975 /* SequenceWrapper.swift */,
+				BB8B292B1C1249C800C91975 /* SetAlgebra.swift */,
+				BB8B292C1C1249C800C91975 /* ShadowProtocols.swift */,
+				BB8B292D1C1249C800C91975 /* Shims.swift */,
+				BB8B292E1C1249C800C91975 /* Slice.swift.gyb */,
+				BB8B292F1C1249C800C91975 /* SliceBuffer.swift */,
+				BB8B29301C1249C800C91975 /* Sort.swift.gyb */,
+				BB8B29311C1249C800C91975 /* StaticString.swift */,
+				BB8B29321C1249C800C91975 /* Stride.swift */,
+				BB8B29331C1249C800C91975 /* StrideMirrors.swift.gyb */,
+				BB8B29341C1249C800C91975 /* String.swift */,
+				BB8B29351C1249C800C91975 /* StringBridge.swift */,
+				BB8B29361C1249C800C91975 /* StringBuffer.swift */,
+				BB8B29371C1249C800C91975 /* StringCharacterView.swift */,
+				BB8B29381C1249C800C91975 /* StringCore.swift */,
+				BB8B29391C1249C800C91975 /* StringInterpolation.swift.gyb */,
+				BB8B293A1C1249C800C91975 /* StringLegacy.swift */,
+				BB8B293B1C1249C800C91975 /* StringUnicodeScalarView.swift */,
+				BB8B293C1C1249C800C91975 /* StringUTF8.swift */,
+				BB8B293D1C1249C800C91975 /* StringUTF16.swift */,
+				BB8B293E1C1249C800C91975 /* StringUTFViewsMirrors.swift.gyb */,
+				BB8B293F1C1249C800C91975 /* SwiftNativeNSArray.swift */,
+				BB8B29401C1249C800C91975 /* UnavailableStringAPIs.swift.gyb */,
+				BB8B29411C1249C800C91975 /* Unicode.swift */,
+				BB8B29421C1249C800C91975 /* UnicodeScalar.swift */,
+				BB8B29431C1249C800C91975 /* UnicodeTrie.swift.gyb */,
+				BB8B29441C1249C800C91975 /* Unmanaged.swift */,
+				BB8B29451C1249C800C91975 /* UnsafeBufferPointer.swift.gyb */,
+				BB8B29461C1249C800C91975 /* UnsafePointer.swift.gyb */,
+				BB8B29471C1249C800C91975 /* VarArgs.swift */,
+				BB8B29481C1249C800C91975 /* Zip.swift */,
+			);
+			name = core;
+			sourceTree = "<group>";
+		};
+		BB8B29981C1249D000C91975 /* Glibc */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B29991C1249E500C91975 /* CMakeLists.txt */,
+				BB8B299A1C1249E500C91975 /* Glibc.swift */,
+				BB8B299B1C1249E500C91975 /* module.map */,
+				BB8B299C1C1249E500C91975 /* README.md */,
+			);
+			name = Glibc;
+			sourceTree = "<group>";
+		};
+		BB8B299F1C1249EE00C91975 /* runtime */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B29A01C124A0C00C91975 /* Casting.cpp */,
+				BB8B29A11C124A0C00C91975 /* CMakeLists.txt */,
+				BB8B29A21C124A0C00C91975 /* Demangle.cpp */,
+				BB8B29A31C124A0C00C91975 /* Enum.cpp */,
+				BB8B29A41C124A0C00C91975 /* ErrorObject.cpp */,
+				BB8B29A51C124A0C00C91975 /* ErrorObject.h */,
+				BB8B29A61C124A0C00C91975 /* ErrorObject.mm */,
+				BB8B29A71C124A0C00C91975 /* Errors.cpp */,
+				BB8B29A81C124A0C00C91975 /* ExistentialMetadataImpl.h */,
+				BB8B29A91C124A0C00C91975 /* Heap.cpp */,
+				BB8B29AA1C124A0C00C91975 /* HeapObject.cpp */,
+				BB8B29AB1C124A0C00C91975 /* KnownMetadata.cpp */,
+				BB8B29AC1C124A0C00C91975 /* Leaks.h */,
+				BB8B29AD1C124A0C00C91975 /* Leaks.mm */,
+				BB8B29AE1C124A0C00C91975 /* Metadata.cpp */,
+				BB8B29AF1C124A0C00C91975 /* MetadataCache.h */,
+				BB8B29B01C124A0C00C91975 /* MetadataImpl.h */,
+				BB8B29B11C124A0C00C91975 /* Once.cpp */,
+				BB8B29B21C124A0C00C91975 /* Private.h */,
+				BB8B29B31C124A0C00C91975 /* Reflection.cpp */,
+				BB8B29B41C124A0C00C91975 /* Reflection.mm */,
+				BB8B29B51C124A0C00C91975 /* Remangle.cpp */,
+				BB8B29B61C124A0C00C91975 /* swift.ld */,
+				BB8B29B71C124A0C00C91975 /* SwiftObject.cpp */,
+				BB8B29B81C124A0C00C91975 /* SwiftObject.mm */,
+				BB8B29B91C124A0C00C91975 /* SwiftRuntimeDTraceProbes.d */,
+				BB8B29BA1C124A0C00C91975 /* UnicodeExtendedGraphemeClusters.cpp.gyb */,
+				BB8B29BB1C124A0C00C91975 /* UnicodeNormalization.cpp */,
+			);
+			name = runtime;
+			sourceTree = "<group>";
+		};
+		BB8B29CF1C124A1800C91975 /* SDK */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B29D01C124A3700C91975 /* AppKit */,
+				BB8B29D11C124A3800C91975 /* AssetsLibrary */,
+				BB8B29D21C124A3800C91975 /* AVFoundation */,
+				BB8B29D31C124A3800C91975 /* CloudKit */,
+				BB8B29D41C124A3800C91975 /* CMakeLists.txt */,
+				BB8B29D51C124A3800C91975 /* Contacts */,
+				BB8B29D61C124A3800C91975 /* CoreAudio */,
+				BB8B29D71C124A3800C91975 /* CoreBluetooth */,
+				BB8B29D81C124A3800C91975 /* CoreData */,
+				BB8B29D91C124A3800C91975 /* CoreGraphics */,
+				BB8B29DA1C124A3800C91975 /* CoreImage */,
+				BB8B29DB1C124A3800C91975 /* CoreLocation */,
+				BB8B29DC1C124A3800C91975 /* CoreMedia */,
+				BB8B29DD1C124A3800C91975 /* Darwin */,
+				BB8B29DE1C124A3800C91975 /* Dispatch */,
+				BB8B29DF1C124A3800C91975 /* EventKit */,
+				BB8B29E01C124A3800C91975 /* Foundation */,
+				BB8B29E11C124A3800C91975 /* GameKit */,
+				BB8B29E21C124A3800C91975 /* GameplayKit */,
+				BB8B29E31C124A3800C91975 /* GLKit */,
+				BB8B29E41C124A3800C91975 /* HomeKit */,
+				BB8B29E51C124A3800C91975 /* LocalAuthentication */,
+				BB8B29E61C124A3800C91975 /* MultipeerConnectivity */,
+				BB8B29E71C124A3800C91975 /* ObjectiveC */,
+				BB8B29E81C124A3800C91975 /* OpenCL */,
+				BB8B29E91C124A3800C91975 /* PassKit */,
+				BB8B29EA1C124A3800C91975 /* SceneKit */,
+				BB8B29EB1C124A3800C91975 /* simd */,
+				BB8B29EC1C124A3800C91975 /* SpriteKit */,
+				BB8B29ED1C124A3800C91975 /* UIKit */,
+				BB8B29EE1C124A3800C91975 /* WatchConnectivity */,
+				BB8B29EF1C124A3800C91975 /* WatchKit */,
+				BB8B29F01C124A3800C91975 /* WebKit */,
+				BB8B29F11C124A3800C91975 /* XCTest */,
+			);
+			name = SDK;
+			sourceTree = "<group>";
+		};
+		BB8B29F21C124A5000C91975 /* stubs */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B29F31C124A6500C91975 /* Availability.mm */,
+				BB8B29F41C124A6500C91975 /* CMakeLists.txt */,
+				BB8B29F51C124A6500C91975 /* FoundationHelpers.mm */,
+				BB8B29F61C124A6500C91975 /* GlobalObjects.cpp */,
+				BB8B29F71C124A6500C91975 /* LibcShims.cpp */,
+				BB8B29F81C124A6500C91975 /* Stubs.cpp */,
+				BB8B29F91C124A6500C91975 /* SwiftNativeNSXXXBase.mm.gyb */,
+			);
+			name = stubs;
+			sourceTree = "<group>";
+		};
+		BB8B29FF1C124A6F00C91975 /* SwiftShims */ = {
+			isa = PBXGroup;
+			children = (
+				BB8B2A001C124A8A00C91975 /* CMakeLists.txt */,
+				BB8B2A011C124A8A00C91975 /* CoreFoundationShims.h */,
+				BB8B2A021C124A8A00C91975 /* FoundationShims.h */,
+				BB8B2A031C124A8A00C91975 /* GlobalObjects.h */,
+				BB8B2A041C124A8A00C91975 /* HeapObject.h */,
+				BB8B2A051C124A8A00C91975 /* LibcShims.h */,
+				BB8B2A061C124A8A00C91975 /* module.map */,
+				BB8B2A071C124A8A00C91975 /* RefCount.h */,
+				BB8B2A081C124A8A00C91975 /* RuntimeShims.h */,
+				BB8B2A091C124A8A00C91975 /* RuntimeStubs.h */,
+				BB8B2A0A1C124A8A00C91975 /* SwiftStddef.h */,
+				BB8B2A0B1C124A8A00C91975 /* SwiftStdint.h */,
+				BB8B2A0C1C124A8A00C91975 /* UnicodeShims.h */,
+			);
+			name = SwiftShims;
+			sourceTree = "<group>";
+		};
+		BB9FD6371C10EF850008A1EA = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6FE1C10F12F0008A1EA /* LICENSE.txt */,
+				BB9FD6FF1C10F12F0008A1EA /* README.md */,
+				BB9FD6FC1C10F12F0008A1EA /* CMakeLists.txt */,
+				BB9FD6FD1C10F12F0008A1EA /* CODE_OWNERS.TXT */,
+				BB9FD64A1C10EFD30008A1EA /* Headers */,
+				BB9FD7981C10F3900008A1EA /* Compiler */,
+				BB8B288E1C12481F00C91975 /* stdlib */,
+				BB8B288D1C12400700C91975 /* Libraries */,
+				BB9FD6411C10EF850008A1EA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		BB9FD6411C10EF850008A1EA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6401C10EF850008A1EA /* swift */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		BB9FD64A1C10EFD30008A1EA /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6FB1C10F11A0008A1EA /* CMakeLists.txt */,
+				BB9FD64B1C10EFED0008A1EA /* swift */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		BB9FD64B1C10EFED0008A1EA /* swift */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6F91C10F1070008A1EA /* CMakeLists.txt */,
+				BB9FD6FA1C10F1070008A1EA /* Config.h.in */,
+				BB9FD6EA1C10F0CF0008A1EA /* Strings.h */,
+				BB9FD6EB1C10F0CF0008A1EA /* Subsystems.h */,
+				BB9FD64C1C10EFFA0008A1EA /* ABI */,
+				BB9FD6511C10F02D0008A1EA /* AST */,
+				BB9FD6AE1C10F04F0008A1EA /* ASTSectionImporter */,
+				BB9FD6B01C10F0770008A1EA /* Basic */,
+				BB9FD6E41C10F09B0008A1EA /* ClangImporter */,
+				BB9FD6EC1C10F0D90008A1EA /* Driver */,
+				BB9FD7011C10F1390008A1EA /* Frontend */,
+				BB9FD7071C10F15A0008A1EA /* IDE */,
+				BB9FD7101C10F1820008A1EA /* Immediate */,
+				BB9FD7121C10F1A60008A1EA /* LLVMPasses */,
+				BB9FD7151C10F1C90008A1EA /* Markup */,
+				BB9FD71D1C10F1E80008A1EA /* Option */,
+				BB9FD7221C10F2050008A1EA /* Parse */,
+				BB9FD72D1C10F2280008A1EA /* PrintAsObjC */,
+				BB9FD72F1C10F24A0008A1EA /* Runtime */,
+				BB9FD73B1C10F2790008A1EA /* Sema */,
+				BB9FD7421C10F2AA0008A1EA /* Serialization */,
+				BB9FD74B1C10F2D30008A1EA /* SIL */,
+				BB9FD7751C10F2FA0008A1EA /* SILAnalysis */,
+				BB9FD78D1C10F32D0008A1EA /* SILPasses */,
+				BB9FD7951C10F3660008A1EA /* SwiftDemangle */,
+			);
+			name = swift;
+			sourceTree = "<group>";
+		};
+		BB9FD64C1C10EFFA0008A1EA /* ABI */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD64D1C10F0280008A1EA /* Class.h */,
+				BB9FD64E1C10F0280008A1EA /* MetadataKind.def */,
+				BB9FD64F1C10F0280008A1EA /* MetadataValues.h */,
+				BB9FD6501C10F0280008A1EA /* System.h */,
+			);
+			name = ABI;
+			sourceTree = "<group>";
+		};
+		BB9FD6511C10F02D0008A1EA /* AST */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6521C10F0460008A1EA /* AnyFunctionRef.h */,
+				BB9FD6531C10F0460008A1EA /* ArchetypeBuilder.h */,
+				BB9FD6541C10F0460008A1EA /* AST.h */,
+				BB9FD6551C10F0460008A1EA /* ASTContext.h */,
+				BB9FD6561C10F0460008A1EA /* ASTNode.h */,
+				BB9FD6571C10F0460008A1EA /* ASTPrinter.h */,
+				BB9FD6581C10F0460008A1EA /* ASTVisitor.h */,
+				BB9FD6591C10F0460008A1EA /* ASTWalker.h */,
+				BB9FD65A1C10F0460008A1EA /* Attr.def */,
+				BB9FD65B1C10F0460008A1EA /* Attr.h */,
+				BB9FD65C1C10F0460008A1EA /* Availability.h */,
+				BB9FD65D1C10F0460008A1EA /* AvailabilitySpec.h */,
+				BB9FD65E1C10F0460008A1EA /* Builtins.def */,
+				BB9FD65F1C10F0460008A1EA /* Builtins.h */,
+				BB9FD6601C10F0460008A1EA /* CanTypeVisitor.h */,
+				BB9FD6611C10F0460008A1EA /* CaptureInfo.h */,
+				BB9FD6621C10F0460008A1EA /* ClangModuleLoader.h */,
+				BB9FD6631C10F0460008A1EA /* Comment.h */,
+				BB9FD6641C10F0460008A1EA /* ConcreteDeclRef.h */,
+				BB9FD6651C10F0460008A1EA /* DebuggerClient.h */,
+				BB9FD6661C10F0460008A1EA /* Decl.h */,
+				BB9FD6671C10F0460008A1EA /* DeclContext.h */,
+				BB9FD6681C10F0460008A1EA /* DeclNodes.def */,
+				BB9FD6691C10F0460008A1EA /* DefaultArgumentKind.h */,
+				BB9FD66A1C10F0460008A1EA /* DiagnosticEngine.h */,
+				BB9FD66B1C10F0460008A1EA /* DiagnosticsAll.def */,
+				BB9FD66C1C10F0460008A1EA /* DiagnosticsClangImporter.def */,
+				BB9FD66D1C10F0460008A1EA /* DiagnosticsClangImporter.h */,
+				BB9FD66E1C10F0460008A1EA /* DiagnosticsCommon.def */,
+				BB9FD66F1C10F0460008A1EA /* DiagnosticsCommon.h */,
+				BB9FD6701C10F0460008A1EA /* DiagnosticsDriver.def */,
+				BB9FD6711C10F0460008A1EA /* DiagnosticsDriver.h */,
+				BB9FD6721C10F0460008A1EA /* DiagnosticsFrontend.def */,
+				BB9FD6731C10F0460008A1EA /* DiagnosticsFrontend.h */,
+				BB9FD6741C10F0460008A1EA /* DiagnosticsIRGen.def */,
+				BB9FD6751C10F0460008A1EA /* DiagnosticsIRGen.h */,
+				BB9FD6761C10F0460008A1EA /* DiagnosticsParse.def */,
+				BB9FD6771C10F0460008A1EA /* DiagnosticsParse.h */,
+				BB9FD6781C10F0460008A1EA /* DiagnosticsSema.def */,
+				BB9FD6791C10F0460008A1EA /* DiagnosticsSema.h */,
+				BB9FD67A1C10F0460008A1EA /* DiagnosticsSIL.def */,
+				BB9FD67B1C10F0460008A1EA /* DiagnosticsSIL.h */,
+				BB9FD67C1C10F0460008A1EA /* Expr.h */,
+				BB9FD67D1C10F0460008A1EA /* ExprHandle.h */,
+				BB9FD67E1C10F0460008A1EA /* ExprNodes.def */,
+				BB9FD67F1C10F0460008A1EA /* ForeignErrorConvention.h */,
+				BB9FD6801C10F0460008A1EA /* GenericSignature.h */,
+				BB9FD6811C10F0460008A1EA /* Identifier.h */,
+				BB9FD6821C10F0460008A1EA /* Initializer.h */,
+				BB9FD6831C10F0460008A1EA /* IRGenOptions.h */,
+				BB9FD6841C10F0460008A1EA /* KnownDecls.def */,
+				BB9FD6851C10F0460008A1EA /* KnownIdentifiers.def */,
+				BB9FD6861C10F0460008A1EA /* KnownProtocols.def */,
+				BB9FD6871C10F0460008A1EA /* KnownProtocols.h */,
+				BB9FD6881C10F0460008A1EA /* LazyResolver.h */,
+				BB9FD6891C10F0460008A1EA /* LinkLibrary.h */,
+				BB9FD68A1C10F0460008A1EA /* Mangle.h */,
+				BB9FD68B1C10F0460008A1EA /* Module.h */,
+				BB9FD68C1C10F0460008A1EA /* ModuleLoader.h */,
+				BB9FD68D1C10F0460008A1EA /* NameLookup.h */,
+				BB9FD68E1C10F0460008A1EA /* Ownership.h */,
+				BB9FD68F1C10F0460008A1EA /* Pattern.h */,
+				BB9FD6901C10F0460008A1EA /* PatternNodes.def */,
+				BB9FD6911C10F0460008A1EA /* PlatformKind.h */,
+				BB9FD6921C10F0460008A1EA /* PlatformKinds.def */,
+				BB9FD6931C10F0460008A1EA /* PrettyStackTrace.h */,
+				BB9FD6941C10F0460008A1EA /* PrintOptions.h */,
+				BB9FD6951C10F0460008A1EA /* ProtocolConformance.h */,
+				BB9FD6961C10F0460008A1EA /* RawComment.h */,
+				BB9FD6971C10F0460008A1EA /* ReferencedNameTracker.h */,
+				BB9FD6981C10F0460008A1EA /* Requirement.h */,
+				BB9FD6991C10F0460008A1EA /* ResilienceExpansion.h */,
+				BB9FD69A1C10F0460008A1EA /* SearchPathOptions.h */,
+				BB9FD69B1C10F0460008A1EA /* SILOptions.h */,
+				BB9FD69C1C10F0460008A1EA /* Stmt.h */,
+				BB9FD69D1C10F0460008A1EA /* StmtNodes.def */,
+				BB9FD69E1C10F0460008A1EA /* Substitution.h */,
+				BB9FD69F1C10F0460008A1EA /* SubstTypeVisitor.h */,
+				BB9FD6A01C10F0460008A1EA /* Type.h */,
+				BB9FD6A11C10F0460008A1EA /* TypeAlignments.h */,
+				BB9FD6A21C10F0460008A1EA /* TypeCheckerDebugConsumer.h */,
+				BB9FD6A31C10F0460008A1EA /* TypeLoc.h */,
+				BB9FD6A41C10F0460008A1EA /* TypeMatcher.h */,
+				BB9FD6A51C10F0460008A1EA /* TypeMemberVisitor.h */,
+				BB9FD6A61C10F0460008A1EA /* TypeNodes.def */,
+				BB9FD6A71C10F0460008A1EA /* TypeRefinementContext.h */,
+				BB9FD6A81C10F0460008A1EA /* TypeRepr.h */,
+				BB9FD6A91C10F0460008A1EA /* TypeReprNodes.def */,
+				BB9FD6AA1C10F0460008A1EA /* Types.h */,
+				BB9FD6AB1C10F0460008A1EA /* TypeVisitor.h */,
+				BB9FD6AC1C10F0460008A1EA /* TypeWalker.h */,
+				BB9FD6AD1C10F0460008A1EA /* USRGeneration.h */,
+			);
+			name = AST;
+			sourceTree = "<group>";
+		};
+		BB9FD6AE1C10F04F0008A1EA /* ASTSectionImporter */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6AF1C10F0660008A1EA /* ASTSectionImporter.h */,
+			);
+			name = ASTSectionImporter;
+			sourceTree = "<group>";
+		};
+		BB9FD6B01C10F0770008A1EA /* Basic */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6B11C10F0930008A1EA /* Algorithm.h */,
+				BB9FD6B21C10F0930008A1EA /* ArrayRefView.h */,
+				BB9FD6B31C10F0930008A1EA /* AssertImplements.h */,
+				BB9FD6B41C10F0930008A1EA /* BlotMapVector.h */,
+				BB9FD6B51C10F0930008A1EA /* BlotSetVector.h */,
+				BB9FD6B61C10F0930008A1EA /* Cache.h */,
+				BB9FD6B71C10F0930008A1EA /* ClusteredBitVector.h */,
+				BB9FD6B81C10F0930008A1EA /* Defer.h */,
+				BB9FD6B91C10F0930008A1EA /* Demangle.h */,
+				BB9FD6BA1C10F0930008A1EA /* DemangleNodes.def */,
+				BB9FD6BB1C10F0930008A1EA /* DemangleWrappers.h */,
+				BB9FD6BC1C10F0930008A1EA /* DiagnosticConsumer.h */,
+				BB9FD6BD1C10F0930008A1EA /* DiagnosticOptions.h */,
+				BB9FD6BE1C10F0930008A1EA /* DiverseList.h */,
+				BB9FD6BF1C10F0930008A1EA /* DiverseStack.h */,
+				BB9FD6C01C10F0930008A1EA /* Dwarf.h */,
+				BB9FD6C11C10F0930008A1EA /* EditorPlaceholder.h */,
+				BB9FD6C21C10F0930008A1EA /* EncodedSequence.h */,
+				BB9FD6C31C10F0930008A1EA /* Fallthrough.h */,
+				BB9FD6C41C10F0930008A1EA /* FileSystem.h */,
+				BB9FD6C51C10F0930008A1EA /* FlaggedPointer.h */,
+				BB9FD6C61C10F0930008A1EA /* JSONSerialization.h */,
+				BB9FD6C71C10F0940008A1EA /* LangOptions.h */,
+				BB9FD6C81C10F0940008A1EA /* Lazy.h */,
+				BB9FD6C91C10F0940008A1EA /* LLVM.h */,
+				BB9FD6CA1C10F0940008A1EA /* LLVMInitialize.h */,
+				BB9FD6CB1C10F0940008A1EA /* Malloc.h */,
+				BB9FD6CC1C10F0940008A1EA /* NullablePtr.h */,
+				BB9FD6CD1C10F0940008A1EA /* OptionalEnum.h */,
+				BB9FD6CE1C10F0940008A1EA /* OptionSet.h */,
+				BB9FD6CF1C10F0940008A1EA /* Platform.h */,
+				BB9FD6D01C10F0940008A1EA /* PrefixMap.h */,
+				BB9FD6D11C10F0940008A1EA /* PrettyStackTrace.h */,
+				BB9FD6D21C10F0940008A1EA /* PrimitiveParsing.h */,
+				BB9FD6D31C10F0940008A1EA /* Program.h */,
+				BB9FD6D41C10F0940008A1EA /* Punycode.h */,
+				BB9FD6D51C10F0940008A1EA /* QuotedString.h */,
+				BB9FD6D61C10F0940008A1EA /* Range.h */,
+				BB9FD6D71C10F0940008A1EA /* RelativePointer.h */,
+				BB9FD6D81C10F0940008A1EA /* SourceLoc.h */,
+				BB9FD6D91C10F0940008A1EA /* SourceManager.h */,
+				BB9FD6DA1C10F0940008A1EA /* STLExtras.h */,
+				BB9FD6DB1C10F0940008A1EA /* StringExtras.h */,
+				BB9FD6DC1C10F0940008A1EA /* SuccessorMap.h */,
+				BB9FD6DD1C10F0940008A1EA /* TaskQueue.h */,
+				BB9FD6DE1C10F0940008A1EA /* ThreadSafeRefCounted.h */,
+				BB9FD6DF1C10F0940008A1EA /* TreeScopedHashTable.h */,
+				BB9FD6E01C10F0940008A1EA /* type_traits.h */,
+				BB9FD6E11C10F0940008A1EA /* Unicode.h */,
+				BB9FD6E21C10F0940008A1EA /* UUID.h */,
+				BB9FD6E31C10F0940008A1EA /* Version.h */,
+			);
+			name = Basic;
+			sourceTree = "<group>";
+		};
+		BB9FD6E41C10F09B0008A1EA /* ClangImporter */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6E51C10F0B40008A1EA /* BuiltinMappedTypes.def */,
+				BB9FD6E61C10F0B40008A1EA /* ClangImporter.h */,
+				BB9FD6E71C10F0B40008A1EA /* ClangImporterOptions.h */,
+				BB9FD6E81C10F0B40008A1EA /* ClangModule.h */,
+				BB9FD6E91C10F0B40008A1EA /* SIMDMappedTypes.def */,
+			);
+			name = ClangImporter;
+			sourceTree = "<group>";
+		};
+		BB9FD6EC1C10F0D90008A1EA /* Driver */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD6ED1C10F0F20008A1EA /* Action.h */,
+				BB9FD6EE1C10F0F20008A1EA /* Compilation.h */,
+				BB9FD6EF1C10F0F20008A1EA /* DependencyGraph.h */,
+				BB9FD6F01C10F0F20008A1EA /* Driver.h */,
+				BB9FD6F11C10F0F20008A1EA /* FrontendUtil.h */,
+				BB9FD6F21C10F0F20008A1EA /* Job.h */,
+				BB9FD6F31C10F0F20008A1EA /* OutputFileMap.h */,
+				BB9FD6F41C10F0F20008A1EA /* ParseableOutput.h */,
+				BB9FD6F51C10F0F20008A1EA /* ToolChain.h */,
+				BB9FD6F61C10F0F20008A1EA /* Types.def */,
+				BB9FD6F71C10F0F20008A1EA /* Types.h */,
+				BB9FD6F81C10F0F20008A1EA /* Util.h */,
+			);
+			name = Driver;
+			sourceTree = "<group>";
+		};
+		BB9FD7011C10F1390008A1EA /* Frontend */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7021C10F1520008A1EA /* DiagnosticVerifier.h */,
+				BB9FD7031C10F1520008A1EA /* Frontend.h */,
+				BB9FD7041C10F1520008A1EA /* FrontendOptions.h */,
+				BB9FD7051C10F1520008A1EA /* PrintingDiagnosticConsumer.h */,
+				BB9FD7061C10F1520008A1EA /* SerializedDiagnosticConsumer.h */,
+			);
+			name = Frontend;
+			sourceTree = "<group>";
+		};
+		BB9FD7071C10F15A0008A1EA /* IDE */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7081C10F1700008A1EA /* CodeCompletion.h */,
+				BB9FD7091C10F1700008A1EA /* CodeCompletionCache.h */,
+				BB9FD70A1C10F1700008A1EA /* CommentConversion.h */,
+				BB9FD70B1C10F1700008A1EA /* ModuleInterfacePrinting.h */,
+				BB9FD70C1C10F1700008A1EA /* REPLCodeCompletion.h */,
+				BB9FD70D1C10F1700008A1EA /* SourceEntityWalker.h */,
+				BB9FD70E1C10F1700008A1EA /* SyntaxModel.h */,
+				BB9FD70F1C10F1700008A1EA /* Utils.h */,
+			);
+			name = IDE;
+			sourceTree = "<group>";
+		};
+		BB9FD7101C10F1820008A1EA /* Immediate */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7111C10F1970008A1EA /* Immediate.h */,
+			);
+			name = Immediate;
+			sourceTree = "<group>";
+		};
+		BB9FD7121C10F1A60008A1EA /* LLVMPasses */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7131C10F1BD0008A1EA /* Passes.h */,
+				BB9FD7141C10F1BD0008A1EA /* PassesFwd.h */,
+			);
+			name = LLVMPasses;
+			sourceTree = "<group>";
+		};
+		BB9FD7151C10F1C90008A1EA /* Markup */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7161C10F1E10008A1EA /* AST.h */,
+				BB9FD7171C10F1E10008A1EA /* ASTNodes.def */,
+				BB9FD7181C10F1E10008A1EA /* LineList.h */,
+				BB9FD7191C10F1E20008A1EA /* Markup.h */,
+				BB9FD71A1C10F1E20008A1EA /* SimpleFields.def */,
+				BB9FD71B1C10F1E20008A1EA /* SourceLoc.h */,
+				BB9FD71C1C10F1E20008A1EA /* XMLUtils.h */,
+			);
+			name = Markup;
+			sourceTree = "<group>";
+		};
+		BB9FD71D1C10F1E80008A1EA /* Option */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD71E1C10F1FC0008A1EA /* CMakeLists.txt */,
+				BB9FD71F1C10F1FC0008A1EA /* FrontendOptions.td */,
+				BB9FD7201C10F1FC0008A1EA /* Options.h */,
+				BB9FD7211C10F1FC0008A1EA /* Options.td */,
+			);
+			name = Option;
+			sourceTree = "<group>";
+		};
+		BB9FD7221C10F2050008A1EA /* Parse */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7231C10F2230008A1EA /* CodeCompletionCallbacks.h */,
+				BB9FD7241C10F2230008A1EA /* DelayedParsingCallbacks.h */,
+				BB9FD7251C10F2230008A1EA /* Lexer.h */,
+				BB9FD7261C10F2230008A1EA /* LocalContext.h */,
+				BB9FD7271C10F2230008A1EA /* Parser.h */,
+				BB9FD7281C10F2230008A1EA /* ParserResult.h */,
+				BB9FD7291C10F2230008A1EA /* PersistentParserState.h */,
+				BB9FD72A1C10F2230008A1EA /* Scope.h */,
+				BB9FD72B1C10F2230008A1EA /* Token.h */,
+				BB9FD72C1C10F2230008A1EA /* Tokens.def */,
+			);
+			name = Parse;
+			sourceTree = "<group>";
+		};
+		BB9FD72D1C10F2280008A1EA /* PrintAsObjC */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD72E1C10F2400008A1EA /* PrintAsObjC.h */,
+			);
+			name = PrintAsObjC;
+			sourceTree = "<group>";
+		};
+		BB9FD72F1C10F24A0008A1EA /* Runtime */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7301C10F2660008A1EA /* Concurrent.h */,
+				BB9FD7311C10F2660008A1EA /* Config.h */,
+				BB9FD7321C10F2660008A1EA /* Debug.h */,
+				BB9FD7331C10F2660008A1EA /* Enum.h */,
+				BB9FD7341C10F2660008A1EA /* Heap.h */,
+				BB9FD7351C10F2660008A1EA /* HeapObject.h */,
+				BB9FD7361C10F2660008A1EA /* InstrumentsSupport.h */,
+				BB9FD7371C10F2660008A1EA /* Metadata.h */,
+				BB9FD7381C10F2660008A1EA /* ObjCBridge.h */,
+				BB9FD7391C10F2660008A1EA /* Once.h */,
+				BB9FD73A1C10F2660008A1EA /* Reflection.h */,
+			);
+			name = Runtime;
+			sourceTree = "<group>";
+		};
+		BB9FD73B1C10F2790008A1EA /* Sema */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD73C1C10F28D0008A1EA /* CodeCompletionTypeChecking.h */,
+				BB9FD73D1C10F28D0008A1EA /* IterativeTypeChecker.h */,
+				BB9FD73E1C10F28D0008A1EA /* SourceLoader.h */,
+				BB9FD73F1C10F28D0008A1EA /* TypeCheckRequest.h */,
+				BB9FD7401C10F28D0008A1EA /* TypeCheckRequestKinds.def */,
+				BB9FD7411C10F28D0008A1EA /* TypeCheckRequestPayloads.def */,
+			);
+			name = Sema;
+			sourceTree = "<group>";
+		};
+		BB9FD7421C10F2AA0008A1EA /* Serialization */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7431C10F2C00008A1EA /* BCReadingExtras.h */,
+				BB9FD7441C10F2C00008A1EA /* DeclTypeRecordNodes.def */,
+				BB9FD7451C10F2C00008A1EA /* ModuleFile.h */,
+				BB9FD7461C10F2C00008A1EA /* ModuleFormat.h */,
+				BB9FD7471C10F2C00008A1EA /* SerializationOptions.h */,
+				BB9FD7481C10F2C00008A1EA /* SerializedModuleLoader.h */,
+				BB9FD7491C10F2C00008A1EA /* SerializedSILLoader.h */,
+				BB9FD74A1C10F2C00008A1EA /* Validation.h */,
+			);
+			name = Serialization;
+			sourceTree = "<group>";
+		};
+		BB9FD74B1C10F2D30008A1EA /* SIL */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD74C1C10F2E70008A1EA /* AbstractionPattern.h */,
+				BB9FD74D1C10F2E70008A1EA /* BridgedTypes.def */,
+				BB9FD74E1C10F2E70008A1EA /* CFG.h */,
+				BB9FD74F1C10F2E70008A1EA /* Consumption.h */,
+				BB9FD7501C10F2E70008A1EA /* DebugUtils.h */,
+				BB9FD7511C10F2E70008A1EA /* Dominance.h */,
+				BB9FD7521C10F2E70008A1EA /* DynamicCasts.h */,
+				BB9FD7531C10F2E70008A1EA /* FormalLinkage.h */,
+				BB9FD7541C10F2E70008A1EA /* LoopInfo.h */,
+				BB9FD7551C10F2E70008A1EA /* Mangle.h */,
+				BB9FD7561C10F2E70008A1EA /* MemLocation.h */,
+				BB9FD7571C10F2E70008A1EA /* PatternMatch.h */,
+				BB9FD7581C10F2E70008A1EA /* PrettyStackTrace.h */,
+				BB9FD7591C10F2E70008A1EA /* Projection.h */,
+				BB9FD75A1C10F2E70008A1EA /* SILAllocated.h */,
+				BB9FD75B1C10F2E70008A1EA /* SILArgument.h */,
+				BB9FD75C1C10F2E70008A1EA /* SILBasicBlock.h */,
+				BB9FD75D1C10F2E70008A1EA /* SILBuilder.h */,
+				BB9FD75E1C10F2E70008A1EA /* SILCloner.h */,
+				BB9FD75F1C10F2E70008A1EA /* SILCoverageMap.h */,
+				BB9FD7601C10F2E70008A1EA /* SILDebuggerClient.h */,
+				BB9FD7611C10F2E70008A1EA /* SILDebugScope.h */,
+				BB9FD7621C10F2E70008A1EA /* SILDeclRef.h */,
+				BB9FD7631C10F2E70008A1EA /* SILExternalSource.h */,
+				BB9FD7641C10F2E70008A1EA /* SILFunction.h */,
+				BB9FD7651C10F2E70008A1EA /* SILGlobalVariable.h */,
+				BB9FD7661C10F2E70008A1EA /* SILInstruction.h */,
+				BB9FD7671C10F2E70008A1EA /* SILLinkage.h */,
+				BB9FD7681C10F2E70008A1EA /* SILLocation.h */,
+				BB9FD7691C10F2E70008A1EA /* SILModule.h */,
+				BB9FD76A1C10F2E70008A1EA /* SILNodes.def */,
+				BB9FD76B1C10F2E70008A1EA /* SILSuccessor.h */,
+				BB9FD76C1C10F2E70008A1EA /* SILType.h */,
+				BB9FD76D1C10F2E70008A1EA /* SILUndef.h */,
+				BB9FD76E1C10F2E70008A1EA /* SILValue.h */,
+				BB9FD76F1C10F2E70008A1EA /* SILVisitor.h */,
+				BB9FD7701C10F2E70008A1EA /* SILVTable.h */,
+				BB9FD7711C10F2E70008A1EA /* SILWitnessTable.h */,
+				BB9FD7721C10F2E70008A1EA /* SILWitnessVisitor.h */,
+				BB9FD7731C10F2E70008A1EA /* TypeLowering.h */,
+				BB9FD7741C10F2E70008A1EA /* TypeSubstCloner.h */,
+			);
+			name = SIL;
+			sourceTree = "<group>";
+		};
+		BB9FD7751C10F2FA0008A1EA /* SILAnalysis */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7761C10F3120008A1EA /* AliasAnalysis.h */,
+				BB9FD7771C10F3120008A1EA /* Analysis.def */,
+				BB9FD7781C10F3120008A1EA /* Analysis.h */,
+				BB9FD7791C10F3120008A1EA /* ARCAnalysis.h */,
+				BB9FD77A1C10F3120008A1EA /* ArraySemantic.h */,
+				BB9FD77B1C10F3120008A1EA /* BasicCalleeAnalysis.h */,
+				BB9FD77C1C10F3120008A1EA /* CallGraph.h */,
+				BB9FD77D1C10F3120008A1EA /* CallGraphAnalysis.h */,
+				BB9FD77E1C10F3120008A1EA /* CFG.h */,
+				BB9FD77F1C10F3120008A1EA /* ClassHierarchyAnalysis.h */,
+				BB9FD7801C10F3120008A1EA /* ColdBlockInfo.h */,
+				BB9FD7811C10F3120008A1EA /* DestructorAnalysis.h */,
+				BB9FD7821C10F3120008A1EA /* DominanceAnalysis.h */,
+				BB9FD7831C10F3120008A1EA /* EscapeAnalysis.h */,
+				BB9FD7841C10F3120008A1EA /* FunctionOrder.h */,
+				BB9FD7851C10F3120008A1EA /* IVAnalysis.h */,
+				BB9FD7861C10F3120008A1EA /* LoopAnalysis.h */,
+				BB9FD7871C10F3120008A1EA /* LoopRegionAnalysis.h */,
+				BB9FD7881C10F3120008A1EA /* PostOrderAnalysis.h */,
+				BB9FD7891C10F3120008A1EA /* RCIdentityAnalysis.h */,
+				BB9FD78A1C10F3120008A1EA /* SideEffectAnalysis.h */,
+				BB9FD78B1C10F3120008A1EA /* SimplifyInstruction.h */,
+				BB9FD78C1C10F3120008A1EA /* ValueTracking.h */,
+			);
+			name = SILAnalysis;
+			sourceTree = "<group>";
+		};
+		BB9FD78D1C10F32D0008A1EA /* SILPasses */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD78F1C10F3500008A1EA /* Passes.def */,
+				BB9FD7901C10F3500008A1EA /* Passes.h */,
+				BB9FD7911C10F3500008A1EA /* PassManager.h */,
+				BB9FD7921C10F3500008A1EA /* PrettyStackTrace.h */,
+				BB9FD7931C10F3500008A1EA /* Transforms.h */,
+				BB9FD7941C10F3500008A1EA /* Utils */,
+			);
+			name = SILPasses;
+			sourceTree = "<group>";
+		};
+		BB9FD7951C10F3660008A1EA /* SwiftDemangle */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7961C10F3780008A1EA /* MangleHack.h */,
+				BB9FD7971C10F3780008A1EA /* SwiftDemangle.h */,
+			);
+			name = SwiftDemangle;
+			sourceTree = "<group>";
+		};
+		BB9FD7981C10F3900008A1EA /* Compiler */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD8431C10F5250008A1EA /* CMakeLists.txt */,
+				BB9FD7991C10F39E0008A1EA /* AST */,
+				BB9FD7EB1C10F43F0008A1EA /* ASTSectionImporter */,
+				BB9FD7EF1C10F4590008A1EA /* Basic */,
+				BB9FD8301C10F4F60008A1EA /* ClangImporter */,
+				BB9FD8441C10F5370008A1EA /* Driver */,
+				BB9FD85D1C10F55D0008A1EA /* Frontend */,
+				BB9FD86B1C10F5970008A1EA /* IDE */,
+				BB9FD8801C10F5AE0008A1EA /* Immediate */,
+				BB9FD8871C10F5CE0008A1EA /* IRGen */,
+				BB9FD9031C10F5F90008A1EA /* LLVMPasses */,
+				BB9FD9111C10F6200008A1EA /* Markup */,
+				BB9FD9191C10F6450008A1EA /* Option */,
+				BB9FD91D1C10F65F0008A1EA /* Parse */,
+				BB9FD9351C10F6910008A1EA /* PrintAsObjC */,
+				BB9FD9391C10F6AE0008A1EA /* Sema */,
+				BB9FD9931C10F6DE0008A1EA /* Serialization */,
+				BB9FD9A61C10F6FA0008A1EA /* SIL */,
+				BB9FD9E71C10F72C0008A1EA /* SILAnalysis */,
+				BB9FDA111C10F7520008A1EA /* SILGen */,
+				BB9FDA5E1C10F7C40008A1EA /* SILPasses */,
+				BB9FDA581C10F77C0008A1EA /* SwiftDemangle */,
+			);
+			name = Compiler;
+			sourceTree = "<group>";
+		};
+		BB9FD7991C10F39E0008A1EA /* AST */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD79A1C10F3CD0008A1EA /* ArchetypeBuilder.cpp */,
+				BB9FD79B1C10F3CD0008A1EA /* ASTContext.cpp */,
+				BB9FD79C1C10F3CD0008A1EA /* ASTDumper.cpp */,
+				BB9FD79D1C10F3CD0008A1EA /* ASTNode.cpp */,
+				BB9FD79E1C10F3CD0008A1EA /* ASTPrinter.cpp */,
+				BB9FD79F1C10F3CD0008A1EA /* ASTWalker.cpp */,
+				BB9FD7A01C10F3CD0008A1EA /* Attr.cpp */,
+				BB9FD7A11C10F3CD0008A1EA /* Availability.cpp */,
+				BB9FD7A21C10F3CD0008A1EA /* AvailabilitySpec.cpp */,
+				BB9FD7A31C10F3CD0008A1EA /* Builtins.cpp */,
+				BB9FD7A41C10F3CD0008A1EA /* CaptureInfo.cpp */,
+				BB9FD7A51C10F3CD0008A1EA /* CMakeLists.txt */,
+				BB9FD7A61C10F3CD0008A1EA /* ConcreteDeclRef.cpp */,
+				BB9FD7A71C10F3CD0008A1EA /* ConformanceLookupTable.cpp */,
+				BB9FD7A81C10F3CD0008A1EA /* ConformanceLookupTable.h */,
+				BB9FD7A91C10F3CD0008A1EA /* Decl.cpp */,
+				BB9FD7AA1C10F3CD0008A1EA /* DeclContext.cpp */,
+				BB9FD7AB1C10F3CD0008A1EA /* DiagnosticEngine.cpp */,
+				BB9FD7AC1C10F3CD0008A1EA /* DiagnosticList.cpp */,
+				BB9FD7AD1C10F3CD0008A1EA /* DocComment.cpp */,
+				BB9FD7AE1C10F3CD0008A1EA /* Expr.cpp */,
+				BB9FD7AF1C10F3CD0008A1EA /* GenericSignature.cpp */,
+				BB9FD7B01C10F3CD0008A1EA /* Identifier.cpp */,
+				BB9FD7B11C10F3CD0008A1EA /* LookupVisibleDecls.cpp */,
+				BB9FD7B21C10F3CD0008A1EA /* Mangle.cpp */,
+				BB9FD7B31C10F3CD0008A1EA /* Module.cpp */,
+				BB9FD7B41C10F3CD0008A1EA /* ModuleNameLookup.cpp */,
+				BB9FD7B51C10F3CD0008A1EA /* NameLookup.cpp */,
+				BB9FD7B61C10F3CD0008A1EA /* NameLookupImpl.h */,
+				BB9FD7B71C10F3CD0008A1EA /* Pattern.cpp */,
+				BB9FD7B81C10F3CD0008A1EA /* PlatformKind.cpp */,
+				BB9FD7B91C10F3CD0008A1EA /* PrettyStackTrace.cpp */,
+				BB9FD7BA1C10F3CD0008A1EA /* ProtocolConformance.cpp */,
+				BB9FD7BB1C10F3CD0008A1EA /* RawComment.cpp */,
+				BB9FD7BC1C10F3CD0008A1EA /* Stmt.cpp */,
+				BB9FD7BD1C10F3CD0008A1EA /* Substitution.cpp */,
+				BB9FD7BE1C10F3CD0008A1EA /* Type.cpp */,
+				BB9FD7BF1C10F3CD0008A1EA /* TypeRefinementContext.cpp */,
+				BB9FD7C01C10F3CD0008A1EA /* TypeRepr.cpp */,
+				BB9FD7C11C10F3CD0008A1EA /* TypeWalker.cpp */,
+				BB9FD7C21C10F3CD0008A1EA /* USRGeneration.cpp */,
+				BB9FD7C31C10F3CD0008A1EA /* Verifier.cpp */,
+			);
+			name = AST;
+			sourceTree = "<group>";
+		};
+		BB9FD7EB1C10F43F0008A1EA /* ASTSectionImporter */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD7EC1C10F4500008A1EA /* ASTSectionImporter.cpp */,
+				BB9FD7ED1C10F4500008A1EA /* CMakeLists.txt */,
+			);
+			name = ASTSectionImporter;
+			sourceTree = "<group>";
+		};
+		BB9FD7EF1C10F4590008A1EA /* Basic */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD8271C10F48D0008A1EA /* Darwin */,
+				BB9FD8281C10F4950008A1EA /* Default */,
+				BB9FD8291C10F4A30008A1EA /* Unix */,
+				BB9FD7F01C10F4770008A1EA /* Cache.cpp */,
+				BB9FD7F11C10F4770008A1EA /* ClusteredBitVector.cpp */,
+				BB9FD7F21C10F4770008A1EA /* CMakeLists.txt */,
+				BB9FD7F31C10F4770008A1EA /* Demangle.cpp */,
+				BB9FD7F41C10F4770008A1EA /* DemangleWrappers.cpp */,
+				BB9FD7F51C10F4770008A1EA /* DiagnosticConsumer.cpp */,
+				BB9FD7F61C10F4770008A1EA /* DiverseStack.cpp */,
+				BB9FD7F71C10F4770008A1EA /* EditorPlaceholder.cpp */,
+				BB9FD7F81C10F4770008A1EA /* FileSystem.cpp */,
+				BB9FD7F91C10F4770008A1EA /* JSONSerialization.cpp */,
+				BB9FD7FA1C10F4770008A1EA /* LangOptions.cpp */,
+				BB9FD7FB1C10F4770008A1EA /* PartsOfSpeech.def */,
+				BB9FD7FC1C10F4770008A1EA /* Platform.cpp */,
+				BB9FD7FD1C10F4770008A1EA /* PrefixMap.cpp */,
+				BB9FD7FE1C10F4770008A1EA /* PrettyStackTrace.cpp */,
+				BB9FD7FF1C10F4770008A1EA /* PrimitiveParsing.cpp */,
+				BB9FD8001C10F4770008A1EA /* Program.cpp */,
+				BB9FD8011C10F4770008A1EA /* Punycode.cpp */,
+				BB9FD8021C10F4770008A1EA /* PunycodeUTF8.cpp */,
+				BB9FD8031C10F4770008A1EA /* QuotedString.cpp */,
+				BB9FD8041C10F4770008A1EA /* Remangle.cpp */,
+				BB9FD8051C10F4770008A1EA /* SourceLoc.cpp */,
+				BB9FD8061C10F4770008A1EA /* StringExtras.cpp */,
+				BB9FD8071C10F4770008A1EA /* TaskQueue.cpp */,
+				BB9FD8081C10F4770008A1EA /* ThreadSafeRefCounted.cpp */,
+				BB9FD8091C10F4770008A1EA /* Unicode.cpp */,
+				BB9FD80A1C10F4770008A1EA /* UnicodeExtendedGraphemeClusters.cpp.gyb */,
+				BB9FD80B1C10F4770008A1EA /* UUID.cpp */,
+				BB9FD80C1C10F4770008A1EA /* Version.cpp */,
+			);
+			name = Basic;
+			sourceTree = "<group>";
+		};
+		BB9FD8271C10F48D0008A1EA /* Darwin */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD82A1C10F4CA0008A1EA /* Cache-Mac.cpp */,
+			);
+			name = Darwin;
+			sourceTree = "<group>";
+		};
+		BB9FD8281C10F4950008A1EA /* Default */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD82C1C10F4D70008A1EA /* TaskQueue.inc */,
+			);
+			name = Default;
+			sourceTree = "<group>";
+		};
+		BB9FD8291C10F4A30008A1EA /* Unix */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD82E1C10F4E50008A1EA /* TaskQueue.inc */,
+			);
+			name = Unix;
+			sourceTree = "<group>";
+		};
+		BB9FD8301C10F4F60008A1EA /* ClangImporter */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD8311C10F50E0008A1EA /* CFDatabase.def */,
+				BB9FD8321C10F50E0008A1EA /* ClangDiagnosticConsumer.cpp */,
+				BB9FD8331C10F50E0008A1EA /* ClangDiagnosticConsumer.h */,
+				BB9FD8341C10F50E0008A1EA /* ClangImporter.cpp */,
+				BB9FD8351C10F50E0008A1EA /* CMakeLists.txt */,
+				BB9FD8361C10F50E0008A1EA /* ImportDecl.cpp */,
+				BB9FD8371C10F50E0008A1EA /* ImporterImpl.h */,
+				BB9FD8381C10F50E0008A1EA /* ImportMacro.cpp */,
+				BB9FD8391C10F50E0008A1EA /* ImportType.cpp */,
+				BB9FD83A1C10F50E0008A1EA /* InferredAttributes.def */,
+				BB9FD83B1C10F50E0008A1EA /* MacroTable.def */,
+				BB9FD83C1C10F50E0008A1EA /* MappedTypes.def */,
+				BB9FD83D1C10F50E0008A1EA /* SortedCFDatabase.def.gyb */,
+			);
+			name = ClangImporter;
+			sourceTree = "<group>";
+		};
+		BB9FD8441C10F5370008A1EA /* Driver */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD8451C10F54E0008A1EA /* Action.cpp */,
+				BB9FD8461C10F54E0008A1EA /* CMakeLists.txt */,
+				BB9FD8471C10F54E0008A1EA /* Compilation.cpp */,
+				BB9FD8481C10F54E0008A1EA /* DependencyGraph.cpp */,
+				BB9FD8491C10F54E0008A1EA /* Driver.cpp */,
+				BB9FD84A1C10F54E0008A1EA /* FrontendUtil.cpp */,
+				BB9FD84B1C10F54E0008A1EA /* Job.cpp */,
+				BB9FD84C1C10F54E0008A1EA /* OutputFileMap.cpp */,
+				BB9FD84D1C10F54E0008A1EA /* ParseableOutput.cpp */,
+				BB9FD84E1C10F54E0008A1EA /* ToolChain.cpp */,
+				BB9FD84F1C10F54E0008A1EA /* ToolChains.cpp */,
+				BB9FD8501C10F54E0008A1EA /* ToolChains.h */,
+				BB9FD8511C10F54E0008A1EA /* Types.cpp */,
+			);
+			name = Driver;
+			sourceTree = "<group>";
+		};
+		BB9FD85D1C10F55D0008A1EA /* Frontend */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD85E1C10F5790008A1EA /* CMakeLists.txt */,
+				BB9FD85F1C10F5790008A1EA /* CompilerInvocation.cpp */,
+				BB9FD8601C10F5790008A1EA /* DiagnosticVerifier.cpp */,
+				BB9FD8611C10F5790008A1EA /* Frontend.cpp */,
+				BB9FD8621C10F5790008A1EA /* FrontendOptions.cpp */,
+				BB9FD8631C10F5790008A1EA /* PrintingDiagnosticConsumer.cpp */,
+				BB9FD8641C10F5790008A1EA /* SerializedDiagnosticConsumer.cpp */,
+			);
+			name = Frontend;
+			sourceTree = "<group>";
+		};
+		BB9FD86B1C10F5970008A1EA /* IDE */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD86C1C10F5A40008A1EA /* CMakeLists.txt */,
+				BB9FD86D1C10F5A40008A1EA /* CodeCompletion.cpp */,
+				BB9FD86E1C10F5A40008A1EA /* CodeCompletionCache.cpp */,
+				BB9FD86F1C10F5A40008A1EA /* CodeCompletionResultBuilder.h */,
+				BB9FD8701C10F5A40008A1EA /* CommentConversion.cpp */,
+				BB9FD8711C10F5A40008A1EA /* ModuleInterfacePrinting.cpp */,
+				BB9FD8721C10F5A40008A1EA /* REPLCodeCompletion.cpp */,
+				BB9FD8731C10F5A40008A1EA /* SourceEntityWalker.cpp */,
+				BB9FD8741C10F5A40008A1EA /* SwiftSourceDocInfo.cpp */,
+				BB9FD8751C10F5A40008A1EA /* SyntaxModel.cpp */,
+				BB9FD8761C10F5A40008A1EA /* Utils.cpp */,
+			);
+			name = IDE;
+			sourceTree = "<group>";
+		};
+		BB9FD8801C10F5AE0008A1EA /* Immediate */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD8811C10F5C40008A1EA /* CMakeLists.txt */,
+				BB9FD8821C10F5C40008A1EA /* Immediate.cpp */,
+				BB9FD8831C10F5C40008A1EA /* ImmediateImpl.h */,
+				BB9FD8841C10F5C40008A1EA /* REPL.cpp */,
+			);
+			name = Immediate;
+			sourceTree = "<group>";
+		};
+		BB9FD8871C10F5CE0008A1EA /* IRGen */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD8881C10F5F10008A1EA /* Address.h */,
+				BB9FD8891C10F5F10008A1EA /* Callee.h */,
+				BB9FD88A1C10F5F10008A1EA /* CallEmission.h */,
+				BB9FD88B1C10F5F10008A1EA /* CallingConvention.h */,
+				BB9FD88C1C10F5F10008A1EA /* ClassMetadataLayout.h */,
+				BB9FD88D1C10F5F10008A1EA /* CMakeLists.txt */,
+				BB9FD88E1C10F5F10008A1EA /* DebugTypeInfo.cpp */,
+				BB9FD88F1C10F5F10008A1EA /* DebugTypeInfo.h */,
+				BB9FD8901C10F5F10008A1EA /* EnumMetadataLayout.h */,
+				BB9FD8911C10F5F10008A1EA /* EnumPayload.cpp */,
+				BB9FD8921C10F5F10008A1EA /* EnumPayload.h */,
+				BB9FD8931C10F5F10008A1EA /* Explosion.h */,
+				BB9FD8941C10F5F10008A1EA /* ExtraInhabitants.cpp */,
+				BB9FD8951C10F5F10008A1EA /* ExtraInhabitants.h */,
+				BB9FD8961C10F5F10008A1EA /* FixedTypeInfo.h */,
+				BB9FD8971C10F5F10008A1EA /* GenArchetype.cpp */,
+				BB9FD8981C10F5F10008A1EA /* GenArchetype.h */,
+				BB9FD8991C10F5F10008A1EA /* GenCast.cpp */,
+				BB9FD89A1C10F5F10008A1EA /* GenCast.h */,
+				BB9FD89B1C10F5F10008A1EA /* GenClangDecl.cpp */,
+				BB9FD89C1C10F5F10008A1EA /* GenClangType.cpp */,
+				BB9FD89D1C10F5F10008A1EA /* GenClass.cpp */,
+				BB9FD89E1C10F5F10008A1EA /* GenClass.h */,
+				BB9FD89F1C10F5F10008A1EA /* GenControl.cpp */,
+				BB9FD8A01C10F5F10008A1EA /* GenCoverage.cpp */,
+				BB9FD8A11C10F5F10008A1EA /* GenDecl.cpp */,
+				BB9FD8A21C10F5F10008A1EA /* GenEnum.cpp */,
+				BB9FD8A31C10F5F10008A1EA /* GenEnum.h */,
+				BB9FD8A41C10F5F10008A1EA /* GenExistential.cpp */,
+				BB9FD8A51C10F5F10008A1EA /* GenExistential.h */,
+				BB9FD8A61C10F5F10008A1EA /* GenFunc.cpp */,
+				BB9FD8A71C10F5F10008A1EA /* GenFunc.h */,
+				BB9FD8A81C10F5F10008A1EA /* GenHeap.cpp */,
+				BB9FD8A91C10F5F10008A1EA /* GenHeap.h */,
+				BB9FD8AA1C10F5F10008A1EA /* GenInit.cpp */,
+				BB9FD8AB1C10F5F10008A1EA /* GenMeta.cpp */,
+				BB9FD8AC1C10F5F10008A1EA /* GenMeta.h */,
+				BB9FD8AD1C10F5F10008A1EA /* GenObjC.cpp */,
+				BB9FD8AE1C10F5F10008A1EA /* GenObjC.h */,
+				BB9FD8AF1C10F5F10008A1EA /* GenOpaque.cpp */,
+				BB9FD8B01C10F5F10008A1EA /* GenOpaque.h */,
+				BB9FD8B11C10F5F10008A1EA /* GenPoly.cpp */,
+				BB9FD8B21C10F5F10008A1EA /* GenPoly.h */,
+				BB9FD8B31C10F5F10008A1EA /* GenProto.cpp */,
+				BB9FD8B41C10F5F10008A1EA /* GenProto.h */,
+				BB9FD8B51C10F5F10008A1EA /* GenSequential.h */,
+				BB9FD8B61C10F5F10008A1EA /* GenStruct.cpp */,
+				BB9FD8B71C10F5F10008A1EA /* GenStruct.h */,
+				BB9FD8B81C10F5F10008A1EA /* GenTuple.cpp */,
+				BB9FD8B91C10F5F10008A1EA /* GenTuple.h */,
+				BB9FD8BA1C10F5F10008A1EA /* GenType.cpp */,
+				BB9FD8BB1C10F5F10008A1EA /* GenType.h */,
+				BB9FD8BC1C10F5F10008A1EA /* HeapTypeInfo.h */,
+				BB9FD8BD1C10F5F10008A1EA /* IndirectTypeInfo.h */,
+				BB9FD8BE1C10F5F10008A1EA /* IRBuilder.h */,
+				BB9FD8BF1C10F5F10008A1EA /* IRGen.cpp */,
+				BB9FD8C01C10F5F10008A1EA /* IRGen.h */,
+				BB9FD8C11C10F5F10008A1EA /* IRGenDebugInfo.cpp */,
+				BB9FD8C21C10F5F10008A1EA /* IRGenDebugInfo.h */,
+				BB9FD8C31C10F5F10008A1EA /* IRGenFunction.cpp */,
+				BB9FD8C41C10F5F10008A1EA /* IRGenFunction.h */,
+				BB9FD8C51C10F5F10008A1EA /* IRGenModule.cpp */,
+				BB9FD8C61C10F5F10008A1EA /* IRGenModule.h */,
+				BB9FD8C71C10F5F10008A1EA /* IRGenSIL.cpp */,
+				BB9FD8C81C10F5F10008A1EA /* Linking.cpp */,
+				BB9FD8C91C10F5F10008A1EA /* Linking.h */,
+				BB9FD8CA1C10F5F10008A1EA /* LoadableTypeInfo.h */,
+				BB9FD8CB1C10F5F10008A1EA /* MetadataLayout.h */,
+				BB9FD8CC1C10F5F10008A1EA /* MetadataPath.h */,
+				BB9FD8CD1C10F5F10008A1EA /* NecessaryBindings.h */,
+				BB9FD8CE1C10F5F10008A1EA /* NonFixedTypeInfo.h */,
+				BB9FD8CF1C10F5F10008A1EA /* ProtocolInfo.h */,
+				BB9FD8D01C10F5F10008A1EA /* ReferenceTypeInfo.h */,
+				BB9FD8D11C10F5F10008A1EA /* ResilientTypeInfo.h */,
+				BB9FD8D21C10F5F10008A1EA /* RuntimeFunctions.def */,
+				BB9FD8D31C10F5F10008A1EA /* ScalarTypeInfo.h */,
+				BB9FD8D41C10F5F10008A1EA /* StructLayout.cpp */,
+				BB9FD8D51C10F5F10008A1EA /* StructLayout.h */,
+				BB9FD8D61C10F5F10008A1EA /* StructMetadataLayout.h */,
+				BB9FD8D71C10F5F10008A1EA /* SwiftTargetInfo.cpp */,
+				BB9FD8D81C10F5F10008A1EA /* SwiftTargetInfo.h */,
+				BB9FD8D91C10F5F10008A1EA /* TypeInfo.h */,
+				BB9FD8DA1C10F5F10008A1EA /* TypeLayoutVerifier.cpp */,
+				BB9FD8DB1C10F5F10008A1EA /* TypeVisitor.h */,
+				BB9FD8DC1C10F5F20008A1EA /* UnimplementedTypeInfo.cpp */,
+				BB9FD8DD1C10F5F20008A1EA /* UnimplementedTypeInfo.h */,
+				BB9FD8DE1C10F5F20008A1EA /* UnownedTypeInfo.h */,
+				BB9FD8DF1C10F5F20008A1EA /* ValueWitness.h */,
+				BB9FD8E01C10F5F20008A1EA /* WeakTypeInfo.h */,
+			);
+			name = IRGen;
+			sourceTree = "<group>";
+		};
+		BB9FD9031C10F5F90008A1EA /* LLVMPasses */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD9041C10F60D0008A1EA /* ARCEntryPointBuilder.h */,
+				BB9FD9051C10F60D0008A1EA /* CMakeLists.txt */,
+				BB9FD9061C10F60D0008A1EA /* LLVMARCContract.cpp */,
+				BB9FD9071C10F60D0008A1EA /* LLVMARCOpts.cpp */,
+				BB9FD9081C10F60D0008A1EA /* LLVMARCOpts.h */,
+				BB9FD9091C10F60D0008A1EA /* LLVMStackPromotion.cpp */,
+				BB9FD90A1C10F60D0008A1EA /* LLVMSwiftAA.cpp */,
+				BB9FD90B1C10F60D0008A1EA /* LLVMSwiftRCIdentity.cpp */,
+			);
+			name = LLVMPasses;
+			sourceTree = "<group>";
+		};
+		BB9FD9111C10F6200008A1EA /* Markup */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD9121C10F6360008A1EA /* AST.cpp */,
+				BB9FD9131C10F6360008A1EA /* CMakeLists.txt */,
+				BB9FD9141C10F6360008A1EA /* LineList.cpp */,
+				BB9FD9151C10F6360008A1EA /* Markup.cpp */,
+			);
+			name = Markup;
+			sourceTree = "<group>";
+		};
+		BB9FD9191C10F6450008A1EA /* Option */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD91A1C10F6580008A1EA /* CMakeLists.txt */,
+				BB9FD91B1C10F6580008A1EA /* Options.cpp */,
+			);
+			name = Option;
+			sourceTree = "<group>";
+		};
+		BB9FD91D1C10F65F0008A1EA /* Parse */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD91E1C10F67C0008A1EA /* CMakeLists.txt */,
+				BB9FD91F1C10F67C0008A1EA /* Lexer.cpp */,
+				BB9FD9201C10F67C0008A1EA /* ParseDecl.cpp */,
+				BB9FD9211C10F67C0008A1EA /* ParseExpr.cpp */,
+				BB9FD9221C10F67C0008A1EA /* ParseGeneric.cpp */,
+				BB9FD9231C10F67C0008A1EA /* ParsePattern.cpp */,
+				BB9FD9241C10F67C0008A1EA /* Parser.cpp */,
+				BB9FD9251C10F67C0008A1EA /* ParseSIL.cpp */,
+				BB9FD9261C10F67C0008A1EA /* ParseStmt.cpp */,
+				BB9FD9271C10F67C0008A1EA /* ParseType.cpp */,
+				BB9FD9281C10F67C0008A1EA /* PersistentParserState.cpp */,
+				BB9FD9291C10F67C0008A1EA /* Scope.cpp */,
+			);
+			name = Parse;
+			sourceTree = "<group>";
+		};
+		BB9FD9351C10F6910008A1EA /* PrintAsObjC */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD9361C10F6A50008A1EA /* CMakeLists.txt */,
+				BB9FD9371C10F6A50008A1EA /* PrintAsObjC.cpp */,
+			);
+			name = PrintAsObjC;
+			sourceTree = "<group>";
+		};
+		BB9FD9391C10F6AE0008A1EA /* Sema */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD93A1C10F6CE0008A1EA /* CMakeLists.txt */,
+				BB9FD93B1C10F6CE0008A1EA /* CodeSynthesis.cpp */,
+				BB9FD93C1C10F6CE0008A1EA /* CodeSynthesis.h */,
+				BB9FD93D1C10F6CE0008A1EA /* Constraint.cpp */,
+				BB9FD93E1C10F6CE0008A1EA /* Constraint.h */,
+				BB9FD93F1C10F6CE0008A1EA /* ConstraintGraph.cpp */,
+				BB9FD9401C10F6CE0008A1EA /* ConstraintGraph.h */,
+				BB9FD9411C10F6CE0008A1EA /* ConstraintGraphScope.h */,
+				BB9FD9421C10F6CE0008A1EA /* ConstraintLocator.cpp */,
+				BB9FD9431C10F6CE0008A1EA /* ConstraintLocator.h */,
+				BB9FD9441C10F6CE0008A1EA /* ConstraintSolverStats.def */,
+				BB9FD9451C10F6CE0008A1EA /* ConstraintSystem.cpp */,
+				BB9FD9461C10F6CE0008A1EA /* ConstraintSystem.h */,
+				BB9FD9471C10F6CE0008A1EA /* CSApply.cpp */,
+				BB9FD9481C10F6CE0008A1EA /* CSDiag.cpp */,
+				BB9FD9491C10F6CE0008A1EA /* CSGen.cpp */,
+				BB9FD94A1C10F6CE0008A1EA /* CSRanking.cpp */,
+				BB9FD94B1C10F6CE0008A1EA /* CSSimplify.cpp */,
+				BB9FD94C1C10F6CE0008A1EA /* CSSolver.cpp */,
+				BB9FD94D1C10F6CE0008A1EA /* DerivedConformanceEquatableHashable.cpp */,
+				BB9FD94E1C10F6CE0008A1EA /* DerivedConformanceErrorType.cpp */,
+				BB9FD94F1C10F6CE0008A1EA /* DerivedConformanceRawRepresentable.cpp */,
+				BB9FD9501C10F6CE0008A1EA /* DerivedConformances.cpp */,
+				BB9FD9511C10F6CE0008A1EA /* DerivedConformances.h */,
+				BB9FD9521C10F6CE0008A1EA /* GenericTypeResolver.h */,
+				BB9FD9531C10F6CE0008A1EA /* ITCDecl.cpp */,
+				BB9FD9541C10F6CE0008A1EA /* ITCNameLookup.cpp */,
+				BB9FD9551C10F6CE0008A1EA /* ITCType.cpp */,
+				BB9FD9561C10F6CE0008A1EA /* IterativeTypeChecker.cpp */,
+				BB9FD9571C10F6CE0008A1EA /* MiscDiagnostics.cpp */,
+				BB9FD9581C10F6CE0008A1EA /* MiscDiagnostics.h */,
+				BB9FD9591C10F6CE0008A1EA /* NameBinding.cpp */,
+				BB9FD95A1C10F6CE0008A1EA /* OverloadChoice.cpp */,
+				BB9FD95B1C10F6CE0008A1EA /* OverloadChoice.h */,
+				BB9FD95C1C10F6CE0008A1EA /* PlaygroundTransform.cpp */,
+				BB9FD95D1C10F6CE0008A1EA /* SourceLoader.cpp */,
+				BB9FD95E1C10F6CE0008A1EA /* TypeCheckAttr.cpp */,
+				BB9FD95F1C10F6CE0008A1EA /* TypeCheckConstraints.cpp */,
+				BB9FD9601C10F6CE0008A1EA /* TypeCheckDecl.cpp */,
+				BB9FD9611C10F6CE0008A1EA /* TypeChecker.cpp */,
+				BB9FD9621C10F6CE0008A1EA /* TypeChecker.h */,
+				BB9FD9631C10F6CE0008A1EA /* TypeCheckError.cpp */,
+				BB9FD9641C10F6CE0008A1EA /* TypeCheckExpr.cpp */,
+				BB9FD9651C10F6CE0008A1EA /* TypeCheckGeneric.cpp */,
+				BB9FD9661C10F6CE0008A1EA /* TypeCheckNameLookup.cpp */,
+				BB9FD9671C10F6CE0008A1EA /* TypeCheckPattern.cpp */,
+				BB9FD9681C10F6CE0008A1EA /* TypeCheckProtocol.cpp */,
+				BB9FD9691C10F6CE0008A1EA /* TypeCheckREPL.cpp */,
+				BB9FD96A1C10F6CE0008A1EA /* TypeCheckRequest.cpp */,
+				BB9FD96B1C10F6CE0008A1EA /* TypeCheckStmt.cpp */,
+				BB9FD96C1C10F6CE0008A1EA /* TypeCheckType.cpp */,
+			);
+			name = Sema;
+			sourceTree = "<group>";
+		};
+		BB9FD9931C10F6DE0008A1EA /* Serialization */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD9941C10F6F10008A1EA /* CMakeLists.txt */,
+				BB9FD9951C10F6F10008A1EA /* Deserialization.cpp */,
+				BB9FD9961C10F6F10008A1EA /* DeserializeSIL.cpp */,
+				BB9FD9971C10F6F10008A1EA /* DeserializeSIL.h */,
+				BB9FD9981C10F6F10008A1EA /* ModuleFile.cpp */,
+				BB9FD9991C10F6F10008A1EA /* Serialization.cpp */,
+				BB9FD99A1C10F6F10008A1EA /* Serialization.h */,
+				BB9FD99B1C10F6F10008A1EA /* SerializedModuleLoader.cpp */,
+				BB9FD99C1C10F6F10008A1EA /* SerializedSILLoader.cpp */,
+				BB9FD99D1C10F6F10008A1EA /* SerializeSIL.cpp */,
+				BB9FD99E1C10F6F10008A1EA /* SILFormat.h */,
+			);
+			name = Serialization;
+			sourceTree = "<group>";
+		};
+		BB9FD9A61C10F6FA0008A1EA /* SIL */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD9A71C10F7110008A1EA /* AbstractionPattern.cpp */,
+				BB9FD9A81C10F7110008A1EA /* Bridging.cpp */,
+				BB9FD9A91C10F7110008A1EA /* CMakeLists.txt */,
+				BB9FD9AA1C10F7110008A1EA /* Dominance.cpp */,
+				BB9FD9AB1C10F7110008A1EA /* DynamicCasts.cpp */,
+				BB9FD9AC1C10F7110008A1EA /* Linker.cpp */,
+				BB9FD9AD1C10F7110008A1EA /* Linker.h */,
+				BB9FD9AE1C10F7110008A1EA /* LoopInfo.cpp */,
+				BB9FD9AF1C10F7110008A1EA /* Mangle.cpp */,
+				BB9FD9B01C10F7110008A1EA /* MemLocation.cpp */,
+				BB9FD9B11C10F7110008A1EA /* PrettyStackTrace.cpp */,
+				BB9FD9B21C10F7110008A1EA /* Projection.cpp */,
+				BB9FD9B31C10F7110008A1EA /* SIL.cpp */,
+				BB9FD9B41C10F7110008A1EA /* SILArgument.cpp */,
+				BB9FD9B51C10F7110008A1EA /* SILBasicBlock.cpp */,
+				BB9FD9B61C10F7110008A1EA /* SILBuilder.cpp */,
+				BB9FD9B71C10F7110008A1EA /* SILCoverageMap.cpp */,
+				BB9FD9B81C10F7110008A1EA /* SILDeclRef.cpp */,
+				BB9FD9B91C10F7110008A1EA /* SILFunction.cpp */,
+				BB9FD9BA1C10F7110008A1EA /* SILFunctionType.cpp */,
+				BB9FD9BB1C10F7110008A1EA /* SILGlobalVariable.cpp */,
+				BB9FD9BC1C10F7110008A1EA /* SILInstruction.cpp */,
+				BB9FD9BD1C10F7110008A1EA /* SILInstructions.cpp */,
+				BB9FD9BE1C10F7110008A1EA /* SILLocation.cpp */,
+				BB9FD9BF1C10F7110008A1EA /* SILModule.cpp */,
+				BB9FD9C01C10F7110008A1EA /* SILPrinter.cpp */,
+				BB9FD9C11C10F7110008A1EA /* SILSuccessor.cpp */,
+				BB9FD9C21C10F7110008A1EA /* SILType.cpp */,
+				BB9FD9C31C10F7110008A1EA /* SILValue.cpp */,
+				BB9FD9C41C10F7110008A1EA /* SILVTable.cpp */,
+				BB9FD9C51C10F7110008A1EA /* SILWitnessTable.cpp */,
+				BB9FD9C61C10F7110008A1EA /* TypeLowering.cpp */,
+				BB9FD9C71C10F7110008A1EA /* Verifier.cpp */,
+			);
+			name = SIL;
+			sourceTree = "<group>";
+		};
+		BB9FD9E71C10F72C0008A1EA /* SILAnalysis */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FD9E81C10F7490008A1EA /* AliasAnalysis.cpp */,
+				BB9FD9E91C10F7490008A1EA /* Analysis.cpp */,
+				BB9FD9EA1C10F7490008A1EA /* ARCAnalysis.cpp */,
+				BB9FD9EB1C10F7490008A1EA /* ArraySemantic.cpp */,
+				BB9FD9EC1C10F7490008A1EA /* BasicCalleeAnalysis.cpp */,
+				BB9FD9ED1C10F7490008A1EA /* CallGraph.cpp */,
+				BB9FD9EE1C10F7490008A1EA /* CFG.cpp */,
+				BB9FD9EF1C10F7490008A1EA /* ClassHierarchyAnalysis.cpp */,
+				BB9FD9F01C10F7490008A1EA /* CMakeLists.txt */,
+				BB9FD9F11C10F7490008A1EA /* ColdBlockInfo.cpp */,
+				BB9FD9F21C10F7490008A1EA /* DestructorAnalysis.cpp */,
+				BB9FD9F31C10F7490008A1EA /* EscapeAnalysis.cpp */,
+				BB9FD9F41C10F7490008A1EA /* FunctionOrder.cpp */,
+				BB9FD9F51C10F7490008A1EA /* IVAnalysis.cpp */,
+				BB9FD9F61C10F7490008A1EA /* LoopAnalysis.cpp */,
+				BB9FD9F71C10F7490008A1EA /* LoopRegionAnalysis.cpp */,
+				BB9FD9F81C10F7490008A1EA /* MemoryBehavior.cpp */,
+				BB9FD9F91C10F7490008A1EA /* RCIdentityAnalysis.cpp */,
+				BB9FD9FA1C10F7490008A1EA /* SideEffectAnalysis.cpp */,
+				BB9FD9FB1C10F7490008A1EA /* SimplifyInstruction.cpp */,
+				BB9FD9FC1C10F7490008A1EA /* ValueTracking.cpp */,
+			);
+			name = SILAnalysis;
+			sourceTree = "<group>";
+		};
+		BB9FDA111C10F7520008A1EA /* SILGen */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDA121C10F76B0008A1EA /* ArgumentSource.cpp */,
+				BB9FDA131C10F76B0008A1EA /* ArgumentSource.h */,
+				BB9FDA141C10F76B0008A1EA /* ASTVisitor.h */,
+				BB9FDA151C10F76B0008A1EA /* Cleanup.cpp */,
+				BB9FDA161C10F76B0008A1EA /* Cleanup.h */,
+				BB9FDA171C10F76B0008A1EA /* CMakeLists.txt */,
+				BB9FDA181C10F76B0008A1EA /* Condition.cpp */,
+				BB9FDA191C10F76B0008A1EA /* Condition.h */,
+				BB9FDA1A1C10F76B0008A1EA /* ExitableFullExpr.h */,
+				BB9FDA1B1C10F76B0008A1EA /* Initialization.h */,
+				BB9FDA1C1C10F76B0008A1EA /* JumpDest.h */,
+				BB9FDA1D1C10F76B0008A1EA /* LValue.h */,
+				BB9FDA1E1C10F76B0008A1EA /* ManagedValue.cpp */,
+				BB9FDA1F1C10F76B0008A1EA /* ManagedValue.h */,
+				BB9FDA201C10F76B0008A1EA /* RValue.cpp */,
+				BB9FDA211C10F76B0008A1EA /* RValue.h */,
+				BB9FDA221C10F76B0008A1EA /* Scope.h */,
+				BB9FDA231C10F76B0008A1EA /* SILGen.cpp */,
+				BB9FDA241C10F76B0008A1EA /* SILGen.h */,
+				BB9FDA251C10F76B0008A1EA /* SILGenApply.cpp */,
+				BB9FDA261C10F76B0008A1EA /* SILGenBridging.cpp */,
+				BB9FDA271C10F76B0008A1EA /* SILGenBuiltin.cpp */,
+				BB9FDA281C10F76B0008A1EA /* SILGenConstructor.cpp */,
+				BB9FDA291C10F76B0008A1EA /* SILGenConvert.cpp */,
+				BB9FDA2A1C10F76B0008A1EA /* SILGenDecl.cpp */,
+				BB9FDA2B1C10F76B0008A1EA /* SILGenDestructor.cpp */,
+				BB9FDA2C1C10F76B0008A1EA /* SILGenDynamicCast.cpp */,
+				BB9FDA2D1C10F76B0008A1EA /* SILGenDynamicCast.h */,
+				BB9FDA2E1C10F76B0008A1EA /* SILGenEpilog.cpp */,
+				BB9FDA2F1C10F76B0008A1EA /* SILGenExpr.cpp */,
+				BB9FDA301C10F76B0008A1EA /* SILGenForeignError.cpp */,
+				BB9FDA311C10F76B0008A1EA /* SILGenFunction.cpp */,
+				BB9FDA321C10F76B0008A1EA /* SILGenFunction.h */,
+				BB9FDA331C10F76B0008A1EA /* SILGenGlobalVariable.cpp */,
+				BB9FDA341C10F76B0008A1EA /* SILGenLValue.cpp */,
+				BB9FDA351C10F76B0008A1EA /* SILGenPattern.cpp */,
+				BB9FDA361C10F76B0008A1EA /* SILGenPoly.cpp */,
+				BB9FDA371C10F76B0008A1EA /* SILGenProfiling.cpp */,
+				BB9FDA381C10F76B0008A1EA /* SILGenProfiling.h */,
+				BB9FDA391C10F76B0008A1EA /* SILGenProlog.cpp */,
+				BB9FDA3A1C10F76B0008A1EA /* SILGenStmt.cpp */,
+				BB9FDA3B1C10F76B0008A1EA /* SILGenType.cpp */,
+				BB9FDA3C1C10F76B0008A1EA /* SpecializedEmitter.h */,
+				BB9FDA3D1C10F76B0008A1EA /* Varargs.h */,
+			);
+			name = SILGen;
+			sourceTree = "<group>";
+		};
+		BB9FDA581C10F77C0008A1EA /* SwiftDemangle */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDA591C10F7B90008A1EA /* CMakeLists.txt */,
+				BB9FDA5A1C10F7B90008A1EA /* MangleHack.cpp */,
+				BB9FDA5B1C10F7B90008A1EA /* SwiftDemangle.cpp */,
+			);
+			name = SwiftDemangle;
+			sourceTree = "<group>";
+		};
+		BB9FDA5E1C10F7C40008A1EA /* SILPasses */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDA8F1C10F81E0008A1EA /* CMakeLists.txt */,
+				BB9FDA7C1C10F7F50008A1EA /* EarlySIL */,
+				BB9FDA5F1C10F7D20008A1EA /* ARC */,
+				BB9FDA901C10F8390008A1EA /* IPO */,
+				BB9FDAA81C10F8560008A1EA /* Loop */,
+				BB9FDAB21C10F8730008A1EA /* PassManager */,
+				BB9FDABA1C10F89F0008A1EA /* Scalar */,
+				BB9FDAE61C10F8C40008A1EA /* SILCombiner */,
+				BB9FDAF31C10F8E30008A1EA /* UtilityPasses */,
+				BB9FDB131C10F9060008A1EA /* Utils */,
+			);
+			name = SILPasses;
+			sourceTree = "<group>";
+		};
+		BB9FDA5F1C10F7D20008A1EA /* ARC */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDA601C10F7F00008A1EA /* ARCBBState.cpp */,
+				BB9FDA611C10F7F00008A1EA /* ARCBBState.h */,
+				BB9FDA621C10F7F00008A1EA /* ARCRegionState.cpp */,
+				BB9FDA631C10F7F00008A1EA /* ARCRegionState.h */,
+				BB9FDA641C10F7F00008A1EA /* ARCSequenceOpts.cpp */,
+				BB9FDA651C10F7F00008A1EA /* CMakeLists.txt */,
+				BB9FDA661C10F7F00008A1EA /* GlobalARCPairingAnalysis.cpp */,
+				BB9FDA671C10F7F00008A1EA /* GlobalARCPairingAnalysis.h */,
+				BB9FDA681C10F7F00008A1EA /* GlobalARCSequenceDataflow.cpp */,
+				BB9FDA691C10F7F00008A1EA /* GlobalARCSequenceDataflow.h */,
+				BB9FDA6A1C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.cpp */,
+				BB9FDA6B1C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.h */,
+				BB9FDA6C1C10F7F00008A1EA /* RCStateTransition.cpp */,
+				BB9FDA6D1C10F7F00008A1EA /* RCStateTransition.def */,
+				BB9FDA6E1C10F7F00008A1EA /* RCStateTransition.h */,
+				BB9FDA6F1C10F7F00008A1EA /* RCStateTransitionVisitors.cpp */,
+				BB9FDA701C10F7F00008A1EA /* RCStateTransitionVisitors.h */,
+				BB9FDA711C10F7F00008A1EA /* RefCountState.cpp */,
+				BB9FDA721C10F7F00008A1EA /* RefCountState.h */,
+			);
+			name = ARC;
+			sourceTree = "<group>";
+		};
+		BB9FDA7C1C10F7F50008A1EA /* EarlySIL */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDA7D1C10F8110008A1EA /* CMakeLists.txt */,
+				BB9FDA7E1C10F8110008A1EA /* ConstantPropagation.cpp */,
+				BB9FDA7F1C10F8110008A1EA /* DataflowDiagnostics.cpp */,
+				BB9FDA801C10F8110008A1EA /* DefiniteInitialization.cpp */,
+				BB9FDA811C10F8110008A1EA /* DiagnoseUnreachable.cpp */,
+				BB9FDA821C10F8110008A1EA /* DIMemoryUseCollector.cpp */,
+				BB9FDA831C10F8110008A1EA /* DIMemoryUseCollector.h */,
+				BB9FDA841C10F8110008A1EA /* InOutDeshadowing.cpp */,
+				BB9FDA851C10F8110008A1EA /* MandatoryInlining.cpp */,
+				BB9FDA861C10F8110008A1EA /* PredictableMemOpt.cpp */,
+			);
+			name = EarlySIL;
+			sourceTree = "<group>";
+		};
+		BB9FDA901C10F8390008A1EA /* IPO */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDA911C10F84F0008A1EA /* CapturePromotion.cpp */,
+				BB9FDA921C10F84F0008A1EA /* CapturePropagation.cpp */,
+				BB9FDA931C10F84F0008A1EA /* ClosureSpecializer.cpp */,
+				BB9FDA941C10F84F0008A1EA /* CMakeLists.txt */,
+				BB9FDA951C10F84F0008A1EA /* DeadFunctionElimination.cpp */,
+				BB9FDA961C10F84F0008A1EA /* ExternalDefsToDecls.cpp */,
+				BB9FDA971C10F84F0008A1EA /* FunctionSignatureOpts.cpp */,
+				BB9FDA981C10F84F0008A1EA /* GlobalOpt.cpp */,
+				BB9FDA991C10F84F0008A1EA /* GlobalPropertyOpt.cpp */,
+				BB9FDA9A1C10F84F0008A1EA /* LetPropertiesOpts.cpp */,
+				BB9FDA9B1C10F84F0008A1EA /* PerformanceInliner.cpp */,
+				BB9FDA9C1C10F84F0008A1EA /* UsePrespecialized.cpp */,
+			);
+			name = IPO;
+			sourceTree = "<group>";
+		};
+		BB9FDAA81C10F8560008A1EA /* Loop */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDAA91C10F86C0008A1EA /* ArrayBoundsCheckOpts.cpp */,
+				BB9FDAAA1C10F86C0008A1EA /* CMakeLists.txt */,
+				BB9FDAAB1C10F86C0008A1EA /* COWArrayOpt.cpp */,
+				BB9FDAAC1C10F86C0008A1EA /* LICM.cpp */,
+				BB9FDAAD1C10F86C0008A1EA /* LoopRotate.cpp */,
+			);
+			name = Loop;
+			sourceTree = "<group>";
+		};
+		BB9FDAB21C10F8730008A1EA /* PassManager */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDAB31C10F8980008A1EA /* CMakeLists.txt */,
+				BB9FDAB41C10F8980008A1EA /* Passes.cpp */,
+				BB9FDAB51C10F8980008A1EA /* PassManager.cpp */,
+				BB9FDAB61C10F8980008A1EA /* PrettyStackTrace.cpp */,
+			);
+			name = PassManager;
+			sourceTree = "<group>";
+		};
+		BB9FDABA1C10F89F0008A1EA /* Scalar */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDABB1C10F8B40008A1EA /* AllocBoxToStack.cpp */,
+				BB9FDABC1C10F8B40008A1EA /* ArrayCountPropagation.cpp */,
+				BB9FDABD1C10F8B40008A1EA /* CMakeLists.txt */,
+				BB9FDABE1C10F8B40008A1EA /* CopyForwarding.cpp */,
+				BB9FDABF1C10F8B40008A1EA /* CSE.cpp */,
+				BB9FDAC01C10F8B40008A1EA /* DeadCodeElimination.cpp */,
+				BB9FDAC11C10F8B40008A1EA /* DeadObjectElimination.cpp */,
+				BB9FDAC21C10F8B40008A1EA /* DeadStoreElimination.cpp */,
+				BB9FDAC31C10F8B40008A1EA /* MergeCondFail.cpp */,
+				BB9FDAC41C10F8B40008A1EA /* RedundantLoadElimination.cpp */,
+				BB9FDAC51C10F8B40008A1EA /* RedundantOverflowCheckRemoval.cpp */,
+				BB9FDAC61C10F8B40008A1EA /* ReleaseDevirtualizer.cpp */,
+				BB9FDAC71C10F8B40008A1EA /* RemovePin.cpp */,
+				BB9FDAC81C10F8B40008A1EA /* SILCleanup.cpp */,
+				BB9FDAC91C10F8B40008A1EA /* SILCodeMotion.cpp */,
+				BB9FDACA1C10F8B40008A1EA /* SILLowerAggregateInstrs.cpp */,
+				BB9FDACB1C10F8B40008A1EA /* SILMem2Reg.cpp */,
+				BB9FDACC1C10F8B40008A1EA /* SILSROA.cpp */,
+				BB9FDACD1C10F8B40008A1EA /* SimplifyCFG.cpp */,
+				BB9FDACE1C10F8B40008A1EA /* Sink.cpp */,
+				BB9FDACF1C10F8B40008A1EA /* SpeculativeDevirtualizer.cpp */,
+				BB9FDAD01C10F8B40008A1EA /* StackPromotion.cpp */,
+			);
+			name = Scalar;
+			sourceTree = "<group>";
+		};
+		BB9FDAE61C10F8C40008A1EA /* SILCombiner */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDAE71C10F8D90008A1EA /* CMakeLists.txt */,
+				BB9FDAE81C10F8D90008A1EA /* SILCombine.cpp */,
+				BB9FDAE91C10F8D90008A1EA /* SILCombiner.h */,
+				BB9FDAEA1C10F8D90008A1EA /* SILCombinerApplyVisitors.cpp */,
+				BB9FDAEB1C10F8D90008A1EA /* SILCombinerBuiltinVisitors.cpp */,
+				BB9FDAEC1C10F8D90008A1EA /* SILCombinerCastVisitors.cpp */,
+				BB9FDAED1C10F8D90008A1EA /* SILCombinerMiscVisitors.cpp */,
+			);
+			name = SILCombiner;
+			sourceTree = "<group>";
+		};
+		BB9FDAF31C10F8E30008A1EA /* UtilityPasses */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDAF41C10F8FC0008A1EA /* AADumper.cpp */,
+				BB9FDAF51C10F8FC0008A1EA /* BasicCalleePrinter.cpp */,
+				BB9FDAF61C10F8FC0008A1EA /* CallGraphPrinter.cpp */,
+				BB9FDAF71C10F8FC0008A1EA /* CFGPrinter.cpp */,
+				BB9FDAF81C10F8FC0008A1EA /* CMakeLists.txt */,
+				BB9FDAF91C10F8FC0008A1EA /* FunctionOrderPrinter.cpp */,
+				BB9FDAFA1C10F8FC0008A1EA /* InstCount.cpp */,
+				BB9FDAFB1C10F8FC0008A1EA /* IVInfoPrinter.cpp */,
+				BB9FDAFC1C10F8FC0008A1EA /* Link.cpp */,
+				BB9FDAFD1C10F8FC0008A1EA /* LoopCanonicalizer.cpp */,
+				BB9FDAFE1C10F8FC0008A1EA /* LoopInfoPrinter.cpp */,
+				BB9FDAFF1C10F8FC0008A1EA /* LoopRegionPrinter.cpp */,
+				BB9FDB001C10F8FC0008A1EA /* MemLocationPrinter.cpp */,
+				BB9FDB011C10F8FC0008A1EA /* StripDebugInfo.cpp */,
+				BB9FDB021C10F8FC0008A1EA /* UpdateEscapeAnalysis.cpp */,
+				BB9FDB031C10F8FC0008A1EA /* UpdateSideEffects.cpp */,
+			);
+			name = UtilityPasses;
+			sourceTree = "<group>";
+		};
+		BB9FDB131C10F9060008A1EA /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				BB9FDB141C10F9200008A1EA /* CFG.cpp */,
+				BB9FDB151C10F9200008A1EA /* CheckedCastBrJumpThreading.cpp */,
+				BB9FDB161C10F9200008A1EA /* CMakeLists.txt */,
+				BB9FDB171C10F9200008A1EA /* ConstantFolding.cpp */,
+				BB9FDB181C10F9200008A1EA /* Devirtualize.cpp */,
+				BB9FDB191C10F9200008A1EA /* GenericCloner.cpp */,
+				BB9FDB1A1C10F9200008A1EA /* Generics.cpp */,
+				BB9FDB1B1C10F9200008A1EA /* Local.cpp */,
+				BB9FDB1C1C10F9200008A1EA /* LoopUtils.cpp */,
+				BB9FDB1D1C10F9200008A1EA /* SILInliner.cpp */,
+				BB9FDB1E1C10F9200008A1EA /* SILSSAUpdater.cpp */,
+			);
+			name = Utils;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BB9FD63F1C10EF850008A1EA /* swift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BB9FD6471C10EF850008A1EA /* Build configuration list for PBXNativeTarget "swift" */;
+			buildPhases = (
+				BB9FD63C1C10EF850008A1EA /* Sources */,
+				BB9FD63D1C10EF850008A1EA /* Frameworks */,
+				BB9FD63E1C10EF850008A1EA /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = swift;
+			productName = swift;
+			productReference = BB9FD6401C10EF850008A1EA /* swift */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		BB9FD6381C10EF850008A1EA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = "John Holdsworth";
+				TargetAttributes = {
+					BB9FD63F1C10EF850008A1EA = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+				};
+			};
+			buildConfigurationList = BB9FD63B1C10EF850008A1EA /* Build configuration list for PBXProject "sourceview" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = BB9FD6371C10EF850008A1EA;
+			productRefGroup = BB9FD6411C10EF850008A1EA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BB9FD63F1C10EF850008A1EA /* swift */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BB9FD63C1C10EF850008A1EA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB9FDAD81C10F8B40008A1EA /* MergeCondFail.cpp in Sources */,
+				BB8B29FC1C124A6500C91975 /* GlobalObjects.cpp in Sources */,
+				BB9FD92F1C10F67C0008A1EA /* Parser.cpp in Sources */,
+				BB9FD8EF1C10F5F20008A1EA /* GenHeap.cpp in Sources */,
+				BB9FD9FF1C10F7490008A1EA /* ARCAnalysis.cpp in Sources */,
+				BB9FD8571C10F54E0008A1EA /* Job.cpp in Sources */,
+				BB9FD8251C10F4770008A1EA /* UUID.cpp in Sources */,
+				BB9FDAD71C10F8B40008A1EA /* DeadStoreElimination.cpp in Sources */,
+				BB9FD96E1C10F6CE0008A1EA /* Constraint.cpp in Sources */,
+				BB9FDAD61C10F8B40008A1EA /* DeadObjectElimination.cpp in Sources */,
+				BB9FD9E31C10F7110008A1EA /* SILVTable.cpp in Sources */,
+				BB9FD8F61C10F5F20008A1EA /* GenStruct.cpp in Sources */,
+				BB9FD9821C10F6CE0008A1EA /* OverloadChoice.cpp in Sources */,
+				BB9FDA491C10F76B0008A1EA /* SILGenDecl.cpp in Sources */,
+				BB9FDAD21C10F8B40008A1EA /* ArrayCountPropagation.cpp in Sources */,
+				BB9FDA0E1C10F7490008A1EA /* SideEffectAnalysis.cpp in Sources */,
+				BB9FDA4F1C10F76B0008A1EA /* SILGenFunction.cpp in Sources */,
+				BB9FDB0D1C10F8FC0008A1EA /* LoopInfoPrinter.cpp in Sources */,
+				BB9FD9871C10F6CE0008A1EA /* TypeCheckDecl.cpp in Sources */,
+				BB8B29FD1C124A6500C91975 /* LibcShims.cpp in Sources */,
+				BB9FD7D41C10F3CD0008A1EA /* DiagnosticList.cpp in Sources */,
+				BB9FD90C1C10F60D0008A1EA /* LLVMARCContract.cpp in Sources */,
+				BB9FDA081C10F7490008A1EA /* FunctionOrder.cpp in Sources */,
+				BB9FD9CA1C10F7110008A1EA /* Dominance.cpp in Sources */,
+				BB9FD8851C10F5C40008A1EA /* Immediate.cpp in Sources */,
+				BB9FD80E1C10F4770008A1EA /* ClusteredBitVector.cpp in Sources */,
+				BB9FDA461C10F76B0008A1EA /* SILGenBuiltin.cpp in Sources */,
+				BB9FDA411C10F76B0008A1EA /* ManagedValue.cpp in Sources */,
+				BB9FD9921C10F6CE0008A1EA /* TypeCheckType.cpp in Sources */,
+				BB9FDA071C10F7490008A1EA /* EscapeAnalysis.cpp in Sources */,
+				BB9FD8221C10F4770008A1EA /* TaskQueue.cpp in Sources */,
+				BB9FDAE21C10F8B40008A1EA /* SimplifyCFG.cpp in Sources */,
+				BB9FD85C1C10F54E0008A1EA /* Types.cpp in Sources */,
+				BB9FDA441C10F76B0008A1EA /* SILGenApply.cpp in Sources */,
+				BB9FD99F1C10F6F10008A1EA /* Deserialization.cpp in Sources */,
+				BB9FDAF01C10F8D90008A1EA /* SILCombinerBuiltinVisitors.cpp in Sources */,
+				BB9FDB0C1C10F8FC0008A1EA /* LoopCanonicalizer.cpp in Sources */,
+				BB32C32F1C124D6000BEA123 /* ErrorObject.mm in Sources */,
+				BB9FDA0D1C10F7490008A1EA /* RCIdentityAnalysis.cpp in Sources */,
+				BB9FD8521C10F54E0008A1EA /* Action.cpp in Sources */,
+				BB9FDAB81C10F8980008A1EA /* PassManager.cpp in Sources */,
+				BB8B29CD1C124A0C00C91975 /* SwiftRuntimeDTraceProbes.d in Sources */,
+				BB9FD87E1C10F5A40008A1EA /* SyntaxModel.cpp in Sources */,
+				BB9FD92B1C10F67C0008A1EA /* ParseDecl.cpp in Sources */,
+				BB9FD9301C10F67C0008A1EA /* ParseSIL.cpp in Sources */,
+				BB9FD7DF1C10F3CD0008A1EA /* PlatformKind.cpp in Sources */,
+				BB9FD9161C10F6360008A1EA /* AST.cpp in Sources */,
+				BB9FDAAF1C10F86C0008A1EA /* COWArrayOpt.cpp in Sources */,
+				BB9FD9E41C10F7110008A1EA /* SILWitnessTable.cpp in Sources */,
+				BB9FD7DE1C10F3CD0008A1EA /* Pattern.cpp in Sources */,
+				BB9FDAA61C10F84F0008A1EA /* PerformanceInliner.cpp in Sources */,
+				BB9FD9781C10F6CE0008A1EA /* DerivedConformanceEquatableHashable.cpp in Sources */,
+				BB9FD9711C10F6CE0008A1EA /* ConstraintSystem.cpp in Sources */,
+				BB9FD98E1C10F6CE0008A1EA /* TypeCheckProtocol.cpp in Sources */,
+				BB9FDB0A1C10F8FC0008A1EA /* IVInfoPrinter.cpp in Sources */,
+				BB9FD8211C10F4770008A1EA /* StringExtras.cpp in Sources */,
+				BB9FD83E1C10F50E0008A1EA /* ClangDiagnosticConsumer.cpp in Sources */,
+				BB9FD9D71C10F7110008A1EA /* SILDeclRef.cpp in Sources */,
+				BB9FD9CB1C10F7110008A1EA /* DynamicCasts.cpp in Sources */,
+				BB9FD7C41C10F3CD0008A1EA /* ArchetypeBuilder.cpp in Sources */,
+				BB8B29BD1C124A0C00C91975 /* Demangle.cpp in Sources */,
+				BB9FDAD31C10F8B40008A1EA /* CopyForwarding.cpp in Sources */,
+				BB9FDB121C10F8FC0008A1EA /* UpdateSideEffects.cpp in Sources */,
+				BB9FDADD1C10F8B40008A1EA /* SILCleanup.cpp in Sources */,
+				BB9FD8E11C10F5F20008A1EA /* DebugTypeInfo.cpp in Sources */,
+				BB9FDAA21C10F84F0008A1EA /* FunctionSignatureOpts.cpp in Sources */,
+				BB9FD9A31C10F6F10008A1EA /* SerializedModuleLoader.cpp in Sources */,
+				BB9FD7D51C10F3CD0008A1EA /* DocComment.cpp in Sources */,
+				BB9FDA011C10F7490008A1EA /* BasicCalleeAnalysis.cpp in Sources */,
+				BB9FD9A21C10F6F10008A1EA /* Serialization.cpp in Sources */,
+				BB9FD9761C10F6CE0008A1EA /* CSSimplify.cpp in Sources */,
+				BB9FDB1F1C10F9200008A1EA /* CFG.cpp in Sources */,
+				BB9FD8F71C10F5F20008A1EA /* GenTuple.cpp in Sources */,
+				BB32C3301C124D6500BEA123 /* SwiftObject.mm in Sources */,
+				BB9FDAB01C10F86C0008A1EA /* LICM.cpp in Sources */,
+				BB9FDA7B1C10F7F00008A1EA /* RefCountState.cpp in Sources */,
+				BB9FD87A1C10F5A40008A1EA /* ModuleInterfacePrinting.cpp in Sources */,
+				BB9FDA871C10F8110008A1EA /* ConstantPropagation.cpp in Sources */,
+				BB9FD9911C10F6CE0008A1EA /* TypeCheckStmt.cpp in Sources */,
+				BB9FD9E11C10F7110008A1EA /* SILType.cpp in Sources */,
+				BB9FDA4D1C10F76B0008A1EA /* SILGenExpr.cpp in Sources */,
+				BB8B29C61C124A0C00C91975 /* Metadata.cpp in Sources */,
+				BB9FDA761C10F7F00008A1EA /* GlobalARCPairingAnalysis.cpp in Sources */,
+				BB9FDAB71C10F8980008A1EA /* Passes.cpp in Sources */,
+				BB9FD9771C10F6CE0008A1EA /* CSSolver.cpp in Sources */,
+				BB9FD98A1C10F6CE0008A1EA /* TypeCheckExpr.cpp in Sources */,
+				BB9FD8F21C10F5F20008A1EA /* GenObjC.cpp in Sources */,
+				BB9FD9861C10F6CE0008A1EA /* TypeCheckConstraints.cpp in Sources */,
+				BB9FD90E1C10F60D0008A1EA /* LLVMStackPromotion.cpp in Sources */,
+				BB9FD87B1C10F5A40008A1EA /* REPLCodeCompletion.cpp in Sources */,
+				BB9FD9801C10F6CE0008A1EA /* MiscDiagnostics.cpp in Sources */,
+				BB9FD8861C10F5C40008A1EA /* REPL.cpp in Sources */,
+				BB9FDADF1C10F8B40008A1EA /* SILLowerAggregateInstrs.cpp in Sources */,
+				BB9FDA101C10F7490008A1EA /* ValueTracking.cpp in Sources */,
+				BB9FD8E81C10F5F20008A1EA /* GenClass.cpp in Sources */,
+				BB9FDAB91C10F8980008A1EA /* PrettyStackTrace.cpp in Sources */,
+				BB9FD7D61C10F3CD0008A1EA /* Expr.cpp in Sources */,
+				BB9FD7E71C10F3CD0008A1EA /* TypeRepr.cpp in Sources */,
+				BB9FDA401C10F76B0008A1EA /* Condition.cpp in Sources */,
+				BB9FD9CD1C10F7110008A1EA /* LoopInfo.cpp in Sources */,
+				BB9FD8F81C10F5F20008A1EA /* GenType.cpp in Sources */,
+				BB9FD8181C10F4770008A1EA /* PrefixMap.cpp in Sources */,
+				BB9FDA001C10F7490008A1EA /* ArraySemantic.cpp in Sources */,
+				BB9FDA7A1C10F7F00008A1EA /* RCStateTransitionVisitors.cpp in Sources */,
+				BB9FD98F1C10F6CE0008A1EA /* TypeCheckREPL.cpp in Sources */,
+				BB9FD9321C10F67C0008A1EA /* ParseType.cpp in Sources */,
+				BB9FDA3F1C10F76B0008A1EA /* Cleanup.cpp in Sources */,
+				BB9FD9101C10F60D0008A1EA /* LLVMSwiftRCIdentity.cpp in Sources */,
+				BB9FD9341C10F67C0008A1EA /* Scope.cpp in Sources */,
+				BB9FD8561C10F54E0008A1EA /* FrontendUtil.cpp in Sources */,
+				BB9FD8791C10F5A40008A1EA /* CommentConversion.cpp in Sources */,
+				BB9FDAE01C10F8B40008A1EA /* SILMem2Reg.cpp in Sources */,
+				BB9FD8191C10F4770008A1EA /* PrettyStackTrace.cpp in Sources */,
+				BB9FD97E1C10F6CE0008A1EA /* ITCType.cpp in Sources */,
+				BB9FD8591C10F54E0008A1EA /* ParseableOutput.cpp in Sources */,
+				BB9FD8F11C10F5F20008A1EA /* GenMeta.cpp in Sources */,
+				BB9FDA051C10F7490008A1EA /* ColdBlockInfo.cpp in Sources */,
+				BB9FD8F31C10F5F20008A1EA /* GenOpaque.cpp in Sources */,
+				BB9FDAE41C10F8B40008A1EA /* SpeculativeDevirtualizer.cpp in Sources */,
+				BB9FD86A1C10F5790008A1EA /* SerializedDiagnosticConsumer.cpp in Sources */,
+				BB9FD92E1C10F67C0008A1EA /* ParsePattern.cpp in Sources */,
+				BB9FD81D1C10F4770008A1EA /* PunycodeUTF8.cpp in Sources */,
+				BB9FD9381C10F6A50008A1EA /* PrintAsObjC.cpp in Sources */,
+				BB9FD9021C10F5F20008A1EA /* UnimplementedTypeInfo.cpp in Sources */,
+				BB9FD8401C10F50E0008A1EA /* ImportDecl.cpp in Sources */,
+				BB8B28B21C1248CE00C91975 /* OpaqueIdentityFunctions.cpp in Sources */,
+				BB9FDA031C10F7490008A1EA /* CFG.cpp in Sources */,
+				BB8B299E1C1249E500C91975 /* README.md in Sources */,
+				BB9FDA731C10F7F00008A1EA /* ARCBBState.cpp in Sources */,
+				BB9FD8E41C10F5F20008A1EA /* GenArchetype.cpp in Sources */,
+				BB9FD8FE1C10F5F20008A1EA /* Linking.cpp in Sources */,
+				BB9FD9D61C10F7110008A1EA /* SILCoverageMap.cpp in Sources */,
+				BB9FD81F1C10F4770008A1EA /* Remangle.cpp in Sources */,
+				BB9FD9C81C10F7110008A1EA /* AbstractionPattern.cpp in Sources */,
+				BB9FD92C1C10F67C0008A1EA /* ParseExpr.cpp in Sources */,
+				BB9FDA571C10F76B0008A1EA /* SILGenType.cpp in Sources */,
+				BB8B29C41C124A0C00C91975 /* KnownMetadata.cpp in Sources */,
+				BB9FD8691C10F5790008A1EA /* PrintingDiagnosticConsumer.cpp in Sources */,
+				BB9FD9E21C10F7110008A1EA /* SILValue.cpp in Sources */,
+				BB9FD8771C10F5A40008A1EA /* CodeCompletion.cpp in Sources */,
+				BB9FDAD41C10F8B40008A1EA /* CSE.cpp in Sources */,
+				BB9FD8231C10F4770008A1EA /* ThreadSafeRefCounted.cpp in Sources */,
+				BB9FD7D01C10F3CD0008A1EA /* ConformanceLookupTable.cpp in Sources */,
+				BB9FD87C1C10F5A40008A1EA /* SourceEntityWalker.cpp in Sources */,
+				BB9FD9841C10F6CE0008A1EA /* SourceLoader.cpp in Sources */,
+				BB9FD7DB1C10F3CD0008A1EA /* Module.cpp in Sources */,
+				BB9FD9FD1C10F7490008A1EA /* AliasAnalysis.cpp in Sources */,
+				BB9FD9881C10F6CE0008A1EA /* TypeChecker.cpp in Sources */,
+				BB9FD7D81C10F3CD0008A1EA /* Identifier.cpp in Sources */,
+				BB9FD9A11C10F6F10008A1EA /* ModuleFile.cpp in Sources */,
+				BB9FD9D11C10F7110008A1EA /* Projection.cpp in Sources */,
+				BB9FD8F91C10F5F20008A1EA /* IRGen.cpp in Sources */,
+				BB9FD81C1C10F4770008A1EA /* Punycode.cpp in Sources */,
+				BB9FD97C1C10F6CE0008A1EA /* ITCDecl.cpp in Sources */,
+				BB9FDB041C10F8FC0008A1EA /* AADumper.cpp in Sources */,
+				BB9FD7DC1C10F3CD0008A1EA /* ModuleNameLookup.cpp in Sources */,
+				BB9FD7DA1C10F3CD0008A1EA /* Mangle.cpp in Sources */,
+				BB9FD8531C10F54E0008A1EA /* Compilation.cpp in Sources */,
+				BB8B29CA1C124A0C00C91975 /* Remangle.cpp in Sources */,
+				BB9FDA4E1C10F76B0008A1EA /* SILGenForeignError.cpp in Sources */,
+				BB9FDA781C10F7F00008A1EA /* GlobalLoopARCSequenceDataflow.cpp in Sources */,
+				BB9FDB201C10F9200008A1EA /* CheckedCastBrJumpThreading.cpp in Sources */,
+				BB9FDAA01C10F84F0008A1EA /* DeadFunctionElimination.cpp in Sources */,
+				BB9FDAEE1C10F8D90008A1EA /* SILCombine.cpp in Sources */,
+				BB9FD7C91C10F3CD0008A1EA /* ASTWalker.cpp in Sources */,
+				BB9FD8F41C10F5F20008A1EA /* GenPoly.cpp in Sources */,
+				BB9FD9DC1C10F7110008A1EA /* SILInstructions.cpp in Sources */,
+				BB9FD9C91C10F7110008A1EA /* Bridging.cpp in Sources */,
+				BB9FDAA31C10F84F0008A1EA /* GlobalOpt.cpp in Sources */,
+				BB9FD87D1C10F5A40008A1EA /* SwiftSourceDocInfo.cpp in Sources */,
+				BB9FD8E51C10F5F20008A1EA /* GenCast.cpp in Sources */,
+				BB9FDA531C10F76B0008A1EA /* SILGenPoly.cpp in Sources */,
+				BB9FDA551C10F76B0008A1EA /* SILGenProlog.cpp in Sources */,
+				BB9FD85A1C10F54E0008A1EA /* ToolChain.cpp in Sources */,
+				BB9FD98B1C10F6CE0008A1EA /* TypeCheckGeneric.cpp in Sources */,
+				BB9FD8FA1C10F5F20008A1EA /* IRGenDebugInfo.cpp in Sources */,
+				BB9FD9811C10F6CE0008A1EA /* NameBinding.cpp in Sources */,
+				BB9FDB0B1C10F8FC0008A1EA /* Link.cpp in Sources */,
+				BB9FD82B1C10F4CA0008A1EA /* Cache-Mac.cpp in Sources */,
+				BB9FD8121C10F4770008A1EA /* DiverseStack.cpp in Sources */,
+				BB9FDA8A1C10F8110008A1EA /* DiagnoseUnreachable.cpp in Sources */,
+				BB9FD9721C10F6CE0008A1EA /* CSApply.cpp in Sources */,
+				BB9FD8EC1C10F5F20008A1EA /* GenEnum.cpp in Sources */,
+				BB9FD8201C10F4770008A1EA /* SourceLoc.cpp in Sources */,
+				BB9FD8131C10F4770008A1EA /* EditorPlaceholder.cpp in Sources */,
+				BB9FDA561C10F76B0008A1EA /* SILGenStmt.cpp in Sources */,
+				BB9FD8141C10F4770008A1EA /* FileSystem.cpp in Sources */,
+				BB9FDA8D1C10F8110008A1EA /* MandatoryInlining.cpp in Sources */,
+				BB9FD9D51C10F7110008A1EA /* SILBuilder.cpp in Sources */,
+				BB9FDA741C10F7F00008A1EA /* ARCRegionState.cpp in Sources */,
+				BB9FD90F1C10F60D0008A1EA /* LLVMSwiftAA.cpp in Sources */,
+				BB9FDA4A1C10F76B0008A1EA /* SILGenDestructor.cpp in Sources */,
+				BB9FD8FF1C10F5F20008A1EA /* StructLayout.cpp in Sources */,
+				BB9FDAD11C10F8B40008A1EA /* AllocBoxToStack.cpp in Sources */,
+				BB9FD7C51C10F3CD0008A1EA /* ASTContext.cpp in Sources */,
+				BB9FDA091C10F7490008A1EA /* IVAnalysis.cpp in Sources */,
+				BB9FD7CE1C10F3CD0008A1EA /* CaptureInfo.cpp in Sources */,
+				BB9FD83F1C10F50E0008A1EA /* ClangImporter.cpp in Sources */,
+				BB9FD9851C10F6CE0008A1EA /* TypeCheckAttr.cpp in Sources */,
+				BB9FD8101C10F4770008A1EA /* DemangleWrappers.cpp in Sources */,
+				BB9FD9E61C10F7110008A1EA /* Verifier.cpp in Sources */,
+				BB9FD90D1C10F60D0008A1EA /* LLVMARCOpts.cpp in Sources */,
+				BB9FD8E61C10F5F20008A1EA /* GenClangDecl.cpp in Sources */,
+				BB9FD9D41C10F7110008A1EA /* SILBasicBlock.cpp in Sources */,
+				BB9FDA8B1C10F8110008A1EA /* DIMemoryUseCollector.cpp in Sources */,
+				BB9FD7E31C10F3CD0008A1EA /* Stmt.cpp in Sources */,
+				BB9FD9791C10F6CE0008A1EA /* DerivedConformanceErrorType.cpp in Sources */,
+				BB9FDAAE1C10F86C0008A1EA /* ArrayBoundsCheckOpts.cpp in Sources */,
+				BB9FD8EB1C10F5F20008A1EA /* GenDecl.cpp in Sources */,
+				BB9FD8421C10F50E0008A1EA /* ImportType.cpp in Sources */,
+				BB9FDA471C10F76B0008A1EA /* SILGenConstructor.cpp in Sources */,
+				BB9FD97D1C10F6CE0008A1EA /* ITCNameLookup.cpp in Sources */,
+				BB9FDADB1C10F8B40008A1EA /* ReleaseDevirtualizer.cpp in Sources */,
+				BB9FD7D71C10F3CD0008A1EA /* GenericSignature.cpp in Sources */,
+				BB9FD7E11C10F3CD0008A1EA /* ProtocolConformance.cpp in Sources */,
+				BB9FD96F1C10F6CE0008A1EA /* ConstraintGraph.cpp in Sources */,
+				BB9FDA451C10F76B0008A1EA /* SILGenBridging.cpp in Sources */,
+				BB9FD7E61C10F3CD0008A1EA /* TypeRefinementContext.cpp in Sources */,
+				BB9FD87F1C10F5A40008A1EA /* Utils.cpp in Sources */,
+				BB9FDB231C10F9200008A1EA /* GenericCloner.cpp in Sources */,
+				BB9FDAF21C10F8D90008A1EA /* SILCombinerMiscVisitors.cpp in Sources */,
+				BB9FDA8E1C10F8110008A1EA /* PredictableMemOpt.cpp in Sources */,
+				BB9FDA3E1C10F76B0008A1EA /* ArgumentSource.cpp in Sources */,
+				BB9FD8681C10F5790008A1EA /* FrontendOptions.cpp in Sources */,
+				BB9FDA751C10F7F00008A1EA /* ARCSequenceOpts.cpp in Sources */,
+				BB9FD8E31C10F5F20008A1EA /* ExtraInhabitants.cpp in Sources */,
+				BB9FDA041C10F7490008A1EA /* ClassHierarchyAnalysis.cpp in Sources */,
+				BB9FD7D91C10F3CD0008A1EA /* LookupVisibleDecls.cpp in Sources */,
+				BB9FDB261C10F9200008A1EA /* LoopUtils.cpp in Sources */,
+				BB9FDB271C10F9200008A1EA /* SILInliner.cpp in Sources */,
+				BB9FDA9D1C10F84F0008A1EA /* CapturePromotion.cpp in Sources */,
+				BB9FDA421C10F76B0008A1EA /* RValue.cpp in Sources */,
+				BB9FD80F1C10F4770008A1EA /* Demangle.cpp in Sources */,
+				BB9FD8111C10F4770008A1EA /* DiagnosticConsumer.cpp in Sources */,
+				BB9FDAD51C10F8B40008A1EA /* DeadCodeElimination.cpp in Sources */,
+				BB9FDA541C10F76B0008A1EA /* SILGenProfiling.cpp in Sources */,
+				BB9FD9D81C10F7110008A1EA /* SILFunction.cpp in Sources */,
+				BB9FDA791C10F7F00008A1EA /* RCStateTransition.cpp in Sources */,
+				BB9FD8151C10F4770008A1EA /* JSONSerialization.cpp in Sources */,
+				BB9FD8161C10F4770008A1EA /* LangOptions.cpp in Sources */,
+				BB9FD9891C10F6CE0008A1EA /* TypeCheckError.cpp in Sources */,
+				BB9FD8651C10F5790008A1EA /* CompilerInvocation.cpp in Sources */,
+				BB9FD8FB1C10F5F20008A1EA /* IRGenFunction.cpp in Sources */,
+				BB9FD97A1C10F6CE0008A1EA /* DerivedConformanceRawRepresentable.cpp in Sources */,
+				BB9FD7E91C10F3CD0008A1EA /* USRGeneration.cpp in Sources */,
+				BB9FD8E21C10F5F20008A1EA /* EnumPayload.cpp in Sources */,
+				BB8B29C81C124A0C00C91975 /* Reflection.cpp in Sources */,
+				BB9FD98D1C10F6CE0008A1EA /* TypeCheckPattern.cpp in Sources */,
+				BB9FD8781C10F5A40008A1EA /* CodeCompletionCache.cpp in Sources */,
+				BB8B29CB1C124A0C00C91975 /* SwiftObject.cpp in Sources */,
+				BB8B29C71C124A0C00C91975 /* Once.cpp in Sources */,
+				BB9FD7CB1C10F3CD0008A1EA /* Availability.cpp in Sources */,
+				BB9FD8ED1C10F5F20008A1EA /* GenExistential.cpp in Sources */,
+				BB9FD8661C10F5790008A1EA /* DiagnosticVerifier.cpp in Sources */,
+				BB9FD7CC1C10F3CD0008A1EA /* AvailabilitySpec.cpp in Sources */,
+				BB9FD8581C10F54E0008A1EA /* OutputFileMap.cpp in Sources */,
+				BB9FDADE1C10F8B40008A1EA /* SILCodeMotion.cpp in Sources */,
+				BB9FDA0C1C10F7490008A1EA /* MemoryBehavior.cpp in Sources */,
+				BB9FD7CD1C10F3CD0008A1EA /* Builtins.cpp in Sources */,
+				BB8B29FA1C124A6500C91975 /* Availability.mm in Sources */,
+				BB9FDB211C10F9200008A1EA /* ConstantFolding.cpp in Sources */,
+				BB8B29C21C124A0C00C91975 /* Heap.cpp in Sources */,
+				BB9FD9181C10F6360008A1EA /* Markup.cpp in Sources */,
+				BB9FD7EA1C10F3CD0008A1EA /* Verifier.cpp in Sources */,
+				BB9FD7EE1C10F4500008A1EA /* ASTSectionImporter.cpp in Sources */,
+				BB9FD7D11C10F3CD0008A1EA /* Decl.cpp in Sources */,
+				BB9FD9DA1C10F7110008A1EA /* SILGlobalVariable.cpp in Sources */,
+				BB9FD7CA1C10F3CD0008A1EA /* Attr.cpp in Sources */,
+				BB9FD7E01C10F3CD0008A1EA /* PrettyStackTrace.cpp in Sources */,
+				BB9FD7D31C10F3CD0008A1EA /* DiagnosticEngine.cpp in Sources */,
+				BB9FD9D31C10F7110008A1EA /* SILArgument.cpp in Sources */,
+				BB9FD96D1C10F6CE0008A1EA /* CodeSynthesis.cpp in Sources */,
+				BB9FD8671C10F5790008A1EA /* Frontend.cpp in Sources */,
+				BB9FD81A1C10F4770008A1EA /* PrimitiveParsing.cpp in Sources */,
+				BB9FD9001C10F5F20008A1EA /* SwiftTargetInfo.cpp in Sources */,
+				BB9FDB051C10F8FC0008A1EA /* BasicCalleePrinter.cpp in Sources */,
+				BB9FDB081C10F8FC0008A1EA /* FunctionOrderPrinter.cpp in Sources */,
+				BB9FD9831C10F6CE0008A1EA /* PlaygroundTransform.cpp in Sources */,
+				BB9FD9CC1C10F7110008A1EA /* Linker.cpp in Sources */,
+				BB9FDB0E1C10F8FC0008A1EA /* LoopRegionPrinter.cpp in Sources */,
+				BB8B29C91C124A0C00C91975 /* Reflection.mm in Sources */,
+				BB9FDB061C10F8FC0008A1EA /* CallGraphPrinter.cpp in Sources */,
+				BB9FDB0F1C10F8FC0008A1EA /* MemLocationPrinter.cpp in Sources */,
+				BB9FD8E71C10F5F20008A1EA /* GenClangType.cpp in Sources */,
+				BB9FD9DF1C10F7110008A1EA /* SILPrinter.cpp in Sources */,
+				BB9FD7DD1C10F3CD0008A1EA /* NameLookup.cpp in Sources */,
+				BB9FD8F51C10F5F20008A1EA /* GenProto.cpp in Sources */,
+				BB9FDAB11C10F86C0008A1EA /* LoopRotate.cpp in Sources */,
+				BB9FDAA41C10F84F0008A1EA /* GlobalPropertyOpt.cpp in Sources */,
+				BB9FDA9E1C10F84F0008A1EA /* CapturePropagation.cpp in Sources */,
+				BB9FD8FD1C10F5F20008A1EA /* IRGenSIL.cpp in Sources */,
+				BB8B29BC1C124A0C00C91975 /* Casting.cpp in Sources */,
+				BB9FDAD91C10F8B40008A1EA /* RedundantLoadElimination.cpp in Sources */,
+				BB9FD81B1C10F4770008A1EA /* Program.cpp in Sources */,
+				BB9FDA521C10F76B0008A1EA /* SILGenPattern.cpp in Sources */,
+				BB9FD7CF1C10F3CD0008A1EA /* ConcreteDeclRef.cpp in Sources */,
+				BB9FDA061C10F7490008A1EA /* DestructorAnalysis.cpp in Sources */,
+				BB8B29FE1C124A6500C91975 /* Stubs.cpp in Sources */,
+				BB9FDA771C10F7F00008A1EA /* GlobalARCSequenceDataflow.cpp in Sources */,
+				BB9FDA5D1C10F7B90008A1EA /* SwiftDemangle.cpp in Sources */,
+				BB9FD8F01C10F5F20008A1EA /* GenInit.cpp in Sources */,
+				BB9FD9CE1C10F7110008A1EA /* Mangle.cpp in Sources */,
+				BB9FD9DB1C10F7110008A1EA /* SILInstruction.cpp in Sources */,
+				BB9FDA8C1C10F8110008A1EA /* InOutDeshadowing.cpp in Sources */,
+				BB9FD8171C10F4770008A1EA /* Platform.cpp in Sources */,
+				BB9FDA4C1C10F76B0008A1EA /* SILGenEpilog.cpp in Sources */,
+				BB9FD8241C10F4770008A1EA /* Unicode.cpp in Sources */,
+				BB9FDA0A1C10F7490008A1EA /* LoopAnalysis.cpp in Sources */,
+				BB9FDB241C10F9200008A1EA /* Generics.cpp in Sources */,
+				BB9FDAF11C10F8D90008A1EA /* SILCombinerCastVisitors.cpp in Sources */,
+				BB9FDAE31C10F8B40008A1EA /* Sink.cpp in Sources */,
+				BB9FD9FE1C10F7490008A1EA /* Analysis.cpp in Sources */,
+				BB9FD9331C10F67C0008A1EA /* PersistentParserState.cpp in Sources */,
+				BB9FDAE11C10F8B40008A1EA /* SILSROA.cpp in Sources */,
+				BB9FD97B1C10F6CE0008A1EA /* DerivedConformances.cpp in Sources */,
+				BB9FD7C71C10F3CD0008A1EA /* ASTNode.cpp in Sources */,
+				BB9FD98C1C10F6CE0008A1EA /* TypeCheckNameLookup.cpp in Sources */,
+				BB8B29C11C124A0C00C91975 /* Errors.cpp in Sources */,
+				BB9FD9DE1C10F7110008A1EA /* SILModule.cpp in Sources */,
+				BB9FD8541C10F54E0008A1EA /* DependencyGraph.cpp in Sources */,
+				BB9FDAA11C10F84F0008A1EA /* ExternalDefsToDecls.cpp in Sources */,
+				BB9FD9D91C10F7110008A1EA /* SILFunctionType.cpp in Sources */,
+				BB8B29C31C124A0C00C91975 /* HeapObject.cpp in Sources */,
+				BB9FD7E21C10F3CD0008A1EA /* RawComment.cpp in Sources */,
+				BB9FD91C1C10F6580008A1EA /* Options.cpp in Sources */,
+				BB9FDAA51C10F84F0008A1EA /* LetPropertiesOpts.cpp in Sources */,
+				BB8B29FB1C124A6500C91975 /* FoundationHelpers.mm in Sources */,
+				BB9FD97F1C10F6CE0008A1EA /* IterativeTypeChecker.cpp in Sources */,
+				BB9FD7D21C10F3CD0008A1EA /* DeclContext.cpp in Sources */,
+				BB9FDB091C10F8FC0008A1EA /* InstCount.cpp in Sources */,
+				BB9FD92D1C10F67C0008A1EA /* ParseGeneric.cpp in Sources */,
+				BB9FD9731C10F6CE0008A1EA /* CSDiag.cpp in Sources */,
+				BB9FDB111C10F8FC0008A1EA /* UpdateEscapeAnalysis.cpp in Sources */,
+				BB9FD7E81C10F3CD0008A1EA /* TypeWalker.cpp in Sources */,
+				BB9FD8EE1C10F5F20008A1EA /* GenFunc.cpp in Sources */,
+				BB9FD9171C10F6360008A1EA /* LineList.cpp in Sources */,
+				BB9FD9D21C10F7110008A1EA /* SIL.cpp in Sources */,
+				BB9FDA0B1C10F7490008A1EA /* LoopRegionAnalysis.cpp in Sources */,
+				BB9FD85B1C10F54E0008A1EA /* ToolChains.cpp in Sources */,
+				BB9FD9011C10F5F20008A1EA /* TypeLayoutVerifier.cpp in Sources */,
+				BB32C32E1C124CFE00BEA123 /* ErrorObject.cpp in Sources */,
+				BB8B29BE1C124A0C00C91975 /* Enum.cpp in Sources */,
+				BB9FD9DD1C10F7110008A1EA /* SILLocation.cpp in Sources */,
+				BB9FDA511C10F76B0008A1EA /* SILGenLValue.cpp in Sources */,
+				BB9FD7C61C10F3CD0008A1EA /* ASTDumper.cpp in Sources */,
+				BB9FDADC1C10F8B40008A1EA /* RemovePin.cpp in Sources */,
+				BB9FDADA1C10F8B40008A1EA /* RedundantOverflowCheckRemoval.cpp in Sources */,
+				BB9FDB281C10F9200008A1EA /* SILSSAUpdater.cpp in Sources */,
+				BB9FDAA71C10F84F0008A1EA /* UsePrespecialized.cpp in Sources */,
+				BB9FDA431C10F76B0008A1EA /* SILGen.cpp in Sources */,
+				BB9FD9D01C10F7110008A1EA /* PrettyStackTrace.cpp in Sources */,
+				BB9FD9A01C10F6F10008A1EA /* DeserializeSIL.cpp in Sources */,
+				BB9FDA9F1C10F84F0008A1EA /* ClosureSpecializer.cpp in Sources */,
+				BB8B28B01C1248CE00C91975 /* InterceptTraps.cpp in Sources */,
+				BB9FD9311C10F67C0008A1EA /* ParseStmt.cpp in Sources */,
+				BB9FD9901C10F6CE0008A1EA /* TypeCheckRequest.cpp in Sources */,
+				BB9FD9CF1C10F7110008A1EA /* MemLocation.cpp in Sources */,
+				BB9FDA881C10F8110008A1EA /* DataflowDiagnostics.cpp in Sources */,
+				BB9FDA021C10F7490008A1EA /* CallGraph.cpp in Sources */,
+				BB9FD9701C10F6CE0008A1EA /* ConstraintLocator.cpp in Sources */,
+				BB9FDB221C10F9200008A1EA /* Devirtualize.cpp in Sources */,
+				BB9FDA501C10F76B0008A1EA /* SILGenGlobalVariable.cpp in Sources */,
+				BB9FDA481C10F76B0008A1EA /* SILGenConvert.cpp in Sources */,
+				BB9FD9E01C10F7110008A1EA /* SILSuccessor.cpp in Sources */,
+				BB9FD92A1C10F67C0008A1EA /* Lexer.cpp in Sources */,
+				BB9FD9E51C10F7110008A1EA /* TypeLowering.cpp in Sources */,
+				BB9FD80D1C10F4770008A1EA /* Cache.cpp in Sources */,
+				BB9FDA4B1C10F76B0008A1EA /* SILGenDynamicCast.cpp in Sources */,
+				BB9FD8551C10F54E0008A1EA /* Driver.cpp in Sources */,
+				BB9FD9A51C10F6F10008A1EA /* SerializeSIL.cpp in Sources */,
+				BB9FD9741C10F6CE0008A1EA /* CSGen.cpp in Sources */,
+				BB9FD81E1C10F4770008A1EA /* QuotedString.cpp in Sources */,
+				BB9FDAE51C10F8B40008A1EA /* StackPromotion.cpp in Sources */,
+				BB9FDB071C10F8FC0008A1EA /* CFGPrinter.cpp in Sources */,
+				BB9FDA0F1C10F7490008A1EA /* SimplifyInstruction.cpp in Sources */,
+				BB9FDB251C10F9200008A1EA /* Local.cpp in Sources */,
+				BB9FD8E91C10F5F20008A1EA /* GenControl.cpp in Sources */,
+				BB9FD8261C10F4770008A1EA /* Version.cpp in Sources */,
+				BB9FD7E41C10F3CD0008A1EA /* Substitution.cpp in Sources */,
+				BB9FD9A41C10F6F10008A1EA /* SerializedSILLoader.cpp in Sources */,
+				BB9FDA5C1C10F7B90008A1EA /* MangleHack.cpp in Sources */,
+				BB9FDA891C10F8110008A1EA /* DefiniteInitialization.cpp in Sources */,
+				BB9FDB101C10F8FC0008A1EA /* StripDebugInfo.cpp in Sources */,
+				BB9FDAEF1C10F8D90008A1EA /* SILCombinerApplyVisitors.cpp in Sources */,
+				BB9FD8FC1C10F5F20008A1EA /* IRGenModule.cpp in Sources */,
+				BB9FD8EA1C10F5F20008A1EA /* GenCoverage.cpp in Sources */,
+				BB9FD9751C10F6CE0008A1EA /* CSRanking.cpp in Sources */,
+				BB9FD8411C10F50E0008A1EA /* ImportMacro.cpp in Sources */,
+				BB9FD7C81C10F3CD0008A1EA /* ASTPrinter.cpp in Sources */,
+				BB9FD7E51C10F3CD0008A1EA /* Type.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BB9FD6451C10EF850008A1EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		BB9FD6461C10EF850008A1EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		BB9FD6481C10EF850008A1EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = (
+					"SWIFT_VERSION_MAJOR=2",
+					"SWIFT_VERSION_MINOR=2",
+					"LTDL_SHLIB_EXT=\\\".dylib\\\"",
+					"PACKAGE_STRING=\"\\\"LLVM 3.8.0svn\\\"\"",
+					"CMARK_ATTRIBUTE=__attribute__",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../build/Ninja-DebugAssert/cmark-macosx-x86_64/src",
+					"../build/Ninja-DebugAssert/swift-macosx-x86_64/include",
+					"../build/Ninja-DebugAssert/swift-macosx-x86_64/lib/ClangImporter",
+					../llvm/include,
+					../clang/include,
+					../llbuild/include,
+					"../build/Ninja-DebugAssert/llvm-macosx-x86_64/include",
+					"../build/Ninja-DebugAssert/llvm-macosx-x86_64/tools/clang/include",
+					../cmark/src,
+					include,
+				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib",
+					"../build/Ninja-DebugAssert/cmark-macosx-x86_64/src",
+					"../build/Xcode-DebugAssert/llvm-macosx-x86_64/Debug/lib",
+				);
+				OTHER_CFLAGS = "-Wno-shorten-64-to-32";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		BB9FD6491C10EF850008A1EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = (
+					"SWIFT_VERSION_MAJOR=2",
+					"SWIFT_VERSION_MINOR=2",
+					"LTDL_SHLIB_EXT=\\\".dylib\\\"",
+					"PACKAGE_STRING=\"\\\"LLVM 3.8.0svn\\\"\"",
+					"CMARK_ATTRIBUTE=__attribute__",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../build/Ninja-DebugAssert/cmark-macosx-x86_64/src",
+					"../build/Ninja-DebugAssert/swift-macosx-x86_64/include",
+					"../build/Ninja-DebugAssert/swift-macosx-x86_64/lib/ClangImporter",
+					../llvm/include,
+					../clang/include,
+					../llbuild/include,
+					"../build/Ninja-DebugAssert/llvm-macosx-x86_64/include",
+					"../build/Ninja-DebugAssert/llvm-macosx-x86_64/tools/clang/include",
+					../cmark/src,
+					include,
+				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"../build/Ninja-DebugAssert/llvm-macosx-x86_64/lib",
+					"../build/Ninja-DebugAssert/cmark-macosx-x86_64/src",
+					"../build/Xcode-DebugAssert/llvm-macosx-x86_64/Debug/lib",
+				);
+				OTHER_CFLAGS = "-Wno-shorten-64-to-32";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BB9FD63B1C10EF850008A1EA /* Build configuration list for PBXProject "sourceview" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BB9FD6451C10EF850008A1EA /* Debug */,
+				BB9FD6461C10EF850008A1EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BB9FD6471C10EF850008A1EA /* Build configuration list for PBXNativeTarget "swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BB9FD6481C10EF850008A1EA /* Debug */,
+				BB9FD6491C10EF850008A1EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = BB9FD6381C10EF850008A1EA /* Project object */;
+}

--- a/QuickLook.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/QuickLook.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
A simplified project to navigate sources quickly as an alternative to the generated Swift.xcodeproj. Compiles to the point of linking.
