### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::addRequirement(…)

### DIFF
--- a/validation-test/IDE/crashers/010-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/IDE/crashers/010-swift-archetypebuilder-addrequirement.swift
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+#^A^#{"
+protocol c{
+func a
+typealias b:c
+typealias e:c


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 105
swift-ide-test: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1235: void swift::ArchetypeBuilder::addRequirement(const swift::Requirement &, swift::RequirementSource): Assertion `!invalid && "Re-introducing invalid requirement"' failed.
8  swift-ide-test  0x0000000000a9ad94 swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) + 532
9  swift-ide-test  0x0000000000a9c563 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, bool, bool) + 531
10 swift-ide-test  0x00000000009575ab swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 91
12 swift-ide-test  0x0000000000957afc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
17 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
18 swift-ide-test  0x0000000000905e02 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1298
19 swift-ide-test  0x0000000000774192 swift::CompilerInstance::performSema() + 2946
20 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'c' at <INPUT-FILE>:3:1
```
