### PR TITLE
[lib/Immediate] Enable built-in REPL on FreeBSD.

### DIFF
--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -33,7 +33,7 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 // FIXME: Support REPL on non-Apple platforms. Ubuntu 14.10's editline does not
 // include the wide character entry points needed by the REPL yet.
 #include <histedit.h>
@@ -130,7 +130,7 @@ public:
 
 using Convert = ConvertForWcharSize<sizeof(wchar_t)>;
   
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 static void convertFromUTF8(llvm::StringRef utf8,
                             llvm::SmallVectorImpl<wchar_t> &out) {
   size_t reserve = out.size() + utf8.size();
@@ -162,7 +162,7 @@ static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
 
 } // end anonymous namespace
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 
 static bool appendToREPLFile(SourceFile &SF,
                              PersistentParserState &PersistentState,


### PR DESCRIPTION
There was an issue in FreeBSD which prevented dlopen() to be called under dl_iterate_phdr() without resulting in a deadlock so the REPL couldn't have been enabled. Now there's a fix for that that's landing in FreeBSD, which basically means we can enable the REPL. This is going to work only on FreeBSD -CURRENT for a while (i.e. until the dlopen() fix isn't backported to STABLE, but it's better than nothing).

% ./swift --version
Swift version 2.2-dev (LLVM 3ebdbb2c7e, Clang f66c5bb67b, Swift 5ce5a5ec4d)
Target: x86_64-unknown-freebsd11.0

% ./swift
**\*  You are running Swift's integrated REPL,  ***
**\*  intended for testing purposes only.       ***
**\*  The full REPL is built as part of LLDB.   ***
**\*  Type ':help' for assistance.              ***
(swift) 1 + 2
// r0 : Int = 3
(swift) import Glibc
(swift) pow(2.0, 2.0)
// r1 : Double = 4.0
