### PR TITLE
Add spaces before and after closure arrow

### DIFF
--- a/docs/Generics.rst
+++ b/docs/Generics.rst
@@ -579,7 +579,7 @@ OrderedCollection>) are just sugar for a where clause.  For example, the
 above find() signature is equivalent to::
 
   func find<C where C : OrderedCollection, C.Element : Comparable>(
-         collection : C, value : C.Element)-> Int
+         collection : C, value : C.Element) -> Int
 
 Note that find<C> is shorthand for (and equivalent to) find<C : Any>, since
 every type conforms to the Any protocol composition.

--- a/docs/StdlibAPIGuidelines.rst
+++ b/docs/StdlibAPIGuidelines.rst
@@ -200,7 +200,7 @@ Acceptable Short or Non-Descriptive Names
 
     func map<U>(transformation: T->U) -> [U] // not this one
 
-    func forEach<S: SequenceType>(body: (S.Generator.Element)->())
+    func forEach<S: SequenceType>(body: (S.Generator.Element) -> ())
 
 Prefixes and Suffixes
 ---------------------

--- a/docs/StringDesign.rst
+++ b/docs/StringDesign.rst
@@ -940,7 +940,7 @@ Searching
 
 :Swift:
   .. parsed-literal::
-       func **find**\ (match: (Character)->Bool) -> Range<String.IndexType>
+       func **find**\ (match: (Character) -> Bool) -> Range<String.IndexType>
 
   .. Admonition:: Usage Example
 
@@ -1100,7 +1100,7 @@ Capitalization
 
 :Swift:
   .. parsed-literal::
-       trim **trim**\ (match: (Character)->Bool) -> String
+       trim **trim**\ (match: (Character) -> Bool) -> String
 
   .. Admonition:: Usage Example
 

--- a/docs/archive/LangRefNew.rst
+++ b/docs/archive/LangRefNew.rst
@@ -1537,8 +1537,8 @@ Short Circuiting Logical Operators
 
 ::
 
-  func && (lhs: Bool, rhs: ()->Bool) -> Bool
-  func || (lhs: Bool, rhs: ()->Bool) -> Bool
+  func && (lhs: Bool, rhs: () -> Bool) -> Bool
+  func || (lhs: Bool, rhs: () -> Bool) -> Bool
 
 Swift has a simplified precedence levels when compared with C.  From highest to
 lowest:

--- a/docs/proposals/InoutCOWOptimization.rst
+++ b/docs/proposals/InoutCOWOptimization.rst
@@ -51,7 +51,7 @@ could be written as follows:
   protocol Sliceable {
     ...
     @mutating
-    func quickSort(compare: (StreamType.Element, StreamType.Element)->Bool) {
+    func quickSort(compare: (StreamType.Element, StreamType.Element) -> Bool) {
       let (start,end) = (startIndex, endIndex)
       if start != end && start.succ() != end {
         let pivot = self[start]

--- a/docs/proposals/Inplace.rst
+++ b/docs/proposals/Inplace.rst
@@ -310,7 +310,7 @@ as though it were written:
 .. parsed-literal::
 
   { 
-    (var y: X)->X in
+    (var y: X) -> X in
     y\ **.=**\ *f*\ (a₀, p₁: a₁, p₂: a₂, …p\ *n*: a\ *n*)
     return y
   }(x)
@@ -344,7 +344,7 @@ as though it were written:
 .. parsed-literal::
 
   { 
-    (var y: X)->X in
+    (var y: X) -> X in
     y *op*\ **=**\ *expression*
     return y
   }(x)

--- a/docs/proposals/ValueSemantics.rst
+++ b/docs/proposals/ValueSemantics.rst
@@ -179,7 +179,7 @@ Here’s a version of cycle_length that works when state is a mutable
 value type::
 
  func cycle_length<State>(
-   s : State, mutate : ( [inout] State )->() 
+   s : State, mutate : ( [inout] State ) -> () 
  ) -> Int
    requires State : EqualityComparable
  {
@@ -211,7 +211,7 @@ classes:
  }
 
  func cycle_length<State>(
-   s : State, mutate : ( [inout] State )->() 
+   s : State, mutate : ( [inout] State ) -> () 
  ) -> Int
    requires State : EqualityComparable, **Clonable**
  {
@@ -233,8 +233,8 @@ clonable classes:
 
  func cycle_length<State>(
    s : State, 
-   **next : (x : State)->State,**
-   **equal : ([inout] x : State, [inout] y : State)->Bool**
+   **next : (x : State) -> State,**
+   **equal : ([inout] x : State, [inout] y : State) -> Bool**
  ) -> Int
    requires State : EqualityComparable
  {

--- a/docs/proposals/valref.rst
+++ b/docs/proposals/valref.rst
@@ -178,7 +178,7 @@ Array elements can be explicitly declared ``val`` or ``ref``::
 When a reference to an array appears without a variable name, it can
 be written using the `usual syntax`__::
 
-  var f : ()->ref Int[42] // a closure returning a reference to an array
+  var f : () -> ref Int[42] // a closure returning a reference to an array
   var b : ref Int[42]     // equivalent to "ref b : Int[42]"
 
 __ `standalone types`_
@@ -191,7 +191,7 @@ brackets, that most users will never touch, e.g.::
   var z : Array<ref Int,42>           // an array of 42 integers-on-the-heap
   var z : Array<ref Array<Int,42>, 2> // an array of 2 references to arrays
   ref a : Array<Int,42>               // a reference to an array of 42 integers
-  var f : ()->ref Array<Int,42>       // a closure returning a reference to an array
+  var f : () -> ref Array<Int,42>       // a closure returning a reference to an array
   var b : ref Array<Int,42>           // equivalent to "ref b : Int[42]"
 
 Rules for copying array elements follow those of instance variables.

--- a/docs/proposals/valref.rst
+++ b/docs/proposals/valref.rst
@@ -179,7 +179,7 @@ When a reference to an array appears without a variable name, it can
 be written using the `usual syntax`__::
 
   var f : () -> ref Int[42] // a closure returning a reference to an array
-  var b : ref Int[42]     // equivalent to "ref b : Int[42]"
+  var b : ref Int[42]       // equivalent to "ref b : Int[42]"
 
 __ `standalone types`_
 
@@ -191,7 +191,7 @@ brackets, that most users will never touch, e.g.::
   var z : Array<ref Int,42>           // an array of 42 integers-on-the-heap
   var z : Array<ref Array<Int,42>, 2> // an array of 2 references to arrays
   ref a : Array<Int,42>               // a reference to an array of 42 integers
-  var f : () -> ref Array<Int,42>       // a closure returning a reference to an array
+  var f : () -> ref Array<Int,42>     // a closure returning a reference to an array
   var b : ref Array<Int,42>           // equivalent to "ref b : Int[42]"
 
 Rules for copying array elements follow those of instance variables.

--- a/stdlib/private/StdlibUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibUnittest/LoggingWrappers.swift.gyb
@@ -540,7 +540,7 @@ public struct Logging${Kind}<Base: ${Kind}Type> : ${Kind}Type, LoggingType {
   /// `preprocess` on `self` and return its result.  Otherwise, return
   /// `nil`.
   public func _preprocessingPass<R>(
-    preprocess: (Logging${Kind})->R
+    preprocess: (Logging${Kind}) -> R
   ) -> R? {
     Log._preprocessingPass[selfType] += 1
     return base._preprocessingPass { _ in preprocess(self) }
@@ -572,7 +572,7 @@ public func expectCustomizable<
   T.Log == T.Base.Log
 >(_: T, _ counters: TypeIndexed<Int>,
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = __FILE__, line: UInt = __LINE__
@@ -590,7 +590,7 @@ public func expectNotCustomizable<
   T.Log == T.Base.Log
 >(_: T, _ counters: TypeIndexed<Int>,
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = __FILE__, line: UInt = __LINE__

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -501,8 +501,8 @@ public func runRaceTest<RT : RaceTestWithPerTrialDataType>(
   let racingThreadCount = threads ?? max(2, _stdlib_getHardwareConcurrency())
   let sharedState = _RaceTestSharedState<RT>(racingThreadCount: racingThreadCount)
 
-  let masterThreadBody: (_: ())->() = {
-    (_: ())->() in
+  let masterThreadBody: (_: ()) -> () = {
+    (_: ()) -> () in
     for _ in 0..<trials {
       autoreleasepool {
         _masterThreadOneTrial(sharedState)
@@ -510,8 +510,8 @@ public func runRaceTest<RT : RaceTestWithPerTrialDataType>(
     }
   }
 
-  let racingThreadBody: (Int)->() = {
-    (tid: Int)->() in
+  let racingThreadBody: (Int) -> () = {
+    (tid: Int) -> () in
     for _ in 0..<trials {
       _workerThreadOneTrial(tid, sharedState)
     }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -87,7 +87,7 @@ public struct SourceLocStack {
 }
 
 %{
-  TRACE = '''@autoclosure _ message: ()->String = "",
+  TRACE = '''@autoclosure _ message: () -> String = "",
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = __FILE__, line: UInt = __LINE__'''
@@ -166,7 +166,7 @@ public func expectationFailure(
 }
 
 public func expectEqual<T>(
-  expected: T, _ actual: T, ${TRACE}, sameValue equal: (T,T)->Bool
+  expected: T, _ actual: T, ${TRACE}, sameValue equal: (T,T) -> Bool
 ) {
   if !equal(expected, actual) {
     expectationFailure(
@@ -195,7 +195,7 @@ public func expectOptionalEqual<T : Equatable>(
 }
 
 public func expectOptionalEqual<T>(
-  expected: T, _ actual: T?, ${TRACE}, sameValue equal: (T,T)->Bool
+  expected: T, _ actual: T?, ${TRACE}, sameValue equal: (T,T) -> Bool
 ) {
   if (actual == nil) || !equal(expected, actual!) {
     expectationFailure(
@@ -1478,7 +1478,7 @@ public func checkHashable<
   Instances: CollectionType where Instances.Generator.Element : Hashable
 >(
   instances: Instances,
-  equalityOracle: (Instances.Index, Instances.Index)->Bool,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   ${TRACE}
 ) {
   checkEquatable(instances, oracle: equalityOracle, ${trace})
@@ -1517,7 +1517,7 @@ public func check${inc.capitalize()}rementable<
   where Instances.Generator.Element : ${protocol}
 >(
   instances: Instances,
-  equalityOracle: (Instances.Index, Instances.Index)->Bool,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   ${end}Index: Instances.Generator.Element, ${TRACE}
 ) {
   checkEquatable(instances, oracle: equalityOracle, ${trace})
@@ -1726,10 +1726,10 @@ internal func _checkIncrementalAdvance<
   Instances: CollectionType where Instances.Generator.Element : ForwardIndexType
 >(
   instances: Instances,
-  equalityOracle: (Instances.Index, Instances.Index)->Bool,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   limit: Instances.Generator.Element,
   sign: Instances.Generator.Element.Distance, // 1 or -1
-  next: (Instances.Generator.Element)->Instances.Generator.Element,
+  next: (Instances.Generator.Element) -> Instances.Generator.Element,
   ${TRACE}
 ) {
   for i in instances {
@@ -1760,7 +1760,7 @@ public func checkForwardIndex<
   Instances: CollectionType where Instances.Generator.Element : ForwardIndexType
 >(
   instances: Instances,
-  equalityOracle: (Instances.Index, Instances.Index)->Bool,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   endIndex: Instances.Generator.Element, ${TRACE}
 ) {
   typealias Index = Instances.Generator.Element
@@ -1786,7 +1786,7 @@ public func checkBidirectionalIndex<
   where Instances.Generator.Element : BidirectionalIndexType
 >(
   instances: Instances,
-  equalityOracle: (Instances.Index, Instances.Index)->Bool,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   startIndex: Instances.Generator.Element, 
   endIndex: Instances.Generator.Element,
   ${TRACE}
@@ -1910,7 +1910,7 @@ public func checkSequence<
 
   // Check that _initializeTo does the right thing if we can do so
   // without destroying the sequence.
-  sequence._preprocessingPass { (sequence)->Void in 
+  sequence._preprocessingPass { (sequence) -> Void in 
     var count = 0
     for _ in sequence { count += 1 }
     let buf = UnsafeMutablePointer<S.Generator.Element>.alloc(count)
@@ -2194,8 +2194,8 @@ public func checkRangeReplaceable<
 where
   C.Generator.Element : Equatable, C.Generator.Element == N.Generator.Element
 >(
-  makeCollection: ()->C,
-  _ makeNewValues: (Int)->N
+  makeCollection: () -> C,
+  _ makeNewValues: (Int) -> N
 ) {
   typealias A = C
 
@@ -2278,7 +2278,7 @@ public func expectEqualSequence<
   Actual: SequenceType
   where Expected.Generator.Element == Actual.Generator.Element
 >(expected: Expected, _ actual: Actual, ${TRACE},
-  sameValue: (Expected.Generator.Element, Expected.Generator.Element)->Bool) {
+  sameValue: (Expected.Generator.Element, Expected.Generator.Element) -> Bool) {
   
   if !expected.elementsEqual(actual, isEquivalent: sameValue) {
     expectationFailure("expected elements: \"\(expected)\"\n"

--- a/stdlib/private/StdlibUnittest/TypeIndexed.swift
+++ b/stdlib/private/StdlibUnittest/TypeIndexed.swift
@@ -55,11 +55,11 @@ public class TypeIndexed<Value> : Resettable {
 extension TypeIndexed where Value : ForwardIndexType {
   public func expectIncrement<R>(
     t: Any.Type,
-    @autoclosure _ message: ()->String = "",
+    @autoclosure _ message: () -> String = "",
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = __FILE__, line: UInt = __LINE__,
-    body: ()->R
+    body: () -> R
   ) -> R {
     let expected = self[t].successor()
     let r = body()
@@ -73,11 +73,11 @@ extension TypeIndexed where Value : ForwardIndexType {
 extension TypeIndexed where Value : Equatable {
   public func expectUnchanged<R>(
     t: Any.Type,
-    @autoclosure _ message: ()->String = "",
+    @autoclosure _ message: () -> String = "",
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = __FILE__, line: UInt = __LINE__,
-    body: ()->R
+    body: () -> R
   ) -> R {
     let expected = self[t]
     let r = body()
@@ -99,7 +99,7 @@ public func <=> <T: Comparable>(
 
 public func expectEqual<V: Comparable>(
   expected: DictionaryLiteral<Any.Type, V>, _ actual: TypeIndexed<V>,
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = __FILE__, line: UInt = __LINE__

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -103,7 +103,7 @@ extension String {
   /// memory referred to by `index`
   func _withOptionalOutParameter<Result>(
     index: UnsafeMutablePointer<Index>,
-    @noescape body: (UnsafeMutablePointer<Int>)->Result
+    @noescape body: (UnsafeMutablePointer<Int>) -> Result
   ) -> Result {
     var utf16Index: Int = 0
     let result = index._withBridgeValue(&utf16Index) {
@@ -118,7 +118,7 @@ extension String {
   /// it into the memory referred to by `range`
   func _withOptionalOutParameter<Result>(
     range: UnsafeMutablePointer<Range<Index>>,
-    @noescape body: (UnsafeMutablePointer<NSRange>)->Result
+    @noescape body: (UnsafeMutablePointer<NSRange>) -> Result
   ) -> Result {
     var nsRange = NSRange(location: 0, length: 0)
     let result = range._withBridgeValue(&nsRange) {
@@ -479,7 +479,7 @@ extension String {
   //     enumerateLinesUsingBlock:(void (^)(NSString *line, BOOL *stop))block
 
   /// Enumerates all the lines in a string.
-  public func enumerateLines(body: (line: String, inout stop: Bool)->()) {
+  public func enumerateLines(body: (line: String, inout stop: Bool) -> ()) {
     _ns.enumerateLinesUsingBlock {
       (line: String, stop: UnsafeMutablePointer<ObjCBool>)
     in
@@ -511,7 +511,7 @@ extension String {
     options opts: NSLinguisticTaggerOptions,
     orthography: NSOrthography?,
     _ body:
-      (String, Range<Index>, Range<Index>, inout Bool)->()
+      (String, Range<Index>, Range<Index>, inout Bool) -> ()
   ) {
     _ns.enumerateLinguisticTagsInRange(
       _toNSRange(range),
@@ -546,7 +546,7 @@ extension String {
     _ body: (
       substring: String?, substringRange: Range<Index>,
       enclosingRange: Range<Index>, inout Bool
-    )->()
+    ) -> ()
   ) {
     _ns.enumerateSubstringsInRange(_toNSRange(range), options: opts) {
       var stop_ = false
@@ -1181,7 +1181,7 @@ extension String {
     aSet: NSCharacterSet,
     options mask:NSStringCompareOptions = [],
     range aRange: Range<Index>? = nil
-  )-> Range<Index>? {
+  ) -> Range<Index>? {
     return _optionalRange(
       _ns.rangeOfCharacterFromSet(
         aSet, options: mask,

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -605,7 +605,7 @@ extension SequenceType
 }
 
 extension CollectionType {
-  public func _preprocessingPass<R>(preprocess: (Self)->R) -> R? {
+  public func _preprocessingPass<R>(preprocess: (Self) -> R) -> R? {
     return preprocess(self)
   }
 }

--- a/stdlib/public/core/Existential.swift
+++ b/stdlib/public/core/Existential.swift
@@ -30,7 +30,7 @@ internal struct _CollectionOf<
   IndexType_ : ForwardIndexType, T
 > : CollectionType {
   init(startIndex: IndexType_, endIndex: IndexType_,
-      _ subscriptImpl: (IndexType_)->T) {
+      _ subscriptImpl: (IndexType_) -> T) {
     self.startIndex = startIndex
     self.endIndex = endIndex
     _subscriptImpl = subscriptImpl
@@ -58,9 +58,9 @@ internal struct _CollectionOf<
     return _subscriptImpl(i)
   }
 
-  let _subscriptImpl: (IndexType_)->T
+  let _subscriptImpl: (IndexType_) -> T
 }
 
-@available(*, unavailable, message="SinkOf has been removed. Use (T)->() closures directly instead.")
+@available(*, unavailable, message="SinkOf has been removed. Use (T) -> () closures directly instead.")
 public struct SinkOf<T> {}
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -87,7 +87,7 @@ public func anyGenerator<G: GeneratorType>(base: G) -> AnyGenerator<G.Element> {
 }
 
 @available(*, deprecated, renamed="AnyGenerator")
-public func anyGenerator<Element>(body: ()->Element?) -> AnyGenerator<Element> {
+public func anyGenerator<Element>(body: () -> Element?) -> AnyGenerator<Element> {
   return AnyGenerator(body: body)
 }
 

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -37,7 +37,7 @@ public struct LazyFilterGenerator<
   /// for which `predicate(x) == true`.
   public init(
     _ base: Base,
-    whereElementsSatisfy predicate: (Base.Element)->Bool
+    whereElementsSatisfy predicate: (Base.Element) -> Bool
   ) {
     self._base = base
     self._predicate = predicate
@@ -50,7 +50,7 @@ public struct LazyFilterGenerator<
   
   /// The predicate used to determine which elements produced by
   /// `base` are also produced by `self`.
-  internal var _predicate: (Base.Element)->Bool
+  internal var _predicate: (Base.Element) -> Bool
 }
 
 /// A sequence whose elements consist of the elements of some base
@@ -73,7 +73,7 @@ public struct LazyFilterSequence<Base : SequenceType>
   /// which `predicate(x) == true`.
   public init(
     _ base: Base,
-    whereElementsSatisfy predicate: (Base.Generator.Element)->Bool
+    whereElementsSatisfy predicate: (Base.Generator.Element) -> Bool
   ) {
     self.base = base
     self._include = predicate
@@ -84,7 +84,7 @@ public struct LazyFilterSequence<Base : SequenceType>
 
   /// The predicate used to determine which elements of `base` are
   /// also elements of `self`.
-  internal let _include: (Base.Generator.Element)->Bool
+  internal let _include: (Base.Generator.Element) -> Bool
 }
 
 /// The `Index` used for subscripting a `LazyFilterCollection`.
@@ -130,7 +130,7 @@ public struct LazyFilterIndex<
 
   /// The predicate used to determine which elements of `base` are
   /// also elements of `self`.
-  internal let _include: (BaseElements.Generator.Element)->Bool
+  internal let _include: (BaseElements.Generator.Element) -> Bool
 
   @available(*, unavailable, renamed="BaseElements")
   public typealias Base = BaseElements
@@ -168,7 +168,7 @@ public struct LazyFilterCollection<
   /// satisfy `predicate`.
   public init(
     _ base: Base,
-    whereElementsSatisfy predicate: (Base.Generator.Element)->Bool
+    whereElementsSatisfy predicate: (Base.Generator.Element) -> Bool
   ) {
     self._base = base
     self._predicate = predicate
@@ -221,7 +221,7 @@ public struct LazyFilterCollection<
   }
 
   var _base: Base
-  var _predicate: (Base.Generator.Element)->Bool
+  var _predicate: (Base.Generator.Element) -> Bool
 }
 
 extension LazySequenceType {
@@ -233,7 +233,7 @@ extension LazySequenceType {
   ///   elements.
   @warn_unused_result
   public func filter(
-    predicate: (Elements.Generator.Element)->Bool
+    predicate: (Elements.Generator.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
     return LazyFilterSequence(
       self.elements, whereElementsSatisfy: predicate)
@@ -249,7 +249,7 @@ extension LazyCollectionType {
   ///   elements.
   @warn_unused_result
   public func filter(
-    predicate: (Elements.Generator.Element)->Bool
+    predicate: (Elements.Generator.Element) -> Bool
   ) -> LazyFilterCollection<Self.Elements> {
     return LazyFilterCollection(
       self.elements, whereElementsSatisfy: predicate)

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -19,7 +19,7 @@ extension LazySequenceType {
   /// - Complexity: O(1)
   @warn_unused_result
   public func flatMap<Intermediate: SequenceType>(
-    transform: (Elements.Generator.Element)->Intermediate
+    transform: (Elements.Generator.Element) -> Intermediate
   ) -> LazySequence<
     FlattenSequence<LazyMapSequence<Elements, Intermediate>>> {
     return self.map(transform).flatten()
@@ -35,7 +35,7 @@ extension LazyCollectionType {
   /// - Complexity: O(1)
   @warn_unused_result
   public func flatMap<Intermediate: CollectionType>(
-    transform: (Elements.Generator.Element)->Intermediate
+    transform: (Elements.Generator.Element) -> Intermediate
   ) -> LazyCollection<
     FlattenCollection<
       LazyMapCollection<Elements, Intermediate>>
@@ -57,7 +57,7 @@ extension LazyCollectionType where Elements.Index : BidirectionalIndexType
     Intermediate: CollectionType
     where Intermediate.Index : BidirectionalIndexType
   >(
-    transform: (Elements.Generator.Element)->Intermediate
+    transform: (Elements.Generator.Element) -> Intermediate
   ) -> LazyCollection<
     FlattenBidirectionalCollection<
       LazyMapCollection<Elements, Intermediate>

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -47,7 +47,7 @@
 ///       /// - Complexity: O(N)
 ///       func scan<ResultElement>(
 ///         initial: ResultElement,
-///         @noescape combine: (ResultElement, Generator.Element)->ResultElement
+///         @noescape combine: (ResultElement, Generator.Element) -> ResultElement
 ///       ) -> [ResultElement] {
 ///         var result = [initial]
 ///         for x in self {
@@ -70,7 +70,7 @@
 ///       }
 ///       private var nextElement: ResultElement? // The next result of next().
 ///       private var base: Base                  // The underlying generator.
-///       private let combine: (ResultElement, Base.Element)->ResultElement
+///       private let combine: (ResultElement, Base.Element) -> ResultElement
 ///     }
 ///     
 ///     struct LazyScanSequence<Base: SequenceType, ResultElement>
@@ -83,7 +83,7 @@
 ///       private let initial: ResultElement
 ///       private let base: Base
 ///       private let combine:
-///         (ResultElement, Base.Generator.Element)->ResultElement
+///         (ResultElement, Base.Generator.Element) -> ResultElement
 ///     }
 ///
 /// and finally, we can give all lazy sequences a lazy `scan` method:
@@ -101,7 +101,7 @@
 ///       /// - Complexity: O(1)
 ///       func scan<ResultElement>(
 ///         initial: ResultElement,
-///         combine: (ResultElement, Generator.Element)->ResultElement
+///         combine: (ResultElement, Generator.Element) -> ResultElement
 ///       ) -> LazyScanSequence<Self, ResultElement> {
 ///         return LazyScanSequence(
 ///           initial: initial, base: self, combine: combine)

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -45,7 +45,7 @@ public class ManagedProtoBuffer<Value, Element> : NonObjectiveCBase {
   /// - Note: This pointer is only valid for the duration of the
   ///   call to `body`.
   public final func withUnsafeMutablePointerToValue<R>(
-    body: (UnsafeMutablePointer<Value>)->R
+    body: (UnsafeMutablePointer<Value>) -> R
   ) -> R {
     return withUnsafeMutablePointers { (v, e) in return body(v) }
   }
@@ -56,7 +56,7 @@ public class ManagedProtoBuffer<Value, Element> : NonObjectiveCBase {
   /// - Note: This pointer is only valid for the duration of the
   ///   call to `body`.
   public final func withUnsafeMutablePointerToElements<R>(
-    body: (UnsafeMutablePointer<Element>)->R
+    body: (UnsafeMutablePointer<Element>) -> R
   ) -> R {
     return withUnsafeMutablePointers { return body($0.1) }
   }
@@ -67,7 +67,7 @@ public class ManagedProtoBuffer<Value, Element> : NonObjectiveCBase {
   /// - Note: These pointers are only valid for the duration of the
   ///   call to `body`.
   public final func withUnsafeMutablePointers<R>(
-    body: (_: UnsafeMutablePointer<Value>, _: UnsafeMutablePointer<Element>)->R
+    body: (_: UnsafeMutablePointer<Value>, _: UnsafeMutablePointer<Element>) -> R
   ) -> R {
     return ManagedBufferPointer(self).withUnsafeMutablePointers(body)
   }
@@ -99,7 +99,7 @@ public class ManagedBuffer<Value, Element>
   /// generate an initial `Value`.
   public final class func create(
     minimumCapacity: Int,
-    initialValue: (ManagedProtoBuffer<Value,Element>)->Value
+    initialValue: (ManagedProtoBuffer<Value,Element>) -> Value
   ) -> ManagedBuffer<Value,Element> {
 
     let p = ManagedBufferPointer<Value,Element>(
@@ -146,7 +146,7 @@ public class ManagedBuffer<Value, Element>
 ///        typealias Manager = ManagedBufferPointer<(Int,String), Element>
 ///        deinit {
 ///          Manager(unsafeBufferObject: self).withUnsafeMutablePointers {
-///            (pointerToValue, pointerToElements)->Void in
+///            (pointerToValue, pointerToElements) -> Void in
 ///            pointerToElements.destroy(self.count)
 ///            pointerToValue.destroy()
 ///          }
@@ -181,7 +181,7 @@ public struct ManagedBufferPointer<Value, Element> : Equatable {
   public init(
     bufferClass: AnyClass,
     minimumCapacity: Int,
-    initialValue: (buffer: AnyObject, allocatedCount: (AnyObject)->Int)->Value
+    initialValue: (buffer: AnyObject, allocatedCount: (AnyObject) -> Int) -> Value
   ) {
     self = ManagedBufferPointer(bufferClass: bufferClass, minimumCapacity: minimumCapacity)
 
@@ -253,7 +253,7 @@ public struct ManagedBufferPointer<Value, Element> : Equatable {
   /// - Note: This pointer is only valid
   ///   for the duration of the call to `body`.
   public func withUnsafeMutablePointerToValue<R>(
-    body: (UnsafeMutablePointer<Value>)->R
+    body: (UnsafeMutablePointer<Value>) -> R
   ) -> R {
     return withUnsafeMutablePointers { (v, e) in return body(v) }
   }
@@ -264,7 +264,7 @@ public struct ManagedBufferPointer<Value, Element> : Equatable {
   /// - Note: This pointer is only valid for the duration of the
   ///   call to `body`.
   public func withUnsafeMutablePointerToElements<R>(
-    body: (UnsafeMutablePointer<Element>)->R
+    body: (UnsafeMutablePointer<Element>) -> R
   ) -> R {
     return withUnsafeMutablePointers { return body($0.1) }
   }
@@ -275,7 +275,7 @@ public struct ManagedBufferPointer<Value, Element> : Equatable {
   /// - Note: These pointers are only valid for the duration of the
   ///   call to `body`.
   public func withUnsafeMutablePointers<R>(
-    body: (_: UnsafeMutablePointer<Value>, _: UnsafeMutablePointer<Element>)->R
+    body: (_: UnsafeMutablePointer<Value>, _: UnsafeMutablePointer<Element>) -> R
   ) -> R {
     let result = body(_valuePointer, _elementPointer)
     _fixLifetime(_nativeBuffer)

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -32,7 +32,7 @@ public struct LazyMapGenerator<
   public var base: Base { return _base }
   
   internal var _base: Base
-  internal var _transform: (Base.Element)->Element
+  internal var _transform: (Base.Element) -> Element
 }
 
 /// A `SequenceType` whose elements consist of those in a `Base`
@@ -61,13 +61,13 @@ public struct LazyMapSequence<Base : SequenceType, Element>
 
   /// Create an instance with elements `transform(x)` for each element
   /// `x` of base.
-  public init(_ base: Base, transform: (Base.Generator.Element)->Element) {
+  public init(_ base: Base, transform: (Base.Generator.Element) -> Element) {
     self._base = base
     self._transform = transform
   }
   
   public var _base: Base
-  internal var _transform: (Base.Generator.Element)->Element
+  internal var _transform: (Base.Generator.Element) -> Element
 
   @available(*, unavailable, renamed="Element")
   public typealias T = Element
@@ -123,13 +123,13 @@ public struct LazyMapCollection<Base : CollectionType, Element>
 
   /// Create an instance with elements `transform(x)` for each element
   /// `x` of base.
-  public init(_ base: Base, transform: (Base.Generator.Element)->Element) {
+  public init(_ base: Base, transform: (Base.Generator.Element) -> Element) {
     self._base = base
     self._transform = transform
   }
   
   public var _base: Base
-  var _transform: (Base.Generator.Element)->Element
+  var _transform: (Base.Generator.Element) -> Element
 
   @available(*, unavailable, renamed="Element")
   public typealias T = Element

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -83,7 +83,7 @@ public struct Mirror {
   ///         children: ["someProperty": self.someProperty],
   ///         ancestorRepresentation: .Customized(super.customMirror)) // <==
   ///     }
-  case Customized(()->Mirror)
+  case Customized(() -> Mirror)
 
   /// Suppress the representation of all ancestor classes.  The
   /// resulting `Mirror`'s `superclassMirror()` is `nil`.
@@ -169,7 +169,7 @@ public struct Mirror {
   @warn_unused_result
   internal static func _superclassGenerator<T: Any>(
     subject: T, _ ancestorRepresentation: AncestorRepresentation
-  ) -> ()->Mirror? {
+  ) -> () -> Mirror? {
 
     if let subject = subject as? AnyObject,
       let subjectClass = T.self as? AnyClass,
@@ -338,7 +338,7 @@ public struct Mirror {
     return _makeSuperclassMirror()
   }
 
-  internal let _makeSuperclassMirror: ()->Mirror?
+  internal let _makeSuperclassMirror: () -> Mirror?
   internal let _defaultDescendantRepresentation: DefaultDescendantRepresentation
 }
 
@@ -552,7 +552,7 @@ internal extension Mirror {
   internal init(
     legacy legacyMirror: _MirrorType,
     subjectType: Any.Type,
-    makeSuperclassMirror: (()->Mirror?)? = nil
+    makeSuperclassMirror: (() -> Mirror?)? = nil
   ) {
     if let makeSuperclassMirror = makeSuperclassMirror {
       self._makeSuperclassMirror = makeSuperclassMirror

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -86,14 +86,14 @@ extension Optional : CustomDebugStringConvertible {
 //
 /// Haskell's fmap for Optionals.
 @available(*, unavailable, message="call the 'map()' method on the optional value")
-public func map<T, U>(x: T?, @noescape _ f: (T)->U) -> U? {
+public func map<T, U>(x: T?, @noescape _ f: (T) -> U) -> U? {
   fatalError("unavailable function can't be called")
 }
 
 
 /// Returns `f(self)!` iff `self` and `f(self)` are not `nil`.
 @available(*, unavailable, message="call the 'flatMap()' method on the optional value")
-public func flatMap<T, U>(x: T?, @noescape _ f: (T)->U?) -> U? {
+public func flatMap<T, U>(x: T?, @noescape _ f: (T) -> U?) -> U? {
   fatalError("unavailable function can't be called")
 }
 

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -343,7 +343,7 @@ public func toDebugString<T>(x: T) -> String {
 }
 
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook : ((String)->Void)? = {_ in () }
+public var _playgroundPrintHook : ((String) -> Void)? = {_ in () }
 
 internal struct _TeeStream<
   L : OutputStreamType, 

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -85,10 +85,10 @@ public typealias Any = protocol<>
 ///       @objc func getCValue() -> Int { return 42 }
 ///     }
 ///
-///     // If x has a method @objc getValue()->Int, call it and
+///     // If x has a method @objc getValue() -> Int, call it and
 ///     // return the result.  Otherwise, return `nil`.
 ///     func getCValue1(x: AnyObject) -> Int? {
-///       if let f: ()->Int = x.getCValue { // <===
+///       if let f: () -> Int = x.getCValue { // <===
 ///         return f()
 ///       }
 ///       return nil
@@ -327,7 +327,7 @@ public protocol Hashable : Equatable {
 }
 
 public protocol _SinkType {}
-@available(*, unavailable, message="SinkType has been removed. Use (T)->() closures directly instead.")
+@available(*, unavailable, message="SinkType has been removed. Use (T) -> () closures directly instead.")
 public typealias SinkType = _SinkType
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -189,7 +189,7 @@ public protocol SequenceType {
   /// If `self` is multi-pass (i.e., a `CollectionType`), invoke
   /// `preprocess` on `self` and return its result.  Otherwise, return
   /// `nil`.
-  func _preprocessingPass<R>(preprocess: (Self)->R) -> R?
+  func _preprocessingPass<R>(preprocess: (Self) -> R) -> R?
 
   /// Create a native array buffer containing the elements of `self`,
   /// in the same order.
@@ -516,7 +516,7 @@ extension SequenceType {
     return 0
   }
 
-  public func _preprocessingPass<R>(preprocess: (Self)->R) -> R? {
+  public func _preprocessingPass<R>(preprocess: (Self) -> R) -> R? {
     return nil
   }
 

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -61,7 +61,7 @@ extension SequenceType
   /// If `self` is multi-pass (i.e., a `CollectionType`), invoke
   /// `preprocess` on `self` and return its result.  Otherwise, return
   /// `nil`.
-  public func _preprocessingPass<R>(preprocess: (Self)->R) -> R? {
+  public func _preprocessingPass<R>(preprocess: (Self) -> R) -> R? {
     return _base._preprocessingPass { _ in preprocess(self) }
   }
 
@@ -137,7 +137,7 @@ extension CollectionType
   /// If `self` is multi-pass (i.e., a `CollectionType`), invoke
   /// `preprocess` on `self` and return its result.  Otherwise, return
   /// `nil`.
-  public func _preprocessingPass<R>(preprocess: (Self)->R) -> R? {
+  public func _preprocessingPass<R>(preprocess: (Self) -> R) -> R? {
     return _base._preprocessingPass { _ in preprocess(self) }
   }
 

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -45,7 +45,7 @@ func _insertionSort<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) {
   if !range.isEmpty {
     let start = range.startIndex
@@ -102,7 +102,7 @@ public func partition<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) -> C.Index {
   fatalError("unavailable function can't be called")
 }
@@ -113,7 +113,7 @@ func _partition<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) -> C.Index {
   var lo = range.startIndex
   var hi = range.endIndex
@@ -168,7 +168,7 @@ func _introSort<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) {
 %   if p:
   var comp = isOrderedBefore
@@ -189,7 +189,7 @@ func _introSortImpl<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""},
+  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""},
   _ depthLimit: Int
 ) {
 
@@ -221,7 +221,7 @@ func _siftDown<
   inout elements: C,
   _ index: C.Index,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) {
   let countToIndex = (range.startIndex..<index).count
   let countFromIndex = (index..<range.endIndex).count
@@ -255,7 +255,7 @@ func _heapify<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) {
   // Here we build a heap starting from the lowest nodes and moving to the root.
   // On every step we sift down the current node to obey the max-heap property:
@@ -276,7 +276,7 @@ func _heapSort<
 >(
   inout elements: C,
   _ range: Range<C.Index> ${"," if p else ""}
-  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"inout _ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) {
   var hi = range.endIndex
   let lo = range.startIndex
@@ -312,7 +312,7 @@ public func sort<
   ${"" if p else ", C.Generator.Element : Comparable"}
 >(
   inout collection: C ${"," if p else ""}
-  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) {
   fatalError("unavailable function can't be called")
 }
@@ -360,7 +360,7 @@ public func sorted<
   C: SequenceType${"" if p else " where C.Generator.Element : Comparable"}
 >(
   source: C ${"," if p else ""}
-  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element)->Bool" if p else ""}
+  ${"_ isOrderedBefore: (C.Generator.Element, C.Generator.Element) -> Bool" if p else ""}
 ) -> [C.Generator.Element] {
   fatalError("unavailable function can't be called")
 }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -310,7 +310,7 @@ extension String {
 @_silgen_name("swift_stdlib_compareNSStringDeterministicUnicodeCollation")
 public func _stdlib_compareNSStringDeterministicUnicodeCollation(
   lhs: AnyObject, _ rhs: AnyObject
-)-> Int32
+) -> Int32
 #endif
 
 extension String : Equatable {

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -46,7 +46,7 @@ extension String {
   ///   that is the target of this method) during the execution of
   ///   `body`: it may not appear to have its correct value.  Instead,
   ///   use only the `String.CharacterView` argument to `body`.
-  public mutating func withMutableCharacters<R>(body: (inout CharacterView)->R) -> R {
+  public mutating func withMutableCharacters<R>(body: (inout CharacterView) -> R) -> R {
     // Naively mutating self.characters forces multiple references to
     // exist at the point of mutation. Instead, temporarily move the
     // core of this string into a CharacterView.

--- a/test/1_stdlib/BridgeNonVerbatim.swift
+++ b/test/1_stdlib/BridgeNonVerbatim.swift
@@ -126,7 +126,7 @@ func testScope() {
 
   objects.withUnsafeMutableBufferPointer {
     // FIXME: Can't elide signature and use $0 here <rdar://problem/17770732> 
-    (inout buf: UnsafeMutableBufferPointer<Int>)->() in
+    (inout buf: UnsafeMutableBufferPointer<Int>) -> () in
     nsx.getObjects(
       UnsafeMutablePointer<AnyObject>(buf.baseAddress),
       range: _SwiftNSRange(location: 1, length: 2))

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -223,7 +223,7 @@ func checkFloatingPointComparison_${FloatSelf}(
   expected: ExpectedComparisonResult,
   _ lhs: ${FloatSelf}, _ rhs: ${FloatSelf},
   //===--- TRACE boilerplate ----------------------------------------------===//
-  // @autoclosure _ message: ()->String = "",
+  // @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = __FILE__, line: UInt = __LINE__

--- a/test/1_stdlib/Inputs/DictionaryKeyValueTypes.swift
+++ b/test/1_stdlib/Inputs/DictionaryKeyValueTypes.swift
@@ -791,7 +791,7 @@ func _checkArrayFastEnumerationImpl(
   expected: [Int],
   _ a: NSArray,
   _ makeEnumerator: () -> NSFastEnumeration,
-  _ useEnumerator: (NSArray, NSFastEnumeration, (AnyObject)->()) -> Void,
+  _ useEnumerator: (NSArray, NSFastEnumeration, (AnyObject) -> ()) -> Void,
   _ convertValue: (AnyObject) -> Int
 ) {
   let expectedContentsWithoutIdentity =
@@ -924,7 +924,7 @@ func _checkSetFastEnumerationImpl(
   expected: [Int],
   _ s: NSSet,
   _ makeEnumerator: () -> NSFastEnumeration,
-  _ useEnumerator: (NSSet, NSFastEnumeration, (AnyObject)->()) -> Void,
+  _ useEnumerator: (NSSet, NSFastEnumeration, (AnyObject) -> ()) -> Void,
   _ convertMember: (AnyObject) -> Int
 ) {
   let expectedContentsWithoutIdentity =
@@ -1142,7 +1142,7 @@ func _checkDictionaryFastEnumerationImpl(
   expected: [(Int, Int)],
   _ d: NSDictionary,
   _ makeEnumerator: () -> NSFastEnumeration,
-  _ useEnumerator: (NSDictionary, NSFastEnumeration, (AnyObjectTuple2)->()) -> Void,
+  _ useEnumerator: (NSDictionary, NSFastEnumeration, (AnyObjectTuple2) -> ()) -> Void,
   _ convertKey: (AnyObject) -> Int,
   _ convertValue: (AnyObject) -> Int
 ) {

--- a/test/1_stdlib/Lazy.swift.gyb
+++ b/test/1_stdlib/Lazy.swift.gyb
@@ -400,7 +400,7 @@ func expectSequencePassthrough<
     _ = s._copyToNativeArrayBuffer()
   }
   
-  SequenceLog._initializeTo.expectIncrement(baseType) { ()->Void in
+  SequenceLog._initializeTo.expectIncrement(baseType) { () -> Void in
     let buf = UnsafeMutablePointer<S.Generator.Element>.alloc(count)
   
     let end = s._initializeTo(buf)
@@ -486,7 +486,7 @@ tests.test("LazyMapSequence") {
 
   var calls = 0
   var mapped = base.map {
-    (x: OpaqueValue<Int>)->OpaqueValue<Double> in
+    (x: OpaqueValue<Int>) -> OpaqueValue<Double> in
     calls += 1
     return OpaqueValue(Double(x.value) / 2.0)
   }
@@ -528,7 +528,7 @@ tests.test("LazyMapCollection/${traversal}") {
 
   var calls = 0
   var mapped = base.map {
-    (x: OpaqueValue<Int>)->OpaqueValue<Double> in
+    (x: OpaqueValue<Int>) -> OpaqueValue<Double> in
     calls += 1
     return OpaqueValue(Double(x.value) / 2.0)
   }
@@ -635,7 +635,7 @@ tests.test("ReverseCollection/Lazy") {
     ExpectType<LazyReversedBase>.test(reversed)
     
     var calls = 0
-    let reversedAndMapped = reversed.map { (x)->Int in calls += 1; return x }
+    let reversedAndMapped = reversed.map { (x) -> Int in calls += 1; return x }
     expectEqual(0, calls)
     checkRandomAccessCollection(0...11, reversedAndMapped)
     expectNotEqual(0, calls)
@@ -657,7 +657,7 @@ tests.test("ReverseCollection/Lazy") {
     ExpectType<LazyReversedBase>.test(reversed)
     
     var calls = 0
-    let reversedAndMapped = reversed.map { (x)->Character in calls += 1; return x }
+    let reversedAndMapped = reversed.map { (x) -> Character in calls += 1; return x }
     expectEqual(0, calls)
     checkBidirectionalCollection("raboof".characters, reversedAndMapped)
     expectNotEqual(0, calls)

--- a/test/1_stdlib/ManagedBuffer.swift
+++ b/test/1_stdlib/ManagedBuffer.swift
@@ -95,7 +95,7 @@ final class TestManagedBuffer<T> : ManagedBuffer<CountAndCapacity,T> {
     let count = self.count
     
     withUnsafeMutablePointerToElements {
-      (x: UnsafeMutablePointer<T>)->() in
+      (x: UnsafeMutablePointer<T>) -> () in
       for i in 0.stride(to: count, by: 2) {
         (x + i).destroy()
       }
@@ -107,7 +107,7 @@ final class TestManagedBuffer<T> : ManagedBuffer<CountAndCapacity,T> {
     precondition(count + 2 <= capacity)
     
     withUnsafeMutablePointerToElements {
-      (p: UnsafeMutablePointer<T>)->() in
+      (p: UnsafeMutablePointer<T>) -> () in
       (p + count).initialize(x)
     }
     self.count = count + 2
@@ -118,7 +118,7 @@ class MyBuffer<T> {
   typealias Manager = ManagedBufferPointer<CountAndCapacity, T>
   deinit {
     Manager(unsafeBufferObject: self).withUnsafeMutablePointers {
-      (pointerToValue, pointerToElements)->Void in
+      (pointerToValue, pointerToElements) -> Void in
       pointerToElements.destroy(self.count)
       pointerToValue.destroy()
     }

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -259,9 +259,9 @@ NSStringAPIs.test("localizedCapitalizedString") {
 ///   executed in the given localeID
 func expectLocalizedEquality(
   expected: String,
-  _ op: (_: NSLocale?)->String,
+  _ op: (_: NSLocale?) -> String,
   _ localeID: String? = nil,
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = __FILE__, line: UInt = __LINE__
@@ -2143,7 +2143,7 @@ func getNullCString() -> UnsafeMutablePointer<CChar> {
   return nil
 }
 
-func getASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: ()->()) {
+func getASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
   let up = UnsafeMutablePointer<CChar>.alloc(100)
   up[0] = 0x61
   up[1] = 0x62
@@ -2151,7 +2151,7 @@ func getASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: ()->()) {
   return (up, { up.dealloc(100) })
 }
 
-func getNonASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: ()->()) {
+func getNonASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
   let up = UnsafeMutablePointer<UInt8>.alloc(100)
   up[0] = 0xd0
   up[1] = 0xb0
@@ -2162,7 +2162,7 @@ func getNonASCIICString() -> (UnsafeMutablePointer<CChar>, dealloc: ()->()) {
 }
 
 func getIllFormedUTF8String1(
-) -> (UnsafeMutablePointer<CChar>, dealloc: ()->()) {
+) -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
   let up = UnsafeMutablePointer<UInt8>.alloc(100)
   up[0] = 0x41
   up[1] = 0xed
@@ -2174,7 +2174,7 @@ func getIllFormedUTF8String1(
 }
 
 func getIllFormedUTF8String2(
-) -> (UnsafeMutablePointer<CChar>, dealloc: ()->()) {
+) -> (UnsafeMutablePointer<CChar>, dealloc: () -> ()) {
   let up = UnsafeMutablePointer<UInt8>.alloc(100)
   up[0] = 0x41
   up[1] = 0xed

--- a/test/1_stdlib/NewArray.swift.gyb
+++ b/test/1_stdlib/NewArray.swift.gyb
@@ -143,7 +143,7 @@ where T.Generator.Element == T._Buffer.Element,
   checkEqual(x, y, false)
 
   func checkReallocations(
-    a: T, _ growthDescription: String, _ growBy1: (inout _: T)->()
+    a: T, _ growthDescription: String, _ growBy1: (inout _: T) -> ()
   ) {
     var a = a
     var reallocations = 0
@@ -167,8 +167,8 @@ where T.Generator.Element == T._Buffer.Element,
     }
   }
 
-  checkReallocations(x, "append") { (inout x: T)->() in x.append(42) }
-  checkReallocations(x, "+=") { (inout x: T)->() in x.append(42) }
+  checkReallocations(x, "append") { (inout x: T) -> () in x.append(42) }
+  checkReallocations(x, "+=") { (inout x: T) -> () in x.append(42) }
   print("done.")
 }
 
@@ -270,7 +270,7 @@ func testCocoa() {
 
   // Prove that we create contiguous storage for an opaque NSArray
   a.withUnsafeBufferPointer {
-    (p)->() in
+    (p) -> () in
     print(p[0])
     // CHECK-NEXT: foo
   }
@@ -348,13 +348,13 @@ let testWidth = 11
 %arrayTypes = ['ContiguousArray', 'Array', 'ArraySlice']
 %for A in arrayTypes:
 
-func testReplace(make: ()->${A}<X>) {
+func testReplace(make: () -> ${A}<X>) {
 
   checkRangeReplaceable(make, { X(100)..<X(100 + $0) })
 }
 
 func testReplace${A}(
-  makeOne: ()->${A}<X> = {
+  makeOne: () -> ${A}<X> = {
     var x = ${A}<X>()
     // make sure some - but not all - replacements will have to grow the buffer
     x.reserveCapacity(testWidth * 3 / 2)

--- a/test/1_stdlib/Reflection.swift
+++ b/test/1_stdlib/Reflection.swift
@@ -173,7 +173,7 @@ print("\(intArrayMirror[0].0): \(intArrayMirror[0].1.summary)")
 // CHECK-NEXT: [4]: 5
 print("\(intArrayMirror[4].0): \(intArrayMirror[4].1.summary)")
 
-var justSomeFunction = { (x:Int)->Int in return x + 1 }
+var justSomeFunction = { (x:Int) -> Int in return x + 1 }
 // CHECK-NEXT: (Function)
 print(_reflect(justSomeFunction).summary)
 

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -238,11 +238,11 @@ Runtime.test("_isClassOrObjCExistential") {
   expectFalse(_isClassOrObjCExistential(SwiftObjectCanaryStruct.self))
   expectFalse(_isClassOrObjCExistential_Opaque(SwiftObjectCanaryStruct.self))
 
-  typealias SwiftClosure = ()->()
+  typealias SwiftClosure = () -> ()
   expectFalse(_isClassOrObjCExistential(SwiftClosure.self))
   expectFalse(_isClassOrObjCExistential_Opaque(SwiftClosure.self))
 
-  typealias ObjCClosure = @convention(block) ()->()
+  typealias ObjCClosure = @convention(block) () -> ()
   expectTrue(_isClassOrObjCExistential(ObjCClosure.self))
   expectTrue(_isClassOrObjCExistential_Opaque(ObjCClosure.self))
 
@@ -272,10 +272,10 @@ Runtime.test("_canBeClass") {
   expectEqual(1, _canBeClass(SwiftObjectCanary.self))
   expectEqual(0, _canBeClass(SwiftObjectCanaryStruct.self))
 
-  typealias SwiftClosure = ()->()
+  typealias SwiftClosure = () -> ()
   expectEqual(0, _canBeClass(SwiftClosure.self))
 
-  typealias ObjCClosure = @convention(block) ()->()
+  typealias ObjCClosure = @convention(block) () -> ()
   expectEqual(1, _canBeClass(ObjCClosure.self))
 
   expectEqual(1, _canBeClass(CFArray.self))

--- a/test/1_stdlib/SequenceWrapperTest.swift
+++ b/test/1_stdlib/SequenceWrapperTest.swift
@@ -27,11 +27,11 @@ let indirect = LoggingSequence(direct)
 let dispatchLog = base.log
 
 func expectWrapperDispatch<R1, R2>(
-  @autoclosure directOperation: ()->R1,
-  @autoclosure _ indirectOperation: ()->R2,
+  @autoclosure directOperation: () -> R1,
+  @autoclosure _ indirectOperation: () -> R2,
   _ counters: TypeIndexed<Int>,
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = __FILE__, line: UInt = __LINE__

--- a/test/1_stdlib/Unicode.swift
+++ b/test/1_stdlib/Unicode.swift
@@ -22,11 +22,11 @@ UnicodeInternals.test("copy") {
   var u16: [UTF16.CodeUnit] = [ 6, 7, 8, 9, 10, 11 ]
 
   u16.withUnsafeMutableBufferPointer {
-    (u16)->() in
+    (u16) -> () in
     let p16 = u16.baseAddress
 
     u8.withUnsafeMutableBufferPointer {
-      (u8)->() in
+      (u8) -> () in
       let p8 = u8.baseAddress
 
       UTF16._copy(p8, destination: p16, count: 3)

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -45,7 +45,7 @@ func foo() {
 
 // <rdar://problem/15536725>
 struct X3<T> {
-  init(_: (T)->()) {}
+  init(_: (T) -> ()) {}
 }
 
 func testX3(x: Int) {
@@ -104,40 +104,40 @@ func testMap() {
 
 
 // <rdar://problem/22333281> QoI: improve diagnostic when contextual type of closure disagrees with arguments
-var _: ()-> Int = {0}
+var _: () -> Int = {0}
 
 // expected-error @+1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{23-23=_ in }}
-var _: (Int)-> Int = {0}
+var _: (Int) -> Int = {0}
 
 // expected-error @+1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{23-23= _ in}}
-var _: (Int)-> Int = { 0 }
+var _: (Int) -> Int = { 0 }
 
 // expected-error @+1 {{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}} {{28-28=_,_ in }}
-var _: (Int, Int)-> Int = {0}
+var _: (Int, Int) -> Int = {0}
 
 // expected-error @+1 {{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 3 were used in closure body}}
-var _: (Int,Int)-> Int = {$0+$1+$2}
+var _: (Int,Int) -> Int = {$0+$1+$2}
 
 // expected-error @+1 {{contextual closure type '(Int, Int, Int) -> Int' expects 3 arguments, but 2 were used in closure body}}
-var _: (Int, Int, Int)-> Int = {$0+$1}
+var _: (Int, Int, Int) -> Int = {$0+$1}
 
 
-var _: ()-> Int = {a in 0}
+var _: () -> Int = {a in 0}
 
 // expected-error @+1 {{contextual closure type '(Int) -> Int' expects 1 argument, but 2 were used in closure body}}
-var _: (Int)-> Int = {a,b in 0}
+var _: (Int) -> Int = {a,b in 0}
 
 // expected-error @+1 {{contextual closure type '(Int) -> Int' expects 1 argument, but 3 were used in closure body}}
-var _: (Int)-> Int = {a,b,c in 0}
+var _: (Int) -> Int = {a,b,c in 0}
 
-var _: (Int, Int)-> Int = {a in 0}
+var _: (Int, Int) -> Int = {a in 0}
 
 // expected-error @+1 {{contextual closure type '(Int, Int, Int) -> Int' expects 3 arguments, but 2 were used in closure body}}
-var _: (Int, Int, Int)-> Int = {a, b in a+b}
+var _: (Int, Int, Int) -> Int = {a, b in a+b}
 
 // <rdar://problem/15998821> Fail to infer types for closure that takes an inout argument
 func r15998821() {
-  func take_closure(x : (inout Int)-> ()) { }
+  func take_closure(x : (inout Int) -> ()) { }
 
   func test1() {
     take_closure { (inout a : Int) in
@@ -159,7 +159,7 @@ func r15998821() {
 }
 
 // <rdar://problem/22602657> better diagnostics for closures w/o "in" clause
-var _: (Int,Int)-> Int = {$0+$1+$2}  // expected-error {{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 3 were used in closure body}}
+var _: (Int,Int) -> Int = {$0+$1+$2}  // expected-error {{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 3 were used in closure body}}
 
 
 // Crash when re-typechecking bodies of non-single expression closures

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -106,13 +106,13 @@ func testMap() {
 // <rdar://problem/22333281> QoI: improve diagnostic when contextual type of closure disagrees with arguments
 var _: () -> Int = {0}
 
-// expected-error @+1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{23-23=_ in }}
+// expected-error @+1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{24-24=_ in }}
 var _: (Int) -> Int = {0}
 
-// expected-error @+1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{23-23= _ in}}
+// expected-error @+1 {{contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored}} {{24-24= _ in}}
 var _: (Int) -> Int = { 0 }
 
-// expected-error @+1 {{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}} {{28-28=_,_ in }}
+// expected-error @+1 {{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}} {{29-29=_,_ in }}
 var _: (Int, Int) -> Int = {0}
 
 // expected-error @+1 {{contextual closure type '(Int, Int) -> Int' expects 2 arguments, but 3 were used in closure body}}

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -12,7 +12,7 @@ f1(f1(f))
 f2(f)
 f2(1.0)
 
-func call_lvalue(@autoclosure rhs: ()->Bool) -> Bool {
+func call_lvalue(@autoclosure rhs: () -> Bool) -> Bool {
   return rhs()
 }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -142,12 +142,12 @@ func test16078944 <T: ForwardIndexType>(lhs: T, args: T) -> Int {
 class r22409190ManagedBuffer<Value, Element> {
   final var value: Value { get {} set {}}
   func withUnsafeMutablePointerToElements<R>(
-    body: (UnsafeMutablePointer<Element>)->R) -> R {
+    body: (UnsafeMutablePointer<Element>) -> R) -> R {
   }
 }
 class MyArrayBuffer<Element>: r22409190ManagedBuffer<UInt, Element> {
   deinit {
-    self.withUnsafeMutablePointerToElements { elems->Void in
+    self.withUnsafeMutablePointerToElements { elems -> Void in
       elems.destroy(self.value)  // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Int'}}
     }
   }

--- a/test/Constraints/invalid_logicvalue_coercion.swift
+++ b/test/Constraints/invalid_logicvalue_coercion.swift
@@ -5,5 +5,5 @@ var c = C()
 if c as C { // expected-error{{type 'C' does not conform to protocol 'BooleanType'}}
 }
 
-if ({1} as ()->Int) { // expected-error{{type '() -> Int' does not conform to protocol 'BooleanType'}}
+if ({1} as () -> Int) { // expected-error{{type '() -> Int' does not conform to protocol 'BooleanType'}}
 }

--- a/test/DebugInfo/autoclosure.swift
+++ b/test/DebugInfo/autoclosure.swift
@@ -17,7 +17,7 @@ infix operator &&&&& {
   precedence 120
 }
 
-func &&&&&(lhs: BooleanType, @autoclosure rhs: ()->BooleanType) -> Bool {
+func &&&&&(lhs: BooleanType, @autoclosure rhs: () -> BooleanType) -> Bool {
   return lhs.boolValue ? rhs().boolValue : false
 }
 

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -45,7 +45,7 @@ struct Wrapper<T: AProtocol> {
 }
 
 // CHECK: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+1]], type: !"_TtFQq_F12generic_args5applyu0_rFTx1fFxq__q_Qq0_F12generic_args5applyu0_rFTx1fFxq__q_")
-func apply<T, U> (x: T, f: (T)->(U)) -> U {
+func apply<T, U> (x: T, f: (T) -> (U)) -> U {
   return f(x)
 }
 

--- a/test/Generics/algorithms.swift
+++ b/test/Generics/algorithms.swift
@@ -80,7 +80,7 @@ func equal<R1 : GeneratorType, R2 : GeneratorType where R1.Element : Eq,
 
 func equalIf<R1 : GeneratorType, R2 : GeneratorType>
        (range1 : R1, range2 : R2,
-        predicate : (R1.Element, R2.Element)-> Bool) -> Bool {
+        predicate : (R1.Element, R2.Element) -> Bool) -> Bool {
   var range1 = range1
   var range2 = range2
   var e1 = range1.next()

--- a/test/Generics/associated_self_constraints.swift
+++ b/test/Generics/associated_self_constraints.swift
@@ -78,5 +78,5 @@ struct IP<T> : P {
 
     func onNext(item: A) { _onNext(item) }
 
-    var _onNext: (A)->()
+    var _onNext: (A) -> ()
 }

--- a/test/Generics/materializable_restrictions.swift
+++ b/test/Generics/materializable_restrictions.swift
@@ -15,10 +15,10 @@ func test20807269() {
 func test15921530() {
     struct X {}
 
-    func makef<T>() -> (T)->() { // expected-note {{in call to function 'makef'}}
+    func makef<T>() -> (T) -> () { // expected-note {{in call to function 'makef'}}
       return {
         x in ()
       }
     }
-    var _: (inout X)->() = makef() // expected-error{{generic parameter 'T' could not be inferred}}
+    var _: (inout X) -> () = makef() // expected-error{{generic parameter 'T' could not be inferred}}
 }

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -48,7 +48,7 @@ struct SatisfySameTypeAssocTypeRequirementDependent<T>
 public struct GeneratorOf<T> : GeneratorType, SequenceType {
 
   /// Construct an instance whose `next()` method calls `nextElement`.
-  public init(_ nextElement: ()->T?) {
+  public init(_ nextElement: () -> T?) {
     self._next = nextElement
   }
   
@@ -74,7 +74,7 @@ public struct GeneratorOf<T> : GeneratorType, SequenceType {
   public func generate() -> GeneratorOf {
     return self
   }
-  let _next: ()->T?
+  let _next: () -> T?
 }
 
 // rdar://problem/19009056
@@ -105,7 +105,7 @@ public final class IterateGenerator<A> : GeneratorType {
 // rdar://problem/18475138
 public protocol Observable : class {
     typealias Output
-    func addObserver(obj : Output->Void)
+    func addObserver(obj : Output -> Void)
 }
 
 public protocol Bindable : class {
@@ -174,7 +174,7 @@ class Cow : Animal {
 
 struct SpecificAnimal<F:Food> : Animal {
     typealias EdibleFood=F
-    let _eat:(f:F)->()
+    let _eat:(f:F) -> ()
 
     init<A:Animal where A.EdibleFood == F>(_ selfie:A) {
         _eat = { selfie.eat($0) }

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -429,9 +429,9 @@ func emptyDocBlockComment3() {}
 
 
 /**/
-func malformedBlockComment(f : ()throws->()) rethrows {}
+func malformedBlockComment(f : () throws -> ()) rethrows {}
 // CHECK: <doc-comment-block>/**/</doc-comment-block>
-// CHECK: <kw>func</kw> malformedBlockComment(f : ()<kw>throws</kw>->()) <attr-builtin>rethrows</attr-builtin> {}
+// CHECK: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <attr-builtin>rethrows</attr-builtin> {}
 
 
 "--\"\(x) --"

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -313,7 +313,7 @@ struct LazyVar3 {
 }
 
 func closureTaker(theFunc:(theValue:Int) -> ()) {}
-func closureTaker2(theFunc: (Value1:Int, Value2:Int) ->()) {}
+func closureTaker2(theFunc: (Value1:Int, Value2:Int) -> ()) {}
 func testClosureParam1() {
   closureTaker { (theValue) -> () in
     #^CLOSURE_PARAM_1^#

--- a/test/IDE/print_module_without_deinit.swift
+++ b/test/IDE/print_module_without_deinit.swift
@@ -39,7 +39,7 @@ public class ImplicitOptionalInitContainer {
 // ATTR1: class AttributeContainer1 {
 public class AttributeContainer1 {
   // ATTR1: func m1(@autoclosure a: () -> Int)
-  public func m1(@autoclosure a : ()->Int) {}
+  public func m1(@autoclosure a : () -> Int) {}
   // ATTR1: func m2(@noescape a: () -> Int)
-  public func m2(@noescape a : ()->Int) {}
+  public func m2(@noescape a : () -> Int) {}
 }

--- a/test/IRGen/mangle-anonclosure.swift
+++ b/test/IRGen/mangle-anonclosure.swift
@@ -4,7 +4,7 @@ import Swift
 
 class HeapStorage<Value, Element> {
   public final func withUnsafeMutablePointerToElements<R>(
-    body: (UnsafeMutablePointer<Element>)->R
+    body: (UnsafeMutablePointer<Element>) -> R
   ) -> R { return body(UnsafeMutablePointer<Element>()) }
 }
 struct CountAndCapacity {}
@@ -14,7 +14,7 @@ class TestHeapStorage<T> : HeapStorage<CountAndCapacity,T> {
       // Don't crash when mangling this closure's name.
       // CHECK: _TFFC4main15TestHeapStoragedU_FGSpQ__T_
       //         ---> main.TestHeapStorage.deinit.(closure #1)
-      (p: UnsafeMutablePointer<T>)->() in
+      (p: UnsafeMutablePointer<T>) -> () in
     }
   }
 }

--- a/test/Interpreter/closures.swift
+++ b/test/Interpreter/closures.swift
@@ -35,11 +35,11 @@ func test() {
 test()
 
 // <rdar://problem/19776288>
-func map<T>(fn: T->()) {
+func map<T>(fn: T -> ()) {
     print("Void overload")
 }
 
-func map<T,U>(fn: T->U) {
+func map<T,U>(fn: T -> U) {
     print("Non-void overload")
 }
 

--- a/test/Interpreter/generics.swift
+++ b/test/Interpreter/generics.swift
@@ -108,7 +108,7 @@ class D1 : Base {
     }
 }
 
-func parse<T:Base>()->T {
+func parse<T:Base>() -> T {
     let inst = T()
     inst.map()
     return inst

--- a/test/Interpreter/optional.swift
+++ b/test/Interpreter/optional.swift
@@ -9,7 +9,7 @@ class B : A {
 }
 
 func printA(v: A) { v.printA() }
-func printOpt<T>(subprint: T->())(x: T?) {
+func printOpt<T>(subprint: T -> ())(x: T?) {
   switch (x) {
   case .Some(let y): print(".Some(", terminator: ""); subprint(y); print(")", terminator: "")
   case .None: print(".None", terminator: "")

--- a/test/Misc/Inputs/dumped_api.swift
+++ b/test/Misc/Inputs/dumped_api.swift
@@ -14,7 +14,7 @@ public class _AnyGeneratorBase {
 ///
 ///     struct AnySequence<S: SequenceType>
 ///     func anyGenerator<G: GeneratorType>(base: G) -> AnyGenerator<G.Element>
-///     func anyGenerator<T>(nextImplementation: ()->T?) -> AnyGenerator<T>
+///     func anyGenerator<T>(nextImplementation: () -> T?) -> AnyGenerator<T>
 public class AnyGenerator<T> : _AnyGeneratorBase, GeneratorType {
   /// Initialize the instance.  May only be called from a subclass
   /// initializer.

--- a/test/Misc/dump_api.swift
+++ b/test/Misc/dump_api.swift
@@ -15,7 +15,7 @@ public class _AnyGeneratorBase {}
 ///
 ///     struct AnySequence<S: SequenceType>
 ///     func anyGenerator<G: GeneratorType>(base: G) -> AnyGenerator<G.Element>
-///     func anyGenerator<T>(nextImplementation: ()->T?) -> AnyGenerator<T>
+///     func anyGenerator<T>(nextImplementation: () -> T?) -> AnyGenerator<T>
 public class AnyGenerator<T> : _AnyGeneratorBase, GeneratorType {
   /// Initialize the instance.  May only be called from a subclass
   /// initializer.

--- a/test/Misc/single_expr_closure_conversion.swift
+++ b/test/Misc/single_expr_closure_conversion.swift
@@ -32,7 +32,7 @@ withBlob { stmt.bind(["1": 1, "2": 2.0, "3": "3", "4": $0]) }
 // <rdar://problem/19840785>
 // We shouldn't crash on the call to 'a.dispatch' below.
 class A {
-	func dispatch(f : ()-> Void) {
+	func dispatch(f : () -> Void) {
 		f()
 	}
 }

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 func statement_starts() {
-  var f : Int-> ()
+  var f : Int -> ()
   f = { (x : Int) -> () in }
 
   f(0)

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -92,8 +92,8 @@ func rethrowsDispatchError(handleError: ((ErrorType) throws -> ()), body: () thr
 
 // <rdar://problem/21432429> Calling rethrows from rethrows crashes Swift compiler
 struct r21432429 {
-  func x(f: () throws ->()) rethrows {}
-  func y(f: () throws ->()) rethrows {
+  func x(f: () throws -> ()) rethrows {}
+  func y(f: () throws -> ()) rethrows {
     x(f)  // expected-error {{call can throw but is not marked with 'try'}} expected-note {{call is to 'rethrows' function, but argument function can throw}}
   }
 }

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -105,7 +105,7 @@ infix operator &>>= { associativity right precedence 90 assignment }
 @_transparent
 public func _assertCond(
   @autoclosure condition: () -> Bool,
-  @autoclosure _ message: ()->String,
+  @autoclosure _ message: () -> String,
   file: StaticString = __FILE__, line: UInt = __LINE__) {
   let ok = condition()
   if _isDebugAssertConfiguration() {

--- a/test/Prototypes/Result.swift
+++ b/test/Prototypes/Result.swift
@@ -24,14 +24,14 @@ case Error(ErrorType)
     self = Error(error)
   }
   
-  func map<U>(@noescape transform: (Value)->U) -> Result<U> {
+  func map<U>(@noescape transform: (Value) -> U) -> Result<U> {
     switch self {
     case Success(let x): return .Success(transform(x))
     case Error(let e): return .Error(e)
     }
   }
 
-  func flatMap<U>(@noescape transform: (Value)->Result<U>) -> Result<U> {
+  func flatMap<U>(@noescape transform: (Value) -> Result<U>) -> Result<U> {
     switch self {
     case Success(let x): return transform(x)
     case Error(let e): return .Error(e)

--- a/test/SILGen/apply_abstraction_nested.swift
+++ b/test/SILGen/apply_abstraction_nested.swift
@@ -9,8 +9,8 @@ func baz<T:P>(inout _: T)(_:Int) {}
 
 func ~> <T: P, Args, Result>(
   inout x: T,
-  m: (inout x: T)->((Args)->Result)
-) -> (Args->Result) {
+  m: (inout x: T) -> ((Args) -> Result)
+) -> (Args -> Result) {
   return m(x: &x)
 }
 

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -506,7 +506,7 @@ func return_generic_tuple()
 @noreturn func testNoReturnAttrPoly<T>(x: T) -> () {}
 
 // CHECK-LABEL: sil hidden @_TF9functions21testNoReturnAttrParam{{.*}} : $@convention(thin) (@owned @noreturn @callee_owned () -> ()) -> ()
-func testNoReturnAttrParam(fptr: @noreturn ()->()) -> () {}
+func testNoReturnAttrParam(fptr: @noreturn () -> ()) -> () {}
 
 // CHECK-LABEL: sil hidden [transparent] @_TF9functions15testTransparent{{.*}} : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
 @_transparent func testTransparent(x: Bool) -> Bool {

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
 
-func foo(f f: (()->())!) {
+func foo(f f: (() -> ())!) {
   var f = f
   f?()
 }

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -42,7 +42,7 @@ func staticMetatypeFromGeneric(x: Generic<S.Type>) -> S.Type {
 // CHECK:         [[META:%.*]] = load [[ADDR]] : $*@thick T.Type
 // CHECK:         return [[META]] : $@thick T.Type
 // CHECK:       }
-func genericMetatypeFromGenericMetatype<T>(x: GenericMetatype<T>)-> T.Type {
+func genericMetatypeFromGenericMetatype<T>(x: GenericMetatype<T>) -> T.Type {
   var x = x
   return x.value
 }

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
 
-func testCall(f: (()->())?) {
+func testCall(f: (() -> ())?) {
   f?()
 }
 // CHECK:    sil hidden @{{.*}}testCall{{.*}}
@@ -23,7 +23,7 @@ func testCall(f: (()->())?) {
 // CHECK-NEXT: enum $Optional<()>, #Optional.None!enumelt
 // CHECK-NEXT: br bb2
 
-func testAddrOnlyCallResult<T>(f: (()->T)?) {
+func testAddrOnlyCallResult<T>(f: (() -> T)?) {
   var f = f
   var x = f?()
 }

--- a/test/SILGen/transparent_attribute.swift
+++ b/test/SILGen/transparent_attribute.swift
@@ -6,7 +6,7 @@
 @_transparent func transparentFuncWithDefaultArgument (x: Int = 1) -> Int {
   return x
 }
-func useTransparentFuncWithDefaultArgument() ->Int {
+func useTransparentFuncWithDefaultArgument() -> Int {
   return transparentFuncWithDefaultArgument();
 
   // CHECK-LABEL: sil hidden @_TF21transparent_attribute37useTransparentFuncWithDefaultArgumentFT_Si

--- a/test/SILOptimizer/allocbox_to_stack_with_false.swift
+++ b/test/SILOptimizer/allocbox_to_stack_with_false.swift
@@ -16,11 +16,11 @@ func g() {
 infix operator ~> { precedence 255 }
 protocol Target {}
 
-func ~> <Target, Arg0, Result>(inout x: Target, f: (inout _: Target, _: Arg0)->Result) -> (Arg0)->Result {
+func ~> <Target, Arg0, Result>(inout x: Target, f: (inout _: Target, _: Arg0) -> Result) -> (Arg0) -> Result {
   return { f(&x, $0) }
 }
 
-func ~> (inout x: Int, f: (inout _: Int, _: Target)->Target) -> (Target)->Target {
+func ~> (inout x: Int, f: (inout _: Int, _: Target) -> Target) -> (Target) -> Target {
   return { f(&x, $0) }
 }
 

--- a/test/SILOptimizer/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/closure_specialize_consolidated.sil
@@ -262,7 +262,7 @@ bb0(%0 : $Builtin.Int32):
   unreachable
 }
 
-sil hidden [fragile] @thunk : $@convention(thin) (@out (), @owned @callee_owned ()->()) -> () {
+sil hidden [fragile] @thunk : $@convention(thin) (@out (), @owned @callee_owned () -> ()) -> () {
 bb0(%0 : $*(), %1 : $@callee_owned () -> ()):
   apply %1() : $@callee_owned () -> ()
   %9999 = tuple()

--- a/test/SILOptimizer/devirt_default_case.swift
+++ b/test/SILOptimizer/devirt_default_case.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -O -module-name devirt_default_case -emit-sil -enable-testing %s | FileCheck -check-prefix=CHECK -check-prefix=CHECK-TESTABLE %s
 
 @_silgen_name("action")
-func action(n:Int)->()
+func action(n:Int) -> ()
 
 // public class
 public class Base1 {
@@ -206,7 +206,7 @@ public class M {
 
 public class M1: M {
   @inline(never)
-  override func foo()->Int32 {
+  override func foo() -> Int32 {
     return 1
   }
 }

--- a/test/SILOptimizer/devirt_inherited_conformance.swift
+++ b/test/SILOptimizer/devirt_inherited_conformance.swift
@@ -114,7 +114,7 @@ infix operator --- { associativity left precedence 140 }
 public protocol Simple {
    func foo(_: Self) -> Bool
    func boo(_: Self, _: Self) -> Bool
-   func ---(_: Self, _: Self)->Bool
+   func ---(_: Self, _: Self) -> Bool
 }
 
 public class C: Equatable, Comparable, Simple {

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | FileCheck %s
 
 public protocol Foo { 
-  func foo(x:Int)->Int
+  func foo(x:Int) -> Int
 }
 
 public extension Foo {
@@ -25,17 +25,17 @@ public class C : Foo {
 }
 
 @_transparent
-func callfoo(f: Foo)->Int {
+func callfoo(f: Foo) -> Int {
   return f.foo(2) + f.foo(2)
 }
 
 @_transparent
-func callboo(f: Foo)->Int32 {
+func callboo(f: Foo) -> Int32 {
   return f.boo(2) + f.boo(2)
 }
 
 @_transparent
-func callGetSelf(f: Foo)->Foo {
+func callGetSelf(f: Foo) -> Foo {
   return f.getSelf()
 }
 
@@ -64,7 +64,7 @@ func callGetSelf(f: Foo)->Foo {
 // CHECK: apply
 // CHECK: br bb1(
 @inline(never)
-public func test_devirt_protocol_method_invocation(c: C)->Int {
+public func test_devirt_protocol_method_invocation(c: C) -> Int {
   return callfoo(c)
 }
 
@@ -84,7 +84,7 @@ public func test_devirt_protocol_method_invocation(c: C)->Int {
 // CHECK: integer_literal
 // CHECK: return
 @inline(never)
-public func test_devirt_protocol_extension_method_invocation(c: C)->Int32 {
+public func test_devirt_protocol_extension_method_invocation(c: C) -> Int32 {
   return callboo(c)
 }
 

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -329,7 +329,7 @@ func add<T : SignedIntegerType>(left: T, _ right: T) -> T {
 }
 
 @_transparent
-func applyBinary<T : SignedIntegerType>(fn: (T, T)->(T), _ left: T, _ right: T) -> T {
+func applyBinary<T : SignedIntegerType>(fn: (T, T) -> (T), _ left: T, _ right: T) -> T {
   return fn(left, right)
 }
 

--- a/test/SILOptimizer/let_propagation.swift
+++ b/test/SILOptimizer/let_propagation.swift
@@ -295,7 +295,7 @@ final public class S3 {
 // DISABLECHECK: load %[[X]]
 // DISABLECHECK-NOT: load %[[X]]
 // DISABLECHECK: return
-public func testLetTuple(s: S3) ->Int32 {
+public func testLetTuple(s: S3) -> Int32 {
   var counter: Int32 = 0
   counter += s.x.0
   action()
@@ -318,7 +318,7 @@ public func testLetTuple(s: S3) ->Int32 {
 // CHECK: load %[[X]]
 // CHECK: load %[[X]]
 // CHECK: return
-public func testVarTuple(s: S3) ->Int32 {
+public func testVarTuple(s: S3) -> Int32 {
   var counter: Int32 = 0
   counter += s.y.0
   action()

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -112,7 +112,7 @@ infix operator ||| {
   precedence 110
 }
 
-@_transparent func &&& (lhs: Bool, @autoclosure rhs: ()->Bool) -> Bool {
+@_transparent func &&& (lhs: Bool, @autoclosure rhs: () -> Bool) -> Bool {
   if lhs {
     return rhs()
   }
@@ -120,7 +120,7 @@ infix operator ||| {
   return false
 }
 
-@_transparent func ||| (lhs: Bool, @autoclosure rhs: ()->Bool) -> Bool {
+@_transparent func ||| (lhs: Bool, @autoclosure rhs: () -> Bool) -> Bool {
   if lhs {
     return true
   }

--- a/test/SILOptimizer/peephole_trunc_and_ext.sil
+++ b/test/SILOptimizer/peephole_trunc_and_ext.sil
@@ -288,7 +288,7 @@ bb0:
 
 
 // sizeof is known to return strictly positive values
-// But Word->Int64 is not a safe conversion
+// But Word ->Int64 is not a safe conversion
 // No peephole for UInt16(UInt32(sizeof(Int)))
 // CHECK-LABEL: sil @_TF4test35test_int16_trunc_s_to_u_zext_sizeofFT_Vs6UInt16 : $@convention(thin) () -> UInt16
 // CHECK: builtin "zextOrBitCast_Word_Int64"

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -35,7 +35,7 @@ func multipleBlocksAllMissing(x: Int) -> Int {
 @noreturn func MYsubscriptNonASCII(idx: Int) -> UnicodeScalar {
 } // no-warning
 
-@noreturn @_silgen_name("exit") func exit ()->()
+@noreturn @_silgen_name("exit") func exit () -> ()
 @noreturn func tryingToReturn (x: Bool) -> () {
   if x {
     return // expected-error {{return from a 'noreturn' function}}

--- a/test/SILOptimizer/sil_combine_enums.sil
+++ b/test/SILOptimizer/sil_combine_enums.sil
@@ -82,8 +82,8 @@ bb1:
 bb2:
   // Invoke something here and jump to bb1. This prevents an cond_br(select_enum) -> switch_enum conversion,
   // since it would introduce a critical edge.
-  %20 = function_ref @external_func: $@convention(thin) ()->()
-  apply %20(): $@convention(thin) ()->()
+  %20 = function_ref @external_func: $@convention(thin) () -> ()
+  apply %20(): $@convention(thin) () -> ()
   br bb1
 }
 
@@ -201,8 +201,8 @@ bb1:
   return %7 : $Int
 
 bb2:
-  %10 = function_ref @external_func: $@convention(thin) ()->()
-  apply %10(): $@convention(thin) ()->()
+  %10 = function_ref @external_func: $@convention(thin) () -> ()
+  apply %10(): $@convention(thin) () -> ()
   br bb1
 }
 

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -380,7 +380,7 @@ bb4(%6 : $Int64):
 // CHECK: return
 // CHECK: }
 
-sil @external_f : $@convention(thin) ()->()
+sil @external_f : $@convention(thin) () -> ()
 
 sil @elim_trampoline4 : $@convention(thin) (Builtin.Int1, Int64, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64, %2 : $Int64):
@@ -393,8 +393,8 @@ bb2:
   br bb4(%2 : $Int64)
   
 bb4(%4 : $Int64):
-  %55 = function_ref @external_f : $@convention(thin) ()->()
-  apply %55() : $@convention(thin) ()->()
+  %55 = function_ref @external_f : $@convention(thin) () -> ()
+  apply %55() : $@convention(thin) () -> ()
   br bb5(%4: $Int64)
 
 bb3(%5 : $Int64):
@@ -473,15 +473,15 @@ bb4(%6 : $Int64):
 // CHECK-NEXT: return %1
 sil @elim_common_arg : $@convention(thin) (Builtin.Int1, Int64) -> Int64 {
 bb0(%0 : $Builtin.Int1, %1 : $Int64):
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   cond_br %0, bb1, bb2
 
 bb1:
-  apply %f1() : $@convention(thin) ()->()
+  apply %f1() : $@convention(thin) () -> ()
   br bb3(%1 : $Int64)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->()
+  apply %f1() : $@convention(thin) () -> ()
   br bb3(%1 : $Int64)
   
 bb3(%a1 : $Int64):
@@ -668,11 +668,11 @@ sil @cannot_optimize_switch_enum : $@convention(thin) (A) -> () {
 bb0(%0 : $A):
 // CHECK: %1 = function_ref
 // CHECK-NEXT: switch_enum %0 : $A, case #A.B!enumelt: bb1, default [[BB:bb[0-9a-zA-Z]+]]
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   switch_enum %0 : $A, case #A.B!enumelt: bb1, default bb2
 
 bb1:
-  apply %f1() : $@convention(thin) ()->()
+  apply %f1() : $@convention(thin) () -> ()
   br bb5
 
 // CHECK: [[BB]]
@@ -681,11 +681,11 @@ bb2:
   switch_enum %0 : $A, case #A.C!enumelt: bb3, default bb4
 
 bb3:
-  apply %f1() : $@convention(thin) ()->()
+  apply %f1() : $@convention(thin) () -> ()
   br bb5
 
 bb4:
-  apply %f1() : $@convention(thin) ()->()
+  apply %f1() : $@convention(thin) () -> ()
   br bb5
 
 bb5:
@@ -1546,8 +1546,8 @@ bb1:
 bb2:
   // Make bb1 not dominated from bb0 to prevent that dominator based
   // simplification does the same thing.
-  %55 = function_ref @external_f : $@convention(thin) ()->()
-  apply %55() : $@convention(thin) ()->()
+  %55 = function_ref @external_f : $@convention(thin) () -> ()
+  apply %55() : $@convention(thin) () -> ()
   cond_br %1, bb1, bb3
 bb3:
   %2 = tuple()
@@ -1573,8 +1573,8 @@ bb1:
 bb2:
   // Make bb1 not dominated from bb0 to prevent that dominator based
   // simplification does the same thing.
-  %55 = function_ref @external_f : $@convention(thin) ()->()
-  apply %55() : $@convention(thin) ()->()
+  %55 = function_ref @external_f : $@convention(thin) () -> ()
+  apply %55() : $@convention(thin) () -> ()
   cond_br %1, bb1, bb3
 bb3:
   %2 = tuple()
@@ -1598,8 +1598,8 @@ bb1:
 bb2:
   // Make bb1 not dominated from bb0 to prevent that dominator based
   // simplification does the same thing.
-  %55 = function_ref @external_f : $@convention(thin) ()->()
-  apply %55() : $@convention(thin) ()->()
+  %55 = function_ref @external_f : $@convention(thin) () -> ()
+  apply %55() : $@convention(thin) () -> ()
   cond_br %1, bb1, bb3
 bb3:
   %2 = tuple()
@@ -1620,8 +1620,8 @@ bb1:
   unreachable
 bb2:
   // Make bb1 not dominated from bb0.
-  %55 = function_ref @external_f : $@convention(thin) ()->()
-  apply %55() : $@convention(thin) ()->()
+  %55 = function_ref @external_f : $@convention(thin) () -> ()
+  apply %55() : $@convention(thin) () -> ()
   cond_br %1, bb1, bb3
 bb3:
   %2 = tuple()
@@ -1643,16 +1643,16 @@ bb3:
 // CHECK:        return
 sil @move_cond_fail : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   cond_br %0, bb2, bb1
 
 bb1:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   %i1 = integer_literal $Builtin.Int1, -1
   br bb3(%i1 : $Builtin.Int1)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%1 : $Builtin.Int1)
 
 bb3(%a3 : $Builtin.Int1):
@@ -1680,15 +1680,15 @@ bb3(%a3 : $Builtin.Int1):
 sil @move_cond_fail_inverted : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   %2 = integer_literal $Builtin.Int1, -1
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   cond_br %0, bb2, bb1
 
 bb1:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%2 : $Builtin.Int1)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%1 : $Builtin.Int1)
 
 bb3(%a3 : $Builtin.Int1):
@@ -1709,15 +1709,15 @@ bb3(%a3 : $Builtin.Int1):
 // CHECK-NEXT:   cond_fail
 sil @dont_move_cond_fail_no_const : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1, %2 : $Builtin.Int1):
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   cond_br %0, bb2, bb1
 
 bb1:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%1 : $Builtin.Int1)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%2 : $Builtin.Int1)
 
 bb3(%a3 : $Builtin.Int1):
@@ -1741,20 +1741,20 @@ bb3(%a3 : $Builtin.Int1):
 // CHECK-NEXT:   cond_fail
 sil @dont_move_cond_fail_no_postdom : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1, %2 : $Builtin.Int1):
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   cond_br %0, bb2, bb1
 
 bb1:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   %i1 = integer_literal $Builtin.Int1, -1
   br bb3(%i1 : $Builtin.Int1)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   cond_br %2, bb3(%1 : $Builtin.Int1), bb4
 
 bb3(%a3 : $Builtin.Int1):
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   cond_fail %a3 : $Builtin.Int1
   br bb4
 
@@ -1775,16 +1775,16 @@ bb4:
 // CHECK-NEXT:   cond_fail
 sil @dont_move_cond_fail_multiple_uses : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   cond_br %0, bb2, bb1
 
 bb1:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   %i1 = integer_literal $Builtin.Int1, -1
   br bb3(%i1 : $Builtin.Int1)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%1 : $Builtin.Int1)
 
 bb3(%a3 : $Builtin.Int1):
@@ -1805,16 +1805,16 @@ bb3(%a3 : $Builtin.Int1):
 // CHECK-NEXT:   return
 sil @dont_move_cond_fail_multiple_uses2 : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
-  %f1 = function_ref @external_f : $@convention(thin) ()->()
+  %f1 = function_ref @external_f : $@convention(thin) () -> ()
   %i1 = integer_literal $Builtin.Int1, -1
   cond_br %0, bb2, bb1
 
 bb1:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%i1 : $Builtin.Int1)
 
 bb2:
-  apply %f1() : $@convention(thin) ()->() // prevent other CFG optimizations
+  apply %f1() : $@convention(thin) () -> () // prevent other CFG optimizations
   br bb3(%1 : $Builtin.Int1)
 
 bb3(%a3 : $Builtin.Int1):
@@ -1921,7 +1921,7 @@ bb4:
   return %41 : $()
 }
 
-sil @f_use : $@convention(thin) (Builtin.Int32)->()
+sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 
 // CHECK-LABEL: sil @switch_enum_jumpthreading_bug
 // CHECK: bb1:
@@ -1962,8 +1962,8 @@ bb4:
  unreachable
 
 bb5(%9 : $Builtin.Int32):
-  %f = function_ref @f_use : $@convention(thin) (Builtin.Int32)->()
-  %a = apply %f(%10) : $@convention(thin) (Builtin.Int32)->()
+  %f = function_ref @f_use : $@convention(thin) (Builtin.Int32) -> ()
+  %a = apply %f(%10) : $@convention(thin) (Builtin.Int32) -> ()
   cond_br %3, bb6, bb10
 
 bb6:
@@ -1977,10 +1977,10 @@ bb11(%100 : $Builtin.Int32):
   return %100 : $Builtin.Int32
 }
 
-sil @a : $@convention(thin) ()->()
-sil @b : $@convention(thin) ()->()
-sil @c : $@convention(thin) ()->()
-sil @d : $@convention(thin) ()->()
+sil @a : $@convention(thin) () -> ()
+sil @b : $@convention(thin) () -> ()
+sil @c : $@convention(thin) () -> ()
+sil @d : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil @jump_thread_diamond
 // CHECK: bb1:
@@ -2105,8 +2105,8 @@ bb10:
   return %21 : $()
 }
 
-sil @fB : $@convention(thin) ()->()
-sil @fC : $@convention(thin) ()->()
+sil @fB : $@convention(thin) () -> ()
+sil @fC : $@convention(thin) () -> ()
 
 
 // Make sure that we correctly thread such that we end up calling @fB on the

--- a/test/SILOptimizer/simplify_cfg_and_combine.sil
+++ b/test/SILOptimizer/simplify_cfg_and_combine.sil
@@ -7,10 +7,10 @@ sil_stage canonical
 import Builtin
 import Swift
 
-sil @external_f1 : $@convention(thin) ()->()
-sil @external_f2 : $@convention(thin) ()->()
-sil @external_f3 : $@convention(thin) ()->()
-sil @external_f4 : $@convention(thin) ()->()
+sil @external_f1 : $@convention(thin) () -> ()
+sil @external_f2 : $@convention(thin) () -> ()
+sil @external_f3 : $@convention(thin) () -> ()
+sil @external_f4 : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil @select_enum_dominance_simplification : $@convention(thin) (Optional<Int32>) -> () {
 // CHECK-NOT: external_f2
@@ -34,23 +34,23 @@ bb2:
   cond_br %3, bb5, bb6
 
 bb3:
-  %f1 = function_ref @external_f1 : $@convention(thin) ()->()
-  apply %f1() : $@convention(thin) ()->()
+  %f1 = function_ref @external_f1 : $@convention(thin) () -> ()
+  apply %f1() : $@convention(thin) () -> ()
   br bb7
 
 bb4:
-  %f2 = function_ref @external_f2 : $@convention(thin) ()->()
-  apply %f2() : $@convention(thin) ()->()
+  %f2 = function_ref @external_f2 : $@convention(thin) () -> ()
+  apply %f2() : $@convention(thin) () -> ()
   br bb7
 
 bb5:
-  %f3 = function_ref @external_f3 : $@convention(thin) ()->()
-  apply %f3() : $@convention(thin) ()->()
+  %f3 = function_ref @external_f3 : $@convention(thin) () -> ()
+  apply %f3() : $@convention(thin) () -> ()
   br bb7
 
 bb6:
-  %f4 = function_ref @external_f4 : $@convention(thin) ()->()
-  apply %f4() : $@convention(thin) ()->()
+  %f4 = function_ref @external_f4 : $@convention(thin) () -> ()
+  apply %f4() : $@convention(thin) () -> ()
   br bb7
 
 bb7:
@@ -74,18 +74,18 @@ bb1:
   cond_br %c, bb2, bb3
 
 bb2:
-  %f1 = function_ref @external_f1 : $@convention(thin) ()->()
-  apply %f1() : $@convention(thin) ()->()
+  %f1 = function_ref @external_f1 : $@convention(thin) () -> ()
+  apply %f1() : $@convention(thin) () -> ()
   br bb5
 
 bb3:
-  %f2 = function_ref @external_f2 : $@convention(thin) ()->()
-  apply %f2() : $@convention(thin) ()->()
+  %f2 = function_ref @external_f2 : $@convention(thin) () -> ()
+  apply %f2() : $@convention(thin) () -> ()
   br bb5
 
 bb4:
-  %f3 = function_ref @external_f3 : $@convention(thin) ()->()
-  apply %f3() : $@convention(thin) ()->()
+  %f3 = function_ref @external_f3 : $@convention(thin) () -> ()
+  apply %f3() : $@convention(thin) () -> ()
   br bb5
 
 bb5:

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -23,7 +23,7 @@ func foreach_variable() {
   }
 }
 
-func takeClosure(fn : (Int)->Int) {}
+func takeClosure(fn : (Int) -> Int) {}
 
 func passClosure() {
   takeClosure { a in

--- a/test/Serialization/Inputs/def_func.swift
+++ b/test/Serialization/Inputs/def_func.swift
@@ -51,7 +51,7 @@ public func differentWrapped<
   return a.getValue() != b.getValue()
 }
 
-@noreturn @_silgen_name("exit") public func exit ()->()
+@noreturn @_silgen_name("exit") public func exit () -> ()
 
 @noreturn public func testNoReturnAttr() -> () { exit() }
 @noreturn public func testNoReturnAttrPoly<T>(x x: T) -> () { exit() }

--- a/test/SourceKit/CodeComplete/complete_structure.swift
+++ b/test/SourceKit/CodeComplete/complete_structure.swift
@@ -15,7 +15,7 @@ struct S1 {
   func method4(_: Int, _: Int) {}
   func method5(inout _: Int, inout b: Int) {}
   func method6(c: Int) throws {}
-  func method7(callback: ()->() throws) rethrows {}
+  func method7(callback: () -> () throws) rethrows {}
   func method8<T, U>(d: (T, U) -> T, e: T -> U) {}
 
   let v1: Int = 1
@@ -68,7 +68,7 @@ func test5() {
 // S1_INIT: ({params:{n:a:}{t: Int}, {n:b:}{t: Int}})
 // S1_INIT: ({params:{n:c:}{t: Int}})
 
-func test6(xyz: S1, fgh: (S1)->S1) {
+func test6(xyz: S1, fgh: (S1) -> S1) {
   #^STMT_0^#
 }
 // STMT_0: {name:func}
@@ -92,8 +92,8 @@ func test7(x: E1) {
 // ENUM_0: {name:C3}({params:{n:l1:}{t: S1}, {n:l2:}{t: S1}})
 
 class C1 {
-  func foo(x: S1, y: S1, z: (S1)->S1) -> S1 {}
-  func zap<T, U>(x: T, y: U, z: (T)->U) -> T {}
+  func foo(x: S1, y: S1, z: (S1) -> S1) -> S1 {}
+  func zap<T, U>(x: T, y: U, z: (T) -> U) -> T {}
 }
 
 class C2 : C1 {

--- a/test/SourceKit/CodeComplete/complete_with_closure_param.swift
+++ b/test/SourceKit/CodeComplete/complete_with_closure_param.swift
@@ -1,6 +1,6 @@
-typealias MyFnTy = Int->Int
+typealias MyFnTy = Int ->Int
 class C {
-  func foo(x: Int->Int) {}
+  func foo(x: Int ->Int) {}
   func foo2(x: MyFnTy) {}
 }
 

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -1,11 +1,11 @@
 // RUN: %sourcekitd-test -req=expand-placeholder %s | FileCheck %s
 
-foo(x: <#T##()->Void#>)
+foo(x: <#T##() -> Void#>)
 // CHECK:      foo {
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
-foo(x: <#T##()->Void#>, y: <#T##Int#>)
+foo(x: <#T##() -> Void#>, y: <#T##Int#>)
 // CHECK:      foo(x: {
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }, y: Int)

--- a/test/SourceKit/CodeFormat/indent-closure.swift
+++ b/test/SourceKit/CodeFormat/indent-closure.swift
@@ -14,8 +14,8 @@ class C {
 }()
 }
 
-func foo1(a: Int, handler : ()->()) {}
-func foo2(handler : () ->()) {}
+func foo1(a: Int, handler : () -> ()) {}
+func foo2(handler : () -> ()) {}
 
 func foo3() {
   foo1(1)

--- a/test/TypeCoercion/overload_noncall.swift
+++ b/test/TypeCoercion/overload_noncall.swift
@@ -25,10 +25,10 @@ func test_conv() {
   a8 = a9
   a9 = a7
 
-  var _ : ((X)->X) -> ((Y) -> Y) = f2
-  var _ : ((x2 : X)-> (X)) -> (((y2 : Y) -> (Y))) = f2
+  var _ : ((X) -> X) -> ((Y) -> Y) = f2
+  var _ : ((x2 : X) -> (X)) -> (((y2 : Y) -> (Y))) = f2
 
-  typealias fp = ((X)->X) -> ((Y) -> Y)
+  typealias fp = ((X) -> X) -> ((Y) -> Y)
   var _ = f2
 }
 

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -14,7 +14,7 @@ func f3(f: UndeclaredFunctionType) rethrows { f() } // expected-error {{use of u
 func cf1(f: () throws -> ())() rethrows { try f() } // expected-warning{{curried function declaration syntax will be removed in a future version of Swift}}
 func cf2(f: () -> ())() rethrows { f() } // expected-error {{'rethrows' function must take a throwing function argument}} expected-warning{{curried function declaration syntax will be removed in a future version of Swift}}
 func cf3(f: UndeclaredFunctionType)() rethrows { f() } // expected-error {{use of undeclared type 'UndeclaredFunctionType'}} expected-warning{{curried function declaration syntax will be removed in a future version of Swift}}
-func cf4(f: () ->())(g: () throws -> ()) rethrows {} // expected-warning{{curried function declaration syntax will be removed in a future version of Swift}}
+func cf4(f: () -> ())(g: () throws -> ()) rethrows {} // expected-warning{{curried function declaration syntax will be removed in a future version of Swift}}
 func cf5() rethrows -> () throws -> () {} // expected-error {{'rethrows' function must take a throwing function argument}}
 
 /** Protocol conformance checking ********************************************/

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -218,11 +218,11 @@ func != <T>(lhs : T, rhs : NoneType) -> Bool { // expected-error{{invalid redecl
 }
 
 // <rdar://problem/15082356>
-func &&(lhs: BooleanType, @autoclosure rhs: ()->BooleanType) -> Bool { // expected-note{{previously declared}}
+func &&(lhs: BooleanType, @autoclosure rhs: () -> BooleanType) -> Bool { // expected-note{{previously declared}}
   return lhs.boolValue && rhs().boolValue
 }
 
-func &&(lhs: BooleanType, @autoclosure rhs: ()->BooleanType) -> Bool { // expected-error{{invalid redeclaration of '&&'}}
+func &&(lhs: BooleanType, @autoclosure rhs: () -> BooleanType) -> Bool { // expected-error{{invalid redeclaration of '&&'}}
   return lhs.boolValue || rhs().boolValue
 }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -11,7 +11,7 @@ func func6c(f: (Int, Int) -> Int, _ n: Int = 0) {} // expected-warning{{prior to
 var closure1 : () -> Int = {4}  // Function producing 4 whenever it is called.
 var closure2 : (Int,Int) -> Int = { 4 } // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}} {{36-36= _,_ in}}
 var closure3a : () -> () -> (Int,Int) = {{ (4, 2) }} // multi-level closing.
-var closure3b : (Int,Int) -> (Int) -> (Int,Int) = {{ (4, 2) }} // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}}  {{48-48=_,_ in }}
+var closure3b : (Int,Int) -> (Int) -> (Int,Int) = {{ (4, 2) }} // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}}  {{52-52=_,_ in }}
 var closure4 : (Int,Int) -> Int = { $0 + $1 }
 var closure5 : (Double) -> Int = {
        $0 + 1.0  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
@@ -59,7 +59,7 @@ func funcdecl5(a: Int, _ y: Int) {
   func6(fn: { a,b in a+b })
   
   // Infer incompatible type.
-  func6(fn: {a,b -> Float in 4.0 })    // expected-error {{declared closure result 'Float' is incompatible with contextual type 'Int'}} {{19-24=Int}}  // Pattern doesn't need to name arguments.
+  func6(fn: {a,b -> Float in 4.0 })    // expected-error {{declared closure result 'Float' is incompatible with contextual type 'Int'}} {{21-26=Int}}  // Pattern doesn't need to name arguments.
   func6(fn: { _,_ in 4 })
   
   func6(fn: {a,b in 4.0 })  // expected-error {{cannot convert value of type 'Double' to closure result type 'Int'}}
@@ -253,7 +253,7 @@ var x = {return $0}(1)
 
 func returnsInt() -> Int { return 0 }
 takesVoidFunc(returnsInt) // expected-error {{cannot convert value of type '() -> Int' to expected argument type '() -> ()'}}
-takesVoidFunc({() -> Int in 0}) // expected-error {{declared closure result 'Int' is incompatible with contextual type '()'}} {{20-23=()}}
+takesVoidFunc({() -> Int in 0}) // expected-error {{declared closure result 'Int' is incompatible with contextual type '()'}} {{22-25=()}}
   
 // These used to crash the compiler, but were fixed to support the implementation of rdar://problem/17228969
 Void(0) // expected-error{{argument passed to call that takes no arguments}}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -10,8 +10,8 @@ func func6c(f: (Int, Int) -> Int, _ n: Int = 0) {} // expected-warning{{prior to
 // from their definition.
 var closure1 : () -> Int = {4}  // Function producing 4 whenever it is called.
 var closure2 : (Int,Int) -> Int = { 4 } // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}} {{36-36= _,_ in}}
-var closure3a : ()->()->(Int,Int) = {{ (4, 2) }} // multi-level closing.
-var closure3b : (Int,Int)->(Int)->(Int,Int) = {{ (4, 2) }} // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}}  {{48-48=_,_ in }}
+var closure3a : () -> () -> (Int,Int) = {{ (4, 2) }} // multi-level closing.
+var closure3b : (Int,Int) -> (Int) -> (Int,Int) = {{ (4, 2) }} // expected-error{{contextual type for closure argument list expects 2 arguments, which cannot be implicitly ignored}}  {{48-48=_,_ in }}
 var closure4 : (Int,Int) -> Int = { $0 + $1 }
 var closure5 : (Double) -> Int = {
        $0 + 1.0  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
@@ -24,7 +24,7 @@ var closure7 : Int =
 
 func funcdecl1(a: Int, _ y: Int) {}
 func funcdecl3() -> Int {}
-func funcdecl4(a: ((Int)->Int), _ b: Int) {}
+func funcdecl4(a: ((Int) -> Int), _ b: Int) {}
 
 func funcdecl5(a: Int, _ y: Int) {
   // Pass in a closure containing the call to funcdecl3.
@@ -59,7 +59,7 @@ func funcdecl5(a: Int, _ y: Int) {
   func6(fn: { a,b in a+b })
   
   // Infer incompatible type.
-  func6(fn: {a,b->Float in 4.0 })    // expected-error {{declared closure result 'Float' is incompatible with contextual type 'Int'}} {{19-24=Int}}  // Pattern doesn't need to name arguments.
+  func6(fn: {a,b -> Float in 4.0 })    // expected-error {{declared closure result 'Float' is incompatible with contextual type 'Int'}} {{19-24=Int}}  // Pattern doesn't need to name arguments.
   func6(fn: { _,_ in 4 })
   
   func6(fn: {a,b in 4.0 })  // expected-error {{cannot convert value of type 'Double' to closure result type 'Int'}}
@@ -73,7 +73,7 @@ func funcdecl5(a: Int, _ y: Int) {
   var fn2 = { 4 }
   
   
-  var c : Int = { a,b-> Int in a+b} // expected-error{{cannot convert value of type '(Int, Int) -> Int' to specified type 'Int'}}
+  var c : Int = { a,b -> Int in a+b} // expected-error{{cannot convert value of type '(Int, Int) -> Int' to specified type 'Int'}}
   
   
 }
@@ -244,16 +244,16 @@ func rdar19179412() -> Int -> Int {
 }
 
 // Test coercion of single-expression closure return types to void.
-func takesVoidFunc(f: ()->()) {}
+func takesVoidFunc(f: () -> ()) {}
 var i: Int = 1
 
 takesVoidFunc({i})
-var f1: ()->() = {i}
+var f1: () -> () = {i}
 var x = {return $0}(1)
 
 func returnsInt() -> Int { return 0 }
 takesVoidFunc(returnsInt) // expected-error {{cannot convert value of type '() -> Int' to expected argument type '() -> ()'}}
-takesVoidFunc({()->Int in 0}) // expected-error {{declared closure result 'Int' is incompatible with contextual type '()'}} {{20-23=()}}
+takesVoidFunc({() -> Int in 0}) // expected-error {{declared closure result 'Int' is incompatible with contextual type '()'}} {{20-23=()}}
   
 // These used to crash the compiler, but were fixed to support the implementation of rdar://problem/17228969
 Void(0) // expected-error{{argument passed to call that takes no arguments}}
@@ -266,7 +266,7 @@ let samples = {
         }()  // expected-error {{cannot invoke closure of type '() -> _' with an argument list of type '()'}}
 
 // <rdar://problem/19756953> Swift error: cannot capture '$0' before it is declared
-func f(fp : (Bool, Bool)-> Bool) {}
+func f(fp : (Bool, Bool) -> Bool) {}
 f { $0 && !$1 }
 
 
@@ -305,7 +305,7 @@ class r22344208 {
   }
 }
 
-var f = { (s: Undeclared)-> Int in 0 } // expected-error {{use of undeclared type 'Undeclared'}}
+var f = { (s: Undeclared) -> Int in 0 } // expected-error {{use of undeclared type 'Undeclared'}}
 
 // <rdar://problem/21375863> Swift compiler crashes when using closure, declared to return illegal type.
 func r21375863() {

--- a/validation-test/stdlib/FixedPointArithmeticTraps.swift.gyb
+++ b/validation-test/stdlib/FixedPointArithmeticTraps.swift.gyb
@@ -25,7 +25,7 @@ import ObjectiveC
 func expectOverflow<T>(
   res: (T, overflow: Bool),
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = __FILE__, line: UInt = __LINE__
@@ -38,7 +38,7 @@ func expectOverflow<T>(
 func expectNoOverflow<T>(
   res: (T, overflow: Bool),
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = __FILE__, line: UInt = __LINE__

--- a/validation-test/stdlib/OpenCLSDKOverlay.swift
+++ b/validation-test/stdlib/OpenCLSDKOverlay.swift
@@ -132,7 +132,7 @@ tests.test("clSetKernelArgsListAPPLE") {
   // Create the compute program from the source buffer
   //
   program = KernelSource.withCString {
-    (s: UnsafePointer<CChar>)->cl_program in
+    (s: UnsafePointer<CChar>) -> cl_program in
     var s = s
     return withUnsafeMutablePointer(&s) {
       return clCreateProgramWithSource(context, 1, $0, nil, &err)

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -544,7 +544,7 @@ tests.test("index-mapping/utf8-to-character") {
   expectEqualSequence(
     winterUtf8Characters,
     winter.utf8.indices.map {
-      (i:String.UTF8Index)->Character? in i.samePositionIn(winter).map {
+      (i:String.UTF8Index) -> Character? in i.samePositionIn(winter).map {
         winter[$0]
       }
     }, sameValue: ==)


### PR DESCRIPTION
I add spaces around all closure arrow like this `()->()`  ->  `() -> ()`
