### PR TITLE
Prune some redundant #includes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -17,25 +17,14 @@
 #ifndef SWIFT_DECL_H
 #define SWIFT_DECL_H
 
-#include "swift/AST/Attr.h"
 #include "swift/AST/CaptureInfo.h"
-#include "swift/AST/DeclContext.h"
 #include "swift/AST/DefaultArgumentKind.h"
 #include "swift/AST/GenericSignature.h"
-#include "swift/AST/KnownProtocols.h"
-#include "swift/AST/Identifier.h"
 #include "swift/AST/LazyResolver.h"
-#include "swift/AST/Requirement.h"
-#include "swift/AST/Substitution.h"
-#include "swift/AST/TypeLoc.h"
 #include "swift/Basic/OptionalEnum.h"
 #include "swift/Basic/Range.h"
-#include "swift/Basic/SourceLoc.h"
-#include "swift/Basic/STLExtras.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include <cstddef>
 
 namespace clang {
   class Decl;

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -18,13 +18,8 @@
 #ifndef SWIFT_BASIC_DIAGNOSTICENGINE_H
 #define SWIFT_BASIC_DIAGNOSTICENGINE_H
 
-#include "swift/Basic/LLVM.h"
-#include "swift/AST/Identifier.h"
-#include "swift/AST/Type.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/Basic/DiagnosticConsumer.h"
-#include "swift/Basic/SourceLoc.h"
-#include "clang/Basic/VersionTuple.h"
 
 namespace swift {
   class Decl;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -19,13 +19,8 @@
 
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ConcreteDeclRef.h"
-#include "swift/AST/DeclContext.h"
-#include "swift/AST/Identifier.h"
-#include "swift/AST/Substitution.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/Availability.h"
-#include "swift/Basic/SourceLoc.h"
-#include "swift/Config.h"
 
 namespace llvm {
   struct fltSemantics;

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -20,7 +20,6 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerUnion.h"
-#include <cstring>
 
 namespace llvm {
   class raw_ostream;

--- a/include/swift/Basic/DiagnosticConsumer.h
+++ b/include/swift/Basic/DiagnosticConsumer.h
@@ -19,10 +19,7 @@
 #ifndef SWIFT_BASIC_DIAGNOSTIC_CONSUMER_H
 #define SWIFT_BASIC_DIAGNOSTIC_CONSUMER_H
 
-#include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SourceMgr.h"
 
 namespace swift {


### PR DESCRIPTION
Inspired by @lattner:s commit https://github.com/apple/swift/commit/d03fc2c536e5f6796f30f4c0b48d2e784ff14f59
