### PR TITLE
Fixed a typo

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -59,7 +59,7 @@ Reducing Dynamic Dispatch
 
 Swift by default is a very dynamic language like Objective-C. Unlike Objective
 C, Swift gives the programmer the ability to improve runtime performance when
-necessary by removing or reducing this dynamicism. This section goes through
+necessary by removing or reducing this dynamism. This section goes through
 several examples of language constructs that can be used to perform such an
 operation.
 


### PR DESCRIPTION
The word “dynamicism” was changed to “dynamism”.
