### PR TITLE
[SIL] Add test case for crash triggered in swift::Decl::walk(…)

### DIFF
--- a/validation-test/SIL/crashers/017-swift-decl-walk.sil
+++ b/validation-test/SIL/crashers/017-swift-decl-walk.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+import Swift func g(@opened(Any


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:13: error: consecutive statements on a line must be separated by ';'
import Swift func g(@opened(Any
            ^
            ;
<stdin>:3:29: error: known id for 'opened' attribute must be a UUID string
import Swift func g(@opened(Any
                            ^
<stdin>:3:29: error: expected ')' after id value for 'opened' attribute
import Swift func g(@opened(Any
                            ^
<stdin>:3:28: note: to match this opening '('
import Swift func g(@opened(Any
                           ^
<stdin>:3:21: error: unnamed parameters must be written with the empty name '_'
import Swift func g(@opened(Any
                    ^
                    _:
<stdin>:3:32: error: expected ',' separator
import Swift func g(@opened(Any
                               ^
                               ,
<stdin>:3:32: error: expected parameter type following ':'
import Swift func g(@opened(Any
                               ^
<stdin>:3:32: error: expected ',' separator
import Swift func g(@opened(Any
                               ^
                               ,
Found opened existential archetype Any outside enclosing OpenExistentialExpr
15 sil-opt         0x0000000000ccd684 swift::Decl::walk(swift::ASTWalker&) + 20
16 sil-opt         0x0000000000d5600e swift::SourceFile::walk(swift::ASTWalker&) + 174
17 sil-opt         0x0000000000d85c44 swift::verify(swift::SourceFile&) + 52
18 sil-opt         0x0000000000a662cb swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1963
19 sil-opt         0x00000000007391c2 swift::CompilerInstance::performSema() + 2946
20 sil-opt         0x0000000000723dfc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While walking into decl 'g' at <stdin>:3:14
2.  While walking into body of 'g' at <stdin>:3:14
```
