### PR TITLE
Assert that a type should never be its own superclass.

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -500,6 +500,8 @@ static void lookupVisibleMemberDeclsImpl(
     ClassDecl *CurClass = dyn_cast<ClassDecl>(CurNominal);
 
     if (CurClass && CurClass->hasSuperclass()) {
+      assert(BaseTy.getPointer() != CurClass->getSuperclass().getPointer() &&
+             "type is its own superclass");
       BaseTy = CurClass->getSuperclass();
       Reason = getReasonForSuper(Reason);
 


### PR DESCRIPTION
Such a condition will create an endless loop in `lookupVisibleMemberDeclsImpl(…)`.
