### PR TITLE
Fix a-vs-an inconsistencies ("an std::…", "a RAII")

### DIFF
--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -367,7 +367,7 @@ struct NodeFactory {
   }
 };
 
-  /// A class for printing to a std::string.
+  /// A class for printing to an std::string.
 class DemanglerPrinter {
 public:
   DemanglerPrinter(std::string &out) : Stream(out) {}

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -59,7 +59,7 @@ public:
     BaseInputs.push_back(BaseInput);
   }
   
-  // This returns a std::string instead of a StringRef so that users can rely
+  // This returns an std::string instead of a StringRef so that users can rely
   // on the data buffer being null-terminated.
   const std::string &getPrimaryOutputFilename() const {
     assert(PrimaryOutputFilenames.size() == 1);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -272,7 +272,7 @@ public:
     Optional<StringRef> LeadingWhitespace;
   };
 
-  /// An RAII object that notes when we have seen a structure marker.
+  /// A RAII object that notes when we have seen a structure marker.
   class StructureMarkerRAII {
     Parser &P;
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1442,7 +1442,7 @@ private:
   }  
 };
 
-/// An RAII version of SILBuilder that automatically sets up identical
+/// A RAII version of SILBuilder that automatically sets up identical
 /// SILDebugScopes for all instructions.  This is useful for
 /// situations where a single SIL instruction is lowered into a
 /// sequence of SIL instructions.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -778,7 +778,7 @@ public:
   CanGenericSignature getEffectiveGenericSignature(AnyFunctionRef fn,
                                                    CaptureInfo captureInfo);
 
-  /// Push a generic function context. See GenericContextScope for an RAII
+  /// Push a generic function context. See GenericContextScope for a RAII
   /// interface to this function.
   ///
   /// Types containing generic parameter references must be lowered in a generic
@@ -792,7 +792,7 @@ public:
     return CurGenericContext;
   }
   
-  /// Pop a generic function context. See GenericContextScope for an RAII
+  /// Pop a generic function context. See GenericContextScope for a RAII
   /// interface to this function. There must be an active generic context.
   void popGenericContext(CanGenericSignature sig);
   

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -211,7 +211,7 @@ private:
   Types_t Types;
 };
 
-/// An RAII interface for entering a generic context for type conversion in
+/// A RAII interface for entering a generic context for type conversion in
 /// a scope.
 class GenericContextScope {
   TypeConverter &TC;

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -288,7 +288,7 @@ private:
   TypeAliasDecl *getMetadataType();
 };
 
-/// \brief An RAII object that autorestores the debug location.
+/// \brief A RAII object that autorestores the debug location.
 class AutoRestoreLocation {
   IRGenDebugInfo *DI;
 public:
@@ -304,7 +304,7 @@ public:
   }
 };
 
-/// \brief An RAII object that temporarily switches to
+/// \brief A RAII object that temporarily switches to
 /// an artificial debug location that has a valid scope, but no line
 /// information. This is useful when emitting compiler-generated
 /// instructions (e.g., ARC-inserted calls to release()) that have no
@@ -324,7 +324,7 @@ public:
   }
 };
 
-/// \brief An RAII object that temporarily switches to an
+/// \brief A RAII object that temporarily switches to an
 /// empty location. This is how the function prologue is represented.
 class PrologueLocation : public AutoRestoreLocation {
 public:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -175,7 +175,7 @@ namespace {
     }
   };
 
-  /// An RAII type to exclude tokens contributing to private decls from the
+  /// A RAII type to exclude tokens contributing to private decls from the
   /// interface hash of the source file. On destruct, it checks if the set of
   /// attributes includes the "private" attribute; if so, it resets the MD5
   /// hash of the source file to what it was when the IgnorePrivateDeclTokens

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -194,7 +194,7 @@ public:
   bool hasAnyActiveCleanups(CleanupsDepth from);
 };
 
-/// An RAII object that allows the state of a cleanup to be
+/// A RAII object that allows the state of a cleanup to be
 /// temporarily modified.
 class CleanupStateRestorationScope {
   CleanupManager &Cleanups;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1003,7 +1003,7 @@ SILGenModule::useConformancesFromSubstitutions(ArrayRef<Substitution> subs) {
 
 namespace {
 
-/// An RAII class to scope source file codegen.
+/// A RAII class to scope source file codegen.
 class SourceFileScope {
   SILGenModule &sgm;
   SourceFile *sf;

--- a/lib/Sema/ConstraintGraphScope.h
+++ b/lib/Sema/ConstraintGraphScope.h
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the \c ConstraintGraphScope class, an RAII object that
+// This file defines the \c ConstraintGraphScope class, a RAII object that
 // introduces a new scope in which changes to the constraint graph are
 // capture and will be reverted when the scope disappears.
 //

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -1144,7 +1144,7 @@ class CheckErrorCoverage : public ErrorHandlingWalker<CheckErrorCoverage> {
     Flags.set(ContextFlags::HasTryThrowSite);
   }
 
-  /// An RAII object for restoring all the interesting state in an
+  /// A RAII object for restoring all the interesting state in an
   /// error-coverage.
   class ContextScope {
     CheckErrorCoverage &Self;


### PR DESCRIPTION
Change to consistent project wide use of:
- "a std::…" → "an std::…"
- "an RAII" → "a RAII"
