### PR TITLE
[AddSwift.cmake] Remove leftover use_internal_sdk parameter values

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1612,14 +1612,12 @@ function(_add_swift_executable_single name)
       "${SWIFTEXE_SINGLE_ARCHITECTURE}"
       "${CMAKE_BUILD_TYPE}"
       "${LLVM_ENABLE_ASSERTIONS}"
-      FALSE
       c_compile_flags)
   _add_variant_link_flags(
       "${SWIFTEXE_SINGLE_SDK}"
       "${SWIFTEXE_SINGLE_ARCHITECTURE}"
       "${CMAKE_BUILD_TYPE}"
       "${LLVM_ENABLE_ASSERTIONS}"
-      FALSE
       link_flags)
 
   list(APPEND link_flags


### PR DESCRIPTION
The `use_internal_sdk` flag has been removed from `_add_variant_link_flags` and `_add_variant_c_compile_flags` in commit d9bbb6caf09a512f10edc4379194ec6a07aed847 by @bitjammer.

In four instances where previously `FALSE` was given as the value for that parameter, this value has not been removed from the function call.
This causes the two functions to try to append flags to `FALSE` instead of the respective link_flags and c_compile_flags variables.
