### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseTypeSimple(…)

### DIFF
--- a/validation-test/SIL/crashers/003-swift-parser-parsetypesimple.swift
+++ b/validation-test/SIL/crashers/003-swift-parser-parsetypesimple.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+func x:inout p<


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:7: error: expected '(' in argument list of function declaration
func x:inout p<
      ^
<stdin>:3:7: error: expected '->' after function parameter tuple
func x:inout p<
      ^
      ->
<stdin>:3:16: error: expected type
func x:inout p<
               ^
sil-opt: /path/to/swift/include/swift/Parse/ParserResult.h:73: T *swift::ParserResult<swift::TypeRepr>::get() const [T = swift::TypeRepr]: Assertion `getPtrOrNull() && "not checked for nullptr"' failed.
8  sil-opt         0x0000000000a54abd swift::Parser::parseTypeSimple(swift::Diag<>, bool) + 1229
9  sil-opt         0x0000000000a5620a swift::Parser::parseType(swift::Diag<>, bool) + 202
10 sil-opt         0x0000000000a1e1fc swift::Parser::parseFunctionSignature(swift::Identifier, swift::DeclName&, llvm::SmallVectorImpl<swift::Pattern*>&, swift::Parser::DefaultArgumentInfo&, swift::SourceLoc&, bool&, swift::TypeRepr*&) + 1020
11 sil-opt         0x0000000000a07cb5 swift::Parser::parseDeclFunc(swift::SourceLoc, swift::StaticSpellingKind, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1957
12 sil-opt         0x00000000009ff69a swift::Parser::parseDecl(llvm::SmallVectorImpl<swift::Decl*>&, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>) + 3306
13 sil-opt         0x0000000000a4968b swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 2027
14 sil-opt         0x00000000009f413c swift::Parser::parseTopLevel() + 156
15 sil-opt         0x00000000009ef6bf swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
16 sil-opt         0x0000000000738da6 swift::CompilerInstance::performSema() + 2918
17 sil-opt         0x00000000007239fc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:4:1
```
