### PR TITLE
Revert "[Performance] iterate the smaller set during Set.intersect()"

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -561,30 +561,13 @@ public struct Set<Element : Hashable> :
   public func intersect<
     S : SequenceType where S.Generator.Element == Element
   >(sequence: S) -> Set<Element> {
-
-    // Attempt to iterate the smaller between `self` and `sequence`.
-    // If sequence is not a set, iterate over it because it may be single-pass.
+    let other = sequence as? Set<Element> ?? Set(sequence)
     var newSet = Set<Element>()
-
-    if let other = sequence as? Set<Element> {
-      let smaller: Set<Element>
-      let bigger: Set<Element>
-      if other.count > count {
-        smaller = self
-        bigger = other
-      } else {
-        smaller = other
-        bigger = self
-      }
-      for element in smaller where bigger.contains(element) {
-        newSet.insert(element)
-      }
-    } else {
-      for element in sequence where contains(element) {
-        newSet.insert(element)
+    for member in self {
+      if other.contains(member) {
+        newSet.insert(member)
       }
     }
-
     return newSet
   }
 


### PR DESCRIPTION
Reverts apple/swift#576

We have detected performance regressions in Set between December 18 and now.  We are not sure which commit caused them, so I'm reverting this change, and will apply them one by one, measuring the performance.
