### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::getTypeOfExpressionWithoutApplying(…)

### DIFF
--- a/validation-test/IDE/crashers/005-swift-typechecker-gettypeofexpressionwithoutapplying.swift
+++ b/validation-test/IDE/crashers/005-swift-typechecker-gettypeofexpressionwithoutapplying.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+t=0.#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 109
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckConstraints.cpp:1247: Optional<swift::Type> swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr *&, swift::DeclContext *, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener *): Assertion `exprType && !exprType->is<ErrorType>() && "erroneous solution?"' failed.
8  swift-ide-test  0x000000000091ca15 swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) + 517
10 swift-ide-test  0x000000000090557e swift::getTypeOfCompletionContextExpr(swift::ASTContext&, swift::DeclContext*, swift::Expr*&) + 1150
12 swift-ide-test  0x0000000000863bd6 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
13 swift-ide-test  0x0000000000773cd4 swift::CompilerInstance::performSema() + 3316
14 swift-ide-test  0x000000000071c633 main + 35027
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:2:3 - line:2:3] RangeText="0"
```
