### PR TITLE
Fix typo in RemovePin.cpp

### DIFF
--- a/lib/SILPasses/Scalar/RemovePin.cpp
+++ b/lib/SILPasses/Scalar/RemovePin.cpp
@@ -38,7 +38,7 @@ STATISTIC(NumPinPairsRemoved, "Num pin pairs removed");
 using namespace swift;
 
 /// \brief Can this instruction read the pinned bit of the reference count.
-/// Reading the pinned prevents us from moving the pin instructions accross it.
+/// Reading the pinned prevents us from moving the pin instructions across it.
 static bool mayReadPinFlag(SILInstruction *I) {
   auto Kind = I->getKind();
   if (Kind == ValueKind::IsUniqueOrPinnedInst)


### PR DESCRIPTION
<code>accross</code> -> <code>across</code>
