### PR TITLE
[SIL] support undef cases in switch_value instructions

### DIFF
--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -862,6 +862,12 @@ SwitchValueInst::SwitchValueInst(SILDebugLocation *Loc, SILValue Operand,
   }
 
   for (unsigned i = 0, size = Cases.size(); i < size; ++i) {
+    // If we have undef, just add the case and continue.
+    if (isa<SILUndef>(Cases[i])) {
+      ::new (succs + i) SILSuccessor(this, BBs[i]);
+      continue;
+    }
+
     if (OperandBitWidth) {
       auto *IL = dyn_cast<IntegerLiteralInst>(Cases[i]);
       assert(IL && "switch_value case value should be of an integer type");

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -1,0 +1,20 @@
+// RUN: %target-sil-opt %s | %target-sil-opt | FileCheck %s
+sil_stage raw
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil @undef_in_switch_value_case : $@convention(thin) () -> ()
+sil @undef_in_switch_value_case : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int1, 0
+  // CHECK: case undef: bb1
+  switch_value %0 : $Builtin.Int1, case undef: bb1
+bb1:
+  %1 = function_ref @undef_in_switch_value_case : $@convention(thin) () -> ()
+  // CHECK: case undef: bb2
+  switch_value %1 : $@convention(thin) () -> (), case undef: bb2
+bb2:
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
This change adds support for undefined cases in the switch_value
instruction. Fixes SR-210.
