### PR TITLE
[abi.rst] Incorrect known-module for Swift

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -1195,7 +1195,7 @@ Predefined Substitutions
 
 ::
 
-  known-module ::= 's'                       // Swift
+  known-module ::= 'Ss'                       // Swift
   known-module ::= 'SC'                      // C
   known-module ::= 'So'                      // Objective-C
   known-nominal-type ::= 'Sa'                // Swift.Array


### PR DESCRIPTION
Known-module should be 'Ss' for Swift, not 's'
