### PR TITLE
[Stdlib] Optimize CollectionType.first

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -262,7 +262,12 @@ extension CollectionType {
   ///
   /// - Complexity: O(1)
   public var first: Generator.Element? {
-    return isEmpty ? nil : self[startIndex]
+    // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
+    // so instead of testing `isEmpty` and then returning the first element,
+    // we'll just rely on the fact that the generator always yields the
+    // first element first.
+    var gen = generate()
+    return gen.next()
   }
 
   /// Returns a value less than or equal to the number of elements in


### PR DESCRIPTION
For lazy collections, `isEmpty` and `startIndex` may be O(N) operations.
The old implementation ended up being potentially O(2N) instead of O(1).
In particular, accessing `col.lazy.filter(pred).first` would evaluate
the predicate on elements twice, once to determine the result of
`isEmpty` and once to determine `startIndex`.

While we're at it, tweak the complexity as well, as lazy collections may
be O(N).
