### PR TITLE
Always print UUIDs using uppercase.

### DIFF
--- a/lib/Basic/UUID.cpp
+++ b/lib/Basic/UUID.cpp
@@ -41,7 +41,7 @@ Optional<UUID> UUID::fromString(const char *s) {
 
 void UUID::toString(llvm::SmallVectorImpl<char> &out) const {
   out.resize(UUID::StringBufferSize);
-  uuid_unparse(Value, out.data());
+  uuid_unparse_upper(Value, out.data());
   // Pop off the null terminator.
   assert(out.back() == '\0' && "did not null-terminate?!");
   out.pop_back();

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-silgen | FileCheck %s
 
-// XFAIL: linux
-
 sil_stage raw // CHECK: sil_stage raw
 
 import Builtin

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -9,8 +9,6 @@
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -sil-serialize-all -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-silgen -Xfrontend -sil-link-all -I %t %s | FileCheck -check-prefix=CHECK_DECL %S/Inputs/def_basic.sil
 
-// XFAIL: linux
-
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none
 


### PR DESCRIPTION
This changes UUID::toString() to always print using upper case. The previous
behavior was platform specific, resulting in difficulty checking UUIDs in tests.
Serialization/basic_sil.swift and SIL/Parser/basic.sil are now expected to pass
on Linux. This resolves bug SR-417.
