### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Expr::propagateLValueAccessKind(…)

### DIFF
--- a/validation-test/IDE/crashers/032-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/IDE/crashers/032-swift-expr-propagatelvalueaccesskind.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{()=(var a{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 116
swift-ide-test: /path/to/swift/lib/AST/Expr.cpp:204: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind): Assertion `(AllowOverwrite || !E->hasLValueAccessKind()) && "l-value access kind has already been set"' failed.
9  swift-ide-test  0x0000000000b524e7 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) + 23
12 swift-ide-test  0x0000000000ae6385 swift::Expr::walk(swift::ASTWalker&) + 69
13 swift-ide-test  0x00000000009b9af6 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
14 swift-ide-test  0x000000000091ebdb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
17 swift-ide-test  0x0000000000981c9a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
18 swift-ide-test  0x00000000009b9c2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
19 swift-ide-test  0x000000000091ebdb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
21 swift-ide-test  0x0000000000981de6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
22 swift-ide-test  0x000000000090907d swift::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 1117
32 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
33 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
34 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
35 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
36 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
37 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
38 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x54b8f10 at <INPUT-FILE>:2:1
2.  While type-checking expression at [<INPUT-FILE>:2:1 - line:2:12] RangeText="{()=(var a{"
3.  While type-checking expression at [<INPUT-FILE>:2:2 - line:2:5] RangeText="()=("
```
