### PR TITLE
Fixed formatting and spelling

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -13,7 +13,7 @@ Abstract
 This document describes the high-level abstraction of built-in Swift
 data structures in SIL that is used by the optimizer. You need to read
 this document if you wish to understand the early stages of the Swift
-optimizer or if you are working on one of the containers in the 
+optimizer or if you are working on one of the containers in the
 standard library.
 
 
@@ -33,22 +33,22 @@ Any Swift developer could identify the redundancy in the code sample above.
 Storing two values into the same key in the dictionary is inefficient.
 However, optimizing compilers are unaware of the special semantics that the
 Swift dictionary has and can't perform this optimization. Traditional
-compilers would start optimizing this code by inlining the subscript 
+compilers would start optimizing this code by inlining the subscript
 function call and try to analyze the sequence of load/store instructions.
 This approach is not very effective because the compiler has to be very
-conservative when optimizing general code with pointers. 
+conservative when optimizing general code with pointers.
 
 On the other hand, compilers for high-level languages usually have special
 bytecode instructions that allow them to perform high-level optimizations.
 However, unlike high-level languages such as JavaScript or Python, Swift
 containers are implemented in Swift itself. Moreover, it is beneficial to
 be able to inline code from the container into the user program and optimize
-them together, especially for code that uses Generics. 
+them together, especially for code that uses Generics.
 
 In order to perform both high-level optimizations, that are common in
 high-level languages, and low-level optimizations we annotate parts of the
 standard library and describe the semantics of a domain-specific high-level
-operations on data types in the Swift standard library. 
+operations on data types in the Swift standard library.
 
 Annotation of code in the standard library
 ------------------------------------------
@@ -78,7 +78,7 @@ operations in the semantic model. One for checking the bounds and
 another one for accessing the elements. With this abstraction the
 optimizer can remove the ``checkSubscript`` instruction and keep the
 getElement instruction::
- 
+
   @public subscript(index: Int) -> Element {
      get {
       checkSubscript(index)
@@ -88,7 +88,7 @@ getElement instruction::
   @_semantics("array.check_subscript") func checkSubscript(index: Int) {
     ...
   }
-	
+
   @_semantics("array.get_element") func getElement(index: Int) -> Element {
     return _buffer[index]
   }
@@ -131,7 +131,7 @@ Array
 
 The following semantic tags describe Array operations. The operations
 are first described in terms of the Array "state". Relations between the
-operations are formally defined below. 'Array' referes to the standard library
+operations are formally defined below. 'Array' refers to the standard library
 Array<T>, ContigousArray<T>, and ArraySlice<T> data-structures.
 
 We consider the array state to consist of a set of disjoint elements
@@ -236,7 +236,7 @@ array.mutate_unknown
 To complete the semantics understood by the optimizer, we define these relations:
 
 interferes-with
-  
+
   Given idempotent ``OpA``, the sequence "``OpA, OpB, OpA``" is
   semantically equivalent to the sequence "``OpA, OpB``" *iff* ``OpB``
   does not interfere with ``OpA``.
@@ -282,18 +282,18 @@ String
 ~~~~~~
 
 string.concat(lhs: String, rhs: String) -> String
-  
+
   Performs concatenation of two strings. Operands are not mutated.
   This operation can be optimized away in case of both operands
   being string literals. In this case, it can be replaced by
   a string literal representing a concatenation of both operands.
-  
+
 string.makeUTF8(start: RawPointer, byteSize: Word, isASCII: Int1) -> String
-  
+
   Converts a built-in UTF8-encoded string literal into a string.
-  
+
 string.makeUTF16(start: RawPointer, numberOfCodeUnits: Word) -> String
-  
+
   Converts a built-in UTF16-encoded string literal into a string.
 
 Dictionary
@@ -323,7 +323,7 @@ readnone
 
 readonly
 
-  function has no side effects, but is dependent on the global 
+  function has no side effects, but is dependent on the global
   state of the program. Calls to readonly functions can be
   eliminated, but cannot be reordered or folded in a way that would
   move calls to the readnone function across side effects.
@@ -358,4 +358,3 @@ The availability attribute supports the following tags:
 availability.osversion(major: Builtin.Word, minor: Builtin.Word, patch: Builtin.Word) -> Builtin.Int1
 
   Returns true if the OS version matches the parameters.
-


### PR DESCRIPTION
The word “referes” was corrected to “refers”. Formatting for other
lines was also fixed.
