### PR TITLE
Various Python cleanups

### DIFF
--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -156,7 +156,7 @@ class ErrorKind(object):
         if value >= len(ErrorKind._kinds):
             ErrorKind._kinds += [None] * (value - len(ErrorKind._kinds) + 1)
         if ErrorKind._kinds[value] is not None:
-            raise ValueError,'ErrorKind already loaded'
+            raise ValueError('ErrorKind already loaded')
         self.value = value
         ErrorKind._kinds[value] = self
         ErrorKind._name_map = None
@@ -177,7 +177,7 @@ class ErrorKind(object):
     @staticmethod
     def from_id(id):
         if id >= len(ErrorKind._kinds) or ErrorKind._kinds[id] is None:
-            raise ValueError,'Unknown type kind %d' % id
+            raise ValueError('Unknown type kind {}'.format(id))
         return ErrorKind._kinds[id]
 
     def __repr__(self):
@@ -239,7 +239,7 @@ class VariantType(object):
         if value >= len(VariantType._kinds):
             VariantType._kinds += [None] * (value - len(VariantType._kinds) + 1)
         if VariantType._kinds[value] is not None:
-            raise ValueError,'VariantType already loaded'
+            raise ValueError('VariantType already loaded')
         self.value = value
         VariantType._kinds[value] = self
         VariantType._name_map = None
@@ -260,7 +260,7 @@ class VariantType(object):
     @staticmethod
     def from_id(id):
         if id >= len(VariantType._kinds) or VariantType._kinds[id] is None:
-            raise ValueError,'Unknown type kind %d' % id
+            raise ValueError('Unknown type kind {}'.format(id))
         return VariantType._kinds[id]
 
     def __repr__(self):
@@ -540,7 +540,7 @@ class Config:
     def set_library_path(path):
         """Set the path in which to search for sourcekitd"""
         if Config.loaded:
-            raise Exception("library path must be set before before using " \
+            raise Exception("library path must be set before before using "
                             "any other functionalities in sourcekitd.")
 
         Config.library_path = path
@@ -549,7 +549,7 @@ class Config:
     def set_library_file(filename):
         """Set the exact location of sourcekitd"""
         if Config.loaded:
-            raise Exception("library file must be set before before using " \
+            raise Exception("library file must be set before before using "
                             "any other functionalities in sourcekitd.")
 
         Config.library_file = filename

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -50,7 +50,7 @@ def addFunction(sizes, function, startAddr, endAddr, groupByPrefix):
     if groupByPrefix:
         for infix in SortedInfixes:
 	    if infix in function:
-               if not GenericFunctionPrefix in function:
+               if GenericFunctionPrefix not in function:
 	           sizes[Infixes[infix]] += size
                    return
         for prefix in SortedPrefixes:

--- a/utils/pass-pipeline/scripts/pipeline_generator.py
+++ b/utils/pass-pipeline/scripts/pipeline_generator.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import argparse
-import itertools
 import json
 import textwrap
 
@@ -31,7 +30,7 @@ disabled_passes = sum(args.disable_pass, [])
 disabled_passpipelines = sum(args.disable_passpipeline, [])
 
 # First filter out pipelines.
-normal_pipeline_generated = [x.generate() for x in normal_pipeline if not x.identifier in disabled_passpipelines]
+normal_pipeline_generated = [x.generate() for x in normal_pipeline if x.identifier not in disabled_passpipelines]
 
 # Then filter out specific passes.
 for i in range(len(normal_pipeline_generated)):

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -9,7 +9,6 @@ import textwrap
 # Append the src dir
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
-import pass_pipeline_library
 import passes
 
 # TODO: This should not be hard coded.

--- a/utils/pass-pipeline/src/pass_pipeline.py
+++ b/utils/pass-pipeline/src/pass_pipeline.py
@@ -1,8 +1,3 @@
-
-import sys
-import json
-import itertools
-
 class Pass(object):
     def __init__(self, name):
         self.name = name


### PR DESCRIPTION
Fixes:
- Unused import
- Redundant backslash
- Use of discouraged if not x in y
- Use of deprecated form of raising exceptions

Follow-up to PR #655 as requested by @gribozavr
