### PR TITLE
Coalesce protocol conformance sections on FreeBSD.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1090,10 +1090,11 @@ function(_add_swift_library_single target name)
     set(PLIST_INFO_BUILD_VERSION)
   endif()
 
-  # On Linux add the linker script that coalesces protocol conformance
-  # sections. This wouldn't be necessary if the link was done by the swift
-  # binary: rdar://problem/19007002
-  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  # On Linux and FreeBSD add the linker script that coalesces protocol
+  # conformance sections. This wouldn't be necessary if the link was done by
+  # the swift binary: rdar://problem/19007002
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR
+    "${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
     list(APPEND link_flags
         "-Xlinker" "-T"
         "-Xlinker" "${SWIFTLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}/swift.ld")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1094,7 +1094,7 @@ function(_add_swift_library_single target name)
   # conformance sections. This wouldn't be necessary if the link was done by
   # the swift binary: rdar://problem/19007002
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR
-    "${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+     "${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
     list(APPEND link_flags
         "-Xlinker" "-T"
         "-Xlinker" "${SWIFTLIB_DIR}/${SWIFTLIB_SINGLE_SUBDIR}/swift.ld")


### PR DESCRIPTION
This patch allows swiftc compiled binaries to run correctly on FreeBSD.
% ./swiftc hello.swift -o hello
davide@rabbit1:/exps/swift/build/Ninja-ReleaseAssert/swift-freebsd-x86_64/bin
% ./hello
hello
% cat hello.swift
print ("hello")

Special thanks to Dmitri Gribenko who provided help debugging the issue
