### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseDeclSIL()

### DIFF
--- a/validation-test/SIL/crashers/009-swift-parser-parsedeclsil.sil
+++ b/validation-test/SIL/crashers/009-swift-parser-parsedeclsil.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil private@s:$()->()


### PR DESCRIPTION
Stack trace:

```
sil-opt: /path/to/swift/lib/SIL/Verifier.cpp:2992: void (anonymous namespace)::SILVerifier::visitSILFunction(swift::SILFunction *): Assertion `F->isAvailableExternally() && "external declaration of internal SILFunction not allowed"' failed.
9  sil-opt         0x0000000000a243f8 swift::Parser::parseDeclSIL() + 5384
10 sil-opt         0x00000000009f5b2a swift::Parser::parseTopLevel() + 378
11 sil-opt         0x00000000009f0fcf swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
12 sil-opt         0x00000000007392a6 swift::CompilerInstance::performSema() + 2918
13 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:22
2.  While verifying SIL function @s for <stdin>:3:13
```
