### PR TITLE
Change c-style for loop to for-in loop based on proposal SE-0007

### DIFF
--- a/stdlib/public/core/Prespecialized.swift
+++ b/stdlib/public/core/Prespecialized.swift
@@ -29,8 +29,8 @@ struct _Prespecialize {
         a[0] = a[j]
       }
 
-      for var i1 = 0; i1 < a.count; i1 += 1 {
-        for var i2 = 0; i2 < a.count; i2 += 1 {
+      for i1 in 0..<a.count {
+        for i2 in 0..<a.count {
           a[i1] = a[i2]
         }
       }


### PR DESCRIPTION
Based on @erica's proposal: [SE-0007](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md), remove C-style for loop in Prespecialized.swift to prevent future warnings and removal in Swift 2.2 and 3.0 respectively
