### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeChecker::typeCheckTopLevelCodeDecl(…)

### DIFF
--- a/validation-test/IDE/crashers/047-swift-typechecker-typechecktoplevelcodedecl.swift
+++ b/validation-test/IDE/crashers/047-swift-typechecker-typechecktoplevelcodedecl.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+if c={func b:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 139
5  swift-ide-test  0x0000000000979936 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
6  swift-ide-test  0x00000000009012cd swift::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 1117
9  swift-ide-test  0x000000000085ce13 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 307
10 swift-ide-test  0x000000000076bb24 swift::CompilerInstance::performSema() + 3316
11 swift-ide-test  0x00000000007152b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
