### PR TITLE
[stdlib] Remove redundant CustomStringConvertible conformance

### DIFF
--- a/stdlib/public/core/UnicodeTrie.swift.gyb
+++ b/stdlib/public/core/UnicodeTrie.swift.gyb
@@ -45,7 +45,7 @@ SuppDataBytesOffset = 12817
 import SwiftShims
 
 public // @testable
-enum _GraphemeClusterBreakPropertyValue : Int, CustomStringConvertible {
+enum _GraphemeClusterBreakPropertyValue : Int {
   case Other = 0
   case CR = 1
   case LF = 2
@@ -59,39 +59,6 @@ enum _GraphemeClusterBreakPropertyValue : Int, CustomStringConvertible {
   case T = 10
   case LV = 11
   case LVT = 12
-
-  /// A textual representation of `self`.
-  public // @testable
-  var description: String {
-    switch self {
-    case Other:
-      return "Other"
-    case CR:
-      return "CR"
-    case LF:
-      return "LF"
-    case Control:
-      return "Control"
-    case Extend:
-      return "Extend"
-    case Regional_Indicator:
-      return "Regional_Indicator"
-    case Prepend:
-      return "Prepend"
-    case SpacingMark:
-      return "SpacingMark"
-    case L:
-      return "L"
-    case V:
-      return "V"
-    case T:
-      return "T"
-    case LV:
-      return "LV"
-    case LVT:
-      return "LVT"
-    }
-  }
 }
 
 // It is expensive to convert a raw enum value to an enum, so we use this type


### PR DESCRIPTION
The implementation is identical to the default string representation. The conformance and description property are never explicitly used, and seem to be a legacy artifact. The patch passes validation tests (`build-script -R -T`) successfully.
