### PR TITLE
[SourceKit] Add test case for crash triggered in swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(…)

### DIFF
--- a/validation-test/IDE/crashers/034-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
+++ b/validation-test/IDE/crashers/034-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+struct A<c{class a<A{enum S:CollectionType
+#^A^#


### PR DESCRIPTION
Sorry, just found another unique SourceKit crash :-)

Stack trace:

```
found code completion token A at offset 148
swift-ide-test: /path/to/swift/lib/AST/Type.cpp:2187: TypeSubstitutionMap swift::GenericParamList::getSubstitutionMap(ArrayRef<swift::Substitution>) const: Assertion `Subs.empty() && "did not use all substitutions?!"' failed.
9  swift-ide-test  0x0000000000b86948 swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 248
10 swift-ide-test  0x0000000000b86632 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 18
11 swift-ide-test  0x0000000000b86de6 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
14 swift-ide-test  0x0000000000b9630c swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 44
15 swift-ide-test  0x0000000000b8f8af swift::Type::subst(swift::ModuleDecl*, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >&, swift::OptionSet<swift::SubstFlags, unsigned int>) const + 111
16 swift-ide-test  0x0000000000b6b907 swift::BoundGenericType::getSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) + 1911
17 swift-ide-test  0x0000000000b8ef93 swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, llvm::SmallVectorImpl<swift::Substitution>&, swift::LazyResolver*, swift::DeclContext*) + 211
18 swift-ide-test  0x0000000000b6c31e swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1246
19 swift-ide-test  0x0000000000964450 swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 96
20 swift-ide-test  0x00000000008e1b7b swift::constraints::ConstraintSystem::simplifyConformsToConstraint(swift::Type, swift::ProtocolDecl*, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, unsigned int) + 123
21 swift-ide-test  0x00000000008e4956 swift::constraints::ConstraintSystem::simplifyConformsToConstraint(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, unsigned int) + 118
22 swift-ide-test  0x00000000008e901e swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 142
23 swift-ide-test  0x00000000008ee2d9 swift::constraints::ConstraintSystem::simplify(bool) + 105
24 swift-ide-test  0x00000000008f16a0 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 48
25 swift-ide-test  0x00000000008f1569 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
26 swift-ide-test  0x00000000008f149b swift::constraints::ConstraintSystem::solveSingle(swift::FreeTypeVariableBinding) + 59
31 swift-ide-test  0x000000000096510b swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2059
39 swift-ide-test  0x0000000000938837 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
40 swift-ide-test  0x0000000000905f8a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1434
41 swift-ide-test  0x0000000000774222 swift::CompilerInstance::performSema() + 2946
42 swift-ide-test  0x000000000071ccc3 main + 35011
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'A' at <INPUT-FILE>:2:1
```
