### PR TITLE
[stdlib] Initial FreeBSD port.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -27,6 +27,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endif()
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   add_subdirectory(Glibc)
 endif()

--- a/stdlib/public/Glibc/CMakeLists.txt
+++ b/stdlib/public/Glibc/CMakeLists.txt
@@ -17,7 +17,12 @@ if (NOT EXISTS "${GLIBC_ARCH_INCLUDE_PATH}/sys")
 endif()
 
 # Generate module.map
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 configure_file(module.map.in "${CMAKE_CURRENT_BINARY_DIR}/module.map" @ONLY)
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+configure_file(module.freebsd.map.in "${CMAKE_CURRENT_BINARY_DIR}/module.map" @ONLY)
+endif()
 
 add_custom_command_target(unused_var
     COMMAND

--- a/stdlib/public/Glibc/Glibc.swift
+++ b/stdlib/public/Glibc/Glibc.swift
@@ -18,10 +18,18 @@
 
 public var errno: Int32 {
   get {
+#if os(FreeBSD)
+    return __error().memory
+#else
     return __errno_location().memory
+#endif
   }
   set(val) {
+#if os(FreeBSD)
+    return __error().memory = val
+#else
     return __errno_location().memory = val
+#endif
   }
 }
 

--- a/stdlib/public/Glibc/module.freebsd.map.in
+++ b/stdlib/public/Glibc/module.freebsd.map.in
@@ -1,0 +1,364 @@
+//===--- module.map -------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// This is a semi-complete modulemap that maps glibc's headers in a roughly
+/// similar way to the Darwin SDK modulemap. We do not take care to list every
+/// single header which may be included by a particular submodule, so there can
+/// still be issues if imported into the same context as one in which someone
+/// included those headers directly.
+///
+/// It's not named just FreeBSD libc so that it doesn't conflict in the event of a
+/// future official FreeBSD libc modulemap.
+module SwiftGlibc [system] {
+  link "pthread"
+  link "dl"
+
+  // C standard library
+  module C {
+    module complex {
+      header "@GLIBC_INCLUDE_PATH@/complex.h"
+      export *
+    }
+    module ctype {
+      header "@GLIBC_INCLUDE_PATH@/ctype.h"
+      export *
+    }
+    module errno {
+      header "@GLIBC_INCLUDE_PATH@/errno.h"
+      export *
+    }
+
+    module fenv {
+      header "@GLIBC_INCLUDE_PATH@/fenv.h"
+      export *
+    }
+    
+    // note: supplied by compiler
+    // module float {
+    //   header "@GLIBC_INCLUDE_PATH@/float.h"
+    //   export *
+    // }
+    
+    module inttypes {
+      header "@GLIBC_INCLUDE_PATH@/inttypes.h"
+      export *
+    }
+    
+    // note: potentially supplied by compiler
+    // module iso646 {
+    //   header "@GLIBC_INCLUDE_PATH@/iso646.h"
+    //   export *
+    // }
+    // module limits {
+    //   header "@GLIBC_INCLUDE_PATH@/limits.h"
+    //   export *
+    // }
+    
+    module locale {
+      header "@GLIBC_INCLUDE_PATH@/locale.h"
+      export *
+    }
+    module math {
+      header "@GLIBC_INCLUDE_PATH@/math.h"
+      export *
+    }
+    module setjmp {
+      header "@GLIBC_INCLUDE_PATH@/setjmp.h"
+      export *
+    }
+    module signal {
+      header "@GLIBC_INCLUDE_PATH@/signal.h"
+      export *
+    }
+
+    // note: supplied by the compiler
+    // module stdarg {
+    //   header "@GLIBC_INCLUDE_PATH@/stdarg.h"
+    //   export *
+    // }
+    // module stdbool {
+    //   header "@GLIBC_INCLUDE_PATH@/stdbool.h"
+    //   export *
+    // }
+    // module stddef {
+    //   header "@GLIBC_INCLUDE_PATH@/stddef.h"
+    //   export *
+    // }    
+    // module stdint {
+    //   header "@GLIBC_INCLUDE_PATH@/stdint.h"
+    //   export *
+    // }
+    
+    module stdio {
+      header "@GLIBC_INCLUDE_PATH@/stdio.h"
+      export *
+    }
+    module stdlib {
+      header "@GLIBC_INCLUDE_PATH@/stdlib.h"
+      export *
+      export stddef
+    }
+    module string {
+      header "@GLIBC_INCLUDE_PATH@/string.h"
+      export *
+    }
+
+    // note: supplied by the compiler
+    // explicit module tgmath {
+    //   header "@GLIBC_INCLUDE_PATH@/tgmath.h"
+    //   export *
+    // }
+    
+    module time {
+      header "@GLIBC_INCLUDE_PATH@/time.h"
+      export *
+    }
+  }
+
+  // POSIX
+  module POSIX {
+    module aio {
+      header "@GLIBC_INCLUDE_PATH@/aio.h"
+      export *
+    }
+    module arpa {
+      module inet {
+        header "@GLIBC_INCLUDE_PATH@/arpa/inet.h"
+        export *
+      }
+      export *
+    }
+    module cpio {
+      header "@GLIBC_INCLUDE_PATH@/cpio.h"
+      export *
+    }
+    module dirent {
+      header "@GLIBC_INCLUDE_PATH@/dirent.h"
+      export *
+    }
+    module dlfcn {
+      header "@GLIBC_INCLUDE_PATH@/dlfcn.h"
+      export *
+    }
+    module fcntl {
+      header "@GLIBC_INCLUDE_PATH@/fcntl.h"
+      export *
+    }
+    module fmtmsg {
+      header "@GLIBC_INCLUDE_PATH@/fmtmsg.h"
+      export *
+    }
+    module fnmatch {
+      header "@GLIBC_INCLUDE_PATH@/fnmatch.h"
+      export *
+    }
+    module ftw {
+      header "@GLIBC_INCLUDE_PATH@/ftw.h"
+      export *
+    }
+    module glob {
+      header "@GLIBC_INCLUDE_PATH@/glob.h"
+      export *
+    }
+    module grp {
+      header "@GLIBC_INCLUDE_PATH@/grp.h"
+      export *
+    }
+    module iconv {
+      header "@GLIBC_INCLUDE_PATH@/iconv.h"
+      export *
+    }
+    module ioctl {
+      header "@GLIBC_ARCH_INCLUDE_PATH@/sys/ioctl.h"
+      export *
+    }
+    module langinfo {
+      header "@GLIBC_INCLUDE_PATH@/langinfo.h"
+      export *
+    }
+    module libgen {
+      header "@GLIBC_INCLUDE_PATH@/libgen.h"
+      export *
+    }
+    module monetary {
+      header "@GLIBC_INCLUDE_PATH@/monetary.h"
+      export *
+    }
+    module netdb {
+      header "@GLIBC_INCLUDE_PATH@/netdb.h"
+      export *
+    }
+    module net {
+      module if {
+        header "@GLIBC_INCLUDE_PATH@/net/if.h"
+        export *
+      }
+    }
+    module netinet {
+      module in {
+        header "@GLIBC_INCLUDE_PATH@/netinet/in.h"
+        export *
+
+        exclude header "@GLIBC_INCLUDE_PATH@/netinet6/in6.h"
+      }
+      module tcp {
+        header "@GLIBC_INCLUDE_PATH@/netinet/tcp.h"
+        export *
+      }
+    }
+    module nl_types {
+      header "@GLIBC_INCLUDE_PATH@/nl_types.h"
+      export *
+    }
+    module poll {
+      header "@GLIBC_INCLUDE_PATH@/poll.h"
+      export *
+    }
+    module pthread {
+      header "@GLIBC_INCLUDE_PATH@/pthread.h"
+      export *
+    }
+    module pwd {
+      header "@GLIBC_INCLUDE_PATH@/pwd.h"
+      export *
+    }
+    module regex {
+      header "@GLIBC_INCLUDE_PATH@/regex.h"
+      export *
+    }
+    module sched {
+      header "@GLIBC_INCLUDE_PATH@/sched.h"
+      export *
+    }
+    module search {
+      header "@GLIBC_INCLUDE_PATH@/search.h"
+      export *
+    }
+    module semaphore {
+      header "@GLIBC_INCLUDE_PATH@/semaphore.h"
+      export *
+    }
+    module spawn {
+      header "@GLIBC_INCLUDE_PATH@/spawn.h"
+      export *
+    }
+    module strings {
+      header "@GLIBC_INCLUDE_PATH@/strings.h"
+      export *
+    }
+
+    module sys {
+      export *
+
+      module ipc {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/ipc.h"
+        export *
+      }
+      module mman {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/mman.h"
+        export *
+      }
+      module msg {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/msg.h"
+        export *
+      }
+      module resource {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/resource.h"
+        export *
+      }
+      module select {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/select.h"
+        export *
+      }
+      module sem {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/sem.h"
+        export *
+      }
+      module shm {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/shm.h"
+        export *
+      }
+      module socket {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/socket.h"
+        export *
+      }
+      module stat {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/stat.h"
+        export *
+      }
+      module statvfs {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/statvfs.h"
+        export *
+      }
+      module time {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/time.h"
+        export *
+      }
+      module times {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/times.h"
+        export *
+      }
+      module types {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/types.h"
+        export *
+      }
+      module uio {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/uio.h"
+        export *
+      }
+      module un {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/un.h"
+        export *
+      }
+      module utsname {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/utsname.h"
+        export *
+      }
+      module wait {
+        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/wait.h"
+        export *
+      }
+    }
+    module syslog {
+      header "@GLIBC_INCLUDE_PATH@/syslog.h"
+      export *
+    }
+    module tar {
+      header "@GLIBC_INCLUDE_PATH@/tar.h"
+      export *
+    }
+    module termios {
+      header "@GLIBC_INCLUDE_PATH@/termios.h"
+      export *
+    }
+    module ulimit {
+      header "@GLIBC_INCLUDE_PATH@/ulimit.h"
+      export *
+    }
+    module unistd {
+      header "@GLIBC_INCLUDE_PATH@/unistd.h"
+      export *
+    }
+    module utime {
+      header "@GLIBC_INCLUDE_PATH@/utime.h"
+      export *
+    }
+    module utmpx {
+      header "@GLIBC_INCLUDE_PATH@/utmpx.h"
+      export *
+    }
+    module wordexp {
+      header "@GLIBC_INCLUDE_PATH@/wordexp.h"
+      export *
+    }
+  }
+}


### PR DESCRIPTION
Dmitri, All the duplication in the overlay code is now gone. Only the module map is duplicated but I'm not too worried about that (would like to hear your opinion). Also, for now, FreeBSD libc is not-entirely-correctly called Glibc -- but I think a renaming can be done later (maybe it should be called Libc?)

Thanks!
## 

Davide
