### PR TITLE
Add 16694-swift-constraints-constraintsystem-opentype.swift as a regression (possible memory corruption)

### DIFF
--- a/validation-test/compiler_crashers/16694-swift-constraints-constraintsystem-opentype.swift
+++ b/validation-test/compiler_crashers/16694-swift-constraints-constraintsystem-opentype.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+var a{class d{var b=B{}let c=(x:d<T{{}}class B<T where h=d>:a


### PR DESCRIPTION
History:
- Marked as fixed in the `swift-compiler-crashes` project in February 2015 - does not crash Xcode 6.3 beta with Swift 1.2 (6D520o).
- Re-opened as regression in December 2015 - crashes Swift version 2.2-dev (LLVM 7bae82deaa, Clang 53d04af5ce, Swift 56a62b7eef).

Possible memory corruption:

```
dmesg:
swift[10043]: segfault at 8 ip 000000000100e5f0 sp 00007ffca9045200 error 4 in swift[400000+3d82000]

valgrind:
==18826== Process terminating with default action of signal 11 (SIGSEGV)
==18826==  Access not within mapped region at address 0x8
==18826==    at 0x100E5F0: swift::TypeBase::getDesugaredType() (in /path/to/swift/bin/swift)
```
