### PR TITLE
[Basic] Implement `CacheImpl::releaseValue`

### DIFF
--- a/lib/Basic/Cache.cpp
+++ b/lib/Basic/Cache.cpp
@@ -105,7 +105,14 @@ bool CacheImpl::getAndRetain(const void *Key, void **Value_out) {
 }
 
 void CacheImpl::releaseValue(void *Value) {
-  // FIXME: Implementation.
+  DefaultCache &DCache = *static_cast<DefaultCache*>(Impl);
+  llvm::sys::ScopedLock L(DCache.Mux);
+
+  for (auto Entry = DCache.Entries.begin(); Entry != DCache.Entries.end(); ++Entry) {
+    if (Entry->second == *Value) {
+      DCache.CBs.valueDestroyCB(Entry->second, nullptr);
+    }
+  }
 }
 
 bool CacheImpl::remove(const void *Key) {


### PR DESCRIPTION
Added implementation similar to the `getAndRetain` and `remove` methods. Given that `DCache.Entries` appears to be a subclass of (or similar to) `std::map`, there isn't a great way to find a specified value without iterating through the map (unless `boost` is included, or unless you're using boost's `bimap`). Therefore, this works by iterating through the cache, finding the specified value, and calling `valueDestroyCB` on it.

Let me know if you envisioned a different solution or if you have any concerns with this. Although this builds and tests without causing errors, the next step (that I'll add to this PR) is to create testcases for this and to integrate `releaseValue` into `getAndRetain` and `setAndRetain` as per the `FIXME`s on lines 88 and 99.
