### PR TITLE
Fix shebang lines in python scripts

### DIFF
--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, re, subprocess
 
 def run():

--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Emulates the frontend of an -embed-bitcode job. That means we have to handle
 # -emit-bc and -c actions.

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Emulates the frontend of a -whole-module-optimization compilation.
 

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # modify-non-primary-files.py simulates a build where the user is modifying the
 # source files during compilation.

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Fails if the input file is named "bad.swift"; otherwise dispatches to
 # update-dependencies.py.
@@ -12,7 +12,7 @@ primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
 
 if os.path.basename(primaryFile) == 'bad.swift':
     print "Handled", os.path.basename(primaryFile)
-    exit(1)
+    sys.exit(1)
 
 dir = os.path.dirname(os.path.abspath(__file__))
 execfile(os.path.join(dir, "update-dependencies.py"))

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # update-dependencies.py simulates a Swift compilation for the purposes of
 # dependency analysis. That means it has two tasks:

--- a/test/Inputs/getmtime.py
+++ b/test/Inputs/getmtime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #===--- apply-fixit-edits.py - Tool for applying edits from .remap files ---===#
 #

--- a/utils/demo-tool
+++ b/utils/demo-tool
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import optparse

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Note: it doesn't matter what directory you invoke this in; it uses
 # your SWIFT_BUILD_ROOT and SWIFT_SOURCE_ROOT settings, just like

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import os.path

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Utility script for submitting benchmark results to an LNT server.

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # A script for viewing the CFG of SIL and llvm IR.
 


### PR DESCRIPTION
The statement `print "..."` can only be used in python 2, not python 3 (python 3 uses `print()`). This makes sure that the files are executed with python 2 and not python 3 because some users may have python 3 as their default.
