### PR TITLE
[stdlib] Tweak comments

### DIFF
--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -80,7 +80,7 @@ internal func _parseAsciiAsUIntMax(
     else { return nil }
   // Disallow < 0.
   if hasMinus && result != 0 { return nil }
-  // Return.
+  // Valid result, return.
   return result
 }
 
@@ -97,12 +97,12 @@ internal func _parseAsciiAsIntMax(
   if utf16.isEmpty { return nil }
   // Parse (optional) sign.
   let (digitsUTF16, hasMinus) = _parseOptionalAsciiSign(utf16)
-  // Parse digits. +1 for because e.g. Int8's range is -128...127.
+  // Parse digits. +1 for negatives because e.g. Int8's range is -128...127.
   let absValueMax = UIntMax(bitPattern: maximum) + (hasMinus ? 1 : 0)
   guard let absValue =
     _parseUnsignedAsciiAsUIntMax(digitsUTF16, radix, absValueMax)
     else { return nil }
-  // Return signed result.
+  // Valid result, return signed.
   return IntMax(bitPattern: hasMinus ? 0 &- absValue : absValue)
 }
 


### PR DESCRIPTION
Slight amendment to #613 to, among others, replace a `// Return` comment with something a bit more useful :).
