### PR TITLE
Cleanup whitespace

### DIFF
--- a/stdlib/public/common/MirrorCommon.py
+++ b/stdlib/public/common/MirrorCommon.py
@@ -23,26 +23,35 @@ def getDisposition(disp=None):
 def _getGenericArgStrings(genericArgs=None,genericConstraints=None):
   if genericArgs == None:
     return ('','')
+
   genericArgString = ''
   first = True
+
   for arg in genericArgs:
     if not first:
       genericArgString  = genericArgString + ','
+
     first = False
     genericArgString = genericArgString + arg
+
   if genericConstraints == None:
     genericConstraintString = genericArgString
+
   else:
     genericConstraintString = ''
     first = True
+
     for arg in genericArgs:
       if not first:
         genericConstraintString = genericConstraintString + ','
+
       first = False
       genericConstraintString = genericConstraintString + arg
+
       if arg in genericConstraints:
         cons = genericConstraints[arg]
         genericConstraintString = genericConstraintString + ' : ' + cons
+
   genericArgString = '<' + genericArgString + '>'
   genericConstraintString = '<' + genericConstraintString + '>'
   return (genericArgString,genericConstraintString)

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -283,107 +283,107 @@ callbacks['dictionary_applier'] = CFUNCTYPE(c_int, c_object_p, Variant, py_objec
 # Functions strictly alphabetical order.
 functionList = [
   ("sourcekitd_cancel_request",
-  	[c_void_p]),
+    [c_void_p]),
 
   ("sourcekitd_initialize",
-  	None),
+    None),
 
   ("sourcekitd_request_array_create",
-  	[POINTER(c_object_p), c_size_t],
-  	c_object_p),
+    [POINTER(c_object_p), c_size_t],
+    c_object_p),
 
   ("sourcekitd_request_array_set_int64",
-  	[Object, c_size_t, c_int64]),
+    [Object, c_size_t, c_int64]),
 
   ("sourcekitd_request_array_set_string",
-  	[Object, c_size_t, c_char_p]),
+    [Object, c_size_t, c_char_p]),
 
   ("sourcekitd_request_array_set_stringbuf",
-  	[Object, c_size_t, c_char_p, c_size_t]),
+    [Object, c_size_t, c_char_p, c_size_t]),
 
   ("sourcekitd_request_array_set_uid",
-  	[Object, c_size_t, UIdent]),
+    [Object, c_size_t, UIdent]),
 
   ("sourcekitd_request_array_set_value",
-  	[Object, c_size_t, Object]),
+    [Object, c_size_t, Object]),
 
   ("sourcekitd_request_create_from_yaml",
-  	[c_char_p, POINTER(c_char_p)],
-  	c_object_p),
+    [c_char_p, POINTER(c_char_p)],
+    c_object_p),
 
   ("sourcekitd_request_description_copy",
-  	[Object],
-  	c_void_p),
+    [Object],
+    c_void_p),
 
   ("sourcekitd_request_description_dump",
-  	[Object]),
+    [Object]),
 
   ("sourcekitd_request_dictionary_create",
-  	[POINTER(c_object_p), POINTER(c_object_p), c_size_t],
-  	c_object_p),
+    [POINTER(c_object_p), POINTER(c_object_p), c_size_t],
+    c_object_p),
 
   ("sourcekitd_request_dictionary_set_int64",
-  	[Object, UIdent, c_int64]),
+    [Object, UIdent, c_int64]),
 
   ("sourcekitd_request_dictionary_set_string",
-  	[Object, UIdent, c_char_p]),
+    [Object, UIdent, c_char_p]),
 
   ("sourcekitd_request_dictionary_set_stringbuf",
-  	[Object, UIdent, c_char_p, c_size_t]),
+    [Object, UIdent, c_char_p, c_size_t]),
 
   ("sourcekitd_request_dictionary_set_uid",
-  	[Object, UIdent, UIdent]),
+    [Object, UIdent, UIdent]),
 
   ("sourcekitd_request_dictionary_set_value",
-  	[Object, UIdent, Object]),
+    [Object, UIdent, Object]),
 
   ("sourcekitd_request_int64_create",
-  	[c_int64],
-  	c_object_p),
+    [c_int64],
+    c_object_p),
 
   ("sourcekitd_request_retain",
-  	[Object],
-  	c_object_p),
+    [Object],
+    c_object_p),
 
   ("sourcekitd_request_release",
-  	[Object]),
+    [Object]),
 
   ("sourcekitd_request_string_create",
-  	[c_char_p],
-  	c_object_p),
+    [c_char_p],
+    c_object_p),
 
   ("sourcekitd_request_uid_create",
-  	[UIdent],
-  	c_object_p),
+    [UIdent],
+    c_object_p),
 
   ("sourcekitd_response_description_copy",
-  	[Response],
-  	c_char_p),
+    [Response],
+    c_char_p),
 
   ("sourcekitd_response_description_dump",
-  	[Response]),
+    [Response]),
 
   ("sourcekitd_response_description_dump_filedesc",
-  	[Response, c_int]),
+    [Response, c_int]),
 
   ("sourcekitd_response_dispose",
-  	[Response]),
+    [Response]),
 
   ("sourcekitd_response_error_get_description",
-  	[Response],
-  	c_char_p),
+    [Response],
+    c_char_p),
 
   ("sourcekitd_response_error_get_kind",
-  	[Response],
-  	ErrorKind.from_id),
+    [Response],
+    ErrorKind.from_id),
 
   ("sourcekitd_response_get_value",
-  	[Response],
-  	Variant),
+    [Response],
+    Variant),
 
   ("sourcekitd_response_is_error",
-  	[Response],
-  	c_bool),
+    [Response],
+    c_bool),
 
 #  ("sourcekitd_send_request",
 
@@ -394,100 +394,99 @@ functionList = [
   # ("sourcekitd_set_interrupted_connection_handler",
 
   ("sourcekitd_shutdown",
-  	None),
+    None),
 
   ("sourcekitd_uid_get_from_buf",
-  	[c_char_p, c_size_t],
-  	c_object_p),
+    [c_char_p, c_size_t],
+    c_object_p),
 
   ("sourcekitd_uid_get_from_cstr",
-  	[c_char_p],
-  	c_object_p),
+    [c_char_p],
+    c_object_p),
 
   ("sourcekitd_uid_get_length",
-  	[UIdent],
-  	c_size_t),
+    [UIdent],
+    c_size_t),
 
   ("sourcekitd_uid_get_string_ptr",
-  	[UIdent],
-  	c_char_p),
+    [UIdent],
+    c_char_p),
 
   ("sourcekitd_variant_array_apply_f",
     [Variant, callbacks['array_applier'], py_object],
     c_bool),
 
-
   ("sourcekitd_variant_array_get_bool",
-  	[Variant, c_size_t],
-  	c_bool),
+    [Variant, c_size_t],
+    c_bool),
 
   ("sourcekitd_variant_array_get_count",
-  	[Variant],
-  	c_size_t),
+    [Variant],
+    c_size_t),
 
   ("sourcekitd_variant_array_get_int64",
-  	[Variant, c_size_t],
-  	c_int64),
+    [Variant, c_size_t],
+    c_int64),
 
   ("sourcekitd_variant_array_get_string",
-  	[Variant, c_size_t],
-  	c_char_p),
+    [Variant, c_size_t],
+    c_char_p),
 
   ("sourcekitd_variant_array_get_uid",
-  	[Variant, c_size_t],
-  	c_object_p),
+    [Variant, c_size_t],
+    c_object_p),
 
   ("sourcekitd_variant_array_get_value",
-  	[Variant, c_size_t],
-  	Variant),
+    [Variant, c_size_t],
+    Variant),
 
   ("sourcekitd_variant_bool_get_value",
-  	[Variant],
-  	c_bool),
+    [Variant],
+    c_bool),
 
   ("sourcekitd_variant_dictionary_apply_f",
     [Variant, callbacks['dictionary_applier'], py_object],
     c_bool),
 
   ("sourcekitd_variant_dictionary_get_bool",
-  	[Variant, UIdent],
-  	c_bool),
+    [Variant, UIdent],
+    c_bool),
 
   ("sourcekitd_variant_dictionary_get_int64",
-  	[Variant, UIdent],
-  	c_int64),
-  
+    [Variant, UIdent],
+    c_int64),
+
   ("sourcekitd_variant_dictionary_get_string",
-  	[Variant, UIdent],
-  	c_char_p),
-  
+    [Variant, UIdent],
+    c_char_p),
+
   ("sourcekitd_variant_dictionary_get_value",
-  	[Variant, UIdent],
-  	Variant),
-  
+    [Variant, UIdent],
+    Variant),
+
   ("sourcekitd_variant_dictionary_get_uid",
-  	[Variant, UIdent],
-  	c_object_p),
-  
+    [Variant, UIdent],
+    c_object_p),
+
   ("sourcekitd_variant_get_type",
-  	[Variant],
-  	VariantType.from_id),
+    [Variant],
+    VariantType.from_id),
 
   ("sourcekitd_variant_string_get_length",
-  	[Variant],
-  	c_size_t),
+    [Variant],
+    c_size_t),
 
   ("sourcekitd_variant_string_get_ptr",
-  	[Variant],
-  	c_char_p),
+    [Variant],
+    c_char_p),
 
   ("sourcekitd_variant_int64_get_value",
-  	[Variant],
-  	c_int64),
+    [Variant],
+    c_int64),
 
   ("sourcekitd_variant_uid_get_value",
-  	[Variant],
-  	c_object_p),
+    [Variant],
+    c_object_p),
   ]
 
 

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -90,16 +90,16 @@ def numeric_type_names_Macintosh_only():
 
 def all_integer_binary_operator_names():
     return ['<<', '>>', '&*', '&', '&+', '&-', '|', '^']
-    
+
 def all_integer_or_real_binary_operator_names():
     return ['*', '/', '%', '+', '-', '..<', '...']
-    
+
 def all_arithmetic_comparison_operator_names():
     return ['<', '<=', '>', '>=', '==', '!=']
-    
+
 def all_integer_assignment_operator_names():
     return ['<<=', '>>=', '&=', '^=', '|=']
-    
+
 def all_integer_or_real_assignment_operator_names():
     return ['=', '*=', '/=', '%=', '+=', '-=']
-    
+

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -51,7 +51,7 @@ def apply_edits(path):
         if not edits_per_file.has_key(fname):
             edits_per_file[fname] = []
         edits_per_file[fname].append((ed[1], ed[2], ed[3]))
-    
+
     for fname, edits in edits_per_file.iteritems():
         print 'Updating', fname
         edits.sort(reverse=True)

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -30,12 +30,12 @@ def stripTrailingNL(s):
 
 def splitLines(s):
     """Split s into a list of lines, each of which has a trailing newline
-    
+
     If the lines are later concatenated, the result is s, possibly
     with a single appended newline.
     """
     return [ l + '\n' for l in s.split('\n') ]
-    
+
 # text on a line up to the first '$$', '${', or '%%'
 literalText = r'(?: [^$\n%] | \$(?![${]) | %(?!%) )*'
 
@@ -137,7 +137,7 @@ def tokenizePythonToUnmatchedCloseCurly(sourceText, start, lineStarts):
         return tokenPosToIndex(errorPos, start, lineStarts)
 
     return len(sourceText)
-    
+
 def tokenizeTemplate(templateText):
     r"""Given the text of a template, returns an iterator over
 (tokenType,token,match) tuples.  
@@ -217,12 +217,12 @@ def tokenizeTemplate(templateText):
 
     while pos < end:
         m = tokenizeRE.match(templateText, pos, end)
-        
+
         # pull out the one matched key (ignoring internal patterns starting with _)
         ((kind, text), ) = (
             (kind,text) for (kind,text) in m.groupdict().items() 
             if text is not None and kind[0] != '_')
-                
+ 
         if kind in ('literal', 'symbol'):
             if len(savedLiteral) == 0:
                 literalFirstMatch = m
@@ -237,7 +237,7 @@ def tokenizeTemplate(templateText):
             # Then yield the thing we found.  If we get a reply, it's
             # the place to resume tokenizing
             pos = yield kind, text, m
-        
+
         # If we were not sent a new position by our client, resume
         # tokenizing at the end of this match.
         if pos is None:
@@ -309,7 +309,7 @@ def splitGybLines(sourceLines):
 
             if tokenText == '\n' and lastTokenText == ':':
                 unmatchedIndents.append(tokenEndLine)
-                
+
             # The tokenizer appends dedents at EOF; don't consider
             # those as matching indentations.  Instead just save them
             # up...
@@ -319,7 +319,7 @@ def splitGybLines(sourceLines):
             if tokenKind != tokenize.DEDENT and dedents > 0:
                 unmatchedIndents = unmatchedIndents[:-dedents]
                 dedents = 0
-                
+
             lastTokenText,lastTokenKind = tokenText,tokenKind
 
     except tokenize.TokenError, (message, errorPos):
@@ -371,7 +371,7 @@ class ParseContext:
 
     def posToLine(self, pos):
         return bisect(self.lineStarts, pos) - 1
-            
+
     def tokenGenerator(self, baseTokens):
         r""" Given an iterator over (kind, text, match) triples (see
         tokenizeTemplate above), return a refined iterator over
@@ -446,7 +446,7 @@ class ParseContext:
         for self.tokenKind, self.tokenText, self.tokenMatch in baseTokens:
             kind = self.tokenKind
             self.codeText = None
-            
+
             # Do we need to close the current lines?
             self.closeLines = kind == 'gybLinesClose'
 
@@ -474,7 +474,7 @@ class ParseContext:
                 baseTokens.send(nextPos)
 
             elif kind == 'gybLines':
-                
+
                 self.codeStartLine = self.posToLine(self.tokenMatch.start('gybLines'))
                 codeStartPos = self.tokenMatch.end('_indent')
                 indentation = self.tokenMatch.group('_indent')
@@ -484,7 +484,7 @@ class ParseContext:
                     '^' + re.escape(indentation), 
                     self.tokenMatch.group('gybLines')+'\n', 
                     flags=re.MULTILINE)[1:]
-                
+
                 if codeStartsWithDedentKeyword(sourceLines):
                     self.closeLines = True
 
@@ -537,10 +537,10 @@ class ExecutionContext:
                     # and try again
                     self.appendText(text[i + 1:], file, line)
                     return
-                    
+
         self.resultText.append(text)
         self.lastFileLine = (file, line + text.count('\n'))
-        
+
 class ASTNode(object):
     """Abstract base class for template AST nodes"""
     def __init__(self):
@@ -633,10 +633,10 @@ class Code(ASTNode):
 
             if context.tokenKind == 'gybLinesClose':
                 context.nextToken()
-        
+
         if context.tokenKind == 'gybLines':
             source, sourceLineCount = accumulateCode()
-            
+
             # Only handle a substitution as part of this code block if
             # we don't already have some %-lines.
         elif context.tokenKind == 'gybBlockOpen':
@@ -676,7 +676,7 @@ class Code(ASTNode):
 
 def parseTemplate(filename, text = None):
     r"""Return an AST corresponding to the given template file.
-    
+
     If text is supplied, it is assumed to be the contents of the file,
     as a string.
 
@@ -971,7 +971,7 @@ def main():
     A GYB template consists of the following elements:
 
       - Literal text which is inserted directly into the output
-    
+
       - %% or $$ in literal text, which insert literal '%' and '$'
         symbols respectively.
 
@@ -1039,7 +1039,7 @@ def main():
     parser.add_argument('--verbose-test', action='store_true', default=False, help='Run a verbose self-test')
     parser.add_argument('--dump', action='store_true', default=False, help='Dump the parsed template to stdout')
     parser.add_argument('--line-directive', default='// ###line', help='Line directive prefix; empty => no line markers')
-    
+
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -1047,17 +1047,16 @@ def main():
         import doctest
         if doctest.testmod(verbose=args.verbose_test).failed:
             exit(1)
-        
+
     bindings = dict( x.split('=', 1) for x in args.defines )
     ast = parseTemplate(args.file.name, args.file.read())
     if args.dump:
         print ast
-        
+
     # Allow the template to import .py files from its own directory
     sys.path = [os.path.split(args.file.name)[0] or '.'] + sys.path
-    
+
     args.target.write(executeTemplate(ast, args.line_directive, **bindings))
 
 if __name__ == '__main__':
     main()
-    

--- a/utils/omit-needless-words.py
+++ b/utils/omit-needless-words.py
@@ -112,7 +112,7 @@ for opt, arg in opts:
     if opt == '-q':
         verbose = 0
         continue
-    
+
     help()
     sys.exit(2)
 

--- a/utils/pass-pipeline/src/pass_pipeline.py
+++ b/utils/pass-pipeline/src/pass_pipeline.py
@@ -1,4 +1,3 @@
-
 import sys
 import json
 import itertools

--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -1,4 +1,3 @@
-
 import pass_pipeline as ppipe
 import passes as p
 
@@ -98,7 +97,7 @@ def lower_passlist():
         p.SpeculativeDevirtualizer,
         p.FunctionSignatureOpts,
     ])
-        
+
 def normal_passpipelines():
     result = []
 

--- a/utils/pass-pipeline/src/passes.py
+++ b/utils/pass-pipeline/src/passes.py
@@ -1,4 +1,3 @@
-
 from pass_pipeline import Pass
 
 # TODO: This should not be hard coded. Create a tool in the compiler that knows

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -86,7 +86,7 @@ def parseGenericOperator(m):
     for m2 in re.finditer(genericParameterConstraint, genericParams, reFlags):
         typeParameter = m2.group(1)
         protocol = m2.group(2)
-        
+
         # we're only interested if we can find a function parameter of that type
         if not re.search(r':\s*%s\s*[,)]' % typeParameter, functionParams): continue
 
@@ -156,16 +156,16 @@ for node in sorted(graph.keys()):
     generics = sorted(genericOperators.get(node, set()))
     style = 'solid' if node.startswith('_') else 'bold'
     divider = '<HR/>\n' if len(requirements) != 0 and len(generics) != 0 else ''
-    
+
     label = node if len(requirements + generics) == 0 else (
         '\n<TABLE BORDER="0">\n<TR><TD>\n%s\n</TD></TR><HR/>\n%s%s%s</TABLE>\n' % (
         node,
         '\n'.join('<TR><TD>%s</TD></TR>' % r for r in requirements),
         divider,
         '\n'.join('<TR><TD>%s</TD></TR>' % g for g in generics)))
-    
+
     print interpolate('    %(node)s [style = %(style)s, label=<%(label)s>]')
-    
+
 for (parent, children) in sorted(graph.items()):
     print '    %s -> {' % parent,
     print '; '.join(

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -20,14 +20,14 @@ class SwiftLexer(RegexLexer):
     _name = r'[a-zA-Z_][a-zA-Z0-9_?]*'
 
     tokens = {
-   
+
         'root' : [
             (r'^', Punctuation, 'root2'),
         ],
  
         'root2' : [
             (r'\n', Text, '#pop'),
-             
+
             (r'//.*?\n', Comment.Single, '#pop'),
             (r'/\*', Comment.Multiline, 'comment'),
 
@@ -45,7 +45,7 @@ class SwiftLexer(RegexLexer):
             (r'(\b[A-Z][a-zA-Z0-9_]*\s?)(\()', bygroups(Name.Constant, Punctuation), 'type-cast'),
             (r'(\b[A-Z][a-zA-Z0-9_]*)(\.)([a-z][a-zA-Z0-9_]*)', bygroups(Name.Constant, Punctuation, Name), 'arg-list'),
             (r'"', String, 'string'),
-            
+
             (r'(\bnew\b\s?)', Keyword.Reserved, 'class-name'),
             (r'\b(true|false)\b', Keyword.Reserved),
             (r'\b(if|else)\s', Keyword.Reserved),
@@ -58,11 +58,11 @@ class SwiftLexer(RegexLexer):
             (r'0x[0-9a-fA-F]+', Number.Hex),
             (r'[0-9]+', Number.Integer),
             (r'\s', Whitespace),
-            
+
             (r'\(', Punctuation, 'tuple'),
-            
+
             include('name'),
-            
+
         ],
 
         'isa' : [
@@ -100,7 +100,7 @@ class SwiftLexer(RegexLexer):
             include('isa'),
             include('root2'),
         ],
-        
+
         'name' : [
             (_name, Name),
         ],
@@ -141,7 +141,7 @@ class SwiftLexer(RegexLexer):
         'ws-pop' : [
             (r'\s?[\s\n]', Whitespace, '#pop'),
         ],
-            
+
         'var-decl' : [ 
             (r'(\[)([\w\s,]*)(\])(\s+)', bygroups(Punctuation, Name.Attribute, Punctuation, Whitespace)),
             include('tuple'),

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -151,7 +151,6 @@ def main():
         print("--verify-build-dir and --verify-xcode can't be used together")
         return 1
 
-
     if args.verify_build_dir is not None:
         commands = get_verify_build_dir_commands(args.verify_build_dir)
 

--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -5,11 +5,13 @@ import itertools
 traversal_options = [ 'Forward', 'Bidirectional', 'RandomAccess' ]
 base_kind_options = [ 'Defaulted', 'Minimal' ]
 mutable_options = [ False, True ]
+
 for traversal, base_kind, mutable in itertools.product(
     traversal_options, base_kind_options, mutable_options):
     # Test Slice<Base> and MutableSlice<Base> of various collections using value
     # types as elements.
     wrapper_types = [ 'Slice', 'MutableSlice' ] if mutable else [ 'Slice' ]
+
     for WrapperType in wrapper_types:
         for name, prefix, suffix in [
           ('FullWidth', '[]', '[]'),


### PR DESCRIPTION
**Note**: Only Python files were edited.

This merge request adds some whitespace to certain areas that makes it easier to read and also removes some whitespace from areas where it is not needed.

There is also a tab-->spaces conversion in tools/SourceKit/bindings/python/sourcekitd/capi.py
