### PR TITLE
[stdlib] Replace `.Some(x)` and `.None` by `x` and `nil`, respectively

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -177,8 +177,8 @@ public struct EnumerateGenerator<
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Element? {
-    guard let b = base.next() else { return .None }
-    return .Some((index: count++, element: b))
+    guard let b = base.next() else { return nil }
+    return (index: count++, element: b)
   }
 }
 

--- a/stdlib/public/core/Bit.swift
+++ b/stdlib/public/core/Bit.swift
@@ -63,7 +63,7 @@ internal struct _BitMirror : _MirrorType {
 
   var valueType: Any.Type { return (_value as Any).dynamicType }
 
-  var objectIdentifier: ObjectIdentifier? { return .None }
+  var objectIdentifier: ObjectIdentifier? { return nil }
 
   var count: Int { return 0 }
 
@@ -78,7 +78,7 @@ internal struct _BitMirror : _MirrorType {
     }
   }
 
-  var quickLookObject: PlaygroundQuickLook? { return .None }
+  var quickLookObject: PlaygroundQuickLook? { return nil }
 
   var disposition: _MirrorDisposition { return .Enum }
 }

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -23,7 +23,7 @@ extension String {
   @warn_unused_result
   public static func fromCString(cs: UnsafePointer<CChar>) -> String? {
     if cs._isNull {
-      return .None
+      return nil
     }
     let len = Int(_swift_stdlib_strlen(cs))
     return String._fromCodeUnitSequence(UTF8.self,
@@ -41,7 +41,7 @@ extension String {
     cs: UnsafePointer<CChar>)
       -> (String?, hadError: Bool) {
     if cs._isNull {
-      return (.None, hadError: false)
+      return (nil, hadError: false)
     }
     let len = Int(_swift_stdlib_strlen(cs))
     let (result, hadError) = String._fromCodeUnitSequenceWithRepair(UTF8.self,
@@ -56,7 +56,7 @@ extension String {
 @warn_unused_result
 public func _persistCString(s: UnsafePointer<CChar>) -> [CChar]? {
   if s == nil {
-    return .None
+    return nil
   }
   let length = Int(_swift_stdlib_strlen(s))
   var result = [CChar](count: length + 1, repeatedValue: 0)

--- a/stdlib/public/core/CollectionMirrors.swift.gyb
+++ b/stdlib/public/core/CollectionMirrors.swift.gyb
@@ -47,7 +47,7 @@ ${MirrorDecl} {
 
   var summary: String { return "${SummaryString}" }
 
-  var quickLookObject: PlaygroundQuickLook? { return .None }
+  var quickLookObject: PlaygroundQuickLook? { return nil }
 }
 
 ${MirrorConformance}

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -29,7 +29,7 @@ public struct GeneratorOfOne<Element> : GeneratorType, SequenceType {
   ///   has returned `nil`.
   public mutating func next() -> Element? {
     let result = elements
-    elements = .None
+    elements = nil
     return result
   }
   var elements: Element?

--- a/stdlib/public/core/Existential.swift
+++ b/stdlib/public/core/Existential.swift
@@ -47,7 +47,7 @@ internal struct _CollectionOf<
         ++index
         return self._subscriptImpl(index)
       }
-      return .None
+      return nil
     }
   }
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -863,7 +863,7 @@ public func _setDownCast<BaseValue, DerivedValue>(source: Set<BaseValue>)
 
 /// Implements a conditional downcast.
 ///
-/// If the cast fails, the function returns `.None`.  All checks should be
+/// If the cast fails, the function returns `nil`.  All checks should be
 /// performed eagerly.
 ///
 /// - Precondition: `DerivedValue` is a subtype of `BaseValue` and both
@@ -901,7 +901,7 @@ public func _setBridgeFromObjectiveC<ObjCValue, SwiftValue>(
 
 /// Implements a conditional downcast that involves bridging.
 ///
-/// If the cast fails, the function returns `.None`.  All checks should be
+/// If the cast fails, the function returns `nil`.  All checks should be
 /// performed eagerly.
 ///
 /// - Precondition: At least one of `SwiftValue` is a bridged value
@@ -1442,7 +1442,7 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
 
 /// Implements a conditional downcast.
 ///
-/// If the cast fails, the function returns `.None`.  All checks should be
+/// If the cast fails, the function returns `nil`.  All checks should be
 /// performed eagerly.
 ///
 /// - Precondition: `DerivedKey` is a subtype of `BaseKey`, `DerivedValue` is
@@ -1492,7 +1492,7 @@ public func _dictionaryBridgeFromObjectiveC<
 
 /// Implements a conditional downcast that involves bridging.
 ///
-/// If the cast fails, the function returns `.None`.  All checks should be
+/// If the cast fails, the function returns `nil`.  All checks should be
 /// performed eagerly.
 ///
 /// - Precondition: At least one of `SwiftKey` or `SwiftValue` is a bridged value

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -653,7 +653,7 @@ public struct Set<Element : Hashable> :
   /// The first element obtained when iterating, or `nil` if `self` is
   /// empty.  Equivalent to `self.generate().next()`.
   public var first: Element? {
-    return count > 0 ? self[startIndex] : .None
+    return count > 0 ? self[startIndex] : nil
   }
 }
 
@@ -881,7 +881,7 @@ public func _setDownCastConditional<BaseValue, DerivedValue>(
       result.insert(derivedMember)
       continue
     }
-    return .None
+    return nil
   }
   return result
 }
@@ -2142,10 +2142,10 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   internal func indexForKey(key: Key) -> Index? {
     if count == 0 {
       // Fast path that avoids computing the hash of the key.
-      return .None
+      return nil
     }
     let (i, found) = _find(key, _bucket(key))
-    return found ? i : .None
+    return found ? i : nil
   }
 
   @warn_unused_result
@@ -2177,7 +2177,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   internal func maybeGet(key: Key) -> Value? {
     if count == 0 {
       // Fast path that avoids computing the hash of the key.
-      return .None
+      return nil
     }
 
     let (i, found) = _find(key, _bucket(key))
@@ -2188,7 +2188,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
       return valueAt(i.offset)
 %end
     }
-    return .None
+    return nil
   }
 
   internal mutating func updateValue(value: Value, forKey: Key) -> Value? {
@@ -2800,7 +2800,7 @@ internal struct _Cocoa${Self}Storage : _HashStorageType {
     // potential savings are significant: we could skip a memory allocation and
     // a linear search.
     if maybeGet(key) == nil {
-      return .None
+      return nil
     }
 
 %if Self == 'Set':
@@ -3080,16 +3080,16 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     switch self {
     case .Native:
       if let nativeIndex = native.indexForKey(key) {
-        return .Some(._Native(nativeIndex))
+        return ._Native(nativeIndex)
       }
-      return .None
+      return nil
     case .Cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       let anyObjectKey: AnyObject = _bridgeToObjectiveCUnconditional(key)
       if let cocoaIndex = cocoaStorage.indexForKey(anyObjectKey) {
-        return .Some(._Cocoa(cocoaIndex))
+        return ._Cocoa(cocoaIndex)
       }
-      return .None
+      return nil
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -3146,7 +3146,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     if let anyObjectValue = cocoaStorage.maybeGet(anyObjectKey) {
       return _forceBridgeFromObjectiveC(anyObjectValue, Value.self)
     }
-    return .None
+    return nil
   }
 #endif
 
@@ -3181,7 +3181,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     }
 
 %if Self == 'Set':
-    let oldValue: Value? = found ? native.keyAt(i.offset) : .None
+    let oldValue: Value? = found ? native.keyAt(i.offset) : nil
     if found {
       native.setKey(key, at: i.offset)
     } else {
@@ -3189,7 +3189,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
       ++native.count
     }
 %elif Self == 'Dictionary':
-    let oldValue: Value? = found ? native.valueAt(i.offset) : .None
+    let oldValue: Value? = found ? native.valueAt(i.offset) : nil
     if found {
       native.setKey(key, value: value, at: i.offset)
     } else {
@@ -3290,7 +3290,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     // Fast path: if the key is not present, we will not mutate the set,
     // so don't force unique storage.
     if !found {
-      return .None
+      return nil
     }
 
     let (reallocated, capacityChanged) =
@@ -3383,7 +3383,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
 #if _runtime(_ObjC)
       let anyObjectKey: AnyObject = _bridgeToObjectiveCUnconditional(key)
       if cocoaStorage.maybeGet(anyObjectKey) == nil {
-        return .None
+        return nil
       }
       migrateDataToNativeStorage(cocoaStorage)
       return nativeRemoveObjectForKey(key)
@@ -3808,7 +3808,7 @@ final internal class _Cocoa${Self}Generator : GeneratorType {
 
   internal func next() -> Element? {
     if itemIndex < 0 {
-      return .None
+      return nil
     }
     let cocoa${Self} = self.cocoa${Self}
     if itemIndex == itemCount {
@@ -3823,7 +3823,7 @@ final internal class _Cocoa${Self}Generator : GeneratorType {
         count: stackBufLength)
       if itemCount == 0 {
         itemIndex = -1
-        return .None
+        return nil
       }
       itemIndex = 0
     }
@@ -3912,7 +3912,7 @@ public struct ${Self}Generator<${TypeParametersDecl}> : GeneratorType {
     switch _state {
     case ._Native(let startIndex, let endIndex, let owner):
       if startIndex == endIndex {
-        return .None
+        return nil
       }
       let result = startIndex.nativeStorage.assertingGet(startIndex)
       _state =
@@ -3948,7 +3948,7 @@ public struct ${Self}Generator<${TypeParametersDecl}> : GeneratorType {
         return (nativeKey, nativeValue)
       }
 %end
-      return .None
+      return nil
 #else
       _sanityCheckFailure("internal error: unexpected cocoa ${Self}")
 #endif
@@ -4157,7 +4157,7 @@ extension ${Self} {
       return ${Self}<${TypeParameters}>(_nativeStorageOwner: nativeOwner)
     }
     // FIXME: what if `s` is native storage, but for different key/value type?
-    return .None
+    return nil
   }
 }
 #endif

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -129,7 +129,7 @@ struct _HeapBuffer<Value, Element> : Equatable {
   }
 
   init() {
-    self._storage = .None
+    self._storage = nil
   }
 
   public // @testable

--- a/stdlib/public/core/Interval.swift.gyb
+++ b/stdlib/public/core/Interval.swift.gyb
@@ -226,6 +226,6 @@ internal struct _IntervalMirror<
   internal var summary: String { return _value.description }
 
   internal var quickLookObject: PlaygroundQuickLook? {
-    return .Some(.Text(summary))
+    return .Text(summary)
   }
 }

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -43,7 +43,7 @@ internal func _toString<T>(x: T) -> String {
 extension ${Type[0]} : _Reflectable {
   /// Returns a mirror that reflects `self`.
   public func _getMirror() -> _MirrorType {
-    return _LeafMirror(self, _toString, { .Some(${Type[1]}(${Type[2]})) })
+    return _LeafMirror(self, _toString, { ${Type[1]}(${Type[2]}) })
   }
 }
 % end

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -407,7 +407,7 @@ struct _ClassMirror : _MirrorType {
 #if _runtime(_ObjC)
     return _getClassPlaygroundQuickLook(data)
 #else
-    return .None
+    return nil
 #endif
   }
   var disposition: _MirrorDisposition { return .Class }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -145,7 +145,7 @@ extension String {
     if let stringBuffer = stringBufferOptional {
       return String(_storage: stringBuffer)
     } else {
-      return .None
+      return nil
     }
   }
 

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -94,7 +94,7 @@ public struct _StringBuffer {
     let inputStream = input.generate()
     guard let (utf16Count, isAscii) = UTF16.measure(encoding, input: inputStream,
         repairIllFormedSequences: repairIllFormedSequences) else {
-      return (.None, true)
+      return (nil, true)
     }
 
     // Allocate storage
@@ -231,7 +231,7 @@ public struct _StringBuffer {
   }
 
   var _anyObject: AnyObject? {
-    return _storage.storage != nil ? .Some(_storage.storage!) : .None
+    return _storage.storage != nil ? _storage.storage! : nil
   }
 
   var _storage: _Storage

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -242,7 +242,7 @@ extension String.CharacterView : CollectionType {
 
     var valueType: Any.Type { return (_value as Any).dynamicType }
 
-    var objectIdentifier: ObjectIdentifier? { return .None }
+    var objectIdentifier: ObjectIdentifier? { return nil }
 
     var disposition: _MirrorDisposition { return .Aggregate }
 
@@ -255,7 +255,7 @@ extension String.CharacterView : CollectionType {
     var summary: String { return "\(_value._utf16Index)" }
 
     var quickLookObject: PlaygroundQuickLook? {
-      return .Some(.Int(Int64(_value._utf16Index)))
+      return .Int(Int64(_value._utf16Index))
     }
   }
 }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -237,7 +237,7 @@ public struct _StringCore {
     return UnsafeMutablePointer(_baseAddress)
   }
 
-  /// the native _StringBuffer, if any, or .None.
+  /// the native _StringBuffer, if any, or `nil`.
   public var nativeBuffer: _StringBuffer? {
     if !hasCocoaBuffer {
       return _owner.map {
@@ -248,7 +248,7 @@ public struct _StringCore {
   }
 
 #if _runtime(_ObjC)
-  /// the Cocoa String buffer, if any, or .None.
+  /// the Cocoa String buffer, if any, or `nil`.
   public var cocoaBuffer: _CocoaStringType? {
     if hasCocoaBuffer {
       return _owner.map {

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -174,7 +174,7 @@ public struct _StringCore {
   public init() {
     self._baseAddress = _emptyStringBase
     self._countAndFlags = 0
-    self._owner = .None
+    self._owner = nil
     _invariantCheck()
   }
 

--- a/stdlib/public/core/StringUTFViewsMirrors.swift.gyb
+++ b/stdlib/public/core/StringUTFViewsMirrors.swift.gyb
@@ -34,6 +34,6 @@ extension String {
 
       var summary: String { return _value.description }
 
-      var quickLookObject: PlaygroundQuickLook? { return .Some(.Text(summary)) }
+      var quickLookObject: PlaygroundQuickLook? { return .Text(summary) }
   }
 }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -44,7 +44,7 @@ extension String {
       }
       mutating func next() -> UTF16.CodeUnit? {
         if idx == core.endIndex {
-          return .None
+          return nil
         }
         return self.core[idx++]
       }
@@ -175,7 +175,7 @@ extension String {
             switch self._asciiBase.next() {
             case let x?:
               result = .Result(UnicodeScalar(x))
-            case .None:
+            case nil:
               result = .EmptyInput
             }
           } else {
@@ -188,7 +188,7 @@ extension String {
         case .Result(let us):
           return us
         case .EmptyInput:
-          return .None
+          return nil
         case .Error:
           return UnicodeScalar(0xfffd)
         }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -947,7 +947,7 @@ extension UTF16 {
         break loop
       case .Error:
         if !repairIllFormedSequences {
-          return .None
+          return nil
         }
         isAscii = false
         count += width(UnicodeScalar(0xfffd))

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -444,7 +444,7 @@ ${MirrorDecl} {
     return "\(selfType)(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
   }
 
-  var quickLookObject: PlaygroundQuickLook? { return .Some(.Text(summary)) }
+  var quickLookObject: PlaygroundQuickLook? { return .Text(summary) }
 }
 
 ${MirrorConformance}

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -53,7 +53,7 @@ public struct Zip2Generator<
       return nil
     }
 
-    return .Some((element0, element1))
+    return (element0, element1)
   }
 
   internal var _baseStreams: (Generator1, Generator2)


### PR DESCRIPTION
Proposal to remove explicit usage of `Optional<T>` enum cases for consistency and reduced clutter ([SR-212](https://bugs.swift.org/browse/SR-212)).
- The SIL for both forms is identical.
- `Optional<T>` takes precedence over other nil literal convertibles.
- `Optional.swift` and `ImplicitlyUnwrappedOptional.swift` still use explicit forms.
- All test pass (didn't run validation tests yet though).
