### PR TITLE
[Parser] Fix-it for declaration attributes being applied to parameter types (SR-215)

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -241,7 +241,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
           // Check if attribute is invalid type attribute
           // and actually a declaration attribute
           if (TypeAttributes::getAttrKindFromString(nextToken.getText()) == TAK_Count 
-              && DeclAttribute::getAttrKindFromString(nextToken.getText()) != TAK_Count) { 
+              && DeclAttribute::getAttrKindFromString(nextToken.getText()) != DAK_Count) { 
             SourceLoc AtLoc = consumeToken(tok::at_sign);
             SourceLoc AttrLoc = consumeToken(tok::identifier);
             diagnose(AtLoc, diag::decl_attribute_applied_to_type)

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -238,8 +238,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         // Check if token is @ sign ergo an attribute
         if (Tok.is(tok::at_sign)) {
           Token nextToken = peekToken();
-          // Fix for SR215
-          // Check if attribute is invalid type attribute 
+          // Check if attribute is invalid type attribute
           // and actually a declaration attribute
           if (TypeAttributes::getAttrKindFromString(nextToken.getText()) == TAK_Count 
               && DeclAttribute::getAttrKindFromString(nextToken.getText()) != TAK_Count) { 
@@ -247,7 +246,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
             SourceLoc AttrLoc = consumeToken(tok::identifier);
             diagnose(AtLoc, diag::decl_attribute_applied_to_type)
               .fixItRemove(SourceRange(AtLoc, AttrLoc))
-              .fixItInsert(StartLoc, "@" + nextToken.getText().str()+" ");              
+              .fixItInsert(StartLoc, "@" + nextToken.getText().str()+" ");
           }
         }
 

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -2,6 +2,8 @@
 
 @noescape var fn : () -> Int = { 4 }  // expected-error {{@noescape may only be used on 'parameter' declarations}} {{1-11=}}
 
+func appliedToType(g: @noescape ()->Void) { g() }  // expected-error {{attribute can only be applied to declarations, not types}} {{20-20=@noescape }} {{23-33=}}
+
 func doesEscape(fn : () -> Int) {}
 
 func takesGenericClosure<T>(a : Int, @noescape _ fn : () -> T) {}


### PR DESCRIPTION
As described in [SR-215](https://bugs.swift.org/browse/SR-215), previously the fix-it was suggesting that declaration attributes applied to parameter types be moved to before the function `func` declaration itself. 

This pull request fixes this so that it is instead moved to before the parameter name. 
