### PR TITLE
[SR-421][builld-script]fix error when osx system region is not set to US

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -36,6 +36,11 @@ LLVM_TARGETS_TO_BUILD="X86;ARM;AArch64"
 # End of configurable options.
 #
 
+# There is an existing issue around OS X & Python locale setting for sphinx
+# See https://bugs.python.org/issue18378#msg215215 for explanation
+LC_CTYPE="en_US.UTF-8"
+
+
 # Declare the set of known settings along with each one's description
 #
 # If you add a user-settable variable, add it to this list.


### PR DESCRIPTION
## Issue

https://bugs.swift.org/browse/SR-421
## Changes

Set LC_CTYPE to en_US.UTF-8  in the build-script to prevent build error when system region is not set to US
see https://bugs.python.org/issue18378#msg215215
