### PR TITLE
[SR-237][build-script] Determine CMake in Python

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -36,6 +36,7 @@ from SwiftBuildSupport import (
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 import swift_build_support.clang
+import swift_build_support.cmake
 from swift_build_support.migration import migrate_impl_args
 
 
@@ -506,6 +507,9 @@ the number of parallel build jobs to use""",
     parser.add_argument("--darwin-xcrun-toolchain",
                         help="the name of the toolchain to use on Darwin",
                         default="default")
+    parser.add_argument("--cmake",
+                        help="the path to a CMake executable that will be "
+                             "used to build Swift")
 
     parser.add_argument("--extra-swift-args", help=textwrap.dedent("""
     Pass through extra flags to swift in the form of a cmake list 'module_regexp;flag'. Can
@@ -518,7 +522,9 @@ the number of parallel build jobs to use""",
         nargs="*")
 
     args = parser.parse_args(migrate_impl_args(sys.argv[1:], [
-        '--darwin-xcrun-toolchain']))
+        '--darwin-xcrun-toolchain',
+        '--cmake',
+    ]))
 
     # Build cmark if any cmark-related options were specified.
     if (args.cmark_build_variant is not None):
@@ -728,12 +734,21 @@ the number of parallel build jobs to use""",
         print_with_argv0(
             "Can't find clang.  Please install clang-3.5 or a later version.")
         return 1
+
+    host_cmake = args.cmake
+    if not host_cmake:
+        host_cmake = swift_build_support.cmake.host_cmake(
+            args.darwin_xcrun_toolchain)
+    if not host_cmake:
+        print_with_argv0("Can't find CMake. Please install CMake.")
+        return 1
     build_script_impl_args = [
         os.path.join(SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl"),
         "--build-dir", build_dir,
         "--host-cc", host_clang.cc,
         "--host-cxx", host_clang.cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
+        "--cmake", host_cmake,
         "--cmark-build-type", args.cmark_build_variant,
         "--llvm-build-type", args.llvm_build_variant,
         "--swift-build-type", args.swift_build_variant,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -672,6 +672,19 @@ if [ ! -e "${WORKSPACE}" ] ; then
     exit 1
 fi
 
+# FIXME: HOST_CC and CMAKE are set, and their presence is validated by,
+#        utils/build-script. These checks are redundant, but must remain until
+#        build-script-impl is merged completely with utils/build-script.
+#        For additional information, see: https://bugs.swift.org/browse/SR-237
+if [ -z "${HOST_CC}" ] ; then
+    echo "Can't find clang.  Please install clang-3.5 or a later version."
+    exit 1
+fi
+if [ -z "${CMAKE}" ] ; then
+    echo "Environment variable CMAKE must be specified."
+    exit 1
+fi
+
 function xcrun_find_tool() {
   xcrun --sdk macosx --toolchain "${DARWIN_XCRUN_TOOLCHAIN}" --find "$@"
 }
@@ -700,14 +713,6 @@ function true_false() {
 #
 # Set default values for command-line parameters.
 #
-
-if [[ "${CMAKE}" == "" ]] ; then
-    if [[ "$(uname -s)" == "Darwin" ]] ; then
-        CMAKE="$(xcrun_find_tool cmake)"
-    else
-        CMAKE="$(which cmake || echo /usr/local/bin/cmake)"
-    fi
-fi
 
 if [[ "${INSTALL_PREFIX}" == "" ]] ; then
     if [[ "$(uname -s)" == "Darwin" ]] ; then
@@ -1037,15 +1042,6 @@ if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
         "${COMMON_CMAKE_OPTIONS[@]}"
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     )
-fi
-
-# FIXME: HOST_CC is set and its presence is validated by utils/build-script.
-#        This check is redundant, but must remain until build-script-impl
-#        is merged completely with utils/build-script.
-#        For additional information, see: https://bugs.swift.org/browse/SR-237
-if [ -z "${HOST_CC}" ] ; then
-    echo "Can't find clang.  Please install clang-3.5 or a later version."
-    exit 1
 fi
 
 if [[ "${DISTCC}" ]] ; then

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -1,0 +1,36 @@
+# swift_build_support/cmake.py - Detect host machine's CMake -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+#
+# Find the path to a CMake executable on the host machine.
+#
+# ----------------------------------------------------------------------------
+
+import platform
+
+from . import xcrun
+from .which import which
+
+
+def host_cmake(xcrun_toolchain):
+    """
+    Return the path to `cmake`, using tools provided by the host platform.
+    If `cmake` cannot be found on OS X, return None.
+    If `cmake` cannot be found on Linux, return a probable path.
+    """
+    if platform.system() == 'Darwin':
+        return xcrun.find(xcrun_toolchain, 'cmake')
+    else:
+        cmake = which('cmake')
+        if cmake:
+            return cmake
+        else:
+            return '/usr/local/bin/cmake'

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -1,0 +1,26 @@
+# test_cmake.py - Unit tests for swift_build_support.cmake -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import os
+import unittest
+
+from swift_build_support.cmake import host_cmake
+
+
+class HostCMakeTestCase(unittest.TestCase):
+    def test_cmake_available_on_this_platform(self):
+        # Test that CMake is installed on this platform, as a means of
+        # testing host_cmake().
+        cmake = host_cmake(xcrun_toolchain='default')
+        self.assertEqual(os.path.split(cmake)[-1], 'cmake')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
SR-237 calls for `build-script` and `build-script-impl` to be merged. This
commit takes another step towards that goal by moving the logic that finds
the path to the CMake executable up into `build-script`.

Users of `build-script` were previously able to specify which CMake
they wished to use via `build-script-impl` args, like so:

```
$ utils/build-script -- --cmake=/foo/bar/cmake
```

This commit preserves that behavior, while also allowing users to
specify that path via `build-script` args:

```
$ utils/build-script --cmake=/baz/cmake -- --other --flags
```
