### PR TITLE
Gets rid of for-loop deprecation compiler warnings in stdlib/private

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -782,7 +782,8 @@ public func runAllTests() {
   } else {
     var runTestsInProcess: Bool = false
     var filter: String? = nil
-    for var i = 0; i < Process.arguments.count; {
+    var i = 0
+    while i < Process.arguments.count {
       let arg = Process.arguments[i]
       if arg == "--stdlib-unittest-in-process" {
         runTestsInProcess = true

--- a/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
+++ b/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
@@ -34,7 +34,7 @@ public struct _stdlib_ShardedAtomicCounter {
     let hardwareConcurrency = _stdlib_getHardwareConcurrency()
     let count = max(8, hardwareConcurrency * hardwareConcurrency)
     let shards = UnsafeMutablePointer<Int>.alloc(count)
-    for var i = 0; i != count; i++ {
+    for i in 0..<count {
       (shards + i).initialize(0)
     }
     self._shardsPtr = shards
@@ -57,7 +57,7 @@ public struct _stdlib_ShardedAtomicCounter {
     var result = 0
     let shards = self._shardsPtr
     let count = self._shardsCount
-    for var i = 0; i != count; i++ {
+    for i in 0..<count {
       result += _swift_stdlib_atomicLoadInt(object: shards + i)
     }
     return result
@@ -72,7 +72,7 @@ public struct _stdlib_ShardedAtomicCounter {
 
     public mutating func randomInt() -> Int {
       var result = 0
-      for var i = 0; i != Int._sizeInBits; ++i {
+      for _ in 0..<Int._sizeInBits {
         result = (result << 1) | (_state & 1)
         _state = (_state >> 1) ^ (-(_state & 1) & Int(bitPattern: 0xD0000001))
       }

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -43,7 +43,7 @@ public func scan<
 
 public func randomShuffle<T>(a: [T]) -> [T] {
   var result = a
-  for var i = a.count - 1; i != 0; --i {
+  for i in (1..<a.count).reverse() {
     // FIXME: 32 bits are not enough in general case!
     let j = Int(rand32(exclusiveUpperBound: UInt32(i + 1)))
     if i != j {


### PR DESCRIPTION
This pull request removes deprecated for loops warnings in `stdlib/private`.
Pull request to remove warnings in `stdlib/public/core` is here: https://github.com/apple/swift/pull/644
