### PR TITLE
[SIL] Add test case for crash triggered in swift::DependentGenericTypeResolver::resolveSelfAssociatedType(…)

### DIFF
--- a/validation-test/SIL/crashers/012-swift-dependentgenerictyperesolver-resolveselfassociatedtype.sil
+++ b/validation-test/SIL/crashers/012-swift-dependentgenerictyperesolver-resolveselfassociatedtype.sil
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-sil-opt %s
+protocol O{func f(<u,a{},a.i


### PR DESCRIPTION
Stack trace:

```
<stdin>:2:23: error: expected '>' to complete generic parameter list
protocol O{func f(<u,a{},a.i
                      ^
<stdin>:2:19: note: to match this opening '<'
protocol O{func f(<u,a{},a.i
                  ^
<stdin>:2:23: error: expected parameter type following ':'
protocol O{func f(<u,a{},a.i
                      ^
<stdin>:2:23: error: expected ',' separator
protocol O{func f(<u,a{},a.i
                      ^
                      ,
<stdin>:2:23: error: expected parameter type following ':'
protocol O{func f(<u,a{},a.i
                      ^
<stdin>:2:23: error: expected ',' separator
protocol O{func f(<u,a{},a.i
                      ^
                      ,
<stdin>:2:26: error: unnamed parameters must be written with the empty name '_'
protocol O{func f(<u,a{},a.i
                         ^
                         _:
<stdin>:2:29: error: expected ',' separator
protocol O{func f(<u,a{},a.i
                            ^
                            ,
<stdin>:2:29: error: expected parameter type following ':'
protocol O{func f(<u,a{},a.i
                            ^
<stdin>:2:29: error: expected ',' separator
protocol O{func f(<u,a{},a.i
                            ^
                            ,
<stdin>:2:29: error: consecutive declarations on a line must be separated by ';'
protocol O{func f(<u,a{},a.i
                            ^
                            ;
<stdin>:2:29: error: expected declaration
protocol O{func f(<u,a{},a.i
                            ^
<unknown>:0: error: type annotation missing in pattern
sil-opt: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:34: virtual swift::Type swift::DependentGenericTypeResolver::resolveDependentMemberType(swift::Type, swift::DeclContext *, swift::SourceRange, swift::ComponentIdentTypeRepr *): Assertion `archetype && "Bad generic context nesting?"' failed.
8  sil-opt         0x0000000000ab8550 swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 0
10 sil-opt         0x0000000000ae6bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 sil-opt         0x0000000000ae6ad4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
14 sil-opt         0x0000000000abeee1 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 721
15 sil-opt         0x0000000000abee38 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 552
17 sil-opt         0x0000000000ab91cc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
22 sil-opt         0x0000000000a9aaf7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
23 sil-opt         0x0000000000a66322 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
24 sil-opt         0x00000000007392c2 swift::CompilerInstance::performSema() + 2946
25 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'O' at <stdin>:2:1
2.  While resolving type a.i at [<stdin>:2:26 - line:2:28] RangeText="a.i"
```
