### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::applyGenericArguments(…)

### DIFF
--- a/validation-test/IDE/crashers/022-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/IDE/crashers/022-swift-typechecker-applygenericarguments.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol a{
+func g:P
+protocol P{
+class B<T
+{struct c{
+#^A^#
+protocol b{typealias e:B<T>


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 159
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:1028: bool swift::TypeChecker::checkGenericArguments(swift::DeclContext *, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature *, ArrayRef<swift::Type>): Assertion `genericParams.size() == genericArgs.size()' failed.
9  swift-ide-test  0x0000000000986288 swift::TypeChecker::applyGenericArguments(swift::Type, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) + 888
14 swift-ide-test  0x000000000098651e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift-ide-test  0x0000000000986414 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
17 swift-ide-test  0x00000000009f6e72 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
18 swift-ide-test  0x00000000009f6777 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 359
19 swift-ide-test  0x000000000092fd49 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
20 swift-ide-test  0x00000000009332f3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1075
25 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
26 swift-ide-test  0x0000000000907312 swift::typeCheckCompletionDecl(swift::Decl*) + 1122
29 swift-ide-test  0x0000000000865a46 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
30 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
31 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'c' at <INPUT-FILE>:6:2
2.  While resolving type B<T> at [<INPUT-FILE>:8:24 - line:8:27] RangeText="B<T>"
```
