### PR TITLE
[cmpcodesize] Fix early return in --list

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -194,7 +194,7 @@ def listFunctionSizes(sizeArray):
     for pair in sorted(sizeArray, key=itemgetter(1)):
         name = pair[0]
         size = pair[1]
-        return "%8d %s" % (size, name)
+        yield "%8d %s" % (size, name)
 
 
 def compareFunctionSizes(oldFiles, newFiles):

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -168,7 +168,7 @@ How to specify files:
             sizes = collections.defaultdict(int)
             for file in oldFiles:
                 readSizes(sizes, file, True, False)
-            print(listFunctionSizes(sizes.items()))
+            print(os.linesep.join(listFunctionSizes(sizes.items())))
         else:
             compareFunctionSizes(oldFiles, newFiles)
     else:

--- a/utils/cmpcodesize/tests/test_list_function_sizes.py
+++ b/utils/cmpcodesize/tests/test_list_function_sizes.py
@@ -6,11 +6,22 @@ from cmpcodesize.compare import listFunctionSizes
 class ListFunctionSizesTestCase(unittest.TestCase):
     def test_when_size_array_is_none_raises(self):
         with self.assertRaises(TypeError):
-            listFunctionSizes(None)
+            list(listFunctionSizes(None))
 
     def test_when_size_array_is_empty_returns_none(self):
-        self.assertIsNone(listFunctionSizes([]))
+        self.assertEqual(list(listFunctionSizes([])), [])
 
+    def test_lists_each_entry(self):
+        sizes = {
+            'foo': 1,
+            'bar': 10,
+            'baz': 100,
+        }
+        self.assertEqual(list(listFunctionSizes(sizes.items())), [
+            '       1 foo',
+            '      10 bar',
+            '     100 baz',
+        ])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a bug, introduced in a1f6040c83d62a3ec354bba398f902b66154ec41,
in which `cmpcodesize -l /path/to/file` would only output the _first_ label,
instead of listing all of them.

---

Whoops, sorry about that! :blush:

This should probably be reviewed by @eeckstein, @swiftix, and @nadavrot.
