### PR TITLE
Re-add SourceKit crash previously marked as fixed

### DIFF
--- a/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol c{func a:P
+protocol P{#^A^#func a:b
+typealias b:a


### PR DESCRIPTION
`024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift` crashes `swift-ide-test` compiled from current master on Linux. I ran the test 1000 times and it failed every single time, so it appears to be a deterministic crash.

See discussion in #607 and previously in #587.

@shahmishal, you reported the non crash in #587 - can you confirm that this case is crashing your setup as well? :-) 
