### PR TITLE
[SIL] Add test case for crash triggered in swift::SILDeclRef::SILDeclRef(…)

### DIFF
--- a/validation-test/SIL/crashers/014-swift-sildeclref-sildeclref.sil
+++ b/validation-test/SIL/crashers/014-swift-sildeclref-sildeclref.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class C}sil_vtable C{#C


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:8: error: expected '{' in class
class C}sil_vtable C{#C
       ^
<stdin>:3:8: error: extraneous '}' at top level
class C}sil_vtable C{#C
       ^

sil-opt: /path/to/swift/lib/SIL/SILDeclRef.cpp:144: swift::SILDeclRef::SILDeclRef(swift::ValueDecl *, SILDeclRef::Kind, swift::ResilienceExpansion, unsigned int, bool): Assertion `(kind == Kind::IVarInitializer || kind == Kind::IVarDestroyer) && "can only create ivar initializer/destroyer SILDeclRef for class"' failed.
8  sil-opt         0x00000000009cf6e6 swift::SILDeclRef::SILDeclRef(swift::ValueDecl*, swift::SILDeclRef::Kind, swift::ResilienceExpansion, unsigned int, bool) + 150
10 sil-opt         0x0000000000a26959 swift::Parser::parseSILVTable() + 905
11 sil-opt         0x00000000009f59e3 swift::Parser::parseTopLevel() + 707
12 sil-opt         0x00000000009f0d3f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
13 sil-opt         0x00000000007391a6 swift::CompilerInstance::performSema() + 2918
14 sil-opt         0x0000000000723dfc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:24
```
