### PR TITLE
Update getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ uploading SSH keys to GitHub):
 
     git clone git@github.com:apple/swift.git
     cd swift
-    ./utils/update-checkout --clone-via-ssh
+    ./utils/update-checkout --clone-with-ssh
 
 [CMake](http://cmake.org) is the core infrastructure used to configure builds of
 Swift and its companion projects; at least version 2.8.12.2 is required. Your


### PR DESCRIPTION
The CLI argument changed 3 days ago: https://github.com/apple/swift/commit/b0c4fbd2429a430cdc583239e973595da4ca7b31

Just updating the README to reflect the changes.
