### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::typeCheckConstructorBodyUntil(…)

### DIFF
--- a/validation-test/IDE/crashers/040-swift-typechecker-typecheckconstructorbodyuntil.swift
+++ b/validation-test/IDE/crashers/040-swift-typechecker-typecheckconstructorbodyuntil.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+t{extension{init(){#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 145
swift-ide-test: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::ClassDecl, const swift::NominalTypeDecl *>::doit(const From *) [To = swift::ClassDecl, From = const swift::NominalTypeDecl *]: Assertion `Val && "isa<> used on a null pointer"' failed.
8  swift-ide-test  0x0000000000978ba4 swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 1780
9  swift-ide-test  0x00000000009781c2 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
10 swift-ide-test  0x0000000000900d88 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
22 swift-ide-test  0x0000000000ae1304 swift::Decl::walk(swift::ASTWalker&) + 20
23 swift-ide-test  0x0000000000b6afbe swift::SourceFile::walk(swift::ASTWalker&) + 174
24 swift-ide-test  0x0000000000b6a1ef swift::ModuleDecl::walk(swift::ASTWalker&) + 79
25 swift-ide-test  0x0000000000b44352 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
26 swift-ide-test  0x000000000085ccda swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
27 swift-ide-test  0x000000000076ba84 swift::CompilerInstance::performSema() + 3316
28 swift-ide-test  0x0000000000715217 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x5e15110 at <INPUT-FILE>:3:1
```
