### PR TITLE
[viewcfg] Add Python code header, prevent execution when importing

### DIFF
--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -1,19 +1,30 @@
 #!/usr/bin/env python
-
-# A script for viewing the CFG of SIL and llvm IR.
-
-# For vim users: use the following lines in .vimrc
+# viewcfg - A script for viewing the CFG of SIL and LLVM IR -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+#
+# For vim users: use the following lines in .vimrc...
 #
 #   com! -nargs=? Funccfg silent ?{$?,/^}/w !viewcfg <args>
 #   com! -range -nargs=? Viewcfg silent <line1>,<line2>w !viewcfg <args>
 #
-# to add these commands:
+# ...to add these commands:
 #
-#   :Funccfg        displays the CFG of the current SIL/llvm function.
+#   :Funccfg        displays the CFG of the current SIL/LLVM function.
 #   :<range>Viewcfg displays the sub-CFG of the selected range.
 #
 # Note: viewcfg should be in the $PATH and .dot files should be associated
 # with the Graphviz app.
+#
+# ----------------------------------------------------------------------------
 
 from __future__ import print_function
 

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -170,5 +170,5 @@ def main():
 
     subprocess.call(["open", fileName])
 
-main()
-
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What's in this pull request?

This adds the standard Python code header to `viewcfg`. It also adds an idiomatic Python check that prevents code from being run if the file is imported by another Python script.
## Why merge this pull request?
- It makes the script more consistent with the rest of the Python code in the Swift codebase.
- It allows the script to be imported and used by other scripts, if that ever becomes desirable.
- It adds the proper copyright to the file.
## What downsides are there to merging this pull request?

One could argue that a code header should be added to all Python files in the codebase at once, in a single commit. I'm not doing so here because I happened upon this file when using it, and decided to send a quick pull request, instead of trying to find all the remaining Python in this repository.
