### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseSILVTable()

### DIFF
--- a/validation-test/SIL/crashers/001-swift-parser-parsesilvtable.sil
+++ b/validation-test/SIL/crashers/001-swift-parser-parsesilvtable.sil
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-sil-opt %s
+sil_vtable i


### PR DESCRIPTION
I've started fuzzing Swift SIL optimizer. This is my first crash :-)

Stack trace:

```
sil-opt: /path/to/swift/lib/Parse/ParseSIL.cpp:790: llvm::PointerUnion<ValueDecl *, Module *> lookupTopDecl(swift::Parser &, swift::Identifier): Assertion `DeclLookup.isSuccess() && DeclLookup.Results.size() == 1' failed.
9  sil-opt         0x0000000000a24740 swift::Parser::parseSILVTable() + 640
10 sil-opt         0x00000000009f38d3 swift::Parser::parseTopLevel() + 707
11 sil-opt         0x00000000009eecbb swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 107
12 sil-opt         0x0000000000738ad6 swift::CompilerInstance::performSema() + 2918
13 sil-opt         0x000000000072373c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:2:13
```
