### PR TITLE
Add link to swift.org in README.md title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
-# Swift Programming Language
+# [Swift Programming Language](https://swift.org/)
 
 **Welcome to Swift!**
 


### PR DESCRIPTION
Fills out the title of the readme and provides a link to swift.org for users viewing the repository somewhere other than on GitHub
