### PR TITLE
FIXME: swift/validation-test/stdlib/Set.swift:95

### DIFF
--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -93,8 +93,7 @@ func helperDeleteThree(k1: TestKeyTy, _ k2: TestKeyTy, _ k3: TestKeyTy) {
 }
 
 func uniformRandom(max: Int) -> Int {
-  // FIXME: this is not uniform.
-  return random() % max
+  return Int(arc4random_uniform(UInt32(max)))
 }
 
 func pickRandom<T>(a: [T]) -> T {


### PR DESCRIPTION
Use real arc4random_uniform() instead of just random() % max
1. Is `truncatingBitPattern` proper way to prevent integer overflow?
2. Does `UInt32` available on every platform?

Off topic question:

Why do you use `if true {}` in test cases? Is it equivalent for `do {}`?
