### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::validateGenericSignature(…)

### DIFF
--- a/validation-test/IDE/crashers/028-swift-typechecker-validategenericsignature.swift
+++ b/validation-test/IDE/crashers/028-swift-typechecker-validategenericsignature.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol c{struct Q<g{var d{{class B<T:e#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 145
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:498: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
9  swift-ide-test  0x0000000000959683 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 403
10 swift-ide-test  0x00000000009599b4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
11 swift-ide-test  0x0000000000933021 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 353
14 swift-ide-test  0x0000000000938707 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
17 swift-ide-test  0x0000000000981c9a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
18 swift-ide-test  0x00000000009b9c2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
19 swift-ide-test  0x000000000091ebdb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
22 swift-ide-test  0x00000000009808db swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
23 swift-ide-test  0x000000000098071e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
24 swift-ide-test  0x0000000000908bd8 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
32 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
33 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
34 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
35 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
36 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
37 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
38 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'c' at <INPUT-FILE>:2:1
2.  While type-checking expression at [<INPUT-FILE>:2:29 - line:2:41] RangeText="{class B<T:e"
3.  While type-checking 'B' at <INPUT-FILE>:2:30
```
