### PR TITLE
[Driver] Denote ABI type in driver invocation

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1115,10 +1115,11 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   // Add the linker script that coalesces protocol conformance sections.
   Arguments.push_back("-Xlinker");
   Arguments.push_back("-T");
-    
-  // FIXME: This should also query the abi type (i.e. gnueabihf)
+
   Arguments.push_back(context.Args.MakeArgString(
-    Twine(RuntimeLibPath) + "/" + getTriple().getArchName() + "/swift.ld"));
+    Twine(RuntimeLibPath) + "/" + getTriple().getArchName() + "-" + \
+    llvm::Triple::getEnvironmentTypeName(getTriple().getEnvironment()) + \
+    "/swift.ld"));
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -100,7 +100,7 @@
 // LINUX-x86_64-DAG: -lswiftCore
 // LINUX-x86_64-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift]]
 // LINUX-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-x86_64-DAG: -Xlinker -T /{{[^ ]+}}/linux/x86_64/swift.ld
+// LINUX-x86_64-DAG: -Xlinker -T /{{[^ ]+}}/linux/x86_64-gnu/swift.ld
 // LINUX-x86_64-DAG: -F foo
 // LINUX-x86_64-DAG: -framework bar
 // LINUX-x86_64-DAG: -L baz


### PR DESCRIPTION
Addresses a FIXME to specify ABI type in the driver invocation.

---

See https://github.com/apple/swift/pull/439 for additional context.
