### PR TITLE
[ClangImporter] Ignore swift_name when calculating enum constant prefix

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1567,7 +1567,7 @@ StringRef ClangImporter::Implementation::getEnumConstantNamePrefix(
     }
   }
 
-  // Compute th e common prefix.
+  // Compute the common prefix.
   StringRef commonPrefix = (*ec)->getName();
   bool followedByNonIdentifier = false;
   for (++ec; ec != ecEnd; ++ec) {
@@ -1602,15 +1602,9 @@ StringRef ClangImporter::Implementation::getEnumConstantNamePrefix(
         checkPrefix = checkPrefix.drop_front();
     }
 
-    // Account for the enum being imported using
-    // __attribute__((swift_private)). This is a little ad hoc, but it's a
-    // rare case anyway.
-    Identifier enumName = importFullName(decl, None, nullptr, &sema).Imported
-                            .getBaseName();
-    StringRef enumNameStr = enumName.str();
-    if (enumNameStr.startswith("__") && !checkPrefix.startswith("__"))
-      enumNameStr = enumNameStr.drop_front(2);
-
+    // Don't use importFullName() here, we want to ignore the swift_name
+    // and swift_private attributes.
+    StringRef enumNameStr = decl->getName();
     StringRef commonWithEnum = getCommonPluralPrefix(checkPrefix,
                                                      enumNameStr);
     size_t delta = commonPrefix.size() - checkPrefix.size();

--- a/test/IDE/Inputs/print_clang_header_swift_name.h
+++ b/test/IDE/Inputs/print_clang_header_swift_name.h
@@ -1,0 +1,31 @@
+@import Foundation;
+
+#define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
+
+#define SWIFT_ENUM(_type, _name) enum _name : _type _name; enum SWIFT_ENUM_EXTRA _name : _type
+
+typedef SWIFT_ENUM(NSInteger, Normal) {
+    NormalOne = 0,
+    NormalTwo,
+    NormalThree
+};
+
+// FIXME (#618): Use SWIFT_ENUM_NAMED() when support for that lands
+#undef SWIFT_ENUM
+#define SWIFT_ENUM(_type, _name) enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_ENUM_NAME); enum SWIFT_COMPILE_NAME(SWIFT_ENUM_NAME) SWIFT_ENUM_EXTRA _name : _type
+
+#define SWIFT_ENUM_NAME "SwiftEnum"
+typedef SWIFT_ENUM(NSInteger, ObjCEnum) {
+    ObjCEnumOne = 0,
+    ObjCEnumTwo,
+    ObjCEnumThree
+};
+
+#undef SWIFT_ENUM_NAME
+#define SWIFT_ENUM_NAME "SwiftEnumTwo"
+typedef SWIFT_ENUM(NSInteger, ObjCEnumTwo) {
+    // the following shouldn't have their prefixes stripped
+    SwiftEnumTwoA,
+    SwiftEnumTwoB,
+    SwiftEnumTwoC
+};

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -1,0 +1,25 @@
+// RUN: echo '#include "print_clang_header_swift_name.h"' > %t.m
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print \
+// RUN:     %S/Inputs/print_clang_header_swift_name.h --cc-args %target-cc-options \
+// RUN:     -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs | FileCheck %s
+
+// CHECK: enum Normal : Int {
+// CHECK-NOT: {{^}}}
+// CHECK: case One
+// CHECK-NEXT: case Two
+// CHECK-NEXT: case Three
+// CHECK-NEXT: }
+
+// CHECK: enum SwiftEnum : Int {
+// CHECK-NOT: {{^}}}
+// CHECK: case One
+// CHECK-NEXT: case Two
+// CHECK-NEXT: case Three
+// CHECK-NEXT: }
+
+// CHECK: enum SwiftEnumTwo : Int {
+// CHECK-NOT: {{^}}}
+// CHECK: case SwiftEnumTwoA
+// CHECK-NEXT: case SwiftEnumTwoB
+// CHECK-NEXT: case SwiftEnumTwoC
+// CHECK-NEXT: }


### PR DESCRIPTION
Enum constants are naturally going to be named after their ObjC name,
not their Swift name. As such, ignore the swift_name attr on the enum
decl when calculating the common prefix. It turns out this is actually
simpler anyway as it also bypasses the swift_private handling that the
code was already trying to work around.
