### PR TITLE
Update LazyFilterCollection.startIndex for removal of ++ operator

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -186,7 +186,7 @@ public struct LazyFilterCollection<
       if _predicate(_base[first]) {
         break
       }
-      ++first
+      first._successorInPlace()
     }
     return LazyFilterIndex(
       _baseElements: _base, base: first, _include: _predicate)


### PR DESCRIPTION
Related to: https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md
