### PR TITLE
[WIP][SR-164] Handle ImplicitlyUnwrappedOptionals specially in IsExpr.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2790,9 +2790,11 @@ namespace {
 
       // Set the type we checked against.
       expr->getCastTypeLoc().setType(toType, /*validated=*/true);
-      auto fromType = sub->getType();
+      auto castFromType = sub->getType();
+      if (auto iuoTy = cs.lookThroughImplicitlyUnwrappedOptionalType(castFromType))
+        castFromType = OptionalType::get(iuoTy);
       auto castKind = tc.typeCheckCheckedCast(
-                        fromType, toType, cs.DC,
+                        castFromType, toType, cs.DC,
                         expr->getLoc(),
                         sub->getSourceRange(),
                         expr->getCastTypeLoc().getSourceRange(),
@@ -2829,6 +2831,7 @@ namespace {
       }
 
       // Dig through the optionals in the from/to types.
+      auto fromType = sub->getType();
       SmallVector<Type, 2> fromOptionals;
       fromType->lookThroughAllAnyOptionalTypes(fromOptionals);
       SmallVector<Type, 2> toOptionals;
@@ -2843,6 +2846,12 @@ namespace {
           castKind == CheckedCastKind::DictionaryDowncastBridged ||
           castKind == CheckedCastKind::SetDowncast ||
           castKind == CheckedCastKind::SetDowncastBridged) {
+        // "is" treats an IUO as an Optional, while "as?"
+        // treats an IUO as the underlying type, so it needs wrapping.
+        if (cs.lookThroughImplicitlyUnwrappedOptionalType(fromType)) {
+          sub = new (tc.Context) InjectIntoOptionalExpr(sub, OptionalType::get(fromType));
+          sub->setImplicit();
+        }
         auto toOptType = OptionalType::get(toType);
         ConditionalCheckedCastExpr *cast
           = new (tc.Context) ConditionalCheckedCastExpr(

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -206,3 +206,9 @@ func forcedDowncastToOptional(b: B) {
 
 _ = b1 as Int    // expected-error {{cannot convert value of type 'Bool' to type 'Int' in coercion}}
 _ = seven as Int // expected-error {{cannot convert value of type 'Double' to type 'Int' in coercion}}
+
+// SR-164
+class A {}
+let iouNoString : A! = A()
+print(iouNoString is CustomStringConvertible)
+


### PR DESCRIPTION
An IUO needs to be treated like an Optional in “is” (e.g.
test/Interpreter/SDK/objc_cast.swift:232), but an IUO is unwrapped and
treated as the underlying type in “as?”. So when converting an IsExpr
to a ConditionalCheckedCastExpr, we need to inject an IUO into a ‘real’
Optional.
