### PR TITLE
Changing the hyperlink word in README.md from 'the website' to 'Swift.org'

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,4 +176,4 @@ Swift community welcoming to everyone.
 To give clarity of what is expected of our members, Swift has adopted the
 code of conduct defined by the Contributor Covenant. This document is used
 across many open source communities, and we think it articulates our values
-well. For more, see [the website](https://swift.org/community/#code-of-conduct).
+well. For more, see [Swift.org](https://swift.org/community/#code-of-conduct).


### PR DESCRIPTION
Changing the hyperlink word in README.md from 'the website' to 'Swift.org'
