### PR TITLE
Revert "Adding missing changes on the Pull Request #402"

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3715,7 +3715,7 @@ void Serializer::writeToStream(raw_ostream &os, ModuleOrSourceFile DC,
     BCBlockRAII moduleBlock(S.Out, MODULE_BLOCK_ID, 2);
     S.writeHeader(options);
     S.writeInputBlock(options);
-    S.writeSIL(SILMod);
+    S.writeSIL(SILMod, options.SerializeAllSIL);
     S.writeAST(DC);
   }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -314,7 +314,7 @@ private:
                     const std::vector<BitOffset> &values);
 
   /// Serializes all transparent SIL functions in the SILModule.
-  void writeSIL(const SILModule *M);
+  void writeSIL(const SILModule *M, bool serializeAllSIL);
 
   /// Top-level entry point for serializing a module.
   void writeAST(ModuleOrSourceFile DC);


### PR DESCRIPTION
Reverts apple/swift#424. It caused massive performance regressions due to removal of -sil-serialize-all.
