### PR TITLE
[build-script] Add flag to export compile commands

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -295,9 +295,12 @@ details of the setups of other systems or automated environments.""")
         dest="build_foundation")
 
     extra_actions_group = parser.add_argument_group(
-        title="Extra actions to perform before building")
+        title="Extra actions to perform before or in addition to building")
     extra_actions_group.add_argument("-c", "--clean",
         help="do a clean build",
+        action="store_true")
+    extra_actions_group.add_argument("--export-compile-commands",
+        help="generate compilation databases in addition to building",
         action="store_true")
 
     build_variant_group = parser.add_mutually_exclusive_group(required=False)
@@ -558,6 +561,11 @@ the number of parallel build jobs to use""",
         args.test = True
 
     build_script_impl_inferred_args = []
+
+    if args.export_compile_commands:
+        build_script_impl_inferred_args += [
+            "--export-compile-commands"
+        ]
 
     if args.cmake_generator == "XcodeIDEOnly":
         args.cmake_generator = "Xcode"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -182,7 +182,7 @@ KNOWN_SETTINGS=(
     darwin-toolchain-installer-package ""        "The path to installer pkg"
     build-jobs ""                                "The number of parallel build jobs to use"
     darwin-toolchain-alias             "swift"   "Swift alias for toolchain"
-
+    export-compile-commands            ""        "set to generate JSON compilation databases for each build product"
 )
 
 function toupper() {
@@ -1032,6 +1032,13 @@ if [[ "${ENABLE_ASAN}" ]] ; then
     COMMON_CMAKE_OPTIONS=(
         "${COMMON_CMAKE_OPTIONS[@]}"
         -DLLVM_USE_SANITIZER="Address"
+    )
+fi
+
+if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
+    COMMON_CMAKE_OPTIONS=(
+        "${COMMON_CMAKE_OPTIONS[@]}"
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     )
 fi
 


### PR DESCRIPTION
CMake supports generation of compilation databases. These have many uses, not
least of which is in supporting code-completion engines like
https://github.com/Valloric/YouCompleteMe.

Add the `--export-compile-commands` flag to `utils/build-script`.
Setting this flag passes `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to CMake,
which results in a `compile_commands.json` file being generated along
with built products like `cmark`, `llvm`, and `swift`.
