### PR TITLE
Revert "Add crash case (see #587) for fixed bug to crashers_fixed/"

### DIFF
--- a/validation-test/IDE/crashers_fixed/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers_fixed/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,4 +1,0 @@
-// RUN: not %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-protocol c{func a:P
-protocol P{#^A^#func a:b
-typealias b:a


### PR DESCRIPTION
Reverts apple/swift#607

This crash test isn't actually fixed, it crashes on Linux and OS X for me.  It might be non-deterministic.
