### PR TITLE
[SR-164][Sema] Fix assert arising from IOU is/as? a protocol type that IOU conforms to.

### DIFF
--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -262,14 +262,12 @@ OptionalTests.test("Optional OutputStream") {
 
   let iouNoString: TestNoString! = TestNoString()
   // IUO directly conforms to CustomStringConvertible.
-  // Disabled pending SR-164
-  //   expectTrue(iouNoString is CustomStringConvertible)
+  expectTrue(iouNoString is CustomStringConvertible)
   expectTrue(canGenericCast(iouNoString, CustomStringConvertible.self))
   expectFalse(iouNoString is Streamable)
   expectFalse(canGenericCast(iouNoString, Streamable.self))
   // CustomDebugStringConvertible conformance is a temporary hack.
-  // Disabled pending SR-164
-  //   expectTrue(iouNoString is CustomDebugStringConvertible)
+  expectTrue(iouNoString is CustomDebugStringConvertible)
   expectTrue(canGenericCast(iouNoString, CustomDebugStringConvertible.self))
   expectEqual(String(iouNoString), "main.TestNoString")
   expectEqual(debugPrintStr(iouNoString), "main.TestNoString")

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -119,3 +119,10 @@ func testVoidOptional() {
   let optNoop: ()? -> ()? = { return $0 }
   voidOptional(optNoop)
 }
+
+// SR-164
+let iouNoString : A! = A()
+let _ = (iouNoString is CustomStringConvertible) // expected-warning {{'is' test is always true}} expected-warning {{conditional cast from 'A!' to 'CustomStringConvertible' always succeeds}}
+let _ = (iouNoString as? CustomStringConvertible) // expected-warning {{conditional cast from 'A!' to 'CustomStringConvertible' always succeeds}}
+
+


### PR DESCRIPTION
In coerceExistential() check to see if the wrapped type conforms to the
protocols first, instead of unconditionally unwrapping it, and unwrap
only if necessary.
