### PR TITLE
[swiftc] Add assertion: Avoid endless loop in case of circular class inheritance

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -71,6 +71,9 @@ bool swift::removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls) {
       // A.init are in the chain. Make sure we still remove A.init from the
       // set in this case.
       if (decl->getFullName().getBaseName() == ctx.Id_init) {
+        /// FIXME: Avoid the possibility of an infinite loop by fixing the root
+        ///        cause instead (incomplete circularity detection).
+        assert(decl != overrides && "Circular class inheritance?");
         decl = overrides;
         continue;
       }

--- a/validation-test/compiler_crashers/28188-swift-removeoverriddendecls.timeout.swift
+++ b/validation-test/compiler_crashers/28188-swift-removeoverriddendecls.timeout.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class A:A{init()


### PR DESCRIPTION
Prior to this commit:

```
$ swiftc -<<<'class A:A{init()}'
[infinite compile time - never returns due to endless loop]
```

After this commit:

```
$ swiftc -<<<'class A:A{init()}'
swift: […]: Assertion `decl != overrides && "Circular class inheritance?"' failed.
```

Please note that this commit does not solve the root cause (incomplete circularity detection), but it makes the compiler fail fast (or at least faster). Failing fast is critical from a fuzzing perspective :-)

In short:
- Short term: introduce `assert(…)` to make sure we fail fast
- Long term: improve detection of circular class inheritance
