### PR TITLE
Revert "[stdlib][performance] skip copying old values during removeAll(keepCapacity: true)"

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3394,21 +3394,27 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     }
   }
 
-  internal mutating func nativeKeepCapacityRemoveAll() {
+  internal mutating func nativeRemoveAll() {
+    var nativeStorage = native
+
+    // FIXME(performance): if the storage is non-uniquely referenced, we
+    // shouldn’t be copying the elements into new storage and then immediately
+    // deleting the elements. We should detect that the storage is not uniquely
+    // referenced and allocate new empty storage of appropriate capacity.
 
     // We have already checked for the empty dictionary case, so we will always
     // mutating the dictionary storage.  Request unique storage.
+    let (reallocated, _) = ensureUniqueNativeStorage(nativeStorage.capacity)
+    if reallocated {
+      nativeStorage = native
+    }
 
-    if !isUniquelyReferenced() {
-      self = .Native(NativeStorageOwner(minimumCapacity: native.capacity))
-    } else {
-      for b in 0..<native.capacity {
-        if native.isInitializedEntry(b) {
-          native.destroyEntryAt(b)
-        }
+    for var b = 0; b != nativeStorage.capacity; ++b {
+      if nativeStorage.isInitializedEntry(b) {
+        nativeStorage.destroyEntryAt(b)
       }
     }
-    native.count = 0
+    nativeStorage.count = 0
   }
 
   internal mutating func removeAll(keepCapacity keepCapacity: Bool) {
@@ -3422,13 +3428,13 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     }
 
     if _fastPath(guaranteedNative) {
-      nativeKeepCapacityRemoveAll()
+      nativeRemoveAll()
       return
     }
 
     switch self {
     case .Native:
-      nativeKeepCapacityRemoveAll()
+      nativeRemoveAll()
     case .Cocoa(let cocoaStorage):
 #if _runtime(_ObjC)
       self = .Native(NativeStorage.Owner(minimumCapacity: cocoaStorage.count))


### PR DESCRIPTION
Reverts apple/swift#616

We have detected performance regressions in Set between December 18 and now. We are not sure which commit caused them, so I'm reverting this change, and will apply them one by one, measuring the performance.
