### PR TITLE
Fix typo in comment in HashedCollections.swift.gyb

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -53,7 +53,7 @@ import SwiftShims
 // does not use tombstones.
 //
 // In addition to the native storage `Dictionary` can also wrap an
-// `NSDictionary` in order to allow brdidging `NSDictionary` to `Dictionary` in
+// `NSDictionary` in order to allow bridging `NSDictionary` to `Dictionary` in
 // `O(1)`.
 //
 // Currently native storage uses a data structure like this::


### PR DESCRIPTION
"brdidging" changed to "bridging"
