### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::addImplicitConstructors(…)

### DIFF
--- a/validation-test/SIL/crashers/010-swift-typechecker-addimplicitconstructors.sil
+++ b/validation-test/SIL/crashers/010-swift-typechecker-addimplicitconstructors.sil
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class C{@NSManaged var S
+var h


### PR DESCRIPTION
Stack trace:

```
<stdin>:4:6: error: consecutive declarations on a line must be separated by ';'
var h
     ^
     ;
<stdin>:4:6: error: expected declaration
var h
     ^
<stdin>:3:24: error: type annotation missing in pattern
class C{@NSManaged var S
                       ^
<stdin>:4:5: error: type annotation missing in pattern
var h
    ^
<stdin>:3:7: error: class 'C' has no initializers
class C{@NSManaged var S
      ^
sil-opt: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:1010: auto isNeverDefaultInitializable(swift::Pattern *)::(anonymous class)::operator()(swift::VarDecl *) const: Assertion `!var->getAttrs().hasAttribute<NSManagedAttr>()' failed.
11 sil-opt         0x0000000000a9ff1f swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1359
14 sil-opt         0x0000000000a9aba7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
15 sil-opt         0x0000000000a663fa swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1610
16 sil-opt         0x00000000007392c2 swift::CompilerInstance::performSema() + 2946
17 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'C' at <stdin>:3:1
```
