### PR TITLE
Fix typo in Arrays.swift.gyb

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -338,7 +338,7 @@ public struct ${Self}<Element>
   }
   
   // Don't inline copyBuffer - this would inline the copy loop into the current
-  // path preventing retains/releases to be matched accross that region.
+  // path preventing retains/releases to be matched across that region.
   @inline(never)
   static internal func _copyBuffer(inout buffer: _Buffer) {
     let newBuffer = _ContiguousArrayBuffer<Element>(


### PR DESCRIPTION
<code>accross</code> -> <code>across</code>
