### PR TITLE
Reorder checks in bindExtensionDecl to avoid crash

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -299,16 +299,6 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
     return;
   }
 
-  // Cannot extend a bound generic type.
-  if (extendedType->isSpecialized()) {
-    TC.diagnose(ED->getLoc(), diag::extension_specialization,
-                extendedType->getAnyNominal()->getName())
-      .highlight(ED->getExtendedTypeLoc().getSourceRange());
-    ED->setInvalid();
-    ED->getExtendedTypeLoc().setInvalidType(TC.Context);
-    return;
-  }
-
   // Dig out the nominal type being extended.
   NominalTypeDecl *extendedNominal = extendedType->getAnyNominal();
   if (!extendedNominal) {
@@ -319,6 +309,16 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
     return;
   }
   assert(extendedNominal && "Should have the nominal type being extended");
+  
+  // Cannot extend a bound generic type.
+  if (extendedType->isSpecialized()) {
+    TC.diagnose(ED->getLoc(), diag::extension_specialization,
+                extendedNominal->getName())
+    .highlight(ED->getExtendedTypeLoc().getSourceRange());
+    ED->setInvalid();
+    ED->getExtendedTypeLoc().setInvalidType(TC.Context);
+    return;
+  }
 
   // If the extended type is generic or is a protocol. Clone or create
   // the generic parameters.

--- a/validation-test/compiler_crashers_fixed/25533-bool.swift
+++ b/validation-test/compiler_crashers_fixed/25533-bool.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
`extendedType->isSpecialized()` was not a sufficient check to assume that the type was nominal. `extendedType->getAnyNominal()` would return null in cases like `([Int], Int)`.
