### PR TITLE
[SourceKit 🎄] Add test case for crash triggered in swift::ConstructorDecl::getResultType()

### DIFF
--- a/validation-test/IDE/crashers/060-swift-constructordecl-getresulttype.swift
+++ b/validation-test/IDE/crashers/060-swift-constructordecl-getresulttype.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+typealias f=B{func a{f#^A^#}}struct B{let d


### PR DESCRIPTION
My Swift fuzzer brought a Christmas gift in the form of a newly discovered SourceKit crash case! Appy holidays all Swift contributors! 🎄

Stack trace:

```
found code completion token A at offset 127
swift-ide-test: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyFunctionType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
8  swift-ide-test  0x0000000000b40991 swift::ConstructorDecl::getResultType() const + 129
19 swift-ide-test  0x0000000000adfdf4 swift::Decl::walk(swift::ASTWalker&) + 20
20 swift-ide-test  0x0000000000b69ade swift::SourceFile::walk(swift::ASTWalker&) + 174
21 swift-ide-test  0x0000000000b68d0f swift::ModuleDecl::walk(swift::ASTWalker&) + 79
22 swift-ide-test  0x0000000000b42e12 swift::DeclContext::walkContext(swift::ASTWalker&) + 146
23 swift-ide-test  0x000000000085c23a swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 138
24 swift-ide-test  0x000000000076b344 swift::CompilerInstance::performSema() + 3316
25 swift-ide-test  0x0000000000714ad7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While walking into decl declaration 0x448df20 at <INPUT-FILE>:2:14
```
