### PR TITLE
[SourceKit] Add test case for crash triggered in swift::CompleteGenericTypeResolver::resolveDependentMemberType(…)

### DIFF
--- a/validation-test/IDE/crashers/048-swift-completegenerictyperesolver-resolvedependentmembertype.swift
+++ b/validation-test/IDE/crashers/048-swift-completegenerictyperesolver-resolvedependentmembertype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+var b{protocol A{enum B<e{func a{struct c<T where T.h:A{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 161
swift-ide-test: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:152: virtual swift::Type swift::CompleteGenericTypeResolver::resolveDependentMemberType(swift::Type, swift::DeclContext *, swift::SourceRange, swift::ComponentIdentTypeRepr *): Assertion `basePA && "Missing potential archetype for base"' failed.
8  swift-ide-test  0x0000000000950114 swift::CompleteGenericTypeResolver::resolveDependentMemberType(swift::Type, swift::DeclContext*, swift::SourceRange, swift::ComponentIdentTypeRepr*) + 708
10 swift-ide-test  0x000000000097e0ce swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift-ide-test  0x000000000097dfc4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
13 swift-ide-test  0x000000000095054b swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 715
14 swift-ide-test  0x0000000000951d30 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 256
15 swift-ide-test  0x0000000000952074 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
16 swift-ide-test  0x000000000092c4c1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 353
19 swift-ide-test  0x0000000000931ec7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
22 swift-ide-test  0x000000000097842b swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
23 swift-ide-test  0x000000000097826e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
24 swift-ide-test  0x0000000000900e28 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
29 swift-ide-test  0x0000000000ae1df4 swift::Decl::walk(swift::ASTWalker&) + 20
30 swift-ide-test  0x0000000000b6baae swift::SourceFile::walk(swift::ASTWalker&) + 174
31 swift-ide-test  0x0000000000b6acdf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
32 swift-ide-test  0x0000000000b44e42 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
33 swift-ide-test  0x000000000085cd6a swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
34 swift-ide-test  0x000000000076bb24 swift::CompilerInstance::performSema() + 3316
35 swift-ide-test  0x00000000007152b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for b at <INPUT-FILE>:2:6
2.  While type-checking 'c' at <INPUT-FILE>:2:34
3.  While resolving type T.h at [<INPUT-FILE>:2:51 - line:2:53] RangeText="T.h"
```
