### PR TITLE
use `pip´, which performs authenticated downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ modules, eliminating the need for headers and the code duplication they entail.
 
 To read the documentation, start by installing the 
 [Sphinx](http://sphinx-doc.org) documentation generator tool (just run 
-`easy_install -U Sphinx` from the command line and you're good to go). Once you
+`pip install --upgrade Sphinx` from the command line and you're good to go). Once you
  have that, you can build the Swift documentation by going into `docs` and 
 typing `make`.  This compiles the `.rst` files in the `docs` directory into 
 HTML in the `docs/_build/html` directory.


### PR DESCRIPTION
`easy_install` is generally deprecated in the Python community, one major reason being that it fetches packages over HTTP and then executes them locally.  https://pip.pypa.io is preferred.
