### PR TITLE
[SR-381]: API to lookup a Type given a top-level class name

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2104,6 +2104,13 @@ struct GenericMetadata {
   const void *getMetadataTemplate() const {
     return reinterpret_cast<const void *>(this + 1);
   }
+
+  /// Return the nominal type descriptor for the template metadata
+  const NominalTypeDescriptor *getTemplateDescription() const {
+    auto bytes = reinterpret_cast<const uint8_t *>(getMetadataTemplate());
+    auto metadata = reinterpret_cast<const Metadata *>(bytes + AddressPoint);
+    return metadata->getNominalTypeDescriptor();
+  }
 };
 
 /// \brief The control structure of a generic protocol conformance.
@@ -2169,6 +2176,24 @@ public:
     }
 
     return DirectType;
+  }
+ 
+  const GenericMetadata *getGenericPattern() const {
+    switch (Flags.getTypeKind()) {
+    case TypeMetadataRecordKind::Universal:
+      return nullptr;
+
+    case TypeMetadataRecordKind::UniqueGenericPattern:
+      break;
+        
+    case TypeMetadataRecordKind::UniqueDirectClass:
+    case TypeMetadataRecordKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
+      assert(false && "not generic metadata pattern");
+    }
+    
+    return GenericPattern;
   }
   
   /// Get the canonical metadata for the type referenced by this record, or

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2125,6 +2125,57 @@ struct GenericWitnessTable {
   void *PrivateData[swift::NumGenericMetadataPrivateDataWords];
 };
 
+/// The structure of a type metadata record.
+///
+/// This contains enough static information to recover type metadata from a
+/// name. It is only emitted for types that do not have an explicit protocol
+/// conformance record. 
+///
+/// This structure is notionally a subtype of a protocol conformance record
+/// but as we cannot change the conformance record layout we have to make do
+/// with some duplicated code.
+struct TypeMetadataRecord {
+private:
+  // Some description of the type that is resolvable at runtime.
+  union {
+    /// A direct reference to the metadata.
+    RelativeDirectPointer<Metadata> DirectType;
+
+    /// The generic metadata pattern for an unbound generic type.
+    RelativeDirectPointer<GenericMetadata> GenericPattern;
+  };
+
+  /// Flags describing the type metadata record.
+  TypeMetadataRecordFlags Flags;
+  
+public:
+  TypeMetadataRecordKind getTypeKind() const {
+    return Flags.getTypeKind();
+  }
+  
+  const Metadata *getDirectType() const {
+    switch (Flags.getTypeKind()) {
+    case TypeMetadataRecordKind::Universal:
+      return nullptr;
+
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::UniqueDirectClass:
+      break;
+        
+    case TypeMetadataRecordKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueGenericPattern:
+      assert(false && "not direct type metadata");
+    }
+
+    return DirectType;
+  }
+  
+  /// Get the canonical metadata for the type referenced by this record, or
+  /// return null if the record references a generic or universal type.
+  const Metadata *getCanonicalTypeMetadata() const;
+};
+
 /// The structure of a protocol conformance record.
 ///
 /// This contains enough static information to recover the witness table for a
@@ -2177,7 +2228,7 @@ public:
     return Flags;
   }
   
-  ProtocolConformanceTypeKind getTypeKind() const {
+  TypeMetadataRecordKind getTypeKind() const {
     return Flags.getTypeKind();
   }
   ProtocolConformanceReferenceKind getConformanceKind() const {
@@ -2186,16 +2237,16 @@ public:
   
   const Metadata *getDirectType() const {
     switch (Flags.getTypeKind()) {
-    case ProtocolConformanceTypeKind::Universal:
+    case TypeMetadataRecordKind::Universal:
       return nullptr;
 
-    case ProtocolConformanceTypeKind::UniqueDirectType:
-    case ProtocolConformanceTypeKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
       break;
         
-    case ProtocolConformanceTypeKind::UniqueDirectClass:
-    case ProtocolConformanceTypeKind::UniqueIndirectClass:
-    case ProtocolConformanceTypeKind::UniqueGenericPattern:
+    case TypeMetadataRecordKind::UniqueDirectClass:
+    case TypeMetadataRecordKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueGenericPattern:
       assert(false && "not direct type metadata");
     }
 
@@ -2205,15 +2256,15 @@ public:
   // FIXME: This shouldn't exist
   const ClassMetadata *getDirectClass() const {
     switch (Flags.getTypeKind()) {
-    case ProtocolConformanceTypeKind::Universal:
+    case TypeMetadataRecordKind::Universal:
       return nullptr;
-    case ProtocolConformanceTypeKind::UniqueDirectClass:
+    case TypeMetadataRecordKind::UniqueDirectClass:
       break;
         
-    case ProtocolConformanceTypeKind::UniqueDirectType:
-    case ProtocolConformanceTypeKind::NonuniqueDirectType:
-    case ProtocolConformanceTypeKind::UniqueGenericPattern:
-    case ProtocolConformanceTypeKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::UniqueGenericPattern:
+    case TypeMetadataRecordKind::UniqueIndirectClass:
       assert(false && "not direct class object");
     }
 
@@ -2224,16 +2275,16 @@ public:
   
   const ClassMetadata * const *getIndirectClass() const {
     switch (Flags.getTypeKind()) {
-    case ProtocolConformanceTypeKind::Universal:
+    case TypeMetadataRecordKind::Universal:
       return nullptr;
 
-    case ProtocolConformanceTypeKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueIndirectClass:
       break;
         
-    case ProtocolConformanceTypeKind::UniqueDirectType:
-    case ProtocolConformanceTypeKind::UniqueDirectClass:
-    case ProtocolConformanceTypeKind::NonuniqueDirectType:
-    case ProtocolConformanceTypeKind::UniqueGenericPattern:
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::UniqueDirectClass:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::UniqueGenericPattern:
       assert(false && "not indirect class object");
     }
     
@@ -2242,16 +2293,16 @@ public:
   
   const GenericMetadata *getGenericPattern() const {
     switch (Flags.getTypeKind()) {
-    case ProtocolConformanceTypeKind::Universal:
+    case TypeMetadataRecordKind::Universal:
       return nullptr;
 
-    case ProtocolConformanceTypeKind::UniqueGenericPattern:
+    case TypeMetadataRecordKind::UniqueGenericPattern:
       break;
         
-    case ProtocolConformanceTypeKind::UniqueDirectClass:
-    case ProtocolConformanceTypeKind::UniqueIndirectClass:
-    case ProtocolConformanceTypeKind::UniqueDirectType:
-    case ProtocolConformanceTypeKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::UniqueDirectClass:
+    case TypeMetadataRecordKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
       assert(false && "not generic metadata pattern");
     }
     
@@ -2817,7 +2868,12 @@ const WitnessTable *swift_conformsToProtocol(const Metadata *type,
 extern "C"
 void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
                                         const ProtocolConformanceRecord *end);
-  
+
+/// Register a block of type metadata records dynamic lookup.
+extern "C"
+void swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
+                                       const TypeMetadataRecord *end);
+
 /// Return the type name for a given type metadata.
 std::string nameForMetadata(const Metadata *type,
                             bool qualified = true);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -443,6 +443,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       // Emit protocol conformances into a section we can recognize at runtime.
       // In JIT mode these are manually registered above.
       IGM.emitProtocolConformances();
+      IGM.emitTypeMetadataRecords();
     }
 
     // Okay, emit any definitions that we suddenly need.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -278,6 +278,14 @@ IRGenModule::IRGenModule(IRGenModuleDispatcher &dispatcher, SourceFile *SF,
   ProtocolConformanceRecordPtrTy
     = ProtocolConformanceRecordTy->getPointerTo(DefaultAS);
 
+  TypeMetadataRecordTy
+    = createStructType(*this, "swift.type_metadata_record", {
+      RelativeAddressTy,
+      Int32Ty
+    });
+  TypeMetadataRecordPtrTy
+    = TypeMetadataRecordTy->getPointerTo(DefaultAS);
+
   FixedBufferTy = nullptr;
   for (unsigned i = 0; i != MaxNumValueWitnesses; ++i)
     ValueWitnessTys[i] = nullptr;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -794,7 +794,9 @@ public:
   Address getAddrOfObjCISAMask();
 
   StringRef mangleType(CanType type, SmallVectorImpl<char> &buffer);
-  
+ 
+  bool hasMetadataPattern(NominalTypeDecl *theDecl);
+ 
   // Get the ArchetypeBuilder for the currently active generic context. Crashes
   // if there is no generic context.
   ArchetypeBuilder &getContextArchetypes();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -85,6 +85,7 @@ namespace swift {
   class IRGenOptions;
   class NormalProtocolConformance;
   class ProtocolConformance;
+  class TypeMetadataRecord;
   class ProtocolCompositionType;
   class ProtocolDecl;
   struct SILDeclRef;
@@ -203,6 +204,9 @@ public:
 
   /// Emit the protocol conformance records needed by each IR module.
   void emitProtocolConformances();
+
+  /// Emit type metadata records for types without explicit protocol conformance.
+  void emitTypeMetadataRecords();
 
   /// Emit everything which is reachable from already emitted IR.
   void emitLazyDefinitions();
@@ -385,6 +389,8 @@ public:
   llvm::PointerType *ObjCBlockPtrTy;   /// %objc_block*
   llvm::StructType *ProtocolConformanceRecordTy;
   llvm::PointerType *ProtocolConformanceRecordPtrTy;
+  llvm::StructType *TypeMetadataRecordTy;
+  llvm::PointerType *TypeMetadataRecordPtrTy;
   llvm::PointerType *ErrorPtrTy;       /// %swift.error*
   llvm::StructType *OpenedErrorTripleTy; /// { %swift.opaque*, %swift.type*, i8** }
   llvm::PointerType *OpenedErrorTriplePtrTy; /// { %swift.opaque*, %swift.type*, i8** }*
@@ -552,6 +558,7 @@ public:
                                 ArrayRef<FieldTypeInfo> fieldTypes,
                                 llvm::Function *fn);
   llvm::Constant *emitProtocolConformances();
+  llvm::Constant *emitTypeMetadataRecords();
 
   llvm::Constant *getOrCreateHelperFunction(StringRef name,
                                             llvm::Type *resultType,
@@ -589,6 +596,8 @@ private:
   SmallVector<llvm::WeakVH, 4> ObjCCategories;
   /// List of protocol conformances to generate records for.
   SmallVector<NormalProtocolConformance *, 4> ProtocolConformances;
+  /// List of nominal types to generate type metadata records for.
+  SmallVector<CanType, 4> RuntimeResolvableTypes;
   /// List of ExtensionDecls corresponding to the generated
   /// categories.
   SmallVector<ExtensionDecl*, 4> ObjCCategoryDecls;
@@ -811,6 +820,7 @@ private:
                                        llvm::Type *defaultType);
 
   void emitLazyPrivateDefinitions();
+  void addRuntimeResolvableType(CanType type);
 
 //--- Global context emission --------------------------------------------------
 public:

--- a/lib/IRGen/RuntimeFunctions.def
+++ b/lib/IRGen/RuntimeFunctions.def
@@ -866,6 +866,11 @@ FUNCTION(RegisterProtocolConformances,
          RETURNS(VoidTy),
          ARGS(ProtocolConformanceRecordPtrTy, ProtocolConformanceRecordPtrTy),
          ATTRS(NoUnwind))
+FUNCTION(RegisterTypeMetadataRecords,
+         swift_registerTypeMetadataRecords, RuntimeCC,
+         RETURNS(VoidTy),
+         ARGS(TypeMetadataRecordPtrTy, TypeMetadataRecordPtrTy),
+         ATTRS(NoUnwind))
 
 FUNCTION(InitializeSuperclass, swift_initializeSuperclass, RuntimeCC,
          RETURNS(VoidTy),

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -83,6 +83,42 @@ func _typeName(type: Any.Type, qualified: Bool = true) -> String {
     input: UnsafeBufferPointer(start: stringPtr, count: count))
 }
 
+@_silgen_name("swift_getTypeByMangledName")
+func _getTypeByMangledName(
+    name: UnsafePointer<UInt8>,
+    _ nameLength: UInt)
+  -> Any.Type?
+
+/// Lookup a class given a name. Until the demangled encoding of type
+/// names is stablized, this is limited to top-level class names (Foo.bar).
+@warn_unused_result
+public // SPI(Foundation)
+func _typeByName(name: String) -> Any.Type? {
+  let components = name.characters.split{$0 == "."}.map(String.init)
+  guard components.count == 2 else {
+    return nil
+  }
+
+  // Note: explicitly build a class name to match on, rather than matching
+  // on the result of _typeName(), to ensure the type we are resolving is
+  // actually a class.
+  var name = "C"
+  if components[0] == "Swift" {
+    name += "Ss"
+  } else {
+    name += String(components[0].characters.count) + components[0]
+  }
+  name += String(components[1].characters.count) + components[1]
+
+  let nameUTF8 = Array(name.utf8)
+  return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
+    let type = _getTypeByMangledName(nameUTF8.baseAddress,
+                                     UInt(nameUTF8.endIndex))
+
+    return type
+  }
+}
+ 
 @warn_unused_result
 @_silgen_name("swift_stdlib_demangleName")
 func _stdlib_demangleNameImpl(

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -42,6 +42,7 @@ add_swift_library(swiftRuntime IS_STDLIB IS_STDLIB_CORE
   HeapObject.cpp
   KnownMetadata.cpp
   Metadata.cpp
+  MetadataLookup.cpp
   Once.cpp
   ProtocolConformance.cpp
   Reflection.cpp

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -4,8 +4,8 @@
 #include "Private.h"
 
 #if SWIFT_OBJC_INTEROP
-
 #include <objc/runtime.h>
+#endif
 
 // Build a demangled type tree for a nominal type.
 static Demangle::NodePointer
@@ -25,7 +25,10 @@ _buildDemanglingForNominalType(Demangle::Node::Kind boundGenericKind,
                  typeBytes + sizeof(void*) * description->GenericParams.Offset);
     for (unsigned i = 0, e = description->GenericParams.NumPrimaryParams;
          i < e; ++i, ++genericParam) {
-      typeParams->addChild(_swift_buildDemanglingForMetadata(*genericParam));
+      auto demangling = _swift_buildDemanglingForMetadata(*genericParam);
+      if (demangling == nullptr)
+        return nullptr;
+      typeParams->addChild(demangling);
     }
 
     auto genericNode = NodeFactory::create(boundGenericKind);
@@ -224,5 +227,3 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
   // Not a type.
   return nullptr;
 }
-
-#endif

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1,0 +1,298 @@
+//===--- MetadataLookup.cpp - Swift Language Type Name Lookup -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementations of runtime functions for looking up a type by name.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/Lazy.h"
+#include "swift/Runtime/Concurrent.h"
+#include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/Metadata.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/StringExtras.h"
+#include "Private.h"
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#elif defined(__ELF__)
+#include <elf.h>
+#include <link.h>
+#endif
+
+#include <dlfcn.h>
+#include <mutex>
+
+using namespace swift;
+using namespace Demangle;
+
+#if SWIFT_OBJC_INTEROP
+#include <objc/runtime.h>
+#include <objc/message.h>
+#include <objc/objc.h>
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+#define SWIFT_TYPE_METADATA_SECTION "__swift2_types"
+#elif defined(__ELF__)
+#define SWIFT_TYPE_METADATA_SECTION ".swift2_type_metadata_start"
+#endif
+
+// Type Metadata Cache.
+
+namespace {
+  struct TypeMetadataSection {
+    const TypeMetadataRecord *Begin, *End;
+    const TypeMetadataRecord *begin() const {
+      return Begin;
+    }
+    const TypeMetadataRecord *end() const {
+      return End;
+    }
+  };
+
+  struct TypeMetadataCacheEntry {
+  private:
+    std::string Name;
+    const Metadata *Metadata;
+
+  public:
+    TypeMetadataCacheEntry(const llvm::StringRef name,
+                           const struct Metadata *metadata) {
+      Name = name.str();
+      Metadata = metadata;
+    }
+
+    bool matches(llvm::StringRef aName) {
+      return aName.equals(Name);
+    }
+
+    const struct Metadata *getMetadata(void) {
+      return Metadata;
+    }
+  };
+}
+
+static void _initializeCallbacksToInspectDylib();
+
+struct TypeMetadataState {
+  ConcurrentMap<size_t, TypeMetadataCacheEntry> Cache;
+  std::vector<TypeMetadataSection> SectionsToScan;
+  pthread_mutex_t SectionsToScanLock;
+
+  TypeMetadataState() {
+    SectionsToScan.reserve(16);
+    pthread_mutex_init(&SectionsToScanLock, nullptr);
+    _initializeCallbacksToInspectDylib();
+  }
+};
+
+static Lazy<TypeMetadataState> TypeMetadataRecords;
+
+static void
+_registerTypeMetadataRecords(TypeMetadataState &T,
+                             const TypeMetadataRecord *begin,
+                             const TypeMetadataRecord *end) {
+  pthread_mutex_lock(&T.SectionsToScanLock);
+  T.SectionsToScan.push_back(TypeMetadataSection{begin, end});
+  pthread_mutex_unlock(&T.SectionsToScanLock);
+}
+
+static void _addImageTypeMetadataRecordsBlock(const uint8_t *records,
+                                              size_t recordsSize) {
+  assert(recordsSize % sizeof(TypeMetadataRecord) == 0
+         && "weird-sized type metadata section?!");
+
+  // If we have a section, enqueue the type metadata for lookup.
+  auto recordsBegin
+    = reinterpret_cast<const TypeMetadataRecord*>(records);
+  auto recordsEnd
+    = reinterpret_cast<const TypeMetadataRecord*>
+                                            (records + recordsSize);
+
+  // type metadata cache should always be sufficiently initialized by this point.
+  _registerTypeMetadataRecords(TypeMetadataRecords.unsafeGetAlreadyInitialized(),
+                               recordsBegin, recordsEnd);
+}
+
+#if defined(__APPLE__) && defined(__MACH__)
+static void _addImageTypeMetadataRecords(const mach_header *mh,
+                                         intptr_t vmaddr_slide) {
+#ifdef __LP64__
+  using mach_header_platform = mach_header_64;
+  assert(mh->magic == MH_MAGIC_64 && "loaded non-64-bit image?!");
+#else
+  using mach_header_platform = mach_header;
+#endif
+
+  // Look for a __swift2_types section.
+  unsigned long recordsSize;
+  const uint8_t *records =
+    getsectiondata(reinterpret_cast<const mach_header_platform *>(mh),
+                   SEG_TEXT, SWIFT_TYPE_METADATA_SECTION,
+                   &recordsSize);
+
+  if (!records)
+    return;
+
+  _addImageTypeMetadataRecordsBlock(records, recordsSize);
+}
+#elif defined(__ELF__)
+static int _addImageTypeMetadataRecords(struct dl_phdr_info *info,
+                                        size_t size, void * /*data*/) {
+  void *handle;
+  if (!info->dlpi_name || info->dlpi_name[0] == '\0') {
+    handle = dlopen(nullptr, RTLD_LAZY);
+  } else
+    handle = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
+  auto records = reinterpret_cast<const uint8_t*>(
+      dlsym(handle, SWIFT_TYPE_METADATA_SECTION));
+
+  if (!records) {
+    // if there are no type metadata records, don't hold this handle open.
+    dlclose(handle);
+    return 0;
+  }
+
+  // Extract the size of the type metadata block from the head of the section
+  auto recordsSize = *reinterpret_cast<const uint64_t*>(records);
+  records += sizeof(recordsSize);
+
+  _addImageTypeMetadataRecordsBlock(records, recordsSize);
+
+  dlclose(handle);
+  return 0;
+}
+#endif
+
+static void _initializeCallbacksToInspectDylib() {
+#if defined(__APPLE__) && defined(__MACH__)
+  // Install our dyld callback.
+  // Dyld will invoke this on our behalf for all images that have already
+  // been loaded.
+  _dyld_register_func_for_add_image(_addImageTypeMetadataRecords);
+#elif defined(__ELF__)
+  // Search the loaded dls. Unlike the above, this only searches the already
+  // loaded ones.
+  // FIXME: Find a way to have this continue to happen after.
+  // rdar://problem/19045112
+  dl_iterate_phdr(_addImageTypeMetadataRecords, nullptr);
+#else
+# error No known mechanism to inspect dynamic libraries on this platform.
+#endif
+}
+
+void
+swift::swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
+                                         const TypeMetadataRecord *end) {
+  auto &T = TypeMetadataRecords.get();
+  _registerTypeMetadataRecords(T, begin, end);
+}
+
+// copied from ProtocolConformanceRecord::getCanonicalTypeMetadata()
+const Metadata *TypeMetadataRecord::getCanonicalTypeMetadata() const {
+  switch (getTypeKind()) {
+  case TypeMetadataRecordKind::UniqueDirectType:
+    return getDirectType();
+  case TypeMetadataRecordKind::NonuniqueDirectType:
+    return swift_getForeignTypeMetadata((ForeignTypeMetadata *)getDirectType());
+  case TypeMetadataRecordKind::UniqueDirectClass:
+    if (auto *ClassMetadata =
+          static_cast<const struct ClassMetadata *>(getDirectType()))
+      return swift_getObjCClassMetadata(ClassMetadata);
+    else
+      return nullptr;
+  default:
+    return nullptr;
+  }
+}
+
+// returns the type metadata for the type named by typeName
+static const Metadata *
+_searchTypeMetadataRecords(const TypeMetadataState &T,
+                           const llvm::StringRef typeName) {
+  unsigned sectionIdx = 0;
+  unsigned endSectionIdx = T.SectionsToScan.size();
+
+  for (; sectionIdx < endSectionIdx; ++sectionIdx) {
+    auto &section = T.SectionsToScan[sectionIdx];
+    for (const auto &record : section) {
+      if (auto metadata = record.getCanonicalTypeMetadata()) {
+        auto ntd = metadata->getNominalTypeDescriptor();
+
+        assert(ntd != nullptr);
+
+        if (typeName == ntd->Name) {
+          return metadata;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+static const Metadata *
+_typeByMangledName(const llvm::StringRef typeName) {
+  const Metadata *foundMetadata = nullptr;
+  auto &T = TypeMetadataRecords.get();
+  size_t hash = llvm::HashString(typeName);
+
+  ConcurrentList<TypeMetadataCacheEntry> &Bucket = T.Cache.findOrAllocateNode(hash);
+
+  // Check name to type metadata cache
+  for (auto &Entry : Bucket) {
+    if (Entry.matches(typeName))
+      return Entry.getMetadata();
+  }
+
+  // Check type metadata records
+  pthread_mutex_lock(&T.SectionsToScanLock);
+  foundMetadata = _searchTypeMetadataRecords(T, typeName);
+  pthread_mutex_unlock(&T.SectionsToScanLock);
+
+  // Check protocol conformances table. Note that this has no support for
+  // resolving generic types yet.
+  if (foundMetadata == nullptr)
+    foundMetadata = _searchConformancesByMangledTypeName(typeName);
+
+  if (foundMetadata != nullptr)
+    Bucket.push_front(TypeMetadataCacheEntry(typeName, foundMetadata));
+
+#if SWIFT_OBJC_INTEROP
+  // Check for ObjC class
+  // FIXME does this have any value? any ObjC class with a Swift name
+  // should already be registered as a Swift type.
+  if (foundMetadata == nullptr) {
+    std::string prefixedName("_Tt" + typeName.str());
+    foundMetadata = reinterpret_cast<ClassMetadata *>
+      (objc_lookUpClass(prefixedName.c_str()));
+  }
+#endif
+
+  return foundMetadata;
+}
+
+/// Return the type metadata for a given mangled name, used in the
+/// implementation of _typeByName(). The human readable name returned
+/// by swift_getTypeName() is non-unique, so we used mangled names
+/// internally.
+extern "C"
+const Metadata *
+swift_getTypeByMangledName(const char *typeName, size_t typeNameLength) {
+  llvm::StringRef name(typeName, typeNameLength);
+  return _typeByMangledName(name);
+}

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -220,25 +220,49 @@ const Metadata *TypeMetadataRecord::getCanonicalTypeMetadata() const {
   }
 }
 
-// returns the type metadata for the type named by typeName
+// returns the type metadata if typeName matches the metadata's name
+const Metadata *
+swift::_matchMetadataByMangledTypeName(const llvm::StringRef typeName,
+                                       const Metadata *metadata,
+                                       const GenericMetadata *pattern) {
+  const NominalTypeDescriptor *ntd = nullptr;
+  const Metadata *foundMetadata = nullptr;
+
+  if (metadata != nullptr)
+    ntd = metadata->getNominalTypeDescriptor();
+  else if (pattern != nullptr)
+    ntd = pattern->getTemplateDescription();
+
+  if (ntd == nullptr || ntd->Name != typeName)
+    return nullptr;
+
+  if (metadata != nullptr) {
+    foundMetadata = metadata;
+  } else if (!ntd->GenericParams.hasGenericParams()) {
+    foundMetadata = swift_getResilientMetadata(const_cast<GenericMetadata *>(pattern));
+  }
+
+  return foundMetadata;
+}
+
+// finds the type metadata for the type named by typeName
 static const Metadata *
 _searchTypeMetadataRecords(const TypeMetadataState &T,
                            const llvm::StringRef typeName) {
   unsigned sectionIdx = 0;
   unsigned endSectionIdx = T.SectionsToScan.size();
+  const Metadata *foundMetadata = nullptr;
 
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = T.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto metadata = record.getCanonicalTypeMetadata()) {
-        auto ntd = metadata->getNominalTypeDescriptor();
+      if (auto metadata = record.getCanonicalTypeMetadata())
+        foundMetadata = _matchMetadataByMangledTypeName(typeName, metadata, nullptr);
+      else if (auto pattern = record.getGenericPattern())
+        foundMetadata = _matchMetadataByMangledTypeName(typeName, nullptr, pattern);
 
-        assert(ntd != nullptr);
-
-        if (typeName == ntd->Name) {
-          return metadata;
-        }
-      }
+      if (foundMetadata != nullptr)
+        return foundMetadata;
     }
   }
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -112,6 +112,11 @@ namespace swift {
   void installCommonValueWitnesses(ValueWitnessTable *vwtable);
 
   const Metadata *
+  _matchMetadataByMangledTypeName(const llvm::StringRef metadataNameRef,
+                                  const Metadata *metadata,
+                                  const GenericMetadata *pattern);
+
+  const Metadata *
   _searchConformancesByMangledTypeName(const llvm::StringRef typeName);
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -111,6 +111,9 @@ namespace swift {
   /// Returns true if common value witnesses were used, false otherwise.
   void installCommonValueWitnesses(ValueWitnessTable *vwtable);
 
+  const Metadata *
+  _searchConformancesByMangledTypeName(const llvm::StringRef typeName);
+
 #if SWIFT_OBJC_INTEROP
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type);
 #endif

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -52,13 +52,13 @@ void ProtocolConformanceRecord::dump() const {
   };
 
   switch (auto kind = getTypeKind()) {
-    case ProtocolConformanceTypeKind::Universal:
+    case TypeMetadataRecordKind::Universal:
       printf("universal");
       break;
-    case ProtocolConformanceTypeKind::UniqueDirectType:
-    case ProtocolConformanceTypeKind::NonuniqueDirectType:
+    case TypeMetadataRecordKind::UniqueDirectType:
+    case TypeMetadataRecordKind::NonuniqueDirectType:
       printf("%s direct type ",
-             kind == ProtocolConformanceTypeKind::UniqueDirectType
+             kind == TypeMetadataRecordKind::UniqueDirectType
              ? "unique" : "nonunique");
       if (auto ntd = getDirectType()->getNominalTypeDescriptor()) {
         printf("%s", ntd->Name);
@@ -66,16 +66,16 @@ void ProtocolConformanceRecord::dump() const {
         printf("<structural type>");
       }
       break;
-    case ProtocolConformanceTypeKind::UniqueDirectClass:
+    case TypeMetadataRecordKind::UniqueDirectClass:
       printf("unique direct class %s",
              class_getName(getDirectClass()));
       break;
-    case ProtocolConformanceTypeKind::UniqueIndirectClass:
+    case TypeMetadataRecordKind::UniqueIndirectClass:
       printf("unique indirect class %s",
              class_getName(*getIndirectClass()));
       break;
       
-    case ProtocolConformanceTypeKind::UniqueGenericPattern:
+    case TypeMetadataRecordKind::UniqueGenericPattern:
       printf("unique generic type %s", symbolName(getGenericPattern()));
       break;
   }
@@ -100,13 +100,13 @@ void ProtocolConformanceRecord::dump() const {
 const Metadata *ProtocolConformanceRecord::getCanonicalTypeMetadata()
 const {
   switch (getTypeKind()) {
-  case ProtocolConformanceTypeKind::UniqueDirectType:
+  case TypeMetadataRecordKind::UniqueDirectType:
     // Already unique.
     return getDirectType();
-  case ProtocolConformanceTypeKind::NonuniqueDirectType:
+  case TypeMetadataRecordKind::NonuniqueDirectType:
     // Ask the runtime for the unique metadata record we've canonized.
     return swift_getForeignTypeMetadata((ForeignTypeMetadata*)getDirectType());
-  case ProtocolConformanceTypeKind::UniqueIndirectClass:
+  case TypeMetadataRecordKind::UniqueIndirectClass:
     // The class may be ObjC, in which case we need to instantiate its Swift
     // metadata. The class additionally may be weak-linked, so we have to check
     // for null.
@@ -114,15 +114,15 @@ const {
       return swift_getObjCClassMetadata(ClassMetadata);
     return nullptr;
       
-  case ProtocolConformanceTypeKind::UniqueDirectClass:
+  case TypeMetadataRecordKind::UniqueDirectClass:
     // The class may be ObjC, in which case we need to instantiate its Swift
     // metadata.
     if (auto *ClassMetadata = getDirectClass())
       return swift_getObjCClassMetadata(ClassMetadata);
     return nullptr;
       
-  case ProtocolConformanceTypeKind::UniqueGenericPattern:
-  case ProtocolConformanceTypeKind::Universal:
+  case TypeMetadataRecordKind::UniqueGenericPattern:
+  case TypeMetadataRecordKind::Universal:
     // The record does not apply to a single type.
     return nullptr;
   }
@@ -564,7 +564,7 @@ recur:
       // An accessor function might still be necessary even if the witness table
       // can be shared.
       } else if (record.getTypeKind()
-                   == ProtocolConformanceTypeKind::UniqueGenericPattern
+                   == TypeMetadataRecordKind::UniqueGenericPattern
                  && record.getConformanceKind()
                    == ProtocolConformanceReferenceKind::WitnessTable) {
 
@@ -593,4 +593,36 @@ recur:
   // Start over with our newly-populated cache.
   type = origType;
   goto recur;
+}
+
+const Metadata *
+swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
+  auto &C = Conformances.get();
+  const Metadata *foundMetadata = nullptr;
+
+  pthread_mutex_lock(&C.SectionsToScanLock);
+
+  unsigned sectionIdx = 0;
+  unsigned endSectionIdx = C.SectionsToScan.size();
+
+  for (; sectionIdx < endSectionIdx; ++sectionIdx) {
+    auto &section = C.SectionsToScan[sectionIdx];
+    for (const auto &record : section) {
+      if (auto metadata = record.getCanonicalTypeMetadata()) {
+        auto ntd = metadata->getNominalTypeDescriptor();
+
+        if (ntd == nullptr)
+          continue;
+
+        if (typeName == ntd->Name) {
+          foundMetadata = metadata;
+          break;
+        }
+      }
+    }
+  }
+
+  pthread_mutex_unlock(&C.SectionsToScanLock);
+
+  return foundMetadata;
 }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -608,18 +608,16 @@ swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
   for (; sectionIdx < endSectionIdx; ++sectionIdx) {
     auto &section = C.SectionsToScan[sectionIdx];
     for (const auto &record : section) {
-      if (auto metadata = record.getCanonicalTypeMetadata()) {
-        auto ntd = metadata->getNominalTypeDescriptor();
+      if (auto metadata = record.getCanonicalTypeMetadata())
+        foundMetadata = _matchMetadataByMangledTypeName(typeName, metadata, nullptr);
+      else if (auto pattern = record.getGenericPattern())
+        foundMetadata = _matchMetadataByMangledTypeName(typeName, nullptr, pattern);
 
-        if (ntd == nullptr)
-          continue;
-
-        if (typeName == ntd->Name) {
-          foundMetadata = metadata;
-          break;
-        }
-      }
+      if (foundMetadata != nullptr)
+        break;
     }
+    if (foundMetadata != nullptr)
+      break;
   }
 
   pthread_mutex_unlock(&C.SectionsToScanLock);

--- a/stdlib/public/runtime/swift.ld
+++ b/stdlib/public/runtime/swift.ld
@@ -5,6 +5,12 @@ SECTIONS
     .swift2_protocol_conformances_start = . ;
     QUAD(SIZEOF(.swift2_protocol_conformances) - 8) ;
     *(.swift2_protocol_conformances) ;
+  },
+  .swift2_type_metadata :
+  {
+    .swift2_type_metadata_start = . ;
+    QUAD(SIZEOF(.swift2_type_metadata) - 8) ;
+    *(.swift2_type_metadata) ;
   }
 }
 INSERT AFTER .dtors

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -308,6 +308,18 @@ Runtime.test("typeName") {
   expectEqual("protocol<>.Protocol", _typeName(a.dynamicType))
 }
 
+class SomeSubclass : SomeClass {}
+
+protocol SomeProtocol {}
+class SomeConformingClass : SomeProtocol {}
+
+Runtime.test("typeByName") {
+  expectTrue(_typeByName("a.SomeClass") == SomeClass.self)
+  expectTrue(_typeByName("a.SomeSubclass") == SomeSubclass.self)
+  // name lookup will be via protocol conformance table
+  expectTrue(_typeByName("a.SomeConformingClass") == SomeConformingClass.self)
+}
+
 Runtime.test("demangleName") {
   expectEqual("", _stdlib_demangleName(""))
   expectEqual("abc", _stdlib_demangleName("abc"))

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -41,6 +41,8 @@ ResilientClassTestSuite.test("ClassWithResilientProperty") {
   expectEqual(c.s.w, 30)
   expectEqual(c.s.h, 40)
   expectEqual(c.color, 50)
+  expectTrue(_typeByName("main.ClassWithResilientProperty")
+    == ClassWithResilientProperty.self)
 }
 
 
@@ -98,6 +100,8 @@ ResilientClassTestSuite.test("ClassWithResilientlySizedProperty") {
   expectEqual(c.r.s.h, 40)
   expectEqual(c.r.color, 50)
   expectEqual(c.color, 60)
+  expectTrue(_typeByName("main.ClassWithResilientlySizedProperty")
+    == ClassWithResilientlySizedProperty.self)
 }
 
 
@@ -125,6 +129,8 @@ ResilientClassTestSuite.test("ChildOfParentWithResilientStoredProperty") {
   expectEqual(c.s.h, 40)
   expectEqual(c.color, 50)
   expectEqual(c.enabled, 60)
+  expectTrue(_typeByName("main.ChildOfParentWithResilientStoredProperty")
+    == ChildOfParentWithResilientStoredProperty.self)
 }
 
 
@@ -152,6 +158,8 @@ ResilientClassTestSuite.test("ChildOfOutsideParentWithResilientStoredProperty") 
   expectEqual(c.s.h, 40)
   expectEqual(c.color, 50)
   expectEqual(c.enabled, 60)
+  expectTrue(_typeByName("main.ChildOfOutsideParentWithResilientStoredProperty")
+    == ChildOfOutsideParentWithResilientStoredProperty.self)
 }
 
 


### PR DESCRIPTION
Implement a `_typeByName(name: String) -> Any.Type?` function, currently explicitly limited to top-level classes.

Type metadata for types that do not explicitly conform to a protocol is emitted in a new section, `.swift2_type_metadata`. The runtime searches both this section and the protocol conformance table.

Whilst implemented on top of an internal API that looks up a type given a mangled name (in order to assure that we are indeed looking up a class), no public Swift APIs are defined that expose the name mangling format.

This is to support [NS-377] Foundation component NSKeyedUnarchiver.

Update: separate generic instantiation into a separate pull request.
