### PR TITLE
[AST] Fix for SR-7: Inferring closure param type to inout crashes compiler

### DIFF
--- a/lib/AST/Verifier.cpp
+++ b/lib/AST/Verifier.cpp
@@ -814,6 +814,13 @@ struct ASTNodeBase {};
     }
 
     void verifyChecked(DeclRefExpr *E) {
+      if (E->getType()->is<InOutType>()) {
+        PrettyStackTraceExpr debugStack(Ctx, "verifying decl reference", E);
+        Out << "reference with inout type "
+          << E->getType().getString() << "\n";
+        E->dump(Out);
+        abort();
+      }
       if (E->getType()->is<PolymorphicFunctionType>()) {
         PrettyStackTraceExpr debugStack(Ctx, "verifying decl reference", E);
         Out << "unspecialized reference with polymorphic type "

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -404,6 +404,16 @@ namespace {
       }
 
       auto type = simplifyType(openedType);
+        
+      // If we've ended up trying to assign an inout type here, it means we're
+      // missing an ampersand in front of the ref.
+      if (auto inoutType = type->getAs<InOutType>()) {
+        auto &tc = cs.getTypeChecker();
+        tc.diagnose(loc, diag::missing_address_of, inoutType->getInOutObjectType())
+          .fixItInsert(loc, "&");
+        return nullptr;
+      }
+        
       return new (ctx) DeclRefExpr(decl, loc, implicit, semantics, type);
     }
 
@@ -5649,6 +5659,8 @@ namespace {
           // Enter the context of the closure when type-checking the body.
           llvm::SaveAndRestore<DeclContext *> savedDC(Rewriter.dc, closure);
           Expr *body = closure->getSingleExpressionBody()->walk(*this);
+          if (!body)
+            return { false, nullptr };
           
           if (body != closure->getSingleExpressionBody())
             closure->setSingleExpressionBody(body);
@@ -5665,7 +5677,7 @@ namespace {
                                              closure,
                                              ConstraintLocator::ClosureResult));
               if (!body)
-                return { false, nullptr } ;
+                return { false, nullptr };
 
               closure->setSingleExpressionBody(body);
             }

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -203,3 +203,7 @@ func testImmutableUnsafePointer(p: UnsafePointer<Int>) {
   p[0] = 1 // expected-error {{cannot assign through subscript: subscript is get-only}}
 }
 
+// <https://bugs.swift.org/browse/SR-7> Inferring closure param type to 
+// inout crashes compiler
+let g = { x in f0(x) } // expected-error{{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{19-19=&}}
+


### PR DESCRIPTION
Diagnose a variable inferred to be inout, but without explicit ‘&’. This fixes https://bugs.swift.org/browse/SR-7.
