### PR TITLE
[SourceKit] Add test case for crash triggered in swift::configureImplicitSelf(…)

### DIFF
--- a/validation-test/IDE/crashers/007-swift-configureimplicitself.swift
+++ b/validation-test/IDE/crashers/007-swift-configureimplicitself.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+extension{enum c{func a:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 129
swift-ide-test: /path/to/swift/lib/AST/Decl.cpp:3439: swift::Type getSelfTypeForContainer(swift::AbstractFunctionDecl *, bool, bool, swift::GenericParamList **): Assertion `containerTy && "stand alone functions don't have 'self'"' failed.
9  swift-ide-test  0x0000000000931a10 swift::configureImplicitSelf(swift::TypeChecker&, swift::AbstractFunctionDecl*, swift::GenericParamList*&) + 176
12 swift-ide-test  0x0000000000937447 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
13 swift-ide-test  0x0000000000906072 swift::typeCheckCompletionDecl(swift::Decl*) + 1122
15 swift-ide-test  0x00000000008647a6 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
16 swift-ide-test  0x00000000007742a4 swift::CompilerInstance::performSema() + 3316
17 swift-ide-test  0x000000000071cbd3 main + 35027
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'a' at <INPUT-FILE>:2:18
```
