### PR TITLE
Fix docs and comments around optional intrinsics

### DIFF
--- a/docs/archive/LangRef.html
+++ b/docs/archive/LangRef.html
@@ -1295,10 +1295,13 @@
           <code>T?</code>.</li>
       </ul>
       To support these intrinsic use cases, the library is required to
-      provide four functions with these exact signatures:
+      provide functions with these exact signatures:
       <ul>
-        <li><code>func _preconditionOptionalHasValue<T>(inout v : T?)</code>
+        <li><code>func _doesOptionalHaveValueAsBool<T>(v : T?) -> Bool</code></li>
+        <li><code>func _diagnoseUnexpectedNilOptional()</code></li>
         <li><code>func _getOptionalValue<T>(v : T?) -> T</code></li>
+        <li><code>func _injectValueIntoOptional<T>(v : T) -> T?</code></li>
+        <li><code>func _injectNothingIntoOptional<T>() -> T?</code></li>
       </ul>
     </p>
 
@@ -1317,7 +1320,7 @@
       var b : Int? = .None
         
       <i>// Declare an array of optionals:</i>
-      var c : Int?[] = new Int?[4]
+      var c : [Int?] = [10, nil, 42]
     </pre>
 
   <!-- _____________________________________________________________________ -->

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -810,7 +810,8 @@ public:
   /// The result is a Builtin.Int1.
   SILValue emitDoesOptionalHaveValue(SILLocation loc, SILValue addrOrValue);
 
-  /// \brief Emit a call to the library intrinsic _preconditionOptionalHasValue.
+  /// \brief Emit a switch_enum to call the library intrinsic
+  /// _diagnoseUnexpectedNilOptional if the optional has no value.
   void emitPreconditionOptionalHasValue(SILLocation loc, SILValue addr);
 
   /// \brief Emit a call to the library intrinsic _getOptionalValue


### PR DESCRIPTION
**docs/archive/LangRef.html** is flagged as unmaintained, but I didn't see much else about optionals in the docs so why not update it anyway!

`emitPreconditionOptionalHasValue` had the switch logic moved from the standard library to **lib/SILGen/SILGenConvert.cpp** back in 9c7417edc2cf8f8 and there's no `_preconditionOptionalHasValue` intrinsic anymore. Updated the comment in the headers to clarify.
