### PR TITLE
(Properly) fix potentially inconsiderate naming

### DIFF
--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -26,12 +26,12 @@ extension String {
 
 enum ThreadID {
   case Primary
-  case Replica
+  case Secondary
 }
 
 var barrierVar: UnsafeMutablePointer<_stdlib_pthread_barrier_t> = nil
 var sharedString: String = ""
-var replicaString: String = ""
+var secondaryString: String = ""
 
 func barrier() {
   var ret = _stdlib_pthread_barrier_wait(barrierVar)
@@ -74,14 +74,14 @@ func sliceConcurrentAppendThread(tid: ThreadID) {
     expectEqual("abc", sharedString)
 
     // Verify that only one thread took ownership of the buffer.
-    if tid == .Replica {
-      replicaString = privateString
+    if tid == .Secondary {
+      secondaryString = privateString
     }
     barrier()
     if tid == .Primary {
       expectTrue(
         (privateString.bufferID == sharedString.bufferID) !=
-          (replicaString.bufferID == sharedString.bufferID))
+          (secondaryString.bufferID == sharedString.bufferID))
     }
   }
 }
@@ -95,7 +95,7 @@ StringTestSuite.test("SliceConcurrentAppend") {
   let (createRet1, tid1) = _stdlib_pthread_create_block(
     nil, sliceConcurrentAppendThread, .Primary)
   let (createRet2, tid2) = _stdlib_pthread_create_block(
-    nil, sliceConcurrentAppendThread, .Replica)
+    nil, sliceConcurrentAppendThread, .Secondary)
 
   expectEqual(0, createRet1)
   expectEqual(0, createRet2)

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -25,13 +25,13 @@ extension String {
 // different non-shared strings that point to the same shared buffer.
 
 enum ThreadID {
-  case Leader
-  case Follower
+  case Primary
+  case Replica
 }
 
 var barrierVar: UnsafeMutablePointer<_stdlib_pthread_barrier_t> = nil
 var sharedString: String = ""
-var followerString: String = ""
+var replicaString: String = ""
 
 func barrier() {
   var ret = _stdlib_pthread_barrier_wait(barrierVar)
@@ -41,7 +41,7 @@ func barrier() {
 func sliceConcurrentAppendThread(tid: ThreadID) {
   for i in 0..<100 {
     barrier()
-    if tid == .Leader {
+    if tid == .Primary {
       // Get a fresh buffer.
       sharedString = ""
       sharedString.appendContentsOf("abc")
@@ -57,7 +57,7 @@ func sliceConcurrentAppendThread(tid: ThreadID) {
     barrier()
 
     // Append to the private string.
-    if tid == .Leader {
+    if tid == .Primary {
       privateString.appendContentsOf("def")
     } else {
       privateString.appendContentsOf("ghi")
@@ -66,7 +66,7 @@ func sliceConcurrentAppendThread(tid: ThreadID) {
     barrier()
 
     // Verify that contents look good.
-    if tid == .Leader {
+    if tid == .Primary {
       expectEqual("abcdef", privateString)
     } else {
       expectEqual("abcghi", privateString)
@@ -74,14 +74,14 @@ func sliceConcurrentAppendThread(tid: ThreadID) {
     expectEqual("abc", sharedString)
 
     // Verify that only one thread took ownership of the buffer.
-    if tid == .Follower {
-      followerString = privateString
+    if tid == .Replica {
+      replicaString = privateString
     }
     barrier()
-    if tid == .Leader {
+    if tid == .Primary {
       expectTrue(
         (privateString.bufferID == sharedString.bufferID) !=
-          (followerString.bufferID == sharedString.bufferID))
+          (replicaString.bufferID == sharedString.bufferID))
     }
   }
 }
@@ -93,9 +93,9 @@ StringTestSuite.test("SliceConcurrentAppend") {
   expectEqual(0, ret)
 
   let (createRet1, tid1) = _stdlib_pthread_create_block(
-    nil, sliceConcurrentAppendThread, .Leader)
+    nil, sliceConcurrentAppendThread, .Primary)
   let (createRet2, tid2) = _stdlib_pthread_create_block(
-    nil, sliceConcurrentAppendThread, .Follower)
+    nil, sliceConcurrentAppendThread, .Replica)
 
   expectEqual(0, createRet1)
   expectEqual(0, createRet2)


### PR DESCRIPTION
So I don't mind master/slave terminology, but if you're going to fix it, at least end up with something others chose too. See django which ended up with Primary/Replica (after first adopting Leader/Follower in django/django#2692) in django/django#2694 (which was just closed, but still changed in https://github.com/django/django/commit/beec05686ccc3bee8461f9a5a02c607a02352ae1 )

The only thing I personally have against Leader/Follower is that it is a bit odd as a german (and seems I'm not alone in that feeling). Though I wouldn't mind that had it not already been changed from master/slave anyway. Just want it changed "properly" if it gets changed at all. It also seems to be used in literature already from what I was told.
