### PR TITLE
Allow @objc(Name) on enums

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2333,9 +2333,7 @@ ERROR(objc_setter_for_nonobjc_subscript,sema_tcd,none,
 ERROR(objc_enum_generic,sema_tcd,none,
       "'@objc' enum cannot be generic", ())
 ERROR(objc_name_req_nullary,sema_objc,none,
-      "'@objc' %select{class|protocol|property}0 must have a simple name", (int))
-ERROR(objc_name_enum,sema_objc,none,
-      "'@objc' enum cannot have a name", ())
+      "'@objc' %select{class|protocol|enum|property}0 must have a simple name", (int))
 ERROR(objc_name_subscript,sema_objc,none,
       "'@objc' subscript cannot have a name; did you mean to put "
       "the name on the getter or setter?", ())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5083,8 +5083,9 @@ classifyEnum(clang::Preprocessor &pp, const clang::EnumDecl *decl) {
   auto loc = decl->getLocStart();
   if (loc.isMacroID()) {
     StringRef MacroName = pp.getImmediateMacroName(loc);
-    if (MacroName == "CF_ENUM" || MacroName == "OBJC_ENUM" ||
-        MacroName == "SWIFT_ENUM" || MacroName == "__CF_NAMED_ENUM")
+    if (MacroName == "CF_ENUM" || MacroName == "__CF_NAMED_ENUM" ||
+        MacroName == "OBJC_ENUM" ||
+        MacroName == "SWIFT_ENUM" || MacroName == "SWIFT_ENUM_NAMED")
       return EnumKind::Enum;
     if (MacroName == "CF_OPTIONS" || MacroName == "OBJC_OPTIONS"
         || MacroName == "SWIFT_OPTIONS")

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7033,14 +7033,16 @@ static void validateAttributes(TypeChecker &TC, Decl *D) {
     // If there is a name, check whether the kind of name is
     // appropriate.
     if (auto objcName = objcAttr->getName()) {
-      if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D) || isa<VarDecl>(D)) {
+      if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D) || isa<EnumDecl>(D) ||
+          isa<VarDecl>(D)) {
         // Types and properties can only have nullary
         // names. Complain and recover by chopping off everything
         // after the first name.
         if (objcName->getNumArgs() > 0) {
-          int which = isa<ClassDecl>(D)? 0 
+          int which = isa<ClassDecl>(D)? 0
                     : isa<ProtocolDecl>(D)? 1
-                    : 2;
+                    : isa<EnumDecl>(D)? 2
+                    : 3;
           SourceLoc firstNameLoc = objcAttr->getNameLocs().front();
           SourceLoc afterFirstNameLoc = 
             Lexer::getLocForEndOfToken(TC.Context.SourceMgr, firstNameLoc);
@@ -7050,10 +7052,6 @@ static void validateAttributes(TypeChecker &TC, Decl *D) {
             ObjCSelector(TC.Context, 0, objcName->getSelectorPieces()[0]),
             /*implicit=*/false);
         }
-      } else if (isa<EnumDecl>(D)) {
-        // Enums don't have runtime names.
-        TC.diagnose(objcAttr->getLParenLoc(), diag::objc_name_enum);
-        const_cast<ObjCAttr *>(objcAttr)->clearName();
       } else if (isa<SubscriptDecl>(D)) {
         // Subscripts can never have names.
         TC.diagnose(objcAttr->getLParenLoc(), diag::objc_name_subscript);

--- a/test/ClangModules/Inputs/enum-objc.h
+++ b/test/ClangModules/Inputs/enum-objc.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+#define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
+#define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); enum SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_EXTRA _name : _type
+
+typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnum, "SwiftEnum") {
+    ObjCEnumOne = 1,
+    ObjCEnumTwo,
+    ObjCEnumThree
+};

--- a/test/ClangModules/MixedSource/Inputs/resolve-cross-language/Base.swift
+++ b/test/ClangModules/MixedSource/Inputs/resolve-cross-language/Base.swift
@@ -21,7 +21,14 @@ extension BaseClass {
   case Zung
 }
 
+@objc(RenamedEnum) public enum SwiftEnum: CShort {
+  case Quux
+  case Corge
+  case Grault
+}
+
 @objc public class AnotherClass {
   @objc public func getEnum() -> BaseEnum { return .Zung }
+  @objc public func getSwiftEnum() -> SwiftEnum { return .Quux }
   public init() {}
 }

--- a/test/ClangModules/MixedSource/Inputs/resolve-cross-language/BaseUser.framework/Headers/BaseUser.h
+++ b/test/ClangModules/MixedSource/Inputs/resolve-cross-language/BaseUser.framework/Headers/BaseUser.h
@@ -13,6 +13,7 @@ void useBaseProtoObjC(id <BaseProto>);
 @interface BaseClass (ObjCExtensions)
 - (void)categoryMethod;
 - (BaseEnum)baseEnumMethod:(BaseEnum)be;
+- (RenamedEnum)renamedEnumMethod:(RenamedEnum)se;
 @end
 
 typedef OBJC_ENUM(unsigned char, BaseEnumObjC) {
@@ -27,8 +28,29 @@ void useBaseEnum(BaseEnum);
 BaseEnumObjC getBaseEnumObjC();
 void useBaseEnumObjC(BaseEnumObjC);
 
+// temporarily redefine OBJC_ENUM because ClangImporter cares about the macro name
+#undef OBJC_ENUM
+#define OBJC_ENUM(_type, _name, SWIFT_NAME) enum _name : _type _name __attribute__((swift_name(SWIFT_NAME))); enum __attribute__((swift_name(SWIFT_NAME))) _name : _type
+
+typedef OBJC_ENUM(unsigned char, RenamedEnumObjC, "SwiftEnumObjC") {
+  RenamedEnumObjCQuux = RenamedEnumQuux,
+  RenamedEnumObjCCorge = RenamedEnumCorge,
+  RenamedEnumObjCGrault = RenamedEnumGrault,
+};
+
+// put OBJC_ENUM back just in case
+#undef OBJC_ENUM
+#define OBJC_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
+
+RenamedEnum getRenamedEnum();
+void useRenamedEnum(RenamedEnum);
+
+RenamedEnumObjC getRenamedEnumObjC();
+void useRenamedEnumObjC(RenamedEnumObjC);
+
 @protocol EnumProto
 - (BaseEnum)getEnum;
+- (RenamedEnum)getSwiftEnum;
 @end
 
 @interface AnotherClass (EnumProtoConformance) <EnumProto>

--- a/test/ClangModules/MixedSource/resolve-cross-language.swift
+++ b/test/ClangModules/MixedSource/resolve-cross-language.swift
@@ -20,6 +20,12 @@ be = getBaseClass().baseEnumMethod(be)
 be = AnotherClass().getEnum()
 var beo: BaseEnumObjC = getBaseEnumObjC()
 useBaseEnumObjC(beo)
+var se: SwiftEnum = getRenamedEnum()
+useRenamedEnum(se)
+se = getBaseClass().renamedEnumMethod(se)
+se = AnotherClass().getSwiftEnum()
+var seo: SwiftEnumObjC = getRenamedEnumObjC()
+useRenamedEnumObjC(seo)
 
 // Check type resolution.
 useBaseClass(getBaseClassObjC())
@@ -43,6 +49,18 @@ beo = BaseEnumObjC.Doo
 beo = BaseEnumObjC.Dah
 
 var beoRaw: CUnsignedChar = beo.rawValue
+
+se = SwiftEnum.Quux
+se = SwiftEnum.Corge
+se = SwiftEnum.Grault
+
+var seRaw: CShort = se.rawValue
+
+seo = SwiftEnumObjC.Quux
+seo = SwiftEnumObjC.Corge
+seo = SwiftEnumObjC.Grault
+
+var seoRaw: CUnsignedChar = seo.rawValue
 
 // Make sure we're actually parsing stuff.
 useBaseClass() // expected-error{{missing argument for parameter #1}}

--- a/test/ClangModules/enum-objc.swift
+++ b/test/ClangModules/enum-objc.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/enum-objc.h -verify
+
+// REQUIRES: objc_interop
+
+func test(value: SwiftEnum) {
+    switch value {
+    case .One: break
+    case .Two: break
+    case .Three: break
+    } // no error
+}

--- a/test/Parse/objc_enum.swift
+++ b/test/Parse/objc_enum.swift
@@ -8,7 +8,7 @@
   case Zim, Zang, Zung
 }
 
-@objc(EnumRuntimeName) enum RuntimeNamed: Int { // expected-error{{'@objc' enum cannot have a name}}
+@objc(EnumRuntimeName) enum RuntimeNamed: Int {
   case Zim, Zang, Zung
 }
 

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -26,6 +26,16 @@ import Foundation
   @objc func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
 }
 
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {
+// CHECK-NEXT:   ObjcEnumNamedA = 0,
+// CHECK-NEXT:   ObjcEnumNamedB = 1,
+// CHECK-NEXT:   ObjcEnumNamedC = 2,
+// CHECK-NEXT: };
+
+@objc(ObjcEnumNamed) enum EnumNamed: Int {
+  case A, B, C
+}
+
 // CHECK-LABEL: typedef SWIFT_ENUM(unsigned int, ExplicitValues) {
 // CHECK-NEXT:   ExplicitValuesZim = 0,
 // CHECK-NEXT:   ExplicitValuesZang = 219,

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1749,6 +1749,9 @@ class BadClass1 { }
 @objc(Protocol:) // expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
 protocol BadProto1 { }
 
+@objc(Enum:) // expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
+enum BadEnum1: Int { case X }
+
 class BadClass2 {
   @objc(badprop:foo:wibble:) // expected-error{{'@objc' property must have a simple name}}{{16-28=}}
   var badprop: Int = 5


### PR DESCRIPTION
This implements support for

``` swift
@objc(ObjCEnum) enum SwiftEnum : Int {
    case One = 1, Two, Three
}
```

A new macro for the generated header is defined called `SWIFT_ENUM_NAMED` and the above declaration looks like

``` objc
typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnum, "SwiftEnum") {
    ObjCEnumOne = 1,
    ObjCEnumTwo = 2,
    ObjCEnumThree = 3,
};
```

Since `swift_name` doesn't actually work properly yet when importing Obj-C enums, there's an XFAILed test that tests the clang importer here.

This does NOT cover support for `@objc(Name)` on the individual `case` declarations.
