### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeBase::getDesugaredType()

### DIFF
--- a/validation-test/IDE/crashers/027-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/IDE/crashers/027-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+class#^A^#class B{class B:a{}let a=B{


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 110
4  swift-ide-test  0x0000000000b919c0 swift::TypeBase::getDesugaredType() + 32
8  swift-ide-test  0x0000000000ae6385 swift::Expr::walk(swift::ASTWalker&) + 69
9  swift-ide-test  0x00000000008cf368 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
10 swift-ide-test  0x00000000009185c0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
11 swift-ide-test  0x000000000091eb69 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
12 swift-ide-test  0x000000000091fc80 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
13 swift-ide-test  0x000000000091fe29 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
15 swift-ide-test  0x0000000000933e4b swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3979
16 swift-ide-test  0x0000000000b7bf7c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
17 swift-ide-test  0x0000000000b7a96c swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2252
18 swift-ide-test  0x000000000095c6ab swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
21 swift-ide-test  0x000000000098651e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
23 swift-ide-test  0x0000000000986414 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
24 swift-ide-test  0x00000000009310d1 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4929
25 swift-ide-test  0x00000000009335a3 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1763
30 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
31 swift-ide-test  0x0000000000905e02 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1298
32 swift-ide-test  0x0000000000774192 swift::CompilerInstance::performSema() + 2946
33 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'B' at <INPUT-FILE>:2:7
2.  While resolving type a at [<INPUT-FILE>:2:23 - line:2:23] RangeText="a"
3.  While type-checking expression at [<INPUT-FILE>:2:32 - line:2:33] RangeText="B{"
```
