### PR TITLE
[stdlib] Fix reference type mutation issues in RangeReplaceableCollectionType

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -459,7 +459,7 @@ public func +<
     where S.Generator.Element == C.Generator.Element
 >(lhs: S, rhs: C) -> C {
   var result = C()
-  result.reserveCapacity(rhs.count + numericCast(rhs.underestimateCount()))
+  result.reserveCapacity(rhs.count + numericCast(lhs.underestimateCount()))
   result.appendContentsOf(lhs)
   result.appendContentsOf(rhs)
   return result

--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -471,11 +471,10 @@ public func +<
     S : CollectionType
     where S.Generator.Element == C.Generator.Element
 >(lhs: C, rhs: S) -> C {
-  var lhs = lhs
-  // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.reserveCapacity(lhs.count + numericCast(rhs.count))
-  lhs.appendContentsOf(rhs)
-  return lhs
+  var result = lhs is AnyObject ? C(lhs) : lhs
+  result.reserveCapacity(lhs.count + numericCast(rhs.count))
+  result.appendContentsOf(rhs)
+  return result
 }
 
 @warn_unused_result

--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -479,6 +479,19 @@ public func +<
 
 @warn_unused_result
 public func +<
+    C : RangeReplaceableCollectionType,
+    S : CollectionType
+    where S.Generator.Element == C.Generator.Element
+>(lhs: S, rhs: C) -> C {
+  var result = C()
+  result.reserveCapacity(rhs.count + numericCast(lhs.count))
+  result.appendContentsOf(lhs)
+  result.appendContentsOf(rhs)
+  return result
+}
+
+@warn_unused_result
+public func +<
     RRC1 : RangeReplaceableCollectionType,
     RRC2 : RangeReplaceableCollectionType 
     where RRC1.Generator.Element == RRC2.Generator.Element

--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -496,11 +496,10 @@ public func +<
     RRC2 : RangeReplaceableCollectionType 
     where RRC1.Generator.Element == RRC2.Generator.Element
 >(lhs: RRC1, rhs: RRC2) -> RRC1 {
-  var lhs = lhs
-  // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.reserveCapacity(lhs.count + numericCast(rhs.count))
-  lhs.appendContentsOf(rhs)
-  return lhs
+  var result = lhs is AnyObject ? RRC1(lhs) : lhs
+  result.reserveCapacity(lhs.count + numericCast(rhs.count))
+  result.appendContentsOf(rhs)
+  return result
 }
 
 @available(*, unavailable, renamed="RangeReplaceableCollectionType")

--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -446,10 +446,9 @@ public func +<
     S : SequenceType
     where S.Generator.Element == C.Generator.Element
 >(lhs: C, rhs: S) -> C {
-  var lhs = lhs
-  // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.appendContentsOf(rhs)
-  return lhs
+  var result = lhs is AnyObject ? C(lhs) : lhs
+  result.appendContentsOf(rhs)
+  return result
 }
 
 @warn_unused_result

--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -447,6 +447,7 @@ public func +<
     where S.Generator.Element == C.Generator.Element
 >(lhs: C, rhs: S) -> C {
   var result = lhs is AnyObject ? C(lhs) : lhs
+  result.reserveCapacity(lhs.count + numericCast(rhs.underestimateCount()))
   result.appendContentsOf(rhs)
   return result
 }


### PR DESCRIPTION
Successfully passed `build-script -t`

The overloads for `CollectionType` appear to be redundant, because `underestimateCount()` returns `count` for a `CollectionType`. Is there any reason to include them?
