### PR TITLE
[SourceKit] Add test case for crash triggered in swift::VarDecl::emitLetToVarNoteIfSimple(…)

### DIFF
--- a/validation-test/IDE/crashers/019-swift-vardecl-emitlettovarnoteifsimple.swift
+++ b/validation-test/IDE/crashers/019-swift-vardecl-emitlettovarnoteifsimple.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+class l{func a=let A{class Q{var _=a={#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 143
swift-ide-test: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::FuncDecl, const swift::AbstractFunctionDecl *>::doit(const From *) [To = swift::FuncDecl, From = const swift::AbstractFunctionDecl *]: Assertion `Val && "isa<> used on a null pointer"' failed.
8  swift-ide-test  0x0000000000b43ac4 swift::VarDecl::emitLetToVarNoteIfSimple(swift::DeclContext*) const + 612
10 swift-ide-test  0x00000000009203b6 swift::constraints::ConstraintSystem::computeAssignDestType(swift::Expr*, swift::SourceLoc) + 966
13 swift-ide-test  0x0000000000ae6385 swift::Expr::walk(swift::ASTWalker&) + 69
14 swift-ide-test  0x00000000008cf368 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
15 swift-ide-test  0x00000000009185c0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
16 swift-ide-test  0x000000000091eb69 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
17 swift-ide-test  0x000000000091fc80 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
18 swift-ide-test  0x000000000091fe29 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
23 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
26 swift-ide-test  0x00000000009808db swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
27 swift-ide-test  0x000000000098071e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift-ide-test  0x0000000000908bd8 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
35 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
36 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
37 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
38 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
39 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
40 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
41 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'l' at <INPUT-FILE>:2:1
2.  While type-checking 'Q' at <INPUT-FILE>:2:22
3.  While type-checking expression at [<INPUT-FILE>:2:36 - line:2:39] RangeText="a={"
```
