### PR TITLE
[SIL] Only move if source != target.

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -411,8 +411,10 @@ public:
   }
 
   ProjectionPath &operator=(ProjectionPath &&O) {
-    *this = std::move(O);
-    O.Path.clear();
+    if (this != &O) {
+      *this = std::move(O);
+      O.Path.clear();
+    }
     return *this;
   }
 


### PR DESCRIPTION
clang was complaining about this.
