### PR TITLE
Implement hasPrefix and hasSuffix

### DIFF
--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -95,8 +95,29 @@ extension String {
   }
 }
 #else
-// FIXME: Implement hasPrefix and hasSuffix without objc
-// rdar://problem/18878343
+extension String {
+  /// Returns `true` iff `self` begins with `prefix`.
+  public func hasPrefix(prefix: String) -> Bool {
+    if prefix.isEmpty { return false }
+
+    let distance = prefix.startIndex.distanceTo(prefix.endIndex)
+
+    let lastIndex = startIndex.advancedBy(distance, limit: endIndex)
+    let prefixSlice = self[startIndex..<lastIndex]
+    return prefixSlice._compareDeterministicUnicodeCollation(prefix) == 0
+  }
+
+  /// Returns `true` iff `self` ends with `suffix`.
+  public func hasSuffix(suffix: String) -> Bool {
+    if suffix.isEmpty { return false }
+
+    let distance = suffix.startIndex.distanceTo(suffix.endIndex)
+
+    let firstIndex = endIndex.advancedBy(-distance, limit: startIndex)
+    let suffixSlice = self[firstIndex..<endIndex]
+    return suffixSlice._compareDeterministicUnicodeCollation(suffix) == 0
+  }
+}
 #endif
 
 // Conversions to string from other types.

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -384,6 +384,27 @@ func checkHasPrefixHasSuffix(
   let expectHasSuffix = lhs.characters.lazy.reverse().startsWith(
     rhs.characters.lazy.reverse(), isEquivalent: (==))
 
+#if _runtime(_ObjC)
+  // To determine the expected results, compare grapheme clusters,
+  // scalar-to-scalar, of the NFD form of the strings.
+  let lhsNFDGraphemeClusters =
+    lhs.decomposedStringWithCanonicalMapping.characters.map {
+      Array(String($0).unicodeScalars)
+  }
+  let rhsNFDGraphemeClusters =
+    rhs.decomposedStringWithCanonicalMapping.characters.map {
+      Array(String($0).unicodeScalars)
+  }
+
+  let expectHasPrefixNFD = lhsNFDGraphemeClusters.startsWith(
+    rhsNFDGraphemeClusters, isEquivalent: (==))
+  let expectHasSuffixNFD = lhsNFDGraphemeClusters.lazy.reverse().startsWith(
+    rhsNFDGraphemeClusters.lazy.reverse(), isEquivalent: (==))
+
+  expectEqual(expectHasPrefixNFD, expectHasPrefix)
+  expectEqual(expectHasSuffixNFD, expectHasSuffix)
+#endif
+
   expectEqual(expectHasPrefix, lhs.hasPrefix(rhs), stackTrace: stackTrace)
   expectEqual(expectHasSuffix, lhs.hasSuffix(rhs), stackTrace: stackTrace)
 }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 
 // XFAIL: interpret
-// XFAIL: linux
 
 import StdlibUnittest
 
@@ -12,9 +11,8 @@ import StdlibUnittest
 import SwiftPrivate
 #if _runtime(_ObjC)
 import ObjectiveC
-#endif
-
 import Foundation
+#endif
 
 extension String {
   var bufferID: UInt {
@@ -809,7 +807,10 @@ func asciiString<
   return s
 }
 
-StringTests.test("stringCoreExtensibility") {
+StringTests.test("stringCoreExtensibility")
+  .skip(.LinuxAny(reason: "Foundation dependency"))
+  .code {
+#if _runtime(_ObjC)
   let ascii = UTF16.CodeUnit(UnicodeScalar("X").value)
   let nonAscii = UTF16.CodeUnit(UnicodeScalar("é").value)
 
@@ -842,9 +843,15 @@ StringTests.test("stringCoreExtensibility") {
       }
     }
   }
+#else
+  expectUnreachable()
+#endif
 }
 
-StringTests.test("stringCoreReserve") {
+StringTests.test("stringCoreReserve")
+  .skip(.LinuxAny(reason: "Foundation dependency"))
+  .code {
+#if _runtime(_ObjC)
   for k in 0...5 {
     var base: String
     var startedNative: Bool
@@ -899,6 +906,9 @@ StringTests.test("stringCoreReserve") {
     }
     expectEqual(expected, base)
   }
+#else
+  expectUnreachable()
+#endif
 }
 
 func makeStringCore(base: String) -> _StringCore {
@@ -1095,12 +1105,22 @@ StringTests.test("Conversions") {
 
 // Check the internal functions are correct for ASCII values
 StringTests.test(
-  "forall x: Int8, y: Int8 . x < 128 ==> x <ascii y == x <unicode y") {
+  "forall x: Int8, y: Int8 . x < 128 ==> x <ascii y == x <unicode y")
+  .skip(.LinuxAny(reason: "String._compareASCII defined when _runtime(_ObjC)"))
+  .code {
+#if _runtime(_ObjC)
   let asciiDomain = (0..<128).map({ String(UnicodeScalar($0)) })
   expectEqualMethodsForDomain(
     asciiDomain, asciiDomain, 
     String._compareDeterministicUnicodeCollation, String._compareASCII)
+#else
+  expectUnreachable()
+#endif
 }
+
+#if os(Linux)
+import Glibc
+#endif
 
 StringTests.test("lowercaseString") {
   // Use setlocale so tolower() is correct on ASCII.
@@ -1238,7 +1258,10 @@ StringTests.test("unicodeViews") {
 
 // Validate that index conversion does something useful for Cocoa
 // programmers.
-StringTests.test("indexConversion") {
+StringTests.test("indexConversion")
+  .skip(.LinuxAny(reason: "Foundation dependency"))
+  .code {
+#if _runtime(_ObjC)
   let re : NSRegularExpression
   do {
     re = try NSRegularExpression(
@@ -1261,6 +1284,9 @@ StringTests.test("indexConversion") {
   }
 
   expectEqual(["furth", "lard", "bart"], matches)
+#else
+  expectUnreachable()
+#endif
 }
 
 StringTests.test("String.append(_: UnicodeScalar)") {

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -375,6 +375,11 @@ let comparisonTests = [
   ComparisonTest(.EQ, "\u{fb01}", "\u{fb01}"),
   ComparisonTest(.LT, "fi", "\u{fb01}"),
 
+  // U+1F1E7 REGIONAL INDICATOR SYMBOL LETTER B
+  // \u{1F1E7}\u{1F1E7} Flag of Barbados
+  ComparisonTest(.LT, "\u{1F1E7}", "\u{1F1E7}\u{1F1E7}",
+    xfail: [.ObjC: "https://bugs.swift.org/browse/SR-367"]),
+
   // Test that Unicode collation is performed in deterministic mode.
   //
   // U+0301 COMBINING ACUTE ACCENT


### PR DESCRIPTION
Using the _compareDeterministicUnicodeCollation method, also used by the == operator.
