### PR TITLE
[SR-165][Parser] Fix diagnosis location for missing while after repeat body

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1812,10 +1812,8 @@ ParserResult<Stmt> Parser::parseStmtRepeat(LabeledStmtInfo labelInfo) {
   SourceLoc whileLoc;
 
   if (!consumeIf(tok::kw_while, whileLoc)) {
-    diagnose(whileLoc, diag::expected_while_after_repeat_body);
-    if (body.isNonNull())
-      return body;
-    return makeParserError();
+    diagnose(body.getPtrOrNull()->getEndLoc(), diag::expected_while_after_repeat_body);
+    return body;
   }
 
   ParserResult<Expr> condition;

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -131,6 +131,12 @@ func missingControllingExprInRepeatWhile() {
   } while { true }() // expected-error{{missing condition in a 'while' statement}} expected-error{{consecutive statements on a line must be separated by ';'}} {{10-10=;}}
 }
 
+// SR-165
+func missingWhileInRepeat() {
+  repeat {
+  } // expected-error {{expected 'while' after body of 'repeat' statement}}
+}
+
 // expected-note @+1 {{in call to function 'acceptsClosure'}}
 func acceptsClosure<T>(t: T) -> Bool { return true }
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -266,7 +266,7 @@ func RepeatWhileStmt1() {
 }
 
 func RepeatWhileStmt2() {
-  repeat // expected-error {{expected '{' after 'repeat'}}
+  repeat // expected-error {{expected '{' after 'repeat'}} expected-error {{expected 'while' after body of 'repeat' statement}}
 }
 
 func RepeatWhileStmt4() {


### PR DESCRIPTION
Also cleaned up unnecessary body.isNonNull() check here. The code just above already constructs a synthetic empty brace stmt for the body if it didn’t have a real one.
