### PR TITLE
Refactor ObjC dependencies in definite_init_diagnostics tests

### DIFF
--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1,10 +1,6 @@
-// RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
-
-// FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
+// RUN: %target-swift-frontend -emit-sil %s -parse-stdlib -o /dev/null -verify
 
 import Swift
-import gizmo
 
 func markUsed<T>(t: T) {}
 
@@ -578,38 +574,6 @@ enum TrivialEnum : TriviallyConstructible {
     self.init(up: y * y)
   }
 }
-
-@requires_stored_property_inits
-class RequiresInitsDerived : Gizmo {
-  var a = 1
-  var b = 2
-  var c = 3
-
-  override init() {
-    super.init()
-  }
-
-  init(i: Int) {
-    if i > 0 {
-      super.init()
-    }
-  } // expected-error{{super.init isn't called on all paths before returning from initializer}}
-
-  init(d: Double) {
-    f() // expected-error {{use of 'self' in method call 'f' before super.init initializes self}}
-    super.init()
-  }
-
-  init(t: ()) {
-    a = 5 // expected-error {{use of 'self' in property access 'a' before super.init initializes self}}
-    b = 10 // expected-error {{use of 'self' in property access 'b' before super.init initializes self}}
-    super.init()
-    c = 15
-  }
-
-  func f() { }
-}
-
 
 // rdar://16119509 - Dataflow problem where we reject valid code.
 class rdar16119509_Buffer {

--- a/test/SILOptimizer/definite_init_diagnostics_objc.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_objc.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -emit-sil -sdk %S/../SILGen/Inputs %s -I %S/../SILGen/Inputs -enable-source-import -parse-stdlib -o /dev/null -verify
+// REQUIRES: objc_interop
+
+import Swift
+import gizmo
+
+@requires_stored_property_inits
+class RequiresInitsDerived : Gizmo {
+  var a = 1
+  var b = 2
+  var c = 3
+
+  override init() {
+    super.init()
+  }
+
+  init(i: Int) {
+    if i > 0 {
+      super.init()
+    }
+  } // expected-error{{super.init isn't called on all paths before returning from initializer}}
+
+  init(d: Double) {
+    f() // expected-error {{use of 'self' in method call 'f' before super.init initializes self}}
+    super.init()
+  }
+
+  init(t: ()) {
+    a = 5 // expected-error {{use of 'self' in property access 'a' before super.init initializes self}}
+    b = 10 // expected-error {{use of 'self' in property access 'b' before super.init initializes self}}
+    super.init()
+    c = 15
+  }
+
+  func f() { }
+}


### PR DESCRIPTION
This change moves functionality that requires ObjC interop into a new file and
removes the XFAIL on Linux. Partially resolves SR-216.
## 

Tested on Ubuntu 14.04 & OS X 10.10.
