### PR TITLE
[stdlib] Fix Int(_:radix:) accepting unintentional cases (SR-187)

### DIFF
--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -76,7 +76,8 @@ internal func _parseAsciiAsUIntMax(
   // Parse (optional) sign
   let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
   // Parse digits
-  guard let result = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, maximum) else { return nil }
+  guard let result = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, maximum)
+    else { return nil }
   // Disallow < 0
   if hasMinus && result != 0 { return nil }
   // Return
@@ -96,9 +97,11 @@ internal func _parseAsciiAsIntMax(
   if utf16.isEmpty { return nil }
   // Parse (optional) sign
   let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
-  // Parse digits
-  let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0) // E.g. Int8's range is -128...127
-  guard let absValue = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, absValueMax) else { return nil }
+  // Parse digits. +1 for negatives because e.g. Int8's range is -128...127.
+  let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0)
+  guard let absValue =
+    _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, absValueMax)
+    else { return nil }
   // Return signed result
   return IntMax(bitPattern: hasMinus ? 0 &- absValue : absValue)
 }

--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -70,18 +70,17 @@ internal func _parseUnsignedAsciiAsUIntMax(
 /// - Note: For text matching the regular expression "-0+", the result
 ///   is `0`, not `nil`.
 internal func _parseAsciiAsUIntMax(
-  u16: String.UTF16View, _ radix: Int, _ maximum: UIntMax
+  utf16: String.UTF16View, _ radix: Int, _ maximum: UIntMax
 ) -> UIntMax? {
-  if u16.isEmpty { return nil }
-  let c = u16.first
-  if _fastPath(c != _ascii16("-")) {
-    let unsignedText
-      = c == _ascii16("+") ? u16.dropFirst() : u16
-    return _parseUnsignedAsciiAsUIntMax(unsignedText, radix, maximum)
-  }
-  else {
-    return _parseAsciiAsIntMax(u16, radix, 0) == 0 ? 0 : nil
-  }
+  if utf16.isEmpty { return nil }
+  // Parse (optional) sign
+  let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
+  // Parse digits
+  guard let result = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, maximum) else { return nil }
+  // Disallow < 0
+  if hasMinus && result != 0 { return nil }
+  // Return
+  return result
 }
 
 /// If text is an ASCII representation in the given `radix` of a
@@ -91,23 +90,28 @@ internal func _parseAsciiAsUIntMax(
 /// - Note: For text matching the regular expression "-0+", the result
 ///   is `0`, not `nil`.
 internal func _parseAsciiAsIntMax(
-  u16: String.UTF16View, _ radix: Int, _ maximum: IntMax
+  utf16: String.UTF16View, _ radix: Int, _ maximum: IntMax
 ) -> IntMax? {
   _sanityCheck(maximum >= 0, "maximum should be non-negative")
+  if utf16.isEmpty { return nil }
+  // Parse (optional) sign
+  let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
+  // Parse digits
+  let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0)
+  guard let absValue = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, absValueMax) else { return nil }
+  // Return signed result
+  return IntMax(bitPattern: hasMinus ? 0 &- absValue : absValue)
+}
 
-  if u16.isEmpty { return nil }
-
-  // Drop any leading "-"
-  let negative = u16.first == _ascii16("-")
-  let absResultText = negative ? u16.dropFirst() : u16
-
-  let absResultMax = UIntMax(bitPattern: maximum) + (negative ? 1 : 0)
-
-  // Parse the result as unsigned
-  if let absResult = _parseAsciiAsUIntMax(absResultText, radix, absResultMax) {
-    return IntMax(bitPattern: negative ? 0 &- absResult : absResult)
+/// Strip an optional single leading ASCII plus/minus sign from `utf16`.
+private func _parseOptionalAsciiSign(
+  utf16: String.UTF16View
+) -> (digitsUTF16: String.UTF16View, isMinus: Bool) {
+  switch utf16.first {
+  case _ascii16("-")?: return (utf16.dropFirst(), true)
+  case _ascii16("+")?: return (utf16.dropFirst(), false)
+  default: return (utf16, false)
   }
-  return nil
 }
 
 //===--- Loop over all integer types --------------------------------------===//

--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -67,8 +67,8 @@ internal func _parseUnsignedAsciiAsUIntMax(
 /// non-negative number <= `maximum`, return that number.  Otherwise,
 /// return `nil`.
 ///
-/// - Note: If `text` begins with `"+"` or `"-"`, even if the rest of
-///   the characters are `"0"`, the result is `nil`.
+/// - Note: For text matching the regular expression "-0+", the result
+///   is `0`, not `nil`.
 internal func _parseAsciiAsUIntMax(
   u16: String.UTF16View, _ radix: Int, _ maximum: UIntMax
 ) -> UIntMax? {

--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -73,14 +73,14 @@ internal func _parseAsciiAsUIntMax(
   utf16: String.UTF16View, _ radix: Int, _ maximum: UIntMax
 ) -> UIntMax? {
   if utf16.isEmpty { return nil }
-  // Parse (optional) sign
+  // Parse (optional) sign.
   let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
-  // Parse digits
+  // Parse digits.
   guard let result = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, maximum)
     else { return nil }
-  // Disallow < 0
+  // Disallow < 0.
   if hasMinus && result != 0 { return nil }
-  // Return
+  // Return.
   return result
 }
 
@@ -95,14 +95,14 @@ internal func _parseAsciiAsIntMax(
 ) -> IntMax? {
   _sanityCheck(maximum >= 0, "maximum should be non-negative")
   if utf16.isEmpty { return nil }
-  // Parse (optional) sign
+  // Parse (optional) sign.
   let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
-  // Parse digits. +1 for negatives because e.g. Int8's range is -128...127.
+  // Parse digits. +1 for because e.g. Int8's range is -128...127.
   let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0)
   guard let absValue =
     _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, absValueMax)
     else { return nil }
-  // Return signed result
+  // Return signed result.
   return IntMax(bitPattern: hasMinus ? 0 &- absValue : absValue)
 }
 

--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -97,7 +97,7 @@ internal func _parseAsciiAsIntMax(
   // Parse (optional) sign
   let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
   // Parse digits
-  let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0)
+  let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0) // E.g. Int8's range is -128...127
   guard let absValue = _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, absValueMax) else { return nil }
   // Return signed result
   return IntMax(bitPattern: hasMinus ? 0 &- absValue : absValue)

--- a/test/1_stdlib/NumericParsing.swift.gyb
+++ b/test/1_stdlib/NumericParsing.swift.gyb
@@ -92,6 +92,10 @@ tests.test("${Self}/success") {
   expectEqual(nil, ${Self}("${minValue - 1}"))
   expectEqual(nil, ${Self}("\u{1D7FF}"))  // MATHEMATICAL MONOSPACE DIGIT NINE
 
+  // Cases that should fail to parse
+  expectEqual(nil, ${Self}("--0")) // Zero w/ repeated plus
+  expectEqual(nil, ${Self}("-+5")) // Non-zero with -+
+
   // Do more exhaustive testing
   % for radix in radices_to_test:
   %   for n in required_values + range(


### PR DESCRIPTION
As described in [SR-187](https://bugs.swift.org/browse/SR-187), `Int(_:radix:)` (and analogous functions on other integer types) used to unintentionally accept the following cases:
- Any number of minuses followed by a 0
- A minus followed by a plus followed by any number 

Where as the docs specify it returns `nil` for anything other than `[-+]?[0-9a-zA-Z]`.

Passes `build-script -R -t` successfully.
