### PR TITLE
Remove Linux XFAIL in stdlib StringTraps tests

### DIFF
--- a/test/1_stdlib/StringTraps.swift
+++ b/test/1_stdlib/StringTraps.swift
@@ -7,10 +7,7 @@
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
 
-// XFAIL: linux
-
 import StdlibUnittest
-import Foundation
 
 // Also import modules which are used by StdlibUnittest internally. This
 // workaround is needed to link all required libraries in case we compile


### PR DESCRIPTION
Partially resolves SR-216.
## 

Tested on Ubuntu 14.04 and OS X 10.10
