### PR TITLE
[stdlib] Use type inference for Bool vars

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -14,8 +14,8 @@ import SwiftShims
 
 public struct _FDInputStream {
   public let fd: CInt
-  public var isClosed: Bool = false
-  public var isEOF: Bool = false
+  public var isClosed = false
+  public var isEOF = false
   internal var _buffer = [UInt8](count: 256, repeatedValue: 0)
   internal var _bufferUsed: Int = 0
 
@@ -93,7 +93,7 @@ public struct _Stderr : OutputStreamType {
 
 public struct _FDOutputStream : OutputStreamType {
   public let fd: CInt
-  public var isClosed: Bool = false
+  public var isClosed = false
 
   public init(fd: CInt) {
     self.fd = fd

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -788,7 +788,7 @@ public struct NSIndexSetGenerator : GeneratorType {
   public typealias Element = Int
 
   internal let _set: NSIndexSet
-  internal var _first: Bool = true
+  internal var _first = true
   internal var _current: Int?
 
   internal init(set: NSIndexSet) {

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -600,7 +600,7 @@ public func XCTAssertEqualWithAccuracy<T : FloatingPointType>(@autoclosure expre
     let expressionValue1 = expressionValue1Optional!
     let expressionValue2 = expressionValue2Optional!
     
-    var equalWithAccuracy: Bool = false
+    var equalWithAccuracy = false
     
     switch (expressionValue1, expressionValue2, accuracy) {
     case let (expressionValue1Double as Double, expressionValue2Double as Double, accuracyDouble as Double):
@@ -668,7 +668,7 @@ public func XCTAssertNotEqualWithAccuracy<T : FloatingPointType>(@autoclosure ex
     let expressionValue1 = expressionValue1Optional!
     let expressionValue2 = expressionValue2Optional!
     
-    var notEqualWithAccuracy: Bool = false
+    var notEqualWithAccuracy = false
     
     switch (expressionValue1, expressionValue2, accuracy) {
     case let (expressionValue1Double as Double, expressionValue2Double as Double, accuracyDouble as Double):

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -194,7 +194,7 @@ public struct StrideThroughGenerator<Element : Strideable> : GeneratorType {
   var current: Element
   let end: Element
   let stride: Element.Stride
-  var done: Bool = false
+  var done = false
 
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -62,7 +62,7 @@ public struct Zip2Generator<
   }
 
   internal var _baseStreams: (Generator1, Generator2)
-  internal var _reachedEnd: Bool = false
+  internal var _reachedEnd = false
 }
 
 /// A sequence of pairs built out of two underlying sequences, where


### PR DESCRIPTION
This commit makes the declarations of boolean variables more concise by using type inference
