### PR TITLE
More error checking for member type lookup

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2313,9 +2313,12 @@ static Type getMemberForBaseType(Module *module,
   // If the parent is an archetype, extract the child archetype with the
   // given name.
   if (auto archetypeParent = substBase->getAs<ArchetypeType>()) {
-    if (!archetypeParent->hasNestedType(name) &&
-        archetypeParent->getParent()->isSelfDerived()) {
-      return archetypeParent->getParent()->getNestedTypeValue(name);
+    if (!archetypeParent->hasNestedType(name)) {
+      const auto parent = archetypeParent->getParent();
+      if (!parent)
+        return ErrorType::get(module->getASTContext());
+      if (parent->isSelfDerived())
+        return parent->getNestedTypeValue(name);
     }
     
     return archetypeParent->getNestedTypeValue(name);

--- a/validation-test/IDE/crashers/018-swift-type-transform.swift
+++ b/validation-test/IDE/crashers/018-swift-type-transform.swift
@@ -1,6 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-protocol A{
-typealias e
-class A{let A{
-protocol A{typealias f=e
-#^A^#

--- a/validation-test/IDE/crashers_fixed/018-swift-type-transform.swift
+++ b/validation-test/IDE/crashers_fixed/018-swift-type-transform.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol A{
+typealias e
+class A{let A{
+protocol A{typealias f=e
+#^A^#

--- a/validation-test/compiler_crashers_fixed/00647-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/00647-std-function-func-swift-type-subst.swift
@@ -1,11 +1,13 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol P{
-typealias e func f:P
-protocol P{
-func f:e
-typealias a
+protocol P {
+protocol A {
+static let c: B<T>)
+}
+func g: A? = .Type) -> {
+let c(("
+typealias B()

--- a/validation-test/compiler_crashers_fixed/01487-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01487-std-function-func-swift-type-subst.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/02030-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/02030-std-function-func-swift-type-subst.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers_fixed/24531-swift-metatypetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/24531-swift-metatypetype-get.swift
@@ -1,8 +1,10 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol A{protocol P{let t:e}let:P
+protocol P{protocol P{class b:e
+let t:e}
 typealias e
+func b:P

--- a/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/zneak (zneak)

--- a/validation-test/compiler_crashers_fixed/25488-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/25488-std-function-func-swift-type-subst.swift
@@ -1,10 +1,8 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol P{protocol P{class b:e
-let t:e}
+protocol A{protocol P{let t:e}let:P
 typealias e
-func b:P

--- a/validation-test/compiler_crashers_fixed/27169-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers_fixed/27169-swift-typechecker-validategenericfuncsignature.swift
@@ -1,13 +1,11 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol P {
-protocol A {
-static let c: B<T>)
-}
-func g: A? = .Type) -> {
-let c(("
-typealias B()
+protocol P{
+typealias e func f:P
+protocol P{
+func f:e
+typealias a


### PR DESCRIPTION
Fixes a couple compiler_crashers and an IDE crasher.
