### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/IDE/crashers/035-swift-typechecker-validatedecl.swift
+++ b/validation-test/IDE/crashers/035-swift-typechecker-validatedecl.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+t{deinit{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 114
swift-ide-test: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::NominalTypeDecl, Y = swift::DeclContext]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
8  swift-ide-test  0x0000000000933801 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 6753
11 swift-ide-test  0x0000000000b5ba16 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 278
23 swift-ide-test  0x0000000000ae6574 swift::Decl::walk(swift::ASTWalker&) + 20
24 swift-ide-test  0x0000000000b6f99e swift::SourceFile::walk(swift::ASTWalker&) + 174
25 swift-ide-test  0x0000000000b6ed7f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
26 swift-ide-test  0x0000000000b494f2 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
27 swift-ide-test  0x00000000008644dd swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
28 swift-ide-test  0x0000000000772e94 swift::CompilerInstance::performSema() + 3316
29 swift-ide-test  0x000000000071c557 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x5d82ef0 at <INPUT-FILE>:2:1
```
