### PR TITLE
Revert "[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::PotentialArchetype::getRepresentative()"

### DIFF
--- a/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-protocol c{func a:P
-protocol P{#^A^#func a:b
-typealias b:a


### PR DESCRIPTION
Reverts apple/swift#587 due to test failure
