### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::resolveTypeInContext(…)

### DIFF
--- a/validation-test/IDE/crashers/037-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/IDE/crashers/037-swift-typechecker-resolvetypeincontext.swift
@@ -1,0 +1,5 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+A{extension{
+class A{func c
+var d=c let t{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 147
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckType.cpp:299: swift::Type swift::TypeChecker::resolveTypeInContext(swift::TypeDecl *, swift::DeclContext *, TypeResolutionOptions, bool, swift::GenericTypeResolver *, UnsatisfiedDependency *): Assertion `ownerNominal && "Owner must be a nominal type"' failed.
8  swift-ide-test  0x000000000097e62c swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1660
12 swift-ide-test  0x000000000097ee1e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift-ide-test  0x000000000097fd64 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
18 swift-ide-test  0x0000000000ae049e swift::Expr::walk(swift::ASTWalker&) + 46
19 swift-ide-test  0x00000000008c6fa8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
20 swift-ide-test  0x0000000000910b10 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
21 swift-ide-test  0x00000000009170b9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
22 swift-ide-test  0x00000000009181d0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
23 swift-ide-test  0x0000000000918379 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
28 swift-ide-test  0x0000000000931a47 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
29 swift-ide-test  0x00000000008ff0e2 swift::typeCheckCompletionDecl(swift::Decl*) + 1122
45 swift-ide-test  0x0000000000ae0864 swift::Decl::walk(swift::ASTWalker&) + 20
46 swift-ide-test  0x0000000000b6a4ee swift::SourceFile::walk(swift::ASTWalker&) + 174
47 swift-ide-test  0x0000000000b6971f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
48 swift-ide-test  0x0000000000b43882 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
49 swift-ide-test  0x000000000085ca3d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
50 swift-ide-test  0x000000000076b914 swift::CompilerInstance::performSema() + 3316
51 swift-ide-test  0x00000000007150b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x50160f0 at <INPUT-FILE>:2:1
2.  While type-checking 'A' at <INPUT-FILE>:3:1
3.  While type-checking expression at [<INPUT-FILE>:4:7 - line:4:7] RangeText="c"
4.  While resolving type A at [<INPUT-FILE>:4:7 - line:4:7] RangeText="c"
```
