### PR TITLE
[cmpcodesize][1] Clean up cmpcodesize argument parsing

### DIFF
--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import re
 import sys
 import os
@@ -8,57 +9,6 @@ import glob
 import subprocess
 import collections
 from operator import itemgetter
-
-def help():
-  print """\
-cmpcodesize [options] <old-files> [--] <new-files>
-
-Compares code sizes of "new" files, taking "old" files as a reference.
-
-Options:
-    -a           Show sizes of additional sections
-    -c           Show functions by category
-    -l           List all functions (can be a very long list)
-    -s           Summarize the sizes of multiple files instead of listing each file separately
-
-Environment variables:
-    SWIFT_NEW_BUILDDIR   The old build-dir
-E.g. $HOME/swift-work/build/Ninja-ReleaseAssert+stdlib-Release/swift-macosx-x86_64
-    SWIFT_OLD_BUILDDIR   The new build-dir
-E.g. $HOME/swift-reference/build/Ninja-ReleaseAssert+stdlib-Release/swift-macosx-x86_64
-
-How to specify files:
-1) No files:
-    Compares codesize of the PerfTests_* executables and the swiftCore dylib in the new and old build-dirs.
-    Example:
-        cmpcodesize
-
-2) One or more paths relative to the build-dirs (can be a pattern):
-    Compares the files in the new and old build-dirs.
-    Aliases:
-        O          => bin/PerfTests_O
-        Ounchecked => bin/PerfTests_Ounchecked
-        Onone      => bin/PerfTests_Onone
-        dylib      => lib/swift/macosx/x86_64/libswiftCore.dylib
-    Examples:
-        cmpcodesize Onone
-        cmpcodesize benchmark/PerfTestSuite/O/*.o
-
-3) Two files:
-    Compares these two files (the first is the old file).
-    Example:
-        cmpcodesize test.o newversion.o
-
-4) Two lists of files, separated by '--':
-    Compares a set a files.
-    Example:
-        cmpcodesize olddir/*.o -- newdir/*.o
-
-5) One file (only available with the -l option):
-    Lists function sizes for that file
-    Example:
-        cmpcodesize -l test.o
-"""
 
 Prefixes = {
     # Cpp
@@ -308,34 +258,99 @@ def compareFunctionSizes(oldFiles, newFiles):
         print "Total size change of functions present in both files: {}".format(sizeIncrease - sizeDecrease)
 
 def main():
-    allSections = False
-    listCategories = False
-    listFunctions = False
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+Compares code sizes of "new" files, taking "old" files as a reference.
+
+Environment variables:
+    SWIFT_NEW_BUILDDIR   The old build-dir
+E.g. $HOME/swift-work/build/Ninja-ReleaseAssert+stdlib-Release/swift-macosx-x86_64
+    SWIFT_OLD_BUILDDIR   The new build-dir
+E.g. $HOME/swift-reference/build/Ninja-ReleaseAssert+stdlib-Release/swift-macosx-x86_64
+
+How to specify files:
+1) No files:
+    Compares codesize of the PerfTests_* executables and the swiftCore dylib in the new and old build-dirs.
+    Example:
+        cmpcodesize
+
+2) One or more paths relative to the build-dirs (can be a pattern):
+    Compares the files in the new and old build-dirs.
+    Aliases:
+        O          => bin/PerfTests_O
+        Ounchecked => bin/PerfTests_Ounchecked
+        Onone      => bin/PerfTests_Onone
+        dylib      => lib/swift/macosx/x86_64/libswiftCore.dylib
+    Examples:
+        cmpcodesize Onone
+        cmpcodesize benchmark/PerfTestSuite/O/*.o
+
+3) Two files:
+    Compares these two files (the first is the old file).
+    Example:
+        cmpcodesize test.o newversion.o
+
+4) Two lists of files, separated by '--':
+    Compares a set a files.
+    Example:
+        cmpcodesize olddir/*.o -- newdir/*.o
+
+5) One file (only available with the -l option):
+    Lists function sizes for that file
+    Example:
+        cmpcodesize -l test.o""")
+
+    # Optional arguments.
+    parser.add_argument('-a', '--additional-sections',
+                        help='Show sizes of additional sections.',
+                        action='store_true',
+                        dest='all_sections',
+                        default=False)
+    parser.add_argument('-c', '--category',
+                        help='Show functions by category.',
+                        action='store_true',
+                        dest='list_categories',
+                        default=False)
+    parser.add_argument('-l', '--list',
+                        help='List all functions (can be a very long list).',
+                        action='store_true',
+                        dest='list_functions',
+                        default=False)
+    parser.add_argument('-s', '--summarize',
+                        help='Summarize the sizes of multiple files instead ' +
+                             'of listing each file separately.',
+                        action='store_true',
+                        dest='sum_sizes',
+                        default=False)
+
+    # Positional arguments.
+    # These can be specififed in means beyond what argparse supports,
+    # so we gather them in a list and parse them manually.
+    parser.add_argument('files', nargs='*',
+                        help='A list of old and new files.')
+
+    # argparse can't handle an '--' argument, so we replace it with
+    # a custom identifier.
+    separator_token = '*-*-*'
+    parsed_arguments = parser.parse_args(
+        [separator_token if arg == '--' else arg for arg in sys.argv[1:]])
+
+    allSections = parsed_arguments.all_sections
+    listCategories = parsed_arguments.list_categories
+    listFunctions = parsed_arguments.list_functions
+    sumSizes = parsed_arguments.sum_sizes
+
     separatorFound = False
-    sumSizes = False
     oldFileArgs = []
     newFileArgs = []
     curFiles = oldFileArgs
-    for arg in sys.argv[1:]:
-        if arg == "-a":
-            allSections = True
-        elif arg == "-c":
-            listCategories = True
-        elif arg == "-s":
-            sumSizes = True
-        elif arg == "-l":
-            listFunctions = True
-        elif arg == "--":
+    for arg in parsed_arguments.files:
+        if arg == separator_token:
             curFiles = newFileArgs
             separatorFound = True
-        elif arg == "-h":
-            help()
-            return
-        elif arg.startswith("-"):
-            sys.exit("Unknown option. Use -h to display usage.")
         else:
             curFiles.append(arg)
-    
 
     oldBuildDir = os.environ.get("SWIFT_OLD_BUILDDIR")
     newBuildDir = os.environ.get("SWIFT_NEW_BUILDDIR")

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -315,7 +315,9 @@ How to specify files:
     parser.add_argument('-l', '--list',
                         help='List all functions (can be a very long list). ' +
                              'Cannot be used in conjunction with ' +
-                             '--additional-sections or --category.',
+                             '--additional-sections or --category. ' +
+                             'You must specify between one and two files ' +
+                             'when using this option.',
                         action='store_true',
                         dest='list_functions',
                         default=False)
@@ -338,15 +340,19 @@ How to specify files:
     parsed_arguments = parser.parse_args(
         [separator_token if arg == '--' else arg for arg in sys.argv[1:]])
 
-    # --list is mutually exclusive with both --additional-sections
-    # and --category. argparse is only capable of expressing mutual
-    # exclusivity among options, not among groups of options, so
-    # we detect this case manually.
     if parsed_arguments.list_functions:
+        # --list is mutually exclusive with both --additional-sections
+        # and --category. argparse is only capable of expressing mutual
+        # exclusivity among options, not among groups of options, so
+        # we detect this case manually.
         assert (not parsed_arguments.all_sections and
                 not parsed_arguments.list_categories), \
             'Incorrect usage: --list cannot be specified in conjunction ' + \
             'with --additional-sections or --category.'
+        # A file must be specified when using --list.
+        assert parsed_arguments.files, \
+            'Incorrect usage: Must specify between one and two files when ' + \
+            'using --list, but you specified no files.'
 
     oldBuildDir = os.environ.get("SWIFT_OLD_BUILDDIR")
     newBuildDir = os.environ.get("SWIFT_NEW_BUILDDIR")
@@ -358,8 +364,6 @@ How to specify files:
     else:
         oldFileArgs = parsed_arguments.files
         if not parsed_arguments.files:
-            if parsed_arguments.list_functions:
-                sys.exit("Must specify file for the -l option")
             if not oldBuildDir:
                 sys.exit("$SWIFT_OLD_BUILDDIR not specified")
             if not newBuildDir:

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -410,5 +410,5 @@ def main():
                 newFile = newFiles[idx]
                 compareSizesOfFile([oldFile], [newFile], allSections, listCategories)
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -341,25 +341,16 @@ How to specify files:
     listFunctions = parsed_arguments.list_functions
     sumSizes = parsed_arguments.sum_sizes
 
-    separatorFound = False
-    oldFileArgs = []
-    newFileArgs = []
-    curFiles = oldFileArgs
-    for arg in parsed_arguments.files:
-        if arg == separator_token:
-            curFiles = newFileArgs
-            separatorFound = True
-        else:
-            curFiles.append(arg)
-
     oldBuildDir = os.environ.get("SWIFT_OLD_BUILDDIR")
     newBuildDir = os.environ.get("SWIFT_NEW_BUILDDIR")
 
-    if separatorFound:
-        oldFiles = oldFileArgs
-        newFiles = newFileArgs
+    if separator_token in parsed_arguments.files:
+        separator_index = parsed_arguments.files.index(separator_token)
+        oldFiles = parsed_arguments.files[:separator_index]
+        newFiles = parsed_arguments.files[separator_index + 1:]
     else:
-        if not oldFileArgs:
+        oldFileArgs = parsed_arguments.files
+        if not parsed_arguments.files:
             if listFunctions:
                 sys.exit("Must specify file for the -l option")
             if not oldBuildDir:

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -388,8 +388,8 @@ How to specify files:
                 file = SHORTCUTS[file]
 
             if not file.startswith("./") and oldBuildDir and newBuildDir:
-                oldExpanded = glob.glob(oldBuildDir + "/" + file)
-                newExpanded = glob.glob(newBuildDir + "/" + file)
+                oldExpanded = glob.glob(os.path.join(oldBuildDir, file))
+                newExpanded = glob.glob(os.path.join(newBuildDir, file))
                 if oldExpanded and newExpanded:
                     oldFiles.extend(oldExpanded)
                     newFiles.extend(newExpanded)

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -354,20 +354,23 @@ How to specify files:
             'Incorrect usage: Must specify between one and two files when ' + \
             'using --list, but you specified no files.'
 
-    oldBuildDir = os.environ.get("SWIFT_OLD_BUILDDIR")
-    newBuildDir = os.environ.get("SWIFT_NEW_BUILDDIR")
-
     if separator_token in parsed_arguments.files:
         separator_index = parsed_arguments.files.index(separator_token)
         oldFiles = parsed_arguments.files[:separator_index]
         newFiles = parsed_arguments.files[separator_index + 1:]
     else:
         oldFileArgs = parsed_arguments.files
+
+        oldBuildDir = os.environ.get("SWIFT_OLD_BUILDDIR")
+        newBuildDir = os.environ.get("SWIFT_NEW_BUILDDIR")
+
         if not parsed_arguments.files:
-            if not oldBuildDir:
-                sys.exit("$SWIFT_OLD_BUILDDIR not specified")
-            if not newBuildDir:
-                sys.exit("$SWIFT_NEW_BUILDDIR not specified")
+            assert oldBuildDir and newBuildDir, \
+                'Incorrect usage: You must specify either a list of ' + \
+                'files, or have both $SWIFT_OLD_BUILDDIR and ' + \
+                '$SWIFT_NEW_BUILDDIR environment variables set.\n' + \
+                '$SWIFT_OLD_BUILDDIR = {0}\n$SWIFT_NEW_BUILDDIR = {1}'.format(
+                    oldBuildDir, newBuildDir)
             oldFileArgs = [ "O", "Ounchecked", "Onone", "dylib" ]
         oldFiles = []
         newFiles = []

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -338,17 +338,13 @@ How to specify files:
     parsed_arguments = parser.parse_args(
         [separator_token if arg == '--' else arg for arg in sys.argv[1:]])
 
-    allSections = parsed_arguments.all_sections
-    listCategories = parsed_arguments.list_categories
-    listFunctions = parsed_arguments.list_functions
-    sumSizes = parsed_arguments.sum_sizes
-
     # --list is mutually exclusive with both --additional-sections
     # and --category. argparse is only capable of expressing mutual
     # exclusivity among options, not among groups of options, so
     # we detect this case manually.
-    if listFunctions:
-        assert not allSections and not listCategories, \
+    if parsed_arguments.list_functions:
+        assert (not parsed_arguments.all_sections and
+                not parsed_arguments.list_categories), \
             'Incorrect usage: --list cannot be specified in conjunction ' + \
             'with --additional-sections or --category.'
 
@@ -362,7 +358,7 @@ How to specify files:
     else:
         oldFileArgs = parsed_arguments.files
         if not parsed_arguments.files:
-            if listFunctions:
+            if parsed_arguments.list_functions:
                 sys.exit("Must specify file for the -l option")
             if not oldBuildDir:
                 sys.exit("$SWIFT_OLD_BUILDDIR not specified")
@@ -402,7 +398,7 @@ How to specify files:
         if not os.path.isfile(file):
             sys.exit("file " + file + " not found")
 
-    if listFunctions:
+    if parsed_arguments.list_functions:
         if not newFiles:
             sizes = collections.defaultdict(int)
             for file in oldFiles:
@@ -412,8 +408,10 @@ How to specify files:
             compareFunctionSizes(oldFiles, newFiles)
     else:
         print "%-26s%16s  %8s  %8s  %s" % ("", "Section", "Old", "New", "Percent")
-        if sumSizes:
-            compareSizesOfFile(oldFiles, newFiles, allSections, listCategories)
+        if parsed_arguments.sum_sizes:
+            compareSizesOfFile(oldFiles, newFiles,
+                               parsed_arguments.all_sections,
+                               parsed_arguments.list_categories)
         else:
             if len(oldFiles) != len(newFiles):
                 sys.exit("number of new files must be the same of old files")
@@ -423,7 +421,9 @@ How to specify files:
 
             for idx, oldFile in enumerate(oldFiles):
                 newFile = newFiles[idx]
-                compareSizesOfFile([oldFile], [newFile], allSections, listCategories)
+                compareSizesOfFile([oldFile], [newFile],
+                                   parsed_arguments.all_sections,
+                                   parsed_arguments.list_categories)
 
 if __name__ == '__main__':
     main()

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -313,7 +313,9 @@ How to specify files:
                         dest='list_categories',
                         default=False)
     parser.add_argument('-l', '--list',
-                        help='List all functions (can be a very long list).',
+                        help='List all functions (can be a very long list). ' +
+                             'Cannot be used in conjunction with ' +
+                             '--additional-sections or --category.',
                         action='store_true',
                         dest='list_functions',
                         default=False)
@@ -340,6 +342,15 @@ How to specify files:
     listCategories = parsed_arguments.list_categories
     listFunctions = parsed_arguments.list_functions
     sumSizes = parsed_arguments.sum_sizes
+
+    # --list is mutually exclusive with both --additional-sections
+    # and --category. argparse is only capable of expressing mutual
+    # exclusivity among options, not among groups of options, so
+    # we detect this case manually.
+    if listFunctions:
+        assert not allSections and not listCategories, \
+            'Incorrect usage: --list cannot be specified in conjunction ' + \
+            'with --additional-sections or --category.'
 
     oldBuildDir = os.environ.get("SWIFT_OLD_BUILDDIR")
     newBuildDir = os.environ.get("SWIFT_NEW_BUILDDIR")
@@ -392,8 +403,6 @@ How to specify files:
             sys.exit("file " + file + " not found")
 
     if listFunctions:
-        if allSections or listCategories:
-            print >> sys.stderr, "Warning: options -a and -c ignored when using -l"
         if not newFiles:
             sizes = collections.defaultdict(int)
             for file in oldFiles:

--- a/utils/cmpcodesize
+++ b/utils/cmpcodesize
@@ -39,6 +39,13 @@ Infixes = {
   "q_" : "Generic Function"
 }
 
+SHORTCUTS = {
+    "O": "bin/PerfTests_O",
+    "Ounchecked": "bin/PerfTests_Ounchecked",
+    "Onone": "bin/PerfTests_Onone",
+    "dylib": "lib/swift/macosx/x86_64/libswiftCore.dylib",
+}
+
 GenericFunctionPrefix = "__TTSg"
 
 SortedPrefixes = sorted(Prefixes)
@@ -371,19 +378,14 @@ How to specify files:
                 '$SWIFT_NEW_BUILDDIR environment variables set.\n' + \
                 '$SWIFT_OLD_BUILDDIR = {0}\n$SWIFT_NEW_BUILDDIR = {1}'.format(
                     oldBuildDir, newBuildDir)
-            oldFileArgs = [ "O", "Ounchecked", "Onone", "dylib" ]
+            oldFileArgs = SHORTCUTS.keys()
+
         oldFiles = []
         newFiles = []
         numExpanded = 0
         for file in oldFileArgs:
-            shortcuts = {
-                "O"          : "bin/PerfTests_O",
-                "Ounchecked" : "bin/PerfTests_Ounchecked",
-                "Onone"      : "bin/PerfTests_Onone",
-                "dylib"      : "lib/swift/macosx/x86_64/libswiftCore.dylib"
-            }
-            if file in shortcuts:
-                file = shortcuts[file]
+            if file in SHORTCUTS:
+                file = SHORTCUTS[file]
 
             if not file.startswith("./") and oldBuildDir and newBuildDir:
                 oldExpanded = glob.glob(oldBuildDir + "/" + file)


### PR DESCRIPTION
According to [this tweet](https://twitter.com/nadavrot/status/676572678606618624) by @nadavrot, `cmpcodesize` could use some refactoring. This pull request is the first of a series of changes, focused on simplifying the argument parsing.
## What's in this pull request?
- fbf720e4520bde0f3a33ad5b0e6edcac729e1b6a adds an idiomatic Python check that ensures the file is not run in the case that it is imported by another Python file.
- f1f94d3c67d8b0c37e4eccca3a52ce344aa780ec uses the Python stdlib `argparse` to parse arguments, simplifying logic in `cmpcodesize` itself.
- The remaining commits attempt to clarify the intent of the script. In general, they aim to reduce the number of mutating variables, reduce the scope in which those variables are used, and exit the script earlier and with better error messages when possible.
## Why merge this pull request?

If not for the (arguably) clearer code, this pull request contains much more descriptive error messages for end users. It's also the basis of ongoing work in #553.
## What downsides are there to merging this pull request?
- This pull request introduces a lot of churn into `cmpcodesize`.
- Although I've tested the script locally, it's possible new bugs may have been introduced.
- This pull request doesn't add any unit tests to `cmpcodesize`, and there are no existing regression tests.
