### PR TITLE
Add <.. operator for half open ranges that exclude the minimum value

### DIFF
--- a/stdlib/private/StdlibUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibUnittest/CheckRangeReplaceableSliceType.swift
@@ -68,7 +68,7 @@ extension TestSuite {
       for test in removeFirstTests.filter({ $0.numberToRemove == 1 }) {
         var c = makeWrappedCollection(test.collection.map(OpaqueValue.init))
         let survivingIndices =
-          Array(c.startIndex.successor()..<c.endIndex)
+          Array(c.startIndex<..c.endIndex)
         let removedElement = c.removeFirst()
         expectEqual(test.collection.first, extractValue(removedElement).value)
         expectEqualSequence(

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -153,6 +153,15 @@ public func == <Element>(lhs: Range<Element>, rhs: Range<Element>) -> Bool {
       lhs.endIndex == rhs.endIndex
 }
 
+/// Forms a half-open range that contains `maximum`, but not
+/// `minimum`.
+@_transparent
+@warn_unused_result
+public func <.. <Pos : ForwardIndexType> (minimum: Pos, maximum: Pos)
+-> Range<Pos> {
+    return Range(start: minimum.successor(), end: maximum.successor())
+}
+
 /// Forms a half-open range that contains `minimum`, but not
 /// `maximum`.
 @_transparent
@@ -172,6 +181,19 @@ public func ... <Pos : ForwardIndexType> (
 }
 
 //===--- Prefer Ranges to Intervals, and add checking ---------------------===//
+
+
+/// Forms a half-open range that contains `end`, but not `start`.
+///
+/// - Requires: `start <= end`.
+@_transparent
+@warn_unused_result
+public func <.. <Pos : ForwardIndexType where Pos : Comparable> (
+start: Pos, end: Pos
+) -> Range<Pos> {
+    _precondition(start <= end, "Can't form Range with end < start")
+    return Range(start: start.successor(), end: end.successor())
+}
 
 /// Forms a half-open range that contains `start`, but not `end`.
 ///


### PR DESCRIPTION
The lack of this operator has hit me more than once. Basically just do the opposite of `..<` + I found an example usage in the existing tests.
