### PR TITLE
Tidy up Python file handlers

### DIFF
--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -34,7 +34,8 @@ def apply_edits(path):
 
     edits_set = set()
     for remap_file in remap_files:
-        json_data = open(remap_file).read()
+        with open(remap_file) as f:
+            json_data = f.read()
         json_data = json_data.replace(",\n }", "\n }")
         json_data = json_data.replace(",\n]", "\n]")
         curr_edits = json.loads(json_data)
@@ -55,13 +56,15 @@ def apply_edits(path):
     for fname, edits in edits_per_file.iteritems():
         print('Updating', fname)
         edits.sort(reverse=True)
-        file_data = open(fname).read()
+        with open(fname) as f:
+            file_data = f.read()
         for ed in edits:
             offset = ed[0]
             length = ed[1]
             text = ed[2]
             file_data = file_data[:offset] + str(text) + file_data[offset+length:]
-        open(fname, 'w').write(file_data)
+        with open(fname, 'w') as f:
+            f.write(file_data)
     return 0
 
 def main():

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -364,9 +364,13 @@ class ParseContext:
     tokens = None       # The rest of the tokens
     closeLines = False
 
-    def __init__(self, filename, template = None):
+    def __init__(self, filename, template=None):
         self.filename = os.path.abspath(filename)
-        self.template = template or open(filename).read()
+        if template is None:
+            with open(filename) as f:
+                self.template = f.read()
+        else:
+            self.template = template
         self.lineStarts = getLineStarts(self.template)
         self.tokens = self.tokenGenerator(tokenizeTemplate(self.template))
         self.nextToken()

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -133,7 +133,8 @@ def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = 
                     
                 rebuilt = True
         else:
-            timingsText = open(timingsFile).read()
+            with open(timingsFile) as f:
+                timingsText = f.read()
             oldRepeat = timingsText.count('\nTotal')
             if oldRepeat < repeat:
                 print('Only %s repeats in existing %s timings file' % (oldRepeat, exe))
@@ -146,8 +147,9 @@ def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = 
                 output = check_output(os.path.join(binDir, exe))
                 print(output)
                 timingsText += output
-                
-            open(timingsFile, 'w').write(timingsText)
+
+            with open(timingsFile, 'w') as outfile:
+                outfile.write(timingsText)
             print('done.')
             
     return cacheDir

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -76,7 +76,8 @@ genericOperators = {}
 comments = r'//.* | /[*] (.|\n)*? [*]/'  # FIXME: doesn't respect strings or comment nesting)
 
 # read source, stripping all comments
-sourceSansComments = re.sub(comments, '', open(args[1]).read(), flags=reFlags)
+with open(args[1]) as src:
+    sourceSansComments = re.sub(comments, '', src.read(), flags=reFlags)
 
 genericParameterConstraint = interpolate(r' (%(identifier)s) \s* : \s* (%(identifier)s) ')
 

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -113,9 +113,8 @@ def run_commands_in_parallel(commands):
     makefile += "all: " + " ".join(targets) + "\n"
 
     temp_dir = tempfile.mkdtemp(prefix="swift-testsuite-main")
-    makefile_file = open(os.path.join(temp_dir, 'Makefile'), 'w')
-    makefile_file.write(makefile)
-    makefile_file.close()
+    with open(os.path.join(temp_dir, 'Makefile'), 'w') as makefile_file:
+        makefile_file.write(makefile)
 
     max_processes = multiprocessing.cpu_count()
     subprocess.check_call([

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -154,9 +154,8 @@ main()
 """
 
     benchRE = re.compile("^\s*func\s\s*bench_([a-zA-Z0-9_]+)\s*\(\s*\)\s*->\s*Int\s*({)?\s*$")
-    f = open(name)
-    lines = f.readlines()
-    f.close()
+    with open(name) as f:
+      lines = list(f)
     output = header
     lookingForCurlyBrace = False
     testNames = []
@@ -190,9 +189,8 @@ main()
       output += mainBody % (n, n)
     processedName = 'processed_' + os.path.basename(name)
     output += mainEnd
-    f = open(processedName, 'w')
-    f.write(output)
-    f.close()
+    with open(processedName, 'w') as f:
+      f.write(output)
     for n in testNames:
       self.tests[name+":"+n].processedSource = processedName
 
@@ -210,9 +208,8 @@ main()
 extern "C" int32_t opaqueGetInt32(int32_t x) { return x; }
 extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
 """
-    f = open('opaque.cpp', 'w')
-    f.write(fileBody)
-    f.close()
+    with open('opaque.cpp', 'w') as f:
+      f.write(fileBody)
     # TODO: Handle subprocess.CalledProcessError for this call:
     self.runCommand(['clang++', 'opaque.cpp', '-o', 'opaque.o', '-c', '-O2'])
 

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -138,27 +138,25 @@ def main():
     # Write the output dot file.
 
     fileName = tempfile.gettempdir() + "/viewcfg" + suffix + ".dot"
-    outFile = open(fileName, "w")
+    with open(fileName 'w') as outFile:
+        outFile = open(fileName, "w")
 
-    outFile.write('digraph "CFG" {\n')
-    for name, block in blocks.iteritems():
-        if block.content is not None:
-            outFile.write("\tNode" + str(block.index) +
-                " [shape=record,label=\"{" + block.content + "}\"];\n")
-        else:
-            outFile.write("\tNode" + str(block.index) +
-                " [shape=record,color=gray,fontcolor=gray,label=\"{" +
-                block.name + "}\"];\n")
+        outFile.write('digraph "CFG" {\n')
+        for name, block in blocks.iteritems():
+            if block.content is not None:
+                outFile.write("\tNode" + str(block.index) +
+                    " [shape=record,label=\"{" + block.content + "}\"];\n")
+            else:
+                outFile.write("\tNode" + str(block.index) +
+                    " [shape=record,color=gray,fontcolor=gray,label=\"{" +
+                    block.name + "}\"];\n")
 
-        for succName in block.getSuccs():
-            succBlock = blocks[succName]
-            outFile.write("\tNode" + str(block.index) + " -> Node" +
-                str(succBlock.index) + ";\n")
+            for succName in block.getSuccs():
+                succBlock = blocks[succName]
+                outFile.write("\tNode" + str(block.index) + " -> Node" +
+                    str(succBlock.index) + ";\n")
 
-    outFile.write("}\n")
-    outFile.flush()
-    os.fsync(outFile.fileno())
-    outFile.close
+        outFile.write("}\n")
 
     # Open the dot file (should be done with Graphviz).
 

--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -19,8 +19,8 @@ for traversal, base_kind, mutable in itertools.product(
         ]:
             Base = '%s%s%sCollection' % (base_kind, traversal, 'Mutable' if mutable else '')
             testFilename = WrapperType + '_Of_' + Base + '_' + name + '.swift'
-            testFile = open(testFilename + '.gyb', 'w')
-            testFile.write("""
+            with open(testFilename + '.gyb', 'w') as testFile:
+                testFile.write("""
 //// Automatically Generated From validation-test/stdlib/Inputs/GenerateSliceTests.py
 //////// Do Not Edit Directly!
 // -*- swift -*-
@@ -69,9 +69,3 @@ runAllTests()
     prefix=prefix,
     suffix=suffix
 ))
-            testFile.close()
-
-
-
-
-


### PR DESCRIPTION
Rather than using `f = open(path).read()`, which leaves the file open
for an indeterminate period of time, switch to the `with open(path) as f`
idiom, which ensures the file is always closed correctly.
