### PR TITLE
Implementation of fcntl() to both Darwin and Glibc overlays.  Ported …

### DIFF
--- a/stdlib/public/Glibc/CMakeLists.txt
+++ b/stdlib/public/Glibc/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(sources
-    Glibc.swift
+	Glibc.swift
+	Misc.c
 )
 
 set(output_dir "${SWIFTLIB_DIR}/glibc")

--- a/stdlib/public/Glibc/CMakeLists.txt
+++ b/stdlib/public/Glibc/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(sources
-	Glibc.swift
-	Misc.c
+    Glibc.swift
+    Misc.c
 )
 
 set(output_dir "${SWIFTLIB_DIR}/glibc")

--- a/stdlib/public/Glibc/Glibc.swift
+++ b/stdlib/public/Glibc/Glibc.swift
@@ -32,34 +32,52 @@ public var errno: Int32 {
 @warn_unused_result
 @_silgen_name("_swift_Glibc_open")
 func _swift_Glibc_open(path: UnsafePointer<CChar>,
-  _ oflag: CInt, _ mode: mode_t) -> CInt
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt
 
 @warn_unused_result
 @_silgen_name("_swift_Glibc_openat")
-func _swift_Glibc_openat(fd: CInt,
+func _swift_Glibc_openat(
+  fd: CInt,
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt, _ mode: mode_t) -> CInt
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt
 
 @warn_unused_result
-public func open(path: UnsafePointer<CChar>, _ oflag: CInt) -> CInt {
+public func open(
+  path: UnsafePointer<CChar>,
+  _ oflag: CInt
+) -> CInt {
   return _swift_Glibc_open(path, oflag, 0)
 }
 
 @warn_unused_result
-public func open(path: UnsafePointer<CChar>, _ oflag: CInt,
-  _ mode: mode_t) -> CInt {
+public func open(
+  path: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt {
   return _swift_Glibc_open(path, oflag, mode)
 }
 
 @warn_unused_result
-public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
-  _ oflag: CInt) -> CInt {
+public func openat(
+  fd: CInt,
+  _ path: UnsafePointer<CChar>,
+  _ oflag: CInt
+) -> CInt {
   return _swift_Glibc_openat(fd, path, oflag, 0)
 }
 
 @warn_unused_result
-public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
-  _ oflag: CInt, _ mode: mode_t) -> CInt {
+public func openat(
+  fd: CInt,
+  _ path: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt {
   return _swift_Glibc_openat(fd, path, oflag, mode)
 }
 
@@ -69,7 +87,7 @@ internal func _swift_Glibc_fcntl(
   fd: CInt,
   _ cmd: CInt,
   _ value: CInt
-  ) -> CInt
+) -> CInt
 
 @warn_unused_result
 @_silgen_name("_swift_Glibc_fcntlPtr")
@@ -77,13 +95,13 @@ internal func _swift_Glibc_fcntlPtr(
   fd: CInt,
   _ cmd: CInt,
   _ ptr: UnsafeMutablePointer<Void>
-  ) -> CInt
+) -> CInt
 
 @warn_unused_result
 public func fcntl(
   fd: CInt,
   _ cmd: CInt
-  ) -> CInt {
+) -> CInt {
   return _swift_Glibc_fcntl(fd, cmd, 0)
 }
 
@@ -92,7 +110,7 @@ public func fcntl(
   fd: CInt,
   _ cmd: CInt,
   _ value: CInt
-  ) -> CInt {
+) -> CInt {
   return _swift_Glibc_fcntl(fd, cmd, value)
 }
 
@@ -101,7 +119,7 @@ public func fcntl(
   fd: CInt,
   _ cmd: CInt,
   _ ptr: UnsafeMutablePointer<Void>
-  ) -> CInt {
+) -> CInt {
   return _swift_Glibc_fcntlPtr(fd, cmd, ptr)
 }
 
@@ -133,8 +151,6 @@ public var S_ISUID: mode_t  { return mode_t(0o004000) }
 public var S_ISGID: mode_t  { return mode_t(0o002000) }
 public var S_ISVTX: mode_t  { return mode_t(0o001000) }
 
-
-
 //===----------------------------------------------------------------------===//
 // signal.h
 //===----------------------------------------------------------------------===//
@@ -158,7 +174,7 @@ public var SIG_HOLD: __sighandler_t {
 
 /// The value returned by `sem_open()` in the case of failure.
 public var SEM_FAILED: UnsafeMutablePointer<sem_t> {
-  // The value is ABI.  Value verified to be correct on Linux.
+  // The value is ABI.  Value verified to be correct on Glibc.
   return UnsafeMutablePointer<sem_t>(bitPattern: 0)
 }
 
@@ -167,7 +183,7 @@ public var SEM_FAILED: UnsafeMutablePointer<sem_t> {
 internal func _swift_Glibc_sem_open2(
   name: UnsafePointer<CChar>,
   _ oflag: CInt
-  ) -> UnsafeMutablePointer<sem_t>
+) -> UnsafeMutablePointer<sem_t>
 
 @warn_unused_result
 @_silgen_name("_swift_Glibc_sem_open4")
@@ -176,13 +192,13 @@ internal func _swift_Glibc_sem_open4(
   _ oflag: CInt,
   _ mode: mode_t,
   _ value: CUnsignedInt
-  ) -> UnsafeMutablePointer<sem_t>
+) -> UnsafeMutablePointer<sem_t>
 
 @warn_unused_result
 public func sem_open(
   name: UnsafePointer<CChar>,
   _ oflag: CInt
-  ) -> UnsafeMutablePointer<sem_t> {
+) -> UnsafeMutablePointer<sem_t> {
   return _swift_Glibc_sem_open2(name, oflag)
 }
 
@@ -192,6 +208,6 @@ public func sem_open(
   _ oflag: CInt,
   _ mode: mode_t,
   _ value: CUnsignedInt
-  ) -> UnsafeMutablePointer<sem_t> {
+) -> UnsafeMutablePointer<sem_t> {
   return _swift_Glibc_sem_open4(name, oflag, mode, value)
 }

--- a/stdlib/public/Glibc/Glibc.swift
+++ b/stdlib/public/Glibc/Glibc.swift
@@ -29,6 +29,82 @@ public var errno: Int32 {
 // fcntl.h
 //===----------------------------------------------------------------------===//
 
+@warn_unused_result
+@_silgen_name("_swift_Glibc_open")
+func _swift_Glibc_open(path: UnsafePointer<CChar>,
+  _ oflag: CInt, _ mode: mode_t) -> CInt
+
+@warn_unused_result
+@_silgen_name("_swift_Glibc_openat")
+func _swift_Glibc_openat(fd: CInt,
+  _ path: UnsafePointer<CChar>,
+  _ oflag: CInt, _ mode: mode_t) -> CInt
+
+@warn_unused_result
+public func open(path: UnsafePointer<CChar>, _ oflag: CInt) -> CInt {
+  return _swift_Glibc_open(path, oflag, 0)
+}
+
+@warn_unused_result
+public func open(path: UnsafePointer<CChar>, _ oflag: CInt,
+  _ mode: mode_t) -> CInt {
+  return _swift_Glibc_open(path, oflag, mode)
+}
+
+@warn_unused_result
+public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
+  _ oflag: CInt) -> CInt {
+  return _swift_Glibc_openat(fd, path, oflag, 0)
+}
+
+@warn_unused_result
+public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
+  _ oflag: CInt, _ mode: mode_t) -> CInt {
+  return _swift_Glibc_openat(fd, path, oflag, mode)
+}
+
+@warn_unused_result
+@_silgen_name("_swift_Glibc_fcntl")
+internal func _swift_Glibc_fcntl(
+  fd: CInt,
+  _ cmd: CInt,
+  _ value: CInt
+  ) -> CInt
+
+@warn_unused_result
+@_silgen_name("_swift_Glibc_fcntlPtr")
+internal func _swift_Glibc_fcntlPtr(
+  fd: CInt,
+  _ cmd: CInt,
+  _ ptr: UnsafeMutablePointer<Void>
+  ) -> CInt
+
+@warn_unused_result
+public func fcntl(
+  fd: CInt,
+  _ cmd: CInt
+  ) -> CInt {
+  return _swift_Glibc_fcntl(fd, cmd, 0)
+}
+
+@warn_unused_result
+public func fcntl(
+  fd: CInt,
+  _ cmd: CInt,
+  _ value: CInt
+  ) -> CInt {
+  return _swift_Glibc_fcntl(fd, cmd, value)
+}
+
+@warn_unused_result
+public func fcntl(
+  fd: CInt,
+  _ cmd: CInt,
+  _ ptr: UnsafeMutablePointer<Void>
+  ) -> CInt {
+  return _swift_Glibc_fcntlPtr(fd, cmd, ptr)
+}
+
 public var S_IFMT: mode_t   { return mode_t(0o170000) }
 public var S_IFIFO: mode_t  { return mode_t(0o010000) }
 public var S_IFCHR: mode_t  { return mode_t(0o020000) }
@@ -57,6 +133,8 @@ public var S_ISUID: mode_t  { return mode_t(0o004000) }
 public var S_ISGID: mode_t  { return mode_t(0o002000) }
 public var S_ISVTX: mode_t  { return mode_t(0o001000) }
 
+
+
 //===----------------------------------------------------------------------===//
 // signal.h
 //===----------------------------------------------------------------------===//
@@ -74,3 +152,46 @@ public var SIG_HOLD: __sighandler_t {
 }
 #endif
 
+//===----------------------------------------------------------------------===//
+// semaphore.h
+//===----------------------------------------------------------------------===//
+
+/// The value returned by `sem_open()` in the case of failure.
+public var SEM_FAILED: UnsafeMutablePointer<sem_t> {
+  // The value is ABI.  Value verified to be correct on Linux.
+  return UnsafeMutablePointer<sem_t>(bitPattern: 0)
+}
+
+@warn_unused_result
+@_silgen_name("_swift_Glibc_sem_open2")
+internal func _swift_Glibc_sem_open2(
+  name: UnsafePointer<CChar>,
+  _ oflag: CInt
+  ) -> UnsafeMutablePointer<sem_t>
+
+@warn_unused_result
+@_silgen_name("_swift_Glibc_sem_open4")
+internal func _swift_Glibc_sem_open4(
+  name: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t,
+  _ value: CUnsignedInt
+  ) -> UnsafeMutablePointer<sem_t>
+
+@warn_unused_result
+public func sem_open(
+  name: UnsafePointer<CChar>,
+  _ oflag: CInt
+  ) -> UnsafeMutablePointer<sem_t> {
+  return _swift_Glibc_sem_open2(name, oflag)
+}
+
+@warn_unused_result
+public func sem_open(
+  name: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t,
+  _ value: CUnsignedInt
+  ) -> UnsafeMutablePointer<sem_t> {
+  return _swift_Glibc_sem_open4(name, oflag, mode, value)
+}

--- a/stdlib/public/Glibc/Misc.c
+++ b/stdlib/public/Glibc/Misc.c
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <semaphore.h>
 
 extern int

--- a/stdlib/public/Glibc/Misc.c
+++ b/stdlib/public/Glibc/Misc.c
@@ -1,4 +1,4 @@
-//===--- Misc.mm - Darwin overlay helpers ---------------------------------===//
+//===--- Misc.c - Glibc overlay helpers -----------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -13,32 +13,32 @@
 #include <fcntl.h>
 #include <semaphore.h>
 
-extern "C" int 
-_swift_Darwin_open(const char *path, int oflag, mode_t mode) {
+extern int
+_swift_Glibc_open(const char *path, int oflag, mode_t mode) {
   return open(path, oflag, mode);
 }
 
-extern "C" int 
-_swift_Darwin_openat(int fd, const char *path, int oflag, mode_t mode) {
+extern int
+_swift_Glibc_openat(int fd, const char *path, int oflag, mode_t mode) {
   return openat(fd, path, oflag, mode);
 }
 
-extern "C" sem_t *_swift_Darwin_sem_open2(const char *name, int oflag) {
+extern sem_t *_swift_Glibc_sem_open2(const char *name, int oflag) {
   return sem_open(name, oflag);
 }
 
-extern "C" sem_t *_swift_Darwin_sem_open4(const char *name, int oflag,
-                                          mode_t mode, unsigned int value) {
+extern sem_t *_swift_Glibc_sem_open4(const char *name, int oflag,
+                                     mode_t mode, unsigned int value) {
   return sem_open(name, oflag, mode, value);
 }
 
-extern "C" int
-_swift_Darwin_fcntl(int fd, int cmd, int value) {
+extern int
+_swift_Glibc_fcntl(int fd, int cmd, int value) {
   return fcntl(fd, cmd, value);
 }
 
-extern "C" int
-_swift_Darwin_fcntlPtr(int fd, int cmd, void* ptr) {
+extern int
+_swift_Glibc_fcntlPtr(int fd, int cmd, void* ptr) {
   return fcntl(fd, cmd, ptr);
 }
 

--- a/stdlib/public/SDK/Darwin/Darwin.swift
+++ b/stdlib/public/SDK/Darwin/Darwin.swift
@@ -79,7 +79,8 @@ func _convertDarwinBooleanToBool(x: DarwinBoolean) -> Bool {
 @_transparent
 @warn_unused_result
 public func && <T : BooleanType>(
-  lhs: T, @autoclosure rhs: () -> DarwinBoolean
+  lhs: T,
+  @autoclosure rhs: () -> DarwinBoolean
 ) -> Bool {
   return lhs.boolValue ? rhs().boolValue : false
 }
@@ -87,7 +88,8 @@ public func && <T : BooleanType>(
 @_transparent
 @warn_unused_result
 public func || <T : BooleanType>(
-  lhs: T, @autoclosure rhs: () -> DarwinBoolean
+  lhs: T,
+  @autoclosure rhs: () -> DarwinBoolean
 ) -> Bool {
   return lhs.boolValue ? true : rhs().boolValue
 }
@@ -145,35 +147,53 @@ public var stderr : UnsafeMutablePointer<FILE> {
 
 @warn_unused_result
 @_silgen_name("_swift_Darwin_open") 
-func _swift_Darwin_open(path: UnsafePointer<CChar>,
-  _ oflag: CInt, _ mode: mode_t) -> CInt
+func _swift_Darwin_open(
+  path: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt
 
 @warn_unused_result
 @_silgen_name("_swift_Darwin_openat")
 func _swift_Darwin_openat(fd: CInt,
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt, _ mode: mode_t) -> CInt
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt
 
 @warn_unused_result
-public func open(path: UnsafePointer<CChar>, _ oflag: CInt) -> CInt {
+public func open(
+  path: UnsafePointer<CChar>,
+  _ oflag: CInt
+) -> CInt {
   return _swift_Darwin_open(path, oflag, 0)
 }
 
 @warn_unused_result
-public func open(path: UnsafePointer<CChar>, _ oflag: CInt,
-  _ mode: mode_t) -> CInt {
+public func open(
+  path: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt {
   return _swift_Darwin_open(path, oflag, mode)
 }
 
 @warn_unused_result
-public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
-  _ oflag: CInt) -> CInt {
+public func openat(
+  fd: CInt,
+  _ path: UnsafePointer<CChar>,
+  _ oflag: CInt
+) -> CInt {
   return _swift_Darwin_openat(fd, path, oflag, 0)
 }
 
 @warn_unused_result
-public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
-  _ oflag: CInt, _ mode: mode_t) -> CInt {
+public func openat(
+  fd: CInt,
+  _ path: UnsafePointer<CChar>,
+  _ oflag: CInt,
+  _ mode: mode_t
+) -> CInt {
   return _swift_Darwin_openat(fd, path, oflag, mode)
 }
 
@@ -183,7 +203,7 @@ internal func _swift_Darwin_fcntl(
   fd: CInt,
   _ cmd: CInt,
   _ value: CInt
-  ) -> CInt
+) -> CInt
 
 @warn_unused_result
 @_silgen_name("_swift_Darwin_fcntlPtr")
@@ -191,13 +211,13 @@ internal func _swift_Darwin_fcntlPtr(
   fd: CInt,
   _ cmd: CInt,
   _ ptr: UnsafeMutablePointer<Void>
-  ) -> CInt
+) -> CInt
 
 @warn_unused_result
 public func fcntl(
   fd: CInt,
   _ cmd: CInt
-  ) -> CInt {
+) -> CInt {
   return _swift_Darwin_fcntl(fd, cmd, 0)
 }
 
@@ -206,7 +226,7 @@ public func fcntl(
   fd: CInt,
   _ cmd: CInt,
   _ value: CInt
-  ) -> CInt {
+) -> CInt {
   return _swift_Darwin_fcntl(fd, cmd, value)
 }
 
@@ -215,7 +235,7 @@ public func fcntl(
   fd: CInt,
   _ cmd: CInt,
   _ ptr: UnsafeMutablePointer<Void>
-  ) -> CInt {
+) -> CInt {
   return _swift_Darwin_fcntlPtr(fd, cmd, ptr)
 }
 

--- a/stdlib/public/SDK/Darwin/Darwin.swift
+++ b/stdlib/public/SDK/Darwin/Darwin.swift
@@ -177,6 +177,48 @@ public func openat(fd: CInt, _ path: UnsafePointer<CChar>,
   return _swift_Darwin_openat(fd, path, oflag, mode)
 }
 
+@warn_unused_result
+@_silgen_name("_swift_Darwin_fcntl")
+internal func _swift_Darwin_fcntl(
+  fd: CInt,
+  _ cmd: CInt,
+  _ value: CInt
+  ) -> CInt
+
+@warn_unused_result
+@_silgen_name("_swift_Darwin_fcntlPtr")
+internal func _swift_Darwin_fcntlPtr(
+  fd: CInt,
+  _ cmd: CInt,
+  _ ptr: UnsafeMutablePointer<Void>
+  ) -> CInt
+
+@warn_unused_result
+public func fcntl(
+  fd: CInt,
+  _ cmd: CInt
+  ) -> CInt {
+  return _swift_Darwin_fcntl(fd, cmd, 0)
+}
+
+@warn_unused_result
+public func fcntl(
+  fd: CInt,
+  _ cmd: CInt,
+  _ value: CInt
+  ) -> CInt {
+  return _swift_Darwin_fcntl(fd, cmd, value)
+}
+
+@warn_unused_result
+public func fcntl(
+  fd: CInt,
+  _ cmd: CInt,
+  _ ptr: UnsafeMutablePointer<Void>
+  ) -> CInt {
+  return _swift_Darwin_fcntlPtr(fd, cmd, ptr)
+}
+
 public var S_IFMT: mode_t   { return mode_t(0o170000) }
 public var S_IFIFO: mode_t  { return mode_t(0o010000) }
 public var S_IFCHR: mode_t  { return mode_t(0o020000) }

--- a/test/1_stdlib/POSIX.swift
+++ b/test/1_stdlib/POSIX.swift
@@ -1,29 +1,32 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// XFAIL: linux
-// FIXME: Glibc needs the same overlay.
-
 import StdlibUnittest
-import Darwin
+#if os(Linux)
+  import Glibc
+#else
+  import Darwin
+#endif
 
-var POSIXSemaphore = TestSuite("POSIXSemaphore")
+var POSIXTests = TestSuite("POSIXTests")
 
 let semaphoreName = "TestSem"
+let fn = "test.txt"
 
-POSIXSemaphore.setUp {
+POSIXTests.setUp {
   sem_unlink(semaphoreName)
+  unlink(fn)
 }
 
 // Failed semaphore creation.
-POSIXSemaphore.test("sem_open fail") {
+POSIXTests.test("sem_open fail") {
   let sem = sem_open(semaphoreName, 0)
   expectEqual(SEM_FAILED, sem)
   expectEqual(ENOENT, errno)
 }
 
 // Successful semaphore creation.
-POSIXSemaphore.test("sem_open success") {
+POSIXTests.test("sem_open success") {
   let sem = sem_open(semaphoreName, O_CREAT, 0o777, 1)
   expectNotEqual(SEM_FAILED, sem)
 
@@ -35,7 +38,7 @@ POSIXSemaphore.test("sem_open success") {
 }
 
 // Successful semaphore creation with O_EXCL.
-POSIXSemaphore.test("sem_open O_EXCL success") {
+POSIXTests.test("sem_open O_EXCL success") {
   let sem = sem_open(semaphoreName, O_CREAT | O_EXCL, 0o777, 1)
   expectNotEqual(SEM_FAILED, sem)
 
@@ -47,7 +50,7 @@ POSIXSemaphore.test("sem_open O_EXCL success") {
 }
 
 // Successful creation and re-obtaining of existing semaphore.
-POSIXSemaphore.test("sem_open existing") {
+POSIXTests.test("sem_open existing") {
   let sem = sem_open(semaphoreName, O_CREAT, 0o777, 1)
   expectNotEqual(SEM_FAILED, sem)
 
@@ -64,7 +67,7 @@ POSIXSemaphore.test("sem_open existing") {
 }
 
 // Fail because the semaphore already exists.
-POSIXSemaphore.test("sem_open existing O_EXCL fail") {
+POSIXTests.test("sem_open existing O_EXCL fail") {
   let sem = sem_open(semaphoreName, O_CREAT, 0o777, 1)
   expectNotEqual(SEM_FAILED, sem)
 
@@ -77,6 +80,111 @@ POSIXSemaphore.test("sem_open existing O_EXCL fail") {
 
   let res2 = sem_unlink(semaphoreName)
   expectEqual(0, res2)
+}
+	
+// Fail because file doesn't exist.
+POSIXTests.test("fcntl(CInt, CInt): fail") {
+  let fd = open(fn, 0)
+  expectEqual(-1, fd)
+  expectEqual(ENOENT, errno)
+	
+  let _ = fcntl(fd, F_GETFL)
+  expectEqual(EBADF, errno)
+}
+
+// Change modes on existing file.
+POSIXTests.test("fcntl(CInt, CInt): F_GETFL/F_SETFL success with file") {
+  // Create and open file.
+  let fd = open(fn, O_CREAT, 0o666)
+  expectGT(Int(fd), 0)
+	
+  var flags = fcntl(fd, F_GETFL)
+  expectGE(Int(flags), 0)
+	
+  // Change to APPEND mode...
+  var rc = fcntl(fd, F_SETFL, O_APPEND)
+  expectEqual(0, rc)
+	
+  flags = fcntl(fd, F_GETFL)
+  expectEqual(flags | O_APPEND, flags)
+	
+  // Change back...
+  rc = fcntl(fd, F_SETFL, 0)
+  expectEqual(0, rc)
+
+  flags = fcntl(fd, F_GETFL)
+  expectGE(Int(flags), 0)
+	
+  // Clean up...
+  rc = close(fd)
+  expectEqual(0, rc)
+	
+  rc = unlink(fn)
+  expectEqual(0, rc)
+}
+
+POSIXTests.test("fcntl(CInt, CInt, CInt): block and unblocking sockets success") {
+  // Create socket, note: socket created by default in blocking mode...
+  let sock = socket(PF_INET, 1, 0)
+  expectGT(Int(sock), 0)
+	
+  var flags = fcntl(sock, F_GETFL)
+  expectGE(Int(flags), 0)
+	
+  // Change mode of socket to non-blocking...
+  var rc = fcntl(sock, F_SETFL, flags | O_NONBLOCK)
+  expectEqual(0, rc)
+	
+  flags = fcntl(sock, F_GETFL)
+  expectEqual((flags | O_NONBLOCK), flags)
+	
+  // Change back to blocking...
+  rc = fcntl(sock, F_SETFL, flags & ~O_NONBLOCK)
+  expectEqual(0, rc)
+	
+  flags = fcntl(sock, F_GETFL)
+  expectGE(Int(flags), 0)
+	
+  // Clean up...
+  rc = close(sock)
+  expectEqual(0, rc)
+}
+
+POSIXTests.test("fcntl(CInt, CInt, UnsafeMutablePointer<Void>): locking and unlocking success") {
+  // Create the file and add data to it...
+  var fd = open(fn, O_CREAT | O_WRONLY, 0o666)
+  expectGT(Int(fd), 0)
+	
+  let data = "Testing 1 2 3"
+  let bytesWritten = write(fd, data, data.utf8.count)
+  expectEqual(data.utf8.count, bytesWritten)
+	
+  var rc = close(fd)
+  expectEqual(0, rc)
+	
+  // Re-open the file...
+  fd = open(fn, 0)
+  expectGT(Int(fd), 0)
+	
+  // Lock for reading...
+  var flck = flock()
+  flck.l_type = Int16(F_RDLCK)
+  flck.l_len = off_t(data.utf8.count)
+  rc = fcntl(fd, F_SETLK, &flck)
+  expectEqual(0, rc)
+	
+  // Unlock for reading...
+  flck = flock()
+  flck.l_type = Int16(F_UNLCK)
+  rc = fcntl(fd, F_SETLK, &flck)
+  expectEqual(0, rc)
+	
+  // Clean up...
+  rc = close(fd)
+  expectEqual(0, rc)
+	
+  rc = unlink(fn)
+  expectEqual(0, rc)
 }
 
 runAllTests()


### PR DESCRIPTION
…open(), openat() and sem_open() from Darwin to Glibc.  Added tests for new fcntl functionality.
