### PR TITLE
Add withVaList() for environments without ObjC

### DIFF
--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -10,11 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if _runtime(_ObjC)
-// Excluded due to use of dynamic casting and Builtin.autorelease, neither
-// of which correctly work without the ObjC Runtime right now.
-// See rdar://problem/18801510
-
 /// Instances of conforming types can be encoded, and appropriately
 /// passed, as elements of a C `va_list`.
 ///
@@ -82,6 +77,11 @@ public func withVaList<R>(builder: VaListBuilder,
   return result
 }
 
+#if _runtime(_ObjC)
+// Excluded due to use of dynamic casting and Builtin.autorelease, neither
+// of which correctly work without the ObjC Runtime right now.
+// See rdar://problem/18801510
+
 /// Returns a `CVaListPointer` built from `args` that's backed by
 /// autoreleased storage.
 ///
@@ -100,6 +100,7 @@ public func getVaList(args: [CVarArgType]) -> CVaListPointer {
   Builtin.autorelease(builder)
   return builder.va_list()
 }
+#endif
 
 @warn_unused_result
 public func _encodeBitsAsWords<T : CVarArgType>(x: T) -> [Int] {
@@ -237,6 +238,7 @@ extension UnsafeMutablePointer : CVarArgType {
   }
 }
 
+#if _runtime(_ObjC)
 extension AutoreleasingUnsafeMutablePointer : CVarArgType {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
@@ -244,6 +246,7 @@ extension AutoreleasingUnsafeMutablePointer : CVarArgType {
     return _encodeBitsAsWords(self)
   }
 }
+#endif
 
 extension Float : _CVarArgPassedAsDouble, _CVarArgAlignedType {
   /// Transform `self` into a series of machine words that can be
@@ -429,4 +432,3 @@ final public class VaListBuilder {
 
 #endif
 
-#endif // _runtime(_ObjC)


### PR DESCRIPTION
Currently Linux edition lacks getVaList() and withVaList().
I agree that getVaList() is not available due to memory management model, but I believe that withVaList() is possible.

Sample code is here: http://qiita.com/cielavenir/items/2598d47b97a7c9caf970
