### PR TITLE
[Performance] iterate the smaller set during Set.intersect()

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -561,13 +561,30 @@ public struct Set<Element : Hashable> :
   public func intersect<
     S : SequenceType where S.Generator.Element == Element
   >(sequence: S) -> Set<Element> {
-    let other = sequence as? Set<Element> ?? Set(sequence)
+
+    // Attempt to iterate the smaller between `self` and `sequence`.
+    // If sequence is not a set, iterate over it because it may be single-pass.
     var newSet = Set<Element>()
-    for member in self {
-      if other.contains(member) {
-        newSet.insert(member)
+
+    if let other = sequence as? Set<Element> {
+      let smaller: Set<Element>
+      let bigger: Set<Element>
+      if other.count > count {
+        smaller = self
+        bigger = other
+      } else {
+        smaller = other
+        bigger = self
+      }
+      for element in smaller where bigger.contains(element) {
+        newSet.insert(element)
+      }
+    } else {
+      for element in sequence where contains(element) {
+        newSet.insert(element)
       }
     }
+
     return newSet
   }
 


### PR DESCRIPTION
For Set's `intersect()` operation, iterate over the smaller of the two.

This change introduces ~~about 1% overhead in speed for average case~~ a small constant cost, but greatly optimizes worst case.

[Benchmark](https://gist.github.com/dduan/76cdee98624f0ef74bde) result:

```
master, -R

small ∩ large * 100 -- 0.268759667873383
large ∩ small * 100 -- 7.67079079151154
small ∩ small * 100 -- 0.279738128185272
large ∩ large * 100 -- 17.1418876051903
total time spent ----- 25.3611761927605

optimized, -R

small ∩ large * 100 -- 0.275687038898468
large ∩ small * 100 -- 0.267830967903137
small ∩ small * 100 -- 0.27216911315918
large ∩ large * 100 -- 17.287498831749
total time spent ----- 18.1031859517097
```

Note: the benchmark was written for `intersectInPlace()`, which simply calls `intersect()`. Tests in *validation-test/stdlib/Set.swift \* passes.
