### PR TITLE
Fixed spelling and grammar

### DIFF
--- a/docs/proposals/OptimizerEffects.rst
+++ b/docs/proposals/OptimizerEffects.rst
@@ -245,7 +245,7 @@ state.
 
 ``@get_subobject_non_bridged``
 
-  A method marked ``@get_subobject`` must fullfill all of ``@preserve_unique``'s
+  A method marked ``@get_subobject`` must fulfill all of ``@preserve_unique``'s
   guarantees. Furthermore, it must return a 'subobject' that is stored by the
   set of storage objects or a value stored in the CoW struct itself. It must be
   guaranteed that the 'subobject' returned is kept alive as long the current
@@ -617,7 +617,7 @@ optimizing the surrounding code.
 For example::
 
   func bar<T>(t: T) {...}
-   
+
   func foo<T>(t: T, N: Int) {
     for _ in 1...N {
       bar(t)


### PR DESCRIPTION
The word “fullfill” was changed to “fulfill”. Formatting for other
lines was also fixed.
