### PR TITLE
compare Set and Dictionary by address for equality

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -678,8 +678,10 @@ public func == <Element : Hashable>(lhs: Set<Element>, rhs: Set<Element>) -> Boo
   case (.Native(let lhsNativeOwner), .Native(let rhsNativeOwner)):
     let lhsNative = lhsNativeOwner.nativeStorage
     let rhsNative = rhsNativeOwner.nativeStorage
-    // FIXME(performance): early exit if lhs and rhs reference the same
-    // storage?
+
+    if lhsNativeOwner === rhsNativeOwner {
+        return true
+    }
 
     if lhsNative.count != rhsNative.count {
       return false
@@ -1184,8 +1186,10 @@ public func == <Key : Equatable, Value : Equatable>(
   case (.Native(let lhsNativeOwner), .Native(let rhsNativeOwner)):
     let lhsNative = lhsNativeOwner.nativeStorage
     let rhsNative = rhsNativeOwner.nativeStorage
-    // FIXME(performance): early exit if lhs and rhs reference the same
-    // storage?
+
+    if lhsNativeOwner === rhsNativeOwner {
+        return true
+    }
 
     if lhsNative.count != rhsNative.count {
       return false


### PR DESCRIPTION
as noted in the comment, the native storage version of Set and Dictionary can
be considered equal if their Owner object have the same address. This should
speed up == by quite a bit in those cases.
