### PR TITLE
Remove unused -DLLVM_TOOL_SWIFT_BUILD

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1497,20 +1497,12 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                     build_targets=(llvm-config llvm-tblgen clang-headers)
                 fi
 
-                # Note: we set the variable:
-                #
-                # LLVM_TOOL_SWIFT_BUILD
-                #
-                # below because this script builds swift separately, and people
-                # often have reasons to symlink the swift directory into
-                # llvm/tools, e.g. to build LLDB.
                 cmake_options=(
                     "${cmake_options[@]}"
                     -DCMAKE_C_FLAGS="$(llvm_c_flags $deployment_target)"
                     -DCMAKE_CXX_FLAGS="$(llvm_c_flags $deployment_target)"
                     -DCMAKE_BUILD_TYPE:STRING="${LLVM_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLVM_ENABLE_ASSERTIONS}")
-                    -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD}"
                     -DLLVM_INCLUDE_TESTS:BOOL=$(true_false "${SOURCE_TREE_INCLUDES_TESTS}")
                     -LLVM_INCLUDE_DOCS:BOOL=TRUE


### PR DESCRIPTION
I don't know if it's the right thing to just remove it like this, but CMake says:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    LLVM_TOOL_SWIFT_BUILD
```

And I can't see that this variable is ever checked by `swift-llvm`. I tried to look for it through the history, but couldn't find it.
