### PR TITLE
Preserve whitespace for first argument on next line.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3173,7 +3173,7 @@ public:
         TAD->getUnderlyingTypeLoc().setInvalidType(TC.Context);
       } else if (TAD->getDeclContext()->isGenericContext()) {
         TAD->setInterfaceType(
-        TC.getInterfaceTypeFromInternalType(TAD->getDeclContext(),
+          TC.getInterfaceTypeFromInternalType(TAD->getDeclContext(),
                                               TAD->getType()));
       }
 


### PR DESCRIPTION
Pull request #138 removed a meaningful whitespace; it has meaning since it's denoting that this line is the first argument of the previous lines function call.

_Note_
I hate to make a pull request for such a small change; and hope I don't fall into the grammar nazi contributors, but I do feel strongly about this. 
It also restore visual alignment of arguments to `TC.getInterfaceTypeFromInternalType` (on the second line).
