### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseExprPostfix(…)

### DIFF
--- a/validation-test/SIL/crashers/019-swift-parser-parseexprpostfix.sil
+++ b/validation-test/SIL/crashers/019-swift-parser-parseexprpostfix.sil
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-sil-opt %s
+C<@convention()>{


### PR DESCRIPTION
Stack trace:

```
<stdin>:2:15: error: expected convention name identifier in 'convention' attribute
C<@convention()>{
              ^
<stdin>:2:16: error: expected type
C<@convention()>{
               ^
<stdin>:2:2: note: while parsing this '<' as a type parameter bracket
C<@convention()>{
 ^
<stdin>:2:18: error: expected '}' at end of closure
C<@convention()>{
                 ^
<stdin>:2:17: note: to match this opening '{'
C<@convention()>{
                ^
sil-opt: /path/to/swift/include/swift/Basic/SourceManager.h:184: std::pair<unsigned int, unsigned int> swift::SourceManager::getLineAndColumn(swift::SourceLoc, unsigned int) const: Assertion `Loc.isValid()' failed.
9  sil-opt         0x0000000000a15dec swift::Parser::parseExprPostfix(swift::Diag<>, bool) + 7628
10 sil-opt         0x0000000000a12e6a swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) + 170
11 sil-opt         0x0000000000a12d5f swift::Parser::parseExprImpl(swift::Diag<>, bool) + 191
12 sil-opt         0x0000000000a495e4 swift::Parser::parseExprOrStmt(swift::ASTNode&) + 420
13 sil-opt         0x0000000000a4b09f swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 1647
14 sil-opt         0x00000000009f5cbc swift::Parser::parseTopLevel() + 156
15 sil-opt         0x00000000009f123f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
16 sil-opt         0x0000000000739206 swift::CompilerInstance::performSema() + 2918
17 sil-opt         0x0000000000723e5c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:2:18
```
