### PR TITLE
Add support in the diagnostic verifier for verifying no fix-its

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -39,6 +39,10 @@ namespace {
     // This is true if a '*' constraint is present to say that the diagnostic
     // may appear (or not) an uncounted number of times.
     bool mayAppear = false;
+      
+    // This is true if a '{{none}}' is present to mark that there should be no
+    // fixits at all.
+    bool noFixitsMayAppear = false;
 
     // This is the raw input buffer for the message text, the part in the
     // {{...}}
@@ -358,6 +362,12 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
       // Prepare for the next round of checks.
       ExtraChecks = ExtraChecks.substr(EndLoc+2).ltrim();
       
+      // Special case for specifying no fixits should appear.
+      if (FixItStr == "none") {
+        Expected.noFixitsMayAppear = true;
+        continue;
+      }
+        
       // Parse the pieces of the fix-it.
       size_t MinusLoc = FixItStr.find('-');
       if (MinusLoc == StringRef::npos) {
@@ -467,20 +477,17 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
       llvm::SMFixIt fix(llvm::SMRange(replStartLoc, replEndLoc), actual);
       addError(IncorrectFixit,
                "expected fix-it not seen; actual fix-its: " + actual, fix);
-#if 0 // TODO: There are still some bugs with this, and we don't have a
-      // policy of requiring a fixit specification on tests.
-    } else if (expected.Fixits.empty() &&
+    } else if (expected.noFixitsMayAppear &&
                !FoundDiagnostic.getFixIts().empty() &&
-               !expected.mayAppear &&
-                              false) {
+               !expected.mayAppear) {
       // If there was no fixit specification, but some were produced, add a
       // fixit to add them in.
       auto actual = renderFixits(FoundDiagnostic.getFixIts(), InputFile);
-      
-      llvm::SMFixIt fix(SMLoc::getFromPointer(expected.ExpectedEnd),
-                        " " + actual);
-      addError(expected.ExpectedEnd, "expected fix-it not specified", fix);
-#endif
+      auto replStartLoc = SMLoc::getFromPointer(expected.ExpectedEnd - 8); // {{none}} length
+      auto replEndLoc = SMLoc::getFromPointer(expected.ExpectedEnd - 1);
+
+      llvm::SMFixIt fix(llvm::SMRange(replStartLoc, replEndLoc), actual);
+      addError(replStartLoc.getPointer(), "expected no fix-its; actual fix-it seen: " + actual, fix);
     }
     
     // Actually remove the diagnostic from the list, so we don't match it

--- a/test/Sema/diag_c_style_for.swift
+++ b/test/Sema/diag_c_style_for.swift
@@ -18,11 +18,11 @@ for var d=100;d<5;d++ { // expected-warning {{C-style for statement is deprecate
 
 // next three aren't auto-fixable
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for var e = 3; e > 4; e++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+for var e = 3; e > 4; e++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}}
 }
 
 // expected-warning @+1 {{'--' is deprecated: it will be removed in Swift 3}}
-for var f = 3; f < 4; f-- { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+for var f = 3; f < 4; f-- { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}}
 }
 
 let start = Int8(4)
@@ -30,7 +30,7 @@ let count = Int8(10)
 var other = Int8(2)
 
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for ; other<count; other++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+for ; other<count; other++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}}
 }
 
 // this should be fixable, and keep the type
@@ -41,15 +41,15 @@ for (var number : Int8 = start; number < count; number++) { // expected-warning 
 
 // should produce extra note
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for (var m : Int8 = start; m < count; ++m) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} expected-note {{C-style for statement can't be automatically fixed to for-in, because the loop variable is modified inside the loop}}
+for (var m : Int8 = start; m < count; ++m) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}} expected-note {{C-style for statement can't be automatically fixed to for-in, because the loop variable is modified inside the loop}}
   m += 3
 }
 
 // could theoretically fix this (and more like it if we auto-suggested "stride:")
-for var o = 2; o < 888; o += 1 { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+for var o = 2; o < 888; o += 1 { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}}
 }
 
 // could theoretically fix this with "..."
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for var p = 2; p <= 8; p++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}}
+for var p = 2; p <= 8; p++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}}
 }


### PR DESCRIPTION
Checked what it would look like to verify fix-its in every case, and
currently the tests are missing expected fix-its in 435 diagnoses in 60
test files.

So as an alternative, added support for a no fix-its marker “{{}}”, and
added that marker to the c-style for deprecation tests where it applies.

See conversation in https://github.com/apple/swift/pull/552 for the motivation for this change.
