### PR TITLE
Update IndexingGenerator.next() function for removal of ++ operator

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -101,8 +101,10 @@ public struct IndexingGenerator<Elements : Indexable>
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Elements._Element? {
-    return _position == _elements.endIndex
-    ? .None : .Some(_elements[_position++])
+    guard _position != _elements.endIndex else { return .None }
+    let element = .Some(_elements[_position])
+    _position = _position.successor()
+    return element
   }
 
   internal let _elements: Elements

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -103,7 +103,7 @@ public struct IndexingGenerator<Elements : Indexable>
   public mutating func next() -> Elements._Element? {
     guard _position != _elements.endIndex else { return nil }
     let element = _elements[_position]
-    _position = _position.successor()
+    _position._successorInPlace()
     return element
   }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -102,7 +102,7 @@ public struct IndexingGenerator<Elements : Indexable>
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Elements._Element? {
     guard _position != _elements.endIndex else { return .None }
-    let element = .Some(_elements[_position])
+    let element: Elements._Element? = .Some(_elements[_position])
     _position = _position.successor()
     return element
   }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -101,7 +101,7 @@ public struct IndexingGenerator<Elements : Indexable>
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Elements._Element? {
-    guard _position != _elements.endIndex else { return nil }
+    if _position == _elements.endIndex { return nil }
     let element = _elements[_position]
     _position._successorInPlace()
     return element

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -101,8 +101,8 @@ public struct IndexingGenerator<Elements : Indexable>
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Elements._Element? {
-    guard _position != _elements.endIndex else { return .None }
-    let element: Elements._Element? = .Some(_elements[_position])
+    guard _position != _elements.endIndex else { return nil }
+    let element = _elements[_position]
     _position = _position.successor()
     return element
   }


### PR DESCRIPTION
Related to: https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md
