### PR TITLE
[SIL] Miscellaneous documentation fixes & updates

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -604,7 +604,7 @@ Some additional meaningful categories of type:
 
 - A *heap object reference* type is a type whose representation consists of a
   single strong-reference-counted pointer. This includes all class types,
-  the ``Builtin.ObjectPointer`` and ``Builtin.ObjCPointer`` types, and
+  the ``Builtin.NativeObject`` and ``Builtin.UnknownObject`` types, and
   archetypes that conform to one or more class protocols.
 - A *reference type* is more general in that its low-level representation may
   include additional global pointers alongside a strong-reference-counted
@@ -2561,13 +2561,13 @@ dynamic_method
   // or protocol type
   //
   // The "self" argument of the method type $@convention(thin) U -> V must be 
-  //   Builtin.ObjCPointer
+  //   Builtin.UnknownObject
 
 Looks up the implementation of an Objective-C method with the same
 selector as the named method for the dynamic type of the
 value inside an existential container. The "self" operand of the result
 function value is represented using an opaque type, the value for which must
-be projected out as a value of type ``Builtin.ObjCPointer``.
+be projected out as a value of type ``Builtin.UnknownObject``.
 
 It is undefined behavior if the dynamic type of the operand does not
 have an implementation for the Objective-C method with the selector to
@@ -2740,7 +2740,7 @@ lowers to an uncurried entry point and is curried in the enclosing function::
     // Create the bar closure
     %bar_uncurried = function_ref @bar : $(Int, Int) -> Int
     %bar = partial_apply %bar_uncurried(%x_box#0, %x_box#1) \
-      : $(Int, Builtin.ObjectPointer, *Int) -> Int
+      : $(Int, Builtin.NativeObject, *Int) -> Int
 
     // Apply it
     %1 = integer_literal $Int, 1
@@ -2778,8 +2778,8 @@ metatype
 
   sil-instruction ::= 'metatype' sil-type
 
-  %1 = metatype $T.metatype
-  // %1 has type $T.metatype
+  %1 = metatype $T.Type
+  // %1 has type $T.Type
 
 Creates a reference to the metatype object for type ``T``.
 
@@ -2789,9 +2789,9 @@ value_metatype
 
   sil-instruction ::= 'value_metatype' sil-type ',' sil-operand
 
-  %1 = value_metatype $T.metatype, %0 : $T
+  %1 = value_metatype $T.Type, %0 : $T
   // %0 must be a value or address of type $T
-  // %1 will be of type $T.metatype
+  // %1 will be of type $T.Type
 
 Obtains a reference to the dynamic metatype of the value ``%0``.
 
@@ -2801,10 +2801,10 @@ existential_metatype
 
   sil-instruction ::= 'existential_metatype' sil-type ',' sil-operand
 
-  %1 = existential_metatype $P.metatype, %0 : $P
+  %1 = existential_metatype $P.Type, %0 : $P
   // %0 must be a value of class protocol or protocol composition
   //   type $P, or an address of address-only protocol type $*P
-  // %1 will be a $P.metatype value referencing the metatype of the
+  // %1 will be a $P.Type value referencing the metatype of the
   //   concrete value inside %0
 
 Obtains the metatype of the concrete value
@@ -3004,16 +3004,16 @@ the enum is injected with an `inject_enum_addr`_ instruction::
   sil @init_with_data : $(AddressOnlyType) -> AddressOnlyEnum {
   entry(%0 : $*AddressOnlyEnum, %1 : $*AddressOnlyType):
     // Store the data argument for the case.
-    %2 = init_enum_data_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData
+    %2 = init_enum_data_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData!enumelt.1
     copy_addr [take] %2 to [initialization] %1 : $*AddressOnlyType
     // Inject the tag.
-    inject_enum_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData
+    inject_enum_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData!enumelt.1
     return
   }
 
   sil @init_without_data : $() -> AddressOnlyEnum {
     // No data. We only need to inject the tag.
-    inject_enum_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.NoData
+    inject_enum_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.NoData!enumelt
     return
   }
 
@@ -3024,7 +3024,7 @@ discriminator and is done with the `switch_enum`_ terminator::
 
   sil @switch_foo : $(Foo) -> () {
   entry(%foo : $Foo):
-    switch_enum %foo : $Foo, case #Foo.A: a_dest, case #Foo.B: b_dest
+    switch_enum %foo : $Foo, case #Foo.A!enumelt.1: a_dest, case #Foo.B!enumelt.1: b_dest
     
   a_dest(%a : $Int):
     /* use %a */
@@ -3041,14 +3041,15 @@ projecting the enum value with `unchecked_take_enum_data_addr`_::
 
   sil @switch_foo : $<T> (Foo<T>) -> () {
   entry(%foo : $*Foo<T>):
-    switch_enum_addr %foo : $*Foo<T>, case #Foo.A: a_dest, case #Foo.B: b_dest
+    switch_enum_addr %foo : $*Foo<T>, case #Foo.A!enumelt.1: a_dest, \
+      case #Foo.B!enumelt.1: b_dest
     
   a_dest:
-    %a = unchecked_take_enum_data_addr %foo : $*Foo<T>, #Foo.A
+    %a = unchecked_take_enum_data_addr %foo : $*Foo<T>, #Foo.A!enumelt.1
     /* use %a */
   
   b_dest:
-    %b = unchecked_take_enum_data_addr %foo : $*Foo<T>, #Foo.B
+    %b = unchecked_take_enum_data_addr %foo : $*Foo<T>, #Foo.B!enumelt.1
     /* use %b */
   }
 
@@ -3058,8 +3059,8 @@ enum
 
   sil-instruction ::= 'enum' sil-type ',' sil-decl-ref (',' sil-operand)?
 
-  %1 = enum $U, #U.EmptyCase
-  %1 = enum $U, #U.DataCase, %0 : $T
+  %1 = enum $U, #U.EmptyCase!enumelt
+  %1 = enum $U, #U.DataCase!enumelt.1, %0 : $T
   // $U must be an enum type
   // #U.DataCase or #U.EmptyCase must be a case of enum $U
   // If #U.Case has a data type $T, %0 must be a value of type $T
@@ -3075,7 +3076,7 @@ unchecked_enum_data
 
   sil-instruction ::= 'unchecked_enum_data' sil-operand ',' sil-decl-ref
 
-  %1 = unchecked_enum_data %0 : $U, #U.DataCase
+  %1 = unchecked_enum_data %0 : $U, #U.DataCase!enumelt.1
   // $U must be an enum type
   // #U.DataCase must be a case of enum $U with data
   // %1 will be of object type $T for the data type of case U.DataCase
@@ -3090,7 +3091,7 @@ init_enum_data_addr
 
   sil-instruction ::= 'init_enum_data_addr' sil-operand ',' sil-decl-ref
 
-  %1 = init_enum_data_addr %0 : $*U, #U.DataCase
+  %1 = init_enum_data_addr %0 : $*U, #U.DataCase!enumelt.1
   // $U must be an enum type
   // #U.DataCase must be a case of enum $U with data
   // %1 will be of address type $*T for the data type of case U.DataCase
@@ -3112,7 +3113,7 @@ inject_enum_addr
 
   sil-instruction ::= 'inject_enum_addr' sil-operand ',' sil-decl-ref
 
-  inject_enum_addr %0 : $*U, #U.Case
+  inject_enum_addr %0 : $*U, #U.Case!enumelt
   // $U must be an enum type
   // #U.Case must be a case of enum $U
   // %0 will be overlaid with the tag for #U.Case
@@ -3132,7 +3133,7 @@ unchecked_take_enum_data_addr
 
   sil-instruction ::= 'unchecked_take_enum_data_addr' sil-operand ',' sil-decl-ref
 
-  %1 = unchecked_take_enum_data_addr %0 : $*U, #U.DataCase
+  %1 = unchecked_take_enum_data_addr %0 : $*U, #U.DataCase!enumelt.1
   // $U must be an enum type
   // #U.DataCase must be a case of enum $U with data
   // %1 will be of address type $*T for the data type of case U.DataCase
@@ -3159,8 +3160,8 @@ select_enum
                       ':' sil-type
 
   %n = select_enum %0 : $U,      \
-    case #U.Case1: %1,           \
-    case #U.Case2: %2, /* ... */ \
+    case #U.Case1!enumelt: %1,           \
+    case #U.Case2!enumelt: %2, /* ... */ \
     default %3 : $T
 
   // $U must be an enum type
@@ -3173,8 +3174,8 @@ enum value. This is equivalent to a trivial `switch_enum`_ branch sequence::
 
   entry:
     switch_enum %0 : $U,            \
-      case #U.Case1: bb1,           \
-      case #U.Case2: bb2, /* ... */ \
+      case #U.Case1!enumelt: bb1,           \
+      case #U.Case2!enumelt: bb2, /* ... */ \
       default bb_default
   bb1:
     br cont(%1 : $T) // value for #U.Case1
@@ -3198,8 +3199,8 @@ select_enum_addr
                       ':' sil-type
 
   %n = select_enum_addr %0 : $*U,      \
-    case #U.Case1: %1,           \
-    case #U.Case2: %2, /* ... */ \
+    case #U.Case1!enumelt: %1,           \
+    case #U.Case2!enumelt: %2, /* ... */ \
     default %3 : $T
 
   // %0 must be the address of an enum type $*U
@@ -3629,7 +3630,7 @@ ref_to_raw_pointer
   sil-instruction ::= 'ref_to_raw_pointer' sil-operand 'to' sil-type
 
   %1 = ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
-  // $C must be a class type, or Builtin.ObjectPointer, or Builtin.ObjCPointer
+  // $C must be a class type, or Builtin.NativeObject, or Builtin.UnknownObject
   // %1 will be of type $Builtin.RawPointer
 
 Converts a heap object reference to a ``Builtin.RawPointer``. The ``RawPointer``
@@ -3644,7 +3645,7 @@ raw_pointer_to_ref
   sil-instruction ::= 'raw_pointer_to_ref' sil-operand 'to' sil-type
 
   %1 = raw_pointer_to_ref %0 : $Builtin.RawPointer to $C
-  // $C must be a class type, or Builtin.ObjectPointer, or Builtin.ObjCPointer
+  // $C must be a class type, or Builtin.NativeObject, or Builtin.UnknownObject
   // %1 will be of type $C
 
 Converts a ``Builtin.RawPointer`` back to a heap object reference. Casting
@@ -3811,10 +3812,10 @@ thick_to_objc_metatype
 
   sil-instruction ::= 'thick_to_objc_metatype' sil-operand 'to' sil-type
 
-  %1 = thick_to_objc_metatype %0 : $@thick T.metatype to $@objc_metatype T.metatype
-  // %0 must be of a thick metatype type $@thick T.metatype
+  %1 = thick_to_objc_metatype %0 : $@thick T.Type to $@objc_metatype T.Type
+  // %0 must be of a thick metatype type $@thick T.Type
   // The destination type must be the corresponding Objective-C metatype type
-  // %1 will be of type $@objc_metatype T.metatype
+  // %1 will be of type $@objc_metatype T.Type
 
 Converts a thick metatype to an Objective-C class metatype. ``T`` must
 be of class, class protocol, or class protocol composition type.
@@ -3825,10 +3826,10 @@ objc_to_thick_metatype
 
   sil-instruction ::= 'objc_to_thick_metatype' sil-operand 'to' sil-type
 
-  %1 = objc_to_thick_metatype %0 : $@objc_metatype T.metatype to $@thick T.metatype
-  // %0 must be of an Objective-C metatype type $@objc_metatype T.metatype
+  %1 = objc_to_thick_metatype %0 : $@objc_metatype T.Type to $@thick T.Type
+  // %0 must be of an Objective-C metatype type $@objc_metatype T.Type
   // The destination type must be the corresponding thick metatype type
-  // %1 will be of type $@thick T.metatype
+  // %1 will be of type $@thick T.Type
 
 Converts an Objective-C class metatype to a thick metatype. ``T`` must
 be of class, class protocol, or class protocol composition type.
@@ -4089,8 +4090,8 @@ switch_enum
                        (',' sil-switch-default)?
   sil-switch-enum-case ::= 'case' sil-decl-ref ':' sil-identifier
 
-  switch_enum %0 : $U, case #U.Foo: label1, \
-                        case #U.Bar: label2, \
+  switch_enum %0 : $U, case #U.Foo!enumelt: label1, \
+                        case #U.Bar!enumelt: label2, \
                         ...,                 \
                         default labelN
 
@@ -4124,9 +4125,9 @@ original enum value.  For example::
   sil @sum_of_foo : $Foo -> Int {
   entry(%x : $Foo):
     switch_enum %x : $Foo,       \
-      case #Foo.Nothing: nothing, \
-      case #Foo.OneInt:  one_int, \
-      case #Foo.TwoInts: two_ints
+      case #Foo.Nothing!enumelt: nothing, \
+      case #Foo.OneInt!enumelt.1:  one_int, \
+      case #Foo.TwoInts!enumelt.1: two_ints
 
   nothing:
     %zero = integer_literal 0 : $Int
@@ -4165,8 +4166,8 @@ switch_enum_addr
                        (',' sil-switch-enum-case)*
                        (',' sil-switch-default)?
 
-  switch_enum_addr %0 : $*U, case #U.Foo: label1, \
-                                          case #U.Bar: label2, \
+  switch_enum_addr %0 : $*U, case #U.Foo!enumelt: label1, \
+                                          case #U.Bar!enumelt: label2, \
                                           ...,                 \
                                           default labelN
 


### PR DESCRIPTION
The following changes remove obsolete constructs:
ObjectPointer becomes NativeObject
ObjcPointer becomes UnknownObject
SomeType.metatype becomes SomeType.Type

Additionally, all enumerator element references in example code have been
updated to use the  'enumelt' subreference.
