### PR TITLE
Add getGenericSignature() helper method to ArchetypeBuilder

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -251,6 +251,14 @@ public:
   bool addGenericSignature(GenericSignature *sig, bool adoptArchetypes,
                            bool treatRequirementsAsExplicit = false);
 
+  /// \brief Get a generic signature based on the provided complete list
+  /// of generic parameter types.
+  ///
+  /// \returns a generic signature build based on the provided list of
+  ///          generic parameter types.
+  GenericSignature *
+  getGenericSignature(ArrayRef<GenericTypeParamType *> genericParamsTypes);
+
   /// Infer requirements from the given type, recursively.
   ///
   /// This routine infers requirements from a type that occurs within the

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1845,3 +1845,169 @@ bool ArchetypeBuilder::addGenericSignature(GenericSignature *sig,
 Type ArchetypeBuilder::substDependentType(Type type) {
   return substConcreteTypesForDependentTypes(*this, type);
 }
+
+/// Add the requirements for the given potential archetype and its nested
+/// potential archetypes to the set of requirements.
+static void
+addRequirements(
+    Module &mod, Type type,
+    ArchetypeBuilder::PotentialArchetype *pa,
+    llvm::SmallPtrSet<ArchetypeBuilder::PotentialArchetype *, 16> &knownPAs,
+    SmallVectorImpl<Requirement> &requirements) {
+  // If the potential archetype has been bound away to a concrete type,
+  // it needs no requirements.
+  if (pa->isConcreteType())
+    return;
+
+  // Add a value witness marker.
+  requirements.push_back(Requirement(RequirementKind::WitnessMarker,
+                                     type, Type()));
+
+  // Add superclass requirement, if needed.
+  if (auto superclass = pa->getSuperclass()) {
+    // FIXME: Distinguish superclass from conformance?
+    // FIXME: What if the superclass type involves a type parameter?
+    requirements.push_back(Requirement(RequirementKind::Conformance,
+                                       type, superclass));
+  }
+
+  // Add conformance requirements.
+  SmallVector<ProtocolDecl *, 4> protocols;
+  for (const auto &conforms : pa->getConformsTo()) {
+    protocols.push_back(conforms.first);
+  }
+
+  ProtocolType::canonicalizeProtocols(protocols);
+  for (auto proto : protocols) {
+    requirements.push_back(Requirement(RequirementKind::Conformance,
+                                       type, proto->getDeclaredType()));
+  }
+}
+
+static void
+addNestedRequirements(
+    Module &mod, Type type,
+    ArchetypeBuilder::PotentialArchetype *pa,
+    llvm::SmallPtrSet<ArchetypeBuilder::PotentialArchetype *, 16> &knownPAs,
+    SmallVectorImpl<Requirement> &requirements) {
+  using PotentialArchetype = ArchetypeBuilder::PotentialArchetype;
+
+  // Collect the nested types, sorted by name.
+  // FIXME: Could collect these from the conformance requirements, above.
+  SmallVector<std::pair<Identifier, PotentialArchetype*>, 16> nestedTypes;
+  for (const auto &nested : pa->getNestedTypes()) {
+    // FIXME: Dropping requirements among different associated types of the
+    // same name.
+    nestedTypes.push_back(std::make_pair(nested.first, nested.second.front()));
+  }
+  std::sort(nestedTypes.begin(), nestedTypes.end(),
+            OrderPotentialArchetypeByName());
+
+  // Add requirements for associated types.
+  for (const auto &nested : nestedTypes) {
+    auto rep = nested.second->getRepresentative();
+    if (knownPAs.insert(rep).second) {
+      // Form the dependent type that refers to this archetype.
+      auto assocType = nested.second->getResolvedAssociatedType();
+      if (!assocType)
+        continue; // FIXME: If we do this late enough, there will be no failure.
+
+      // Skip nested types bound to concrete types.
+      if (rep->isConcreteType())
+        continue;
+
+      auto nestedType = DependentMemberType::get(type, assocType,
+                                                 mod.getASTContext());
+
+      addRequirements(mod, nestedType, rep, knownPAs, requirements);
+      addNestedRequirements(mod, nestedType, rep, knownPAs, requirements);
+    }
+  }
+}
+
+
+/// Collect the set of requirements placed on the given generic parameters and
+/// their associated types.
+static void collectRequirements(ArchetypeBuilder &builder,
+                                ArrayRef<GenericTypeParamType *> params,
+                                SmallVectorImpl<Requirement> &requirements) {
+  typedef ArchetypeBuilder::PotentialArchetype PotentialArchetype;
+
+  // Find the "primary" potential archetypes, from which we'll collect all
+  // of the requirements.
+  llvm::SmallPtrSet<PotentialArchetype *, 16> knownPAs;
+  llvm::SmallVector<GenericTypeParamType *, 8> primary;
+  for (auto param : params) {
+    auto pa = builder.resolveArchetype(param);
+    assert(pa && "Missing potential archetype for generic parameter");
+
+    // We only care about the representative.
+    pa = pa->getRepresentative();
+
+    if (knownPAs.insert(pa).second)
+      primary.push_back(param);
+  }
+
+  // Add all of the conformance and superclass requirements placed on the given
+  // generic parameters and their associated types.
+  unsigned primaryIdx = 0, numPrimary = primary.size();
+  while (primaryIdx < numPrimary) {
+    unsigned depth = primary[primaryIdx]->getDepth();
+
+    // For each of the primary potential archetypes, add the requirements.
+    // Stop when we hit a parameter at a different depth.
+    // FIXME: This algorithm falls out from the way the "all archetypes" lists
+    // are structured. Once those lists no longer exist or are no longer
+    // "the truth", we can simplify this algorithm considerably.
+    unsigned lastPrimaryIdx = primaryIdx;
+    for (unsigned idx = primaryIdx;
+         idx < numPrimary && primary[idx]->getDepth() == depth;
+         ++idx, ++lastPrimaryIdx) {
+      auto param = primary[idx];
+      auto pa = builder.resolveArchetype(param)->getRepresentative();
+
+      // Add other requirements.
+      addRequirements(builder.getModule(), param, pa, knownPAs,
+                      requirements);
+    }
+
+    // For each of the primary potential archetypes, add the nested requirements.
+    for (unsigned idx = primaryIdx; idx < lastPrimaryIdx; ++idx) {
+      auto param = primary[idx];
+      auto pa = builder.resolveArchetype(param)->getRepresentative();
+      addNestedRequirements(builder.getModule(), param, pa, knownPAs,
+                            requirements);
+    }
+
+    primaryIdx = lastPrimaryIdx;
+  }
+
+
+  // Add all of the same-type requirements.
+  for (auto req : builder.getSameTypeRequirements()) {
+    auto firstType = req.first->getDependentType(builder, false);
+    Type secondType;
+    if (auto concrete = req.second.dyn_cast<Type>())
+      secondType = concrete;
+    else if (auto secondPA = req.second.dyn_cast<PotentialArchetype*>())
+      secondType = secondPA->getDependentType(builder, false);
+
+    if (firstType->is<ErrorType>() || secondType->is<ErrorType>() ||
+        firstType->isEqual(secondType))
+      continue;
+
+    requirements.push_back(Requirement(RequirementKind::SameType,
+                                       firstType, secondType));
+  }
+}
+
+GenericSignature *ArchetypeBuilder::getGenericSignature(
+    ArrayRef<GenericTypeParamType *> genericParamTypes) {
+  // Collect the requirements placed on the generic parameter types.
+  SmallVector<Requirement, 4> requirements;
+  collectRequirements(*this, genericParamTypes, requirements);
+
+  auto sig = GenericSignature::get(genericParamTypes, requirements);
+  return sig;
+}
+

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -363,186 +363,6 @@ static void collectGenericParamTypes(
   }
 }
 
-namespace {
-  /// \brief Function object that orders potential archetypes by name.
-  struct OrderPotentialArchetypeByName {
-    using PotentialArchetype = ArchetypeBuilder::PotentialArchetype;
-
-    bool operator()(std::pair<Identifier, PotentialArchetype *> X,
-                    std::pair<Identifier, PotentialArchetype *> Y) const {
-      return X.first.str() < Y.second->getName().str();
-    }
-
-    bool operator()(std::pair<Identifier, PotentialArchetype *> X,
-                    Identifier Y) const {
-      return X.first.str() < Y.str();
-    }
-
-    bool operator()(Identifier X,
-                    std::pair<Identifier, PotentialArchetype *> Y) const {
-      return X.str() < Y.first.str();
-    }
-
-    bool operator()(Identifier X, Identifier Y) const {
-      return X.str() < Y.str();
-    }
-  };
-}
-
-/// Add the requirements for the given potential archetype and its nested
-/// potential archetypes to the set of requirements.
-static void
-addRequirements(
-    Module &mod, Type type,
-    ArchetypeBuilder::PotentialArchetype *pa,
-    llvm::SmallPtrSet<ArchetypeBuilder::PotentialArchetype *, 16> &knownPAs,
-    SmallVectorImpl<Requirement> &requirements) {
-  // If the potential archetype has been bound away to a concrete type,
-  // it needs no requirements.
-  if (pa->isConcreteType())
-    return;
-  
-  // Add a value witness marker.
-  requirements.push_back(Requirement(RequirementKind::WitnessMarker,
-                                     type, Type()));
-
-  // Add superclass requirement, if needed.
-  if (auto superclass = pa->getSuperclass()) {
-    // FIXME: Distinguish superclass from conformance?
-    // FIXME: What if the superclass type involves a type parameter?
-    requirements.push_back(Requirement(RequirementKind::Conformance,
-                                       type, superclass));
-  }
-
-  // Add conformance requirements.
-  SmallVector<ProtocolDecl *, 4> protocols;
-  for (const auto &conforms : pa->getConformsTo()) {
-    protocols.push_back(conforms.first);
-  }
-
-  ProtocolType::canonicalizeProtocols(protocols);
-  for (auto proto : protocols) {
-    requirements.push_back(Requirement(RequirementKind::Conformance,
-                                       type, proto->getDeclaredType()));
-  }
-}
-
-static void
-addNestedRequirements(
-    Module &mod, Type type,
-    ArchetypeBuilder::PotentialArchetype *pa,
-    llvm::SmallPtrSet<ArchetypeBuilder::PotentialArchetype *, 16> &knownPAs,
-    SmallVectorImpl<Requirement> &requirements) {
-  using PotentialArchetype = ArchetypeBuilder::PotentialArchetype;
-
-  // Collect the nested types, sorted by name.
-  // FIXME: Could collect these from the conformance requirements, above.
-  SmallVector<std::pair<Identifier, PotentialArchetype*>, 16> nestedTypes;
-  for (const auto &nested : pa->getNestedTypes()) {
-    // FIXME: Dropping requirements among different associated types of the
-    // same name.
-    nestedTypes.push_back(std::make_pair(nested.first, nested.second.front()));
-  }
-  std::sort(nestedTypes.begin(), nestedTypes.end(),
-            OrderPotentialArchetypeByName());
-
-  // Add requirements for associated types.
-  for (const auto &nested : nestedTypes) {
-    auto rep = nested.second->getRepresentative();
-    if (knownPAs.insert(rep).second) {
-      // Form the dependent type that refers to this archetype.
-      auto assocType = nested.second->getResolvedAssociatedType();
-      if (!assocType)
-        continue; // FIXME: If we do this late enough, there will be no failure.
-
-      // Skip nested types bound to concrete types.
-      if (rep->isConcreteType())
-        continue;
-
-      auto nestedType = DependentMemberType::get(type, assocType,
-                                                 mod.getASTContext());
-
-      addRequirements(mod, nestedType, rep, knownPAs, requirements);
-      addNestedRequirements(mod, nestedType, rep, knownPAs, requirements);
-    }
-  }
-}
-
-/// Collect the set of requirements placed on the given generic parameters and
-/// their associated types.
-static void collectRequirements(ArchetypeBuilder &builder,
-                                ArrayRef<GenericTypeParamType *> params,
-                                SmallVectorImpl<Requirement> &requirements) {
-  typedef ArchetypeBuilder::PotentialArchetype PotentialArchetype;
-
-  // Find the "primary" potential archetypes, from which we'll collect all
-  // of the requirements.
-  llvm::SmallPtrSet<PotentialArchetype *, 16> knownPAs;
-  llvm::SmallVector<GenericTypeParamType *, 8> primary;
-  for (auto param : params) {
-    auto pa = builder.resolveArchetype(param);
-    assert(pa && "Missing potential archetype for generic parameter");
-
-    // We only care about the representative.
-    pa = pa->getRepresentative();
-
-    if (knownPAs.insert(pa).second)
-      primary.push_back(param);
-  }
-
-  // Add all of the conformance and superclass requirements placed on the given
-  // generic parameters and their associated types.
-  unsigned primaryIdx = 0, numPrimary = primary.size();
-  while (primaryIdx < numPrimary) {
-    unsigned depth = primary[primaryIdx]->getDepth();
-
-    // For each of the primary potential archetypes, add the requirements.
-    // Stop when we hit a parameter at a different depth.
-    // FIXME: This algorithm falls out from the way the "all archetypes" lists
-    // are structured. Once those lists no longer exist or are no longer
-    // "the truth", we can simplify this algorithm considerably.
-    unsigned lastPrimaryIdx = primaryIdx;
-    for (unsigned idx = primaryIdx;
-         idx < numPrimary && primary[idx]->getDepth() == depth;
-         ++idx, ++lastPrimaryIdx) {
-      auto param = primary[idx];
-      auto pa = builder.resolveArchetype(param)->getRepresentative();
-
-      // Add other requirements.
-      addRequirements(builder.getModule(), param, pa, knownPAs,
-                      requirements);
-    }
-
-    // For each of the primary potential archetypes, add the nested requirements.
-    for (unsigned idx = primaryIdx; idx < lastPrimaryIdx; ++idx) {
-      auto param = primary[idx];
-      auto pa = builder.resolveArchetype(param)->getRepresentative();
-      addNestedRequirements(builder.getModule(), param, pa, knownPAs,
-                            requirements);
-    }
-
-    primaryIdx = lastPrimaryIdx;
-  }
-
-
-  // Add all of the same-type requirements.
-  for (auto req : builder.getSameTypeRequirements()) {
-    auto firstType = req.first->getDependentType(builder, false);
-    Type secondType;
-    if (auto concrete = req.second.dyn_cast<Type>())
-      secondType = concrete;
-    else if (auto secondPA = req.second.dyn_cast<PotentialArchetype*>())
-      secondType = secondPA->getDependentType(builder, false);
-
-    if (firstType->is<ErrorType>() || secondType->is<ErrorType>() ||
-        firstType->isEqual(secondType))
-      continue;
-
-    requirements.push_back(Requirement(RequirementKind::SameType,
-                                       firstType, secondType));
-  }
-}
-
 /// Check the signature of a generic function.
 static bool checkGenericFuncSignature(TypeChecker &tc,
                                       ArchetypeBuilder *builder,
@@ -675,12 +495,8 @@ bool TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
                            func->getDeclContext(),
                            allGenericParams);
 
-  // Collect the requirements placed on the generic parameter types.
-  SmallVector<Requirement, 4> requirements;
-  collectRequirements(builder, allGenericParams, requirements);
-  
-  auto sig = GenericSignature::get(allGenericParams, requirements);
-  
+  auto sig = builder.getGenericSignature(allGenericParams);
+
   // Debugging of the archetype builder and generic signature generation.
   if (sig && Context.LangOpts.DebugGenericSignatures) {
     func->dumpRef(llvm::errs());
@@ -910,14 +726,8 @@ GenericSignature *TypeChecker::validateGenericSignature(
   SmallVector<GenericTypeParamType *, 4> allGenericParams;
   collectGenericParamTypes(genericParams, dc, allGenericParams);
 
-  // Collect the requirements placed on the generic parameter types.
-  // FIXME: This ends up copying all of the requirements from outer scopes,
-  // which is mostly harmless (but quite annoying).
-  SmallVector<Requirement, 4> requirements;
-  collectRequirements(builder, allGenericParams, requirements);
-
   // Record the generic type parameter types and the requirements.
-  auto sig = GenericSignature::get(allGenericParams, requirements);
+  auto sig = builder.getGenericSignature(allGenericParams);
 
   // Debugging of the archetype builder and generic signature generation.
   if (Context.LangOpts.DebugGenericSignatures) {


### PR DESCRIPTION
This is just a small re-factoring moving some code around to make it possible for an ArchetypeBuilder to create a generic signature based on a provided list of generic parameter types and a set of archetype and requirements already known to the builder.
