### PR TITLE
Fix typo in SideEffectAnalysis.h

### DIFF
--- a/include/swift/SILAnalysis/SideEffectAnalysis.h
+++ b/include/swift/SILAnalysis/SideEffectAnalysis.h
@@ -182,7 +182,7 @@ public:
     bool ReadsRC = false;
     
     /// Returns the effecs for an address or reference. This might be a
-    /// paramter, the LocalEffects or, if the value can not be associated to one
+    /// parameter, the LocalEffects or, if the value can not be associated to one
     /// of them, the GlobalEffects.
     Effects *getEffectsOn(SILValue Addr);
     


### PR DESCRIPTION
<code>paramter</code> -> <code>parameter</code>
