### PR TITLE
Make local variable name more expressive

### DIFF
--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -135,9 +135,9 @@ public struct StrideToGenerator<Element : Strideable> : GeneratorType {
     if stride > 0 ? current >= end : current <= end {
       return nil
     }
-    let element = current
+    let result = current
     current += stride
-    return element
+    return result
   }
 }
 
@@ -209,9 +209,9 @@ public struct StrideThroughGenerator<Element : Strideable> : GeneratorType {
       }
       return nil
     }
-    let element = current
+    let result = current
     current += stride
-    return element
+    return result
   }
 }
 

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -135,9 +135,9 @@ public struct StrideToGenerator<Element : Strideable> : GeneratorType {
     if stride > 0 ? current >= end : current <= end {
       return nil
     }
-    let ret = current
+    let element = current
     current += stride
-    return ret
+    return element
   }
 }
 
@@ -209,9 +209,9 @@ public struct StrideThroughGenerator<Element : Strideable> : GeneratorType {
       }
       return nil
     }
-    let ret = current
+    let element = current
     current += stride
-    return ret
+    return element
   }
 }
 


### PR DESCRIPTION
It seems that `element` would also be more consistent with the documentation
