### PR TITLE
[SourceKit] Add test case for crash triggered in swift::DeclContext::getProtocolSelf()

### DIFF
--- a/validation-test/IDE/crashers/006-swift-declcontext-getprotocolself.swift
+++ b/validation-test/IDE/crashers/006-swift-declcontext-getprotocolself.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+extension{protocol a{func p)struct A{protocol c
+let a{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 159
4  swift-ide-test  0x0000000000b462ee swift::DeclContext::getProtocolSelf() const + 30
6  swift-ide-test  0x00000000009305a0 swift::configureImplicitSelf(swift::TypeChecker&, swift::AbstractFunctionDecl*, swift::GenericParamList*&) + 176
9  swift-ide-test  0x0000000000930acd swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 797
14 swift-ide-test  0x0000000000b59c4d swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1117
24 swift-ide-test  0x0000000000ae4334 swift::Decl::walk(swift::ASTWalker&) + 20
25 swift-ide-test  0x0000000000b6d88e swift::SourceFile::walk(swift::ASTWalker&) + 174
26 swift-ide-test  0x0000000000b6cc6f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
27 swift-ide-test  0x0000000000b473a2 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
28 swift-ide-test  0x0000000000863b2d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
29 swift-ide-test  0x0000000000773cd4 swift::CompilerInstance::performSema() + 3316
30 swift-ide-test  0x000000000071c633 main + 35027
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x4253e40 at <INPUT-FILE>:2:1
2.  While type-checking 'p' at <INPUT-FILE>:2:22
```
