### PR TITLE
[cmpcodesize][1] Extract otool subprocess calls

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -1,8 +1,9 @@
 import re
 import os
-import subprocess
 import collections
 from operator import itemgetter
+
+from cmpcodesize import otool
 
 Prefixes = {
     # Cpp
@@ -64,19 +65,10 @@ def addFunction(sizes, function, startAddr, endAddr, groupByPrefix):
         sizes[function] += size
 
 
-def flatten(*args):
-    for x in args:
-        if hasattr(x, '__iter__'):
-            for y in flatten(*x):
-                yield y
-        else:
-            yield x
-
-
 def readSizes(sizes, fileName, functionDetails, groupByPrefix):
     # Check if multiple architectures are supported by the object file.
     # Prefer arm64 if available.
-    architectures = subprocess.check_output(["otool", "-V", "-f", fileName]).split("\n")
+    architectures = otool.fat_headers(fileName).split('\n')
     arch = None
     archPattern = re.compile('architecture ([\S]+)')
     for architecture in architectures:
@@ -86,16 +78,14 @@ def readSizes(sizes, fileName, functionDetails, groupByPrefix):
                 arch = archMatch.group(1)
             if "arm64" in arch:
                 arch = "arm64"
-    if arch is not None:
-      archParams = ["-arch", arch]
-    else:
-      archParams = []
 
     if functionDetails:
-        content = subprocess.check_output(flatten(["otool", archParams, "-l", "-v", "-t", fileName])).split("\n")
-        content += subprocess.check_output(flatten(["otool", archParams, "-v", "-s", "__TEXT", "__textcoal_nt", fileName])).split("\n")
+        content = otool.load_commands(fileName,
+                                      architecture=arch,
+                                      include_text_sections=True).split('\n')
+        content += otool.text_sections(fileName, architecture=arch).split('\n')
     else:
-        content = subprocess.check_output(flatten(["otool", archParams, "-l", fileName])).split("\n")
+        content = otool.load_commands(fileName, architecture=arch).split('\n')
 
     sectName = None
     currFunc = None

--- a/utils/cmpcodesize/cmpcodesize/otool.py
+++ b/utils/cmpcodesize/cmpcodesize/otool.py
@@ -1,0 +1,45 @@
+import subprocess
+
+
+def _command_for_architecture(architecture=None):
+    if architecture is None:
+        return ['otool']
+    else:
+        return ['otool', '-arch', architecture]
+
+
+def fat_headers(path):
+    """
+    Returns the headers for the executable at the given path.
+    Raises a subprocess.CalledProcessError if otool encounters an error,
+    such as not finding a file at the given path.
+    """
+    return subprocess.check_output(['otool', '-V', '-f', path])
+
+
+def load_commands(path, architecture=None, include_text_sections=False):
+    """
+    Returns the load commands for the executable at the given path,
+    for the given architecture. If print_text_section is specified,
+    the disassembled text section of the load commands is also output.
+
+    Raises a subprocess.CalledProcessError if otool encounters an error,
+    such as not finding a file at the given path.
+    """
+    command = _command_for_architecture(architecture) + ['-l']
+    if include_text_sections:
+        command += ['-v', '-t']
+    return subprocess.check_output(command + [path])
+
+
+def text_sections(path, architecture=None):
+    """
+    Returns the contents of the text sections of the executable at the
+    given path, for the given architecture.
+
+    Raises a subprocess.CalledProcessError if otool encounters an error,
+    such as not finding a file at the given path.
+    """
+    return subprocess.check_output(
+        _command_for_architecture(architecture) +
+        ['-v', '-s', '__TEXT', '__textcoal_nt', path])

--- a/utils/cmpcodesize/tests/test_otool.py
+++ b/utils/cmpcodesize/tests/test_otool.py
@@ -1,0 +1,73 @@
+import subprocess
+import unittest
+
+from cmpcodesize import otool
+
+
+# Store parameters passed to subprocess.check_output into
+# this global variable.
+_subprocess_check_output_arguments = []
+
+
+# We'll monkey-patch subprocess.check_output with this stub
+# function, which simply records whatever's passed to
+# check_output into the global variables above.
+def _stub_subprocess_check_output(arguments, *args, **kwargs):
+    global _subprocess_check_output_arguments
+    _subprocess_check_output_arguments = arguments
+
+
+class OtoolTestCase(unittest.TestCase):
+    def setUp(self):
+        # Monkey-patch subprocess.check_output with our stub function.
+        self._original_check_output = subprocess.check_output
+        subprocess.check_output = _stub_subprocess_check_output
+
+    def tearDown(self):
+        # Undo the monkey-patching.
+        subprocess.check_output = self._original_check_output
+
+    def test_fat_headers(self):
+        otool.fat_headers('/path/to/foo')
+        self.assertEqual(_subprocess_check_output_arguments,
+                         ['otool', '-V', '-f', '/path/to/foo'])
+
+    def test_load_commands_with_no_architecture(self):
+        otool.load_commands('/path/to/bar')
+        self.assertEqual(_subprocess_check_output_arguments,
+                         ['otool', '-l', '/path/to/bar'])
+
+    def test_load_commands_with_architecture(self):
+        otool.load_commands('/path/to/baz', architecture='arch-foo')
+        self.assertEqual(
+            _subprocess_check_output_arguments,
+            ['otool', '-arch', 'arch-foo', '-l', '/path/to/baz'])
+
+    def test_load_commands_no_architecture_but_including_text_sections(self):
+        otool.load_commands(
+            '/path/to/flim', include_text_sections=True)
+        self.assertEqual(
+            _subprocess_check_output_arguments,
+            ['otool', '-l', '-v', '-t', '/path/to/flim'])
+
+    def test_load_commands_with_architecture_and_including_text_sections(self):
+        otool.load_commands(
+            '/path/to/flam',
+            architecture='arch-bar',
+            include_text_sections=True)
+        self.assertEqual(
+            _subprocess_check_output_arguments,
+            ['otool', '-arch', 'arch-bar', '-l', '-v', '-t', '/path/to/flam'])
+
+    def test_text_sections_no_architecture(self):
+        otool.text_sections('/path/to/fish')
+        self.assertEqual(
+            _subprocess_check_output_arguments,
+            ['otool', '-v', '-s', '__TEXT', '__textcoal_nt', '/path/to/fish'])
+
+    def test_text_sections_with_architecture(self):
+        otool.text_sections('/path/to/frosh', architecture='arch-baz')
+        self.assertEqual(
+            _subprocess_check_output_arguments,
+            ['otool', '-arch', 'arch-baz', '-v', '-s',
+             '__TEXT', '__textcoal_nt', '/path/to/frosh'])


### PR DESCRIPTION
## What's in this pull request?

The functions in `cmpcodesize.compare` do several things: they call otool, they use regex matchers to extract information from otool's output, and they output that information using `print()`.

Currently, the only way to test cmpcodesize is via functional tests: ones that actually run on a dylib like libswiftCore.dylib. This takes a lot of time and is difficult to fully automate.

The commit in this pull request extracts otool calls from `cmpcodesize.compare`. It also adds tests for those calls.

Future commits can test the functions in `cmpcodesize.compare` using canned strings, instead of actual otool output.
## Why merge this pull request?
- It makes `cmpcodesize.compare` more modular, and eliminates all uses of the `flatten()` function.
- It improves test coverage.
- It makes it easier to start testing the rest of `cmpcodesize`. Instead of running functional tests\* on a sample dylib, we can refactor it such that we pass `cmpcodesize` sample strings, and verify its behavior parsing those sample strings.

> \* I have some functional tests running locally. They verify the results of running `cmpcodesize` on a test fixture: `libswiftCore.dylib`. `libswiftCore.dylib` is **9 MB**, so including it as a test fixture in source control may not be desirable.
## What downsides are there to merging this pull request?

I suppose some could argue the tests in `utils/cmpcodesize/tests/test_otool.py` don't provide much value--they're testing some very simple logic.
