### PR TITLE
Use a More Specific Assert for RValue Type Lowering

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -71,7 +71,7 @@ ManagedValue SILGenFunction::emitManagedRValueWithCleanup(SILValue v) {
 
 ManagedValue SILGenFunction::emitManagedRValueWithCleanup(SILValue v,
                                                const TypeLowering &lowering) {
-  assert(lowering.getLoweredType() == v.getType());
+  assert(lowering.getLoweredType().getSwiftRValueType() == v.getType().getSwiftRValueType());
   if (lowering.isTrivial())
     return ManagedValue::forUnmanaged(v);
   

--- a/validation-test/compiler_crashers/21815-swift-lowering-silgen-emitmanagedrvaluewithcleanup.swift
+++ b/validation-test/compiler_crashers/21815-swift-lowering-silgen-emitmanagedrvaluewithcleanup.swift
@@ -1,0 +1,12 @@
+// RUN: --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+
+struct S<T> {
+    init(f: AutoreleasingUnsafeMutablePointer<T?> -> ()) {
+        var t: T?
+        f(&t)
+    }
+}
+

--- a/validation-test/compiler_crashers_fixed/21815-swift-lowering-silgen-emitmanagedrvaluewithcleanup.swift
+++ b/validation-test/compiler_crashers_fixed/21815-swift-lowering-silgen-emitmanagedrvaluewithcleanup.swift
@@ -1,4 +1,4 @@
-// RUN: --crash %target-swift-frontend %s -parse
+// RUN: %target-swift-frontend %s -emit-ir
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
Fixes a crash caused by the lowering mechanism editing the storage flags for a type.
