### PR TITLE
[SourceKit] Add test case for crash triggered in swift::constraints::ConstraintSystem::matchDeepEqualityTypes(…)

### DIFF
--- a/validation-test/IDE/crashers/036-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/IDE/crashers/036-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+extension{enum B{enum B{enum S{func c
+let t=c{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 151
swift-ide-test: /path/to/swift/lib/Sema/CSSimplify.cpp:981: ConstraintSystem::SolutionKind swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder): Assertion `(bool)nominal1->getParent() == (bool)nominal2->getParent() && "Mismatched parents of nominal types"' failed.
8  swift-ide-test  0x00000000008e0af8 swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder) + 1000
9  swift-ide-test  0x00000000008e138b swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1019
10 swift-ide-test  0x00000000008dea63 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 10035
11 swift-ide-test  0x00000000008e08a6 swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder) + 406
12 swift-ide-test  0x00000000008e138b swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1019
13 swift-ide-test  0x00000000008dea63 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 10035
14 swift-ide-test  0x00000000008e83ff swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 639
15 swift-ide-test  0x00000000009ae0c7 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
16 swift-ide-test  0x00000000009b0bb1 swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, bool, bool, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, swift::constraints::DependentTypeOpener*) + 3297
17 swift-ide-test  0x00000000009b1527 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 535
18 swift-ide-test  0x00000000008e8501 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 897
19 swift-ide-test  0x00000000009ae0c7 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
20 swift-ide-test  0x00000000009b12a7 swift::constraints::ConstraintSystem::addOverloadSet(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::constraints::ConstraintLocator*, swift::constraints::OverloadChoice*) + 327
21 swift-ide-test  0x00000000008e6a1d swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 605
22 swift-ide-test  0x00000000008e81c5 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 69
23 swift-ide-test  0x00000000009ae0c7 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
28 swift-ide-test  0x0000000000ae792e swift::Expr::walk(swift::ASTWalker&) + 46
29 swift-ide-test  0x00000000008ce5e8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
30 swift-ide-test  0x0000000000918180 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
31 swift-ide-test  0x000000000091e729 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
32 swift-ide-test  0x000000000091f840 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
33 swift-ide-test  0x000000000091f9e9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
40 swift-ide-test  0x0000000000938ba7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
41 swift-ide-test  0x0000000000906602 swift::typeCheckCompletionDecl(swift::Decl*) + 1122
45 swift-ide-test  0x00000000008649b6 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 230
46 swift-ide-test  0x00000000007731b4 swift::CompilerInstance::performSema() + 3316
47 swift-ide-test  0x000000000071c897 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'B' at <INPUT-FILE>:2:18
2.  While type-checking expression at [<INPUT-FILE>:3:7 - line:3:9] RangeText="c{"
```
