### PR TITLE
[SourceKit] Add test case for crash triggered in swift::GenericFunctionType::get(…)

### DIFF
--- a/validation-test/IDE/crashers/064-swift-genericfunctiontype-get.swift
+++ b/validation-test/IDE/crashers/064-swift-genericfunctiontype-get.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+extension{enum a<H{enum b{case
+func a(=#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 144
swift-ide-test: /path/to/swift/lib/AST/ASTContext.cpp:2868: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &): Assertion `sig && "no generic signature for generic function type?!"' failed.
8  swift-ide-test  0x0000000000aa633e swift::GenericFunctionType::get(swift::GenericSignature*, swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) + 574
10 swift-ide-test  0x000000000092addc swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 780
15 swift-ide-test  0x0000000000b51f70 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1168
18 swift-ide-test  0x000000000085c193 swift::performDelayedParsing(swift::DeclContext*, swift::PersistentParserState&, swift::CodeCompletionCallbacksFactory*) + 307
19 swift-ide-test  0x000000000076b5a4 swift::CompilerInstance::performSema() + 3316
20 swift-ide-test  0x0000000000714cc3 main + 33379
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking declaration 0x4dd8ad0 at <INPUT-FILE>:2:27
```
