### PR TITLE
[stdlib] Remove redundant +(_:_:) overload in RangeReplaceableCollectionType

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -448,6 +448,7 @@ public func +<
 >(lhs: C, rhs: S) -> C {
   var lhs = lhs
   // FIXME: what if lhs is a reference type?  This will mutate it.
+  lhs.reserveCapacity(lhs.count + numericCast(rhs.underestimateCount()))
   lhs.appendContentsOf(rhs)
   return lhs
 }

--- a/stdlib/public/core/RangeReplaceableCollectionType.swift
+++ b/stdlib/public/core/RangeReplaceableCollectionType.swift
@@ -468,19 +468,6 @@ public func +<
 
 @warn_unused_result
 public func +<
-    C : RangeReplaceableCollectionType,
-    S : CollectionType
-    where S.Generator.Element == C.Generator.Element
->(lhs: C, rhs: S) -> C {
-  var lhs = lhs
-  // FIXME: what if lhs is a reference type?  This will mutate it.
-  lhs.reserveCapacity(lhs.count + numericCast(rhs.count))
-  lhs.appendContentsOf(rhs)
-  return lhs
-}
-
-@warn_unused_result
-public func +<
     RRC1 : RangeReplaceableCollectionType,
     RRC2 : RangeReplaceableCollectionType 
     where RRC1.Generator.Element == RRC2.Generator.Element


### PR DESCRIPTION
It looks like the overload for `CollectionType` is redundant, because the implementations of the `CollectionType` and `SequenceType` overloads are equivalent (as `underestimateCount()` returns `count` for a `CollectionType`).

There appear to be no other relevant overloads in the standard library.
