### PR TITLE
[SR-176] Skip type checking case patterns when switch is error type.

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1229,7 +1229,7 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
                              IP->getLoc(),
                              IP->getLoc(),IP->getCastTypeLoc().getSourceRange(),
                              [](Type) { return false; },
-                             /*suppressDiagnostics=*/ false);
+                             /*suppressDiagnostics=*/ type->is<ErrorType>());
     switch (castKind) {
     case CheckedCastKind::Unresolved:
       return false;
@@ -1288,8 +1288,9 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
       if (type->getAnyNominal())
         elt = lookupEnumMemberElement(*this, dc, type, EEP->getName());
       if (!elt) {
-        diagnose(EEP->getLoc(), diag::enum_element_pattern_member_not_found,
-                 EEP->getName().str(), type);
+        if (!type->is<ErrorType>())
+          diagnose(EEP->getLoc(), diag::enum_element_pattern_member_not_found,
+                   EEP->getName().str(), type);
         return true;
       }
       enumTy = type;

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -228,7 +228,7 @@ func missingControllingExprInSwitch() {
   }
 
   switch { // expected-error {{expected expression in 'switch' statement}}
-    case Int: return // expected-error {{'is' keyword required to pattern match against type name}} {{10-10=is }} expected-warning {{cast from '<<error type>>' to unrelated type 'Int' always fails}}
+    case Int: return // expected-error {{'is' keyword required to pattern match against type name}} {{10-10=is }} 
     case _: return
   }
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -261,3 +261,11 @@ func enumElementSyntaxOnTuple() {
   }
 }
 
+// sr-176
+enum Whatever { case Thing }
+func f0(values: [Whatever]) {
+    switch value { // expected-error {{use of unresolved identifier 'value'}}
+    case .Thing: // Ok. Don't emit diagnostics about enum case not found in type <<error type>>.
+        break
+    }
+}


### PR DESCRIPTION
This stops emitting unhelpful diagnostics about “<<error type>>” (as in
SR-176) while still complaining about the switch itself and any other
errors in case bodies.
