### PR TITLE
Fix typo "nul-terminated" -> "null-terminated"

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -51,7 +51,7 @@ extension String {
 }
 
 /// From a non-`nil` `UnsafePointer` to a null-terminated string
-/// with possibly-transient lifetime, create a nul-terminated array of 'C' char.
+/// with possibly-transient lifetime, create a null-terminated array of 'C' char.
 /// Returns `nil` if passed a null pointer.
 @warn_unused_result
 public func _persistCString(s: UnsafePointer<CChar>) -> [CChar]? {


### PR DESCRIPTION
See pr #447  nul-terminated => null-terminated
One line before used as => From a non-`nil` `UnsafePointer` to a null-terminated string
in next line => with possibly-transient lifetime, create a nul-terminated array of 'C' char
 nul-terminated should be the same as null-terminated
