### PR TITLE
Fix exit bugs of multiple python scripts

### DIFF
--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -8,7 +8,7 @@ ns-html2rst - Convert Cocoa HTML documentation into ReST
 
 usage: nshtml2rst < NSString.html > NSString.rst
         """
-        exit(0)
+        sys.exit(0)
 
     html = sys.stdin.read()
 

--- a/test/Driver/Dependencies/Inputs/fail.py
+++ b/test/Driver/Dependencies/Inputs/fail.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
 
-exit(1)
+import sys
+sys.exit(1)

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -12,7 +12,7 @@ primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
 
 if os.path.basename(primaryFile) == 'bad.swift':
     print "Handled", os.path.basename(primaryFile)
-    exit(1)
+    sys.exit(1)
 
 dir = os.path.dirname(os.path.abspath(__file__))
 execfile(os.path.join(dir, "update-dependencies.py"))

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -350,7 +350,7 @@ def main():
             if not oldBuildDir:
                 sys.exit("$SWIFT_OLD_BUILDDIR not specified")
             if not newBuildDir:
-                die("$SWIFT_NEW_BUILDDIR not specified")
+                sys.exit("$SWIFT_NEW_BUILDDIR not specified")
             oldFileArgs = [ "O", "Ounchecked", "Onone", "dylib" ]
         oldFiles = []
         newFiles = []

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1046,7 +1046,8 @@ def main():
     if args.test or args.verbose_test:
         import doctest
         if doctest.testmod(verbose=args.verbose_test).failed:
-            exit(1)
+            import sys
+            sys.exit(1)
         
     bindings = dict( x.split('=', 1) for x in args.defines )
     ast = parseTemplate(args.file.name, args.file.read())

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -31,7 +31,7 @@ def capture_with_result(args, include_stderr=False):
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=stderr)
     except OSError,e:
         if e.errno == errno.ENOENT:
-            fatal('no such file or directory: %r when running %s.' % (
+            sys.exit('no such file or directory: %r when running %s.' % (
                   args[0], ' '.join(args)))
         raise
     out,_ = p.communicate()


### PR DESCRIPTION
Make sure that the system uses `sys.exit(1)` rather than just `exit(1)` because `exit(1)` should not be used in production.

`exit()` should not be used in production code. This is because it only works if the `site` module is loaded. Instead, this function should only be used in the interpreter.

Unlike `exit()` or `quit()` however, `sys.exit` is considered good to use in production code. This is because the `sys` module will always be there. 
