### PR TITLE
[stdlib] Used map and guard for nil handling

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -177,9 +177,8 @@ public struct EnumerateGenerator<
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Element? {
-    let b = base.next()
-    if b == nil { return .None }
-    return .Some((index: count++, element: b!))
+    guard let b = base.next() else { return .None }
+    return .Some((index: count++, element: b))
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -765,8 +765,7 @@ public struct PermutationGenerator<
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Element? {
-    let result = indices.next()
-    return result != nil ? seq[result!] : .None
+    return indices.next().map { seq[$0] }
   }
 
   /// Construct a *generator* over a permutation of `elements` given


### PR DESCRIPTION
Changed nil handling by using map statements.
I think these changes should have `guard let` or `map` as it is more expressive.
Please let me know if anything else needed.
Thanks to swift team
