### PR TITLE
Make documented complexity consistent

### DIFF
--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -45,7 +45,7 @@ protocol _ArrayType
   /// - Postcondition: `capacity >= minimumCapacity` and the array has
   ///   mutable contiguous storage.
   ///
-  /// - Complexity: O(`count`).
+  /// - Complexity: O(`self.count`).
   mutating func reserveCapacity(minimumCapacity: Int)
 
   /// Operator form of `appendContentsOf`.

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -618,7 +618,7 @@ extension ${Self} : _ArrayType {
   /// - Postcondition: `capacity >= minimumCapacity` and the array has
   ///   mutable contiguous storage.
   ///
-  /// - Complexity: O(`count`).
+  /// - Complexity: O(`self.count`).
   @_semantics("array.mutate_unknown")
   public mutating func reserveCapacity(minimumCapacity: Int) {
     if _buffer.requestUniqueMutableBackingBuffer(minimumCapacity) == nil {
@@ -722,7 +722,7 @@ extension ${Self} : _ArrayType {
   ///
   /// - Requires: `i <= count`.
   ///
-  /// - Complexity: O(`count`).
+  /// - Complexity: O(`self.count`).
   public mutating func insert(newElement: Element, atIndex i: Int) {
     _checkIndex(i)
     self.replaceRange(i..<i, with: CollectionOfOne(newElement))
@@ -732,7 +732,7 @@ extension ${Self} : _ArrayType {
   ///
   /// Invalidates all indices with respect to `self`.
   ///
-  /// - Complexity: O(`count`).
+  /// - Complexity: O(`self.count`).
   public mutating func removeAtIndex(index: Int) -> Element {
     let result = self[index]
     self.replaceRange(index..<(index + 1), with: EmptyCollection())

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1078,7 +1078,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///
   /// Invalidates all indices with respect to `self`.
   ///
-  /// - Complexity: O(`count`).
+  /// - Complexity: O(`self.count`).
   public mutating func removeAtIndex(index: Index) -> Element {
     return _variantStorage.removeAtIndex(index)
   }
@@ -1101,7 +1101,7 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   storage capacity that the collection has, otherwise the underlying
   ///   storage is released.  The default is `false`.
   ///
-  /// Complexity: O(`count`).
+  /// Complexity: O(`self.count`).
   public mutating func removeAll(keepCapacity keepCapacity: Bool = false) {
     // The 'will not decrease' part in the documentation comment is worded very
     // carefully.  The capacity can increase if we replace Cocoa storage with


### PR DESCRIPTION
Since most of the documentation in the code use O(`self.count`) instead of O(`count`), change the inconsistent code documentation to O(`self.count`).
