### PR TITLE
[SR-153] Add IsClosureCapture flag to VarDecl

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -351,10 +351,8 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// a.storage for lazy var a is a decl that cannot be accessed.
     unsigned IsUserAccessible : 1;
     
-    /// \brief Whether this property is assignable by swift users; for instance,
-    /// a weak closure capture is mutable by the runtime, but not user assignable.
-    /// Note that a 'let' property is user assignable (once).
-    unsigned IsUserAssignable : 1;
+    /// \brief Whether this is a closure capture vardecl.
+    unsigned IsClosureCapture : 1;
   };
   enum { NumVarDeclBits = NumAbstractStorageDeclBits + 6 };
   static_assert(NumVarDeclBits <= 32, "fits in an unsigned");
@@ -4035,9 +4033,9 @@ protected:
     : AbstractStorageDecl(Kind, DC, Name, NameLoc) 
   {
     VarDeclBits.IsUserAccessible = true;
-    VarDeclBits.IsUserAssignable = true;
     VarDeclBits.IsStatic = IsStatic;
     VarDeclBits.IsLet = IsLet;
+    VarDeclBits.IsClosureCapture = false;
     VarDeclBits.IsDebuggerVar = false;
     VarDeclBits.HasNonPatternBindingInit = false;
     setType(Ty);
@@ -4135,9 +4133,9 @@ public:
   bool isLet() const { return VarDeclBits.IsLet; }
   void setLet(bool IsLet) { VarDeclBits.IsLet = IsLet; }
 
-  /// Is this assignable by the user?
-  bool isUserAssignable() const { return VarDeclBits.IsUserAssignable; }
-  void setIsUserAssignable(bool IsUserAssignable) { VarDeclBits.IsUserAssignable = IsUserAssignable; }
+  /// Is this a closure capture?
+  bool isClosureCapture() const { return VarDeclBits.IsClosureCapture; }
+  void setIsClosureCapture(bool IsClosureCapture) { VarDeclBits.IsClosureCapture = IsClosureCapture; }
 
   /// Return true if this vardecl has an initial value bound to it in a way
   /// that isn't represented in the AST with an initializer in the pattern

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -350,8 +350,13 @@ class alignas(1 << DeclAlignInBits) Decl {
     /// Whether the decl can be accessed by swift users; for instance,
     /// a.storage for lazy var a is a decl that cannot be accessed.
     unsigned IsUserAccessible : 1;
+    
+    /// \brief Whether this property is assignable by swift users; for instance,
+    /// a weak closure capture is mutable by the runtime, but not user assignable.
+    /// Note that a 'let' property is user assignable (once).
+    unsigned IsUserAssignable : 1;
   };
-  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 5 };
+  enum { NumVarDeclBits = NumAbstractStorageDeclBits + 6 };
   static_assert(NumVarDeclBits <= 32, "fits in an unsigned");
   
   class EnumElementDeclBitfields {
@@ -4030,6 +4035,7 @@ protected:
     : AbstractStorageDecl(Kind, DC, Name, NameLoc) 
   {
     VarDeclBits.IsUserAccessible = true;
+    VarDeclBits.IsUserAssignable = true;
     VarDeclBits.IsStatic = IsStatic;
     VarDeclBits.IsLet = IsLet;
     VarDeclBits.IsDebuggerVar = false;
@@ -4128,6 +4134,10 @@ public:
   /// Is this an immutable 'let' property?
   bool isLet() const { return VarDeclBits.IsLet; }
   void setLet(bool IsLet) { VarDeclBits.IsLet = IsLet; }
+
+  /// Is this assignable by the user?
+  bool isUserAssignable() const { return VarDeclBits.IsUserAssignable; }
+  void setIsUserAssignable(bool IsUserAssignable) { VarDeclBits.IsUserAssignable = IsUserAssignable; }
 
   /// Return true if this vardecl has an initial value bound to it in a way
   /// that isn't represented in the AST with an initializer in the pattern

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3086,7 +3086,7 @@ static bool isSettable(const AbstractStorageDecl *decl) {
 bool VarDecl::isSettable(const DeclContext *UseDC,
                          const DeclRefExpr *base) const {
 
-  if (!isUserAssignable())
+  if (isClosureCapture())
       return false;
     
   // If this is a 'var' decl, then we're settable if we have storage or a
@@ -3313,8 +3313,8 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
   // If it isn't a 'let', don't touch it.
   if (!isLet()) return;
 
-  // Don't suggest mutability if the var isn't user assignable at all.
-  if (!isUserAssignable()) return;
+  // Similarly, if it is a closure capture, don't touch it.
+  if (isClosureCapture()) return;
 
   // If this is the 'self' argument of a non-mutating method in a value type,
   // suggest adding 'mutating' to the method.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3085,6 +3085,10 @@ static bool isSettable(const AbstractStorageDecl *decl) {
 /// is a let member in an initializer.
 bool VarDecl::isSettable(const DeclContext *UseDC,
                          const DeclRefExpr *base) const {
+
+  if (!isUserAssignable())
+      return false;
+    
   // If this is a 'var' decl, then we're settable if we have storage or a
   // setter.
   if (!isLet())
@@ -3308,6 +3312,9 @@ ObjCSelector VarDecl::getDefaultObjCSetterSelector(ASTContext &ctx,
 void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
   // If it isn't a 'let', don't touch it.
   if (!isLet()) return;
+
+  // Don't suggest mutability if the var isn't user assignable at all.
+  if (!isUserAssignable()) return;
 
   // If this is the 'self' argument of a non-mutating method in a value type,
   // suggest adding 'mutating' to the method.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1678,6 +1678,8 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
       auto *VD = new (Context) VarDecl(/*isStatic*/false,
                                        /*isLet*/ownershipKind !=Ownership::Weak,
                                        nameLoc, name, Type(), CurDeclContext);
+      VD->setIsUserAssignable(false);
+
       // Attributes.
       if (ownershipKind != Ownership::Strong)
         VD->getAttrs().add(new (Context) OwnershipAttr(ownershipKind));

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1678,7 +1678,7 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
       auto *VD = new (Context) VarDecl(/*isStatic*/false,
                                        /*isLet*/ownershipKind !=Ownership::Weak,
                                        nameLoc, name, Type(), CurDeclContext);
-      VD->setIsUserAssignable(false);
+      VD->setIsClosureCapture(true);
 
       // Attributes.
       if (ownershipKind != Ownership::Strong)

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -914,7 +914,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
     message += VD->getName().str().str();
     message += "'";
  
-    if (VD->isImplicit() || !VD->isUserAssignable())
+    if (VD->isImplicit() || VD->isClosureCapture())
       message += " is immutable";
     else if (VD->isLet())
       message += " is a 'let' constant";

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -914,7 +914,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
     message += VD->getName().str().str();
     message += "'";
  
-    if (VD->isImplicit())
+    if (VD->isImplicit() || !VD->isUserAssignable())
       message += " is immutable";
     else if (VD->isLet())
       message += " is a 'let' constant";

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2353,6 +2353,7 @@ void Serializer::writeDecl(const Decl *D) {
   case DeclKind::Var: {
     auto var = cast<VarDecl>(D);
     verifyAttrSerializable(var);
+    assert(!var->isClosureCapture() && "should not serialize closure capture vardecls");
 
     auto contextID = addDeclContextRef(var->getDeclContext());
     Type type = var->hasType() ? var->getType() : nullptr;

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -183,7 +183,6 @@ func testCaptureBehavior(ptr : SomeClass) {
   let v2 : SomeClass = ptr
 
   doStuff { [weak v1] in v1!.foo() }
-  // expected-warning @+2 {{variable 'v1' was written to, but never read}}
   doStuff { [weak v1,                 // expected-note {{previous}}
              weak v1] in v1!.foo() }  // expected-error {{definition conflicts with previous value}}
   doStuff { [unowned v2] in v2.foo() }
@@ -191,8 +190,12 @@ func testCaptureBehavior(ptr : SomeClass) {
   doStuff { [unowned(safe) v2] in v2.foo() }
   doStuff { [weak v1, weak v2] in v1!.foo() + v2!.foo() }
 
+  // Test constness of captures.  
+  doVoidStuff { [weak v2] in v2 = SomeClass() } // expected-error {{cannot assign to value: 'v2' is immutable}}
+  doVoidStuff { [unowned v2] in v2 = SomeClass() } // expected-error {{cannot assign to value: 'v2' is immutable}}
+  doVoidStuff { [v2] in v2 = SomeClass() } // expected-error {{cannot assign to value: 'v2' is immutable}}
+
   let i = 42
-  // expected-warning @+1 {{variable 'i' was never mutated}} {{19-20=let}}
   doStuff { [weak i] in i! }   // expected-error {{'weak' may only be applied to class and class-bound protocol types, not 'Int'}}
 }
 


### PR DESCRIPTION
That flag helps distinguish between truly constant vars and those which
aren’t assignable but need to be mutable (like weak closure captures).
Also fixes sr-153 by improving error reporting in these cases.
