### PR TITLE
[abi.rst] Fix incorrect mangling substitution example

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -1180,7 +1180,7 @@ third argument type will mangle using the substitution for ``zim``,
 ``CS_7zippity``. (It also acquires substitution ``S2_`` which would be used
 if it mangled again.) The result type will mangle using the substitution for
 ``zim.zang``, ``CS0_zoo`` (and acquire substitution ``S3_``). The full
-function type thus mangles as ``fTCC3zim4zang4zungCS1_CS_7zippity_CS0_zoo``.
+function type thus mangles as ``fTCC3zim4zang4zungCS1_CS_7zippity_CS0_3zoo``.
 
 ::
 

--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -1179,7 +1179,7 @@ using its substitution, ``CS1_``. The
 third argument type will mangle using the substitution for ``zim``,
 ``CS_7zippity``. (It also acquires substitution ``S2_`` which would be used
 if it mangled again.) The result type will mangle using the substitution for
-``zim.zang``, ``CS0_zoo`` (and acquire substitution ``S3_``). The full
+``zim.zang``, ``CS0_3zoo`` (and acquire substitution ``S3_``). The full
 function type thus mangles as ``fTCC3zim4zang4zungCS1_CS_7zippity_CS0_3zoo``.
 
 ::


### PR DESCRIPTION
Before: CS0_zoo -> after: CS0_3zoo - note the missing 'normal' to determine identifier length
