### PR TITLE
[Serialization] Errors when referencing subtype named "Type"

### DIFF
--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -46,6 +46,20 @@ extension S1 {} // no-error
 extension S1.Type {} // expected-error {{cannot extend a metatype 'S1.Type'}}
 extension S1.NestedStruct {} // no-error
 
+struct S1_2 {
+  // expected-error @+4 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+3 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-note @+2 {{backticks can escape this name if it is important to use}} {{8-12=`Type`}}
+  // expected-note @+1 {{backticks can escape this name if it is important to use}} {{8-12=`Type`}}
+  enum Type {}
+}
+struct S1_3 {
+  enum `Type` {} // no-error
+}
+
+extension S1_2.Type {} // expected-error {{cannot extend a metatype 'S1_2.Type'}}
+extension S1_3.`Type` {} // no-error
+
 typealias TA_S1 = S1
 extension TA_S1 {} // no-error
 

--- a/test/decl/nested.swift
+++ b/test/decl/nested.swift
@@ -194,3 +194,22 @@ func outerGenericFunction<T>(t: T) {
     func genericMethod<V where V : Racoon, V.Stripes == T>(t: T, u: U) -> V {}
   }
 }
+
+struct S1 {
+  // expected-error @+4 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-error @+3 {{type member may not be named 'Type', since it would conflict with the 'foo.Type' expression}}
+  // expected-note @+2 {{backticks can escape this name if it is important to use}} {{8-12=`Type`}}
+  // expected-note @+1 {{backticks can escape this name if it is important to use}} {{8-12=`Type`}}
+  enum Type {
+    case A
+  }
+}
+
+struct S2 {
+  enum `Type` {
+    case A
+  }
+}
+
+let s1: S1.Type = .A // expected-error{{type of expression is ambiguous without more context}}
+let s2: S2.`Type` = .A // no-error


### PR DESCRIPTION
### Update:

Thanks to @lattner for fixing this in https://github.com/apple/swift/commit/e9d1857ca357defa4836b97d2a76270528825f0a. I rebased and updated the tests to reflect the new diagnostics.
### Old description

_First Swift PR, so don't hesitate to yell if I did something wrong_

I haven't been able to fix this myself, so this _WIP_ PR only includes a few failing tests.

``` bash
$ swift/utils/build-script -R && llvm/utils/lit/lit.py -sv build/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/decl

.../swift/test/decl/ext/extensions.swift:53:1: error: unexpected error produced: cannot extend a metatype 'S1_2.Type'
extension S1_2.Type {} // no-error

.../swift/test/decl/nested.swift:93:18: error: unexpected error produced: type of expression is ambiguous without more context
let s: S.Type = .A
```

Looks like the first error is generated in `createProtocolGenericParams` in `TypeChecker.cpp`, so I looked at how `ModuleFile::getType` is implemented and I'm not sure why it would detect the type as `METATYPE_TYPE` instead of `PAREN_TYPE` (given that that `case` is first), so I imagine the root of the issue might be somewhere else.

It's possible that this problem exists with other types of declarations, I'll add more tests if I can think of other examples.

I'm kind of stuck so I'd appreciate any pointers! I'm also not entirely sure whether this can be fixed 100%, given that some declarations would always be ambiguous, but I think at least the first example should work, and the second one should emit a better diagnostic. Alternatively maybe `Swift` should just emit an error when defining the `Type` subtype?
