### PR TITLE
[Sema] Highlight angle brackets <…> in diagnostics

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -158,18 +158,18 @@ enum ContextualTypePurpose {
   CTP_DictionaryValue,  ///< DictionaryExpr values should have a specific type.
   CTP_CoerceOperand,    ///< CoerceExpr operand coerced to specific type.
   CTP_AssignSource,     ///< AssignExpr source operand coerced to result type.
-  
+
   CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
 };
 
-  
+
 
 /// Flags that can be used to control name lookup.
 enum class TypeCheckExprFlags {
   /// Whether we know that the result of the expression is discarded.  This
   /// disables constraints forcing an lvalue result to be loadable.
   IsDiscarded = 0x01,
-  
+
   /// Whether the client wants to disable the structural syntactic restrictions
   /// that we force for style or other reasons.
   DisableStructuralChecks = 0x02,
@@ -183,7 +183,7 @@ enum class TypeCheckExprFlags {
   /// system is not applied to the expression AST, but the ConstraintSystem is
   /// left in-tact.
   AllowUnresolvedTypeVariables = 0x08,
-  
+
   /// If set, the 'convertType' specified to typeCheckExpression should not
   /// produce a conversion constraint, but it should be used to guide the
   /// solution in terms of performance optimizations of the solver, and in terms
@@ -194,12 +194,12 @@ enum class TypeCheckExprFlags {
   /// statement. This should only be used for syntactic restrictions, and should
   /// not affect type checking itself.
   IsExprStmt = 0x20,
-  
+
   /// If set, this expression is being re-type checked as part of diagnostics,
   /// and so we should not visit bodies of non-single expression closures.
   SkipMultiStmtClosures = 0x40,
 };
-  
+
 typedef OptionSet<TypeCheckExprFlags> TypeCheckExprOptions;
 
 inline TypeCheckExprOptions operator|(TypeCheckExprFlags flag1,
@@ -316,7 +316,7 @@ enum TypeResolutionFlags : unsigned {
   /// Whether we are in the input type of a function, or under one level of
   /// tuple type.  This is not set for multi-level tuple arguments.
   TR_FunctionInput = 0x20,
-  
+
   /// Whether this is the immediate input type to a function type,
   TR_ImmediateFunctionInput = 0x40,
 
@@ -326,13 +326,13 @@ enum TypeResolutionFlags : unsigned {
   /// Whether we are in the result type of a function body that is
   /// known to produce dynamic Self.
   TR_DynamicSelfResult = 0x100,
-  
+
   /// Whether this is a resolution based on a non-inferred type pattern.
   TR_FromNonInferredPattern = 0x200,
-  
+
   /// Whether we are the variable type in a for/in statement.
   TR_EnumerationVariable = 0x400,
-  
+
   /// Whether we are looking only in the generic signature of the context
   /// we're searching, rather than the entire context.
   TR_GenericSignature = 0x800,
@@ -348,13 +348,13 @@ enum TypeResolutionFlags : unsigned {
   /// This affects what sort of dependencies are recorded when resolving the
   /// type.
   TR_InExpression = 0x4000,
-  
+
   /// Whether this type resolution is guaranteed not to affect downstream files.
   TR_KnownNonCascadingDependency = 0x8000,
 
   /// Whether we should allow references to unavailable types.
   TR_AllowUnavailable = 0x10000,
-  
+
   /// Whether this is the payload subpattern of an enum pattern.
   TR_EnumPatternPayload = 0x20000,
 
@@ -460,7 +460,7 @@ public:
   /// This can't use CanTypes because typealiases may have more limited types
   /// than their underlying types.
   llvm::DenseMap<Type, Accessibility> TypeAccessibilityCache;
-  
+
   // We delay validation of C and Objective-C type-bridging functions in the
   // standard library until we encounter a declaration that requires one. This
   // flag is set to 'true' once the bridge functions have been checked.
@@ -491,7 +491,7 @@ public:
   ///     use(x)
   ///   }
   /// }
-  
+
   llvm::SmallDenseMap<AnyFunctionRef, SmallVector<AnyFunctionRef, 4>, 4>
     ForwardCapturedFuncs;
 
@@ -523,13 +523,13 @@ private:
 
   /// The \c Swift.UnsafeMutablePointer<T> declaration.
   Optional<NominalTypeDecl *> ArrayDecl;
-  
+
   /// A set of types that can be trivially mapped to Objective-C types.
   llvm::DenseSet<CanType> ObjCMappedTypes;
 
   /// A set of types that can be mapped to C integer types.
   llvm::DenseSet<CanType> CIntegerTypes;
-  
+
   /// The set of expressions currently being analyzed for failures.
   llvm::DenseMap<Expr*, Expr*> DiagnosedExprs;
 
@@ -578,7 +578,7 @@ public:
   void setInImmediateMode(bool InImmediateMode) {
     this->InImmediateMode = InImmediateMode;
   }
-  
+
   template<typename ...ArgTypes>
   InFlightDiagnostic diagnose(ArgTypes &&...Args) {
     return Diags.diagnose(std::forward<ArgTypes>(Args)...);
@@ -603,12 +603,12 @@ public:
                              bool diagnoseErrors,
                              GenericTypeResolver *resolver,
                              UnsatisfiedDependency *unsatisfiedDependency);
-  
+
   /// Bind an UnresolvedDeclRefExpr by performing name lookup and
   /// returning the resultant expression.  Context is the DeclContext used
   /// for the lookup.
   Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context);
-  
+
   /// \brief Validate the given type.
   ///
   /// Type validation performs name binding, checking of generic arguments,
@@ -728,7 +728,7 @@ public:
 
   /// Apply generic arguments to the given type.
   ///
-  /// This functions requires a valid unbound generic type with the correct
+  /// This function requires a valid unbound generic type with the correct
   /// number of generic arguments given, whereas applyGenericArguments emits
   /// diagnostics in those cases.
   ///
@@ -810,7 +810,7 @@ public:
   /// \returns true if a checked cast from \c t1 to \c t2 may succeed, and
   /// false if it will certainly fail, e.g. because the types are unrelated.
   bool checkedCastMaySucceed(Type t1, Type t2, DeclContext *dc);
-  
+
   /// \brief Determine whether a constraint of the given kind can be satisfied
   /// by the two types.
   ///
@@ -945,7 +945,7 @@ public:
                       GenericSignature *outerSignature,
                       std::function<bool(ArchetypeBuilder &)> inferRequirements,
                       bool &invalid);
-                        
+
   /// Validate the signature of a generic type.
   ///
   /// \param nominal The generic type.
@@ -1022,7 +1022,7 @@ public:
   /// \brief Add the RawOptionSet (todo:, Equatable, and Hashable) methods to an
   /// imported NS_OPTIONS struct.
   void addImplicitStructConformances(StructDecl *ED);
-  
+
   /// \brief Add the RawRepresentable, Equatable, and Hashable methods to an
   /// enum with a raw type.
   void addImplicitEnumConformances(EnumDecl *ED);
@@ -1070,7 +1070,7 @@ public:
   /// \brief Fold the given sequence expression into an (unchecked) expression
   /// tree.
   Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);
-  
+
   /// \brief Type check the given expression.
   ///
   /// \param expr The expression to type-check, which will be modified in
@@ -1105,7 +1105,7 @@ public:
                                TypeCheckExprOptions(), listener);
   }
 
-  
+
   /// \brief Type check the given expression and return its type without
   /// applying the solution.
   ///
@@ -1121,7 +1121,7 @@ public:
   /// \returns the type of \p expr on success, None otherwise.
   /// FIXME: expr may still be modified...
   Optional<Type> getTypeOfExpressionWithoutApplying(
-      Expr *&expr, DeclContext *dc, 
+      Expr *&expr, DeclContext *dc,
       FreeTypeVariableBinding allowFreeTypeVariables =
                               FreeTypeVariableBinding::Disallow,
       ExprTypeCheckListener *listener = nullptr);
@@ -1160,7 +1160,7 @@ public:
   /// \returns true if an error occurred, false otherwise.
   bool typeCheckStmtCondition(StmtCondition &cond, DeclContext *dc,
                               Diag<> diagnosticForAlwaysTrue);
-  
+
   /// \brief Determine the semantics of a checked cast operation.
   ///
   /// \param fromType       The source type of the cast.
@@ -1222,7 +1222,7 @@ public:
   /// name lookup information. Must be done before type-checking the pattern.
   Pattern *resolvePattern(Pattern *P, DeclContext *dc,
                           bool isStmtCondition);
-  
+
   /// Type check the given pattern.
   ///
   /// \param P The pattern to type check.
@@ -1311,10 +1311,10 @@ public:
   ///
   /// \returns true if an error occurred, false otherwise.
   bool convertToType(Expr *&expr, Type type, DeclContext *dc);
-  
+
   /// \brief Coerce the given expression to an rvalue, if it isn't already.
   Expr *coerceToRValue(Expr *expr);
-  
+
   /// \brief Coerce the given expression to materializable type, if it
   /// isn't already.
   Expr *coerceToMaterializable(Expr *expr);
@@ -1361,7 +1361,7 @@ public:
   ///
   /// \param name The name of the method to call.
   ///
-  /// \param arguments The arguments to 
+  /// \param arguments The arguments to
   ///
   /// \param brokenProtocolDiag Diagnostic to emit if the protocol is broken.
   ///
@@ -1447,7 +1447,7 @@ public:
   ValueDecl *deriveProtocolRequirement(DeclContext *DC,
                                        NominalTypeDecl *TypeDecl,
                                        ValueDecl *Requirement);
-  
+
   /// Derive an implicit type witness for the given associated type in
   /// the conformance of the given nominal type to some known
   /// protocol.
@@ -1481,7 +1481,7 @@ public:
   /// \brief Look up a member type within the given type.
   ///
   /// This routine looks for member types with the given name within the
-  /// given type. 
+  /// given type.
   ///
   /// \param dc The context that needs the member.
   /// \param type The type in which we will look for a member type.
@@ -1518,7 +1518,7 @@ public:
   bool diagnoseExplicitUnavailability(const ValueDecl *D,
                                       SourceRange R,
                                       const DeclContext *DC);
-  
+
   /// @}
 
   /// Fix the name of the given function to the target name, attaching
@@ -1608,7 +1608,7 @@ public:
                                           Type T, SourceRange TypeRange);
 
   void fillObjCRepresentableTypeCache(const DeclContext *DC);
-  
+
   ArchetypeBuilder createArchetypeBuilder(Module *mod);
 
   /// \name Availability checking
@@ -1786,7 +1786,7 @@ public:
 class CleanupIllFormedExpressionRAII {
   ASTContext &Context;
   Expr **expr;
-  
+
 public:
   CleanupIllFormedExpressionRAII(ASTContext &Context, Expr *&expr)
     : Context(Context), expr(&expr) { }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -702,7 +702,35 @@ public:
                             UnsatisfiedDependency *unsatisfiedDependency
                               = nullptr);
 
-  /// \brief Apply generic arguments to the given type.
+  /// Apply generic arguments to the given type.
+  ///
+  /// This function emits diagnostics about an invalid type or the wrong number
+  /// of generic arguments, whereas applyUnboundGenericArguments requires this
+  /// to be in a correct and valid form.
+  ///
+  /// \param type The generic type to which to apply arguments.
+  /// \param loc The source location for diagnostic reporting.
+  /// \param dc The context where the arguments are applied.
+  /// \param generic The arguments to apply with the angle bracket range for
+  /// diagnostics.
+  /// \param isGenericSignature True if we are looking only in the generic
+  /// signature of the context.
+  /// \param resolver The generic type resolver.
+  ///
+  /// \returns A BoundGenericType bound to the given arguments, or null on
+  /// error.
+  ///
+  /// \see applyUnboundGenericArguments
+  Type applyGenericArguments(Type type, SourceLoc loc, DeclContext *dc,
+                             GenericIdentTypeRepr *generic,
+                             bool isGenericSignature,
+                             GenericTypeResolver *resolver);
+
+  /// Apply generic arguments to the given type.
+  ///
+  /// This functions requires a valid unbound generic type with the correct
+  /// number of generic arguments given, whereas applyGenericArguments emits
+  /// diagnostics in those cases.
   ///
   /// \param unbound The unbound generic type to which to apply arguments.
   /// \param loc The source location for diagnostic reporting.
@@ -714,8 +742,9 @@ public:
   ///
   /// \returns A BoundGenericType bound to the given arguments, or null on
   /// error.
-  Type applyUnboundGenericArguments(UnboundGenericType *unbound,
-                                    SourceLoc loc,
+  ///
+  /// \see applyGenericArguments
+  Type applyUnboundGenericArguments(UnboundGenericType *unbound, SourceLoc loc,
                                     DeclContext *dc,
                                     MutableArrayRef<TypeLoc> genericArgs,
                                     bool isGenericSignature,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -704,7 +704,7 @@ public:
 
   /// \brief Apply generic arguments to the given type.
   ///
-  /// \param type The unbound generic type to which to apply arguments.
+  /// \param unbound The unbound generic type to which to apply arguments.
   /// \param loc The source location for diagnostic reporting.
   /// \param dc The context where the arguments are applied.
   /// \param genericArgs The list of generic arguments to apply to the type.
@@ -714,12 +714,12 @@ public:
   ///
   /// \returns A BoundGenericType bound to the given arguments, or null on
   /// error.
-  Type applyGenericArguments(Type type,
-                             SourceLoc loc,
-                             DeclContext *dc,
-                             MutableArrayRef<TypeLoc> genericArgs,
-                             bool isGenericSignature,
-                             GenericTypeResolver *resolver);
+  Type applyUnboundGenericArguments(UnboundGenericType *unbound,
+                                    SourceLoc loc,
+                                    DeclContext *dc,
+                                    MutableArrayRef<TypeLoc> genericArgs,
+                                    bool isGenericSignature,
+                                    GenericTypeResolver *resolver);
 
   /// \brief Substitute the given base type into the type of the given member,
   /// producing the effective type that the member will have.

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -211,7 +211,7 @@ func useNested(ii: Int, hni: HasNested<Int>,
 }
 
 var dfail : Dictionary<Int> // expected-error{{generic type 'Dictionary' specialized with too few type parameters (got 1, but expected 2)}}
-var notgeneric : Int<Float> // expected-error{{cannot specialize non-generic type 'Int'}}
+var notgeneric : Int<Float> // expected-error{{cannot specialize non-generic type 'Int'}}{{21-28=}}
 
 // Check unqualified lookup of inherited types.
 class Foo<T> {
@@ -247,7 +247,7 @@ extension Bar {
   struct Inner2 {
     func f(x: Int) -> Nested {
       return x
-    }    
+    }
   }
   */
 }
@@ -263,7 +263,7 @@ class XArray : ArrayLiteralConvertible {
 
 class YArray : XArray {
   typealias Element = Int
-  required init(arrayLiteral elements: Int...) { 
+  required init(arrayLiteral elements: Int...) {
     super.init()
   }
 }


### PR DESCRIPTION
Move the checks for invalid generic arguments into `applyGenericTypeReprArgs` so we can pass the `GenericIdentTypeRepr` into it to access the angle bracket range while `resolveDictionaryType` can still use `applyUnboundGenericArguments` without an `GenericIdentTypeRepr`.

Edit: `check-swift` passed
