### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::bindGenericParameters(…)

### DIFF
--- a/validation-test/IDE/crashers/025-swift-mangle-mangler-bindgenericparameters.swift
+++ b/validation-test/IDE/crashers/025-swift-mangle-mangler-bindgenericparameters.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol a{struct c<w{let a{func u#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 139
swift-ide-test: /path/to/swift/lib/AST/Mangle.cpp:356: void swift::Mangle::Mangler::bindGenericParameters(swift::CanGenericSignature, const swift::GenericParamList *): Assertion `ArchetypesDepth == genericParams->getDepth()' failed.
8  swift-ide-test  0x0000000000b61a65 swift::Mangle::Mangler::bindGenericParameters(swift::CanGenericSignature, swift::GenericParamList const*) + 565
9  swift-ide-test  0x0000000000b612c4 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 340
10 swift-ide-test  0x0000000000b65cf6 swift::Mangle::Mangler::mangleAccessorEntity(swift::AccessorKind, swift::AddressorKind, swift::AbstractStorageDecl const*, swift::ResilienceExpansion) + 86
11 swift-ide-test  0x0000000000b61741 swift::Mangle::Mangler::mangleEntity(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 417
12 swift-ide-test  0x0000000000b9fe7f swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 815
14 swift-ide-test  0x000000000077bd88 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
15 swift-ide-test  0x000000000077c508 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
19 swift-ide-test  0x0000000000b5bd5b swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 555
28 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
29 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
30 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
31 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
32 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
33 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
34 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'a' at <INPUT-FILE>:2:1
```
