### PR TITLE
[build-script] Reduce the size of development snapshots

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -995,12 +995,12 @@ To build with AddressSanitizer:
 
   [~/src/s]$ ./swift/utils/build-script --preset=asan
 
-To build a root for Xcode XYZ, '/tmp/xcode-xyz-root.tar.gz':
+To build a root for Xcode XYZ, '/tmp/xcode-xyz-root.tar.xz':
 
   [~/src/s]$ ./swift/utils/build-script --preset=buildbot_BNI_internal_XYZ \\
       install_destdir="/tmp/install"
       install_symroot="/tmp/symroot"
-      installable_package="/tmp/xcode-xyz-root.tar.gz"
+      installable_package="/tmp/xcode-xyz-root.tar.xz"
 
 If you have your own favorite set of options, you can create your own, local,
 preset.  For example, let's create a preset called 'ds' (which stands for

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2775,15 +2775,15 @@ function build_and_test_installable_package() {
           # host_install_destdir contains the toolchain prefix.
           # We want to create the package in host_install_destdir_nonprefixed.
           with_pushd "${host_install_destdir}" \
-              call tar -c -z -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}"
+              call tar -c -J -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}"
         else
             # tar on OS X doesn't support --owner/--group.
             if [[ "$(uname -s)" == "Darwin" ]] ; then
                 with_pushd "${host_install_destdir}" \
-                    tar -c -z -f "${package_for_host}" "${host_install_prefix/#\/}"
+                    tar -c -J -f "${package_for_host}" "${host_install_prefix/#\/}"
             else
                 with_pushd "${host_install_destdir}" \
-                    tar -c -z -f "${package_for_host}" --owner=0 --group=0 "${host_install_prefix/#\/}"
+                    tar -c -J -f "${package_for_host}" --owner=0 --group=0 "${host_install_prefix/#\/}"
             fi
         fi
         if [[ "${TEST_INSTALLABLE_PACKAGE}" ]] ; then
@@ -2803,7 +2803,7 @@ function build_and_test_installable_package() {
             call rm -rf "${PKG_TESTS_SANDBOX_PARENT}"
             call mkdir -p "${PKG_TESTS_SANDBOX}"
             with_pushd "${PKG_TESTS_SANDBOX_PARENT}" \
-                call tar xzf "${package_for_host}"
+                call tar xf "${package_for_host}"
 
             with_pushd "${PKG_TESTS_SOURCE_DIR}" \
                 call python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param filecheck="${FILECHECK_EXECUTABLE_PATH}" --param test-exec-root="${PKG_TESTS_TEMPS}"


### PR DESCRIPTION
Currently development snapshots for Linux are provided as `*.tar.gz` files (Gzip compression). This patch switches the archive format to `*.tar.xz` (LZMA2 compression).

There are lots of discussions out there that talk about why LZMA2 format might be preferred over Gzip so I'll omit them here.

For this project, the major benefit is an [approximate 46% reduction](http://www.wolframalpha.com/input/?i=percent+difference&f1=60306748&f=PercentDifference.number1_60306748&f2=88476335&f=PercentDifference.number2_88476335) in the source snapshots provided on Swift.org (from ~85MB to ~58MB). The trade-off is that it does add a little bit of time to the build, on my machine it amounts to another minute or so. Considering that the over-all build currently takes longer than an hour I would consider this addition "in-the-noise" and a fair trade off. Your experience and opinion may differ. Additionally another often cited negative about LZMA2 vs Gzip is compatibility. Both of the targeted Linux builds `tar` utilities support LZMA2.

My expectation is that the number of downloads is much much greater than than the number of people building from source and packaging. With that in mind this seems like an easy gain with little downside.
