### PR TITLE
Compiler crashers: Sync with https://github.com/practicalswift/swift-compiler-crashes

### DIFF
--- a/validation-test/compiler_crashers/23639-llvm-jit-runfunction.runtime.swift
+++ b/validation-test/compiler_crashers/23639-llvm-jit-runfunction.runtime.swift
@@ -1,0 +1,16 @@
+// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// http://www.openradar.me/19423783
+
+protocol A {
+    var a: Int {
+        get
+    }
+}
+class B: A {
+    let a = 42
+}
+let b = B()
+let c = [b]
+let d = c as [A]

--- a/validation-test/compiler_crashers/24887-no-stack-trace.swift
+++ b/validation-test/compiler_crashers/24887-no-stack-trace.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -c -o /dev/null
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/codafi (Robert Widmann)
+
+struct X<T> {
+	let s : X<X>
+}

--- a/validation-test/compiler_crashers/25962-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers/25962-swift-archetypebuilder-getallarchetypes.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/adocyn (adocyn)
+
+extension CollectionType {
+    func f<T where T=Generator>() {
+    }
+}

--- a/validation-test/compiler_crashers/26298-llvm-densemapbase.swift
+++ b/validation-test/compiler_crashers/26298-llvm-densemapbase.swift
@@ -1,0 +1,5 @@
+// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/airspeedswift (airspeedswift)
+
+["1"].map { String($0) }

--- a/validation-test/compiler_crashers/26303-llvm-llvm-unreachable-internal.swift
+++ b/validation-test/compiler_crashers/26303-llvm-llvm-unreachable-internal.swift
@@ -1,0 +1,12 @@
+// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/airspeedswift (airspeedswift)
+
+struct S<T> {
+    var a: [T] = []
+}
+extension S {
+    init(other: [T]) {
+        a = other
+    }
+}

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision 736d5c8bee75f676ff3750e4ad3165d81059fe03
+Tests updated as of revision 26d1d4cb0a23cc55722a153b82f4f8ab9f8f4653


### PR DESCRIPTION
Add 5 compiler crashes.

Verified with `utils/build-script -RT`.
