### PR TITLE
Remove outdated, incorrect comment

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -275,8 +275,6 @@ class WeakRefCount {
 
   enum : uint32_t {
     // There isn't really a flag here.
-    // Making weak RC_ONE == strong RC_ONE saves an
-    // instruction in allocation on arm64.
     RC_UNUSED_FLAG = 1,
 
     RC_FLAGS_COUNT = 1,


### PR DESCRIPTION
As found by [Mike Ash](https://mikeash.com/pyblog/friday-qa-2015-12-11-swift-weak-references.html), StrongRefCount::RC_ONE no longer equals WeakRefCount::RC_ONE which invalidates this comment.
