### PR TITLE
[lit] The cmp() function should be treated as gone in Python 3

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -53,7 +53,13 @@ def darwin_sdk_build_version_split(version):
 
 
 def darwin_sdk_build_version_cmp(lhs, rhs):
-    return cmp(
+    # The `_cmp` function is provided to port the Python 2 global `cmp`
+    # function forward to Python 3. The function implementation is taken
+    # directly from the recommendation that announced its removal.
+    # See: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+    def _cmp(a, b):
+      return (a > b) - (a < b)
+    return _cmp(
         darwin_sdk_build_version_split(lhs),
         darwin_sdk_build_version_split(rhs))
 


### PR DESCRIPTION
As noted in the ["What's New in Python 3.0"](https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons) documentation the Python 2 `cmp` function no longer exists in Python 3. The document goes on to say that if you really need the `cmp` function you should define your own.

Since the function appears to only be used once in the script I defined a local function rather than shadow the Python 2 function. The local function, `_cmp`, implements the recommended expression from the ["What's New in Python 3.0"](https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons) document. The behavior is now defined on both Python 2 and 3.
