### PR TITLE
[stdlib] Refactor availability code

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -58,30 +58,30 @@ public func == (
 /// Lexicographic comparison of version components.
 @warn_unused_result
 public func < (
-  _lhs: _SwiftNSOperatingSystemVersion,
-  _rhs: _SwiftNSOperatingSystemVersion
+  lhs: _SwiftNSOperatingSystemVersion,
+  rhs: _SwiftNSOperatingSystemVersion
 ) -> Bool {
-  if _lhs.majorVersion > _rhs.majorVersion {
+  if lhs.majorVersion > rhs.majorVersion {
     return false
   }
 
-  if _lhs.majorVersion < _rhs.majorVersion {
+  if lhs.majorVersion < rhs.majorVersion {
     return true
   }
 
-  if _lhs.minorVersion > _rhs.minorVersion {
+  if lhs.minorVersion > rhs.minorVersion {
     return false
   }
 
-  if _lhs.minorVersion < _rhs.minorVersion {
+  if lhs.minorVersion < rhs.minorVersion {
     return true
   }
 
-  if _lhs.patchVersion > _rhs.patchVersion {
+  if lhs.patchVersion > rhs.patchVersion {
     return false
   }
 
-  if _lhs.patchVersion < _rhs.patchVersion {
+  if lhs.patchVersion < rhs.patchVersion {
     return true
   }
 

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -61,29 +61,14 @@ public func < (
   lhs: _SwiftNSOperatingSystemVersion,
   rhs: _SwiftNSOperatingSystemVersion
 ) -> Bool {
-  if lhs.majorVersion > rhs.majorVersion {
-    return false
+  // Compare by major version
+  if lhs.majorVersion != rhs.majorVersion {
+    return lhs.majorVersion < rhs.majorVersion
   }
-
-  if lhs.majorVersion < rhs.majorVersion {
-    return true
+  // Compare by minor version
+  if lhs.minorVersion != rhs.minorVersion {
+    return lhs.minorVersion < rhs.minorVersion
   }
-
-  if lhs.minorVersion > rhs.minorVersion {
-    return false
-  }
-
-  if lhs.minorVersion < rhs.minorVersion {
-    return true
-  }
-
-  if lhs.patchVersion > rhs.patchVersion {
-    return false
-  }
-
-  if lhs.patchVersion < rhs.patchVersion {
-    return true
-  }
-
-  return false
+  // Compare by patch version
+  return lhs.patchVersion < rhs.patchVersion
 }

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -47,12 +47,12 @@ extension _SwiftNSOperatingSystemVersion : Comparable { }
 
 @warn_unused_result
 public func == (
-  left: _SwiftNSOperatingSystemVersion,
-  right: _SwiftNSOperatingSystemVersion
+  lhs: _SwiftNSOperatingSystemVersion,
+  rhs: _SwiftNSOperatingSystemVersion
 ) -> Bool {
-  return left.majorVersion == right.majorVersion &&
-         left.minorVersion == right.minorVersion &&
-         left.patchVersion == right.patchVersion
+  return lhs.majorVersion == rhs.majorVersion &&
+         lhs.minorVersion == rhs.minorVersion &&
+         lhs.patchVersion == rhs.patchVersion
 }
 
 /// Lexicographic comparison of version components.

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -87,35 +87,3 @@ public func < (
 
   return false
 }
-
-@warn_unused_result
-public func >= (
-  _lhs: _SwiftNSOperatingSystemVersion,
-  _rhs: _SwiftNSOperatingSystemVersion
-) -> Bool {
-  if _lhs.majorVersion < _rhs.majorVersion {
-    return false
-  }
-
-  if _lhs.majorVersion > _rhs.majorVersion {
-    return true
-  }
-
-  if _lhs.minorVersion < _rhs.minorVersion {
-    return false
-  }
-
-  if _lhs.minorVersion > _rhs.minorVersion {
-    return true
-  }
-
-  if _lhs.patchVersion < _rhs.patchVersion {
-    return false
-  }
-
-  if _lhs.patchVersion > _rhs.patchVersion {
-    return true
-  }
-
-  return true
-}


### PR DESCRIPTION
Miscellaneous refactoring:
- Removed (correct me if I'm wrong) redundant code.
- Renamed local variables for consistency.
- Rewrote `< (_:_:)` implementation for readability.
  - New implementation does one more comparison in case `lhs.majorVersion < rhs.majorVersion` but equal or less comparisons in all other cases. Not sure if it matters after optimization though.
- Patch passes `build-script -R -t`.
