### PR TITLE
Beginning support for ARMv7 hosts (RasPi, etc.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,18 +385,28 @@ endfunction()
 # FIXME: separate the notions of SDKs used for compiler tools and target
 # binaries.
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-  configure_sdk_unix(LINUX "Linux" "linux" "linux" "x86_64" "x86_64-unknown-linux-gnu")
-
   set(CMAKE_EXECUTABLE_FORMAT "ELF")
 
   set(SWIFT_HOST_VARIANT "linux" CACHE STRING
       "Deployment OS for Swift host tools (the compiler) [linux].")
 
   set(SWIFT_HOST_VARIANT_SDK "LINUX")
-  set(SWIFT_HOST_VARIANT_ARCH "x86_64")
-
   set(SWIFT_PRIMARY_VARIANT_SDK_default "LINUX")
-  set(SWIFT_PRIMARY_VARIANT_ARCH_default "x86_64")
+
+  # FIXME: This will not work while trying to cross-compile
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    configure_sdk_unix(LINUX "Linux" "linux" "linux" "x86_64" "x86_64-unknown-linux-gnu")
+    set(SWIFT_HOST_VARIANT_ARCH "x86_64")
+    set(SWIFT_PRIMARY_VARIANT_ARCH_default "x86_64")
+  # FIXME: This only matches ARMv7l (by far the most common variant)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    configure_sdk_unix(LINUX "Linux" "linux" "linux" "armv7" "armv7-unknown-linux-gnueabihf")
+    set(SWIFT_HOST_VARIANT_ARCH "armv7")
+    set(SWIFT_PRIMARY_VARIANT_ARCH_default "armv7")
+  else()
+    message(FATAL_ERROR "Unknown or unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
   configure_sdk_unix(FREEBSD "FreeBSD" "freebsd" "freebsd" "x86_64" "x86_64-freebsd10")
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1115,8 +1115,10 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   // Add the linker script that coalesces protocol conformance sections.
   Arguments.push_back("-Xlinker");
   Arguments.push_back("-T");
-  Arguments.push_back(
-      context.Args.MakeArgString(Twine(RuntimeLibPath) + "/x86_64/swift.ld"));
+    
+  // FIXME: This should also query the abi type (i.e. gnueabihf)
+  Arguments.push_back(context.Args.MakeArgString(
+    Twine(RuntimeLibPath) + "/" + getTriple().getArchName() + "/swift.ld"));
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -28,7 +28,11 @@ namespace swift { extern "C" {
 
 // This declaration is not universally correct.  We verify its correctness for
 // the current platform in the runtime code.
+#if defined(__linux__) && defined (__arm__)
+typedef      int __swift_ssize_t;
+#else
 typedef long int __swift_ssize_t;
+#endif
 
 // General utilities <stdlib.h>
 // Memory management functions

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -216,7 +216,8 @@ extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
 // This implementation is copied here to avoid a new dependency
 // on compiler-rt on Linux.
 // FIXME: rdar://14883575 Libcompiler_rt omits muloti4
-#if __arm64__ || !defined(__APPLE__)
+#if (defined(__APPLE__) && defined(__arm64__)) || \
+    (defined(__linux__) && defined(__x86_64__))
 
 typedef int      ti_int __attribute__ ((mode (TI)));
 extern "C"
@@ -259,6 +260,54 @@ __muloti4(ti_int a, ti_int b, int* overflow)
     return result;
 }
 
+#endif
+
+#if defined(__linux__) && defined(__arm__)
+// Similar to above, but with mulodi4.  Perhaps this is
+// something that shouldn't be done, and is a bandaid over
+// some other lower-level architecture issue that I'm
+// missing.  Perhaps relevant bug report:
+// FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
+typedef int      di_int __attribute__ ((mode (DI)));
+extern "C"
+di_int
+__mulodi4(di_int a, di_int b, int* overflow)
+{
+    const int N = (int)(sizeof(di_int) * CHAR_BIT);
+    const di_int MIN = (di_int)1 << (N-1);
+    const di_int MAX = ~MIN;
+    *overflow = 0;
+    di_int result = a * b;
+    if (a == MIN)
+    {
+        if (b != 0 && b != 1)
+            *overflow = 1;
+        return result;
+    }
+    if (b == MIN)
+    {
+        if (a != 0 && a != 1)
+            *overflow = 1;
+        return result;
+    }
+    di_int sa = a >> (N - 1);
+    di_int abs_a = (a ^ sa) - sa;
+    di_int sb = b >> (N - 1);
+    di_int abs_b = (b ^ sb) - sb;
+    if (abs_a < 2 || abs_b < 2)
+        return result;
+    if (sa == sb)
+    {
+        if (abs_a > MAX / abs_b)
+            *overflow = 1;
+    }
+    else
+    {
+        if (abs_a > MIN / -abs_b)
+            *overflow = 1;
+    }
+    return result;
+}
 #endif
 
 // We can't return Float80, but we can receive a pointer to one, so

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -12,16 +12,18 @@
 // RUN: FileCheck -check-prefix watchOS_SIMPLE %s < %t.simple.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
-// RUN: FileCheck -check-prefix LINUX %s < %t.linux.txt
+// RUN: FileCheck -check-prefix LINUX-x86_64 %s < %t.linux.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Ffoo -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: FileCheck -check-prefix LINUX-armv7 %s < %t.linux.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -emit-library -target x86_64-apple-macosx10.9.1 %s -sdk %S/../Inputs/clang-importer-sdk -lfoo -framework bar -Lbaz -Fgarply -Xlinker -undefined -Xlinker dynamic_lookup -o sdk.out 2>&1 > %t.complex.txt
 // RUN: FileCheck %s < %t.complex.txt
 // RUN: FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | FileCheck -check-prefix DEBUG %s
-
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 %s | FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0 %s | FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10   %s | FileCheck -check-prefix NO_ARCLITE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0        %s | FileCheck -check-prefix NO_ARCLITE %s
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name LINKER | FileCheck -check-prefix INFERRED_NAME %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -o libLINKER.dylib | FileCheck -check-prefix INFERRED_NAME %s
@@ -90,21 +92,37 @@
 // watchOS_SIMPLE: -o linker
 
 
-// LINUX: swift
-// LINUX: -o [[OBJECTFILE:.*]]
+// LINUX-x86_64: swift
+// LINUX-x86_64: -o [[OBJECTFILE:.*]]
 
-// LINUX: clang++{{"? }}
-// LINUX-DAG: [[OBJECTFILE]]
-// LINUX-DAG: -lswiftCore
-// LINUX-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
-// LINUX-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-DAG: -Xlinker -T /{{[^ ]+}}/linux/x86_64/swift.ld
-// LINUX-DAG: -F foo
-// LINUX-DAG: -framework bar
-// LINUX-DAG: -L baz
-// LINUX-DAG: -lboo
-// LINUX-DAG: -Xlinker -undefined
-// LINUX: -o linker
+// LINUX-x86_64: clang++{{"? }}
+// LINUX-x86_64-DAG: [[OBJECTFILE]]
+// LINUX-x86_64-DAG: -lswiftCore
+// LINUX-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
+// LINUX-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
+// LINUX-x86_64-DAG: -Xlinker -T /{{[^ ]+}}/linux/x86_64/swift.ld
+// LINUX-x86_64-DAG: -F foo
+// LINUX-x86_64-DAG: -framework bar
+// LINUX-x86_64-DAG: -L baz
+// LINUX-x86_64-DAG: -lboo
+// LINUX-x86_64-DAG: -Xlinker -undefined
+// LINUX-x86_64: -o linker
+
+// LINUX-armv7: swift
+// LINUX-armv7: -o [[OBJECTFILE:.*]]
+
+// LINUX-armv7: clang++{{"? }}
+// LINUX-armv7-DAG: [[OBJECTFILE]]
+// LINUX-armv7-DAG: -lswiftCore
+// LINUX-armv7-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
+// LINUX-armv7-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
+// LINUX-armv7-DAG: -Xlinker -T /{{[^ ]+}}/linux/armv7/swift.ld
+// LINUX-armv7-DAG: -F foo
+// LINUX-armv7-DAG: -framework bar
+// LINUX-armv7-DAG: -L baz
+// LINUX-armv7-DAG: -lboo
+// LINUX-armv7-DAG: -Xlinker -undefined
+// LINUX-armv7: -o linker
 
 // COMPLEX: bin/ld{{"? }}
 // COMPLEX-DAG: -dylib

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -607,7 +607,7 @@ if run_vendor == 'apple':
         "%s ld -L%s" %
         (xcrun_prefix, os.path.join(test_resource_dir, config.target_sdk_name)))
 
-elif run_os == 'linux-gnu':
+elif run_os == 'linux-gnu' or run_os == 'linux-gnueabihf':
     # Linux
     lit_config.note("Testing Linux " + config.variant_triple)
     config.target_object_format = "elf"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -227,6 +227,9 @@ function set_deployment_target_based_options() {
         linux-x86_64)
             SWIFT_HOST_VARIANT_ARCH="x86_64"
             ;;
+        linux-armv7)
+            SWIFT_HOST_VARIANT_ARCH="armv7"
+            ;;
         freebsd-x86_64)
             SWIFT_HOST_VARIANT_ARCH="x86_64"
             ;;
@@ -730,8 +733,8 @@ if [[ "$(uname -s)" == "Darwin" ]] ; then
     TOOLCHAIN_PREFIX=$(echo ${INSTALL_PREFIX} | sed -E 's/\/usr$//')
 fi
 
-# A list of deployment targets to compile the Swift host tools for, in case when
-# we can run the resulting binaries natively on the build machine.
+# A list of deployment targets to compile the Swift host tools for, in cases
+# where we can run the resulting binaries natively on the build machine.
 NATIVE_TOOLS_DEPLOYMENT_TARGETS=()
 
 # A list of deployment targets to cross-compile the Swift host tools for.
@@ -740,20 +743,24 @@ CROSS_TOOLS_DEPLOYMENT_TARGETS=()
 
 # Determine the native deployment target for the build machine, that will be
 # used to jumpstart the standard library build when cross-compiling.
-case "$(uname -s)" in
-    Linux)
+case "$(uname -s -m)" in
+    Linux\ x86_64)
         NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
             "linux-x86_64"
         )
         ;;
-
-    Darwin)
+    Linux\ armv7*)
+        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
+            "linux-armv7"
+        )
+        ;;
+    Darwin\ x86_64)
         NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
             "macosx-x86_64"
         )
         ;;
 
-    FreeBSD)
+    FreeBSD\ x86_64)
         NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
             "freebsd-x86_64"
         )
@@ -805,15 +812,18 @@ function is_cross_tools_deployment_target() {
 # A list of deployment targets that we compile or cross-compile the
 # Swift standard library for.
 STDLIB_DEPLOYMENT_TARGETS=()
-
-case "$(uname -s)" in
-    Linux)
+case "$(uname -s -m)" in
+    Linux\ x86_64)
         STDLIB_DEPLOYMENT_TARGETS=(
             "linux-x86_64"
         )
         ;;
-
-    Darwin)
+    Linux\ armv7*)
+        STDLIB_DEPLOYMENT_TARGETS=(
+            "linux-armv7"
+        )
+        ;;
+    Darwin\ x86_64)
         STDLIB_DEPLOYMENT_TARGETS=(
             "macosx-x86_64"
             "iphonesimulator-i386"
@@ -830,7 +840,7 @@ case "$(uname -s)" in
         )
         ;;
 
-    FreeBSD)
+    FreeBSD\ x86_64)
         STDLIB_DEPLOYMENT_TARGETS=(
             "freebsd-x86_64"
         )


### PR DESCRIPTION
I'm almost finished with enabling native compilation on ARMv7 hosts such as the Raspberry Pi, BeagleBone, Nvidia Tegras, etc...

The build of the swift compiler and standard library complete.  The compiler is also capable of generating executables, though there is a remaining linker problem.  I'm not sure where to move from here, so I'm hoping that this work can be a starting point for some.  The error is: unexpected reloc type 0x03

I've tested this patch in attempt to determine whether it negatively effects building on MacOS or Ubuntu 15.10 on x68_64.  In MacOS, the test suite completes with 2 unexpected failures, 2350 expected passes, 5 expected failures, and 33 unsupported tests.  The x86_64 linux build completes with 1682 expected passes, 92 expected failures, 575 unsupported failures (apparently no unexpected failures).  Finally, the linux arm port completes the testing suite with 1456 expected passes, 81 expected failures, 639 unsupported tests, and 155 unexpected failures.

I'm happy to make any changes to requested, and I'd be overjoyed if anyone had a crumb trail I could follow to address the linking issued.

Any comments are very appreciated!
