### PR TITLE
[cmpcodesize] Add code headers

### DIFF
--- a/utils/cmpcodesize/cmpcodesize.py
+++ b/utils/cmpcodesize/cmpcodesize.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+# cmpcodesize.py - Compare sizes of built products -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 from cmpcodesize.main import main
 

--- a/utils/cmpcodesize/cmpcodesize/__init__.py
+++ b/utils/cmpcodesize/cmpcodesize/__init__.py
@@ -1,3 +1,20 @@
+# cmpcodesize/__init__.py - Compare sizes of built products -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+#
+# This file needs to be here in order for Python to treat the
+# utils/cmpcodesize/cmpcodesize directory as a module.
+#
+# ----------------------------------------------------------------------------
+
 __author__ = 'Brian Gesiak'
 __email__ = 'modocache@gmail.com'
 __versioninfo__ = (0, 1, 0)

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -1,3 +1,13 @@
+# cmpcodesize/compare.py - Compare sizes of built products -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 from __future__ import print_function
 
 import re

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python
+# cmpcodesize/main.py - Command-line entry point for cmpcodesize -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 from __future__ import print_function
 

--- a/utils/cmpcodesize/setup.py
+++ b/utils/cmpcodesize/setup.py
@@ -1,3 +1,13 @@
+# cmpcodesize/setup.py - Install script for cmpcodesize -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 import os
 import setuptools
 

--- a/utils/cmpcodesize/tests/__init__.py
+++ b/utils/cmpcodesize/tests/__init__.py
@@ -1,0 +1,16 @@
+# cmpcodesize/tests/__init__.py - Unit tests for cmpcodesize -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+#
+# This file needs to be here in order for Python to treat the
+# utils/cmpcodesize/tests/ directory as a module.
+#
+# ----------------------------------------------------------------------------

--- a/utils/cmpcodesize/tests/test_list_function_sizes.py
+++ b/utils/cmpcodesize/tests/test_list_function_sizes.py
@@ -1,3 +1,13 @@
+# test_list_function_sizes.py - Unit tests for listFunctionSizes -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 import unittest
 
 from cmpcodesize.compare import listFunctionSizes


### PR DESCRIPTION
Add code headers missing from the Python files in utils/cmpcodesize, as per
the template from #762.
