### PR TITLE
[SR-184] Better diagnose error via unwrapping optional before initialized.

### DIFF
--- a/lib/SILPasses/EarlySIL/DefiniteInitialization.cpp
+++ b/lib/SILPasses/EarlySIL/DefiniteInitialization.cpp
@@ -1094,6 +1094,8 @@ void LifetimeChecker::handleEscapeUse(const DIMemoryUse &Use) {
       DiagMessage = diag::variable_closure_use_uninit;
     else
       DiagMessage = diag::variable_function_use_uninit;
+  } else if (isa<UncheckedTakeEnumDataAddrInst>(Inst)) {
+    DiagMessage = diag::variable_used_before_initialized;
   } else {
     DiagMessage = diag::variable_closure_use_uninit;
   }

--- a/test/SILPasses/definite_init_diagnostics.swift
+++ b/test/SILPasses/definite_init_diagnostics.swift
@@ -78,6 +78,12 @@ func test2() {
   takes_closure {     // ok.
     markUsed(b3)
   }
+    
+  var b4 : Int?
+  takes_closure {     // ok.
+    markUsed(b4!)
+  }
+  b4 = 7
 
   // Structs
   var s1 : SomeStruct
@@ -1184,3 +1190,9 @@ func test22436880() {
   x = 1
   bug22436880(&x) // expected-error {{immutable value 'x' may not be passed inout}}
 }
+
+// sr-184
+let x: String? // expected-note 2 {{constant defined here}}
+print(x?.characters.count) // expected-error {{constant 'x' used before being initialized}}
+print(x!) // expected-error {{constant 'x' used before being initialized}}
+


### PR DESCRIPTION
Added a check for whether the escape use is due to an UncheckedTakeEnumDataAddrInst, which accesses the memory to grab the .Some part of an Optional during “?.” or “!”. In that case, use the
generic used-before-initialized diagnostic, since it isn’t actually because of closure capture.

Added test cases, including specifically testing that capturing in a closure in order to unwrap the optional is still ok.
