### PR TITLE
[Stdlib] Tweak doc comment for Indexable.startIndex

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -36,7 +36,8 @@ public protocol Indexable {
   ///
   /// In an empty collection, `startIndex == endIndex`.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) in most cases, possibly O(N) for some lazy
+  ///   collections.
   var startIndex: Index {get}
 
   /// The collection's "past the end" position.


### PR DESCRIPTION
The complexity of this property may actually be O(N) for some lazy
collections.

Fixes [SR-425](https://bugs.swift.org/browse/SR-425).
