### PR TITLE
Convert [Cc]an not -> [Cc]annot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,7 +461,7 @@ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   endif()
 
   if(XCODE)
-    # FIXME: Can not cross-compile stdlib using Xcode.  Xcode insists on
+    # FIXME: Cannot cross-compile stdlib using Xcode.  Xcode insists on
     # passing -mmacosx-version-min to the compiler, and we want to pass
     # -mios-version-min.  Clang sees both options and complains.
     set(swift_can_crosscompile_stdlib FALSE)

--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -166,9 +166,9 @@ array.uninitialized(count: Builtin.Word) -> (Array<T>, Builtin.RawPointer)
 array.props.isCocoa/needsElementTypeCheck -> Bool
   Reads storage descriptors properties (isCocoa, needsElementTypeCheck).
   This is not control dependent or guarded. The optimizer has
-  semantic knowledge of the state transfer those properties can not make:
-  An array that is not ``isCocoa`` can not transfer to ``isCocoa``.
-  An array that is not ``needsElementTypeCheck`` can not transfer to
+  semantic knowledge of the state transfer those properties cannot make:
+  An array that is not ``isCocoa`` cannot transfer to ``isCocoa``.
+  An array that is not ``needsElementTypeCheck`` cannot transfer to
   ``needsElementTypeCheck``.
 
 array.get_element(index: Int) -> Element

--- a/docs/IndexInvalidation.rst
+++ b/docs/IndexInvalidation.rst
@@ -128,7 +128,7 @@ Consequences:
   any indices.  Indices are composites of offsets, so replacing the value does
   not change the shape of the data structure and preserves offsets.
 
-- A value type mutable linked list can not conform to
+- A value type mutable linked list cannot conform to
   ``MutableCollectionType``.  An index for a linked list has to be implemented
   as a pointer to the list node to provide O(1) element access.  Mutating an
   element of a non-uniquely referenced linked list will create a copy of the

--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -176,7 +176,7 @@ Advice: Use value types in Array
 
 In Swift, types can be divided into two different categories: value types
 (structs, enums, tuples) and reference types (classes). A key distinction is
-that value types can not be included inside an NSArray. Thus when using value
+that value types cannot be included inside an NSArray. Thus when using value
 types, the optimizer can remove most of the overhead in Array that is necessary
 to handle the possibility of the array being backed an NSArray.
 
@@ -265,7 +265,7 @@ Swift eliminates integer overflow bugs by checking for overflow when performing
 normal arithmetic. These checks are not appropriate in high performance code
 where one knows that no memory safety issues can result.
 
-Advice: Use unchecked integer arithmetic when you can prove that overflow can not occur
+Advice: Use unchecked integer arithmetic when you can prove that overflow cannot occur
 ---------------------------------------------------------------------------------------
 
 In performance-critical code you can elide overflow checks if you know it is

--- a/docs/proposals/containers_value_type.html
+++ b/docs/proposals/containers_value_type.html
@@ -231,7 +231,7 @@ rely on a high quality and strictly followed naming conventions such as
 those used in Cocoa.  Now there is absolutely nothing wrong with high
 quality, strictly followed naming conventions. But they aren't checked
 by the compiler.  Having the compiler be able to confirm: yes, this
-argument can be modified / no, that argument can not be modified; is a
+argument can be modified / no, that argument cannot be modified; is a
 <i>tremendous</i> productivity booster.
 </p>
 
@@ -482,7 +482,7 @@ use of '<code>&amp;</code>' at the call site.  Thus the programmer can
 more easily spot the few cases where this is desired.
 </p>
 <ul>
-<li>Swift can not provide such protection for types with reference semantics.</li>
+<li>Swift cannot provide such protection for types with reference semantics.</li>
 </ul>
 </li>
 

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -281,7 +281,7 @@ public:
   template <typename T>
   typename std::remove_reference<T>::type *AllocateObjectCopy(T &&t,
               AllocationArena arena = AllocationArena::Permanent) const {
-    // This function can not be named AllocateCopy because it would always win
+    // This function cannot be named AllocateCopy because it would always win
     // overload resolution over the AllocateCopy(ArrayRef<T>).
     using TNoRef = typename std::remove_reference<T>::type;
     TNoRef *res = (TNoRef *) Allocate(sizeof(TNoRef), alignof(TNoRef), arena);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4430,14 +4430,14 @@ public:
   }
   void setBody(BraceStmt *S, BodyKind NewBodyKind = BodyKind::Parsed) {
     assert(getBodyKind() != BodyKind::Skipped &&
-           "can not set a body if it was skipped");
+           "cannot set a body if it was skipped");
 
     Body = S;
     setBodyKind(NewBodyKind);
   }
 
   /// \brief Note that the body was skipped for this function.  Function body
-  /// can not be attached after this call.
+  /// cannot be attached after this call.
   void setBodySkipped(SourceRange bodyRange) {
     assert(getBodyKind() == BodyKind::None);
     BodyRange = bodyRange;

--- a/include/swift/Basic/BlotSetVector.h
+++ b/include/swift/Basic/BlotSetVector.h
@@ -99,7 +99,7 @@ public:
   /// V1.
   void replace(const ValueT &V1, const ValueT &V2) {
     auto Iter1 = Map.find(V1);
-    assert(Iter1 != Map.end() && "Can not replace value that is not in set");
+    assert(Iter1 != Map.end() && "Cannot replace value that is not in set");
     unsigned V1Index = Iter1->second;
     Map.erase(V1);
 

--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -90,7 +90,7 @@ enum class FunctionSigSpecializationParamKind : unsigned {
 
 /// The pass that caused the specialization to occur. We use this to make sure
 /// that two passes that generate similar changes do not yield the same
-/// mangling. This currently can not happen, so this is just a safety measure
+/// mangling. This currently cannot happen, so this is just a safety measure
 /// that creates separate name spaces.
 enum class SpecializationPass : uint8_t {
   AllocBoxToStack,

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -22,7 +22,7 @@
 
 namespace swift {
 
-/// Same as \c std::is_trivially_copyable, which we can not use directly
+/// Same as \c std::is_trivially_copyable, which we cannot use directly
 /// because it is not implemented yet in all C++11 standard libraries.
 ///
 /// Unlike \c llvm::isPodLike, this trait should produce a precise result and

--- a/include/swift/Parse/ParserResult.h
+++ b/include/swift/Parse/ParserResult.h
@@ -49,7 +49,7 @@ public:
 
   /// Construct a successful parser result.
   explicit ParserResult(T *Result) : PtrAndBits(Result) {
-    assert(Result && "a successful parser result can not be null");
+    assert(Result && "a successful parser result cannot be null");
   }
 
   /// Convert from a different but compatible parser result.

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -624,11 +624,11 @@ public:
   }
 
   bool isRoot() const {
-    // Root does not have a parent. So if we have a parent, we can not be root.
+    // Root does not have a parent. So if we have a parent, we cannot be root.
     if (Parent.hasValue()) {
       assert(Proj.hasValue() && "If parent is not none, then P should be not "
              "none");
-      assert(Index != RootIndex && "If parent is not none, we can not be root");
+      assert(Index != RootIndex && "If parent is not none, we cannot be root");
       return false;
     } else {
       assert(!Proj.hasValue() && "If parent is none, then P should be none");

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -546,17 +546,17 @@ public:
   //===--------------------------------------------------------------------===//
 
   SILArgument *getArgument(unsigned i) {
-    assert(!empty() && "Can not get argument of a function without a body");
+    assert(!empty() && "Cannot get argument of a function without a body");
     return begin()->getBBArg(i);
   }
 
   const SILArgument *getArgument(unsigned i) const {
-    assert(!empty() && "Can not get argument of a function without a body");
+    assert(!empty() && "Cannot get argument of a function without a body");
     return begin()->getBBArg(i);
   }
 
   ArrayRef<SILArgument *> getArguments() const {
-    assert(!empty() && "Can not get arguments of a function without a body");
+    assert(!empty() && "Cannot get arguments of a function without a body");
     return begin()->getBBArgs();
   }
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -459,7 +459,7 @@ public:
   ///
   /// \arg C The protocol conformance mapped key to use to lookup the witness
   ///        table.
-  /// \arg deserializeLazily If we can not find the witness table should we
+  /// \arg deserializeLazily If we cannot find the witness table should we
   ///                        attempt to lazily deserialize it.
   std::pair<SILWitnessTable *, ArrayRef<Substitution>>
   lookUpWitnessTable(const ProtocolConformance *C, bool deserializeLazily=true);

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -83,7 +83,7 @@ public:
   enum class AliasResult : unsigned {
     NoAlias=0,      ///< The two values have no dependencies on each
                     ///  other.
-    MayAlias,       ///< The two values can not be proven to alias or
+    MayAlias,       ///< The two values cannot be proven to alias or
                     ///  not alias. Anything could happen.
     PartialAlias,   ///< The two values overlap in a partial manner.
     MustAlias,      ///< The two values are equal.
@@ -166,7 +166,7 @@ public:
     return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::PartialAlias;
   }
 
-  /// Convenience method that returns true if V1, V2 can not alias.
+  /// Convenience method that returns true if V1, V2 cannot alias.
   bool isNoAlias(SILValue V1, SILValue V2, SILType TBAAType1 = SILType(),
                  SILType TBAAType2 = SILType()) {
     return alias(V1, V2, TBAAType1, TBAAType2) == AliasResult::NoAlias;

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -245,7 +245,7 @@ public:
     /// a basic block. The iterator can only be compared against another invalid
     /// iterator. Any other use causes an unreachable being hit.
     ///
-    /// The reason this is needed is because basic blocks can not have
+    /// The reason this is needed is because basic blocks cannot have
     /// subregions, yet many graph algorithms want to be able to iterate over
     /// the subregions of a region regardless of whether it is a basic block,
     /// loop, or function. By allowing for invalid iterators for basic blocks,
@@ -346,7 +346,7 @@ private:
   /// this BB, we can represent each jump as individual non-local edges in
   /// between loops.
   ///
-  /// *NOTE* This list is not sorted, but can not have any duplicate
+  /// *NOTE* This list is not sorted, but cannot have any duplicate
   /// elements. We have a check in LoopRegionFunctionInfo::verify to make sure
   /// that this stays true. The reason why this is necessary is that subregions
   /// of a loop, may have a non-local successor edge pointed at this region's
@@ -600,20 +600,20 @@ private:
         IsUnknownControlFlowEdgeTail(false) {}
 
   void setParent(LoopRegion *PR) {
-    assert(!isFunction() && "Functions can not be subregions");
-    assert(!PR->isBlock() && "BB regions can not be parents of a region");
+    assert(!isFunction() && "Functions cannot be subregions");
+    assert(!PR->isBlock() && "BB regions cannot be parents of a region");
     ParentID = PR->getID();
   }
 
   void addPred(LoopRegion *LNR) {
-    assert(!isFunction() && "Functions can not have predecessors");
+    assert(!isFunction() && "Functions cannot have predecessors");
     if (std::count(pred_begin(), pred_end(), LNR->getID()))
       return;
     Preds.push_back(LNR->ID);
   }
 
   unsigned addSucc(LoopRegion *Successor) {
-    assert(!isFunction() && "Functions can not have successors");
+    assert(!isFunction() && "Functions cannot have successors");
     return Succs.insert(SuccessorID(Successor->getID(), false));
   }
 
@@ -644,14 +644,14 @@ private:
   void removeLocalSucc(unsigned ID) { Succs.erase(SuccessorID(ID, false)); }
 
   void addBlockSubregion(LoopRegion *R) {
-    assert(!isBlock() && "Blocks can not have subregions");
+    assert(!isBlock() && "Blocks cannot have subregions");
     assert(R->isBlock() && "Assumed R was a basic block");
     R->setParent(this);
     getSubregionData().addBlockSubregion(R);
   }
 
   void addLoopSubregion(LoopRegion *L, LoopRegion *Header) {
-    assert(!isBlock() && "Blocks can not have subregions");
+    assert(!isBlock() && "Blocks cannot have subregions");
     assert(L->isLoop() && "Assumed L was a loop");
     assert(Header->isBlock() && "Assumed Header was a loop");
     L->setParent(this);

--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -182,7 +182,7 @@ public:
     bool ReadsRC = false;
     
     /// Returns the effecs for an address or reference. This might be a
-    /// parameter, the LocalEffects or, if the value can not be associated to one
+    /// parameter, the LocalEffects or, if the value cannot be associated to one
     /// of them, the GlobalEffects.
     Effects *getEffectsOn(SILValue Addr);
     

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3163,9 +3163,9 @@ ProtocolType::ProtocolType(ProtocolDecl *TheDecl, const ASTContext &Ctx)
 
 LValueType *LValueType::get(Type objectTy) {
   assert(!objectTy->is<ErrorType>() &&
-         "can not have ErrorType wrapped inside LValueType");
+         "cannot have ErrorType wrapped inside LValueType");
   assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
-         "can not have 'inout' or @lvalue wrapped inside an @lvalue");
+         "cannot have 'inout' or @lvalue wrapped inside an @lvalue");
 
   auto properties = objectTy->getRecursiveProperties()
                     | RecursiveTypeProperties::IsLValue;
@@ -3183,9 +3183,9 @@ LValueType *LValueType::get(Type objectTy) {
 
 InOutType *InOutType::get(Type objectTy) {
   assert(!objectTy->is<ErrorType>() &&
-         "can not have ErrorType wrapped inside InOutType");
+         "cannot have ErrorType wrapped inside InOutType");
   assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
-         "can not have 'inout' or @lvalue wrapped inside an 'inout'");
+         "cannot have 'inout' or @lvalue wrapped inside an 'inout'");
 
   auto properties = objectTy->getRecursiveProperties() |
                      RecursiveTypeProperties::HasInOut;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2481,7 +2481,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     else
       D = T->getAnyNominal();
 
-    // If we can not find the declaration, be extra careful and print
+    // If we cannot find the declaration, be extra careful and print
     // the type qualified.
     if (!D)
       return true;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2472,7 +2472,7 @@ bool ProtocolDecl::inheritsFrom(const ProtocolDecl *super) const {
 bool ProtocolDecl::requiresClassSlow() {
   ProtocolDeclBits.RequiresClass = false;
 
-  // Ensure that the result can not change in future.
+  // Ensure that the result cannot change in future.
   assert(isInheritedProtocolsValid() || isBeingTypeChecked());
 
   if (getAttrs().hasAttribute<ObjCAttr>() || isObjC()) {

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -122,7 +122,7 @@ static bool isDeclVisibleInLookupMode(ValueDecl *Member, LookupState LS,
   }
 
   if (auto *FD = dyn_cast<FuncDecl>(Member)) {
-    // Can not call static functions on non-metatypes.
+    // Cannot call static functions on non-metatypes.
     if (!LS.isOnMetatype() && FD->isStatic())
       return false;
 
@@ -130,27 +130,27 @@ static bool isDeclVisibleInLookupMode(ValueDecl *Member, LookupState LS,
     return true;
   }
   if (auto *VD = dyn_cast<VarDecl>(Member)) {
-    // Can not use static properties on non-metatypes.
+    // Cannot use static properties on non-metatypes.
     if (!(LS.isQualified() && LS.isOnMetatype()) && VD->isStatic())
       return false;
 
-    // Can not use instance properties on metatypes.
+    // Cannot use instance properties on metatypes.
     if (LS.isOnMetatype() && !VD->isStatic())
       return false;
 
     return true;
   }
   if (isa<EnumElementDecl>(Member)) {
-    // Can not reference enum elements on non-metatypes.
+    // Cannot reference enum elements on non-metatypes.
     if (!(LS.isQualified() && LS.isOnMetatype()))
       return false;
   }
   if (auto CD = dyn_cast<ConstructorDecl>(Member)) {
-    // Constructors with stub implementations can not be called in Swift.
+    // Constructors with stub implementations cannot be called in Swift.
     if (CD->hasStubImplementation())
       return false;
     if (LS.isQualified() && LS.isOnSuperclass()) {
-      // Can not call initializers from a superclass, except for inherited
+      // Cannot call initializers from a superclass, except for inherited
       // convenience initializers.
       return LS.isInheritsSuperclassInitializers() && CD->isInheritable();
     }
@@ -277,7 +277,7 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
       if (D->getOverriddenDecl())
         return;
 
-      // Initializers can not be found by dynamic lookup.
+      // Initializers cannot be found by dynamic lookup.
       if (isa<ConstructorDecl>(D))
         return;
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -145,7 +145,7 @@ GenericParamList *ProtocolConformance::getGenericParams() const {
 
   case ProtocolConformanceKind::Specialized:
     // If we have a specialized protocol conformance, since we do not support
-    // currently partial specialization, we know that it can not have any open
+    // currently partial specialization, we know that it cannot have any open
     // type variables.
     return nullptr;
   }
@@ -174,7 +174,7 @@ GenericSignature *ProtocolConformance::getGenericSignature() const {
 
   case ProtocolConformanceKind::Specialized:
     // If we have a specialized protocol conformance, since we do not support
-    // currently partial specialization, we know that it can not have any open
+    // currently partial specialization, we know that it cannot have any open
     // type variables.
     return nullptr;
   }

--- a/lib/AST/Verifier.cpp
+++ b/lib/AST/Verifier.cpp
@@ -675,7 +675,7 @@ struct ASTNodeBase {};
       if (auto Overridden = D->getOverriddenDecl()) {
         if (D->getDeclContext() == Overridden->getDeclContext()) {
           PrettyStackTraceDecl debugStack("verifying overriden", D);
-          Out << "can not override a decl in the same DeclContext";
+          Out << "cannot override a decl in the same DeclContext";
           D->dump(Out);
           Overridden->dump(Out);
           abort();
@@ -1914,7 +1914,7 @@ struct ASTNodeBase {};
       PrettyStackTraceDecl debugStack("verifying DestructorDecl", DD);
 
       if (DD->isGeneric()) {
-        Out << "DestructorDecl can not be generic";
+        Out << "DestructorDecl cannot be generic";
         abort();
       }
       if (DD->getBodyParamPatterns().size() != 1) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -75,7 +75,7 @@ StringRef getCommandName(CodeCompletionCommandKind Kind) {
   CHECK_CASE(recommended)
   CHECK_CASE(recommendedover)
 #undef CHECK_CASE
-  llvm_unreachable("Can not handle this Kind.");
+  llvm_unreachable("Cannot handle this Kind.");
 }
 
 bool containsInterestedWords(StringRef Content, StringRef Splitter,
@@ -1769,7 +1769,7 @@ public:
     assert(VD->isStatic() ||
            !(InsideStaticMethod &&
             VD->getDeclContext() == CurrentMethod->getDeclContext()) &&
-           "name lookup bug -- can not see an instance variable "
+           "name lookup bug -- cannot see an instance variable "
            "in a static function");
 
     CommandWordsPairs Pairs;
@@ -2057,7 +2057,7 @@ public:
     case LookupKind::EnumElement:
     case LookupKind::Type:
     case LookupKind::TypeInDeclContext:
-      llvm_unreachable("can not have a method call while doing a "
+      llvm_unreachable("cannot have a method call while doing a "
                        "type completion");
     case LookupKind::ImportFromModule:
       IsImplicitlyCurriedInstanceMethod = false;
@@ -2245,7 +2245,7 @@ public:
   }
 
   void addSubscriptCall(const SubscriptDecl *SD, DeclVisibilityKind Reason) {
-    assert(!HaveDot && "can not add a subscript after a dot");
+    assert(!HaveDot && "cannot add a subscript after a dot");
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
         Sink,
@@ -2463,11 +2463,11 @@ public:
       }
 
       if (auto *FD = dyn_cast<FuncDecl>(D)) {
-        // We can not call operators with a postfix parenthesis syntax.
+        // We cannot call operators with a postfix parenthesis syntax.
         if (FD->isBinaryOperator() || FD->isUnaryOperator())
           return;
 
-        // We can not call accessors.  We use VarDecls and SubscriptDecls to
+        // We cannot call accessors.  We use VarDecls and SubscriptDecls to
         // produce completions that refer to getters and setters.
         if (FD->isAccessor())
           return;
@@ -2525,11 +2525,11 @@ public:
       }
 
       if (auto *FD = dyn_cast<FuncDecl>(D)) {
-        // We can not call operators with a postfix parenthesis syntax.
+        // We cannot call operators with a postfix parenthesis syntax.
         if (FD->isBinaryOperator() || FD->isUnaryOperator())
           return;
 
-        // We can not call accessors.  We use VarDecls and SubscriptDecls to
+        // We cannot call accessors.  We use VarDecls and SubscriptDecls to
         // produce completions that refer to getters and setters.
         if (FD->isAccessor())
           return;
@@ -3670,7 +3670,7 @@ public:
       if (FD->isBinaryOperator() || FD->isUnaryOperator())
         return;
 
-      // We can not override individual accessors.
+      // We cannot override individual accessors.
       if (FD->isAccessor())
         return;
 

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -293,7 +293,7 @@ public:
     if (!Name.empty()) {
       StringRef NameStr = Name.str();
 
-      // 'self' is a keyword, we can not allow to insert it into the source
+      // 'self' is a keyword, we cannot allow to insert it into the source
       // buffer.
       bool IsAnnotation = (NameStr == "self");
 

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -310,7 +310,7 @@ public:
 /// instructions (e.g., ARC-inserted calls to release()) that have no
 /// source location associated with them. The DWARF specification
 /// allows the compiler to use the special line number 0 to indicate
-/// code that can not be attributed to any source location.
+/// code that cannot be attributed to any source location.
 class ArtificialLocation : public AutoRestoreLocation {
 public:
   /// \brief Set the current location to line 0, but within scope DS.

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -21,7 +21,7 @@
 namespace swift {
 
 /// A class for building ARC entry points. It is a composition wrapper around an
-/// IRBuilder and a constant Cache. It can not be moved or copied. It is meant
+/// IRBuilder and a constant Cache. It cannot be moved or copied. It is meant
 /// to be created once and passed around by reference.
 class ARCEntryPointBuilder {
   using IRBuilder = llvm::IRBuilder<>;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2195,7 +2195,7 @@ void Parser::parseDeclDelayed() {
   // Ensure that we restore the parser state at exit.
   ParserPositionRAII PPR(*this);
 
-  // Create a lexer that can not go past the end state.
+  // Create a lexer that cannot go past the end state.
   Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
 
   // Temporarily swap out the parser's current lexer with our new one.
@@ -2520,8 +2520,8 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
       return parseDecl(MemberDecls, Options);
     });
-    // Don't propagate the code completion bit from members: we can not help
-    // code completion inside a member decl, and our callers can not do
+    // Don't propagate the code completion bit from members: we cannot help
+    // code completion inside a member decl, and our callers cannot do
     // anything about it either.  But propagate the error bit.
     if (BodyStatus.isError())
       status.setIsParseError();
@@ -3288,7 +3288,7 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags, Pattern *Indices,
         Attributes = DeclAttributes();
       }
       if (!IsFirstAccessor) {
-        // Can not have an implicit getter after other accessor.
+        // Cannot have an implicit getter after other accessor.
         diagnose(Tok, diag::expected_accessor_kw);
         skipUntil(tok::r_brace);
         // Don't signal an error since we recovered.
@@ -3419,7 +3419,7 @@ void Parser::parseAccessorBodyDelayed(AbstractFunctionDecl *AFD) {
   // Ensure that we restore the parser state at exit.
   ParserPositionRAII PPR(*this);
 
-  // Create a lexer that can not go past the end state.
+  // Create a lexer that cannot go past the end state.
   Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
 
   // Temporarily swap out the parser's current lexer with our new one.
@@ -4220,7 +4220,7 @@ bool Parser::parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD) {
   // Ensure that we restore the parser state at exit.
   ParserPositionRAII PPR(*this);
 
-  // Create a lexer that can not go past the end state.
+  // Create a lexer that cannot go past the end state.
   Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
 
   // Temporarily swap out the parser's current lexer with our new one.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -649,7 +649,7 @@ static bool isStartOfGetSetAccessor(Parser &P) {
       NextToken.isContextualKeyword("willSet"))
     return true;
 
-  // If we don't have attributes, then it can not be an accessor block.
+  // If we don't have attributes, then it cannot be an accessor block.
   if (NextToken.isNot(tok::at_sign))
     return false;
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -208,7 +208,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         param.FirstName = Context.getIdentifier(Tok.getText());
         param.FirstNameLoc = consumeToken();
 
-        // Operators can not have API names.
+        // Operators cannot have API names.
         if (paramContext == ParameterContextKind::Operator &&
             param.PoundLoc.isValid()) {
           diagnose(param.PoundLoc, 
@@ -240,7 +240,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         param.SecondNameLoc = consumeToken();
       }
 
-      // Operators can not have API names.
+      // Operators cannot have API names.
       if (paramContext == ParameterContextKind::Operator &&
           !param.FirstName.empty() &&
           param.SecondNameLoc.isValid()) {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -453,7 +453,7 @@ void Parser::parseTopLevelCodeDeclDelayed() {
   // Ensure that we restore the parser state at exit.
   ParserPositionRAII PPR(*this);
 
-  // Create a lexer that can not go past the end state.
+  // Create a lexer that cannot go past the end state.
   Lexer LocalLex(*L, BeginParserPosition.LS, EndLexerState);
 
   // Temporarily swap out the parser's current lexer with our new one.

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -315,7 +315,7 @@ ParserResult<IdentTypeRepr> Parser::parseTypeIdentifier() {
     if (Tok.is(tok::kw_Self)) {
       Loc = consumeIdentifier(&Name);
     } else {
-      // FIXME: specialize diagnostic for 'Type': type can not start with
+      // FIXME: specialize diagnostic for 'Type': type cannot start with
       // 'metatype'
       // FIXME: offer a fixit: 'self' -> 'Self'
       if (parseIdentifier(Name, Loc, diag::expected_identifier_in_dotted_type))

--- a/lib/SIL/Dominance.cpp
+++ b/lib/SIL/Dominance.cpp
@@ -68,7 +68,7 @@ void DominanceInfo::verify() const {
 PostDominanceInfo::PostDominanceInfo(SILFunction *F)
   : DominatorTreeBase(/*isPostDom*/ true) {
   assert(!F->isExternalDeclaration() &&
-         "Can not construct a post dominator tree for a declaration");
+         "Cannot construct a post dominator tree for a declaration");
   recalculate(*F);
 }
 

--- a/lib/SIL/Mangle.cpp
+++ b/lib/SIL/Mangle.cpp
@@ -171,7 +171,7 @@ FunctionSignatureSpecializationMangler::mangleConstantProp(LiteralInst *LI) {
     StringLiteralInst *SLI = cast<StringLiteralInst>(LI);
     StringRef V = SLI->getValue();
 
-    assert(V.size() <= 32 && "Can not encode string of length > 32");
+    assert(V.size() <= 32 && "Cannot encode string of length > 32");
 
     llvm::SmallString<33> Str;
     Str += "u";

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -488,7 +488,7 @@ hasNonEmptySymmetricDifference(const ProjectionPath &RHS) const {
 SubSeqRelation_t
 ProjectionPath::
 computeSubSeqRelation(const ProjectionPath &RHS) const {
-  // If either path is empty, we can not prove anything, return Unrelated.
+  // If either path is empty, we cannot prove anything, return Unrelated.
   if (empty() || RHS.empty())
     return SubSeqRelation_t::Unknown;
 
@@ -510,7 +510,7 @@ computeSubSeqRelation(const ProjectionPath &RHS) const {
     // in common and should return unrelated. If Index is greater than zero,
     // then we know that the two projection paths have a common base but a
     // non-empty symmetric difference. For now we just return Unrelated since I
-    // can not remember why I had the special check in the
+    // cannot remember why I had the special check in the
     // hasNonEmptySymmetricDifference code.
     if (LHSProj != RHSProj)
       return SubSeqRelation_t::Unknown;
@@ -588,7 +588,7 @@ findMatchingValueProjectionPaths(SILInstruction *I,
 
 Optional<ProjectionPath>
 ProjectionPath::subtractPaths(const ProjectionPath &LHS, const ProjectionPath &RHS) {
-  // If RHS is greater than or equal to LHS in size, RHS can not be a prefix of
+  // If RHS is greater than or equal to LHS in size, RHS cannot be a prefix of
   // LHS. Return None.
   unsigned RHSSize = RHS.size();
   unsigned LHSSize = LHS.size();
@@ -636,7 +636,7 @@ ProjectionPath::expandTypeIntoLeafProjectionPaths(SILType B, SILModule *Mod,
     Projections.clear();
     Projection::getFirstLevelAddrProjections(Ty, *Mod, Projections);
 
-    // Reached the end of the projection tree, this field can not be expanded
+    // Reached the end of the projection tree, this field cannot be expanded
     // anymore.
     if (Projections.empty()) {
       Paths.push_back(std::move(PP.getValue()));
@@ -700,7 +700,7 @@ ProjectionPath::expandTypeIntoNodeProjectionPaths(SILType B, SILModule *Mod,
     Projections.clear();
     Projection::getFirstLevelAddrProjections(Ty, *Mod, Projections);
 
-    // Reached the end of the projection tree, this field can not be expanded
+    // Reached the end of the projection tree, this field cannot be expanded
     // anymore.
     if (Projections.empty()) {
       Paths.push_back(std::move(PP.getValue()));
@@ -1141,7 +1141,7 @@ public:
   }
 
   SILInstruction *createInstruction() const {
-    assert(isComplete() && "Can not create instruction until the aggregate is "
+    assert(isComplete() && "Cannot create instruction until the aggregate is "
            "complete");
     assert(!Invalidated && "Must not be invalidated to create an instruction");
     const_cast<AggregateBuilder *>(this)->Invalidated = true;

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -542,7 +542,7 @@ bool TupleExtractInst::isTrivialEltOfOneRCIDTuple() const {
   if (!getType().isTrivial(Mod))
     return false;
 
-  // If the elt we are extracting is trivial, we can not have any non trivial
+  // If the elt we are extracting is trivial, we cannot have any non trivial
   // fields.
   if (getOperand().getType().isTrivial(Mod))
     return false;
@@ -585,7 +585,7 @@ bool TupleExtractInst::isTrivialEltOfOneRCIDTuple() const {
 bool TupleExtractInst::isEltOnlyNonTrivialElt() const {
   SILModule &Mod = getModule();
 
-  // If the elt we are extracting is trivial, we can not be a non-trivial
+  // If the elt we are extracting is trivial, we cannot be a non-trivial
   // field... return false.
   if (getType().isTrivial(Mod))
     return false;
@@ -625,7 +625,7 @@ bool StructExtractInst::isTrivialFieldOfOneRCIDStruct() const {
 
   SILType StructTy = getOperand().getType();
 
-  // If the elt we are extracting is trivial, we can not have any non trivial
+  // If the elt we are extracting is trivial, we cannot have any non trivial
   // fields.
   if (StructTy.isTrivial(Mod))
     return false;
@@ -669,7 +669,7 @@ bool StructExtractInst::isTrivialFieldOfOneRCIDStruct() const {
 bool StructExtractInst::isFieldOnlyNonTrivialField() const {
   SILModule &Mod = getModule();
 
-  // If the field we are extracting is trivial, we can not be a non-trivial
+  // If the field we are extracting is trivial, we cannot be a non-trivial
   // field... return false.
   if (getType().isTrivial(Mod))
     return false;
@@ -776,7 +776,7 @@ OperandValueArrayRef CondBranchInst::getFalseArgs() const {
 
 SILValue
 CondBranchInst::getArgForDestBB(SILBasicBlock *DestBB, SILArgument *A) {
-  // If TrueBB and FalseBB equal, we can not find an arg for this DestBB so
+  // If TrueBB and FalseBB equal, we cannot find an arg for this DestBB so
   // return an empty SILValue.
   if (getTrueBB() == getFalseBB()) {
     assert(DestBB == getTrueBB() && "DestBB is not a target of this cond_br");

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -139,7 +139,7 @@ SILWitnessTable *
 SILModule::createWitnessTableDeclaration(ProtocolConformance *C,
                                          SILLinkage linkage) {
   // If we are passed in a null conformance (a valid value), just return nullptr
-  // since we can not map a witness table to it.
+  // since we cannot map a witness table to it.
   if (!C)
     return nullptr;
 
@@ -382,7 +382,7 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
   F->setDeclContext(constant.hasDecl() ? constant.getDecl() : nullptr);
 
   // If this function has a self parameter, make sure that it has a +0 calling
-  // convention. This can not be done for general function types, since
+  // convention. This cannot be done for general function types, since
   // function_ref's SILFunctionTypes do not have archetypes associated with
   // it.
   CanSILFunctionType FTy = F->getLoweredFunctionType();

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -416,7 +416,7 @@ bool SILType::aggregateContainsRecord(SILType Record, SILModule &Mod) const {
       for (VarDecl *Var : S->getStoredProperties())
         Worklist.push_back(Ty.getFieldType(Var, Mod));
 
-    // If we have a class address, it is a pointer so it can not contain other
+    // If we have a class address, it is a pointer so it cannot contain other
     // types.
 
     // If we reached this point, then this type has no subrecords. Since it does

--- a/lib/SIL/SILValueProjection.cpp
+++ b/lib/SIL/SILValueProjection.cpp
@@ -152,7 +152,7 @@ SILValue LSValue::reduce(LSLocation &Base, SILModule *M,
 
     // In 3 cases do we need aggregation.
     //
-    // 1. If there is only 1 child and we can not strip off any projections,
+    // 1. If there is only 1 child and we cannot strip off any projections,
     // that means we need to create an aggregation.
     // 
     // 2. There are multiple children and they have the same base, but empty
@@ -242,7 +242,7 @@ bool LSLocation::isMustAliasLSLocation(const LSLocation &RHS,
   // If the bases are not must-alias, the locations may not alias.
   if (!AA->isMustAlias(Base, RHS.getBase()))
     return false;
-  // If projection paths are different, then the locations can not alias.
+  // If projection paths are different, then the locations cannot alias.
   if (!hasIdenticalProjectionPath(RHS))
     return false;
   return true;
@@ -250,7 +250,7 @@ bool LSLocation::isMustAliasLSLocation(const LSLocation &RHS,
 
 bool LSLocation::isMayAliasLSLocation(const LSLocation &RHS,
                                       AliasAnalysis *AA) {
-  // If the bases do not alias, then the locations can not alias.
+  // If the bases do not alias, then the locations cannot alias.
   if (AA->isNoAlias(Base, RHS.getBase()))
     return false;
   // If one projection path is a prefix of another, then the locations

--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -42,7 +42,7 @@ SILWitnessTable *
 SILWitnessTable::create(SILModule &M, SILLinkage Linkage, bool IsFragile,
                         NormalProtocolConformance *Conformance,
                         ArrayRef<SILWitnessTable::Entry> entries) {
-  assert(Conformance && "Can not create a witness table for a null "
+  assert(Conformance && "Cannot create a witness table for a null "
          "conformance.");
 
   // Create the mangled name of our witness table...
@@ -70,7 +70,7 @@ SILWitnessTable::create(SILModule &M, SILLinkage Linkage, bool IsFragile,
 SILWitnessTable *
 SILWitnessTable::create(SILModule &M, SILLinkage Linkage,
                         NormalProtocolConformance *Conformance) {
-  assert(Conformance && "Can not create a witness table for a null "
+  assert(Conformance && "Cannot create a witness table for a null "
          "conformance.");
 
   // Create the mangled name of our witness table...

--- a/lib/SILOptimizer/ARC/ARCBBState.h
+++ b/lib/SILOptimizer/ARC/ARCBBState.h
@@ -55,7 +55,7 @@ public:
   ///   builtin "int_trap"() : $()
   ///   unreachable
   ///
-  /// This can not have any uses of reference counted values since the frontend
+  /// This cannot have any uses of reference counted values since the frontend
   /// just leaks at that point.
   bool isTrapBB() const { return IsTrapBB; }
 

--- a/lib/SILOptimizer/ARC/ARCRegionState.cpp
+++ b/lib/SILOptimizer/ARC/ARCRegionState.cpp
@@ -163,8 +163,8 @@ static bool isARCSignificantTerminator(TermInst *TI) {
   case TermKind::Invalid:
     llvm_unreachable("Expected a TermInst");
   case TermKind::UnreachableInst:
-  // br is a forwarding use for its arguments. It can not in of itself extend
-  // the lifetime of an object (just like a phi-node) can not.
+  // br is a forwarding use for its arguments. It cannot in of itself extend
+  // the lifetime of an object (just like a phi-node) cannot.
   case TermKind::BranchInst:
   // A cond_br is a forwarding use for its non-operand arguments in a similar
   // way to br. Its operand must be an i1 that has a different lifetime from any
@@ -192,7 +192,7 @@ static bool isARCSignificantTerminator(TermInst *TI) {
 // into all of our predecessors, allowing us to be conservatively correct in all
 // cases.
 //
-// The key thing to notice is that in general this can not happen due to
+// The key thing to notice is that in general this cannot happen due to
 // critical edge splitting. To trigger this, one would need a terminator that
 // uses a reference counted value and only has one successor due to critical
 // edge splitting. This is just to be conservative when faced with the unknown
@@ -300,7 +300,7 @@ static bool getInsertionPtsForLoopRegionExits(
     llvm::SmallVectorImpl<SILInstruction *> &InsertPts) {
   assert(R->isLoop() && "Expected a loop region that is representing a loop");
 
-  // Go through all of our non local successors. If any of them can not be
+  // Go through all of our non local successors. If any of them cannot be
   // ignored, we bail for simplicity. This means that for now we do not handle
   // early exits.
   if (any_of(R->getNonLocalSuccs(), [&](unsigned SuccID) -> bool {

--- a/lib/SILOptimizer/ARC/GlobalARCPairingAnalysis.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCPairingAnalysis.cpp
@@ -269,7 +269,7 @@ ARCMatchingSetBuilder::matchDecrementsToIncrements() {
 
 /// Visit each retain/release that is matched up to our operand over and over
 /// again until we converge by not adding any more to the set which we can move.
-/// If we find a situation that we can not handle, we bail and return false. If
+/// If we find a situation that we cannot handle, we bail and return false. If
 /// we succeed and it is safe to move increment/releases, we return true.
 bool ARCMatchingSetBuilder::matchUpIncDecSetsForPtr() {
   bool KnownSafeTD = true;

--- a/lib/SILOptimizer/ARC/GlobalARCPairingAnalysis.h
+++ b/lib/SILOptimizer/ARC/GlobalARCPairingAnalysis.h
@@ -56,7 +56,7 @@ struct ARCMatchingSet {
   /// reference counted value could be used.
   llvm::SetVector<SILInstruction *> DecrementInsertPts;
 
-  // This is a data structure that can not be moved or copied.
+  // This is a data structure that cannot be moved or copied.
   ARCMatchingSet() = default;
   ARCMatchingSet(const ARCMatchingSet &) = delete;
   ARCMatchingSet(ARCMatchingSet &&) = delete;

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -205,8 +205,8 @@ static bool isARCSignificantTerminator(TermInst *TI) {
   case TermKind::Invalid:
     llvm_unreachable("Expected a TermInst");
   case TermKind::UnreachableInst:
-  // br is a forwarding use for its arguments. It can not in of itself extend
-  // the lifetime of an object (just like a phi-node) can not.
+  // br is a forwarding use for its arguments. It cannot in of itself extend
+  // the lifetime of an object (just like a phi-node) cannot.
   case TermKind::BranchInst:
   // A cond_br is a forwarding use for its non-operand arguments in a similar
   // way to br. Its operand must be an i1 that has a different lifetime from any
@@ -239,7 +239,7 @@ static bool isARCSignificantTerminator(TermInst *TI) {
 /// pointer in a function that implies that the pointer is alive up to that
 /// point. We "freeze" (i.e. do not attempt to remove or move) such releases if
 /// FreezeOwnedArgEpilogueReleases is set. This is useful since in certain cases
-/// due to dataflow issues, we can not properly propagate the last use
+/// due to dataflow issues, we cannot properly propagate the last use
 /// information. Instead we run an extra iteration of the ARC optimizer with
 /// this enabled in a side table so the information gets propagated everywhere in
 /// the CFG.
@@ -299,7 +299,7 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
   // This is ignoring the possibility that we may have a loop with an
   // interesting terminator but for which, we are going to clear all state
   // (since it is a loop boundary). We may in such a case, be too conservative
-  // with our other predecessors. Luckily this can not happen since cond_br is
+  // with our other predecessors. Luckily this cannot happen since cond_br is
   // the only terminator that allows for critical edges and all other
   // "interesting terminators" always having multiple successors. This means
   // that this block could not have multiple predecessors since otherwise, the

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -188,7 +188,7 @@ void LoopARCSequenceDataflowEvaluator::mergeSuccessors(const LoopRegion *Region,
 /// pointer in a function that implies that the pointer is alive up to that
 /// point. We "freeze" (i.e. do not attempt to remove or move) such releases if
 /// FreezeOwnedArgEpilogueReleases is set. This is useful since in certain cases
-/// due to dataflow issues, we can not properly propagate the last use
+/// due to dataflow issues, we cannot properly propagate the last use
 /// information. Instead we run an extra iteration of the ARC optimizer with
 /// this enabled in a side table so the information gets propagated everywhere in
 /// the CFG.

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -117,7 +117,7 @@ bool BottomUpRefCountState::mightRemoveMutators() {
 
 /// Uninitialize the current state.
 void BottomUpRefCountState::clear() {
-  // If we can not conservatively prove that the given RefCountState will not
+  // If we cannot conservatively prove that the given RefCountState will not
   // be removed, be conservative and clear the transition state, so we do not
   // propagate KnownSafety forward.
   if (mightRemoveMutators())
@@ -351,7 +351,7 @@ bool BottomUpRefCountState::handlePotentialGuaranteedUser(
   if (!valueCanBeGuaranteedUsedGivenLatticeState())
     return false;
 
-  // If we can prove that Other can not use the pointer we are tracking,
+  // If we can prove that Other cannot use the pointer we are tracking,
   // return...
   if (!mayGuaranteedUseValue(PotentialGuaranteedUser, getRCRoot(), AA))
     return false;
@@ -384,7 +384,7 @@ bool BottomUpRefCountState::handlePotentialDecrement(
   if (!valueCanBeDecrementedGivenLatticeState())
     return false;
 
-  // If we can prove that Other can not use the pointer we are tracking,
+  // If we can prove that Other cannot use the pointer we are tracking,
   // return...
   if (!mayDecrementRefCount(PotentialDecrement, getRCRoot(), AA))
     return false;
@@ -795,7 +795,7 @@ bool TopDownRefCountState::handlePotentialGuaranteedUser(
   if (!valueCanBeGuaranteedUsedGivenLatticeState())
     return false;
 
-  // If we can prove that Other can not use the pointer we are tracking,
+  // If we can prove that Other cannot use the pointer we are tracking,
   // return...
   if (!mayGuaranteedUseValue(PotentialGuaranteedUser, getRCRoot(), AA))
     return false;
@@ -823,7 +823,7 @@ bool TopDownRefCountState::handlePotentialDecrement(
   if (!valueCanBeDecrementedGivenLatticeState())
     return false;
 
-  // If we can prove that Other can not use the pointer we are tracking,
+  // If we can prove that Other cannot use the pointer we are tracking,
   // return...
   if (!mayDecrementRefCount(PotentialDecrement, getRCRoot(), AA))
     return false;

--- a/lib/SILOptimizer/ARC/RefCountState.h
+++ b/lib/SILOptimizer/ARC/RefCountState.h
@@ -57,7 +57,7 @@ protected:
   /// semantics.
   InstructionSet InsertPts;
 
-  /// Have we performed any partial merges of insertion points? We can not
+  /// Have we performed any partial merges of insertion points? We cannot
   /// perform two partial merges in a row unless we are able to reason about
   /// control dependency (which avoid for now).
   bool Partial = false;
@@ -176,7 +176,7 @@ public:
     MightBeUsed,        ///< The pointer will be used and then at this point
                         ///  be decremented
     MightBeDecremented, ///< The pointer might be decremented again implying
-                        ///  that we can not, without being known safe remove
+                        ///  that we cannot, without being known safe remove
                         ///  this decrement.
   };
 

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -44,7 +44,7 @@ bool swift::mayDecrementRefCount(SILInstruction *User,
   if (auto *BI = dyn_cast<BuiltinInst>(User))
     return AA->canBuiltinDecrementRefCount(BI, Ptr);
 
-  // We can not conservatively prove that this instruction can not decrement the
+  // We cannot conservatively prove that this instruction cannot decrement the
   // ref count of Ptr. So assume that it does.
   return true;
 }
@@ -57,10 +57,10 @@ bool swift::mayCheckRefCount(SILInstruction *User) {
 //                                Use Analysis
 //===----------------------------------------------------------------------===//
 
-/// Returns true if a builtin apply can not use reference counted values.
+/// Returns true if a builtin apply cannot use reference counted values.
 ///
 /// The main case that this handles here are builtins that via read none imply
-/// that they can not read globals and at the same time do not take any
+/// that they cannot read globals and at the same time do not take any
 /// non-trivial types via the arguments. The reason why we care about taking
 /// non-trivial types as arguments is that we want to be careful in the face of
 /// intrinsics that may be equivalent to bitcast and inttoptr operations.
@@ -257,7 +257,7 @@ bool swift::mayUseValue(SILInstruction *User, SILValue Ptr,
   }
 
   // If we have a terminator instruction, see if it can use ptr. This currently
-  // means that we first show that TI can not indirectly use Ptr and then use
+  // means that we first show that TI cannot indirectly use Ptr and then use
   // alias analysis on the arguments.
   if (auto *TI = dyn_cast<TermInst>(User))
     return canTerminatorUseValue(TI, Ptr, AA);
@@ -344,7 +344,7 @@ valueHasARCUsesInInstructionRange(SILValue Op,
     ++Start;
   }
 
-  // If all such instructions can not use Op, return false.
+  // If all such instructions cannot use Op, return false.
   return None;
 }
 
@@ -375,7 +375,7 @@ swift::valueHasARCUsesInReverseInstructionRange(SILValue Op,
     --End;
   }
 
-  // If all such instructions can not use Op, return false.
+  // If all such instructions cannot use Op, return false.
   return None;
 }
 
@@ -407,7 +407,7 @@ valueHasARCDecrementOrCheckInInstructionRange(SILValue Op,
     ++Start;
   }
 
-  // If all such instructions can not decrement Op, return nothing.
+  // If all such instructions cannot decrement Op, return nothing.
   return None;
 }
 
@@ -428,7 +428,7 @@ mayGuaranteedUseValue(SILInstruction *User, SILValue Ptr, AliasAnalysis *AA) {
 
   // Ok, we have an apply site with arguments. Look at the function type and
   // iterate through the function parameters. If any of the parameters are
-  // guaranteed, attempt to prove that the passed in parameter can not alias
+  // guaranteed, attempt to prove that the passed in parameter cannot alias
   // Ptr. If we fail, return true.
   CanSILFunctionType FType = FAS.getSubstCalleeType();
   auto Params = FType->getParameters();
@@ -489,7 +489,7 @@ void ConsumedArgToEpilogueReleaseMatcher::findMatchingReleases(
        II != IE; ++II) {
     // If we do not have a release_value or strong_release...
     if (!isa<ReleaseValueInst>(*II) && !isa<StrongReleaseInst>(*II)) {
-      // And the object can not use values in a manner that will keep the object
+      // And the object cannot use values in a manner that will keep the object
       // alive, continue. We may be able to find additional releases.
       if (canNeverUseValues(&*II))
         continue;

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -156,7 +156,7 @@ static bool isSameValueOrGlobal(SILValue V1, SILValue V2) {
   return false;
 }
 
-/// Is this a literal which we know can not refer to a global object?
+/// Is this a literal which we know cannot refer to a global object?
 ///
 /// FIXME: function_ref?
 static bool isLocalLiteral(SILValue V) {
@@ -177,12 +177,12 @@ static bool isIdentifiedFunctionLocal(SILValue V) {
 }
 
 /// Returns true if we can prove that the two input SILValues which do not equal
-/// can not alias.
+/// cannot alias.
 static bool aliasUnequalObjects(SILValue O1, SILValue O2) {
   assert(O1 != O2 && "This function should only be called on unequal values.");
 
   // If O1 and O2 do not equal and they are both values that can be statically
-  // and uniquely identified, they can not alias.
+  // and uniquely identified, they cannot alias.
   if (areDistinctIdentifyableObjects(O1, O2)) {
     DEBUG(llvm::dbgs() << "            Found two unequal identified "
           "objects.\n");
@@ -385,17 +385,17 @@ static bool typedAccessTBAABuiltinTypesMayAlias(SILType LTy, SILType RTy,
   // 2. (Pointer, Pointer): If we have two pointers to pointers, since we know
   // that the two values do not equal due to previous AA calculations, one must
   // be a native object and the other is an unknown object type (i.e. an objc
-  // object) which can not alias.
+  // object) which cannot alias.
   //
   // 3. (Scalar, Scalar): If we have two scalar pointers, since we know that the
-  // types are already not equal, we know that they can not alias. For those
+  // types are already not equal, we know that they cannot alias. For those
   // unfamiliar even though BuiltinIntegerType/BuiltinFloatType are single
   // classes, the AST represents each integer/float of different bit widths as
   // different types, so equality of SILTypes allows us to know that they have
   // different bit widths.
   //
   // Thus we can just return false since in none of the aforementioned cases we
-  // can not alias, so return false.
+  // cannot alias, so return false.
   return false;
 }
 
@@ -470,7 +470,7 @@ static bool typedAccessTBAAMayAlias(SILType LTy, SILType RTy, SILModule &Mod) {
 
   // FIXME: All the code following could be made significantly more aggressive
   // by saying that aggregates of the same type that do not contain each other
-  // can not alias.
+  // cannot alias.
 
   // Tuples do not alias non-tuples.
   bool LTyTT = LTy.is<TupleType>();
@@ -589,7 +589,7 @@ AliasResult AliasAnalysis::aliasInner(SILValue V1, SILValue V2,
   DEBUG(llvm::dbgs() << "        Underlying V1:" << *O1.getDef());
   DEBUG(llvm::dbgs() << "        Underlying V2:" << *O2.getDef());
 
-  // If O1 and O2 do not equal, see if we can prove that they can not be the
+  // If O1 and O2 do not equal, see if we can prove that they cannot be the
   // same object. If we can, return No Alias.
   if (O1 != O2 && aliasUnequalObjects(O1, O2))
     return AliasResult::NoAlias;

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -177,7 +177,7 @@ void LoopRegionFunctionInfo::verify() {
     if (!R->ParentID.hasValue()) {
       auto NLSuccs = R->getNonLocalSuccs();
       assert(NLSuccs.begin() == NLSuccs.end() &&
-             "Can not have non local "
+             "Cannot have non local "
              "successors without a parent node");
       continue;
     }

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -103,7 +103,7 @@ public:
   MemBehavior visitReleaseValueInst(ReleaseValueInst *BI);
 
   // Instructions which are none if our SILValue does not alias one of its
-  // arguments. If we can not prove such a thing, return the relevant memory
+  // arguments. If we cannot prove such a thing, return the relevant memory
   // behavior.
 #define OPERANDALIAS_MEMBEHAVIOR_INST(Name)                             \
   MemBehavior visit##Name(Name *I) {                                    \
@@ -176,7 +176,7 @@ MemBehavior MemoryBehaviorVisitor::visitStoreInst(StoreInst *SI) {
     return MemBehavior::None;
 
   // If the store dest cannot alias the pointer in question, then the
-  // specified value can not be modified by the store.
+  // specified value cannot be modified by the store.
   if (AA->isNoAlias(SI->getDest(), V, computeTBAAType(SI->getDest()),
                    getValueTBAAType())) {
     DEBUG(llvm::dbgs() << "  Store Dst does not alias inst. Returning "

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -162,7 +162,7 @@ static llvm::Optional<bool> proveNonPayloadedEnumCase(SILBasicBlock *BB,
 bool RCIdentityFunctionInfo::
 findDominatingNonPayloadedEdge(SILBasicBlock *IncomingEdgeBB,
                                SILValue RCIdentity) {
-  // First grab the NonPayloadedEnumBB and RCIdentityBB. If we can not find
+  // First grab the NonPayloadedEnumBB and RCIdentityBB. If we cannot find
   // either of them, return false.
   SILBasicBlock *RCIdentityBB = RCIdentity->getParentBB();
   if (!RCIdentityBB)
@@ -226,7 +226,7 @@ findDominatingNonPayloadedEdge(SILBasicBlock *IncomingEdgeBB,
   return false;
 }
 
-/// Return the underlying SILValue after stripping off SILArguments that can not
+/// Return the underlying SILValue after stripping off SILArguments that cannot
 /// affect RC identity.
 ///
 /// This code is meant to enable RCIdentity to be ascertained in the following

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -248,7 +248,7 @@ static bool valueMayBeCaptured(SILValue V, CaptureException Exception) {
       continue;
     }
 
-    // An apply of a builtin that does not read memory can not capture a value.
+    // An apply of a builtin that does not read memory cannot capture a value.
     //
     // TODO: Use analysis of the other function perhaps to see if it captures
     // memory in some manner?
@@ -325,7 +325,7 @@ bool swift::pointsToLocalObject(SILValue V,
 /// from the function.
 bool swift::isNonEscapingLocalObject(SILValue V) {
   // If this is a local allocation, or the result of a no read apply inst (which
-  // can not affect memory in the caller), check to see if the allocation
+  // cannot affect memory in the caller), check to see if the allocation
   // escapes.
   if (isa<AllocationInst>(*V) || isNoReadBuiltinInst(V))
     return !valueMayBeCaptured(V, CaptureException::ReturnsCannotCapture);

--- a/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
@@ -229,16 +229,16 @@ void ArgumentDescriptor::computeOptimizedInterfaceParams(
     return;
   }
 
-  // If this argument is live, but we can not optimize it.
+  // If this argument is live, but we cannot optimize it.
   if (!canOptimizeLiveArg()) {
-    DEBUG(llvm::dbgs() << "            Can not optimize live arg!\n");
+    DEBUG(llvm::dbgs() << "            Cannot optimize live arg!\n");
     Out.push_back(ParameterInfo);
     return;
   }
 
-  // If we can not explode this value, handle callee release and return.
+  // If we cannot explode this value, handle callee release and return.
   if (!shouldExplode()) {
-    DEBUG(llvm::dbgs() << "            ProjTree can not explode arg.\n");
+    DEBUG(llvm::dbgs() << "            ProjTree cannot explode arg.\n");
     // If we found a release in the callee in the last BB on an @owned
     // parameter, change the parameter to @guaranteed and continue...
     if (CalleeRelease) {

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -192,7 +192,7 @@ mayChangeArraySize(SILInstruction *I, ArrayCallKind &Kind, SILValue &Array,
   return ArrayBoundsEffect::kMayChangeAny;
 }
 
-/// Two allocations of a mutable array struct can not reference the same
+/// Two allocations of a mutable array struct cannot reference the same
 /// storage after modification. So we can treat them as not aliasing for the
 /// purpose of bound checking. The change would only be tracked through one of
 /// the allocations.

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1348,7 +1348,7 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
         // reference to the array by performing an array operation: for example,
         // storing or appending one array into an two-dimensional array.
         // Checking
-        // that all types are the same make guarantees that this can not happen.
+        // that all types are the same make guarantees that this cannot happen.
         if (SameTy.isNull()) {
           SameTy =
               Sem.getSelf().getType().getSwiftRValueType()->getCanonicalType();
@@ -1395,7 +1395,7 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
         if (MatchedReleases.count(&RVI->getOperandRef()))
           continue;
 
-      // Ignore fix_lifetime. It can not increment ref counts.
+      // Ignore fix_lifetime. It cannot increment ref counts.
       if (isa<FixLifetimeInst>(Inst))
         continue;
 

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -51,7 +51,7 @@ static bool hasLoopInvariantOperands(SILInstruction *I, SILLoop *L,
   });
 }
 
-/// We can not duplicate blocks with AllocStack instructions (they need to be
+/// We cannot duplicate blocks with AllocStack instructions (they need to be
 /// FIFO). Other instructions can be moved to the preheader.
 static bool
 canDuplicateOrMoveToPreheader(SILLoop *L, SILBasicBlock *Preheader,

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -284,9 +284,9 @@ SILInstruction *
 SILCombiner::
 replaceInstUsesWith(SILInstruction &I, ValueBase *V, unsigned IIndex,
                     unsigned VIndex) {
-  assert(IIndex < I.getNumTypes() && "Can not have more results than "
+  assert(IIndex < I.getNumTypes() && "Cannot have more results than "
          "types.");
-  assert(VIndex < V->getNumTypes() && "Can not have more results than "
+  assert(VIndex < V->getNumTypes() && "Cannot have more results than "
          "types.");
 
   // Add all modified instrs to worklist.
@@ -301,7 +301,7 @@ replaceInstUsesWith(SILInstruction &I, ValueBase *V, unsigned IIndex,
 }
 
 // Some instructions can never be "trivially dead" due to side effects or
-// producing a void value. In those cases, since we can not rely on
+// producing a void value. In those cases, since we cannot rely on
 // SILCombines trivially dead instruction DCE in order to delete the
 // instruction, visit methods should use this method to delete the given
 // instruction and upon completion of their peephole return the value returned

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -172,7 +172,7 @@ public:
                                       unsigned IIndex, unsigned VIndex=0);
 
   // Some instructions can never be "trivially dead" due to side effects or
-  // producing a void value. In those cases, since we can not rely on
+  // producing a void value. In those cases, since we cannot rely on
   // SILCombines trivially dead instruction DCE in order to delete the
   // instruction, visit methods should use this method to delete the given
   // instruction and upon completion of their peephole return the value returned

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -232,7 +232,7 @@ public:
   void visitDeallocStackInst(DeallocStackInst *I) {}
 
   void visitInitExistentialAddrInst(InitExistentialAddrInst *I) {
-    // If we have already seen an init_existential_addr, we can not
+    // If we have already seen an init_existential_addr, we cannot
     // optimize. This is because we only handle the single init_existential_addr
     // case.
     if (IEI || HaveSeenCopyInto) {
@@ -243,7 +243,7 @@ public:
   }
 
   void visitOpenExistentialAddrInst(OpenExistentialAddrInst *I) {
-    // If we have already seen an open_existential_addr, we can not
+    // If we have already seen an open_existential_addr, we cannot
     // optimize. This is because we only handle the single open_existential_addr
     // case.
     if (OEI) {
@@ -508,7 +508,7 @@ SILInstruction *SILCombiner::visitRetainValueInst(RetainValueInst *RVI) {
   //
   // Due to the matching pairs being in different basic blocks, the ARC
   // Optimizer (which is currently local to one basic block does not handle
-  // it). But that does not mean that we can not eliminate this pair with a
+  // it). But that does not mean that we cannot eliminate this pair with a
   // peephole.
 
   // If we are not the first instruction in this basic block...
@@ -586,7 +586,7 @@ SILInstruction *SILCombiner::visitStrongRetainInst(StrongRetainInst *SRI) {
   //
   // Due to the matching pairs being in different basic blocks, the ARC
   // Optimizer (which is currently local to one basic block does not handle
-  // it). But that does not mean that we can not eliminate this pair with a
+  // it). But that does not mean that we cannot eliminate this pair with a
   // peephole.
 
   // If we are not the first instruction in this basic block...
@@ -883,7 +883,7 @@ visitUncheckedTakeEnumDataAddrInst(UncheckedTakeEnumDataAddrInst *TEDAI) {
   if (TEDAI->use_empty())
     return nullptr;
 
-  // If our enum type is address only, we can not do anything here. The key
+  // If our enum type is address only, we cannot do anything here. The key
   // thing to remember is that an enum is address only if any of its cases are
   // address only. So we *could* have a loadable payload resulting from the
   // TEDAI without the TEDAI being loadable itself.

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -79,7 +79,7 @@ static SILFunction *getDestructor(AllocRefInst *ARI) {
 
   DEBUG(llvm::dbgs() << "    Found destructor!\n");
 
-  // If the destructor has an objc_method calling convention, we can not
+  // If the destructor has an objc_method calling convention, we cannot
   // analyze it since it could be swapped out from under us at runtime.
   if (Fn->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod) {
     DEBUG(llvm::dbgs() << "        Found objective-c destructor. Can't "
@@ -146,7 +146,7 @@ static bool doesDestructorHaveSideEffects(AllocRefInst *ARI) {
       }
 
       // dealloc_ref on self can be ignored, but dealloc_ref on anything else
-      // can not be eliminated.
+      // cannot be eliminated.
       if (auto *DeallocRef = dyn_cast<DeallocRefInst>(&I)) {
         if (DeallocRef->getOperand().stripCasts().getDef() == Self) {
           DEBUG(llvm::dbgs() << "            SAFE! dealloc_ref on self.\n");
@@ -741,7 +741,7 @@ bool DeadObjectElimination::processAllocRef(AllocRefInst *ARI) {
   // escape, then we can completely remove the use graph of this alloc_ref.
   UserList UsersToRemove;
   if (hasUnremoveableUsers(ARI, UsersToRemove)) {
-    DEBUG(llvm::dbgs() << "    Found a use that can not be zapped...\n");
+    DEBUG(llvm::dbgs() << "    Found a use that cannot be zapped...\n");
     return false;
   }
 
@@ -761,7 +761,7 @@ bool DeadObjectElimination::processAllocStack(AllocStackInst *ASI) {
 
   UserList UsersToRemove;
   if (hasUnremoveableUsers(ASI, UsersToRemove)) {
-    DEBUG(llvm::dbgs() << "    Found a use that can not be zapped...\n");
+    DEBUG(llvm::dbgs() << "    Found a use that cannot be zapped...\n");
     return false;
   }
 

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -388,7 +388,7 @@ class DSEContext {
   ///  }
   ///  x.a = 12
   ///
-  /// In this case, DSE can not remove the x.a = 13 inside the loop.
+  /// In this case, DSE cannot remove the x.a = 13 inside the loop.
   ///
   /// To do this, when the algorithm reaches the beginning of the basic block in
   /// the loop it will need to invalidate the LSLocation in the BBWriteSetOut.

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -45,7 +45,7 @@
 /// 2 Int fields. A store like this will generate 2 *indivisible* LSLocations,
 /// 1 for each field and in addition to keeping a list of LSLocation, RLE also
 /// keeps their available LSValues. We call it *indivisible* because it
-/// can not be broken down to more LSLocations.
+/// cannot be broken down to more LSLocations.
 ///
 /// LSValue consists of a base - a SILValue from the load or store inst,
 /// as well as a projection path to which the field it represents. So, a
@@ -707,8 +707,8 @@ bool BlockState::optimize(RLEContext &Ctx, RLEKind Kind) {
     if (!Inst->mayReadOrWriteMemory())
       continue;
 
-    // If we have an instruction that may write to memory and we can not prove
-    // that it and its operands can not alias a load we have visited, invalidate
+    // If we have an instruction that may write to memory and we cannot prove
+    // that it and its operands cannot alias a load we have visited, invalidate
     // that load.
     if (Inst->mayWriteToMemory()) {
       processUnknownWriteInst(Ctx, Inst, Kind);

--- a/lib/SILOptimizer/Transforms/RemovePin.cpp
+++ b/lib/SILOptimizer/Transforms/RemovePin.cpp
@@ -119,7 +119,7 @@ public:
               ++NumPinPairsRemoved;
             } else {
               DEBUG(llvm::dbgs()
-                    << "        Pin users are not safe! Can not remove!\n");
+                    << "        Pin users are not safe! Cannot remove!\n");
             }
 
             continue;

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -812,7 +812,7 @@ static bool tryToSinkRefCountInst(SILBasicBlock::iterator T,
   // successor.
   if (CanSinkToSuccessors) {
     // If we have a switch, try to sink ref counts across it and then return
-    // that result. We do not keep processing since the code below can not
+    // that result. We do not keep processing since the code below cannot
     // properly sink ref counts over switch_enums so we might as well exit
     // early.
     if (auto *S = dyn_cast<SwitchEnumInst>(T))
@@ -838,7 +838,7 @@ static bool tryToSinkRefCountInst(SILBasicBlock::iterator T,
   }
 
   // Ok, we have a ref count instruction that *could* be sunk. If we have a
-  // terminator that we can not sink through or the cfg will not let us sink
+  // terminator that we cannot sink through or the cfg will not let us sink
   // into our predecessors, just move the increment before the terminator.
   if (!CanSinkToSuccessors ||
       (!isa<CheckedCastBranchInst>(T) && !isa<CondBranchInst>(T))) {
@@ -1323,7 +1323,7 @@ mergePredecessorStates(BBToDataflowStateMap &BBToStateMap) {
   llvm::SmallVector<SILValue, 4> CurBBValuesToBlot;
 
   // If we do not find state for a specific value in any of our predecessor BBs,
-  // we can not be the end of a switch region since we can not cover our
+  // we cannot be the end of a switch region since we cannot cover our
   // predecessor BBs with enum decls. Blot after the loop.
   llvm::SmallVector<SILValue, 4> PredBBValuesToBlot;
 
@@ -1357,9 +1357,9 @@ mergePredecessorStates(BBToDataflowStateMap &BBToStateMap) {
       // the predecessor we are processing.
       auto PredValue = PredBBState->ValueToCaseMap.find(P->first);
 
-      // If we can not find the state associated with this SILValue in this
+      // If we cannot find the state associated with this SILValue in this
       // predecessor or the value in the corresponding predecessor was blotted,
-      // we can not find a covering switch for this BB or forward any enum tag
+      // we cannot find a covering switch for this BB or forward any enum tag
       // information for this enum value.
       if (PredValue == PredBBState->ValueToCaseMap.end() || !(*PredValue)->first) {
         // Otherwise, we are conservative and do not forward the EnumTag that we
@@ -1371,7 +1371,7 @@ mergePredecessorStates(BBToDataflowStateMap &BBToStateMap) {
       }
 
       // Check if out predecessor has any other successors. If that is true we
-      // clear all the state since we can not hoist safely.
+      // clear all the state since we cannot hoist safely.
       if (!PredBB->getSingleSuccessor()) {
         EnumToEnumBBCaseListMap.clear();
         DEBUG(llvm::dbgs() << "                Predecessor has other "
@@ -1497,9 +1497,9 @@ BBEnumTagDataflowState::hoistDecrementsIntoSwitchRegions(AliasAnalysis *AA) {
     }
 
     // Finally ensure that we have no users of this operand preceding the
-    // release_value in this BB. If we have users like that we can not hoist the
+    // release_value in this BB. If we have users like that we cannot hoist the
     // release past them unless we know that there is an additional set of
-    // releases that together post-dominate this release. If we can not do this,
+    // releases that together post-dominate this release. If we cannot do this,
     // skip this release.
     //
     // TODO: We need information from the ARC optimizer to prove that property
@@ -1525,7 +1525,7 @@ BBEnumTagDataflowState::hoistDecrementsIntoSwitchRegions(AliasAnalysis *AA) {
       // Otherwise create the release_value before the terminator of the
       // predecessor.
       assert(P.first->getSingleSuccessor() &&
-             "Can not hoist release into BB that has multiple successors");
+             "Cannot hoist release into BB that has multiple successors");
       SILBuilderWithScope Builder(P.first->getTerminator(), RVI);
       createRefCountOpForPayload(Builder, RVI, P.second);
     }
@@ -1563,7 +1563,7 @@ findLastSinkableMatchingEnumValueRCIncrementInPred(AliasAnalysis *AA,
 
     // Otherwise, see if there are any instructions in between FirstPredInc and
     // the end of the given basic block that could decrement first pred. If such
-    // an instruction exists, we can not perform this optimization so continue.
+    // an instruction exists, we cannot perform this optimization so continue.
     if (valueHasARCDecrementOrCheckInInstructionRange(
             EnumValue, (*FirstInc).getIterator(),
             BB->getTerminator()->getIterator(), AA))

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -143,7 +143,7 @@ bool SROAMemoryUseAnalyzer::analyze() {
     SILInstruction *User = Operand->getUser();
     DEBUG(llvm::dbgs() << "    Visiting use: " << *User);
 
-    // If we store the alloca pointer, we can not analyze its uses so bail...
+    // If we store the alloca pointer, we cannot analyze its uses so bail...
     // It is ok if we store into the alloca pointer though.
     if (auto *SI = dyn_cast<StoreInst>(User)) {
       if (SI->getDest().getDef() == AI) {

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -147,7 +147,7 @@ static unsigned basicBlockInlineCost(SILBasicBlock *BB, unsigned Cutoff) {
   return Cost;
 }
 
-/// We can not duplicate blocks with AllocStack instructions (they need to be
+/// We cannot duplicate blocks with AllocStack instructions (they need to be
 /// FIFO). Other instructions can be duplicated.
 static bool canDuplicateBlock(SILBasicBlock *BB) {
   for (auto &I : *BB) {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -264,7 +264,7 @@ ApplySite swift::trySpecializeApplyOfGeneric(ApplySite Apply,
 
   // We do not support partial specialization.
   if (hasUnboundGenericTypes(InterfaceSubs)) {
-    DEBUG(llvm::dbgs() << "    Can not specialize with interface subs.\n");
+    DEBUG(llvm::dbgs() << "    Cannot specialize with interface subs.\n");
     return ApplySite();
   }
   if (hasDynamicSelfTypes(InterfaceSubs)) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -335,7 +335,7 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name) {
 }
 
 /// Helper function to find a SILGlobalVariable given its name. It first checks
-/// in the module. If we can not find it in the module, we attempt to
+/// in the module. If we cannot find it in the module, we attempt to
 /// deserialize it.
 SILGlobalVariable *SILDeserializer::getGlobalForReference(StringRef name) {
   // Check to see if we have a global by this name already.
@@ -2117,8 +2117,8 @@ void SILDeserializer::getAllWitnessTables() {
 
 SILWitnessTable *
 SILDeserializer::lookupWitnessTable(SILWitnessTable *existingWt) {
-  assert(existingWt && "Can not deserialize a null witness table declaration.");
-  assert(existingWt->isDeclaration() && "Can not deserialize a witness table "
+  assert(existingWt && "Cannot deserialize a null witness table declaration.");
+  assert(existingWt->isDeclaration() && "Cannot deserialize a witness table "
                                         "definition.");
 
   // If we don't have a witness table list, we can't look anything up.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1220,7 +1220,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
 
         if (!M) {
           // The dependency module could not be loaded.  Just make a guess
-          // about the import kind, we can not do better.
+          // about the import kind, we cannot do better.
           Kind = ImportKind::Func;
         } else {
           SmallVector<ValueDecl *, 8> Decls;
@@ -1466,7 +1466,7 @@ Optional<BriefAndRawComment> ModuleFile::getCommentForDecl(const Decl *D) {
   // Keep these as assertions instead of early exits to ensure that we are not
   // doing extra work.  These cases should be handled by clients of this API.
   assert(!D->hasClangNode() &&
-         "can not find comments for Clang decls in Swift modules");
+         "cannot find comments for Clang decls in Swift modules");
   assert(D->getDeclContext()->getModuleScopeContext() == FileContext &&
          "Decl is from a different serialized file");
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -246,7 +246,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   // 1. shared_external linkage is just a hack to tell the optimizer that a
   // shared function was deserialized.
   //
-  // 2. We can not just serialize a declaration to a shared_external function
+  // 2. We cannot just serialize a declaration to a shared_external function
   // since shared_external functions still have linkonce_odr linkage at the LLVM
   // level. This means they must be defined not just declared.
   //

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -40,7 +40,7 @@ add_swift_library(swiftStdlibUnittest SHARED IS_STDLIB
   LifetimeTracked.swift
   ${swift_stdlib_unittest_platform_sources}
 
-  # Can not serialize StdlibUnittest because of:
+  # Cannot serialize StdlibUnittest because of:
   # <rdar://problem/18917405> Compiling StdlibUnittest with -sil-serialize-all
   # crashes in SIL serializer
   #

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -186,7 +186,7 @@ public func expectNotEqual<T : Equatable>(expected: T, _ actual: T, ${TRACE}) {
   }
 }
 
-// Can not write a sane set of overloads using generics because of:
+// Cannot write a sane set of overloads using generics because of:
 // <rdar://problem/17015923> Array->NSArray implicit conversion insanity
 public func expectOptionalEqual<T : Equatable>(
   expected: T, _ actual: T?, ${TRACE}

--- a/stdlib/private/StdlibUnittestFoundationExtras/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittestFoundationExtras/CMakeLists.txt
@@ -3,7 +3,7 @@ add_swift_library(swiftStdlibUnittestFoundationExtras SHARED IS_STDLIB
   # filename.
   StdlibUnittestFoundationExtras.swift
 
-  # Can not serialize StdlibUnittestFoundationExtras because of:
+  # Cannot serialize StdlibUnittestFoundationExtras because of:
   # <rdar://problem/18917405> Compiling StdlibUnittest with -sil-serialize-all
   # crashes in SIL serializer
   #

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -29,7 +29,7 @@ public protocol _ObjectiveCBridgeable {
   static func _isBridgedToObjectiveC() -> Bool
 
   // _getObjectiveCType is a workaround: right now protocol witness
-  // tables don't include associated types, so we can not find
+  // tables don't include associated types, so we cannot find
   // '_ObjectiveCType.self' from them.
 
   /// Must return `_ObjectiveCType.self`.

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -165,7 +165,7 @@ public struct Character :
     subscript(position: Int) -> UTF8.CodeUnit {
       _sanityCheck(position >= 0)
       _sanityCheck(position < Int(count))
-      // Note: using unchecked arithmetic because overflow can not happen if the
+      // Note: using unchecked arithmetic because overflow cannot happen if the
       // above sanity checks hold.
       return UTF8.CodeUnit(
         truncatingBitPattern: data >> (UInt64(position) &* 8))
@@ -237,7 +237,7 @@ public struct Character :
     subscript(position: Int) -> UTF16.CodeUnit {
       _sanityCheck(position >= 0)
       _sanityCheck(position < Int(count))
-      // Note: using unchecked arithmetic because overflow can not happen if the
+      // Note: using unchecked arithmetic because overflow cannot happen if the
       // above sanity checks hold.
       return UTF16.CodeUnit(truncatingBitPattern:
         data >> ((UInt64(count) &- UInt64(position) &- 1) &* 16))

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -734,10 +734,10 @@ internal func _writeBackMutableSlice<
 
   _precondition(
     selfElementIndex == selfElementsEndIndex,
-    "Can not replace a slice of a MutableCollectionType with a slice of a larger size")
+    "Cannot replace a slice of a MutableCollectionType with a slice of a larger size")
   _precondition(
     newElementIndex == newElementsEndIndex,
-    "Can not replace a slice of a MutableCollectionType with a slice of a smaller size")
+    "Cannot replace a slice of a MutableCollectionType with a slice of a smaller size")
 }
 
 /// Returns the range of `x`'s valid index values.

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -586,7 +586,7 @@ extension _ContiguousArrayBuffer {
 /// It avoids the extra retain, release overhead from storing the
 /// ContiguousArrayBuffer into
 /// _UnsafePartiallyInitializedContiguousArrayBuffer. Since we do not support
-/// ARC loops, the extra retain, release overhead can not be eliminated which
+/// ARC loops, the extra retain, release overhead cannot be eliminated which
 /// makes assigning ranges very slow. Once this has been implemented, this code
 /// should be changed to use _UnsafePartiallyInitializedContiguousArrayBuffer.
 @warn_unused_result

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -666,23 +666,23 @@ extension ${Self} {
     // <rdar://problem/17959546> Float80.isFinite is missing
     _precondition(
       other.isFinite,
-      "floating point value can not be converted to ${Self} because it is either infinite or NaN")
+      "floating point value cannot be converted to ${Self} because it is either infinite or NaN")
 %      if signed:
     // FIXME: Float80 doesn't have a _fromBitPattern
     // ${That}(roundTowardsZero: ${Self}.min)
     // > ${getMinFloat(srcBits, incIfSigned(intFormatFix(bits), signed))}
     _precondition(other >= ${That}._fromBitPattern(${getMinFloat(srcBits,
       incIfSigned(intFormatFix(bits), signed))}),
-      "floating point value can not be converted to ${Self} because it is less than ${Self}.min")
+      "floating point value cannot be converted to ${Self} because it is less than ${Self}.min")
 %      else:
     _precondition(other >= (0.0 as ${That}),
-      "floating point value can not be converted to ${Self} because it is less than ${Self}.min")
+      "floating point value cannot be converted to ${Self} because it is less than ${Self}.min")
 %      end
     // ${That}(roundTowardsZero: ${Self}.max)
     // > ${getMaxFloat(srcBits, incIfSigned(intFormatFix(bits), signed))}
     _precondition(other <= ${That}._fromBitPattern(${getMaxFloat(srcBits,
       incIfSigned(intFormatFix(bits), signed))}),
-      "floating point value can not be converted to ${Self} because it is greater than ${Self}.max")
+      "floating point value cannot be converted to ${Self} because it is greater than ${Self}.max")
 
 %     end
     self._value =

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1420,7 +1420,7 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
   switch source._variantStorage {
   case .Native(let nativeOwner):
     // FIXME(performance): this introduces an indirection through Objective-C
-    // runtime, even though we access native storage.  But we can not
+    // runtime, even though we access native storage.  But we cannot
     // unsafeBitCast the owner object, because that would change the generic
     // arguments.
     //
@@ -2252,7 +2252,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
 #if _runtime(_ObjC)
 /// Storage for bridged `${Self}` elements.  We could have used
-/// `${Self}<${AnyTypeParameters}>`, but `AnyObject` can not be a Key because
+/// `${Self}<${AnyTypeParameters}>`, but `AnyObject` cannot be a Key because
 /// it is not `Hashable`.
 internal struct _BridgedNative${Self}Storage {
   internal typealias StorageImpl =
@@ -2860,19 +2860,19 @@ internal struct _Cocoa${Self}Storage : _HashStorageType {
   }
 
   internal mutating func updateValue(value: Value, forKey: Key) -> Value? {
-    _sanityCheckFailure("can not mutate NS${Self}")
+    _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   internal mutating func removeAtIndex(index: Index) -> SequenceElement {
-    _sanityCheckFailure("can not mutate NS${Self}")
+    _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   internal mutating func removeValueForKey(key: Key) -> Value? {
-    _sanityCheckFailure("can not mutate NS${Self}")
+    _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   internal mutating func removeAll(keepCapacity keepCapacity: Bool) {
-    _sanityCheckFailure("can not mutate NS${Self}")
+    _sanityCheckFailure("cannot mutate NS${Self}")
   }
 
   internal var count: Int {
@@ -3584,7 +3584,7 @@ internal struct _Cocoa${Self}Index : ForwardIndexType, Comparable {
   @warn_unused_result
   internal func successor() -> _Cocoa${Self}Index {
     _precondition(
-      currentKeyIndex < allKeys.value, "can not increment endIndex")
+      currentKeyIndex < allKeys.value, "cannot increment endIndex")
     return _Cocoa${Self}Index(cocoa${Self}, allKeys, currentKeyIndex + 1)
   }
 }
@@ -3592,7 +3592,7 @@ internal struct _Cocoa${Self}Index : ForwardIndexType, Comparable {
 @warn_unused_result
 internal func ==(lhs: _Cocoa${Self}Index, rhs: _Cocoa${Self}Index) -> Bool {
   _precondition(lhs.cocoa${Self} === rhs.cocoa${Self},
-    "can not compare indexes pointing to different ${Self}s")
+    "cannot compare indexes pointing to different ${Self}s")
   _precondition(lhs.allKeys.value == rhs.allKeys.value,
     "one or both of the indexes have been invalidated")
 
@@ -3602,7 +3602,7 @@ internal func ==(lhs: _Cocoa${Self}Index, rhs: _Cocoa${Self}Index) -> Bool {
 @warn_unused_result
 internal func <(lhs: _Cocoa${Self}Index, rhs: _Cocoa${Self}Index) -> Bool {
   _precondition(lhs.cocoa${Self} === rhs.cocoa${Self},
-    "can not compare indexes pointing to different ${Self}s")
+    "cannot compare indexes pointing to different ${Self}s")
   _precondition(lhs.allKeys.value == rhs.allKeys.value,
     "one or both of the indexes have been invalidated")
 
@@ -3648,7 +3648,7 @@ public struct ${Self}Index<${TypeParametersDecl}> :
   // not, because neither NSEnumerator nor fast enumeration support moving
   // backwards.  Even if they did, there is another issue: NSEnumerator does
   // not support NSCopying, and fast enumeration does not document that it is
-  // safe to copy the state.  So, we can not implement Index that is a value
+  // safe to copy the state.  So, we cannot implement Index that is a value
   // type for bridged NS${Self} in terms of Cocoa enumeration facilities.
 
   internal typealias _NativeIndex = _Native${Self}Index<${TypeParameters}>
@@ -3771,7 +3771,7 @@ public func < <${TypeParametersDecl}> (
 final internal class _Cocoa${Self}Generator : GeneratorType {
   internal typealias Element = ${AnySequenceType}
 
-  // Cocoa ${Self} generator has to be a class, otherwise we can not
+  // Cocoa ${Self} generator has to be a class, otherwise we cannot
   // guarantee that the fast enumeration struct is pinned to a certain memory
   // location.
 
@@ -3796,7 +3796,7 @@ final internal class _Cocoa${Self}Generator : GeneratorType {
     return UnsafeMutablePointer(_fastEnumerationStatePtr + 1)
   }
 
-  // These members have to be word-sized integers, they can not be limited to
+  // These members have to be word-sized integers, they cannot be limited to
   // Int8 just because our buffer holds 16 elements: fast enumeration is
   // allowed to return inner pointers to the container, which can be much
   // larger.
@@ -4100,7 +4100,7 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
   @warn_unused_result
   public mutating func take() -> ${Self}<${TypeParameters}> {
     _precondition(_actualCount >= 0,
-      "can not take the result twice")
+      "cannot take the result twice")
     _precondition(_actualCount == _requestedCount,
       "the number of members added does not match the promised count")
 

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -166,7 +166,7 @@ func _squeezeHashValue(hashValue: Int, _ resultRange: Range<Int>) -> Int {
   // We perform the unchecked arithmetic on `UInt` (instead of doing
   // straightforward computations on `Int`) in order to handle the following
   // tricky case: `startIndex` is negative, and `resultCardinality >= Int.max`.
-  // We can not convert the latter to `Int`.
+  // We cannot convert the latter to `Int`.
   return
     Int(bitPattern:
       UInt(bitPattern: resultRange.startIndex) &+ unsignedResult)

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -124,7 +124,7 @@ func _stdlib_demangleName(mangledName: String) -> String {
 public // @testable
 func _floorLog2(x: Int64) -> Int {
   _sanityCheck(x > 0, "_floorLog2 operates only on non-negative integers")
-  // Note: use unchecked subtraction because we this expression can not
+  // Note: use unchecked subtraction because we this expression cannot
   // overflow.
   return 63 &- Int(_countLeadingZeros(x))
 }

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -112,7 +112,7 @@ public struct _StringBuffer {
       let hadError = transcode(
         encoding, UTF32.self, input.generate(), sink,
         stopOnError: true)
-      _sanityCheck(!hadError, "string can not be ASCII if there were decoding errors")
+      _sanityCheck(!hadError, "string cannot be ASCII if there were decoding errors")
       return (result, hadError)
     }
     else {

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -88,7 +88,7 @@ extension String.CharacterView : CollectionType {
     ///
     /// - Requires: The next value is representable.
     public func successor() -> Index {
-      _precondition(_base != _base._viewEndIndex, "can not increment endIndex")
+      _precondition(_base != _base._viewEndIndex, "cannot increment endIndex")
       return Index(_base: _endBase)
     }
 
@@ -97,7 +97,7 @@ extension String.CharacterView : CollectionType {
     /// - Requires: The previous value is representable.
     public func predecessor() -> Index {
       _precondition(_base != _base._viewStartIndex,
-          "can not decrement startIndex")
+          "cannot decrement startIndex")
       let predecessorLengthUTF16 =
           Index._measureExtendedGraphemeClusterBackward(_base)
       return Index(

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -217,7 +217,7 @@ extension String {
     ///   `position != endIndex`.
     public subscript(position: Index) -> UTF8.CodeUnit {
       let result: UTF8.CodeUnit = numericCast(position._buffer & 0xFF)
-      _precondition(result != 0xFF, "can not subscript using endIndex")
+      _precondition(result != 0xFF, "cannot subscript using endIndex")
       return result
     }
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -124,7 +124,7 @@ extension String {
       case .Result(let us):
         return us
       case .EmptyInput:
-        _sanityCheckFailure("can not subscript using an endIndex")
+        _sanityCheckFailure("cannot subscript using an endIndex")
       case .Error:
         return UnicodeScalar(0xfffd)
       }

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -18,7 +18,7 @@ stringSubscriptComment = """
   /// different interpretations in different libraries and system
   /// components.  The correct interpretation should be selected
   /// according to the use case and the APIs involved, so `String`
-  /// can not be subscripted with an integer.
+  /// cannot be subscripted with an integer.
   ///
   /// Swift provides several different ways to access the character
   /// data stored inside strings.

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -79,7 +79,7 @@ public struct UTF8 : UnicodeCodecType {
   public init() {}
 
   /// Returns the number of expected trailing bytes for a given first byte: 0,
-  /// 1, 2 or 3.  If the first byte can not start a valid UTF-8 code unit
+  /// 1, 2 or 3.  If the first byte cannot start a valid UTF-8 code unit
   /// sequence, returns 4.
   @warn_unused_result
   public static func _numTrailingBytes(cu0: CodeUnit) -> UInt8 {

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -679,7 +679,7 @@ NSStringAPIs.test("getBytes(_:maxLength:usedLength:encoding:options:range:remain
 NSStringAPIs.test("getCString(_:maxLength:encoding:)") {
   var s = "abc あかさた"
   do {
-    // The largest buffer that can not accommodate the string plus null terminator.
+    // The largest buffer that cannot accommodate the string plus null terminator.
     let bufferLength = 16
     var buffer = Array(
       count: bufferLength, repeatedValue: CChar(bitPattern: 0xff))
@@ -1187,7 +1187,7 @@ NSStringAPIs.test("rangeOfString(_:options:range:locale:)") {
     expectEmpty(s.rangeOfString("す"))
 
     // Note: here `rangeOfString` API produces indexes that don't point between
-    // grapheme cluster boundaries -- these can not be created with public
+    // grapheme cluster boundaries -- these cannot be created with public
     // String interface.
     //
     // FIXME: why does this search succeed and the above queries fail?  There is

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -409,7 +409,7 @@ struct Struct2ConformsToP1<T : BooleanType> : BooleanType, Q1 {
   var value: T
 }
 
-// A large struct that can not be stored inline in an opaque buffer.
+// A large struct that cannot be stored inline in an opaque buffer.
 struct Struct3ConformsToP2 : CustomStringConvertible, Q1 {
   var a: UInt64 = 10
   var b: UInt64 = 20
@@ -428,7 +428,7 @@ struct Struct3ConformsToP2 : CustomStringConvertible, Q1 {
   }
 }
 
-// A large struct that can not be stored inline in an opaque buffer.
+// A large struct that cannot be stored inline in an opaque buffer.
 struct Struct4ConformsToP2<T : CustomStringConvertible> : CustomStringConvertible, Q1 {
   var value: T
   var e: UInt64 = 50

--- a/test/IDE/comment_attach.swift
+++ b/test/IDE/comment_attach.swift
@@ -149,7 +149,7 @@ struct decl_struct_1 {
   /// NestedEnum Aaa.
   enum NestedEnum {}
 
-  // Can not declare a nested protocol.
+  // Cannot declare a nested protocol.
   // protocol NestedProtocol {}
 
   /// NestedTypealias Aaa.

--- a/test/IDE/complete_member_decls_from_parent_decl_context.swift
+++ b/test/IDE/complete_member_decls_from_parent_decl_context.swift
@@ -59,7 +59,7 @@ class CodeCompletionInClassMethods1 {
   struct NestedStruct {}
   class NestedClass {}
   enum NestedEnum {}
-  // Can not declare a nested protocol.
+  // Cannot declare a nested protocol.
   // protocol NestedProtocol {}
 
   typealias NestedTypealias = Int
@@ -162,7 +162,7 @@ struct CodeCompletionInStructMethods1 {
   struct NestedStruct {}
   class NestedClass {}
   enum NestedEnum {}
-  // Can not declare a nested protocol.
+  // Cannot declare a nested protocol.
   // protocol NestedProtocol {}
 
   typealias NestedTypealias = Int

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -271,7 +271,7 @@ struct FooStruct {
   struct NestedStruct {}
   class NestedClass {}
   enum NestedEnum {}
-  // Can not declare a nested protocol.
+  // Cannot declare a nested protocol.
   // protocol NestedProtocol {}
 
   typealias NestedTypealias = Int

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -228,7 +228,7 @@ struct d0100_FooStruct {
 // PASS_COMMON-NEXT: {{^}}  enum NestedEnum {{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
-  // Can not declare a nested protocol.
+  // Cannot declare a nested protocol.
   // protocol NestedProtocol {}
 
   typealias NestedTypealias = Int

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -44,7 +44,7 @@ public protocol SplittableCollectionType : CollectionType {
   /// FIXME: a better name.  Users will never want to call this method
   /// directly.
   ///
-  /// FIXME: return an optional for the common case when split() can not
+  /// FIXME: return an optional for the common case when split() cannot
   /// subdivide the range further.
   func split(range: Range<Index>) -> [Range<Index>]
 }

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -46,11 +46,11 @@ struct StructLvl1 {
   var x : Builtin.Int64
 }
 
-// Two values with different underlying alloc_stack can not alias.
+// Two values with different underlying alloc_stack cannot alias.
 //
 // CHECK-LABEL: @different_alloc_stack_dont_alias
 
-// @local_storage can not alias non @local_storage types.
+// @local_storage cannot alias non @local_storage types.
 // CHECK: PAIR #0.
 // CHECK-NEXT: (0):   %0 = alloc_stack $StructLvl1
 // CHECK-NEXT: (0):   %0 = alloc_stack $StructLvl1
@@ -156,7 +156,7 @@ sil @different_alloc_stack_dont_alias : $@convention(thin) () -> () {
   return %12 : $()
 }
 
-// Function Arguments can not alias with no alias arguments or with identified
+// Function Arguments cannot alias with no alias arguments or with identified
 // function locals.
 //
 // @args_dont_alias_with_identified_function_locals

--- a/test/SILOptimizer/closure_specialize_simple.sil
+++ b/test/SILOptimizer/closure_specialize_simple.sil
@@ -16,7 +16,7 @@ bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1):
 
 bb1:
   %1 = integer_literal $Builtin.Int1, 0
-  // We can not do anything here for now but in the future I think we should try
+  // We cannot do anything here for now but in the future I think we should try
   // to handle this in closure specialization potentially.
   %2 = apply %0(%1) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
   strong_release %0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1
@@ -34,7 +34,7 @@ bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1, %1 : $@callee_owned (Bui
 
 bb1:
   %2 = integer_literal $Builtin.Int1, 0
-  // We can not do anything here for now but in the future I think we should try
+  // We cannot do anything here for now but in the future I think we should try
   // to handle this in closure specialization potentially.
   apply %0(%2) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
   strong_release %0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1
@@ -53,7 +53,7 @@ bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1):
 
 bb1:
   %1 = integer_literal $Builtin.Int1, 0
-  // We can not do anything here for now but in the future I think we should try
+  // We cannot do anything here for now but in the future I think we should try
   // to handle this in closure specialization potentially.
   %2 = apply %0(%1) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
   strong_release %0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -142,7 +142,7 @@ bb0:
   return %4 : $()                                 // id: %6
 }
 
-// We can not remove the local store that is read.
+// We cannot remove the local store that is read.
 //
 // DISABLECHECK-LABEL: blocking_read_on_local_store
 // DISABLECHECK: bb0
@@ -271,7 +271,7 @@ bb2:
   return %9999 : $()
 }
 
-// We can not remove the local store as the debug_value_addr could
+// We cannot remove the local store as the debug_value_addr could
 // be turned to a debug_value and thus act as a read on the memory
 // location..
 //
@@ -941,7 +941,7 @@ bb4:                                              // Preds: bb2 bb3
   return %24 : $()                                // id: %26
 }
 
-// Can not remove partially dead store in split block for simple class.
+// Cannot remove partially dead store in split block for simple class.
 //
 // CHECK-LABEL: partial_dead_store_simple_class
 // CHECK: bb1:
@@ -980,7 +980,7 @@ bb4:                                              // Preds: bb2 bb3
   return %19 : $()                                // id: %21
 }
 
-// Can not remove partially dead store in split block for simple class.
+// Cannot remove partially dead store in split block for simple class.
 //
 // CHECK-LABEL: partial_dead_store_with_function_call
 // CHECK: bb1:
@@ -1060,7 +1060,7 @@ bb2:                                              // Preds: bb1
 }
 
 
-// store to stack allocated memory can not alias with incoming argument.
+// store to stack allocated memory cannot alias with incoming argument.
 //
 // CHECK-LABEL: DeadStoreInoutAndStackAlias
 // CHECK: bb0
@@ -1289,7 +1289,7 @@ bb0(%0 : $*S8):
 }
 
 /// Make sure we do not remove the first store as there is no way to prove
-/// %0 and %1 can not alias here.
+/// %0 and %1 cannot alias here.
 ///
 /// CHECK-LABEL: NoDeadStoreWithInterferingLoad
 /// CHECK: store

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -281,7 +281,7 @@ bb4:
   return %2 : $()
 }
 
-// This test makes sure that we do move ref counts over instructions that can not reference it.
+// This test makes sure that we do move ref counts over instructions that cannot reference it.
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_4 :
 // CHECK: bb0({{%[0-9]+}} : $Optional<Builtin.Int32>, [[ARG1:%[0-9]+]] : $Optional<Builtin.NativeObject>):
 // CHECK-NOT: retain_value [[ARG1]]
@@ -884,7 +884,7 @@ bb3:
   return %9999 : $()
 }
 
-// Because our enum is not local to this function, we can not move retain_value
+// Because our enum is not local to this function, we cannot move retain_value
 // %0 past blocker.
 //
 // CHECK-LABEL: sil @enum_simplification_test6b : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -256,7 +256,7 @@ bb2:
   return %2 : $()
 }
 
-// In this case the release is not in the exit, so we can not specialize.
+// In this case the release is not in the exit, so we cannot specialize.
 // CHECK-LABEL: sil [fragile] @owned_to_guaranteed_multibb_callee_with_release_not_in_exit : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK-NOT: @guaranteed
 sil [fragile] @owned_to_guaranteed_multibb_callee_with_release_not_in_exit : $@convention(thin) (@owned Builtin.NativeObject) -> () {

--- a/test/SILOptimizer/globalarcopts.sil
+++ b/test/SILOptimizer/globalarcopts.sil
@@ -604,7 +604,7 @@ bb2:
   return %9999 : $()
 }
 
-// This hammock can not be optimized.
+// This hammock cannot be optimized.
 // CHECK-LABEL: sil @hammock2 : $@convention(thin) (Builtin.NativeObject) -> () {
 // CHECK: bb0
 // CHECK-NEXT: strong_retain

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -459,7 +459,7 @@ bb4:
   return %2 : $()
 }
 
-// This test makes sure that we do move ref counts over instructions that can not reference it.
+// This test makes sure that we do move ref counts over instructions that cannot reference it.
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_4 :
 // CHECK: bb0({{%[0-9]+}} : $FakeOptional<Builtin.Int32>, [[ARG1:%[0-9]+]] : $FakeOptional<Builtin.NativeObject>):
 // CHECK-NOT: retain_value [[ARG1]]
@@ -1062,7 +1062,7 @@ bb3:
   return %9999 : $()
 }
 
-// Because our enum is not local to this function, we can not move retain_value
+// Because our enum is not local to this function, we cannot move retain_value
 // %0 past blocker.
 //
 // CHECK-LABEL: sil @enum_simplification_test6b : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {

--- a/test/SILOptimizer/redundantloadelimination.sil
+++ b/test/SILOptimizer/redundantloadelimination.sil
@@ -171,7 +171,7 @@ bb2:
 // DISABLE this test for now. it seems DCE is not getting rid of the load in bb8 after the RLE happens.
 //
 // Make sure the switch does not affect the forwarding of the load.
-// switch_enum can not have BBArgument, but the %17 = load %2 : $*Int32 is not produced in the
+// switch_enum cannot have BBArgument, but the %17 = load %2 : $*Int32 is not produced in the
 // switch basic block.
 // DISABLE_CHECK-LABEL: load_elimination_disregard_switch_enum
 // DISABLE_CHECK: bb8

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2777,7 +2777,7 @@ bb0(%0 : $*B, %1 : $B, %2 : $Builtin.Int1):
 }
 
 // Make sure that we do not crash when determining if a value is not zero and
-// has a value that can not be stored in a UInt64. The specific issue is that we
+// has a value that cannot be stored in a UInt64. The specific issue is that we
 // were using getZExtValue before which assumes that an APInt can be stored in a
 // UInt64.
 //

--- a/test/SILOptimizer/typed-access-tb-aa.sil
+++ b/test/SILOptimizer/typed-access-tb-aa.sil
@@ -243,7 +243,7 @@ bb0:
 // CHECK: NoAlias
 
 // Next check that Int8 addresses can only alias Int8 addresses and raw
-// pointers. This includes ensuring that Int8 can not alias Int32 addresses.
+// pointers. This includes ensuring that Int8 cannot alias Int32 addresses.
 // CHECK: PAIR #184.
 // CHECK: (1):   %3 = alloc_box $Builtin.Int8
 // CHECK: (1):   %4 = alloc_box $Builtin.Int32
@@ -287,7 +287,7 @@ bb0:
 
 // Finally conclude by checking that FPIEEE32 addresses only can alias raw
 // pointer addresses and other FPIEEE32 addresses. Again this includes proving
-// that FPIEEE64 addresses can not alias FPIEEE32.
+// that FPIEEE64 addresses cannot alias FPIEEE32.
 // CHECK: PAIR #266.
 // CHECK: (1):   %5 = alloc_box $Builtin.FPIEEE32
 // CHECK: (1):   %6 = alloc_box $Builtin.FPIEEE64

--- a/test/Sema/diag_values_of_module_type.swift
+++ b/test/Sema/diag_values_of_module_type.swift
@@ -52,7 +52,7 @@ func goodTest1() {
   _ = diag_values_of_module_type_foo.SomeClass.staticVar1
   _ = diag_values_of_module_type_foo.SomeStruct()
   _ = diag_values_of_module_type_foo.SomeEnum.Foo
-  // Can not default-construct a protocol.
+  // Cannot default-construct a protocol.
   // _ = diag_values_of_module_type_foo.SomeExistential()
   _ = diag_values_of_module_type_foo.SomeTypealias()
 

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -110,7 +110,7 @@ var implicitGet3: Int {
 
 // Here we used apply weak to the getter itself, not to the variable.
 var x15: Int {
-  // For the purpose of this test we need to use an attribute that can not be
+  // For the purpose of this test we need to use an attribute that cannot be
   // applied to the getter.
   weak
   var foo: SomeClass? = SomeClass()  // expected-warning {{variable 'foo' was written to, but never read}}

--- a/validation-test/stdlib/Assert.swift
+++ b/validation-test/stdlib/Assert.swift
@@ -30,13 +30,13 @@ func testTrapsAreNoreturn(i: Int) -> Int {
   // are @noreturn.
   switch i {
   case 2:
-    preconditionFailure("can not happen")
+    preconditionFailure("cannot happen")
   case 3:
-    _preconditionFailure("can not happen")
+    _preconditionFailure("cannot happen")
   case 4:
-    _debugPreconditionFailure("can not happen")
+    _debugPreconditionFailure("cannot happen")
   case 5:
-    _sanityCheckFailure("can not happen")
+    _sanityCheckFailure("cannot happen")
 
   default:
     return 0

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -696,7 +696,7 @@ DictionaryTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     assert(d[10]! == 1010)
 
     d.removeAll()
-    // We can not assert that identity changed, since the new buffer of smaller
+    // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = unsafeBitCast(d, Int.self)
     assert(d._variantStorage.native.capacity < originalCapacity)
@@ -782,7 +782,7 @@ DictionaryTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     assert(d[TestKeyTy(10)]!.value == 1010)
 
     d.removeAll()
-    // We can not assert that identity changed, since the new buffer of smaller
+    // We cannot assert that identity changed, since the new buffer of smaller
     // size can be allocated at the same address as the old one.
     var identity1 = unsafeBitCast(d, Int.self)
     assert(d._variantStorage.native.capacity < originalCapacity)
@@ -2199,7 +2199,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
   assert(isCocoaDictionary(d))
 
   var gen = d.generate()
-  // Can not write code below because of
+  // Cannot write code below because of
   // <rdar://problem/16811736> Optional tuples are broken as optionals regarding == comparison
   // assert(gen.next() == .None)
   assert(gen.next() == nil)
@@ -2217,7 +2217,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
   assert(isNativeDictionary(d))
 
   var gen = d.generate()
-  // Can not write code below because of
+  // Cannot write code below because of
   // <rdar://problem/16811736> Optional tuples are broken as optionals regarding == comparison
   // assert(gen.next() == .None)
   assert(gen.next() == nil)
@@ -3540,7 +3540,7 @@ class ObjCThunksHelper : NSObject {
   }
 
   dynamic func acceptArrayBridgedNonverbatim(array: [TestBridgedValueTy]) {
-    // Can not check elements because doing so would bridge them.
+    // Cannot check elements because doing so would bridge them.
     expectEqual(3, array.count)
   }
 
@@ -3565,7 +3565,7 @@ class ObjCThunksHelper : NSObject {
   dynamic func acceptDictionaryBridgedNonverbatim(
       d: [TestBridgedKeyTy : TestBridgedValueTy]) {
     expectEqual(3, d.count)
-    // Can not check elements because doing so would bridge them.
+    // Cannot check elements because doing so would bridge them.
   }
 
   dynamic func returnDictionaryBridgedVerbatim() ->

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -794,7 +794,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     expectTrue(s.contains(1010))
 
     s.removeAll()
-    // We can not expectTrue that identity changed, since the new buffer of
+    // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = unsafeBitCast(s, Int.self)
     expectTrue(s._variantStorage.native.capacity < originalCapacity)
@@ -880,7 +880,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     expectTrue(s.contains(TestKeyTy(1010)))
 
     s.removeAll()
-    // We can not expectTrue that identity changed, since the new buffer of
+    // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
     var identity1 = unsafeBitCast(s, Int.self)
     expectTrue(s._variantStorage.native.capacity < originalCapacity)

--- a/validation-test/stdlib/UnicodeTrieGenerator.gyb
+++ b/validation-test/stdlib/UnicodeTrieGenerator.gyb
@@ -79,7 +79,7 @@ class UncompressableProperty(UnicodeProperty):
     def get_value(self, cp):
         # Split Unicode codespace into 128-entry "pages".  Start each page with
         # a unique sequence of property values (page number) so that the result
-        # can not be compressed.
+        # cannot be compressed.
         page_number = cp >> 7
         if cp % 0x80 == 1:
             return page_number & 0xff


### PR DESCRIPTION
- `can not -> cannot`
- `Can not` -> `Cannot`

This pull request is related to #710 and #718. 
This can finish correcting "[Cc]an not"
