### PR TITLE
[stdlib] Remove explicit Equatable implementation for FloatingPointClassification

### DIFF
--- a/stdlib/public/core/FloatingPointOperations.swift.gyb
+++ b/stdlib/public/core/FloatingPointOperations.swift.gyb
@@ -33,28 +33,6 @@ public enum FloatingPointClassification {
   case PositiveInfinity
 }
 
-extension FloatingPointClassification : Equatable {}
-
-public 
-func ==(lhs: FloatingPointClassification, rhs: FloatingPointClassification) -> Bool {
-  switch (lhs, rhs) {
-  case (.SignalingNaN, .SignalingNaN),
-       (.QuietNaN, .QuietNaN),
-       (.NegativeInfinity, .NegativeInfinity),
-       (.NegativeNormal, .NegativeNormal),
-       (.NegativeSubnormal, .NegativeSubnormal),
-       (.NegativeZero, .NegativeZero),
-       (.PositiveZero, .PositiveZero),
-       (.PositiveSubnormal, .PositiveSubnormal),
-       (.PositiveNormal, .PositiveNormal),
-       (.PositiveInfinity, .PositiveInfinity):
-    return true
-
-  default:
-    return false
-  }
-}
-
 /// A set of common requirements for Swift's floating point types.
 public protocol FloatingPointType : Strideable {
   typealias _BitsType

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -650,7 +650,9 @@ FloatingPoint.test("Float80/Literals") {
 var FloatingPointClassification = TestSuite("NumericParsing")
 
 FloatingPointClassification.test("FloatingPointClassification/Equatable") {
-  let values: [FloatingPointClassification] = [ .SignalingNaN, .QuietNaN, .NegativeInfinity, .NegativeNormal, .NegativeSubnormal, .NegativeZero, .PositiveZero, .PositiveSubnormal, .PositiveNormal, .PositiveInfinity ]
+  let values: [FloatingPointClassification] = [
+    .SignalingNaN, .QuietNaN, .NegativeInfinity, .NegativeNormal, .NegativeSubnormal,
+    .NegativeZero, .PositiveZero, .PositiveSubnormal, .PositiveNormal, .PositiveInfinity ]
   checkEquatable(values, oracle: { $0 == $1 }) // Values should be equal iff indices equal
 }
 

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -647,5 +647,12 @@ FloatingPoint.test("Float80/Literals") {
 
 #endif
 
+var FloatingPointClassification = TestSuite("NumericParsing")
+
+FloatingPointClassification.test("FloatingPointClassification/Equatable") {
+  let values: [FloatingPointClassification] = [ .SignalingNaN, .QuietNaN, .NegativeInfinity, .NegativeNormal, .NegativeSubnormal, .NegativeZero, .PositiveZero, .PositiveSubnormal, .PositiveNormal, .PositiveInfinity ]
+  checkEquatable(values, oracle: { $0 == $1 }) // Values should be equal iff indices equal
+}
+
 runAllTests()
 

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -651,9 +651,19 @@ var FloatingPointClassification = TestSuite("NumericParsing")
 
 FloatingPointClassification.test("FloatingPointClassification/Equatable") {
   let values: [FloatingPointClassification] = [
-    .SignalingNaN, .QuietNaN, .NegativeInfinity, .NegativeNormal, .NegativeSubnormal,
-    .NegativeZero, .PositiveZero, .PositiveSubnormal, .PositiveNormal, .PositiveInfinity ]
-  checkEquatable(values, oracle: { $0 == $1 }) // Values should be equal iff indices equal
+    .SignalingNaN,
+    .QuietNaN,
+    .NegativeInfinity,
+    .NegativeNormal,
+    .NegativeSubnormal,
+    .NegativeZero,
+    .PositiveZero,
+    .PositiveSubnormal,
+    .PositiveNormal,
+    .PositiveInfinity
+  ]
+  // Values should be equal iff indices equal
+  checkEquatable(values, oracle: { $0 == $1 }) 
 }
 
 runAllTests()


### PR DESCRIPTION
The implementation as it was provided seems identical to the default `Equatable` implementation for enums. Passes `build-script -R -t` successfully. Is there any reason for the explicit implementation?
