### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Decl::walk(…)

### DIFF
--- a/validation-test/IDE/crashers/029-swift-decl-walk.swift
+++ b/validation-test/IDE/crashers/029-swift-decl-walk.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{var f={{#^A^#}r


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 114
child source range not contained within its parent: var f
  parent range: [<INPUT-FILE>:2:1 - line:2:11] RangeText="{var f={{}"
  child range: [<INPUT-FILE>:2:2 - line:2:12] RangeText="var f={{}r"
14 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
15 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
16 swift-ide-test  0x0000000000ba00c4 swift::verify(swift::SourceFile&) + 52
17 swift-ide-test  0x000000000086a4a3 swift::Parser::parseTopLevel() + 563
18 swift-ide-test  0x000000000086591b swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 107
19 swift-ide-test  0x0000000000774176 swift::CompilerInstance::performSema() + 2918
20 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  With parser at source location: <INPUT-FILE>:2:13
2.  While walking into decl declaration 0x5338df0 at <INPUT-FILE>:2:1
3.  While verifying ranges declaration 0x53390a8 at <INPUT-FILE>:2:2
```
