### PR TITLE
Revert "Remove duplicated line"

### DIFF
--- a/test/IDE/Inputs/dumped_api.swift
+++ b/test/IDE/Inputs/dumped_api.swift
@@ -95,6 +95,7 @@ public func anyGenerator<T>(nextImplementation: ()->T?) -> AnyGenerator<T>
 
 
 // FIXME: can't make this a protocol due to <rdar://20209031>
+// FIXME: can't make this a protocol due to <rdar://20209031>
 
 /// A type-erased sequence.
 ///


### PR DESCRIPTION
Reverts apple/swift#559

Reverting this change due to test failure "IDE/dump_api.swift"
