### PR TITLE
[SIL] Add test case for crash triggered in swift::GenericParamList::getAsGenericSignatureElements(…)

### DIFF
--- a/validation-test/SIL/crashers/008-swift-genericparamlist-getasgenericsignatureelements.sil
+++ b/validation-test/SIL/crashers/008-swift-genericparamlist-getasgenericsignatureelements.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil@__:$<__ where τ:k>()->(


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:29: error: expected type
sil@__:$<__ where τ:k>()->(
<stdin>:3:29: error: expected ',' separator
sil@__:$<__ where τ:k>()->(
<stdin>:3:19: error: use of undeclared type 'τ'
sil@__:$<__ where τ:k>()->(
sil-opt: /path/to/llvm/include/llvm/ADT/ArrayRef.h:172: ArrayRef<T> llvm::ArrayRef<swift::ArchetypeType *>::slice(unsigned int, unsigned int) const [T = swift::ArchetypeType *]: Assertion `N+M <= size() && "Invalid specifier"' failed.
8  sil-opt         0x0000000000d20b65 swift::GenericParamList::getAsGenericSignatureElements(swift::ASTContext&, llvm::DenseMap<swift::ArchetypeType*, swift::Type, llvm::DenseMapInfo<swift::ArchetypeType*>, llvm::detail::DenseMapPair<swift::ArchetypeType*, swift::Type> >&, llvm::SmallVectorImpl<swift::GenericTypeParamType*>&, llvm::SmallVectorImpl<swift::Requirement>&) const + 2693
9  sil-opt         0x0000000000d1ff3c swift::GenericParamList::getAsCanonicalGenericSignature(llvm::DenseMap<swift::ArchetypeType*, swift::Type, llvm::DenseMapInfo<swift::ArchetypeType*>, llvm::detail::DenseMapPair<swift::ArchetypeType*, swift::Type> >&, swift::ASTContext&) const + 92
13 sil-opt         0x0000000000ae6c04 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
14 sil-opt         0x0000000000a66c5f swift::performTypeLocChecking(swift::ASTContext&, swift::TypeLoc&, bool, swift::DeclContext*, bool) + 1007
16 sil-opt         0x0000000000a23163 swift::Parser::parseDeclSIL() + 627
17 sil-opt         0x00000000009f5b2a swift::Parser::parseTopLevel() + 378
18 sil-opt         0x00000000009f0fcf swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
19 sil-opt         0x00000000007392a6 swift::CompilerInstance::performSema() + 2918
20 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:29
2.  While resolving type @convention(thin) () -> ()sil-opt: /path/to/swift/include/swift/Basic/SourceLoc.h:93: swift::SourceRange::SourceRange(swift::SourceLoc, swift::SourceLoc): Assertion `Start.isValid() == End.isValid() && "Start and end should either both be valid or both be invalid!"' failed.
```
