### PR TITLE
[build-scripts] Check for empty array and `skip-test-swift` argument before printing.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -993,7 +993,7 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
 done
 
 echo "Building the standard library for: ${SWIFT_STDLIB_TARGETS[@]}"
-if [[ "${SWIFT_TEST_TARGETS[@]}" ]] ; then
+if [[ "${SWIFT_TEST_TARGETS[@]}" ]] && ! [[ "${SKIP_TEST_SWIFT}" ]]; then
     echo "Running Swift tests for: ${SWIFT_TEST_TARGETS[@]}"
 fi
 echo

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -988,13 +988,14 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
               SWIFT_TEST_TARGETS=(
                  "${SWIFT_TEST_TARGETS[@]}" "check-swift-all-optimize-${deployment_target}")
             fi
-
         fi
     fi
 done
 
 echo "Building the standard library for: ${SWIFT_STDLIB_TARGETS[@]}"
-echo "Running Swift tests for: ${SWIFT_TEST_TARGETS[@]}"
+if [[ "${SWIFT_TEST_TARGETS[@]}" ]] ; then
+    echo "Running Swift tests for: ${SWIFT_TEST_TARGETS[@]}"
+fi
 echo
 
 # CMake options used for all targets, including LLVM/Clang


### PR DESCRIPTION
Currently, `build-script-impl` prints the following, irrespective of the setting of the `-t` or `--test` flag on `build-script`.

> Building the standard library for: swift-stdlib-macosx-x86_64
> Running Swift tests for: check-swift-macosx-x86_64

This seems misleading and I recommend removing the second line when the `-t` or `--test` flag is omitted.

Additionally, if the flags passed to `build-script-impl` are set in such a way that testing should occur, yet the SWIFT_TEST_TARGETS array is empty, the output would appear as:

> Building the standard library for: swift-stdlib-macosx-x86_64
> Running Swift tests for:

This edit will drop the second line of output in both cases above.
