### PR TITLE
Make scripts/pipeline_generator.py usable again

### DIFF
--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -102,10 +102,6 @@ def lower_passlist():
 def normal_passpipelines():
     result = []
 
-    x = ppipe.PassPipeline('PreSpecialize', {'name': 'run_to_fixed_point'})
-    x.addPass(specialization_passlist())
-    result.append(x)
-
     x = ppipe.PassPipeline('HighLevel', {'name': 'run_n_times', 'count': 2})
     x.addPass(ssapass_passlist('high'))
     result.append(x)


### PR DESCRIPTION
Before this commit:

```
$ utils/pass-pipeline/scripts/pipeline_generator.py
utils/pass-pipeline/scripts/pipeline_generator.py
Traceback (most recent call last):
  File "utils/pass-pipeline/scripts/pipeline_generator.py", line 15, in <module>
    normal_pipeline = [x for x in pass_pipeline_library.normal_passpipelines()]
  File "/path/to/swift/utils/pass-pipeline/src/pass_pipeline_library.py", line 106, in normal_passpipelines
    x.addPass(specialization_passlist())
NameError: global name 'specialization_passlist' is not defined
```

After this commit:

```
$ utils/pass-pipeline/scripts/pipeline_generator.py
[
    [
        "HighLevel",
        "run_n_times",
        2,
        "SimplifyCFG",
…
```
