### PR TITLE
[SourceKit] Add test case for crash triggered in swift::lookupVisibleDecls(…)

### DIFF
--- a/validation-test/IDE/crashers/011-swift-lookupvisibledecls.swift
+++ b/validation-test/IDE/crashers/011-swift-lookupvisibledecls.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+enum S<T where g:A{struct T enum S:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 140
swift-ide-test: /path/to/swift/include/swift/AST/Decl.h:2210: swift::Accessibility swift::ValueDecl::getFormalAccess() const: Assertion `hasAccessibility() && "accessibility not computed yet"' failed.
12 swift-ide-test  0x0000000000b5bf8d swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1117
14 swift-ide-test  0x0000000000865a46 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
15 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
16 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
