### PR TITLE
[SourceKit] Add test case for crash triggered in llvm::llvm_unreachable_internal(…)

### DIFF
--- a/validation-test/IDE/crashers/012-swift-mangle-mangler-manglecontext.swift
+++ b/validation-test/IDE/crashers/012-swift-mangle-mangler-manglecontext.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+class a{var _={func b#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 126
pattern-binding bound no variables?
UNREACHABLE executed at /path/to/swift/lib/AST/Mangle.cpp:189!
6  swift-ide-test  0x0000000002b6105d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  swift-ide-test  0x0000000000b60b96 swift::Mangle::Mangler::mangleContext(swift::DeclContext const*, swift::Mangle::Mangler::BindGenerics) + 1062
8  swift-ide-test  0x0000000000b65b4e swift::Mangle::Mangler::mangleClosureComponents(swift::Type, unsigned int, bool, swift::DeclContext const*, swift::DeclContext const*) + 94
9  swift-ide-test  0x0000000000b61741 swift::Mangle::Mangler::mangleEntity(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 417
10 swift-ide-test  0x0000000000b9fe7f swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 815
12 swift-ide-test  0x000000000077bd88 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
13 swift-ide-test  0x000000000077c508 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
17 swift-ide-test  0x0000000000b5bc46 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 278
20 swift-ide-test  0x0000000000865a46 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
21 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
22 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
