### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::mangleType(…)

### DIFF
--- a/validation-test/IDE/crashers/026-swift-mangle-mangler-mangletype.swift
+++ b/validation-test/IDE/crashers/026-swift-mangle-mangler-mangletype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+let a{enum S<w{class B<T{func b{class A{{}class a<a{func a{func e:T{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 173
swift-ide-test: /path/to/swift/lib/AST/Mangle.cpp:1276: void swift::Mangle::Mangler::mangleType(swift::Type, swift::ResilienceExpansion, unsigned int): Assertion `ArchetypesDepth >= info.Depth' failed.
8  swift-ide-test  0x0000000000b63cc8 swift::Mangle::Mangler::mangleType(swift::Type, swift::ResilienceExpansion, unsigned int) + 7160
9  swift-ide-test  0x0000000000b6431e swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 238
10 swift-ide-test  0x0000000000b9fe7f swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 815
12 swift-ide-test  0x000000000077bd88 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
13 swift-ide-test  0x000000000077c508 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
17 swift-ide-test  0x0000000000b5bd5b swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 555
22 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
23 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
24 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
25 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
26 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
27 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
28 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:2:6
```
