### PR TITLE
[test] Run Python unit tests in validation tests

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -313,6 +313,8 @@ Other substitutions:
 * ``%platform-sdk-overlay-dir``: absolute path of the directory where the SDK
   overlay module files for the target platform are stored.
 
+* ``%{python}``: run the same Python interpreter that's being used to run the
+  current ``lit`` test.
 
 When writing a test where output (or IR, SIL) depends on the bitness of the
 target CPU, use this pattern::

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -22,6 +22,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 import tempfile
 
 import lit.formats
@@ -271,6 +272,7 @@ completion_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-completion-cach
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 
+config.substitutions.append( ('%{python}', sys.executable) )
 config.substitutions.append( ('%mcp_opt', mcp_opt) )
 config.substitutions.append( ('%swift_driver_plain', "%r" % config.swift) )
 config.substitutions.append( ('%swiftc_driver_plain', "%r" % config.swiftc) )

--- a/validation-test/Python/cmpcodesize.swift
+++ b/validation-test/Python/cmpcodesize.swift
@@ -1,0 +1,1 @@
+// RUN: %{python} -m unittest discover -s %S/../../utils/cmpcodesize


### PR DESCRIPTION
This repository includes several Python modules, each with unit tests.
Add a step to the validation tests to ensure these tests pass.

---

For now, there's only one module being tested: `cmpcodesize`. #761 adds unit tests for several components of `utils/build-script`, and I plan to add those tests to this command as well.
