### PR TITLE
[python] Use PEP-0008 compliant code headers

### DIFF
--- a/stdlib/public/common/MirrorCommon.py
+++ b/stdlib/public/common/MirrorCommon.py
@@ -1,17 +1,20 @@
-#//===--- MirrorCommon.py -------------------------------------*- python -*-===//
-#//
-#// This source file is part of the Swift.org open source project
-#//
-#// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
-#// Licensed under Apache License v2.0 with Runtime Library Exception
-#//
-#// See http://swift.org/LICENSE.txt for license information
-#// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#//
-#//===----------------------------------------------------------------------===//
+# MirrorCommon.py -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+#
 # This file contains utility functions that are used by the gyb template files
 # that generate Mirrors for the Swift Standard Library.
 # If you edit this, make sure to also accordingly tweak the actual template files.
+#
+# -----------------------------------------------------------------------------
 
 def getDisposition(disp=None):
   if disp is None:

--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -1,6 +1,12 @@
-# -*- Python -*-
-
-# Configuration file for the 'lit' test runner.
+# test/Unit/lit.cfg - Configuration for the 'lit' test runner. -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import os
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1,14 +1,14 @@
-##===--- lit.cfg ---------------------------------------------*- Python -*-===##
-##
-## This source file is part of the Swift.org open source project
-##
-## Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
-## Licensed under Apache License v2.0 with Runtime Library Exception
-##
-## See http://swift.org/LICENSE.txt for license information
-## See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-##
-##===----------------------------------------------------------------------===##
+# swift/test/lit.cfg - Configuration for the 'lit' test runner -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
 #
 # This is a configuration file for the 'lit' test runner.
 #
@@ -16,7 +16,7 @@
 #
 # Update docs/Testing.rst when changing this file.
 #
-##===----------------------------------------------------------------------===##
+# -----------------------------------------------------------------------------
 
 import os
 import platform

--- a/tools/SourceKit/bindings/python/sourcekitd/__init__.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/__init__.py
@@ -1,4 +1,4 @@
-#===- __init__.py - sourcekitd Python Bindings ---------------*- python -*--===#
+# __init__.py - sourcekitd Python Bindings -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -7,8 +7,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 r"""
 sourcekitd framework bindings

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -1,4 +1,4 @@
-#===- capi.py - sourcekitd Python Bindings -------------------*- python -*--===#
+# capi.py - sourcekitd Python Bindings -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -7,8 +7,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 from ctypes import (
     CFUNCTYPE,

--- a/tools/SourceKit/bindings/python/sourcekitd/request.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/request.py
@@ -1,4 +1,4 @@
-#===- request.py - sourcekitd Python Bindings ----------------*- python -*--===#
+# request.py - sourcekitd Python Bindings -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -7,8 +7,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 import capi
 

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -1,4 +1,4 @@
-#===--- SwiftBuildSupport.py - Utilities for Swift build scripts -----------===#
+# utils/SwiftBuildSupport.py - Utilities for Swift build scripts -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -7,8 +7,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 from __future__ import print_function
 

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-
-#===--- apply-fixit-edits.py - Tool for applying edits from .remap files ---===#
+# utils/apply-fixit-edits.py - Apply edits from .remap files -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -9,8 +8,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 from __future__ import print_function
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
-#===--- build-script - The ultimate tool for building Swift ----------------===#
+# utils/build-script - The ultimate tool for building Swift -*- python -*-
 #
-## This source file is part of the Swift.org open source project
-##
-## Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
-## Licensed under Apache License v2.0 with Runtime Library Exception
-##
-## See http://swift.org/LICENSE.txt for license information
-## See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# This source file is part of the Swift.org open source project
 #
-#===------------------------------------------------------------------------===#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 from __future__ import print_function
 

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#===------------------------------------------------------------------------===#
+# utils/sil-opt-verify-all-modules.py - Verifies Swift modules -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -8,8 +8,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 from __future__ import print_function
 

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#===--- update-checkout - Utility to update your local checkouts -----------===#
+# utils/update-checkout - Utility to update your local checkouts -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -8,8 +8,6 @@
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-#===------------------------------------------------------------------------===#
 
 from __future__ import print_function
 


### PR DESCRIPTION
Running the Python style guide checker [`pep8`](https://pypi.python.org/pypi/pep8) on the Python code headers in this repository results in the following error being emitted:

```
$ pep8 utils/build-script
utils/build-script:1:1: E265 block comment should start with '# '
utils/build-script:3:1: E266 too many leading '#' for block comment
utils/build-script:5:1: E266 too many leading '#' for block comment
utils/build-script:6:1: E266 too many leading '#' for block comment
utils/build-script:8:1: E266 too many leading '#' for block comment
utils/build-script:9:1: E266 too many leading '#' for block comment
utils/build-script:11:1: E265 block comment should start with '# '
utils/build-script:11:80: E501 line too long (80 > 79 characters)
```

The problem is that the code header used in most Python files in the repository:
1. Do not place a space in between `#` and the rest of the comment.
2. Contains some lines that just barely exceed the recommend length
   limit.

In addition, not all code headers in the repository follow the same template.

This commit moves all Python code headers to the following template:

```
# subfolder/file_name.py - Very brief description
#
# This source file is part of the Swift.org open source project
#
# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
# Licensed under Apache License v2.0 with Runtime Library Exception
#
# See http://swift.org/LICENSE.txt for license information
# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
#
# -----------------------------------------------------------------------------
#
# This file contains stuff that I am describing here in the header and will
# be sure to keep up to date.
#
# -----------------------------------------------------------------------------
```

---

There are also many Python files in this repository without any code headers at all. If we can agree upon a template I'll send another pull request to add all the missing headers.
