### PR TITLE
[SourceKit/swift-ide-test] Assertion: Avoid endless loop in case of circular class inheritance.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -305,9 +305,10 @@ Type TypeChecker::resolveTypeInContext(
       continue;
 
     // Search the type of this context and its supertypes.
+    Type superClassOfFromType;
     for (auto fromType = resolver->resolveTypeOfContext(parentDC);
          fromType;
-         fromType = getSuperClassOf(fromType)) {
+         fromType = superClassOfFromType) {
       // If the nominal type declaration of the context type we're looking at
       // matches the owner's nominal type declaration, this is how we found
       // the member type declaration. Substitute the type we're coming from as
@@ -336,6 +337,11 @@ Type TypeChecker::resolveTypeInContext(
           conformance) {
         return conformance->getTypeWitness(assocType, this).getReplacement();
       }
+      superClassOfFromType = getSuperClassOf(fromType);
+      /// FIXME: Avoid the possibility of an infinite loop by fixing the root
+      ///        cause instead (incomplete circularity detection).
+      assert(fromType.getPointer() != superClassOfFromType.getPointer() &&
+             "Infinite loop due to circular class inheritance?");
     }
   }
 


### PR DESCRIPTION
Prior to this commit:

```
$ echo 'class D{protocol b{{}class A:A{var f={struct B:b var o#^A^#' > /tmp/hang.swift
$ swift-ide-test -code-completion -code-completion-token=A -source-filename=/tmp/hang.swift
[infinite compile time - never returns due to endless loop]
```

After this commit:

```
$ echo 'class D{protocol b{{}class A:A{var f={struct B:b var o#^A^#' > /tmp/hang.swift
$ swift-ide-test -code-completion -code-completion-token=A -source-filename=/tmp/hang.swift
swift-ide-test: […]: Assertion `fromType.getPointer() != superClassOfFromType.getPointer() && "Infinite loop due to circular class inheritance?"' failed.
```

Please note that this commit does not solve the root cause (incomplete circularity detection), but it makes the compiler fail fast. Failing fast is critical from a fuzzing perspective :-)

In short:
- Short term: introduce `assert(…)` to make sure we fail fast
- Long term: improve detection of circular class inheritance
