### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::PotentialArchetype::getRepresentative()

### DIFF
--- a/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol c{func a:P
+protocol P{#^A^#func a:b
+typealias b:a


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 136
4  swift-ide-test  0x0000000000a96594 swift::ArchetypeBuilder::PotentialArchetype::getRepresentative() + 4
5  swift-ide-test  0x0000000000956eab swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 27
6  swift-ide-test  0x00000000009859cc swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 796
10 swift-ide-test  0x000000000098651e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift-ide-test  0x0000000000986414 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
14 swift-ide-test  0x0000000000957afc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
17 swift-ide-test  0x00000000009331e0 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 800
18 swift-ide-test  0x0000000000b7bf7c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
19 swift-ide-test  0x0000000000b7a96c swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2252
20 swift-ide-test  0x000000000095c6ab swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
23 swift-ide-test  0x000000000098651e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
25 swift-ide-test  0x0000000000986414 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
26 swift-ide-test  0x00000000009f6e72 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
27 swift-ide-test  0x00000000009f6777 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 359
28 swift-ide-test  0x000000000092fd49 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
29 swift-ide-test  0x00000000009332f3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1075
30 swift-ide-test  0x0000000000b7bf7c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
31 swift-ide-test  0x0000000000b7a96c swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2252
32 swift-ide-test  0x000000000095c6ab swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
35 swift-ide-test  0x000000000098651e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
37 swift-ide-test  0x0000000000986414 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
39 swift-ide-test  0x0000000000957afc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
44 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
45 swift-ide-test  0x0000000000905e02 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1298
46 swift-ide-test  0x0000000000774192 swift::CompilerInstance::performSema() + 2946
47 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'c' at <INPUT-FILE>:2:1
2.  While resolving type P at [<INPUT-FILE>:2:19 - line:2:19] RangeText="P"
3.  While resolving type a at [<INPUT-FILE>:4:13 - line:4:13] RangeText="a"
4.  While type-checking 'a' at <INPUT-FILE>:3:13
5.  While resolving type b at [<INPUT-FILE>:3:20 - line:3:20] RangeText="b"
```
