### PR TITLE
[build-script] Do not determine build jobs in impl

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -14,6 +14,7 @@
 from __future__ import print_function
 
 import argparse
+import multiprocessing
 import os
 import shutil
 import sys
@@ -485,7 +486,8 @@ placed""",
         help="""
 the number of parallel build jobs to use""",
         type=int,
-        dest="build_jobs")
+        dest="build_jobs",
+        default=multiprocessing.cpu_count())
 
     parser.add_argument("--extra-swift-args", help=textwrap.dedent("""
     Pass through extra flags to swift in the form of a cmake list 'module_regexp;flag'. Can
@@ -713,10 +715,9 @@ the number of parallel build jobs to use""",
         "--swift-enable-assertions", str(args.swift_assertions).lower(),
         "--swift-stdlib-enable-assertions", str(args.swift_stdlib_assertions).lower(),
         "--cmake-generator", args.cmake_generator,
+        "--build-jobs", str(args.build_jobs),
         "--workspace", SWIFT_SOURCE_ROOT
     ]
-    if args.build_jobs:
-        build_script_impl_args += ["--build-jobs", str(args.build_jobs)]
     if args.build_foundation:
         build_script_impl_args += [
             "--foundation-build-type", args.foundation_build_variant

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -195,26 +195,6 @@ function to_varname() {
     toupper "${1//-/_}"
 }
 
-function get_make_parallelism() {
-    case "$(uname -s)" in
-        Linux)
-            nproc
-            ;;
-
-        Darwin)
-            sysctl -n hw.activecpu
-            ;;
-
-        *)
-            echo 8
-            ;;
-    esac
-}
-
-function get_dsymutil_parallelism() {
-    get_make_parallelism
-}
-
 function set_lldb_build_mode() {
     LLDB_BUILD_MODE="CustomSwift-${LLDB_BUILD_TYPE}"
 }
@@ -1114,19 +1094,13 @@ fi
 
 case "${CMAKE_GENERATOR}" in
     Ninja)
+        BUILD_ARGS="${BUILD_ARGS} -j${BUILD_JOBS}"
         if [[ "${VERBOSE_BUILD}" ]] ; then
             BUILD_ARGS="${BUILD_ARGS} -v"
         fi
-        if [[ "${BUILD_JOBS}" ]] ; then
-            BUILD_ARGS="${BUILD_ARGS} -j${BUILD_JOBS}"
-        fi
         ;;
     'Unix Makefiles')
-        if [[ "${BUILD_JOBS}" ]] ; then
-            BUILD_ARGS="${BUILD_ARGS} -j${BUILD_JOBS}"
-        else
-            BUILD_ARGS="${BUILD_ARGS:--j$(get_make_parallelism)}"
-        fi
+        BUILD_ARGS="${BUILD_ARGS} -j${BUILD_JOBS}"
         if [[ "${VERBOSE_BUILD}" ]] ; then
             BUILD_ARGS="${BUILD_ARGS} VERBOSE=1"
         fi
@@ -1136,9 +1110,7 @@ case "${CMAKE_GENERATOR}" in
         # but since we're not using proper Xcode 4 schemes, this is the
         # only way to get target-level parallelism.
         BUILD_ARGS="${BUILD_ARGS} -parallelizeTargets"
-        if [[ "${BUILD_JOBS}" ]] ; then
-            BUILD_ARGS="${BUILD_ARGS} -jobs ${BUILD_JOBS}"
-        fi
+        BUILD_ARGS="${BUILD_ARGS} -jobs ${BUILD_JOBS}"
         BUILD_TARGET_FLAG="-target"
         COMMON_CMAKE_OPTIONS=(
             "${COMMON_CMAKE_OPTIONS[@]}"
@@ -2246,13 +2218,13 @@ if [[ "${DARWIN_INSTALL_EXTRACT_SYMBOLS}" ]] ; then
        grep -v swift-stdlib-tool | \
        grep -v crashlog.py | \
        grep -v symbolication.py | \
-       xargs -n 1 -P $(get_dsymutil_parallelism) $(xcrun_find_tool dsymutil))
+       xargs -n 1 -P $(BUILD_JOBS) $(xcrun_find_tool dsymutil))
 
     # Strip executables, shared libraries and static libraries in
     # INSTALL_DESTDIR.
     find "${INSTALL_DESTDIR}"/"${TOOLCHAIN_PREFIX}" \
       \( -perm -0111 -or -name "*.a" \) -type f -print | \
-      xargs -n 1 -P $(get_dsymutil_parallelism) $(xcrun_find_tool strip) -S
+      xargs -n 1 -P $(BUILD_JOBS) $(xcrun_find_tool strip) -S
 
     { set +x; } 2>/dev/null
 fi


### PR DESCRIPTION
Begins work on [SR-237](https://bugs.swift.org/browse/SR-237).

Rather than determining the number of jobs to use for `make` or `dsymutil` from within build-script-impl, this change passes in those values from above.

Furthermore, because we can determine the number of build jobs via a builtin Python function, we figure out the number of jobs to use from within `utils/build-script`. Now, by default, the same number of jobs will be used to build this project as there are cores on the host machine. Users may still specify a different number, as before, using the `--jobs` option.

This introduces a behavioral change. Before, running `utils/build-script`, without specifying any additional options, would run something like the following `cmake` command:

``` sh
cmake --build /build/Ninja-DebugAssert/llvm-macosx-x86_64 -- all
```

Notice the lack of jobs specified. The new default is something like the following:

``` sh
cmake --build /build/Ninja-DebugAssert/llvm-macosx-x86_64 -- -j8 all
```

Notice that the number of jobs is exlicitly passed to the command.
