### PR TITLE
XFAIL Serialization/basic_sil.swift on Linux again

### DIFF
--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -9,6 +9,8 @@
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -sil-serialize-all -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-silgen -Xfrontend -sil-link-all -I %t %s | FileCheck -check-prefix=CHECK_DECL %S/Inputs/def_basic.sil
 
+// XFAIL: linux
+
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none
 


### PR DESCRIPTION
This disables Serialization/basic_sil.swift again on Linux. It was enabled as
part of commit b013be97, but this was a mistake as the test still fails.
