### PR TITLE
[SIL] Add test case for crash triggered in swift::SILFunction::verify()

### DIFF
--- a/validation-test/SIL/crashers/005-swift-silfunction-verify.sil
+++ b/validation-test/SIL/crashers/005-swift-silfunction-verify.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil shared_external@a:$()->()


### PR DESCRIPTION
Stack trace:

```
sil-opt: /path/to/swift/lib/SIL/Verifier.cpp:2995: void (anonymous namespace)::SILVerifier::visitSILFunction(swift::SILFunction *): Assertion `!hasSharedVisibility(F->getLinkage()) && "external declarations of SILFunctions with shared visibility is not " "allowed"' failed.
8  sil-opt         0x00000000009aad02 swift::SILFunction::verify() const + 402
9  sil-opt         0x0000000000a243f8 swift::Parser::parseDeclSIL() + 5384
10 sil-opt         0x00000000009f5b2a swift::Parser::parseTopLevel() + 378
11 sil-opt         0x00000000009f0fcf swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
12 sil-opt         0x00000000007392a6 swift::CompilerInstance::performSema() + 2918
13 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:4:1
2.  While verifying SIL function @a for <stdin>:3:21
```
