### PR TITLE
Update RangeGenerator.next() function for removal of ++ operator

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -28,9 +28,7 @@ public struct RangeGenerator<
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.
   public mutating func next() -> Element? {
-    if startIndex == endIndex {
-      return .None
-    }
+    if startIndex == endIndex { return nil }
     let element = startIndex
     startIndex._successorInPlace()
     return element

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -31,7 +31,9 @@ public struct RangeGenerator<
     if startIndex == endIndex {
       return .None
     }
-    return startIndex++
+    let element = startIndex
+    startIndex._successorInPlace()
+    return element
   }
 
   /// The lower bound of the remaining range.


### PR DESCRIPTION
Related to: https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md
