### PR TITLE
[Optimization] skip copying old values during Set's removeAll()

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -575,6 +575,13 @@ public struct Set<Element : Hashable> :
   public mutating func intersectInPlace<
     S : SequenceType where S.Generator.Element == Element
   >(sequence: S) {
+    if let other = sequence as? Set<Element> {
+      // removeAll() is fast, prefer using it when possible
+      if other.isEmpty {
+        removeAll()
+      }
+    }
+
     // Because `intersect` needs to both modify and iterate over
     // the left-hand side, the index may become invalidated during
     // traversal so an intermediate set must be created.
@@ -3394,26 +3401,27 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
   }
 
   internal mutating func nativeRemoveAll() {
-    var nativeStorage = native
-
-    // FIXME(performance): if the storage is non-uniquely referenced, we
-    // shouldn’t be copying the elements into new storage and then immediately
-    // deleting the elements. We should detect that the storage is not uniquely
-    // referenced and allocate new empty storage of appropriate capacity.
 
     // We have already checked for the empty dictionary case, so we will always
     // mutating the dictionary storage.  Request unique storage.
-    let (reallocated, _) = ensureUniqueNativeStorage(nativeStorage.capacity)
-    if reallocated {
-      nativeStorage = native
-    }
 
-    for var b = 0; b != nativeStorage.capacity; ++b {
-      if nativeStorage.isInitializedEntry(b) {
-        nativeStorage.destroyEntryAt(b)
+    if !isUniquelyReferenced() {
+      switch self {
+      case .Native(let owner):
+        owner.deinitializeHeapBufferBridged()
+      case .Cocoa:
+        _sanityCheckFailure("internal error: not backed by native storage")
+      }
+      let newNativeOwner = NativeStorageOwner(minimumCapacity: native.capacity)
+      self = .Native(newNativeOwner)
+    } else {
+      for b in 0..<native.capacity {
+        if native.isInitializedEntry(b) {
+          native.destroyEntryAt(b)
+        }
       }
     }
-    nativeStorage.count = 0
+    native.count = 0
   }
 
   internal mutating func removeAll(keepCapacity keepCapacity: Bool) {


### PR DESCRIPTION
As noted in FIXME(performance), when not uniquely referenced,
Set.nativeRemoveAll() makes a copy of the memory with same content
and only then proceed to remove each element.

This patch makes nativeRemoveAll() skip the copying step.
