### PR TITLE
[utils] Remove wildcard imports

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -21,8 +21,15 @@ import textwrap
 
 sys.path.append(os.path.dirname(__file__))
 
-from SwiftBuildSupport import *
-
+from SwiftBuildSupport import (
+    SWIFT_SOURCE_ROOT,
+    SWIFT_BUILD_ROOT,
+    print_with_argv0,
+    quote_shell_command,
+    check_call,
+    get_preset_options,
+    get_all_preset_names
+)
 
 # Main entry point for the preset mode.
 def main_preset():

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -8,7 +8,7 @@ import filecmp
 import os
 import shutil
 
-from SwiftBuildSupport import *
+from SwiftBuildSupport import check_call
 
 def merge_file_lists(src_root_dirs, skip_files, skip_subpaths):
     """Merges the file lists recursively from all src_root_dirs supplied,

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -19,7 +19,8 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))
 
-from SwiftBuildSupport import *
+from SwiftBuildSupport import (
+    SWIFT_SOURCE_ROOT, check_call, check_output, WorkingDirectory)
 
 
 def update_git_svn(repo_path):


### PR DESCRIPTION
From [PEP 0008](https://www.python.org/dev/peps/pep-0008/):

> Wildcard imports (`from <module> import *`) should be avoided, as they make
>   it unclear which names are present in the namespace, confusing both readers
>   and many automated tools.

Using wildcard imports for `SwiftBuildSupport.py` makes it difficult to understand which exported functions are actually being used. These commits make this clearer--in some cases, it reveals that only one symbol is being used, or in the case of #751, that a function is never used at all.
