### PR TITLE
Fix duplicate error and re-categorize test

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3194,12 +3194,11 @@ public:
   void visitAssociatedTypeDecl(AssociatedTypeDecl *assocType) {
     if (assocType->isBeingTypeChecked()) {
 
-      if (!assocType->hasType()) {
+      if (!assocType->isInvalid()) {
         assocType->setInvalid();
         assocType->overwriteType(ErrorType::get(TC.Context));
+        TC.diagnose(assocType->getLoc(), diag::circular_type_alias, assocType->getName());
       }
-
-      TC.diagnose(assocType->getLoc(), diag::circular_type_alias, assocType->getName());
       return;
     }
 

--- a/validation-test/compiler_crashers_fixed/1741-swift-constraints-constraintsystem-simplifymemberconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/1741-swift-constraints-constraintsystem-simplifymemberconstraint.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
This crashing test became non-crashing in #138. #138 also emitted multiple instances of the same diagnostic, which was causing `-verify` to fail on `decl/protocol/req/recursion.swift`.
