### PR TITLE
[SourceKit] Add test case for crash triggered in swift::constraints::Solution::coerceToType(…)

### DIFF
--- a/validation-test/IDE/crashers/061-swift-constraints-solution-coercetotype.swift
+++ b/validation-test/IDE/crashers/061-swift-constraints-solution-coercetotype.swift
@@ -1,0 +1,12 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+protocol P{
+protocol A{
+let t={
+protocol c{
+let:n
+class A{
+func c
+let s=c
+protocol e{
+typealias f=#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 224
Unhandled coercion
UNREACHABLE executed at /path/to/swift/lib/Sema/CSApply.cpp:4918!
6  swift-ide-test  0x0000000002a638ed llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
8  swift-ide-test  0x00000000009b4ac6 swift::constraints::Solution::coerceToType(swift::Expr*, swift::Type, swift::constraints::ConstraintLocator*, bool) const + 326
10 swift-ide-test  0x00000000009170c6 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 854
11 swift-ide-test  0x00000000009180c0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
12 swift-ide-test  0x0000000000918269 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
14 swift-ide-test  0x000000000092cd04 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3940
19 swift-ide-test  0x0000000000b5563d swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1117
21 swift-ide-test  0x000000000085c2e3 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 307
22 swift-ide-test  0x000000000076b344 swift::CompilerInstance::performSema() + 3316
23 swift-ide-test  0x0000000000714ad7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking expression at [<INPUT-FILE>:10:7 - line:10:7] RangeText="c"
```
