### PR TITLE
[validation-test] Add line-directive doctests

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -1,5 +1,21 @@
 #!/usr/bin/env python
-#convert line numbers in error messages according to "line directive" comments
+# line-directive.py - Transform line numbers in error messages -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+#
+# Converts line numbers in error messages according to "line directive"
+# comments.
+#
+# ----------------------------------------------------------------------------
+
 import sys
 import re
 import bisect

--- a/validation-test/Python/line-directive.swift
+++ b/validation-test/Python/line-directive.swift
@@ -1,0 +1,1 @@
+// RUN: %{python} %S/../../utils/line-directive


### PR DESCRIPTION
## What's in this pull request?

This adds the standard Python code header to `utils/line-directive`. It also adds that script's tests to the `validation-test` targets.
## Why merge this pull request?
- It makes the script more consistent with the rest of the Python code in the Swift codebase.
- It adds the proper copyright to the file.
- It ensures the tests for this file pass, without requiring developers to run them manually.
## What downsides are there to merging this pull request?
- There's only a single doctest in `utils/line-directive`. It's not a very robust test suite in the first place, so the value of adding it to `validation-test` is questionable.
- One could argue that a code header should be added to all Python files in the codebase at once, in a single commit. I'm not doing so here because I happened upon this file when using it, and decided to send a quick pull request, instead of trying to find all the remaining Python in this repository.
