### PR TITLE
Don't assume multiarch locations in Glibc module map

### DIFF
--- a/stdlib/public/Glibc/.gitignore
+++ b/stdlib/public/Glibc/.gitignore
@@ -1,0 +1,1 @@
+module.map

--- a/stdlib/public/Glibc/CMakeLists.txt
+++ b/stdlib/public/Glibc/CMakeLists.txt
@@ -1,3 +1,16 @@
+# If CMAKE_LIBRARY_ARCHITECTURE is set, we're probably on a Debian
+# style multiarch system and Glibc headers are in /usr/include/{triplet},
+# otherwise they're in /usr/include. This is the best way to determine
+# this path until https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=796545
+# is fixed.
+if(CMAKE_LIBRARY_ARCHITECTURE)
+    set(arch_include_dir "/usr/include/${CMAKE_LIBRARY_ARCHITECTURE}")
+else()
+    set(arch_include_dir "/usr/include")
+endif()
+
+configure_file(module.map.in "${CMAKE_CURRENT_SOURCE_DIR}/module.map")
+
 set(sources
   module.map
   )

--- a/stdlib/public/Glibc/module.map.in
+++ b/stdlib/public/Glibc/module.map.in
@@ -184,7 +184,7 @@ module SwiftGlibc [system] {
       export *
     }
     module ioctl {
-      header "/usr/include/x86_64-linux-gnu/sys/ioctl.h"
+      header "@arch_include_dir@/sys/ioctl.h"
       export *
     }
     module langinfo {
@@ -266,71 +266,71 @@ module SwiftGlibc [system] {
       export *
 
       module ipc {
-        header "/usr/include/x86_64-linux-gnu/sys/ipc.h"
+        header "@arch_include_dir@/sys/ipc.h"
         export *
       }
       module mman {
-        header "/usr/include/x86_64-linux-gnu/sys/mman.h"
+        header "@arch_include_dir@/sys/mman.h"
         export *
       }
       module msg {
-        header "/usr/include/x86_64-linux-gnu/sys/msg.h"
+        header "@arch_include_dir@/sys/msg.h"
         export *
       }
       module resource {
-        header "/usr/include/x86_64-linux-gnu/sys/resource.h"
+        header "@arch_include_dir@/sys/resource.h"
         export *
       }
       module select {
-        header "/usr/include/x86_64-linux-gnu/sys/select.h"
+        header "@arch_include_dir@/sys/select.h"
         export *
       }
       module sem {
-        header "/usr/include/x86_64-linux-gnu/sys/sem.h"
+        header "@arch_include_dir@/sys/sem.h"
         export *
       }
       module shm {
-        header "/usr/include/x86_64-linux-gnu/sys/shm.h"
+        header "@arch_include_dir@/sys/shm.h"
         export *
       }
       module socket {
-        header "/usr/include/x86_64-linux-gnu/sys/socket.h"
+        header "@arch_include_dir@/sys/socket.h"
         export *
       }
       module stat {
-        header "/usr/include/x86_64-linux-gnu/sys/stat.h"
+        header "@arch_include_dir@/sys/stat.h"
         export *
       }
       module statvfs {
-        header "/usr/include/x86_64-linux-gnu/sys/statvfs.h"
+        header "@arch_include_dir@/sys/statvfs.h"
         export *
       }
       module time {
-        header "/usr/include/x86_64-linux-gnu/sys/time.h"
+        header "@arch_include_dir@/sys/time.h"
         export *
       }
       module times {
-        header "/usr/include/x86_64-linux-gnu/sys/times.h"
+        header "@arch_include_dir@/sys/times.h"
         export *
       }
       module types {
-        header "/usr/include/x86_64-linux-gnu/sys/types.h"
+        header "@arch_include_dir@/sys/types.h"
         export *
       }
       module uio {
-        header "/usr/include/x86_64-linux-gnu/sys/uio.h"
+        header "@arch_include_dir@/sys/uio.h"
         export *
       }
       module un {
-        header "/usr/include/x86_64-linux-gnu/sys/un.h"
+        header "@arch_include_dir@/sys/un.h"
         export *
       }
       module utsname {
-        header "/usr/include/x86_64-linux-gnu/sys/utsname.h"
+        header "@arch_include_dir@/sys/utsname.h"
         export *
       }
       module wait {
-        header "/usr/include/x86_64-linux-gnu/sys/wait.h"
+        header "@arch_include_dir@/sys/wait.h"
         export *
       }
     }


### PR DESCRIPTION
This is the best way I could find to handle the fact that these headers are not in `/usr/include/{arch-triplet}` on most distros, but directly in `/usr/include`. There will probably be a cleaner way to get this path than checking if `CMAKE_LIBRARY_ARCHITECTURE` is set when [this bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=796545) is fixed.
