### PR TITLE
[SR-226] Deprecation of C-style for loops

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2014,6 +2014,12 @@ NOTE(change_to_mutating,sema_tcs,none,
      "mark %select{method|accessor}0 'mutating' to make 'self' mutable",
      (bool))
 
+// For Stmt
+WARNING(deprecated_c_style_for_stmt,sema_tcs,none,
+"C-style for statement is deprecated and will be removed in a future version of Swift", ())
+NOTE(cant_fix_c_style_for_stmt,sema_tcs,none,
+"C-style for statement can't be automatically fixed to for-in, because the loop variable is modified inside the loop", ())
+
 // ForEach Stmt
 ERROR(sequence_protocol_broken,sema_tcs,none,
       "SequenceType protocol definition is broken", ())

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -800,6 +800,9 @@ public:
   
   SourceLoc getStartLoc() const { return getLabelLocOrKeywordLoc(ForLoc); }
   SourceLoc getEndLoc() const { return Body->getEndLoc(); }
+
+  SourceLoc getFirstSemicolonLoc() const { return Semi1Loc; }
+  SourceLoc getSecondSemicolonLoc() const { return Semi2Loc; }
   
   NullablePtr<Expr> getInitializer() const { return Initializer; }
   void setInitializer(Expr *V) { Initializer = V; }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -162,16 +162,16 @@ func missingControllingExprInFor() {
   }
 
   // Ensure that we don't do recovery in the following cases.
-  for ; ; {
+  for ; ; { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   }
 
-  for { true }(); ; {
+  for { true }(); ; { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   }
 
-  for ; { true }() ; {
+  for ; { true }() ; { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   }
 
-  for acceptsClosure { 42 }; ; {
+  for acceptsClosure { 42 }; ; { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   }
 
   // A trailing closure is not accepted for the condition.

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -161,15 +161,15 @@ func for_loops1(x: Int, c: Bool) {
     markUsed(i)
   }
   
-  for ; x < 40;  {
+  for ; x < 40;  { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
    markUsed(x)
    x += 1
   }
   
-  for var i = 0; i < 100; ++i {
+  for var i = 0; i < 100; ++i { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   }
   
-  for let i = 0; i < 100; i {
+  for let i = 0; i < 100; i { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   }
 }
 

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -16,7 +16,7 @@ func testUnreachableAfterIfReturn(a: Bool) -> Int {
 }
 
 func testUnreachableForAfterContinue(b: Bool) {
-  for (var i:Int = 0; i<10; i++) { 
+  for (var i:Int = 0; i<10; i++) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
     var y: Int = 300;
     y++;
     if b {
@@ -45,7 +45,7 @@ func testUnreachableWhileAfterContinue(b: Bool) {
 func testBreakAndContinue() {
   var i = 0;
   var m = 0;
-  for (i = 0; i < 10; ++i) {
+  for (i = 0; i < 10; ++i) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
     m += 1
     if m == 15 {
       break

--- a/test/Sema/diag_c_style_for.swift
+++ b/test/Sema/diag_c_style_for.swift
@@ -1,0 +1,45 @@
+// RUN: %target-parse-verify-swift
+
+for var a = 0; a < 10; a++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-13= in }} {{14-20= ..< }} {{22-27=}}
+}
+
+for var b = 0; b < 10; ++b { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-13= in }} {{14-20= ..< }} {{22-27=}}
+}
+
+for var c=1;c != 5 ;++c { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-11= in }} {{12-18= ..< }} {{20-24=}}
+}
+
+for var d=100;d<5;d++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-11= in }} {{14-17= ..< }} {{18-22=}}
+}
+
+// next three aren't auto-fixable
+for var e = 3; e > 4; e++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+}
+
+for var f = 3; f < 4; f-- { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+}
+
+let start = Int8(4)
+let count = Int8(10)
+var other = Int8(2)
+
+for ; other<count; other++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+}
+
+// this should be fixable, and keep the type
+for (var number : Int8 = start; number < count; number++) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{23-26= in }} {{31-42= ..< }} {{47-57=}}
+  print(number)
+}
+
+// should produce extra note
+for (var m : Int8 = start; m < count; ++m) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} expected-note {{C-style for statement can't be automatically fixed to for-in, because the loop variable is modified inside the loop}}
+  m += 3
+}
+
+// could theoretically fix this (and more like it if we auto-suggested "stride:")
+for var o = 2; o < 888; o += 1 { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+}
+
+// could theoretically fix this with "..."
+for var p = 2; p <= 8; p++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -120,23 +120,23 @@ SomeGeneric<Int>
 
 func for_loop() {
   var x = 0
-  for ;; { }
-  for x = 1; x != 42; ++x { }
-  for infloopbooltest(); x != 12; infloopbooltest() {}
+  for ;; { } // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for x = 1; x != 42; ++x { } // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for infloopbooltest(); x != 12; infloopbooltest() {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   
   for ; { } // expected-error {{expected ';' in 'for' statement}}
   
-  for var y = 1; y != 42; ++y {}
-  for (var y = 1; y != 42; ++y) {}
+  for var y = 1; y != 42; ++y {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for (var y = 1; y != 42; ++y) {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   var z = 10
-  for (; z != 0; --z) {}
-  for (z = 10; z != 0; --z) {}
-  for var (a,b) = (0,12); a != b; --b {++a}
-  for (var (a,b) = (0,12); a != b; --b) {++a}
+  for (; z != 0; --z) {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for (z = 10; z != 0; --z) {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for var (a,b) = (0,12); a != b; --b {++a} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for (var (a,b) = (0,12); a != b; --b) {++a} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   var j, k : Int
-  for ((j,k) = (0,10); j != k; --k) {}
-  for var i = 0, j = 0; i * j < 10; i++, j++ {}
-  for j = 0, k = 52; j < k; ++j, --k { }
+  for ((j,k) = (0,10); j != k; --k) {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for var i = 0, j = 0; i * j < 10; i++, j++ {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+  for j = 0, k = 52; j < k; ++j, --k { } // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
   // rdar://19540536
   // expected-error@+4{{expected var declaration in a 'for' statement}}
   // expected-error@+3{{expression resolves to an unused function}}
@@ -145,7 +145,7 @@ func for_loop() {
   for @ {}
 
   // <rdar://problem/17462274> Is increment in for loop optional?
-  for (let i = 0; i < 10; ) {}
+  for (let i = 0; i < 10; ) {} // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
 }
 
 break // expected-error {{'break' is only allowed inside a loop, if, do, or switch}}
@@ -426,13 +426,13 @@ func testThrowNil() throws {
 // <rdar://problem/16650625>
 func for_ignored_lvalue_init() {
   var i = 0
-  for i;  // expected-error {{expression resolves to an unused l-value}}
+  for i;  // expected-error {{expression resolves to an unused l-value}} expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
     i < 10; ++i {}
 }
 
 // rdar://problem/18643692
 func for_loop_multi_iter() {
-  for (var i = 0, x = 0; i < 10; i++,
+  for (var i = 0, x = 0; i < 10; i++, // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
        x) { // expected-error {{expression resolves to an unused l-value}}
     x -= 1
   }


### PR DESCRIPTION
Warns of deprecation, checks all the appropriate bits to see if we can do an automatic fix, and generates fix-its if that is valid.

Also adds a note if the loop looks like it ought to be a simple for-each, but really isn’t because the loop var is modified inside the loop.

I do have one outstanding FIXIT that the first replace range can be wrong. And, of course, there are lots of tests and stdlib places to fix to get rid of the warnings this’ll produce.

I chose to do the diagnostics here after type checking instead of early in the parser because while most of this would be more easily done in the parser, the check for modifying the loop var in the body would be Very Difficult. Would love feedback. Especially if there is a cleaner way to do all the AST tree pattern matching required here (all the if dyn_casts).
