### PR TITLE
Add Flag to Disable Implicit Optional Conversions

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -153,7 +153,10 @@ namespace swift {
     
     /// Don't mangle the Self type as part of declaration manglings.
     bool DisableSelfTypeMangling = true;
-    
+
+    /// Don't implicitly up/down cast between values and optionals.
+    bool DisableImplicitOptionalConversions = false;
+
     /// Sets the target we are building for and updates configuration options
     /// to match.
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -193,6 +193,9 @@ def use_native_super_method : Flag<["-"], "use-native-super-method">,
 def disable_self_type_mangling : Flag<["-"], "disable-self-type-mangling">,
   HelpText<"Disable including Self type in method type manglings">;
 
+def disable_implicit_optional_conversion : Flag<["-"], "disable-implicit-optional-conversion">,
+  HelpText<"Disable implicit conversions between optional and non-optional types">;
+
 def enable_experimental_patterns : Flag<["-"], "enable-experimental-patterns">,
   HelpText<"Enable experimental 'switch' pattern matching features">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -664,6 +664,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableSelfTypeMangling |=
     Args.hasArg(OPT_disable_self_type_mangling);
 
+  Opts.DisableImplicitOptionalConversions |=
+    Args.hasArg(OPT_disable_implicit_optional_conversion);
+
   Opts.EnableResilience = false;
   if (auto A = Args.getLastArg(OPT_enable_resilience,
                                OPT_disable_resilience)) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1922,7 +1922,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
   // A value of type T? can be converted to type U? if T is convertible to U.
   // The above conversions also apply to implicitly unwrapped optional types,
   // except that there is no implicit conversion from T? to T!.
-  {
+  if (!TC.getLangOpts().DisableImplicitOptionalConversions) {
     BoundGenericType *boundGenericType2;
     
     if (concrete && kind >= TypeMatchKind::Subtype &&
@@ -1964,7 +1964,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
 
   // A value of type T! can be (unsafely) forced to U if T
   // is convertible to U.
-  {
+  if (!TC.getLangOpts().DisableImplicitOptionalConversions) {
     Type objectType1;
     if (concrete && kind >= TypeMatchKind::Conversion &&
         (objectType1 = lookThroughImplicitlyUnwrappedOptionalType(type1))) {

--- a/test/Sema/disable_implicit_optional_conversions.swift
+++ b/test/Sema/disable_implicit_optional_conversions.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -disable-implicit-optional-conversion -emit-sil %s
+
+func f(x : Int?) -> Int {
+  if let y = x {
+    return y
+  }
+  return 0
+}
+
+let x : Int = 5
+
+f(x) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Int?'}}
+
+let y : Int? = 5 // expected-error {{cannot convert value of type 'Int' to specified type 'Int?'}}
+
+f(y)
+
+let z : Int?! = .Some(.Some(5)) // expected-error {{cannot convert value of type 'Int?!' to expected argument type 'Int?'}}
+
+f(z)
+
+


### PR DESCRIPTION
:warning: Controversial :warning: 

Adds the flag `-disable-implicit-optional-conversion` to the frontend.  When enabled, the compiler will reject:
- Implicit wrapping of value types into optionals
- Implicit unwrapping of IUO values
