### PR TITLE
Expand tuple properties in Zip2Sequence/Generator

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -56,7 +56,8 @@ public struct Zip2Generator<
     return (element1, element2)
   }
 
-  internal var _baseStream1: Generator1, _baseStream2: Generator2
+  internal var _baseStream1: Generator1
+  internal var _baseStream2: Generator2
   internal var _reachedEnd: Bool = false
 }
 
@@ -88,7 +89,8 @@ public struct Zip2Sequence<Sequence1 : SequenceType, Sequence2 : SequenceType>
       _sequence2.generate())
   }
 
-  internal let _sequence1: Sequence1, _sequence2: Sequence2
+  internal let _sequence1: Sequence1
+  internal let _sequence2: Sequence2
 }
 
 @available(*, unavailable, renamed="Zip2Generator")

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -28,7 +28,7 @@ public struct Zip2Generator<
 
   /// Construct around a pair of underlying generators.
   public init(_ generator1: Generator1, _ generator2: Generator2) {
-    _baseStreams = (generator1, generator2)
+    (_baseStream1, _baseStream2) = (generator1, generator2)
   }
 
   /// Advance to the next element and return it, or `nil` if no next
@@ -48,15 +48,15 @@ public struct Zip2Generator<
       return nil
     }
 
-    guard let element0 = _baseStreams.0.next(), element1 = _baseStreams.1.next() else {
+    guard let element1 = _baseStream1.next(), element2 = _baseStream2.next() else {
       _reachedEnd = true
       return nil
     }
 
-    return (element0, element1)
+    return (element1, element2)
   }
 
-  internal var _baseStreams: (Generator1, Generator2)
+  internal var _baseStream1: Generator1, _baseStream2: Generator2
   internal var _reachedEnd: Bool = false
 }
 
@@ -76,7 +76,7 @@ public struct Zip2Sequence<Sequence1 : SequenceType, Sequence2 : SequenceType>
   /// Construct an instance that makes pairs of elements from `sequence1` and
   /// `sequence2`.
   public init(_ sequence1: Sequence1, _ sequence2: Sequence2) {
-    _sequences = (sequence1, sequence2)
+    (_sequence1, _sequence2) = (sequence1, sequence2)
   }
 
   /// Return a *generator* over the elements of this *sequence*.
@@ -84,11 +84,11 @@ public struct Zip2Sequence<Sequence1 : SequenceType, Sequence2 : SequenceType>
   /// - Complexity: O(1).
   public func generate() -> Generator {
     return Generator(
-      _sequences.0.generate(),
-      _sequences.1.generate())
+      _sequence1.generate(),
+      _sequence2.generate())
   }
 
-  internal let _sequences: (Sequence1, Sequence2)
+  internal let _sequence1: Sequence1, _sequence2: Sequence2
 }
 
 @available(*, unavailable, renamed="Zip2Generator")


### PR DESCRIPTION
The previous arrangement made the numbering inconsistent, e.g. `baseStreams.1` was of type `Generator2`.
- The SIL ([comparison](https://gist.github.com/PatrickPijnappel/9aa593cb6e17100ebafc)) is equivalent except for the obvious `tuple_element_addr` and `struct_element_addr` differences.
- Ran full normal test set, all passed.
