### PR TITLE
[SourceKit] Add test case for crash triggered in swift::IterativeTypeChecker::processInheritedProtocols(…)

### DIFF
--- a/validation-test/IDE/crashers/059-swift-iterativetypechecker-processinheritedprotocols.swift
+++ b/validation-test/IDE/crashers/059-swift-iterativetypechecker-processinheritedprotocols.swift
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol e:A.a
+class A{
+protocol c:e
+func a<H:A.c func a#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 182
swift-ide-test: /path/to/swift/include/swift/AST/Decl.h:3488: void swift::ProtocolDecl::setInheritedProtocols(ArrayRef<swift::ProtocolDecl *>): Assertion `!InheritedProtocolsSet && "protocols already set"' failed.
8  swift-ide-test  0x00000000009f0002 swift::IterativeTypeChecker::processInheritedProtocols(swift::ProtocolDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 1602
9  swift-ide-test  0x00000000009ee83d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
10 swift-ide-test  0x00000000009289f0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
11 swift-ide-test  0x0000000000a92011 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
14 swift-ide-test  0x0000000000a9392f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
15 swift-ide-test  0x0000000000a91d7b swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
16 swift-ide-test  0x0000000000a91afc swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
17 swift-ide-test  0x000000000094fe67 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
18 swift-ide-test  0x000000000095171f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
19 swift-ide-test  0x0000000000951ad4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
20 swift-ide-test  0x000000000092c2b1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1153
21 swift-ide-test  0x0000000000b75afc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
22 swift-ide-test  0x00000000009548ba swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 282
24 swift-ide-test  0x000000000097daee swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
26 swift-ide-test  0x000000000097d9e4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
27 swift-ide-test  0x0000000000929e21 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4929
28 swift-ide-test  0x000000000094fe55 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 373
30 swift-ide-test  0x000000000095027c swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
33 swift-ide-test  0x000000000092c150 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 800
34 swift-ide-test  0x0000000000b75afc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
35 swift-ide-test  0x00000000009548ba swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 282
37 swift-ide-test  0x000000000097daee swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
39 swift-ide-test  0x000000000097d9e4 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 212
40 swift-ide-test  0x00000000009ef5b2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
41 swift-ide-test  0x00000000009ee83d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
42 swift-ide-test  0x00000000009ee9c9 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
43 swift-ide-test  0x00000000009289f0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
44 swift-ide-test  0x0000000000a92011 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
47 swift-ide-test  0x0000000000a9392f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
48 swift-ide-test  0x0000000000a91d7b swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
49 swift-ide-test  0x0000000000a91afc swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
50 swift-ide-test  0x000000000094fe67 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
51 swift-ide-test  0x000000000095171f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
52 swift-ide-test  0x0000000000951ad4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
53 swift-ide-test  0x000000000092c2b1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1153
56 swift-ide-test  0x0000000000931967 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
57 swift-ide-test  0x00000000008fd9f2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
58 swift-ide-test  0x000000000076b262 swift::CompilerInstance::performSema() + 2946
59 swift-ide-test  0x0000000000714b67 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'e' at <INPUT-FILE>:3:1
2.  While resolving type A.a at [<INPUT-FILE>:3:12 - line:3:14] RangeText="A.a"
3.  While type-checking 'a' at <INPUT-FILE>:6:1
4.  While resolving type A.c at [<INPUT-FILE>:6:10 - line:6:12] RangeText="A.c"
```
