### PR TITLE
[SourceKit] Add test case for crash triggered in swift::performDelayedParsing(…)

### DIFF
--- a/validation-test/IDE/crashers/009-swift-performdelayedparsing.swift
+++ b/validation-test/IDE/crashers/009-swift-performdelayedparsing.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+enum b:a{var f={static#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 127
swift-ide-test: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::ExtensionDecl, Y = const swift::DeclContext]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
12 swift-ide-test  0x0000000000865a46 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
13 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
14 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
