### PR TITLE
[attr] change all -> () to Void in /test/attr

### DIFF
--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -36,7 +36,7 @@ public func || <T: BooleanType>(
 }
 
 // <rdar://problem/19707366> QoI: @autoclosure declaration change fixit
-let migrate4 : @autoclosure() -> ()   // expected-error {{@autoclosure is now an attribute of the parameter declaration, not its type}} {{1-1=@autoclosure }} {{16-28=}}
+let migrate4 : @autoclosure() -> Void   // expected-error {{@autoclosure is now an attribute of the parameter declaration, not its type}} {{1-1=@autoclosure }} {{16-28=}}
 
 
 struct SomeStruct {
@@ -62,17 +62,17 @@ protocol P2 : P1 {
   typealias Element
 }
 
-func overloadedEach<O: P1>(source: O, _ closure: () -> ()) {
+func overloadedEach<O: P1>(source: O, _ closure: () -> Void) {
 }
 
-func overloadedEach<P: P2>(source: P, _ closure: () -> ()) {
+func overloadedEach<P: P2>(source: P, _ closure: () -> Void) {
 }
 
 struct S : P2 {
   typealias Element = Int
-  func each(@autoclosure closure: () -> ()) {
-    overloadedEach(self, closure) // expected-error {{cannot invoke 'overloadedEach' with an argument list of type '(S, @autoclosure () -> ())'}}
- // expected-note @-1 {{overloads for 'overloadedEach' exist with these partially matching parameter lists: (O, () -> ()), (P, () -> ())}}
+  func each(@autoclosure closure: () -> Void) {
+    overloadedEach(self, closure) // expected-error {{cannot invoke 'overloadedEach' with an argument list of type '(S, @autoclosure () -> Void)'}}
+ // expected-note @-1 {{overloads for 'overloadedEach' exist with these partially matching parameter lists: (O, () -> Void), (P, () -> Void)}}
   }
 }
 
@@ -82,22 +82,22 @@ struct AutoclosureEscapeTest {
 }
 
 // @autoclosure(escaping)
-func func10(@autoclosure(escaping _: () -> ()) { } // expected-error{{expected ')' in @autoclosure}}
+func func10(@autoclosure(escaping _: () -> Void) { } // expected-error{{expected ')' in @autoclosure}}
 // expected-note@-1{{to match this opening '('}}
 
-func func11(@autoclosure(escaping) @noescape _: () -> ()) { } // expected-error{{@noescape conflicts with @autoclosure(escaping)}} {{36-46=}}
+func func11(@autoclosure(escaping) @noescape _: () -> Void) { } // expected-error{{@noescape conflicts with @autoclosure(escaping)}} {{36-46=}}
 
 
 class Super {
-  func f1(@autoclosure(escaping) x: () -> ()) { }
-  func f2(@autoclosure(escaping) x: () -> ()) { }
-  func f3(@autoclosure x: () -> ()) { }
+  func f1(@autoclosure(escaping) x: () -> Void) { }
+  func f2(@autoclosure(escaping) x: () -> Void) { }
+  func f3(@autoclosure x: () -> Void) { }
 }
 
 class Sub : Super {
-  override func f1(@autoclosure(escaping) x: () -> ()) { }
-  override func f2(@autoclosure x: () -> ()) { } // expected-error{{does not override any method}}
-  override func f3(@autoclosure(escaping) x: () -> ()) { }  // expected-error{{does not override any method}}
+  override func f1(@autoclosure(escaping) x: () -> Void) { }
+  override func f2(@autoclosure x: () -> Void) { } // expected-error{{does not override any method}}
+  override func f3(@autoclosure(escaping) x: () -> Void) { }  // expected-error{{does not override any method}}
 }
 
 func func12_sink(x: () -> Int) { }

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -119,7 +119,7 @@ let _: Int
 let _: Int
 
 @available(*, deprecated, unavailable, message="message") // expected-error{{'available' attribute cannot be both unconditionally 'unavailable' and 'deprecated'}}
-struct BadUnconditionalAvailability { };
+struct BadUnconditionalAvailability { }
 
 // Encoding in messages
 @available(*, deprecated, message="Say \"Hi\"")

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -11,15 +11,15 @@ class IBOutletClassTy {}
 struct IBStructTy {}
 
 @IBAction // expected-error {{only instance methods can be declared @IBAction}} {{1-11=}}
-func IBFunction() -> () {}
+func IBFunction() -> Void {}
 
 class IBActionWrapperTy {
   @IBAction
-  func click(_: AnyObject) -> () {} // no-warning
+  func click(_: AnyObject) -> Void {} // no-warning
 
-  func outer(_: AnyObject) -> () {
+  func outer(_: AnyObject) -> Void {
     @IBAction  // expected-error {{only instance methods can be declared @IBAction}} {{5-15=}}
-    func inner(_: AnyObject) -> () {}
+    func inner(_: AnyObject) -> Void {}
   }
   @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{3-13=}}
   var value : Void = ()
@@ -30,12 +30,12 @@ class IBActionWrapperTy {
   // @IBAction does /not/ semantically imply @objc.
   @IBAction // expected-note {{attribute already specified here}}
   @IBAction // expected-error {{duplicate attribute}}
-  func doMagic(_: AnyObject) -> () {}
+  func doMagic(_: AnyObject) -> Void {}
 
   @IBAction @objc
-  func moreMagic(_: AnyObject) -> () {} // no-warning
+  func moreMagic(_: AnyObject) -> Void {} // no-warning
   @objc @IBAction
-  func evenMoreMagic(_: AnyObject) -> () {} // no-warning
+  func evenMoreMagic(_: AnyObject) -> Void {} // no-warning
 }
 
 struct S { }

--- a/test/attr/attr_iboutlet.swift
+++ b/test/attr/attr_iboutlet.swift
@@ -11,7 +11,7 @@ class IBOutletClassTy {}
 struct IBStructTy {}
 
 @IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{1-11=}}
-func IBFunction() -> () {}
+func IBFunction() -> Void {}
 
 @objc
 class IBOutletWrapperTy {
@@ -24,7 +24,7 @@ class IBOutletWrapperTy {
   // expected-error@-2 {{class stored properties not yet supported}}
 
   @IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{3-13=}}
-  func click() -> () {}
+  func click() -> Void {}
 
   @IBOutlet // expected-error {{@IBOutlet attribute requires property to be mutable}} {{3-13=}}
   let immutable: IBOutletWrapperTy? = nil

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -226,7 +226,7 @@ class NoEscapeImmediatelyApplied {
 public func XCTAssertTrue(@autoclosure expression: () -> BooleanType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) -> Void {
 }
 public func XCTAssert( @autoclosure expression: () -> BooleanType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__)  -> Void {
-  XCTAssertTrue(expression, message, file: file, line: line);
+  XCTAssertTrue(expression, message, file: file, line: line)
 }
 
 

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -154,7 +154,7 @@ class SomeClass {
 // Implicit conversions (in this case to @convention(block)) are ok.
 @_silgen_name("whatever")
 func takeNoEscapeAsObjCBlock(@noescape _: @convention(block) () -> Void)
-func takeNoEscapeTest2(@noescape fn : () -> ()) {
+func takeNoEscapeTest2(@noescape fn : () -> Void) {
   takeNoEscapeAsObjCBlock(fn)
 }
 
@@ -178,16 +178,16 @@ protocol P2 : P1 {
   typealias Element
 }
 
-func overloadedEach<O: P1, T>(source: O, _ transform: O.Element -> (), _: T) {}
+func overloadedEach<O: P1, T>(source: O, _ transform: O.Element -> Void, _: T) {}
 
-func overloadedEach<P: P2, T>(source: P, _ transform: P.Element -> (), _: T) {}
+func overloadedEach<P: P2, T>(source: P, _ transform: P.Element -> Void, _: T) {}
 
 struct S : P2 {
   typealias Element = Int
-  func each(@noescape transform: Int -> ()) {
-    overloadedEach(self,  // expected-error {{cannot invoke 'overloadedEach' with an argument list of type '(S, @noescape Int -> (), Int)'}}
+  func each(@noescape transform: Int -> Void) {
+    overloadedEach(self,  // expected-error {{cannot invoke 'overloadedEach' with an argument list of type '(S, @noescape Int -> Void, Int)'}}
                    transform, 1)
-    // expected-note @-2 {{overloads for 'overloadedEach' exist with these partially matching parameter lists: (O, O.Element -> (), T), (P, P.Element -> (), T)}}
+    // expected-note @-2 {{overloads for 'overloadedEach' exist with these partially matching parameter lists: (O, O.Element -> (), T), (P, P.Element -> Void, T)}}
   }
 }
 
@@ -202,9 +202,9 @@ func r19763676Caller(@noescape g: (Int) -> Int) {
 
 
 // <rdar://problem/19763732> False positive in @noescape analysis triggered by default arguments
-func calleeWithDefaultParameters(@noescape f: () -> (), x : Int = 1) {}  // expected-warning {{closure parameter prior to parameters with default arguments will not be treated as a trailing closure}}
+func calleeWithDefaultParameters(@noescape f: () -> Void, x : Int = 1) {}  // expected-warning {{closure parameter prior to parameters with default arguments will not be treated as a trailing closure}}
 
-func callerOfDefaultParams(@noescape g: () -> ()) {
+func callerOfDefaultParams(@noescape g: () -> Void) {
   calleeWithDefaultParameters(g)
 }
 

--- a/test/attr/attr_noreturn.swift
+++ b/test/attr/attr_noreturn.swift
@@ -42,11 +42,11 @@ class InvalidOnClassMembers {
 }
 
 protocol TestProtocol {
-  // expected-note@+1 {{protocol requires function 'neverReturns()' with type '@noreturn () -> ()'}}
+  // expected-note@+1 {{protocol requires function 'neverReturns()' with type '@noreturn () -> Void'}}
   @noreturn func neverReturns()
   func doesReturn()
 
-  // expected-note@+1 {{protocol requires function 'neverReturnsStatic()' with type '@noreturn () -> ()'}}
+  // expected-note@+1 {{protocol requires function 'neverReturnsStatic()' with type '@noreturn () -> Void'}}
   @noreturn static func neverReturnsStatic()
   static func doesReturnStatic()
 }
@@ -107,29 +107,29 @@ struct MethodWithNoreturn {
 }
 
 func printInt(_: Int) {}
-var maybeReturns: (Int) -> () = exit // no-error
+var maybeReturns: (Int) -> Void = exit // no-error
 var neverReturns1 = exit
-neverReturns1 = printInt // expected-error {{cannot assign value of type '(Int) -> ()' to type '@noreturn (Int) -> ()'}}
+neverReturns1 = printInt // expected-error {{cannot assign value of type '(Int) -> Void' to type '@noreturn (Int) -> Void'}}
 
-var neverReturns2: MethodWithNoreturn -> @noreturn () -> () = MethodWithNoreturn.neverReturns
+var neverReturns2: MethodWithNoreturn -> @noreturn () -> Void = MethodWithNoreturn.neverReturns
 
 exit(5) // no-error
 
 @noreturn
-func exit() -> () {}
+func exit() -> Void {}
 @noreturn
-func testFunctionOverload() -> () {
+func testFunctionOverload() -> Void {
   exit()
 }
 
-func testRvalue(lhs: (), rhs: @noreturn () -> ()) -> () {
+func testRvalue(lhs: (), rhs: @noreturn () -> Void) -> Void {
   return rhs()
 }
 
-var fnr: @noreturn (_: Int) -> () = exit
+var fnr: @noreturn (_: Int) -> Void = exit
 // This might be a desirable syntax, but it does not get properly propagated to SIL, so reject it for now.
 @noreturn // expected-error {{@noreturn may only be used on 'func' declarations}}{{1-11=}}
-var fpr: (_: Int) -> () = exit
+var fpr: (_: Int) -> Void = exit
 
 func testWitnessMethod<T: TestProtocol>(t: T) {
   _ = T.neverReturnsStatic

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -609,45 +609,45 @@ class infer_instanceFunc1 {
 
   @objc func func16_(a: AnyObject) {} // no-error
 
-  func func17(a: () -> ()) {}
-// CHECK-LABEL: {{^}}  @objc func func17(a: () -> ()) {
+  func func17(a: () -> Void) {}
+// CHECK-LABEL: {{^}}  @objc func func17(a: () -> Void) {
 
-  @objc func func17_(a: () -> ()) {}
+  @objc func func17_(a: () -> Void) {}
 
-  func func18(a: (Int) -> (), b: Int) {}
-// CHECK-LABEL: {{^}}  @objc func func18(a: (Int) -> (), b: Int)
+  func func18(a: (Int) -> Void, b: Int) {}
+// CHECK-LABEL: {{^}}  @objc func func18(a: (Int) -> Void, b: Int)
 
-  @objc func func18_(a: (Int) -> (), b: Int) {}
+  @objc func func18_(a: (Int) -> Void, b: Int) {}
 
-  func func19(a: (String) -> (), b: Int) {}
-// CHECK-LABEL: {{^}}  @objc func func19(a: (String) -> (), b: Int) {
+  func func19(a: (String) -> Void, b: Int) {}
+// CHECK-LABEL: {{^}}  @objc func func19(a: (String) -> Void, b: Int) {
 
-  @objc func func19_(a: (String) -> (), b: Int) {}
+  @objc func func19_(a: (String) -> Void, b: Int) {}
 
-  func func_FunctionReturn1() -> () -> () {}
-// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn1() -> () -> () {
+  func func_FunctionReturn1() -> Void -> Void {}
+// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn1() -> Void -> Void {
 
-  @objc func func_FunctionReturn1_() -> () -> () {}
+  @objc func func_FunctionReturn1_() -> Void -> Void {}
 
-  func func_FunctionReturn2() -> (Int) -> () {}
-// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn2() -> (Int) -> () {
+  func func_FunctionReturn2() -> (Int) -> Void {}
+// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn2() -> (Int) -> Void {
 
-  @objc func func_FunctionReturn2_() -> (Int) -> () {}
+  @objc func func_FunctionReturn2_() -> (Int) -> Void {}
 
-  func func_FunctionReturn3() -> () -> Int {}
-// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn3() -> () -> Int {
+  func func_FunctionReturn3() -> Void -> Int {}
+// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn3() -> Void -> Int {
 
-  @objc func func_FunctionReturn3_() -> () -> Int {}
+  @objc func func_FunctionReturn3_() -> Void -> Int {}
 
-  func func_FunctionReturn4() -> (String) -> () {}
-// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn4() -> (String) -> () {
+  func func_FunctionReturn4() -> (String) -> Void {}
+// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn4() -> (String) -> Void {
 
-  @objc func func_FunctionReturn4_() -> (String) -> () {}
+  @objc func func_FunctionReturn4_() -> (String) -> Void {}
 
-  func func_FunctionReturn5() -> () -> String {}
-// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn5() -> () -> String {
+  func func_FunctionReturn5() -> Void -> String {}
+// CHECK-LABEL: {{^}}  @objc func func_FunctionReturn5() -> Void -> String {
 
-  @objc func func_FunctionReturn5_() -> () -> String {}
+  @objc func func_FunctionReturn5_() -> Void -> String {}
 
 
   func func_ZeroParams1() {}
@@ -1176,8 +1176,8 @@ class infer_instanceVar1 {
   var var_Optional_fail21: AnyObject.Type??
 // CHECK-NOT: @objc{{.*}}Optional_fail
 
-  // CHECK-LABEL: @objc var var_CFunctionPointer_1: @convention(c) () -> ()
-  var var_CFunctionPointer_1: @convention(c) () -> ()
+  // CHECK-LABEL: @objc var var_CFunctionPointer_1: @convention(c) () -> Void
+  var var_CFunctionPointer_1: @convention(c) () -> Void
   // CHECK-LABEL: @objc var var_CFunctionPointer_invalid_1: Int
   var var_CFunctionPointer_invalid_1: @convention(c) Int // expected-error {{attribute only applies to syntactic function types}}
   // CHECK-LABEL: {{^}} var var_CFunctionPointer_invalid_2: @convention(c) PlainStruct -> Int
@@ -1240,94 +1240,94 @@ class infer_instanceVar1 {
 // CHECK-NOT: @objc{{.*}}Unowned_fail
 
 
-  var var_FunctionType1: () -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType1: () -> ()
+  var var_FunctionType1: () -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType1: () -> Void
 
-  var var_FunctionType2: (Int) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType2: (Int) -> ()
+  var var_FunctionType2: (Int) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType2: (Int) -> Void
 
   var var_FunctionType3: (Int) -> Int
 // CHECK-LABEL: {{^}}  @objc var var_FunctionType3: (Int) -> Int
 
-  var var_FunctionType4: (Int, Double) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType4: (Int, Double) -> ()
+  var var_FunctionType4: (Int, Double) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType4: (Int, Double) -> Void
 
-  var var_FunctionType5: (String) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType5: (String) -> ()
+  var var_FunctionType5: (String) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType5: (String) -> Void
 
   var var_FunctionType6: () -> String
 // CHECK-LABEL: {{^}}  @objc var var_FunctionType6: () -> String
 
-  var var_FunctionType7: (PlainClass) -> ()
-// CHECK-NOT: @objc var var_FunctionType7: (PlainClass) -> ()
+  var var_FunctionType7: (PlainClass) -> Void
+// CHECK-NOT: @objc var var_FunctionType7: (PlainClass) -> Void
 
   var var_FunctionType8: () -> PlainClass
 // CHECK-NOT: @objc var var_FunctionType8: () -> PlainClass
 
-  var var_FunctionType9: (PlainStruct) -> ()
-// CHECK-LABEL: {{^}}  var var_FunctionType9: (PlainStruct) -> ()
+  var var_FunctionType9: (PlainStruct) -> Void
+// CHECK-LABEL: {{^}}  var var_FunctionType9: (PlainStruct) -> Void
 
   var var_FunctionType10: () -> PlainStruct
 // CHECK-LABEL: {{^}}  var var_FunctionType10: () -> PlainStruct
 
-  var var_FunctionType11: (PlainEnum) -> ()
-// CHECK-LABEL: {{^}}  var var_FunctionType11: (PlainEnum) -> ()
+  var var_FunctionType11: (PlainEnum) -> Void
+// CHECK-LABEL: {{^}}  var var_FunctionType11: (PlainEnum) -> Void
 
-  var var_FunctionType12: (PlainProtocol) -> ()
-// CHECK-LABEL: {{^}}  var var_FunctionType12: (PlainProtocol) -> ()
+  var var_FunctionType12: (PlainProtocol) -> Void
+// CHECK-LABEL: {{^}}  var var_FunctionType12: (PlainProtocol) -> Void
 
-  var var_FunctionType13: (Class_ObjC1) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType13: (Class_ObjC1) -> ()
+  var var_FunctionType13: (Class_ObjC1) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType13: (Class_ObjC1) -> Void
 
-  var var_FunctionType14: (Protocol_Class1) -> ()
-// CHECK-LABEL: {{^}}  var var_FunctionType14: (Protocol_Class1) -> ()
+  var var_FunctionType14: (Protocol_Class1) -> Void
+// CHECK-LABEL: {{^}}  var var_FunctionType14: (Protocol_Class1) -> Void
 
-  var var_FunctionType15: (Protocol_ObjC1) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType15: (Protocol_ObjC1) -> ()
+  var var_FunctionType15: (Protocol_ObjC1) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType15: (Protocol_ObjC1) -> Void
 
-  var var_FunctionType16: (AnyObject) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType16: (AnyObject) -> ()
+  var var_FunctionType16: (AnyObject) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType16: (AnyObject) -> Void
 
-  var var_FunctionType17: (() -> ()) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType17: (() -> ()) -> ()
+  var var_FunctionType17: (() -> Void) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType17: (() -> Void) -> Void
 
-  var var_FunctionType18: ((Int) -> (), Int) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType18: ((Int) -> (), Int) -> ()
+  var var_FunctionType18: ((Int) -> Void, Int) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType18: ((Int) -> Void, Int) -> Void
 
-  var var_FunctionType19: ((String) -> (), Int) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionType19: ((String) -> (), Int) -> ()
-
-
-  var var_FunctionTypeReturn1: () -> () -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn1: () -> () -> ()
-
-  @objc var var_FunctionTypeReturn1_: () -> () -> () // no-error
-
-  var var_FunctionTypeReturn2: () -> (Int) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn2: () -> (Int) -> ()
-
-  @objc var var_FunctionTypeReturn2_: () -> (Int) -> () // no-error
-
-  var var_FunctionTypeReturn3: () -> () -> Int
-// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn3: () -> () -> Int
-
-  @objc var var_FunctionTypeReturn3_: () -> () -> Int // no-error
-
-  var var_FunctionTypeReturn4: () -> (String) -> ()
-// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn4: () -> (String) -> ()
-
-  @objc var var_FunctionTypeReturn4_: () -> (String) -> () // no-error
-
-  var var_FunctionTypeReturn5: () -> () -> String
-// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn5: () -> () -> String
-
-  @objc var var_FunctionTypeReturn5_: () -> () -> String // no-error
+  var var_FunctionType19: ((String) -> Void, Int) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionType19: ((String) -> Void, Int) -> Void
 
 
-  var var_BlockFunctionType1: @convention(block) () -> ()
-// CHECK-LABEL: @objc var var_BlockFunctionType1: @convention(block) () -> ()
+  var var_FunctionTypeReturn1: () -> Void -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn1: () -> Void -> Void
 
-  @objc var var_BlockFunctionType1_: @convention(block) () -> () // no-error
+  @objc var var_FunctionTypeReturn1_: () -> Void -> Void // no-error
+
+  var var_FunctionTypeReturn2: () -> (Int) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn2: () -> (Int) -> Void
+
+  @objc var var_FunctionTypeReturn2_: () -> (Int) -> Void // no-error
+
+  var var_FunctionTypeReturn3: () -> Void -> Int
+// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn3: () -> Void -> Int
+
+  @objc var var_FunctionTypeReturn3_: () -> Void -> Int // no-error
+
+  var var_FunctionTypeReturn4: () -> (String) -> Void
+// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn4: () -> (String) -> Void
+
+  @objc var var_FunctionTypeReturn4_: () -> (String) -> Void // no-error
+
+  var var_FunctionTypeReturn5: () -> Void -> String
+// CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn5: () -> Void -> String
+
+  @objc var var_FunctionTypeReturn5_: () -> Void -> String // no-error
+
+
+  var var_BlockFunctionType1: @convention(block) () -> Void
+// CHECK-LABEL: @objc var var_BlockFunctionType1: @convention(block) () -> Void
+
+  @objc var var_BlockFunctionType1_: @convention(block) () -> Void // no-error
 
   var var_ArrayType1: [AnyObject]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType1: [AnyObject]
@@ -1695,7 +1695,7 @@ class HasNSManaged {
   func mutableAutoreleasingUnsafeMutablePointerToAnyObject(p: AutoreleasingUnsafeMutablePointer<AnyObject>) {}
   // CHECK-LABEL: {{^}} @objc func mutableAutoreleasingUnsafeMutablePointerToAnyObject(p: AutoreleasingUnsafeMutablePointer<AnyObject>) {
 
-  func cFunctionPointer(p: CFunctionPointer<() -> ()>) {} // expected-error{{unavailable}}
+  func cFunctionPointer(p: CFunctionPointer<() -> Void>) {} // expected-error{{unavailable}}
   // CHECK-LABEL: {{^}} func cFunctionPointer(p: <<error type>>) -> <<error type>>
 }
 
@@ -1845,32 +1845,32 @@ struct NotObjCStruct {}
 // CHECK-LABEL: @objc class ClosureArguments
 @objc class ClosureArguments {
   // CHECK: @objc func foo
-  @objc func foo(f: Int -> ()) {}
+  @objc func foo(f: Int -> Void) {}
   // CHECK: @objc func bar
   @objc func bar(f: NotObjCEnum -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func bas
-  @objc func bas(f: NotObjCEnum -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc func bas(f: NotObjCEnum -> Void) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zim
   @objc func zim(f: () -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zang
-  @objc func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
-  @objc func zangZang(f: (Int...) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc func zang(f: (NotObjCEnum, NotObjCStruct) -> Void) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc func zangZang(f: (Int...) -> Void) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func fooImplicit
-  func fooImplicit(f: Int -> ()) {}
+  func fooImplicit(f: Int -> Void) {}
   // CHECK: {{^}}  func barImplicit
   func barImplicit(f: NotObjCEnum -> NotObjCStruct) {}
   // CHECK: {{^}}  func basImplicit
-  func basImplicit(f: NotObjCEnum -> ()) {}
+  func basImplicit(f: NotObjCEnum -> Void) {}
   // CHECK: {{^}}  func zimImplicit
   func zimImplicit(f: () -> NotObjCStruct) {}
   // CHECK: {{^}}  func zangImplicit
-  func zangImplicit(f: (NotObjCEnum, NotObjCStruct) -> ()) {}
+  func zangImplicit(f: (NotObjCEnum, NotObjCStruct) -> Void) {}
   // CHECK: {{^}}  func zangZangImplicit
-  func zangZangImplicit(f: (Int...) -> ()) {}
+  func zangZangImplicit(f: (Int...) -> Void) {}
 }
 
-typealias GoodBlock = @convention(block) Int -> ()
-typealias BadBlock = @convention(block) NotObjCEnum -> () // expected-error{{'NotObjCEnum -> ()' is not representable in Objective-C, so it cannot be used with '@convention(block)'}}
+typealias GoodBlock = @convention(block) Int -> Void
+typealias BadBlock = @convention(block) NotObjCEnum -> Void // expected-error{{'NotObjCEnum -> Void' is not representable in Objective-C, so it cannot be used with '@convention(block)'}}
 
 
 @objc class AccessControl {

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -167,17 +167,17 @@ var rdar16654075b = {
     override func foo() {}  // expected-error{{method does not override any method from its superclass}}
   }
 }
-var rdar16654075c = { () -> () in
+var rdar16654075c = { () -> Void in
   override func foo() {} // expected-error {{'override' can only be specified on class members}} {{3-12=}}
   ()
 }
-var rdar16654075d = { () -> () in
+var rdar16654075d = { () -> Void in
   class A {
     override func foo() {} // expected-error {{method does not override any method from its superclass}}
   }
   A().foo()
 }
-var rdar16654075e = { () -> () in
+var rdar16654075e = { () -> Void in
   class A {
     func foo() {}
   }

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -54,7 +54,7 @@ func zang()() {} // expected-warning{{curried function declaration syntax will b
 func zung<T>(_: T) {}
 @_transparent // expected-error{{@_transparent cannot be applied to stored properties}} {{1-15=}}
 var zippity : Int
-func zoom(x: @_transparent () -> ()) { } // expected-error{{attribute can only be applied to declarations, not types}} {{1-1=@_transparent }} {{14-28=}}
+func zoom(x: @_transparent () -> Void) { } // expected-error{{attribute can only be applied to declarations, not types}} {{1-1=@_transparent }} {{14-28=}}
 protocol ProtoWithTransparent {
   @_transparent// expected-error{{@_transparent is not supported on declarations within protocols}} {{3-16=}}
   func transInProto()
@@ -116,7 +116,7 @@ class transparentOnCalssVar2 {
 };
 
 @thin  // expected-error {{attribute can only be applied to types, not declarations}}
-func testThinDecl() -> () {}
+func testThinDecl() -> Void {}
 
 protocol Class : class {}
 protocol NonClass {}
@@ -191,7 +191,7 @@ func func_result_attr() -> @xyz Int {       // expected-error {{unknown attribut
 }
 
 // @thin is not supported except in SIL.
-var thinFunc : @thin () -> () // expected-error {{attribute is not supported}}
+var thinFunc : @thin () -> Void // expected-error {{attribute is not supported}}
 
 @inline(never) func nolineFunc() {}
 @inline(never) var noinlineVar : Int // expected-error {{@inline(never) cannot be applied to this declaration}} {{1-16=}}


### PR DESCRIPTION
Based on [devforum](https://devforums.apple.com/message/1133616#1133616), make code read better by returning Void instead of ()
