### PR TITLE
[SourceKit] Add test case for crash triggered in swift::DependentGenericTypeResolver::resolveSelfAssociatedType(…)

### DIFF
--- a/validation-test/IDE/crashers/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/IDE/crashers/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,0 +1,5 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol A{protocol A{
+typealias e:a
+func a<T:e
+enum b{func a{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 167
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:46: virtual swift::Type swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext *, swift::AssociatedTypeDecl *): Assertion `archetype && "Bad generic context nesting?"' failed.
8  swift-ide-test  0x000000000094fc1d swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 125
9  swift-ide-test  0x000000000097d53c swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 796
13 swift-ide-test  0x000000000097e0ce swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
15 swift-ide-test  0x000000000097dfc4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
16 swift-ide-test  0x000000000092a351 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4929
17 swift-ide-test  0x00000000009503f5 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 373
19 swift-ide-test  0x000000000095081c swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
22 swift-ide-test  0x000000000092c680 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 800
23 swift-ide-test  0x0000000000b77a1c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
24 swift-ide-test  0x0000000000b7640c swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2252
25 swift-ide-test  0x00000000009541ab swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
28 swift-ide-test  0x000000000097e0ce swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
30 swift-ide-test  0x000000000097dfc4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
31 swift-ide-test  0x00000000009ef4e2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
32 swift-ide-test  0x00000000009eede7 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 359
33 swift-ide-test  0x0000000000928fc9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
34 swift-ide-test  0x000000000092c793 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1075
35 swift-ide-test  0x000000000092c420 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 192
36 swift-ide-test  0x000000000092c105 swift::configureImplicitSelf(swift::TypeChecker&, swift::AbstractFunctionDecl*) + 85
37 swift-ide-test  0x000000000092cfec swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3212
39 swift-ide-test  0x0000000000b57578 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 808
50 swift-ide-test  0x0000000000ae1df4 swift::Decl::walk(swift::ASTWalker&) + 20
51 swift-ide-test  0x0000000000b6baae swift::SourceFile::walk(swift::ASTWalker&) + 174
52 swift-ide-test  0x0000000000b6acdf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
53 swift-ide-test  0x0000000000b44e42 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
54 swift-ide-test  0x000000000085cd6a swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
55 swift-ide-test  0x000000000076bb24 swift::CompilerInstance::performSema() + 3316
56 swift-ide-test  0x00000000007152b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl 'A' at <INPUT-FILE>:2:1
2.  While resolving type a at [<INPUT-FILE>:3:13 - line:3:13] RangeText="a"
3.  While type-checking 'a' at <INPUT-FILE>:4:1
4.  While resolving type e at [<INPUT-FILE>:4:10 - line:4:10] RangeText="e"
```
