### PR TITLE
[stdlib][performance] skip copying old values during removeAll(keepCapacity: true)

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3393,27 +3393,21 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     }
   }
 
-  internal mutating func nativeRemoveAll() {
-    var nativeStorage = native
-
-    // FIXME(performance): if the storage is non-uniquely referenced, we
-    // shouldn’t be copying the elements into new storage and then immediately
-    // deleting the elements. We should detect that the storage is not uniquely
-    // referenced and allocate new empty storage of appropriate capacity.
+  internal mutating func nativeKeepCapacityRemoveAll() {
 
     // We have already checked for the empty dictionary case, so we will always
     // mutating the dictionary storage.  Request unique storage.
-    let (reallocated, _) = ensureUniqueNativeStorage(nativeStorage.capacity)
-    if reallocated {
-      nativeStorage = native
-    }
 
-    for var b = 0; b != nativeStorage.capacity; ++b {
-      if nativeStorage.isInitializedEntry(b) {
-        nativeStorage.destroyEntryAt(b)
+    if !isUniquelyReferenced() {
+      self = .Native(NativeStorageOwner(minimumCapacity: native.capacity))
+    } else {
+      for b in 0..<native.capacity {
+        if native.isInitializedEntry(b) {
+          native.destroyEntryAt(b)
+        }
       }
     }
-    nativeStorage.count = 0
+    native.count = 0
   }
 
   internal mutating func removeAll(keepCapacity keepCapacity: Bool) {
@@ -3427,13 +3421,13 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     }
 
     if _fastPath(guaranteedNative) {
-      nativeRemoveAll()
+      nativeKeepCapacityRemoveAll()
       return
     }
 
     switch self {
     case .Native:
-      nativeRemoveAll()
+      nativeKeepCapacityRemoveAll()
     case .Cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       self = .Native(NativeStorage.Owner(minimumCapacity: cocoaStorage.count))


### PR DESCRIPTION
(This is a re-submission of #477 with clearer patch and description.)

For `.removeAll(keepCapacity: true)` on a non-uniquely referenced `Dictionary` or `Set`, the existing code implements COW by calling `ensureUniqueNativeStorage()`, which actually copies the content of its storage. Only then the elements get deleted one by one.

A _FIXME(performance)_ comment stated this wastefulness ([benchmark](https://gist.github.com/dduan/279b3a1a83e31cec5ec1) result posted in #477 agrees). A better solution is directly replace the native storage with equal capacity.

_A note on Set:_ As @dabrahams pointed out, `aSet.removeAll()` is the equivalent of `aSet.intersectInPlace([])`. Ideally, `intersectInPlace()`, being the more general case, should be the target for optimization. In successfully doing so, the equivalence in math can be directly realized in code.

In that light, this patch can be treated as solely an optimization for `Dictionary`. The speedup for Set is a side-effect (courtesy of GYP and architect of this file).

Tests in both `swift/validation-test/stdlib/Set.swift` and `./lit swift/validation-test/stdlib/Dictionary.swift` are passing.
