### PR TITLE
Revert "[Python] Use explicit imports"

### DIFF
--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -10,22 +10,7 @@
 #
 #===------------------------------------------------------------------------===#
 
-from ctypes import (
-    CFUNCTYPE,
-    POINTER,
-    Structure,
-    addressof,
-    c_bool,
-    c_char_p,
-    c_int,
-    c_int64,
-    c_size_t,
-    c_uint64,
-    c_void_p,
-    cdll,
-    py_object,
-    string_at,
-)
+from ctypes import *
 
 # ctypes doesn't implicitly convert c_void_p to the appropriate wrapper
 # object. This is a problem, because it means that from_parameter will see an

--- a/utils/build-script
+++ b/utils/build-script
@@ -21,16 +21,8 @@ import textwrap
 
 sys.path.append(os.path.dirname(__file__))
 
-from SwiftBuildSupport import (
-    HOME,
-    SWIFT_BUILD_ROOT,
-    SWIFT_SOURCE_ROOT,
-    check_call,
-    get_all_preset_names,
-    get_preset_options,
-    print_with_argv0,
-    quote_shell_command,
-)
+from SwiftBuildSupport import *
+
 
 # Main entry point for the preset mode.
 def main_preset():

--- a/utils/cmpcodesize/cmpcodesize.py
+++ b/utils/cmpcodesize/cmpcodesize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from cmpcodesize.main import main
+import cmpcodesize
 
 if __name__ == '__main__':
-    main()
+    cmpcodesize.main()

--- a/utils/cmpcodesize/cmpcodesize/__init__.py
+++ b/utils/cmpcodesize/cmpcodesize/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from .main import main
+
 __author__ = 'Brian Gesiak'
 __email__ = 'modocache@gmail.com'
 __versioninfo__ = (0, 1, 0)

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -2,21 +2,8 @@
 
 import re
 
-from pygments.lexer import (
-    Comment,
-    Generic,
-    Keyword,
-    Name,
-    Number,
-    Operator,
-    Punctuation,
-    RegexLexer,
-    String,
-    Text,
-    Whitespace,
-    bygroups,
-    include,
-)
+from pygments.lexer import RegexLexer, include, bygroups
+from pygments.token import *
 
 __all__ = ['SwiftLexer', 'SwiftConsoleLexer']
 

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -8,7 +8,7 @@ import filecmp
 import os
 import shutil
 
-from SwiftBuildSupport import check_call
+from SwiftBuildSupport import *
 
 def merge_file_lists(src_root_dirs, skip_files, skip_subpaths):
     """Merges the file lists recursively from all src_root_dirs supplied,

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -19,12 +19,8 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))
 
-from SwiftBuildSupport import (
-    SWIFT_SOURCE_ROOT,
-    WorkingDirectory,
-    check_call,
-    check_output,
-)
+from SwiftBuildSupport import *
+
 
 def update_git_svn(repo_path):
     with WorkingDirectory(repo_path):


### PR DESCRIPTION
Reverts apple/swift#752

I got following build error on macos:

Exception occurred:
  File "/Users/erik/proj/main-swift/swift/utils/pygments/swift.py", line 5, in <module>
    from pygments.lexer import (
ImportError: cannot import name Comment
