### PR TITLE
Make the collections implementation of `indexOf` a little bit more Swift-like

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -43,10 +43,8 @@ extension CollectionType where ${GElement} : Equatable {
       return result
     }
 
-    for i in self.indices {
-      if self[i] == element {
-        return i
-      }
+    for i in self.indices where self[i] == element {
+      return i
     }
     return nil
   }
@@ -61,10 +59,8 @@ extension CollectionType {
   public func indexOf(
     @noescape predicate: (${GElement}) throws -> Bool
   ) rethrows -> Index? {
-    for i in self.indices {
-      if try predicate(self[i]) {
-        return i
-      }
+    for i in self.indices where try predicate(self[i]) {
+      return i
     }
     return nil
   }


### PR DESCRIPTION
I'm not sure if these changes are welcome. I think both of these changes are a bit more Swift-like. They remove a level of indentation (which I think is mostly a good thing).

I've checked the SIL and it seems to be exactly the same (except that the branches are swapped around).
