### PR TITLE
Implement hasPrefix and hasSuffix without objc

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -100,18 +100,14 @@ extension String {
 extension String {
   /// Returns `true` iff `self` begins with `prefix`.
   public func hasPrefix(prefix: String) -> Bool {
-    if prefix.isEmpty {
-      return false
-    }
-    return prefix == String(self.characters.prefix(prefix.characters.count))
+    return prefix.isEmpty ? false :
+      prefix == String(self.characters.prefix(prefix.characters.count))
   }
 
   /// Returns `true` iff `self` ends with `suffix`.
   public func hasSuffix(suffix: String) -> Bool {
-    if suffix.isEmpty {
-      return false
-    }
-    return suffix == String(self.characters.suffix(suffix.characters.count))
+    return suffix.isEmpty ? false :
+      suffix == String(self.characters.suffix(suffix.characters.count))
   }
 }
 #endif

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -95,8 +95,19 @@ extension String {
   }
 }
 #else
-// FIXME: Implement hasPrefix and hasSuffix without objc
+// Implement hasPrefix and hasSuffix without objc
 // rdar://problem/18878343
+extension String {
+  /// Returns `true` iff `self` begins with `prefix`.
+  public func hasPrefix(prefix: String) -> Bool {
+    return prefix == String(self.characters.prefix(prefix.characters.count))
+  }
+
+  /// Returns `true` iff `self` ends with `suffix`.
+  public func hasSuffix(suffix: String) -> Bool {
+    return suffix == String(self.characters.suffix(suffix.characters.count))
+  }
+}
 #endif
 
 // Conversions to string from other types.

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -100,11 +100,17 @@ extension String {
 extension String {
   /// Returns `true` iff `self` begins with `prefix`.
   public func hasPrefix(prefix: String) -> Bool {
+    if prefix.isEmpty {
+      return false
+    }
     return prefix == String(self.characters.prefix(prefix.characters.count))
   }
 
   /// Returns `true` iff `self` ends with `suffix`.
   public func hasSuffix(suffix: String) -> Bool {
+    if suffix.isEmpty {
+      return false
+    }
     return suffix == String(self.characters.suffix(suffix.characters.count))
   }
 }


### PR DESCRIPTION
This is a "Swift native" implementation of `String`'s `hasPrefix` and `hasSuffix` methods, useful on that platforms where these methods are not yet implemented, such as on Linux.
rdar://problem/18878343
