### PR TITLE
[compile error] a typo in source code

### DIFF
--- a/tools/SourceKit/lib/Support/Tracing.cpp
+++ b/tools/SourceKit/lib/Support/Tracing.cpp
@@ -64,7 +64,7 @@ uint64_t trace::startOperation(trace::OperationKind OpKind,
   if (trace::enabled()) {
     auto Node = consumers.load(std::memory_order_acquire);
     while (Node) {
-      Node->Consumer->opertationStarted(OpId, OpKind, Inv, OpArgs);
+      Node->Consumer->operationStarted(OpId, OpKind, Inv, OpArgs);
       Node = Node->Next;
     }
   }

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XpcTracing.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XpcTracing.cpp
@@ -104,16 +104,16 @@ public:
   virtual void operationFinished(uint64_t OpId) override;
 
   // Trace start of SourceKit operation
-  virtual void opertationStarted(uint64_t OpId, OperationKind OpKind,
-                                 const SwiftInvocation &Inv,
-                                 const StringPairs &OpArgs) override;
+  virtual void operationStarted(uint64_t OpId, OperationKind OpKind,
+                                const SwiftInvocation &Inv,
+                                const StringPairs &OpArgs) override;
 };
 
 // Trace start of SourceKit operation
-void XpcTraceConsumer::opertationStarted(uint64_t OpId,
-                                         OperationKind OpKind,
-                                         const SwiftInvocation &Inv,
-                                         const StringPairs &OpArgs) {
+void XpcTraceConsumer::operationStarted(uint64_t OpId,
+                                        OperationKind OpKind,
+                                        const SwiftInvocation &Inv,
+                                        const StringPairs &OpArgs) {
   xpc_object_t Contents = xpc_array_create(nullptr, 0);
   append(Contents, ActionKind::OperationStarted);
   append(Contents, OpId);


### PR DESCRIPTION
I have tried to run `utils/build-script` and got:

``` bash
+ /usr/local/bin/cmake --build /Users/arsen/dev/apple/build/Ninja-DebugAssert/swift-macosx-x86_64 -- -j4 all swift-stdlib-macosx-x86_64
[15/399] Building CXX object tools/SourceKit/lib/Support/CMakeFiles/SourceKitSupport.dir/Tracing.cpp.o
FAILED: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++   -DGTEST_HAS_RTTI=0 -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Itools/SourceKit/lib/Support -I/Users/arsen/dev/apple/swift/tools/SourceKit/lib/Support -I/Users/arsen/dev/apple/swift/tools/SourceKit/include -Iinclude -I/Users/arsen/dev/apple/swift/include -I/Users/arsen/dev/apple/build/Ninja-DebugAssert/llvm-macosx-x86_64/include -I/Users/arsen/dev/apple/llvm/include -I/Users/arsen/dev/apple/build/Ninja-DebugAssert/llvm-macosx-x86_64/tools/clang/include -I/Users/arsen/dev/apple/llvm/tools/clang/include -I/Users/arsen/dev/apple/cmark/src -I/Users/arsen/dev/apple/build/Ninja-DebugAssert/cmark-macosx-x86_64/src -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wcovered-switch-default -Wnon-virtual-dtor -Werror=date-time -std=c++11 -fcolor-diagnostics -Wdocumentation -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -mmacosx-version-min=10.11 -g    -fno-exceptions -fno-rtti -MMD -MT tools/SourceKit/lib/Support/CMakeFiles/SourceKitSupport.dir/Tracing.cpp.o -MF tools/SourceKit/lib/Support/CMakeFiles/SourceKitSupport.dir/Tracing.cpp.o.d -o tools/SourceKit/lib/Support/CMakeFiles/SourceKitSupport.dir/Tracing.cpp.o -c /Users/arsen/dev/apple/swift/tools/SourceKit/lib/Support/Tracing.cpp
/Users/arsen/dev/apple/swift/tools/SourceKit/lib/Support/Tracing.cpp:67:23: error: no member named 'opertationStarted' in 'SourceKit::trace::TraceConsumer'; did you mean 'operationStarted'?
      Node->Consumer->opertationStarted(OpId, OpKind, Inv, OpArgs);
                      ^~~~~~~~~~~~~~~~~
                      operationStarted
/Users/arsen/dev/apple/swift/tools/SourceKit/include/SourceKit/Support/Tracing.h:70:16: note: 'operationStarted' declared here
  virtual void operationStarted(uint64_t OpId, OperationKind OpKind,
               ^

```
