### PR TITLE
Return a closure instead of using curried syntax

### DIFF
--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -1395,8 +1395,8 @@ NSStringAPIs.test("stringByFoldingWithOptions(_:locale:)") {
 
   func fwo(
     s: String, _ options: NSStringCompareOptions
-  )(loc: NSLocale?) -> String {
-    return s.stringByFoldingWithOptions(options, locale: loc)
+  ) -> (NSLocale?) -> String {
+    return { loc in s.stringByFoldingWithOptions(options, locale: loc) }
   }
   
   expectLocalizedEquality("abcd", fwo("abCD", .CaseInsensitiveSearch), "en")


### PR DESCRIPTION
In preparation for SE-0002
