### PR TITLE
Update Python build scripts to use the print function

### DIFF
--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import sys, re, subprocess
 
 def run():
     if len(sys.argv) > 1:
-        print """
+        print("""
 ns-html2rst - Convert Cocoa HTML documentation into ReST
 
 usage: nshtml2rst < NSString.html > NSString.rst
-        """
+        """)
         exit(0)
 
     html = sys.stdin.read()

--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -3,6 +3,8 @@
 # Emulates the frontend of an -embed-bitcode job. That means we have to handle
 # -emit-bc and -c actions.
 
+from __future__ import print_function
+
 import os
 import shutil
 import sys
@@ -18,8 +20,8 @@ with open(outputFile, 'a'):
     os.utime(outputFile, None)
 
 if '-emit-bc' in sys.argv:
-  print "Handled", os.path.basename(primaryFile)
+  print("Handled", os.path.basename(primaryFile))
 elif '-c' in sys.argv:
-  print "Produced", os.path.basename(outputFile)
+  print("Produced", os.path.basename(outputFile))
 else:
   assert False, "unknown action"

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -2,6 +2,8 @@
 
 # Emulates the frontend of a -whole-module-optimization compilation.
 
+from __future__ import print_function
+
 import os
 import shutil
 import sys
@@ -16,4 +18,4 @@ outputFile = sys.argv[sys.argv.index('-o') + 1]
 with open(outputFile, 'a'):
     os.utime(outputFile, None)
 
-print "Produced", os.path.basename(outputFile)
+print("Produced", os.path.basename(outputFile))

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -3,6 +3,8 @@
 # modify-non-primary-files.py simulates a build where the user is modifying the
 # source files during compilation.
 
+from __future__ import print_function
+
 import os
 import shutil
 import sys
@@ -32,6 +34,6 @@ with open(outputFile, 'a'):
     os.utime(outputFile, None)
 
 if primaryFile:
-  print "Handled", os.path.basename(primaryFile)
+  print("Handled", os.path.basename(primaryFile))
 else:
-  print "Produced", os.path.basename(outputFile)
+  print("Produced", os.path.basename(outputFile))

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -3,6 +3,8 @@
 # Fails if the input file is named "bad.swift"; otherwise dispatches to
 # update-dependencies.py.
 
+from __future__ import print_function
+
 import os
 import sys
 
@@ -11,7 +13,7 @@ assert sys.argv[1] == '-frontend'
 primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
 
 if os.path.basename(primaryFile) == 'bad.swift':
-    print "Handled", os.path.basename(primaryFile)
+    print("Handled", os.path.basename(primaryFile))
     exit(1)
 
 dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -14,6 +14,8 @@
 #
 # If invoked in non-primary-file mode, it only creates the output file.
 
+from __future__ import print_function
+
 import os
 import shutil
 import sys
@@ -37,6 +39,6 @@ with open(outputFile, 'a'):
     os.utime(outputFile, None)
 
 if primaryFile:
-  print "Handled", os.path.basename(primaryFile)
+  print("Handled", os.path.basename(primaryFile))
 else:
-  print "Produced", os.path.basename(outputFile)
+  print("Produced", os.path.basename(outputFile))

--- a/test/Inputs/getmtime.py
+++ b/test/Inputs/getmtime.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import sys
 
-print os.path.getmtime(sys.argv[1])
+print(os.path.getmtime(sys.argv[1]))

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -12,6 +12,7 @@
 #
 #===------------------------------------------------------------------------===#
 
+from __future__ import print_function
 
 import subprocess
 import json
@@ -29,7 +30,7 @@ def find_remap_files(path):
 def apply_edits(path):
     remap_files = find_remap_files(path)
     if not remap_files:
-        print "No remap files found"
+        print("No remap files found")
         return 1;
 
     edits_set = set()
@@ -53,7 +54,7 @@ def apply_edits(path):
         edits_per_file[fname].append((ed[1], ed[2], ed[3]))
     
     for fname, edits in edits_per_file.iteritems():
-        print 'Updating', fname
+        print('Updating', fname)
         edits.sort(reverse=True)
         file_data = open(fname).read()
         for ed in edits:

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import re
 import os
 import subprocess
@@ -145,7 +147,7 @@ def compareSizes(oldSizes, newSizes, nameKey, title):
             perc = "%.1f%%" % ((1.0 - float(newSize) / float(oldSize)) * 100.0)
         else:
             perc = "- "
-        print "%-26s%16s: %8d  %8d  %6s" % (title, nameKey, oldSize, newSize, perc)
+        print("%-26s%16s: %8d  %8d  %6s" % (title, nameKey, oldSize, newSize, perc))
 
 
 def compareSizesOfFile(oldFiles, newFiles, allSections, listCategories):
@@ -226,21 +228,21 @@ def compareFunctionSizes(oldFiles, newFiles):
             onlyInFile2Size += newSize
 
     if onlyInFile1:
-        print "Only in old file(s)"
-        print listFunctionSizes(onlyInFile1)
-        print "Total size of functions only in old file: {}".format(onlyInFile1Size)
-        print
+        print("Only in old file(s)")
+        print(listFunctionSizes(onlyInFile1))
+        print("Total size of functions only in old file: {}".format(onlyInFile1Size))
+        print()
 
     if onlyInFile2:
-        print "Only in new files(s)"
-        print listFunctionSizes(onlyInFile2)
-        print "Total size of functions only in new file: {}".format(onlyInFile2Size) 
-        print
+        print("Only in new files(s)")
+        print(listFunctionSizes(onlyInFile2))
+        print("Total size of functions only in new file: {}".format(onlyInFile2Size))
+        print()
 
     if inBoth:
         sizeIncrease = 0
         sizeDecrease = 0
-        print "%8s %8s %8s" % ("old", "new", "diff")
+        print("%8s %8s %8s" % ("old", "new", "diff"))
         for triple in sorted(inBoth, key=lambda tup: (tup[2] - tup[1], tup[1])):
             func = triple[0]
             oldSize = triple[1]
@@ -252,8 +254,8 @@ def compareFunctionSizes(oldFiles, newFiles):
                 sizeDecrease -= diff
             if diff == 0:
                 inBothSize += newSize
-            print "%8d %8d %8d %s" %(oldSize, newSize, newSize - oldSize, func)
-        print "Total size of functions with the same size in both files: {}".format(inBothSize)
-        print "Total size of functions that got smaller: {}".format(sizeDecrease)
-        print "Total size of functions that got bigger: {}".format(sizeIncrease)
-        print "Total size change of functions present in both files: {}".format(sizeIncrease - sizeDecrease)
+            print("%8d %8d %8d %s" %(oldSize, newSize, newSize - oldSize, func))
+        print("Total size of functions with the same size in both files: {}".format(inBothSize))
+        print("Total size of functions that got smaller: {}".format(sizeDecrease))
+        print("Total size of functions that got bigger: {}".format(sizeIncrease))
+        print("Total size change of functions present in both files: {}".format(sizeIncrease - sizeDecrease))

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import sys
 import os
@@ -132,7 +134,7 @@ How to specify files:
                 '$SWIFT_NEW_BUILDDIR environment variables set.\n' + \
                 '$SWIFT_OLD_BUILDDIR = {0}\n$SWIFT_NEW_BUILDDIR = {1}'.format(
                     oldBuildDir, newBuildDir)
-            oldFileArgs = SHORTCUTS.keys()
+            oldFileArgs = list(SHORTCUTS.keys())
 
         oldFiles = []
         newFiles = []
@@ -150,7 +152,7 @@ How to specify files:
                     numExpanded += 1
 
         if numExpanded != 0 and numExpanded != len(oldFileArgs):
-            sys.exit("mix of expanded/not-expanded arguments") 
+            sys.exit("mix of expanded/not-expanded arguments")
         if numExpanded == 0:
             if len(oldFileArgs) > 2:
                 sys.exit("too many arguments")
@@ -166,11 +168,11 @@ How to specify files:
             sizes = collections.defaultdict(int)
             for file in oldFiles:
                 readSizes(sizes, file, True, False)
-            print listFunctionSizes(sizes.items())
+            print(listFunctionSizes(sizes.items()))
         else:
             compareFunctionSizes(oldFiles, newFiles)
     else:
-        print "%-26s%16s  %8s  %8s  %s" % ("", "Section", "Old", "New", "Percent")
+        print("%-26s%16s  %8s  %8s  %s" % ("", "Section", "Old", "New", "Percent"))
         if parsed_arguments.sum_sizes:
             compareSizesOfFile(oldFiles, newFiles,
                                parsed_arguments.all_sections,

--- a/utils/demo-tool
+++ b/utils/demo-tool
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import json
 import optparse
 import subprocess
@@ -115,10 +117,10 @@ for example::
     def prompterPrint(string):
         if hasColor:
             attr = [ '32', '1' ]
-            print '\x1b[%sm%s\x1b[0m' % (';'.join(attr), string)
+            print('\x1b[%sm%s\x1b[0m' % (';'.join(attr), string))
         else:
-            print string
     
+            print(string)
     def send(*args, **kwargs):
         return send_to_screen(opts.screen_name, *args, **kwargs)
     parser.add_option("-S", "--screen-name", dest="screen_name", metavar="NAME",
@@ -162,7 +164,7 @@ for example::
 
         if command:
             # Send the command slowly, as if it was typed.
-            print "sending command: %r" % (command.replace('\n', '<cr>'),)
+            print("sending command: %r" % (command.replace('\n', '<cr>'),))
             for c in command:
                 send(c)
                 if c == "\n":
@@ -179,7 +181,7 @@ for example::
             raw_input('press enter to continue to next command...')
             # Send the command slowly, as if it was typed.
             if shouldClear:
-                print "clearing screen"
+                print("clearing screen")
                 send(command="clear")
                 send('\n')
 

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -2,6 +2,8 @@
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 
+from __future__ import print_function
+
 import re
 from cStringIO import StringIO
 import tokenize
@@ -1051,8 +1053,8 @@ def main():
     bindings = dict( x.split('=', 1) for x in args.defines )
     ast = parseTemplate(args.file.name, args.file.read())
     if args.dump:
-        print ast
         
+        print(ast)
     # Allow the template to import .py files from its own directory
     sys.path = [os.path.split(args.file.name)[0] or '.'] + sys.path
     

--- a/utils/omit-needless-words.py
+++ b/utils/omit-needless-words.py
@@ -4,6 +4,8 @@
 # heuristics that omit 'needless' words from APIs imported from Clang
 # into Swift.
 
+from __future__ import print_function
+
 import argparse
 import subprocess
 
@@ -52,32 +54,32 @@ def main():
 
     swift_ide_test_cmd = [args.swift_ide_test, '-print-module', '-source-filename', source_filename, '-sdk', sdkroot, '-target', args.target, '-module-print-skip-overlay', '-skip-unavailable', '-module-print-submodules', '-skip-imports', '-module-to-print=%s' % (args.module)]
     omit_needless_words_args = ['-enable-omit-needless-words', '-enable-infer-default-arguments']
-    
+
     # Determine the output files.
     # No good way with argparse to set default value based on depenency of other arg.
     if not args.before_file:
         args.before_file = '%s.before.txt' % (args.module)
     if not args.after_file:
         args.after_file = '%s.after.txt' % (args.module)
-    
+
     # Create a .swift file we can feed into swift-ide-test
     subprocess.call(['touch', source_filename])
-    
+
     if not args.only_after:
       # Print the interface without omitting needless words
       if not args.quiet:
           print('Writing %s...' % args.before_file)
       output_command_result_to_file(swift_ide_test_cmd, args.before_file)
-    
+
     if not args.only_before:
       # Print the interface omitting needless words
       if not args.quiet:
           print('Writing %s...' % args.after_file)
       output_command_result_to_file(swift_ide_test_cmd + omit_needless_words_args, args.after_file)
-    
+
     # Remove the .swift file we fed into swift-ide-test
     subprocess.call(['rm', '-f', source_filename])
-    
+
     # Diff them
     subprocess.call([args.diff_tool, args.before_file, args.after_file])
 

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -8,6 +8,8 @@
 # this script somewhere outside the source tree and then move it back
 # when your changes are finished.
 
+from __future__ import print_function
+
 import subprocess
 import sys
 import os
@@ -33,8 +35,8 @@ def print_call(*args, **kw):
     if isinstance(args[0], (str, unicode)):
         args = [args]
         
-    print '$ ' + ' '.join(shell_quote(x) for x in args[0]) + '   # %r, %r' % (args[1:], kw)
     
+    print('$ ' + ' '.join(shell_quote(x) for x in args[0]) + '   # %r, %r' % (args[1:], kw))
 def check_call(*args, **kw):
     print_call(*args, **kw)
     try:
@@ -173,7 +175,8 @@ def getScores(fname):
     f = open(fname)
     try:
         for line in f:
-            if VERBOSE: print "Parsing", line,
+            if VERBOSE:
+                print("Parsing", line)
             m = SCORERE.match(line)
             if not m:
                 continue
@@ -214,12 +217,14 @@ def compareTimingsFiles(file1, file2):
     scores1, runs1 = getScores(file1)
     scores2, runs2 = getScores(file2)
     runs = min(runs1, runs2)
-    if VERBOSE: print scores1; print scores2
     keys = [f for f in set(scores1.keys() + scores2.keys())]
+    if VERBOSE:
+        print(scores1)
+        print(scores2)
     keys.sort()
     if VERBOSE:
-        print "comparing ", file1, "vs", file2, "=",
-        print file1, "/", file2
+        print("comparing ", file1, "vs", file2, "=", end='')
+        print(file1, "/", file2)
 
     rows =  [["benchmark"]]
     for i in range(0,runs):
@@ -229,11 +234,11 @@ def compareTimingsFiles(file1, file2):
     rows[0] += ["delta", "speedup"]
 
     for key in keys:
-        if not key in scores1:
-            print key, "not in", file1
+        if key not in scores1:
+            print(key, "not in", file1)
             continue
-        if not key in scores2:
-            print key, "not in", file2
+        if key not in scores2:
+            print(key, "not in", file2)
             continue
         rows.append(compareScores(key, scores1[key], scores2[key], runs))
         
@@ -247,9 +252,9 @@ def compareTimingsFiles(file1, file2):
     for row in rows:
         for n, x in enumerate(row):
             if n != 0:
-                print ',',
-            print ((widths[n] - len(x)) * ' ') + x,
-        print ''
+                print(',', end='')
+            print(((widths[n] - len(x)) * ' ') + x, end='')
+        print()
 
 def checkAndUpdatePerfTestSuite(sourceDir):
     """Check that the performance testsuite directory is in its appropriate
@@ -303,7 +308,7 @@ if __name__ == '__main__':
         print('No changes between work tree and %s; nothing to compare.' % args.baseline)
     else:
         for exe in exeNames:
-            print '=' * 20, exe, '=' * 20
+            print('=' * 20, exe, '=' * 20)
             timingsFileName = exe + '.out'
             compareTimingsFiles(
                 os.path.join(baselineCacheDir, timingsFileName),

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -22,6 +22,8 @@
 #   && open /tmp/protocols.svg
 #===----------------------------------------------------------------------===#
 
+from __future__ import print_function
+
 import re
 import sys
 import os
@@ -139,17 +141,17 @@ clusterEdges = set(
     for s in elements 
     for t in graph[s] if t in elements)
 
-print 'digraph ProtocolHierarchies {'
-print '  mclimit = 100; ranksep=1.5; ' # ; packmode="array1"
-print '  edge [dir="back"];'
-print '  node [shape = box, fontname = Helvetica, fontsize = 10];'
+print('digraph ProtocolHierarchies {')
+print('  mclimit = 100; ranksep=1.5; ') # ; packmode="array1"
+print('  edge [dir="back"];')
+print('  node [shape = box, fontname = Helvetica, fontsize = 10];')
 
 for c in sorted(clusters):
-    print '  subgraph "cluster_%s" {' % c
+    print('  subgraph "cluster_%s" {' % c)
     for (s, t) in sorted(clusterEdges):
         if s in clusters[c]:
-            print '%s -> %s [weight=100];' % (s, t)
-    print '}'
+            print('%s -> %s [weight=100];' % (s, t))
+    print('}')
 
 for node in sorted(graph.keys()):
     requirements = body.get(node, [])
@@ -164,12 +166,12 @@ for node in sorted(graph.keys()):
         divider,
         '\n'.join('<TR><TD>%s</TD></TR>' % g for g in generics)))
     
-    print interpolate('    %(node)s [style = %(style)s, label=<%(label)s>]')
     
+    print(interpolate('    %(node)s [style = %(style)s, label=<%(label)s>]'))
 for (parent, children) in sorted(graph.items()):
-    print '    %s -> {' % parent,
-    print '; '.join(
-        sorted(child for child in children if not (parent, child) in clusterEdges)),
-    print '}'
+    print('    %s -> {' % parent, end=' ')
+    print('; '.join(
+        sorted(child for child in children if not (parent, child) in clusterEdges)), end=' ')
+    print('}')
 
-print '}'    
+print('}')

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import argparse
 import os.path
 import filecmp
@@ -47,7 +49,7 @@ def merge_lipo_files(src_root_dirs, file_list, copy_verbatim_subpaths,
         file_paths = [os.path.join(dir, file) for dir in src_root_dirs
                      if os.path.exists(os.path.join(dir, file))]
         if len(file_paths) == 0:
-            print "-- Warning: Can't locate source file %s" % file
+            print("-- Warning: Can't locate source file %s" % file)
             continue
 
         destPath = os.path.join(dest_root_dir, os.path.relpath(file_paths[0],
@@ -55,39 +57,39 @@ def merge_lipo_files(src_root_dirs, file_list, copy_verbatim_subpaths,
 
         if all([os.path.islink(item) for item in file_paths]):
             #It's a symlink in all found instances, copy the link.
-            print "-- Creating symlink %s" % destPath
+            print("-- Creating symlink %s" % destPath)
             os.symlink(os.readlink(file_paths[0]), destPath)
         elif all([os.path.isdir(item) for item in file_paths]):
             # It's a subdir in all found instances.
             # See if we should copy verbatim or create the destination subdir.
             if file in copy_verbatim_subpaths:
-                print "-- Copying subdir verbatim %s" % destPath
+                print("-- Copying subdir verbatim %s" % destPath)
                 if os.path.isdir(destPath):
                     shutil.rmtree(destPath)
                 shutil.copytree(file_paths[0], destPath, symlinks=True)
             else:
-                print "-- Creating subdir %s" % destPath
+                print("-- Creating subdir %s" % destPath)
                 if not os.path.isdir(destPath):
                     os.makedirs(destPath)
         elif all([os.path.isfile(item) for item in file_paths]):
             # It's a regular file in all found instances, see if they're identical.
             if all([filecmp.cmp(item, file_paths[0]) for item in file_paths]):
                 # All instances are identical, just copy the unique file.
-                print "-- Copying file %s" % destPath
+                print("-- Copying file %s" % destPath)
                 shutil.copy2(file_paths[0], destPath)
             elif all([os.access(item, os.X_OK) for item in file_paths]):
                 # Multiple instances are different and executable, try lipo.
                 if verbose:
-                    print "-- Running lipo %s to %s" % (file_paths, destPath)
+                    print("-- Running lipo %s to %s" % (file_paths, destPath))
                 else:
-                    print "-- Running lipo %s" % destPath
+                    print("-- Running lipo %s" % destPath)
                 check_call(lipo_cmd + ["-output", destPath] + file_paths,
                            print_command=verbose, verbose=verbose)
             else:
                 # Multiple instances are different, and they're not executable.
-                print "-- Warning: non-executable source files are different, skipping: %s" % file_paths
+                print("-- Warning: non-executable source files are different, skipping: %s" % file_paths)
         else:
-            print "-- Warning: Unsupport file type, skipping: %s" % file_paths
+            print("-- Warning: Unsupport file type, skipping: %s" % file_paths)
 
 
 def main():
@@ -135,7 +137,7 @@ verbatim. This is useful if some subdirectories already contain fat binaries.
                                  copy_verbatim_subpaths)
 
     if args.verbose:
-        print "Discovered files and dirs: %s" % file_list
+        print("Discovered files and dirs: %s" % file_list)
 
     merge_lipo_files(args.src_root_dirs, file_list, copy_verbatim_subpaths,
                    args.destination, args.verbose, args.lipo)

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -4,6 +4,8 @@
 Utility script for submitting benchmark results to an LNT server.
 """
 
+from __future__ import print_function
+
 import datetime
 import errno
 import json
@@ -60,13 +62,13 @@ def submit_results_to_server(results_data, submit_url):
         return json.loads(result_data)
     except:
         import traceback
-        print "Unable to load result, not a valid JSON object."
-        print
-        print "Traceback:"
+        print("Unable to load result, not a valid JSON object.")
+        print()
+        print("Traceback:")
         traceback.print_exc()
-        print
-        print "Result:"
-        print result_data
+        print()
+        print("Result:")
+        print(result_data)
         return
 
 ###

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -34,6 +34,8 @@
 # Ideas for the harness improvement and development are welcomed here:
 # rdar://problem/18072938
 
+from __future__ import print_function
+
 import subprocess
 import numpy
 import time

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -15,6 +15,8 @@
 # Note: viewcfg should be in the $PATH and .dot files should be associated
 # with the Graphviz app.
 
+from __future__ import print_function
+
 import re
 import sys
 import tempfile
@@ -22,14 +24,14 @@ import subprocess
 import os
 
 def help():
-  print """\
+  print("""\
 Usage:
 
 viewcfg [output-suffix] < file
 
 By default all CFGs are opened in the same window.
 Use the a unique output-suffix to open a CFG in a new window.
-"""
+""")
 
 class Block:
 

--- a/validation-test/stdlib/UnicodeTrieGenerator.gyb
+++ b/validation-test/stdlib/UnicodeTrieGenerator.gyb
@@ -2,6 +2,8 @@
 
 # RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s | FileCheck %s
 
+from __future__ import print_function
+
 from GYBUnicodeDataUtils import *
 
 def test_trie_generation(property_table, configure_generator=None):
@@ -14,7 +16,7 @@ def test_trie_generation(property_table, configure_generator=None):
     trie_generator.freeze()
     trie_generator.verify(property_table)
     trie_generator.serialize(property_table)
-    print (
+    print((
         trie_generator.BMP_first_level_index_bits,
         trie_generator.BMP_data_offset_bits,
         trie_generator.supp_first_level_index_bits,
@@ -33,7 +35,7 @@ def test_trie_generation(property_table, configure_generator=None):
         trie_generator.supp_lookup1_bytes_offset - trie_generator.BMP_data_bytes_offset,
         trie_generator.supp_lookup2_bytes_offset - trie_generator.supp_lookup1_bytes_offset,
         trie_generator.supp_data_bytes_offset - trie_generator.supp_lookup2_bytes_offset,
-        len(trie_generator.trie_bytes) - trie_generator.supp_data_bytes_offset)
+        len(trie_generator.trie_bytes) - trie_generator.supp_data_bytes_offset))
 
 class PerfectlyCompressableProperty(UnicodeProperty):
     def __init__(self):
@@ -53,7 +55,7 @@ class PerfectlyCompressableProperty(UnicodeProperty):
     def get_numeric_value(self, cp):
         return self.to_numeric_value(self.get_value(cp))
 
-print 'PerfectlyCompressableProperty'
+print('PerfectlyCompressableProperty')
 test_trie_generation(PerfectlyCompressableProperty())
 # CHECK-LABEL: PerfectlyCompressableProperty
 # CHECK: (8, 8, 5, 8, 8,  1, 1, 1, 1, 1,  1041,  256, 256, 17, 256, 256)
@@ -93,7 +95,7 @@ class UncompressableProperty(UnicodeProperty):
     def get_numeric_value(self, cp):
         return self.to_numeric_value(self.get_value(cp))
 
-print 'UncompressableProperty, default trie parameters'
+print('UncompressableProperty, default trie parameters')
 test_trie_generation(UncompressableProperty())
 # CHECK-LABEL: UncompressableProperty, default trie parameters
 # CHECK: (8, 8, 5, 8, 8,  2, 1, 1, 2, 1,  1123601,  512, 65536, 17, 8704, 1048832)
@@ -112,7 +114,7 @@ def configure_generator_for_16_bit_indexes(trie_generator):
     trie_generator.supp_first_level_index_bits = 10
     trie_generator.supp_second_level_index_bits = 2
 
-print 'UncompressableProperty, 16-bit indexes'
+print('UncompressableProperty, 16-bit indexes')
 test_trie_generation(UncompressableProperty(),
     configure_generator_for_16_bit_indexes)
 # CHECK-LABEL: UncompressableProperty, 16-bit indexes
@@ -130,7 +132,7 @@ test_trie_generation(UncompressableProperty(),
 # gyb will print line markers after our output, so make sure that those
 # don't accidentally match any other CHECK lines.
 
-print 'THE END'
+print('THE END')
 # CHECK-LABEL: THE END
 
 }%


### PR DESCRIPTION
In Python 3, 'print' was changed from a statement to a function.  Using
the __future__ module allows scripts to use print function whether
running with Python 2.6+ or Python 3.x.  This commit changes as many
instances of print as I could find to use the print function and the
__future__ module.

This is part of ongoing work to get the Python scripts running under
both Python 2 and 3; see PR #90.
