### PR TITLE
Remove unused diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -58,8 +58,6 @@ ERROR(cannot_open_serialized_file,frontend,none,
   "cannot open file '%0' for diagnostics emission (%1)", (StringRef, StringRef))
 ERROR(error_open_input_file,frontend,none,
   "error opening input file '%0' (%1)", (StringRef, StringRef))
-ERROR(error_clang_importer_not_linked_in,frontend,none,
-  "clang importer not available", ())
 ERROR(error_clang_importer_create_fail,frontend,none,
   "clang importer creation failed", ())
 ERROR(error_missing_arg_value,frontend,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -175,15 +175,8 @@ ERROR(decl_inner_scope,decl_parsing,none,
 ERROR(decl_not_static,decl_parsing,none,
       "declaration cannot be marked %0", (StaticSpellingKind))
 
-ERROR(ownership_not_attribute,decl_parsing,none,
-      "'@%0' is not an attribute, use the '%0' keyword instead",
-      (StringRef))
- 
 ERROR(cskeyword_not_attribute,decl_parsing,none,
       "'%0' is a declaration modifier, not an attribute", (StringRef))
-
-ERROR(convenience_invalid,sema_tcd,none,
-      "'convenience' is not valid on this declaration", ())
 
 ERROR(decl_already_static,decl_parsing,none,
       "%0 specified twice", (StaticSpellingKind))
@@ -288,11 +281,6 @@ ERROR(static_func_decl_global_scope,decl_parsing,none,
       (StaticSpellingKind))
 ERROR(func_decl_expected_arrow,decl_parsing,none,
       "expected '->' after function parameter tuple", ())
-ERROR(func_static_not_allowed,decl_parsing,none,
-      "static functions are not allowed in this context, "
-      "use 'class' to declare a class method", ())
-ERROR(func_conversion,decl_parsing,none,
-      "'__conversion' functions are no longer allowed", ())
 
 // Enum
 ERROR(expected_lbrace_enum,decl_parsing,PointsToFirstBadToken,
@@ -468,8 +456,6 @@ ERROR(sil_integer_literal_not_integer_type,decl_parsing,none,
       "integer_literal instruction requires a 'Builtin.Int<n>' type", ())
 ERROR(sil_float_literal_not_float_type,decl_parsing,none,
       "float_literal instruction requires a 'Builtin.FP<n>' type", ())
-ERROR(sil_apply_archetype_not_found,decl_parsing,none,
-      "archetype name not found in polymorphic function type of apply instruction", ())
 ERROR(sil_substitutions_on_non_polymorphic_type,decl_parsing,none,
       "apply of non-polymorphic function cannot have substitutions", ())
 ERROR(sil_witness_method_not_protocol,decl_parsing,none,
@@ -504,8 +490,6 @@ ERROR(sil_basicblock_arg_rparen, decl_parsing,none,
       "expected ')' in basic block argument list", ())
 
 // SIL Functions
-ERROR(expected_sil_linkage_or_function, decl_parsing,none,
-      "expected SIL linkage type or function name", ())
 ERROR(expected_sil_function_name, decl_parsing,none,
       "expected SIL function name", ())
 ERROR(expected_sil_rbrace, decl_parsing,none,
@@ -590,8 +574,6 @@ ERROR(expected_type_function_result,type_parsing,PointsToFirstBadToken,
       "expected type for function result", ())
 ERROR(generic_non_function,type_parsing,PointsToFirstBadToken,
       "only syntactic function types can be generic", ())
-ERROR(throwing_non_function,type_parsing,PointsToFirstBadToken,
-      "only function types may throw", ())
 ERROR(rethrowing_function_type,type_parsing,PointsToFirstBadToken,
       "only function declarations may be marked 'rethrows'", ())
 ERROR(throws_after_function_result,type_parsing,none,
@@ -762,8 +744,6 @@ ERROR(expected_expr_conditional_letbinding,stmt_parsing,none,
 ERROR(expected_expr_conditional_letbinding_bool_conditions,stmt_parsing,none,
       "expected 'let' or 'var' in conditional; "
       "use '&&' to join boolean conditions", ())
-ERROR(expected_simple_identifier_pattern,stmt_parsing,none,
-      "expected simple identifier pattern in optional binding condition", ())
 ERROR(expected_expr_conditional_var,stmt_parsing,PointsToFirstBadToken,
       "expected expression after '=' in conditional binding", ())
 ERROR(expected_expr_conditional_where,stmt_parsing,PointsToFirstBadToken,
@@ -817,8 +797,6 @@ ERROR(expected_while_after_repeat_body,stmt_parsing,PointsToFirstBadToken,
       "expected 'while' after body of 'repeat' statement", ())
 ERROR(expected_expr_repeat_while,stmt_parsing,PointsToFirstBadToken,
       "expected expression in 'repeat-while' condition", ())
-ERROR(missing_condition_after_repeat_while,stmt_parsing,none,
-      "missing condition in a 'repeat-while' statement", ())
 
 ERROR(do_while_now_repeat_while,stmt_parsing,none,
       "'do-while' statement is not allowed; use 'repeat-while' instead", ())
@@ -1113,14 +1091,6 @@ ERROR(attr_availability_renamed, attribute_parsing, none,
 ERROR(attr_autoclosure_expected_r_paren,attribute_parsing,PointsToFirstBadToken,
       "expected ')' in @autoclosure", ())
 
-// cc
-ERROR(cc_attribute_expected_lparen,attribute_parsing,none,
-      "expected '(' after 'cc' attribute", ())
-ERROR(cc_attribute_expected_name,attribute_parsing,none,
-      "expected calling convention name identifier in 'cc' attribute", ())
-ERROR(cc_attribute_expected_rparen,attribute_parsing,none,
-      "expected ')' after calling convention name for 'cc' attribute", ())
-
 // convention
 ERROR(convention_attribute_expected_lparen,attribute_parsing,none,
       "expected '(' after 'convention' attribute", ())
@@ -1255,9 +1225,6 @@ WARNING(unknown_build_config,parsing,none,
 //------------------------------------------------------------------------------
 // Availability query parsing diagnostics
 //------------------------------------------------------------------------------
-ERROR(avail_query_not_enabled,parsing,Fatal,
-      "experimental availability checking not enabled", ())
-
 ERROR(avail_query_expected_condition,parsing,PointsToFirstBadToken,
       "expected availability condition", ())
 ERROR(avail_query_expected_platform_name,parsing,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -397,9 +397,6 @@ ERROR(serialization_target_too_new_repl,sema,none,
       "module file's minimum deployment target is %0 v%1.%2%select{|.%3}3: %4",
       (StringRef, unsigned, unsigned, unsigned, StringRef))
 
-ERROR(unknown_name_in_type,sema_nb,none,
-      "use of unknown scope %0 in type reference", (Identifier))
-
 ERROR(invalid_redecl,sema_nb,none,"invalid redeclaration of %0", (DeclName))
 NOTE(invalid_redecl_prev,sema_nb,none,
      "%0 previously declared here", (DeclName))
@@ -564,9 +561,6 @@ ERROR(downcast_same_type,sema_tcc,none,
       (Type, Type, StringRef))
 WARNING(downcast_to_unrelated,sema_tcc,none,
         "cast from %0 to unrelated type %1 always fails", (Type, Type))
-ERROR(downcast_from_existential_to_unrelated,sema_tcc,none,
-      "cannot cast from protocol type %0 to non-conforming type %1",
-      (Type, Type))
 ERROR(downcast_to_more_optional,sema_tcc,none,
       "cannot downcast from %0 to a more optional type %1",
       (Type, Type))
@@ -1241,9 +1235,6 @@ ERROR(override_multiple_decls_base,sema_tcd,none,
 ERROR(override_multiple_decls_arg_mismatch,sema_tcd,none,
       "declaration %0 has different argument names from any potential "
       "overrides", (DeclName))
-ERROR(override_multiple_decls_derived,sema_tcd,none,
-      "declaration cannot be overridden by more than one subclass "
-      "declaration", ())
 NOTE(overridden_near_match_here,sema_tcd,none,
      "potential overridden %select{method|initializer}0 %1 here",
       (bool, DeclName))
@@ -1355,10 +1346,6 @@ ERROR(override_mutable_covariant_subscript,sema_tcd,none,
       (Type, Type))
 ERROR(decl_already_final,sema_tcd,none,
       "static declarations are already final", ())
-ERROR(decl_no_default_init,sema_tcd,none,
-      "cannot default-initialize variable of type %0", (Type))
-ERROR(decl_no_default_init_ivar_hole,sema_tcd,none,
-      "cannot use initial value when one of the variables is '_'", ())
 NOTE(decl_init_here,sema_tcd,none,
      "initial value is here", ())
 
@@ -1504,8 +1491,6 @@ ERROR(override_rethrows_with_non_rethrows,sema_tcd,none,
 ERROR(rethrows_without_throwing_parameter,sema_tcd,none,
       "'rethrows' function must take a throwing function argument", ())
 
-ERROR(inconsistent_attribute_override,sema_tcd,none,
-      "@%0 must be consistent between a method and its override", (StringRef))
 ERROR(autoclosure_function_type,attribute_parsing,none,
       "@autoclosure may only be applied to values of function type",
       ())
@@ -1730,13 +1715,8 @@ NOTE(subscript_decl_here,sema_tca,none,
      "subscript operator declared here", ())
 ERROR(condition_broken_proto,sema_tce,none,
       "protocol 'BooleanType' is broken", ())
-ERROR(option_type_broken,sema_tce,none,
-      "type 'Optional' is broken", ())
 
 ERROR(broken_bool,sema_tce,none, "type 'Bool' is broken", ())
-ERROR(binding_explicit_downcast,sema_tce,none,
-      "operand of postfix '?' is a forced downcast to type %0; use 'as?' to "
-      "perform a conditional downcast", (Type))
 
 WARNING(inject_forced_downcast,sema_tce,none,
         "treating a forced downcast to %0 as optional will never produce 'nil'",
@@ -1766,11 +1746,6 @@ ERROR(migrate_from_allZeros,sema_tce,none,
 
 ERROR(migrate_to_raw_to_raw_value,sema_tce,none,
       "method 'fromRaw' has been replaced with a property 'rawValue'", ())
-
-ERROR(new_array_bound_zero,sema_tce,none,
-      "array type cannot have zero length", ())
-ERROR(non_constant_array,type_parsing,none,
-      "array has non-constant size", ())
 
 ERROR(interpolation_missing_proto,sema_tce,none,
       "string interpolation requires the protocol 'StringInterpolationConvertible' to be defined",
@@ -1902,11 +1877,6 @@ ERROR(transitive_capture_before_declaration,tce_sema,none,
 NOTE(transitive_capture_through_here,tce_sema,none,
      "%0, declared here, captures %1",
      (Identifier, Identifier))
-ERROR(unsupported_local_function_reference,tce_sema,none,
-      "cannot reference a local function with captures from another local "
-      "function", ())
-ERROR(unsupported_recursive_local_function,tce_sema,none,
-      "local functions cannot reference themselves", ())
 
 WARNING(recursive_accessor_reference,tce_sema,none,
         "attempting to %select{access|modify}1 %0 within its own "
@@ -2104,8 +2074,6 @@ ERROR(tuple_pattern_label_mismatch,sema_tcp,none,
       "tuple pattern element label %0 must be %1", (Identifier, Identifier))
 ERROR(enum_element_pattern_member_not_found,sema_tcp,none,
       "enum case '%0' not found in type %1", (StringRef, Type))
-ERROR(enum_element_pattern_not_enum,sema_tcp,none,
-      "enum case pattern cannot match values of the non-enum type %0", (Type))
 ERROR(optional_element_pattern_not_valid_type,sema_tcp,none,
       "'?' pattern cannot match values of type %0", (Type))
 ERROR(condition_optional_element_pattern_not_valid_type,sema_tcp,none,
@@ -2283,8 +2251,6 @@ NOTE(overridden_required_initializer_here,sema_tcd,none,
 // Functions
 ERROR(attribute_requires_function_type,attribute_parsing,none,
       "attribute only applies to syntactic function types", ())
-ERROR(first_class_generic_function,type_parsing,PointsToFirstBadToken,
-      "generic types cannot be used as first-class types", ())
 ERROR(objc_block_cannot_be_thin,attribute_parsing,none,
       "@objc_block function type cannot be @thin", ())
 ERROR(attribute_not_supported,attribute_parsing,none,
@@ -2316,8 +2282,6 @@ ERROR(sil_function_multiple_results,type_parsing,PointsToFirstBadToken,
       "SIL function types cannot have multiple results", ())
 ERROR(sil_function_multiple_error_results,type_parsing,PointsToFirstBadToken,
       "SIL function types cannot have multiple @error results", ())
-ERROR(unsupported_cc_representation_combo,type_parsing,none,
-      "cc unsupported with this sil representation", ())
 ERROR(unsupported_sil_convention,type_parsing,none,
       "convention '%0' not supported in SIL", (StringRef))
 ERROR(sil_deprecated_convention_attribute,type_parsing,none,


### PR DESCRIPTION
These diagnostics are defined but not used in sources.

Removal suggested by @gribozavr in #688.
