### PR TITLE
Fix grammar of variable

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -673,10 +673,10 @@ case BuiltinValueKind::id:
       return nullptr;
     APFloat TruncVal = V->getValue();
     Type DestTy = Builtin.Types[1];
-    bool loosesInfo;
+    bool losesInfo;
     APFloat::opStatus ConversionStatus = TruncVal.convert(
         DestTy->castTo<BuiltinFloatType>()->getAPFloatSemantics(),
-        APFloat::rmNearestTiesToEven, &loosesInfo);
+        APFloat::rmNearestTiesToEven, &losesInfo);
     SILLocation Loc = BI->getLoc();
 
     // Check if conversion was successful.


### PR DESCRIPTION
Fix grammar of variable to match method signature of [APFloat::convert](http://llvm.org/docs/doxygen/html/classllvm_1_1APFloat.html#a4fa2f1464bb4f645082d8aa0e0a9bc0e).
