### PR TITLE
[stdlib] Fix bug in Bit with-overflow arithmetic

### DIFF
--- a/stdlib/public/core/Bit.swift
+++ b/stdlib/public/core/Bit.swift
@@ -98,7 +98,8 @@ extension Bit : IntegerArithmeticType {
     if let b = Bit(rawValue: v.0) {
       return (b, v.overflow)
     } else {
-      return (Bit(rawValue: v.0 % 2)!, true)
+      let bitRaw = v.0 > 0 ? v.0 % 2 : v.0 % 2 + 2
+      return (Bit(rawValue: bitRaw)!, true)
     }
   }
 

--- a/stdlib/public/core/Bit.swift
+++ b/stdlib/public/core/Bit.swift
@@ -96,10 +96,11 @@ public func < (lhs: Bit, rhs: Bit) -> Bool {
 extension Bit : IntegerArithmeticType {
   static func _withOverflow(intResult: Int, overflow: Bool) -> (Bit, overflow: Bool) {
     if let bit = Bit(rawValue: intResult) {
-      return (bit, overflow)
+      return (bit, overflow: overflow)
     } else {
-      let bitRaw = intResult > 0 ? intResult % 2 : intResult % 2 + 2
-      return (Bit(rawValue: bitRaw)!, overflow: true)
+      let bitRaw = intResult % 2 + (intResult < 0 ? 2 : 0)
+      let bit = Bit(rawValue: bitRaw)!
+      return (bit, overflow: true)
     }
   }
 

--- a/stdlib/public/core/Bit.swift
+++ b/stdlib/public/core/Bit.swift
@@ -94,7 +94,9 @@ public func < (lhs: Bit, rhs: Bit) -> Bool {
 }
 
 extension Bit : IntegerArithmeticType {
-  static func _withOverflow(intResult: Int, overflow: Bool) -> (Bit, overflow: Bool) {
+  static func _withOverflow(
+    intResult: Int, overflow: Bool
+  ) -> (Bit, overflow: Bool) {
     if let bit = Bit(rawValue: intResult) {
       return (bit, overflow: overflow)
     } else {

--- a/stdlib/public/core/Bit.swift
+++ b/stdlib/public/core/Bit.swift
@@ -94,12 +94,12 @@ public func < (lhs: Bit, rhs: Bit) -> Bool {
 }
 
 extension Bit : IntegerArithmeticType {
-  static func _withOverflow(v: (Int, overflow: Bool)) -> (Bit, overflow: Bool) {
-    if let b = Bit(rawValue: v.0) {
-      return (b, v.overflow)
+  static func _withOverflow(intResult: Int, overflow: Bool) -> (Bit, overflow: Bool) {
+    if let bit = Bit(rawValue: intResult) {
+      return (bit, overflow)
     } else {
-      let bitRaw = v.0 > 0 ? v.0 % 2 : v.0 % 2 + 2
-      return (Bit(rawValue: bitRaw)!, true)
+      let bitRaw = intResult > 0 ? intResult % 2 : intResult % 2 + 2
+      return (Bit(rawValue: bitRaw)!, overflow: true)
     }
   }
 

--- a/test/1_stdlib/Bit.swift
+++ b/test/1_stdlib/Bit.swift
@@ -27,6 +27,8 @@ print(one.predecessor().rawValue)
 
 // CHECK-NEXT: 0
 print((one &+ one).rawValue)
+// CHECK-NEXT: 1
+print((zero &- one).rawValue)
 
 // CHECK: done.
 print("done.")


### PR DESCRIPTION
The original code would crash on negative values.
- Added a test for this case.
- Patch passes `build-script -R -t`.
