### PR TITLE
[build-script] Create 'buildbot_linux' preset to reduce duplication

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -506,35 +506,27 @@ install-destdir=%(install_destdir)s
 # Path to the .tar.gz package we would create.
 installable-package=%(installable_package)s
 
-# This preset builds foundation
+[preset: buildbot_linux]
+mixin-preset=mixin_linux_installation
+build-subdir=buildbot_linux
+lldb
+release
+test
+validation-test
+foundation
+
+dash-dash
+
+install-foundation
+reconfigure
+
+# Ubuntu 15.10 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1510]
-mixin-preset=mixin_linux_installation
-build-subdir=buildbot_linux
-lldb
-release
-test
-validation-test
-foundation
+mixin-preset=buildbot_linux
 
-dash-dash
-
-install-foundation
-reconfigure
-
-# This preset does not build Foundation due to unavailable ICU versions on Ubuntu 14.04
+# Ubuntu 14.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1404]
-mixin-preset=mixin_linux_installation
-build-subdir=buildbot_linux
-lldb
-release
-test
-validation-test
-foundation
-
-dash-dash
-
-install-foundation
-reconfigure
+mixin-preset=buildbot_linux
 
 #===------------------------------------------------------------------------===#
 # OS X Package Builders
@@ -619,7 +611,7 @@ installable-package=%(installable_package)s
 # Path to the .tar.gz symbols package
 symbols-package=%(symbols_package)s
 
-# Info.plist 
+# Info.plist
 darwin-toolchain-bundle-identifier=%(darwin_toolchain_bundle_identifier)s
 darwin-toolchain-display-name=%(darwin_toolchain_display_name)s
 darwin-toolchain-name=%(darwin_toolchain_xctoolchain_name)s


### PR DESCRIPTION
The Ubuntu 14.04 preset existed to skip building Foundation due to
unavailable ICU versions. The problem was corrected, but the
comment and preset duplication of 'buildbot_linux_*' in
build-presets.ini remained.

This change adds a 'buildbot_linux' preset as the primary Linux
preset and changes 'buildbot_linux_*' to use it as a mixin.

Implemented as discussed with Dmitri Gribenko on swift-dev.
