### PR TITLE
Fix spelling error in name of function

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -41,7 +41,7 @@ public:
 
   /// Return true if the other dominator tree does not match this dominator
   /// tree.
-  inline bool errorOccuredOnComparison(const DominanceInfo &Other) const {
+  inline bool errorOccurredOnComparison(const DominanceInfo &Other) const {
     const auto *R = getRootNode();
     const auto *OtherR = Other.getRootNode();
 
@@ -131,7 +131,7 @@ public:
 
   /// Return true if the other dominator tree does not match this dominator
   /// tree.
-  inline bool errorOccuredOnComparison(const PostDominanceInfo &Other) const {
+  inline bool errorOccurredOnComparison(const PostDominanceInfo &Other) const {
     const auto *R = getRootNode();
     const auto *OtherR = Other.getRootNode();
 

--- a/lib/SIL/Dominance.cpp
+++ b/lib/SIL/Dominance.cpp
@@ -55,7 +55,7 @@ void DominanceInfo::verify() const {
   DominanceInfo OtherDT(F);
 
   // And compare.
-  if (errorOccuredOnComparison(OtherDT)) {
+  if (errorOccurredOnComparison(OtherDT)) {
     llvm::errs() << "DominatorTree is not up to date!\nComputed:\n";
     print(llvm::errs());
     llvm::errs() << "\nActual:\n";
@@ -102,7 +102,7 @@ void PostDominanceInfo::verify() const {
   PostDominanceInfo OtherDT(F);
 
   // And compare.
-  if (errorOccuredOnComparison(OtherDT)) {
+  if (errorOccurredOnComparison(OtherDT)) {
     llvm::errs() << "PostDominatorTree is not up to date!\nComputed:\n";
     print(llvm::errs());
     llvm::errs() << "\nActual:\n";


### PR DESCRIPTION
Function name is changed as well as every time that function appears in the code

Note: Every instance of this method name appearing was changed, and therefore nothing will attempt to call the old function name.
