### PR TITLE
Remove unnecessary 'visitDecl' default cases.

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -156,9 +156,6 @@ class UIdentVisitor : public ASTVisitor<UIdentVisitor,
 public:
   explicit UIdentVisitor(bool IsRef) : IsRef(IsRef) { }
 
-  /// TODO: reconsider whether having a default case is a good idea.
-  UIdent visitDecl(const Decl *D) { return UIdent(); }
-
   UIdent visitFuncDecl(const FuncDecl *D);
   UIdent visitVarDecl(const VarDecl *D);
   UIdent visitExtensionDecl(const ExtensionDecl *D);

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -781,10 +781,6 @@ public:
     return Result;
   }
 
-  void visitDecl(Decl *D) {
-    // FIXME: maybe don't have a default case
-  }
-
   void visitStructDecl(StructDecl *SD) {
     auto ResultSD = std::make_shared<sma::StructDecl>();
     ResultSD->Name = convertToIdentifier(SD->getName());


### PR DESCRIPTION
The default cases are unnecessary and provide no benefits so they should
just be removed.
