### PR TITLE
[SR-197] Skip generic specialization when generic is <<error type>>

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -367,8 +367,10 @@ Type TypeChecker::applyGenericArguments(Type type,
   if (!unbound) {
     // FIXME: Highlight generic arguments and introduce a Fix-It to remove
     // them.
-    diagnose(loc, diag::not_a_generic_type, type);
-
+    if (!type->is<ErrorType>()) {
+      diagnose(loc, diag::not_a_generic_type, type);
+    }
+    
     // Just return the type; this provides better recovery anyway.
     return type;
   }

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -168,6 +168,9 @@ typealias Typealias1 = FooNonExistentProtocol // expected-error {{use of undecla
 // NO-TYREPR: {{^}}typealias Typealias1 = <<error type>>{{$}}
 // TYREPR: {{^}}typealias Typealias1 = FooNonExistentProtocol{{$}}
 
+// sr-197
+func foo(bar: Typealias1<Int>) {} // Should not generate error "cannot specialize non-generic type '<<error type>>'"
+
 // Associated types.
 
 protocol AssociatedType1 {


### PR DESCRIPTION
This disables the _'cannot specialize non-generic type'_ error message when the type is `<<error type>>` since it doesn't convey any additional information to the user.

This code represents an instance of this problem:

```
$ cat a.swift 
typealias SomeType = NonExistentType
func foo(bar: SomeType<Int>) {

}
$ swiftc -c  a.swift 
a.swift:1:22: error: use of undeclared type 'NonExistentType'
typealias SomeType = NonExistentType
                     ^~~~~~~~~~~~~~~
a.swift:2:15: error: cannot specialize non-generic type '<<error type>>'
func foo(bar: SomeType<Int>) {
```

This would be the first time I contribute code to Swift, so I might have made some rookie mistake. In particular, from what I saw on the discussion of #432, this might not be the place where the problem should be addressed.

I'm currently running the test suite, but I think it should pass since I haven't found any test checking this particular case. Should one be added?

EDIT: the tests just finished:

```
  Expected Passes    : 2350
  Expected Failures  : 5
  Unsupported Tests  : 34
```
