### PR TITLE
Fixed issue in design document where incorrect word mentioned

### DIFF
--- a/docs/Generics.rst
+++ b/docs/Generics.rst
@@ -814,7 +814,7 @@ because code like this::
 
 will essentially parse the type as::
 
-  identifier operator Int operator
+  identifier operator identifier operator
 
 and verify that the operators are '<' and '>', respectively. Cases
 involving <> are more interesting, because the type of::


### PR DESCRIPTION
The document incorrectly uses the word `Int` instead of the word `identifier` in the following line:
`identifier operator Int operator`

It is clear that `identifier` was intended since the next line reads
`identifier operator identifier operator identifier operator operator`
which correctly calls `Int` an identifier.
