### PR TITLE
[AST] Abort execution instead of entering an endless loop in lookupVisibleMemberDeclsImpl(…)

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -500,6 +500,9 @@ static void lookupVisibleMemberDeclsImpl(
     ClassDecl *CurClass = dyn_cast<ClassDecl>(CurNominal);
 
     if (CurClass && CurClass->hasSuperclass()) {
+      // FIXME: This should be an assertion, we shouldn't ever have a type that is its own superclass.
+      if (BaseTy.getPointer() == CurClass->getSuperclass().getPointer())
+        return;
       BaseTy = CurClass->getSuperclass();
       Reason = getReasonForSuper(Reason);
 


### PR DESCRIPTION
Abort execution instead of entering an endless loop in `lookupVisibleMemberDeclsImpl(…)`.

Before this commit the endless loop could be entered using:

```
$ echo 'protocol A{class A:A{{{{}}}var f{if#^A^#' > /tmp/test.swift
$ swift-ide-test -code-completion -code-completion-token=A -source-filename=/tmp/test.swift
```
