### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::lookupUnqualified(…)

### DIFF
--- a/validation-test/IDE/crashers/015-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/IDE/crashers/015-swift-typechecker-lookupunqualified.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+T{struct B{let h=protocol P{struct B<T where h:e{var f=B#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 161
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:225: swift::LookupResult swift::TypeChecker::lookupUnqualified(swift::DeclContext *, swift::DeclName, swift::SourceLoc, NameLookupOptions): Assertion `foundInType && "bogus base declaration?"' failed.
8  swift-ide-test  0x000000000095c869 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 633
9  swift-ide-test  0x0000000000917959 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 121
11 swift-ide-test  0x0000000000ae6353 swift::Expr::walk(swift::ASTWalker&) + 19
12 swift-ide-test  0x0000000000918537 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
13 swift-ide-test  0x000000000091efed swift::TypeChecker::getTypeOfExpressionWithoutApplying(swift::Expr*&, swift::DeclContext*, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*) + 221
15 swift-ide-test  0x0000000000907c7e swift::getTypeOfCompletionContextExpr(swift::ASTContext&, swift::DeclContext*, swift::Expr*&) + 1150
17 swift-ide-test  0x0000000000865a46 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
18 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
19 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:2:56 - line:2:56] RangeText="B"
```
