### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeBase::get…

### DIFF
--- a/validation-test/IDE/crashers/003-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/IDE/crashers/003-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+extension{struct E{enum C{let a{#^A^#


### PR DESCRIPTION
…CanonicalType()

Stack trace:

```
found code completion token A at offset 137
4  swift-ide-test  0x0000000000b8adc4 swift::TypeBase::getCanonicalType() + 20
6  swift-ide-test  0x0000000000936237 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
7  swift-ide-test  0x0000000000904e72 swift::typeCheckCompletionDecl(swift::Decl*) + 1122
18 swift-ide-test  0x0000000000ae4594 swift::Decl::walk(swift::ASTWalker&) + 20
19 swift-ide-test  0x0000000000b6db1e swift::SourceFile::walk(swift::ASTWalker&) + 174
20 swift-ide-test  0x0000000000b6ceff swift::ModuleDecl::walk(swift::ASTWalker&) + 79
21 swift-ide-test  0x0000000000b47602 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
22 swift-ide-test  0x0000000000863d8d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
23 swift-ide-test  0x0000000000773d54 swift::CompilerInstance::performSema() + 3316
24 swift-ide-test  0x000000000071c7c3 main + 35027
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x<INPUT-FILE>:2:1
2.  While type-checking 'C' at <INPUT-FILE>:2:20
```
