### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::getGenericSignature(…)

### DIFF
--- a/validation-test/IDE/crashers/041-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/IDE/crashers/041-swift-archetypebuilder-getgenericsignature.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol A{class d<g{var e{enum b<T:a#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 163
swift-ide-test: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1942: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
8  swift-ide-test  0x0000000000a97574 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 1620
9  swift-ide-test  0x0000000000951cdc swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 332
10 swift-ide-test  0x0000000000951fd4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
11 swift-ide-test  0x000000000092c421 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 353
14 swift-ide-test  0x0000000000931e27 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
17 swift-ide-test  0x000000000097838b swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
18 swift-ide-test  0x00000000009781ce swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
19 swift-ide-test  0x0000000000900d88 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
27 swift-ide-test  0x0000000000ae1304 swift::Decl::walk(swift::ASTWalker&) + 20
28 swift-ide-test  0x0000000000b6afbe swift::SourceFile::walk(swift::ASTWalker&) + 174
29 swift-ide-test  0x0000000000b6a1ef swift::ModuleDecl::walk(swift::ASTWalker&) + 79
30 swift-ide-test  0x0000000000b44352 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
31 swift-ide-test  0x000000000085ccda swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
32 swift-ide-test  0x000000000076ba84 swift::CompilerInstance::performSema() + 3316
33 swift-ide-test  0x0000000000715217 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'A' at <INPUT-FILE>:3:1
2.  While type-checking 'b' at <INPUT-FILE>:3:28
```
