### PR TITLE
Compiler crashers: Normalize format of "RUN:" directives.

### DIFF
--- a/validation-test/compiler_crashers_fixed/00015-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00015-no-stacktrace.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -emit-silgen 
+// RUN: not %target-swift-frontend %s -emit-silgen
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/00035-cerror.swift
+++ b/validation-test/compiler_crashers_fixed/00035-cerror.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -parse 
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/00045-swift-lowering-adjustfunctiontype.swift
+++ b/validation-test/compiler_crashers_fixed/00045-swift-lowering-adjustfunctiontype.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -parse 
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -emit-sil 
+// RUN: not %target-swift-frontend %s -emit-sil
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/rnapier (Rob Napier)

--- a/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
+++ b/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -parse 
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)

--- a/validation-test/compiler_crashers_fixed/01413-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
+++ b/validation-test/compiler_crashers_fixed/01413-std-function-func-swift-constraints-constraintsystem-simplifytype.swift
@@ -1,4 +1,4 @@
-// RUN: not  %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/25908-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/25908-swift-constraints-solution-computesubstitutions.swift
@@ -1,4 +1,4 @@
-// RUN: not  %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
Will allow for easy parsing of common "RUN:" directives.
