### PR TITLE
Update README.md to show the correct utils/update-checkout option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ uploading SSH keys to GitHub):
 
     git clone git@github.com:apple/swift.git
     cd swift
-    ./utils/update-checkout --clone-via-ssh
+    ./utils/update-checkout --clone-with-ssh
 
 [CMake](http://cmake.org) is the core infrastructure used to configure builds of
 Swift and its companion projects; at least version 2.8.12.2 is required. Your


### PR DESCRIPTION
Update the README.md instructions for utils/update-checkout option. Should read `--clone-with-ssh`.

https://github.com/apple/swift/blob/master/utils/update-checkout#L89
