### PR TITLE
[SourceKit] Add test case for crash triggered in swift::Mangle::Mangler::mangleGenericSignatureParts(…)

### DIFF
--- a/validation-test/IDE/crashers/052-swift-mangle-mangler-manglegenericsignatureparts.swift
+++ b/validation-test/IDE/crashers/052-swift-mangle-mangler-manglegenericsignatureparts.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+var b{class d<A{
+func a{struct S<T
+{func a{
+func b<i{let h:St
+class a{var _=#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 202
swift-ide-test: /path/to/swift/lib/AST/Mangle.cpp:731: void swift::Mangle::Mangler::mangleGenericSignatureParts(ArrayRef<swift::GenericTypeParamType *>, unsigned int, ArrayRef<swift::Requirement>, swift::ResilienceExpansion): Assertion `param->getDepth() > depth && "generic params not ordered"' failed.
8  swift-ide-test  0x0000000000b609bd swift::Mangle::Mangler::mangleGenericSignatureParts(llvm::ArrayRef<swift::GenericTypeParamType*>, unsigned int, llvm::ArrayRef<swift::Requirement>, swift::ResilienceExpansion) + 1053
9  swift-ide-test  0x0000000000b5ff45 swift::Mangle::Mangler::mangleDeclType(swift::ValueDecl const*, swift::ResilienceExpansion, unsigned int) + 213
10 swift-ide-test  0x0000000000b9b67f swift::ide::printDeclUSR(swift::ValueDecl const*, llvm::raw_ostream&) + 815
12 swift-ide-test  0x0000000000773918 copyAssociatedUSRs(llvm::BumpPtrAllocatorImpl<llvm::MallocAllocator, 4096ul, 4096ul>&, swift::Decl const*) + 104
13 swift-ide-test  0x0000000000774098 swift::ide::CodeCompletionResultBuilder::takeResult() + 1624
17 swift-ide-test  0x0000000000b574bb swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 555
22 swift-ide-test  0x0000000000ae1e34 swift::Decl::walk(swift::ASTWalker&) + 20
23 swift-ide-test  0x0000000000b6baee swift::SourceFile::walk(swift::ASTWalker&) + 174
24 swift-ide-test  0x0000000000b6ad1f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
25 swift-ide-test  0x0000000000b44e82 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
26 swift-ide-test  0x000000000085c9fa swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
27 swift-ide-test  0x000000000076ba24 swift::CompilerInstance::performSema() + 3316
28 swift-ide-test  0x00000000007151b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for b at <INPUT-FILE>:3:6
```
