### PR TITLE
[SIL] Add test case for crash triggered in swift::AbstractStorageDecl::makeComputed(…)

### DIFF
--- a/validation-test/SIL/crashers/007-swift-abstractstoragedecl-makecomputed.sil
+++ b/validation-test/SIL/crashers/007-swift-abstractstoragedecl-makecomputed.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+protocol a{@sil_stored var e:a{get


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:35: error: expected '}' at end of variable get/set clause
protocol a{@sil_stored var e:a{get
                                  ^
<stdin>:3:31: note: to match this opening '{'
protocol a{@sil_stored var e:a{get
                              ^
<stdin>:3:35: error: consecutive declarations on a line must be separated by ';'
protocol a{@sil_stored var e:a{get
                                  ^
                                  ;
<stdin>:3:35: error: expected declaration
protocol a{@sil_stored var e:a{get
                                  ^
<stdin>:3:12: error: attribute cannot be applied to declaration
protocol a{@sil_stored var e:a{get
           ^~~~~~~~~~~

<stdin>:3:28: error: property in protocol must have explicit { get } or { get set } specifier
protocol a{@sil_stored var e:a{get
                           ^
sil-opt: /path/to/swift/lib/AST/Decl.cpp:2788: void swift::AbstractStorageDecl::makeComputed(swift::SourceLoc, swift::FuncDecl *, swift::FuncDecl *, swift::FuncDecl *, swift::SourceLoc): Assertion `getStorageKind() == Stored && "StorageKind already set"' failed.
8  sil-opt         0x0000000000d28290 swift::AbstractStorageDecl::makeComputed(swift::SourceLoc, swift::FuncDecl*, swift::FuncDecl*, swift::FuncDecl*, swift::SourceLoc) + 352
9  sil-opt         0x0000000000af320d swift::convertStoredVarInProtocolToComputed(swift::VarDecl*, swift::TypeChecker&) + 45
14 sil-opt         0x0000000000a9aba7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
15 sil-opt         0x0000000000a66372 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
16 sil-opt         0x00000000007392c2 swift::CompilerInstance::performSema() + 2946
17 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'a' at <stdin>:3:1
```
