### PR TITLE
[Cmake] Generalize build script to work on Fedora.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -641,7 +641,10 @@ if [[ "$SKIP_TEST_WATCHOS" ]] ; then
     SKIP_TEST_WATCHOS_SIMULATOR=1
 fi
 
-if [[ "${CMAKE_GENERATOR}" == "Ninja" ]] && [[ -z "$(which ninja)" ]] ; then
+# Some Linux distributions, e.g. Fedora, use 'ninja-build' instead of
+# 'ninja' as binary name. Check for both.
+if [[ "${CMAKE_GENERATOR}" == "Ninja" ]] && which ninja > /dev/null 2>&1 &&
+   which ninja-build > /dev/null 2>&1 ; then
     BUILD_NINJA=1
 fi
 


### PR DESCRIPTION
I decided to spawn a Linux VM to ensure my FreeBSD patches don't break anything, and I noticed the build script didn't work out-the-box on Fedora. 
In particular. Fedora uses 'ninja-build' and not 'ninja' as executable name
for the Ninja build system. We check for both to avoid problems.
This patch is an attempt to fix.
