### PR TITLE
[SourceKit] Add test case for crash triggered in swift::TypeBase::getSuperclass(…)

### DIFF
--- a/validation-test/IDE/crashers/053-swift-typebase-getsuperclass.swift
+++ b/validation-test/IDE/crashers/053-swift-typebase-getsuperclass.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+(){extension{class b<e{class d:d{extension{var b{class a:c#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 163
swift-ide-test: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::BoundGenericType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
8  swift-ide-test  0x0000000000b8e399 swift::TypeBase::getSuperclass(swift::LazyResolver*) + 857
9  swift-ide-test  0x0000000000937c11 swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) + 113
10 swift-ide-test  0x0000000000936e44 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1332
11 swift-ide-test  0x000000000092a3dc swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5996
12 swift-ide-test  0x000000000092c68a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1738
13 swift-ide-test  0x0000000000b763bc swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2108
14 swift-ide-test  0x0000000000953d9b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
17 swift-ide-test  0x000000000097dc7e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
19 swift-ide-test  0x000000000097db74 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
20 swift-ide-test  0x0000000000929fb1 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4929
21 swift-ide-test  0x000000000092c68a swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1738
24 swift-ide-test  0x0000000000931af7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
27 swift-ide-test  0x000000000097801b swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
28 swift-ide-test  0x0000000000977e5e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
29 swift-ide-test  0x0000000000900ab8 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
47 swift-ide-test  0x0000000000ae1e34 swift::Decl::walk(swift::ASTWalker&) + 20
48 swift-ide-test  0x0000000000b6baee swift::SourceFile::walk(swift::ASTWalker&) + 174
49 swift-ide-test  0x0000000000b6ad1f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
50 swift-ide-test  0x0000000000b44e82 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
51 swift-ide-test  0x000000000085c9fa swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
52 swift-ide-test  0x000000000076ba24 swift::CompilerInstance::performSema() + 3316
53 swift-ide-test  0x00000000007151b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x5f070c0 at <INPUT-FILE>:2:1
2.  While type-checking 'a' at <INPUT-FILE>:2:50
3.  While resolving type c at [<INPUT-FILE>:2:58 - line:2:58] RangeText="c"
4.  While defining default constructor for 'd' at <INPUT-FILE>:2:24
```
