### PR TITLE
[SIL] Add test case for crash triggered in swift::SyntaxSugarType::getImplementationType()

### DIFF
--- a/validation-test/SIL/crashers/006-swift-syntaxsugartype-getimplementationtype.sil
+++ b/validation-test/SIL/crashers/006-swift-syntaxsugartype-getimplementationtype.sil
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class C
+struct e{weak var x:C


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:8: error: expected '{' in class
class C
       ^
<stdin>:4:22: error: consecutive declarations on a line must be separated by ';'
struct e{weak var x:C
                     ^
                     ;
<stdin>:4:22: error: expected declaration
struct e{weak var x:C
                     ^
sil-opt: /path/to/swift/lib/AST/Type.cpp:1361: swift::Type swift::SyntaxSugarType::getImplementationType(): Assertion `implDecl && "Optional type has not been set yet"' failed.
8  sil-opt         0x0000000000d776ed swift::SyntaxSugarType::getImplementationType() + 77
9  sil-opt         0x0000000000d7754f swift::TypeBase::getDesugaredType() + 15
11 sil-opt         0x0000000000d33e7f swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) + 3039
12 sil-opt         0x0000000000d3314f swift::DiagnosticEngine::flushActiveDiagnostic() + 319
13 sil-opt         0x0000000000a73ed5 swift::TypeChecker::checkOwnershipAttr(swift::VarDecl*, swift::OwnershipAttr*) + 309
14 sil-opt         0x0000000000a73bac swift::TypeChecker::checkTypeModifyingDeclAttributes(swift::VarDecl*) + 76
15 sil-opt         0x0000000000abfbfc swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 2332
16 sil-opt         0x0000000000abf00c swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 780
18 sil-opt         0x0000000000a95fc6 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3974
19 sil-opt         0x0000000000af8f53 swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 451
20 sil-opt         0x0000000000a9fee3 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1299
23 sil-opt         0x0000000000a9aba7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
24 sil-opt         0x0000000000a66372 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
25 sil-opt         0x00000000007392c2 swift::CompilerInstance::performSema() + 2946
26 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'e' at <stdin>:4:1
```
