### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ModuleDecl::forAllVisibleModules(…)

### DIFF
--- a/validation-test/IDE/crashers/054-swift-moduledecl-forallvisiblemodules.swift
+++ b/validation-test/IDE/crashers/054-swift-moduledecl-forallvisiblemodules.swift
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+extension String->[Void{#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 150
6  swift-ide-test  0x0000000000b6a8cd swift::ModuleDecl::forAllVisibleModules(llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, bool, llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) + 477
7  swift-ide-test  0x0000000000b6aa41 swift::FileUnit::forAllVisibleModules(llvm::function_ref<bool (std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*>)>) + 81
8  swift-ide-test  0x00000000008fdc00 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1376
9  swift-ide-test  0x000000000076b8b2 swift::CompilerInstance::performSema() + 2946
10 swift-ide-test  0x00000000007151b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
```
