### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::mangleDeclType(…)

### DIFF
--- a/validation-test/IDE/crashers/030-swift-mangle-mangler-mangledecltype.swift
+++ b/validation-test/IDE/crashers/030-swift-mangle-mangler-mangledecltype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+let A{n{func a<A{struct S<T{func b{init(={func a{var f{class B:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 168
swift-ide-test: /path/to/llvm/include/llvm/ADT/ArrayRef.h:172: ArrayRef<T> llvm::ArrayRef<swift::ArchetypeType *>::slice(unsigned int, unsigned int) const [T = swift::ArchetypeType *]: Assertion `N+M <= size() && "Invalid specifier"' failed.
10 swift-ide-test  0x0000000000b64392 swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 354
11 swift-ide-test  0x0000000000b614dc swift::Mangle::Mangler::mangleConstructorEntity(swift::ConstructorDecl const*, bool, swift::ResilienceExpansion, unsigned int) + 76
12 swift-ide-test  0x0000000000b61092 swift::Mangle::Mangler::mangleDefaultArgumentEntity(swift::DeclContext const*, unsigned int) + 66
13 swift-ide-test  0x0000000000b65b4e swift::Mangle::Mangler::mangleClosureComponents(swift::Type, unsigned int, bool, swift::DeclContext const*, swift::DeclContext const*) + 94
14 swift-ide-test  0x0000000000b61741 swift::Mangle::Mangler::mangleEntity(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 417
15 swift-ide-test  0x0000000000b65cf6 swift::Mangle::Mangler::mangleAccessorEntity(swift::AccessorKind, swift::AddressorKind, swift::AbstractStorageDecl const*, swift::ResilienceExpansion) + 86
16 swift-ide-test  0x0000000000b61270 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 256
17 swift-ide-test  0x0000000000b9fe22 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 722
19 swift-ide-test  0x000000000077bd88 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
20 swift-ide-test  0x000000000077c508 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
23 swift-ide-test  0x0000000000b5bd5b swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 555
27 swift-ide-test  0x0000000000ae6734 swift::Decl::walk(swift::ASTWalker&) + 20
28 swift-ide-test  0x0000000000b6fbce swift::SourceFile::walk(swift::ASTWalker&) + 174
29 swift-ide-test  0x0000000000b6efaf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
30 swift-ide-test  0x0000000000b49722 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
31 swift-ide-test  0x000000000086599d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
32 swift-ide-test  0x0000000000774304 swift::CompilerInstance::performSema() + 3316
33 swift-ide-test  0x000000000071cc33 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for A at <INPUT-FILE>:2:6
```
