### PR TITLE
[stdlib] Refactor min()/max()

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -52,11 +52,11 @@ public func min<T : Comparable>(x: T, _ y: T) -> T {
 /// Returns the least argument passed.
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
-  var r = min(min(x, y), z)
-  for t in rest where t < r {
-    r = t
+  var minValue = min(min(x, y), z)
+  for value in rest where value < minValue {
+    minValue = value
   }
-  return r
+  return minValue
 }
 
 /// Returns the greater of `x` and `y`.
@@ -68,11 +68,11 @@ public func max<T : Comparable>(x: T, _ y: T) -> T {
 /// Returns the greatest argument passed.
 @warn_unused_result
 public func max<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
-  var r = max(max(x, y), z)
-  for t in rest where t >= r {
-    r = t
+  var maxValue = max(max(x, y), z)
+  for value in rest where value >= maxValue {
+    maxValue = value
   }
-  return r
+  return maxValue
 }
 
 /// Returns the result of slicing `elements` into sub-sequences that

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -46,11 +46,7 @@ public func find<
 /// Returns the lesser of `x` and `y`.
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T) -> T {
-  var r = x
-  if y < x {
-    r = y
-  }
-  return r
+  return y < x ? y : x
 }
 
 /// Returns the least argument passed.

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -52,17 +52,9 @@ public func min<T : Comparable>(x: T, _ y: T) -> T {
 /// Returns the least argument passed.
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
-  var r = x
-  if y < x {
-    r = y
-  }
-  if z < r {
-    r = z
-  }
-  for t in rest {
-    if t < r {
-      r = t
-    }
+  var r = min(min(x, y), z)
+  for t in rest where t < r {
+    r = t
   }
   return r
 }

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -44,6 +44,8 @@ public func find<
 }
 
 /// Returns the lesser of `x` and `y`.
+///
+/// If `x == y`, returns `x`.
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T) -> T {
   // In case `x == y` we pick `x`.
@@ -54,6 +56,8 @@ public func min<T : Comparable>(x: T, _ y: T) -> T {
 }
 
 /// Returns the least argument passed.
+///
+/// If there are multiple equal least arguments, returns the first one.
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var minValue = min(min(x, y), z)
@@ -65,6 +69,8 @@ public func min<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 }
 
 /// Returns the greater of `x` and `y`.
+///
+/// If `x == y`, returns `y`.
 @warn_unused_result
 public func max<T : Comparable>(x: T, _ y: T) -> T {
   // In case `x == y`, we pick `y`. See min(_:_:).
@@ -72,6 +78,8 @@ public func max<T : Comparable>(x: T, _ y: T) -> T {
 }
 
 /// Returns the greatest argument passed.
+///
+/// If there are multiple equal greatest arguments, returns the last one.
 @warn_unused_result
 public func max<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var maxValue = max(max(x, y), z)

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -46,6 +46,10 @@ public func find<
 /// Returns the lesser of `x` and `y`.
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T) -> T {
+  // In case `x == y` we pick `x`.
+  // This preserves any pre-existing order in case `T` has identity,
+  // which is important for e.g. the stability of sorting algorithms.
+  // `(min(x, y), max(x, y))` should return `(x, y)` in case `x == y`.
   return y < x ? y : x
 }
 
@@ -53,6 +57,7 @@ public func min<T : Comparable>(x: T, _ y: T) -> T {
 @warn_unused_result
 public func min<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var minValue = min(min(x, y), z)
+  // In case `value == minValue`, we pick `minValue`. See min(_:_:).
   for value in rest where value < minValue {
     minValue = value
   }
@@ -62,6 +67,7 @@ public func min<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 /// Returns the greater of `x` and `y`.
 @warn_unused_result
 public func max<T : Comparable>(x: T, _ y: T) -> T {
+  // In case `x == y`, we pick `y`. See min(_:_:).
   return y >= x ? y : x
 }
 
@@ -69,6 +75,7 @@ public func max<T : Comparable>(x: T, _ y: T) -> T {
 @warn_unused_result
 public func max<T : Comparable>(x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var maxValue = max(max(x, y), z)
+  // In case `value == maxValue`, we pick `value`. See min(_:_:).
   for value in rest where value >= maxValue {
     maxValue = value
   }


### PR DESCRIPTION
Refactors `min()` and `max()`:
- Adds a comment about #137.
- Makes `min()` consistent with `max()` changes introduced in #566.
- Removes unnecessary local variable abbreviations.
- Passes `build-script -R -t`

**Important**
Comparing the [generated SIL](https://gist.github.com/PatrickPijnappel/c362aa5fb5dc18a55816), the new version seems to be **worse**. Also, the calls to `min(_:_:)` from `min(_:_:_:_:)` do not appear to be inlined. I'm not sure if this wil still be optimized away, or that I'm invoking the sil generation wrong? I'm using `$ swiftc -O -emit-sil New.swift -o New.sil.c`. If this version is indeed less performant, that would also apply to the changes to `max()` introduced in #566.
