### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::typeCheckFunctionBodyUntil(…)

### DIFF
--- a/validation-test/SIL/crashers/016-swift-typechecker-typecheckfunctionbodyuntil.sil
+++ b/validation-test/SIL/crashers/016-swift-typechecker-typecheckfunctionbodyuntil.sil
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-sil-opt %s
+func n->a{return:}class a


### PR DESCRIPTION
Stack trace:

```
<stdin>:2:7: error: expected '(' in argument list of function declaration
func n->a{return:}class a
      ^
<stdin>:2:17: error: expected expression in 'return' statement
func n->a{return:}class a
                ^
<stdin>:2:19: error: consecutive statements on a line must be separated by ';'
func n->a{return:}class a
                  ^
                  ;
<stdin>:2:26: error: expected '{' in class
func n->a{return:}class a
                         ^
sil-opt: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::ProtocolDecl, const swift::NominalTypeDecl *>::doit(const From *) [To = swift::ProtocolDecl, From = const swift::NominalTypeDecl *]: Assertion `Val && "isa<> used on a null pointer"' failed.
11 sil-opt         0x0000000000ae0d3b swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
12 sil-opt         0x0000000000ae0b7e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
13 sil-opt         0x0000000000ae17a8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
15 sil-opt         0x0000000000a6620b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1771
16 sil-opt         0x00000000007391c2 swift::CompilerInstance::performSema() + 2946
17 sil-opt         0x0000000000723dfc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'n' at <stdin>:2:1
```
