### PR TITLE
Don't add constraints for invalid subscript declarations.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1517,8 +1517,11 @@ namespace {
 
     Type visitSubscriptExpr(SubscriptExpr *expr) {
       ValueDecl *decl = nullptr;
-      if (expr->hasDecl())
+      if (expr->hasDecl()) {
         decl = expr->getDecl().getDecl();
+        if (decl->isInvalid())
+          return Type();
+      }
       return addSubscriptConstraints(expr, expr->getBase(), expr->getIndex(),
                                      decl);
     }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -259,3 +259,18 @@ func testSubscript1(s2 : SubscriptTest2) {
   let b = s2[1, "foo"] // expected-error {{cannot subscript a value of type 'SubscriptTest2' with an index of type '(Int, String)'}}
   // expected-note @-1 {{expected an argument list of type '(String, String)'}}
 }
+
+// sr-114 & rdar://22007370
+
+class Foo {
+    subscript(key: String) -> String { // expected-note {{'subscript' previously declared here}}
+        get { a } // expected-error {{use of unresolved identifier 'a'}}
+        set { b } // expected-error {{use of unresolved identifier 'b'}}
+    }
+    
+    subscript(key: String) -> String { // expected-error {{invalid redeclaration of 'subscript'}}
+        get { a } // expected-error {{use of unresolved identifier 'a'}}
+        set { b } // expected-error {{use of unresolved identifier 'b'}}
+    }
+}
+


### PR DESCRIPTION
This fixes the crash in sr-114.
