### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::getDeclTypeForMangling(…)

### DIFF
--- a/validation-test/IDE/crashers/038-swift-mangle-mangler-getdecltypeformangling.swift
+++ b/validation-test/IDE/crashers/038-swift-mangle-mangler-getdecltypeformangling.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+struct a<T{var d{enum b{func c{func b{#^A^#class A


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 143
4  swift-ide-test  0x0000000000b5efd9 swift::Mangle::Mangler::getDeclTypeForMangling(swift::ValueDecl const*, llvm::ArrayRef<swift::GenericTypeParamType*>&, unsigned int&, llvm::ArrayRef<swift::Requirement>&, llvm::SmallVectorImpl<swift::Requirement>&) + 665
5  swift-ide-test  0x0000000000b5ebc4 swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 116
6  swift-ide-test  0x0000000000b5bda1 swift::Mangle::Mangler::mangleEntity(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 417
7  swift-ide-test  0x0000000000b5b8d0 swift::Mangle::Mangler::mangleNominalType(swift::NominalTypeDecl const*, swift::ResilienceExpansion, swift::Mangle::Mangler::BindGenerics, swift::CanGenericSignature, swift::GenericParamList const*) + 256
8  swift-ide-test  0x0000000000b9a322 swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 722
10 swift-ide-test  0x0000000000773808 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
11 swift-ide-test  0x0000000000773f88 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
15 swift-ide-test  0x0000000000b5619b swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 555
22 swift-ide-test  0x0000000000ae0b44 swift::Decl::walk(swift::ASTWalker&) + 20
23 swift-ide-test  0x0000000000b6a7ce swift::SourceFile::walk(swift::ASTWalker&) + 174
24 swift-ide-test  0x0000000000b699ff swift::ModuleDecl::walk(swift::ASTWalker&) + 79
25 swift-ide-test  0x0000000000b43b62 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
26 swift-ide-test  0x000000000085ca3d swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 61
27 swift-ide-test  0x000000000076b914 swift::CompilerInstance::performSema() + 3316
28 swift-ide-test  0x00000000007150b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'a' at <INPUT-FILE>:2:1
```
