### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::mangleNominalType(…)

### DIFF
--- a/validation-test/IDE/crashers/031-swift-mangle-mangler-manglenominaltype.swift
+++ b/validation-test/IDE/crashers/031-swift-mangle-mangler-manglenominaltype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+let a{struct S<T{var f=a#^A^#let a{func l{init(={struct S{enum a{struct B{var _=


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 129
swift-ide-test: /path/to/llvm/include/llvm/ADT/ArrayRef.h:172: ArrayRef<T> llvm::ArrayRef<swift::ArchetypeType *>::slice(unsigned int, unsigned int) const [T = swift::ArchetypeType *]: Assertion `N+M <= size() && "Invalid specifier"' failed.
9  swift-ide-test  0x0000000000b612c4 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 340
10 swift-ide-test  0x0000000000b65cf6 swift::Mangle::Mangler::mangleAccessorEntity(swift::AccessorKind, swift::AddressorKind, swift::AbstractStorageDecl const*, swift::ResilienceExpansion) + 86
11 swift-ide-test  0x0000000000b61741 swift::Mangle::Mangler::mangleEntity(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 417
12 swift-ide-test  0x0000000000b614dc swift::Mangle::Mangler::mangleConstructorEntity(swift::ConstructorDecl const*, bool, swift::ResilienceExpansion, unsigned int) + 76
13 swift-ide-test  0x0000000000b61092 swift::Mangle::Mangler::mangleDefaultArgumentEntity(swift::DeclContext const*, unsigned int) + 66
14 swift-ide-test  0x0000000000b65b4e swift::Mangle::Mangler::mangleClosureComponents(swift::Type, unsigned int, bool, swift::DeclContext const*, swift::DeclContext const*) + 94
15 swift-ide-test  0x0000000000b61270 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 256
16 swift-ide-test  0x0000000000b61270 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 256
17 swift-ide-test  0x0000000000b61270 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 256
18 swift-ide-test  0x0000000000b9fe22 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 722
20 swift-ide-test  0x000000000077bd88 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
21 swift-ide-test  0x000000000077c508 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
29 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
30 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
31 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
32 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
33 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
34 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
35 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:2:6
```
