### PR TITLE
[build-script] Don't hardcode macosx-x86_64

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1557,10 +1557,9 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 if [[ $(is_cross_tools_deployment_target $deployment_target) ]] ; then
                     build_tests_this_time=false
 
-                    # FIXME: don't hardcode macosx-x86_64.
-                    native_llvm_tools_path="$(build_directory macosx-x86_64 llvm)/bin"
-                    native_clang_tools_path="$(build_directory macosx-x86_64 llvm)/bin"
-                    native_swift_tools_path="$(build_directory macosx-x86_64 swift)/bin"
+                    native_llvm_tools_path="$(build_directory $deployment_target llvm)/bin"
+                    native_clang_tools_path="$(build_directory $deployment_target llvm)/bin"
+                    native_swift_tools_path="$(build_directory $deployment_target swift)/bin"
 
                     cmake_options=(
                         "${cmake_options[@]}"


### PR DESCRIPTION
Resolve FIXME by using `build_directory()` function.

---

(The following isn't part of any commit message in this pull request.)

It seems like `utils/build-script-impl` contains a lot of hardcoded references to `macosx-x86_64`. I happened to find this one while looking at https://github.com/apple/swift/blob/91bfa8d0d5fb07cd143607798d3b6f33729d6547/test/lit.cfg#L173.

If this is the right approach I'll send up more pull requests for the others--but let me know if the problem isn't as straightforward as I'm making it out to be.
