### PR TITLE
Fix typo in CapturePromotion.cpp

### DIFF
--- a/lib/SILPasses/IPO/CapturePromotion.cpp
+++ b/lib/SILPasses/IPO/CapturePromotion.cpp
@@ -528,7 +528,7 @@ void ClosureCloner::visitDebugValueAddrInst(DebugValueAddrInst *Inst) {
 }
 
 /// \brief Handle a strong_release instruction during cloning of a closure; if
-/// it is a strong release of a promoted box argument, then it is replaced wit
+/// it is a strong release of a promoted box argument, then it is replaced with
 /// a ReleaseValue of the new object type argument, otherwise it is handled
 /// normally.
 void


### PR DESCRIPTION
`wit` -> `with`.
