### PR TITLE
Merge guards in Zip2Generator

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -48,12 +48,7 @@ public struct Zip2Generator<
       return nil
     }
 
-    guard let e0 = _baseStreams.0.next() else {
-      _reachedEnd = true
-      return nil
-    }
-
-    guard let e1 = _baseStreams.1.next() else {
+    guard let e0 = _baseStreams.0.next(), e1 = _baseStreams.1.next() else {
       _reachedEnd = true
       return nil
     }


### PR DESCRIPTION
Removes the duplication of the guard body code
