### PR TITLE
Bash: Build script cleanups

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -390,7 +390,6 @@ function set_deployment_target_based_options() {
                     ;;
             esac
 
-            native_llvm_build=$(build_directory macosx-x86_64 llvm)
             llvm_cmake_options=(
                 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="${cmake_osx_deployment_target}"
                 -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk $xcrun_sdk_name --show-sdk-path)"
@@ -1040,7 +1039,6 @@ COMMON_CMAKE_OPTIONS=(
 )
 
 COMMON_C_FLAGS=""
-COMMON_CXX_FLAGS=""
 
 if [[ "${ENABLE_ASAN}" ]] ; then
     COMMON_CMAKE_OPTIONS=(

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1744,7 +1744,7 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 fi
 
                 # Get the build date
-                LLDB_BUILD_DATE=`date +%Y-%m-%d`
+                LLDB_BUILD_DATE=$(date +%Y-%m-%d)
 
                 case "$(uname -s)" in
                     Linux)
@@ -2172,10 +2172,10 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                     continue
                 fi
                 LIB_TARGET="linux"
-                if [[ `uname -s` == "FreeBSD" ]]; then
+                if [[ $(uname -s) == "FreeBSD" ]]; then
                     LIB_TARGET="freebsd"
                 fi
-                if [[ `uname -s` == "Darwin" ]]; then
+                if [[ $(uname -s) == "Darwin" ]]; then
                     LIB_TARGET="macosx"
                 fi
                 XCTEST_INSTALL_PREFIX="${INSTALL_DESTDIR}"/"${INSTALL_PREFIX}"/lib/swift/"${LIB_TARGET}"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1329,7 +1329,7 @@ function should_build_perftestsuite() {
         return
     fi
 
-    echo $(true_false "${BUILD_SWIFT_PERF_TESTSUITE}")
+    true_false "${BUILD_SWIFT_PERF_TESTSUITE}"
 }
 
 function set_swiftpm_bootstrap_command() {


### PR DESCRIPTION
Fixes:
- Unused variable
- Superfluous echo
- Use of discouraged back-tick execution (instead of recommended `$(cmd)`)
