### PR TITLE
[SIL] Add test case for crash triggered in swift::performNameBinding(…)

### DIFF
--- a/validation-test/SIL/crashers/002-swift-performnamebinding.sil
+++ b/validation-test/SIL/crashers/002-swift-performnamebinding.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+import Builtin.I


### PR DESCRIPTION
Stack trace:

```
sil-opt: /path/to/swift/lib/Sema/NameBinding.cpp:196: void (anonymous namespace)::NameBinder::addImport(SmallVectorImpl<std::pair<ImportedModule, ImportOptions> > &, swift::ImportDecl *): Assertion `topLevelModule && "top-level module missing"' failed.
8  sil-opt         0x0000000000a5ae29 swift::performNameBinding(swift::SourceFile&, unsigned int) + 6969
9  sil-opt         0x0000000000a63a37 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 55
10 sil-opt         0x0000000000738af2 swift::CompilerInstance::performSema() + 2946
11 sil-opt         0x000000000072373c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
```
