### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::validateGenericFuncSignature(…)

### DIFF
--- a/validation-test/IDE/crashers/020-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/IDE/crashers/020-swift-typechecker-validategenericfuncsignature.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol a{struct B<e{let a{protocol a{func a<T:s#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 154
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:498: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
9  swift-ide-test  0x0000000000957c0f swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 399
14 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
17 swift-ide-test  0x00000000009808db swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
18 swift-ide-test  0x000000000098071e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
19 swift-ide-test  0x0000000000908bd8 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
28 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
29 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
30 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
31 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
32 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
33 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
34 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'a' at <INPUT-FILE>:2:1
2.  While type-checking 'a' at <INPUT-FILE>:2:29
```
