### PR TITLE
Fix typo in SIL.rst

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4316,7 +4316,7 @@ constant replacement but leave the function application to be serialized to
 sil).
 
 The compiler flag that influences the value of the ``assert_configuration``
-funtion application is the optimization flag: at ``-Onone` the application will
+function application is the optimization flag: at ``-Onone` the application will
 be replaced by ``Debug`` at higher optimization levels the instruction will be
 replaced by ``Release``. Optionally, the value to use for replacement can be
 specified with the ``-AssertConf`` flag which overwrites the value selected by


### PR DESCRIPTION
'funtion' -> 'function'
