### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseSILGlobal()

### DIFF
--- a/validation-test/SIL/crashers/013-swift-parser-parsesilglobal.sil
+++ b/validation-test/SIL/crashers/013-swift-parser-parsesilglobal.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil_global@_a:$()sil_global[fragile@_a:$(


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:36: error: expected ']' or ',' in attribute list
sil_global@_a:$()sil_global[fragile@_a:$(
                                   ^
<stdin>:3:42: error: expected type
sil_global@_a:$()sil_global[fragile@_a:$(
                                         ^
<stdin>:3:42: error: expected ',' separator
sil_global@_a:$()sil_global[fragile@_a:$(
                                         ^
                                         ,
sil-opt: /path/to/swift/lib/SIL/SILGlobalVariable.cpp:29: static swift::SILGlobalVariable *swift::SILGlobalVariable::create(swift::SILModule &, swift::SILLinkage, bool, llvm::StringRef, swift::SILType, Optional<swift::SILLocation>, swift::VarDecl *): Assertion `!entry->getValue() && "global variable already exists"' failed.
9  sil-opt         0x0000000000a25f6c swift::Parser::parseSILGlobal() + 684
10 sil-opt         0x00000000009f5c3b swift::Parser::parseTopLevel() + 731
11 sil-opt         0x00000000009f0f7f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
12 sil-opt         0x00000000007392a6 swift::CompilerInstance::performSema() + 2918
13 sil-opt         0x0000000000723efc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:42
```
