### PR TITLE
Make Swift work on Linux/armv7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,7 +400,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set(SWIFT_PRIMARY_VARIANT_ARCH_default "x86_64")
   # FIXME: This only matches ARMv7l (by far the most common variant).
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
-    configure_sdk_unix(LINUX "Linux" "linux" "linux" "armv7" "armv7-unknown-linux-gnueabihf")
+    configure_sdk_unix(LINUX "Linux" "linux" "linux" "armv7" "thumbv7-unknown-linux-gnueabihf")
     set(SWIFT_HOST_VARIANT_ARCH "armv7")
     set(SWIFT_PRIMARY_VARIANT_ARCH_default "armv7")
   elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -160,8 +160,14 @@ function(_add_variant_link_flags
 
   if("${sdk}" STREQUAL "LINUX")
     list(APPEND result "-lpthread" "-ldl")
+    if("${arch}" MATCHES "^arm")
+      list(APPEND result "-Wl,-Bsymbolic")
+    endif()
   elseif("${sdk}" STREQUAL "FREEBSD")
     # No extra libraries required.
+    if("${arch}" MATCHES "^arm")
+      list(APPEND result "-Wl,-Bsymbolic")
+    endif()
   else()
     list(APPEND result "-lobjc")
   endif()

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -110,6 +110,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   // Set the "arch" target configuration.
   switch (Target.getArch()) {
   case llvm::Triple::ArchType::arm:
+  case llvm::Triple::ArchType::thumb:
     addTargetConfigOption("arch", "arm");
     break;
   case llvm::Triple::ArchType::aarch64:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1047,6 +1047,16 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     break;
   case LinkKind::DynamicLibrary:
     Arguments.push_back("-shared");
+    switch (getTriple().getArch()) {
+      default:
+        break;
+      case llvm::Triple::arm:
+      case llvm::Triple::armeb:
+        // Avoid emitting R_ARM_REL32 which is not supported by shared objects
+        // on ELF targets.
+        Arguments.push_back("-Wl,-Bsymbolic");
+        break;
+    }
     break;
   }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1052,6 +1052,8 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
         break;
       case llvm::Triple::arm:
       case llvm::Triple::armeb:
+      case llvm::Triple::thumb:
+      case llvm::Triple::thumbeb:
         // Avoid emitting R_ARM_REL32 which is not supported by shared objects
         // on ELF targets.
         Arguments.push_back("-Wl,-Bsymbolic");

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -74,15 +74,30 @@ add_swift_library(swiftRuntime IS_STDLIB IS_STDLIB_CORE
 foreach(sdk ${SWIFT_CONFIGURED_SDKS})
   if("${sdk}" STREQUAL "LINUX" OR "${sdk}" STREQUAL "FREEBSD")
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
-      set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
+      if ("${sdk}" STREQUAL "LINUX" AND "${arch}" STREQUAL "armv7")
+        # Handle special case for ARM on Linux.
+        # FIXME: Find a more elegant way to handle this case.
+        foreach(subarch armv7;armv7l)
+          set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${subarch}")
 
-      # FIXME: We will need a different linker script for 32-bit builds.
-      configure_file(
-          "swift.ld" "${SWIFTLIB_DIR}/${arch_subdir}/swift.ld" COPYONLY)
+          configure_file(
+              "swift.ld" "${SWIFTLIB_DIR}/${arch_subdir}/swift.ld" COPYONLY)
 
-      swift_install_in_component(compiler
-          FILES "swift.ld"
-          DESTINATION "lib/swift/${arch_subdir}")
+          swift_install_in_component(compiler
+              FILES "swift.ld"
+              DESTINATION "lib/swift/${arch_subdir}")
+
+        endforeach()
+      else ()
+        set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
+
+        configure_file(
+            "swift.ld" "${SWIFTLIB_DIR}/${arch_subdir}/swift.ld" COPYONLY)
+
+        swift_install_in_component(compiler
+            FILES "swift.ld"
+            DESTINATION "lib/swift/${arch_subdir}")
+      endif ()
 
     endforeach()
   endif()

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -75,9 +75,9 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
   if("${sdk}" STREQUAL "LINUX" OR "${sdk}" STREQUAL "FREEBSD")
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       if ("${sdk}" STREQUAL "LINUX" AND "${arch}" STREQUAL "armv7")
-        # Handle special case for ARM on Linux.
+        # Handle special case for ARM/Thumb on Linux.
         # FIXME: Find a more elegant way to handle this case.
-        foreach(subarch armv7;armv7l)
+        foreach(subarch armv7;armv7l;thumbv7;thumbv7l)
           set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${subarch}")
 
           configure_file(

--- a/test/1_stdlib/FloatingPointIR.swift
+++ b/test/1_stdlib/FloatingPointIR.swift
@@ -42,6 +42,9 @@ func testConstantFoldFloatLiterals() {
 // armv7: call void @{{.*}}_TF15FloatingPointIR13acceptFloat32FSfT_(float 1.000000e+00)
 // armv7: call void @{{.*}}_TF15FloatingPointIR13acceptFloat64FSdT_(double 1.000000e+00)
 
+// thumbv7: call void @{{.*}}_TF15FloatingPointIR13acceptFloat32FSfT_(float 1.000000e+00)
+// thumbv7: call void @{{.*}}_TF15FloatingPointIR13acceptFloat64FSdT_(double 1.000000e+00)
+
 // armv7k: call void @{{.*}}_TF15FloatingPointIR13acceptFloat32FSfT_(float 1.000000e+00)
 // armv7k: call void @{{.*}}_TF15FloatingPointIR13acceptFloat64FSdT_(double 1.000000e+00)
 


### PR DESCRIPTION
This change completes the work started by William Dillon in order to support ARM (and Thumb) on Linux and make it work. The change also enables support for other architectures that do not support direct references between distinct sections, actually I have a working Swift on Linux/PowerPC as well in order to verify the indirection works as good as on ARM, but that requires some more changes being a big endian target. I'll eventually provide a patch for that if there's interest.
