### PR TITLE
Remove unused diagnostic "expected_field_spec_name_tuple_expr"

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -962,8 +962,6 @@ ERROR(availability_query_outside_if_stmt_guard, expr_parsing, none,
 
 ERROR(expected_identifier_after_dot_expr,expr_parsing,none,
       "expected identifier after '.' expression", ())
-ERROR(expected_field_spec_name_tuple_expr,expr_parsing,none,
-      "expected field specifier name in tuple expression", ())
 
 ERROR(expected_identifier_after_super_dot_expr,expr_parsing,
       PointsToFirstBadToken,


### PR DESCRIPTION
Unused since at most two days ago.
