### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ValueDecl::getOverloadSignature()

### DIFF
--- a/validation-test/IDE/crashers/055-swift-valuedecl-getoverloadsignature.swift
+++ b/validation-test/IDE/crashers/055-swift-valuedecl-getoverloadsignature.swift
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+let a{
+protocol A{
+extension{
+struct B{func i(Void
+func#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 160
swift-ide-test: /path/to/swift/lib/AST/Decl.cpp:1769: swift::Type swift::ValueDecl::getInterfaceType() const: Assertion `(type.isNull() || !type->is<PolymorphicFunctionType>()) && "decl has polymorphic function type but no interface type"' failed.
9  swift-ide-test  0x0000000000b381ae swift::ValueDecl::getOverloadSignature() const + 398
13 swift-ide-test  0x0000000000931af7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
14 swift-ide-test  0x00000000008ff1f2 swift::typeCheckCompletionDecl(swift::Decl*) + 1122
19 swift-ide-test  0x0000000000ae1e34 swift::Decl::walk(swift::ASTWalker&) + 20
20 swift-ide-test  0x0000000000b6baee swift::SourceFile::walk(swift::ASTWalker&) + 174
21 swift-ide-test  0x0000000000b6ad1f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
22 swift-ide-test  0x0000000000b44e82 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
23 swift-ide-test  0x000000000085c9fa swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
24 swift-ide-test  0x000000000076ba24 swift::CompilerInstance::performSema() + 3316
25 swift-ide-test  0x00000000007151b7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for a at <INPUT-FILE>:2:6
2.  While type-checking 'B' at <INPUT-FILE>:5:1
```
