### PR TITLE
[SIL] Add test case for crash triggered in swift::TypeChecker::typeCheckDecl(…)

### DIFF
--- a/validation-test/SIL/crashers/021-swift-typechecker-typecheckdecl.sil
+++ b/validation-test/SIL/crashers/021-swift-typechecker-typecheckdecl.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+protocol P{var e:<T>()->(


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:26: error: expected type
protocol P{var e:<T>()->(
                         ^
<stdin>:3:26: error: expected ',' separator
protocol P{var e:<T>()->(
                         ^
                         ,
<stdin>:3:26: error: consecutive declarations on a line must be separated by ';'
protocol P{var e:<T>()->(
                         ^
                         ;
<stdin>:3:26: error: expected declaration
protocol P{var e:<T>()->(
                         ^
sil-opt: /path/to/swift/lib/AST/Decl.cpp:1782: void swift::ValueDecl::setInterfaceType(swift::Type): Assertion `(type.isNull() || !type->is<PolymorphicFunctionType>()) && "setting polymorphic function type as interface type"' failed.
13 sil-opt         0x0000000000a9b8c7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
14 sil-opt         0x0000000000a67012 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
15 sil-opt         0x0000000000738fc2 swift::CompilerInstance::performSema() + 2946
16 sil-opt         0x00000000007238ac main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'P' at <stdin>:3:1
```
