### PR TITLE
[SourceKit/swift-ide-test] Assertion: Avoid endless loop in case of circular class inheritance (follow-up to #845)

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -306,6 +306,7 @@ Type TypeChecker::resolveTypeInContext(
 
     // Search the type of this context and its supertypes.
     Type superClassOfFromType;
+    int traversedClassHierarchyDepth = 0;
     for (auto fromType = resolver->resolveTypeOfContext(parentDC);
          fromType;
          fromType = superClassOfFromType) {
@@ -341,6 +342,8 @@ Type TypeChecker::resolveTypeInContext(
       /// FIXME: Avoid the possibility of an infinite loop by fixing the root
       ///        cause instead (incomplete circularity detection).
       assert(fromType.getPointer() != superClassOfFromType.getPointer() &&
+             "Infinite loop due to circular class inheritance.");
+      assert(traversedClassHierarchyDepth++ <= 16384 &&
              "Infinite loop due to circular class inheritance?");
     }
   }


### PR DESCRIPTION
(This issue is related but not identical to #845 merged by @dabrahams.)

Prior to this commit:

```
$ echo 'let n{protocol a{class a:B#^A^#class B:a' > /tmp/hang.swift
$ swift-ide-test -code-completion -code-completion-token=A -source-filename=/tmp/hang.swift
[infinite compile time - never returns due to endless loop]
```

After this commit:

```
$ echo 'let n{protocol a{class a:B#^A^#class B:a' > /tmp/hang.swift
$ swift-ide-test -code-completion -code-completion-token=A -source-filename=/tmp/hang.swift
swift-ide-test: […]: Assertion `traversedClassHierarchyDepth++ <= 16384 && "Infinite loop due to circular class inheritance?"' failed.
```

Please note that this commit does not solve the root cause (incomplete circularity detection), but it makes the compiler fail fast. Failing fast is critical from a fuzzing perspective :-)

In short:
- Short term: introduce `assert(…)` to make sure we fail fast
- Long term: improve detection of circular class inheritance
