### PR TITLE
[swiftc] Add assertion: Avoid endless loop in case of circular protocol inheritance

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -491,6 +491,10 @@ void ConformanceLookupTable::expandImpliedConformances(NominalTypeDecl *nominal,
   // may be reallocated during this traversal, so pay the lookup cost
   // during each iteration.
   for (unsigned i = 0; i != AllConformances[dc].size(); ++i) {
+    /// FIXME: Avoid the possibility of an infinite loop by fixing the root
+    ///        cause instead (incomplete circularity detection).
+    assert(i <= 16384 &&
+           "Infinite loop due to circular protocol inheritance?");
     ConformanceEntry *conformanceEntry = AllConformances[dc][i];
     ProtocolDecl *conformingProtocol = conformanceEntry->getProtocol();
 

--- a/validation-test/compiler_crashers/10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
+++ b/validation-test/compiler_crashers/10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol c:A
+protocol A:d
+protocol d:d


### PR DESCRIPTION
Prior to this commit:

```
$ swiftc -<<<'protocol A:B{};protocol B:B{};protocol C:A{}'
[infinite compile time - never returns due to endless loop]
```

After this commit:

```
$ swiftc -<<<'protocol A:B{};protocol B:B{};protocol C:A{}'
swift: […]: Assertion `i <= 16384 && "Infinite loop due to circular protocol inheritance?"' failed.
```

Please note that this commit does not solve the root cause (incomplete circularity detection), but it makes the compiler fail fast (or at least faster). Failing fast is critical from a fuzzing perspective :-)

In short:
- Short term: introduce `assert(…)` to make sure we fail fast(-er)
- Long term: improve detection of circular protocol inheritance
