### PR TITLE
Fix NameError bug: specialization_passlist is not defined.

### DIFF
--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -103,7 +103,7 @@ def normal_passpipelines():
     result = []
 
     x = ppipe.PassPipeline('PreSpecialize', {'name': 'run_to_fixed_point'})
-    x.addPass(specialization_passlist())
+    x.addPass(diagnostic_passlist())
     result.append(x)
 
     x = ppipe.PassPipeline('HighLevel', {'name': 'run_n_times', 'count': 2})


### PR DESCRIPTION
Please check this one.
- A. `specialization_passlist` is not defined so that is an error.
- B. From reading the code it appears as if `diagnostic_passlist` (not referenced before this fix) is what was meant to be referenced.

I'm not certain about B so please double check :-)
