### PR TITLE
[Python] Use explicit imports in utils/pygments/swift.py

### DIFF
--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -2,8 +2,23 @@
 
 import re
 
-from pygments.lexer import RegexLexer, include, bygroups
-from pygments.token import *
+from pygments.lexer import (
+    RegexLexer,
+    bygroups,
+    include,
+)
+from pygments.token import (
+    Comment,
+    Generic,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Text,
+    Whitespace,
+)
 
 __all__ = ['SwiftLexer', 'SwiftConsoleLexer']
 


### PR DESCRIPTION
Correct imports this time around. See #757.
