### PR TITLE
[SourceKit] Add test case for crash triggered in swift::BoundGenericType::getSubstitutions(…)

### DIFF
--- a/validation-test/IDE/crashers/043-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/IDE/crashers/043-swift-boundgenerictype-getsubstitutions.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+class A<h{#^A^#class B<a{let:AnyObject.Type=B


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 115
swift-ide-test: /path/to/llvm/include/llvm/ADT/ArrayRef.h:297: T &llvm::MutableArrayRef<swift::GenericTypeParamDecl *>::operator[](size_t) const [T = swift::GenericTypeParamDecl *]: Assertion `Index < this->size() && "Invalid index!"' failed.
8  swift-ide-test  0x0000000000b67222 swift::BoundGenericType::getSubstitutions(swift::ModuleDecl*, swift::LazyResolver*, swift::DeclContext*) + 2962
9  swift-ide-test  0x0000000000b8a323 swift::TypeBase::gatherAllSubstitutions(swift::ModuleDecl*, llvm::SmallVectorImpl<swift::Substitution>&, swift::LazyResolver*, swift::DeclContext*) + 211
10 swift-ide-test  0x0000000000b6781e swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1246
11 swift-ide-test  0x000000000095be10 swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 96
12 swift-ide-test  0x00000000008d9b5b swift::constraints::ConstraintSystem::simplifyConformsToConstraint(swift::Type, swift::ProtocolDecl*, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, unsigned int) + 123
13 swift-ide-test  0x00000000008d99e3 swift::constraints::ConstraintSystem::matchExistentialTypes(swift::Type, swift::Type, swift::constraints::ConstraintKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 211
14 swift-ide-test  0x00000000008dad30 swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 2512
15 swift-ide-test  0x00000000008d7895 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 10101
16 swift-ide-test  0x00000000008d7005 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 7909
17 swift-ide-test  0x00000000008e1aef swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 639
18 swift-ide-test  0x00000000009a6177 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
20 swift-ide-test  0x0000000000911011 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 385
21 swift-ide-test  0x0000000000917539 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
22 swift-ide-test  0x0000000000918650 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
23 swift-ide-test  0x00000000009187f9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
29 swift-ide-test  0x0000000000931ec7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
30 swift-ide-test  0x00000000008fe05a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1610
31 swift-ide-test  0x000000000076b9b2 swift::CompilerInstance::performSema() + 2946
32 swift-ide-test  0x00000000007152b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'A' at <INPUT-FILE>:2:1
2.  While type-checking expression at [<INPUT-FILE>:2:41 - line:2:41] RangeText="B"
```
