### PR TITLE
[stdlib] Define global function replace(_:with:)

### DIFF
--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -375,3 +375,10 @@ public func swap<T>(inout a : T, inout _ b : T) {
   // Initialize P2.
   Builtin.initialize(tmp, p2)
 }
+
+/// Replace the value of `a` with `b` and return the old value.
+public func replace<T>(inout a: T, with b: T) -> T {
+    var value = b
+    swap(&a, &value)
+    return value
+}


### PR DESCRIPTION
This is put into Sort.swift.gyb because that's where `swap(_:_:)` is
defined and there's no obvious better candidate.
