### PR TITLE
[SIL] Update integer_literal formatting in docs

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1389,7 +1389,7 @@ gets lowered to SIL as::
 
   sil @inout : $(@inout Int) -> () {
   entry(%x : $*Int):
-    %1 = integer_literal 1 : $Int
+    %1 = integer_literal $Int, 1
     store %1 to %x
     return
   }
@@ -4130,7 +4130,7 @@ original enum value.  For example::
       case #Foo.TwoInts!enumelt.1: two_ints
 
   nothing:
-    %zero = integer_literal 0 : $Int
+    %zero = integer_literal $Int, 0
     return %zero : $Int
 
   one_int(%y : $Int):


### PR DESCRIPTION
Fixes the formatting for integer_literal in the documentation so that it
conforms with the SIL grammar.
