### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseSILWitnessTable(…)

### DIFF
--- a/validation-test/SIL/crashers/015-swift-parser-parsesilwitnesstable.sil
+++ b/validation-test/SIL/crashers/015-swift-parser-parsesilwitnesstable.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+sil_witness_table():i


### PR DESCRIPTION
Stack trace:

```
sil-opt: /path/to/swift/lib/Parse/ParseSIL.cpp:790: llvm::PointerUnion<ValueDecl *, Module *> lookupTopDecl(swift::Parser &, swift::Identifier): Assertion `DeclLookup.isSuccess() && DeclLookup.Results.size() == 1' failed.
11 sil-opt         0x0000000000a27272 swift::Parser::parseSILWitnessTable() + 450
12 sil-opt         0x00000000009f5a13 swift::Parser::parseTopLevel() + 755
13 sil-opt         0x00000000009f0d3f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
14 sil-opt         0x00000000007391a6 swift::CompilerInstance::performSema() + 2918
15 sil-opt         0x0000000000723dfc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:22
```
