### PR TITLE
[SourceKit] Add test case for crash triggered in swift::constraints::Solution::computeSubstitutions(…)

### DIFF
--- a/validation-test/IDE/crashers/062-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/IDE/crashers/062-swift-constraints-solution-computesubstitutions.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+struct A<H:A.c{protocol c func b
+var _=b}#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 167
swift-ide-test: /path/to/swift/lib/AST/Substitution.cpp:67: swift::Substitution::Substitution(swift::ArchetypeType *, swift::Type, ArrayRef<swift::ProtocolConformance *>): Assertion `Conformance.size() == Archetype->getConformsTo().size() && "substitution conformances don't match archetype"' failed.
9  swift-ide-test  0x00000000009ad85a swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const + 1594
13 swift-ide-test  0x0000000000adfa45 swift::Expr::walk(swift::ASTWalker&) + 69
14 swift-ide-test  0x00000000009b1246 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
15 swift-ide-test  0x000000000091701b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
17 swift-ide-test  0x00000000009cd2e9 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 6649
18 swift-ide-test  0x00000000009d020e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
19 swift-ide-test  0x0000000000910b95 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
20 swift-ide-test  0x0000000000916fa9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
21 swift-ide-test  0x00000000009180c0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
22 swift-ide-test  0x0000000000918269 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
27 swift-ide-test  0x00000000009318d7 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 151
28 swift-ide-test  0x00000000008fd962 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
29 swift-ide-test  0x000000000076b1d2 swift::CompilerInstance::performSema() + 2946
30 swift-ide-test  0x0000000000714ad7 main + 33239
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'A' at <INPUT-FILE>:3:1
2.  While type-checking expression at [<INPUT-FILE>:4:7 - line:4:7] RangeText="b"
3.  While type-checking expression at [<INPUT-FILE>:4:7 - line:4:7] RangeText="b"
```
