### PR TITLE
Propagate ErrorType when checking subscript decls

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3371,7 +3371,10 @@ void SubscriptDecl::setIndices(Pattern *p) {
 }
 
 Type SubscriptDecl::getIndicesType() const {
-  return getType()->castTo<AnyFunctionType>()->getInput();
+  const auto type = getType();
+  if (type->is<ErrorType>())
+    return type;
+  return type->castTo<AnyFunctionType>()->getInput();
 }
 
 Type SubscriptDecl::getIndicesInterfaceType() const {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2987,6 +2987,9 @@ bool TypeChecker::isRepresentableInObjC(const SubscriptDecl *SD,
     if (TupleTy->getNumElements() == 1 && !TupleTy->getElement(0).isVararg())
       IndicesType = TupleTy->getElementType(0);
   }
+  
+  if (IndicesType->is<ErrorType>())
+    return false;
 
   bool IndicesResult = isRepresentableInObjC(SD->getDeclContext(), IndicesType);
   bool ElementResult = isRepresentableInObjC(SD->getDeclContext(),

--- a/validation-test/compiler_crashers_fixed/24670-isunknownobjecttype.swift
+++ b/validation-test/compiler_crashers_fixed/24670-isunknownobjecttype.swift
@@ -1,7 +1,7 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-{@objc protocol P{subscript(t:String)->S
+@objc protocol a{subscript(t)->a

--- a/validation-test/compiler_crashers_fixed/27787-swift-typechecker-overapproximateosversionsatlocation.swift
+++ b/validation-test/compiler_crashers_fixed/27787-swift-typechecker-overapproximateosversionsatlocation.swift
@@ -1,7 +1,7 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-@objc protocol a{subscript(t)->a
+{@objc protocol P{subscript(t:String)->S


### PR DESCRIPTION
Fixes a couple compiler_crashers.
