### PR TITLE
[SIL] Add test case for assertion (previously infinite loop) triggered in swift::removeOverriddenDecls(…)

### DIFF
--- a/validation-test/SIL/crashers/022-swift-removeoverriddendecls.sil
+++ b/validation-test/SIL/crashers/022-swift-removeoverriddendecls.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+class a:a{init()


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:17: error: consecutive declarations on a line must be separated by ';'
class a:a{init()
                ^
                ;
<stdin>:3:17: error: expected declaration
class a:a{init()
                ^
<stdin>:3:11: error: overriding declaration requires an 'override' keyword
class a:a{init()
          ^
          override
<stdin>:3:11: note: overridden declaration is here
class a:a{init()
          ^
sil-opt: /path/to/swift/lib/AST/NameLookup.cpp:76: bool swift::removeOverriddenDecls(SmallVectorImpl<swift::ValueDecl *> &): Assertion `decl != overrides && "Circular class inheritance?"' failed.
8  sil-opt         0x0000000000d62d8c swift::removeOverriddenDecls(llvm::SmallVectorImpl<swift::ValueDecl*>&) + 1404
11 sil-opt         0x0000000000ac4243 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 355
12 sil-opt         0x0000000000ac4b39 swift::TypeChecker::lookupConstructors(swift::DeclContext*, swift::Type, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 41
13 sil-opt         0x0000000000aa73f3 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1555
14 sil-opt         0x0000000000a9ad12 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5970
15 sil-opt         0x0000000000a9ce69 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
18 sil-opt         0x0000000000aa2096 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 sil-opt         0x0000000000a6df82 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
20 sil-opt         0x0000000000739852 swift::CompilerInstance::performSema() + 2946
21 sil-opt         0x000000000072411c main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking 'a' at <stdin>:3:1
```
