### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeBase::getMemberSubstitutions(…)

### DIFF
--- a/validation-test/IDE/crashers_fixed/004-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/IDE/crashers_fixed/004-swift-typebase-getmembersubstitutions.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{class d<T where g:e{class B{var b=B p#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 143
swift-ide-test: /path/to/swift/lib/AST/Type.cpp:2492: TypeSubstitutionMap swift::TypeBase::getMemberSubstitutions(swift::DeclContext *): Assertion `baseTy && "Couldn't find appropriate context"' failed.
8  swift-ide-test  0x0000000000b957c0 swift::TypeBase::getMemberSubstitutions(swift::DeclContext*) + 432
9  swift-ide-test  0x0000000000b95abd swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext*) + 61
10 swift-ide-test  0x000000000098363b swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1435
14 swift-ide-test  0x0000000000983f0e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift-ide-test  0x0000000000984e54 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift-ide-test  0x0000000000ae41e5 swift::Expr::walk(swift::ASTWalker&) + 69
20 swift-ide-test  0x00000000008ccec8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
21 swift-ide-test  0x0000000000916120 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
22 swift-ide-test  0x000000000091c6c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
23 swift-ide-test  0x000000000091d7e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
24 swift-ide-test  0x000000000091d989 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
31 swift-ide-test  0x0000000000936237 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
34 swift-ide-test  0x000000000097f68a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
35 swift-ide-test  0x00000000009b77ec swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
36 swift-ide-test  0x000000000091c73b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
38 swift-ide-test  0x000000000097f7d6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
39 swift-ide-test  0x00000000009039cd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1405
40 swift-ide-test  0x0000000000773be2 swift::CompilerInstance::performSema() + 2946
41 swift-ide-test  0x000000000071c7c3 main + 35027
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:2:1 - line:2:39] RangeText="{class d<T where g:e{class B{var b=B p"
2.  While type-checking 'd' at <INPUT-FILE>:2:2
3.  While type-checking expression at [<INPUT-FILE>:2:36 - line:2:36] RangeText="B"
4.  While resolving type B at [<INPUT-FILE>:2:36 - line:2:36] RangeText="B"
```
