### PR TITLE
[SIL] Add test case for crash triggered in swift::ModuleDecl::lookupConformance(…)

### DIFF
--- a/validation-test/SIL/crashers/020-swift-moduledecl-lookupconformance.sil
+++ b/validation-test/SIL/crashers/020-swift-moduledecl-lookupconformance.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+enum l<V>:V


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:12: error: expected '{' in enum
enum l<V>:V
           ^
<stdin>:3:6: error: missing protocol 'RawRepresentable'
enum l<V>:V
     ^
<stdin>:3:6: error: missing protocol 'IntegerLiteralConvertible'
enum l<V>:V
     ^
4  sil-opt         0x0000000000d5139a swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 106
5  sil-opt         0x0000000000ac5da0 swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 96
9  sil-opt         0x0000000000a9c0d7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
10 sil-opt         0x0000000000a678aa swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1610
11 sil-opt         0x0000000000738d52 swift::CompilerInstance::performSema() + 2946
12 sil-opt         0x000000000072398c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'l' at <stdin>:3:1
```
