### PR TITLE
[SIL] Add test case for crash triggered in swift::Expr::getSourceRange()

### DIFF
--- a/validation-test/SIL/crashers/004-swift-expr-getsourcerange.sil
+++ b/validation-test/SIL/crashers/004-swift-expr-getsourcerange.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+l<@convention()>(


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:15: error: expected convention name identifier in 'convention' attribute
l<@convention()>(
              ^
<stdin>:3:16: error: expected type
l<@convention()>(
               ^
<stdin>:3:2: note: while parsing this '<' as a type parameter bracket
l<@convention()>(
 ^
<stdin>:3:18: error: expected expression in list of expressions
l<@convention()>(
                 ^
<stdin>:3:18: error: expected ',' separator
l<@convention()>(
                 ^
                 ,
<stdin>:3:1: error: expressions are not allowed at the top level
l<@convention()>(
^
sil-opt: /path/to/swift/include/swift/Basic/SourceLoc.h:93: swift::SourceRange::SourceRange(swift::SourceLoc, swift::SourceLoc): Assertion `Start.isValid() == End.isValid() && "Start and end should either both be valid or both be invalid!"' failed.
8  sil-opt         0x0000000000d3598b swift::Expr::getSourceRange() const + 1371
17 sil-opt         0x0000000000ccbfd4 swift::Decl::walk(swift::ASTWalker&) + 20
18 sil-opt         0x0000000000d5495e swift::SourceFile::walk(swift::ASTWalker&) + 174
19 sil-opt         0x0000000000d84594 swift::verify(swift::SourceFile&) + 52
20 sil-opt         0x00000000009f50b3 swift::Parser::parseTopLevel() + 563
21 sil-opt         0x00000000009f049f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
22 sil-opt         0x0000000000739116 swift::CompilerInstance::performSema() + 2918
23 sil-opt         0x0000000000723d6c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:18
2.  While walking into decl declaration 0x5fa2ee0 at <stdin>:3:1
3.  While verifying ranges expression at [<stdin>:3:1 - line:3:1] RangeText="l"
```
