### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::validateType(…)

### DIFF
--- a/validation-test/SIL/crashers/011-swift-typechecker-validatetype.sil
+++ b/validation-test/SIL/crashers/011-swift-typechecker-validatetype.sil
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-sil-opt %s
+sil@s:$()->(@owned T c:t


### PR DESCRIPTION
Stack trace:

```
<stdin>:2:22: error: expected ',' separator
sil@s:$()->(@owned T c:t
                     ^
                    ,
<stdin>:2:25: error: expected ',' separator
sil@s:$()->(@owned T c:t
                        ^
                        ,
<stdin>:2:25: error: expected type
sil@s:$()->(@owned T c:t
                        ^
<stdin>:2:25: error: expected ',' separator
sil@s:$()->(@owned T c:t
                        ^
                        ,
<stdin>:2:20: error: use of undeclared type 'T'
sil@s:$()->(@owned T c:t
                   ^
NamedTypeRepr only shows up as an element of Tuple
UNREACHABLE executed at /path/to/swift/lib/Sema/TypeCheckType.cpp:1400!
6  sil-opt         0x0000000002c0db6d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
12 sil-opt         0x0000000000ae6ad4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
13 sil-opt         0x0000000000a66c0f swift::performTypeLocChecking(swift::ASTContext&, swift::TypeLoc&, bool, swift::DeclContext*, bool) + 1007
15 sil-opt         0x0000000000a23113 swift::Parser::parseDeclSIL() + 627
16 sil-opt         0x00000000009f5ada swift::Parser::parseTopLevel() + 378
17 sil-opt         0x00000000009f0f7f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
18 sil-opt         0x00000000007392a6 swift::CompilerInstance::performSema() + 2918
19 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:2:25
2.  While resolving type @convention(thin) () -> ( T, c: t)sil-opt: /path/to/swift/include/swift/Basic/SourceLoc.h:93: swift::SourceRange::SourceRange(swift::SourceLoc, swift::SourceLoc): Assertion `Start.isValid() == End.isValid() && "Start and end should either both be valid or both be invalid!"' failed.
```
