### PR TITLE
[SourceKit] Add test case for crash triggered in swift::ArchetypeBuilder::getAllArchetypes()

### DIFF
--- a/validation-test/IDE/crashers/056-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/IDE/crashers/056-swift-archetypebuilder-getallarchetypes.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+var e{
+protocol A{
+func b:e protocol e{
+typealias e:e:protocol e{
+enum a{
+func a<d{func b<a
+protocol c:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 229
swift-ide-test: /path/to/swift/include/swift/AST/Types.h:3582: swift::ArchetypeType *swift::ArchetypeType::NestedType::castToArchetype() const: Assertion `!isConcreteType()' failed.
8  swift-ide-test  0x0000000000a94424 swift::ArchetypeBuilder::getAllArchetypes() + 564
12 swift-ide-test  0x00000000009312b7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
15 swift-ide-test  0x00000000009777db swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 379
16 swift-ide-test  0x000000000097761e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
17 swift-ide-test  0x0000000000900278 swift::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 1128
21 swift-ide-test  0x0000000000adf4d4 swift::Decl::walk(swift::ASTWalker&) + 20
22 swift-ide-test  0x0000000000b6918e swift::SourceFile::walk(swift::ASTWalker&) + 174
23 swift-ide-test  0x0000000000b683bf swift::ModuleDecl::walk(swift::ASTWalker&) + 79
24 swift-ide-test  0x0000000000b42522 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
25 swift-ide-test  0x000000000085c1ba swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
26 swift-ide-test  0x000000000076b1e4 swift::CompilerInstance::performSema() + 3316
27 swift-ide-test  0x0000000000714977 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl getter for e at <INPUT-FILE>:3:6
2.  While type-checking 'b' at <INPUT-FILE>:8:10
```
