### PR TITLE
Simplify filter implementation

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -25,13 +25,12 @@ public struct LazyFilterGenerator<
   ///   since the copy was made, and no preceding call to `self.next()`
   ///   has returned `nil`.
   public mutating func next() -> Base.Element? {
-    var n: Base.Element?
-    for/*ever*/;; {
-      n = _base.next()
-      if n != nil ? _predicate(n!) : true {
+    while let n = _base.next() {
+      if _predicate(n) {
         return n
       }
     }
+    return nil
   }
 
   /// Creates an instance that produces the elements `x` of `base`


### PR DESCRIPTION
This simplifies the filter implementation. I've run emit-sil, and the sil for the while loop is a tiny bit smaller (because it doesn't need to reference !=). I think the readability is much better. I'm not 100% if performance is better. What's the recommended way to performance-test this?
