### PR TITLE
Fix some guidelines violations and typos

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -919,7 +919,7 @@ public:
   }
 
   /// Hoists the necessary check for beginning and end of the induction
-  /// encapsulated by this acess function to the header.
+  /// encapsulated by this access function to the header.
   void hoistCheckToPreheader(ArraySemanticsCall CheckToHoist,
                              SILBasicBlock *Preheader,
                              DominanceInfo *DT) {

--- a/test/SILGen/coverage_member_closure.swift
+++ b/test/SILGen/coverage_member_closure.swift
@@ -10,6 +10,6 @@ class C {
 
   // Closures in members show up at the end of the constructor's map.
   // CHECK-NOT: sil_coverage_map
-  // CHECK: [[@LINE+1]]:55 -> [[@LINE+1]]:77 : 2
-  var completionHandler: (String, [String]) -> Void = {(foo, bar) in return}
+  // CHECK: [[@LINE+1]]:55 -> [[@LINE+1]]:79 : 2
+  var completionHandler: (String, [String]) -> Void = { (foo, bar) in return }
 }

--- a/test/sil-extract/basic.swift
+++ b/test/sil-extract/basic.swift
@@ -69,17 +69,17 @@ struct X {
 }
 
 class Vehicle {
-    var num_of_wheels: Int
+    var numOfWheels: Int
 
     init(n: Int) {
-      num_of_wheels = n
+      numOfWheels = n
     }
 
     func now() -> Int {
-        return num_of_wheels;
+        return numOfWheels
     }
 }
 
 func foo() -> Int {
-  return 7;
+  return 7
 }


### PR DESCRIPTION
Copy of https://github.com/apple/swift/pull/202 but it works.

Output of `utils/build-script -RT`:

```
********************
Testing Time: 1453.92s
********************
Failing Tests (1):
    Swift :: IDE/crashers/026-swift-mangle-mangler-mangletype.swift

  Expected Passes    : 7660
  Expected Failures  : 8
  Unsupported Tests  : 38
  Unexpected Failures: 1
*** Failed while running tests for swift (check-swift-all-macosx-x86_64)
utils/build-script: command terminated with a non-zero exit status 1, aborting
```

I expect `IDE/crashers/026-swift-mangle-mangler-mangletype.swift` must fail?
