### PR TITLE
Change () -> () to () -> Void in foreign_errors

### DIFF
--- a/test/ClangModules/foreign_errors.swift
+++ b/test/ClangModules/foreign_errors.swift
@@ -98,7 +98,7 @@ func testSwiftError() throws {
 }
 
 // rdar://21074857
-func needsNonThrowing(fn: () -> ()) {}
+func needsNonThrowing(fn: () -> Void) {}
 func testNSErrorExhaustive() {
   needsNonThrowing {
     do {


### PR DESCRIPTION
Based on [devforum](https://devforums.apple.com/message/1133616#1133616), switch style of () -> () to () -> Void
