### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::typeCheckFunctionBodyUntil(…)

### DIFF
--- a/validation-test/IDE/crashers/008-swift-typechecker-typecheckfunctionbodyuntil.swift
+++ b/validation-test/IDE/crashers/008-swift-typechecker-typecheckfunctionbodyuntil.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+func a(={#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 114
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckStmt.cpp:1235: bool swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl *, swift::SourceLoc): Assertion `BS && "Should have a body"' failed.
8  swift-ide-test  0x000000000097f61d swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 541
9  swift-ide-test  0x000000000097f3be swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
10 swift-ide-test  0x0000000000907878 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
12 swift-ide-test  0x00000000008646e6 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
13 swift-ide-test  0x00000000007741e4 swift::CompilerInstance::performSema() + 3316
14 swift-ide-test  0x000000000071cb33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
