### PR TITLE
[stdlib] [documentation] correct Set/Dictionary removeAll() Complexity

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1120,7 +1120,8 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   storage capacity that the collection has, otherwise the underlying
   ///   storage is released.  The default is `false`.
   ///
-  /// Complexity: O(`self.count`).
+  /// - Complexity: O(`self.count`) if `keepCapacity` is `true`, O(1)
+  ///   otherwise.
   public mutating func removeAll(keepCapacity keepCapacity: Bool = false) {
     // The 'will not decrease' part in the documentation comment is worded very
     // carefully.  The capacity can increase if we replace Cocoa storage with


### PR DESCRIPTION
The complexity of `removeAll()` is no longer _O(N)_ in general now that #616 is merged.

When `keepCapacity` is set to `true` and Set/Dictionary is uniquely referenced,
elements will be deleted one by one. Otherwise this operation only involves
creating new storage.
