### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::resolveIdentifierType(…)

### DIFF
--- a/validation-test/IDE/crashers/021-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/IDE/crashers/021-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{class T{protocol b{#^A^#typealias b:B<T>struct B<b


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 125
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckType.cpp:428: swift::Type swift::TypeChecker::applyGenericArguments(swift::Type, swift::SourceLoc, swift::DeclContext *, MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver *): Assertion `genericSig != nullptr' failed.
13 swift-ide-test  0x000000000098651e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
15 swift-ide-test  0x0000000000986414 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
16 swift-ide-test  0x00000000009f6e72 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
17 swift-ide-test  0x00000000009f6777 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 359
18 swift-ide-test  0x000000000092fd49 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
19 swift-ide-test  0x00000000009332f3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1075
24 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
27 swift-ide-test  0x0000000000981c9a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
28 swift-ide-test  0x00000000009b9c2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
29 swift-ide-test  0x000000000091ebdb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
31 swift-ide-test  0x0000000000981de6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
32 swift-ide-test  0x0000000000905e6d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1405
33 swift-ide-test  0x0000000000774192 swift::CompilerInstance::performSema() + 2946
34 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:2:1 - line:2:47] RangeText="{class T{protocol b{typealias b:B<T>struct B<b"
2.  While type-checking 'T' at <INPUT-FILE>:2:2
3.  While resolving type B<T> at [<INPUT-FILE>:2:34 - line:2:37] RangeText="B<T>"
```
