### PR TITLE
[SIL] Add test case for crash triggered in swift::ValueDecl::getInterfaceType()

### DIFF
--- a/validation-test/SIL/crashers/018-swift-valuedecl-getinterfacetype.sil
+++ b/validation-test/SIL/crashers/018-swift-valuedecl-getinterfacetype.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+@objc protocol P{func t throw


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:25: error: expected '(' in argument list of function declaration
@objc protocol P{func t throw
                        ^
<stdin>:3:25: error: expected throwing specifier; did you mean 'throws'?
@objc protocol P{func t throw
                        ^~~~~
                        throws
<stdin>:3:30: error: consecutive declarations on a line must be separated by ';'
@objc protocol P{func t throw
                             ^
                             ;
<stdin>:3:30: error: expected declaration
@objc protocol P{func t throw
                             ^
4  sil-opt         0x0000000000d2488c swift::ValueDecl::getInterfaceType() const + 12
5  sil-opt         0x0000000000d25486 swift::TypeDecl::getDeclaredInterfaceType() const + 6
6  sil-opt         0x0000000000aea9bf swift::TypeChecker::isRepresentableInObjC(swift::AbstractFunctionDecl const*, swift::ObjCReason, llvm::Optional<swift::ForeignErrorConvention>&) + 1631
11 sil-opt         0x0000000000a9adb7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
12 sil-opt         0x0000000000a665e2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
13 sil-opt         0x0000000000739222 swift::CompilerInstance::performSema() + 2946
14 sil-opt         0x0000000000723e5c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'P' at <stdin>:3:7
```
