### PR TITLE
[StdLib] Refactor ObjC dependencies in ArrayTraps test

### DIFF
--- a/test/1_stdlib/ArrayTraps.swift.gyb
+++ b/test/1_stdlib/ArrayTraps.swift.gyb
@@ -8,8 +8,6 @@
 // RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
 
-// XFAIL: linux
-
 import StdlibUnittest
 
 // Also import modules which are used by StdlibUnittest internally. This
@@ -136,67 +134,6 @@ ${ArrayTy}Traps.test("${'removeAtIndex(_:)/%s' % index}")
 %   end
 % end
 
-class Base { }
-class Derived : Base { }
-class Derived2 : Derived { }
-
-ArrayTraps.test("downcast1")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  let ba: [Base] = [ Derived(), Base() ]
-  let da = ba as! [Derived]
-  let d0 = da[0]
-  expectCrashLater()
-  da[1]
-}
-
-import Foundation
-
-ArrayTraps.test("downcast2")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  let a: [AnyObject] = [ "String", 1 ]
-  let sa = a as! [NSString]
-  let s0 = sa[0]
-  expectCrashLater()
-  sa[1]
-}
-
-ArrayTraps.test("downcast3")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  let ba: [Base] = [ Derived2(), Derived(), Base() ]
-  let d2a = ba as! [Derived2]
-  let d2a0 = d2a[0]
-  let d1a = d2a as [Derived]
-  let d1a0 = d1a[0]
-  let d1a1 = d1a[1]
-  expectCrashLater()
-  d1a[2]
-}
-
-@objc protocol ObjCProto { }
-class ObjCBase : NSObject, ObjCProto { }
-class ObjCDerived : ObjCBase { }
-
-ArrayTraps.test("downcast4")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .code {
-  let ba: [ObjCProto] = [ ObjCDerived(), ObjCBase() ]
-  let da = ba as! [ObjCDerived]
-  let d0 = da[0]
-  expectCrashLater()
-  da[1]
-}
-
 ArrayTraps.test("unsafeLength")
   .skip(.Custom(
     { _isFastAssertConfiguration() },
@@ -211,118 +148,6 @@ ArrayTraps.test("unsafeLength")
   a.withUnsafeBufferPointer {
     UnsafeBufferPointer(start: $0.baseAddress, count: -1)
   }
-}
-
-ArrayTraps.test("bounds_with_downcast")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "fatal error: Index out of range" : "")
-  .code {
-  let ba: [Base] = [ Derived(), Base() ]
-  let da = ba as! [Derived]
-  expectCrashLater()
-  let x = da[2]
-}
-
-var ArraySemanticOptzns = TestSuite("ArraySemanticOptzns")
-
-class BaseClass {
-}
-
-class ElementClass : BaseClass {
-  var val: String
-  init(_ x: String) {
-    val = x
-  }
-}
-
-class ViolateInoutSafetySwitchToObjcBuffer {
-  final var anArray: [ElementClass] = []
-
-  let nsArray = NSArray(
-    objects: ElementClass("a"), ElementClass("b"), ElementClass("c"))
-
-  @inline(never)
-  func accessArrayViaInoutViolation() {
-    anArray = _convertNSArrayToArray(nsArray)
-  }
-
-  @inline(never)
-  func runLoop(inout A: [ElementClass]) {
-    // Simulate what happens if we hoist array properties out of a loop and the
-    // loop calls a function that violates inout safety and overrides the array.
-    let isNativeTypeChecked = A._hoistableIsNativeTypeChecked()
-    for i in 0..<A.count {
-      let t = A._checkSubscript(
-        i, wasNativeTypeChecked: isNativeTypeChecked)
-      _ = A._getElement(
-        i, wasNativeTypeChecked: isNativeTypeChecked, matchingSubscriptCheck: t)
-      accessArrayViaInoutViolation()
-    }
-  }
-
-  @inline(never)
-  func inoutViolation() {
-    anArray = [ ElementClass("1"), ElementClass("2"), ElementClass("3") ]
-    runLoop(&anArray)
-  }
-}
-
-ArraySemanticOptzns.test("inout_rule_violated_isNativeBuffer")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))  
-  .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "fatal error: inout rules were violated: the array was overwritten" : "")
-  .code {
-  let v = ViolateInoutSafetySwitchToObjcBuffer()
-  expectCrashLater()
-  v.inoutViolation()
-}
-
-class ViolateInoutSafetyNeedElementTypeCheck {
-  final var anArray : [ElementClass] = []
-
-  @inline(never)
-  func accessArrayViaInoutViolation() {
-    // Overwrite the array with one that needs an element type check.
-    let ba: [BaseClass] = [ BaseClass(), BaseClass() ]
-    anArray = ba as! [ElementClass]
-  }
-
-  @inline(never)
-  func runLoop(inout A : [ElementClass]) {
-    // Simulate what happens if we hoist array properties out of a loop and the
-    // loop calls a function that violates inout safety and overrides the array.
-    let isNativeTypeChecked = A._hoistableIsNativeTypeChecked()
-    for i in 0..<A.count {
-      let t = A._checkSubscript(
-        i, wasNativeTypeChecked: isNativeTypeChecked)
-      _ = A._getElement(
-        i, wasNativeTypeChecked: isNativeTypeChecked, matchingSubscriptCheck: t)
-      accessArrayViaInoutViolation()
-    }
-  }
-
-  @inline(never)
-  func inoutViolation() {
-    anArray = [ ElementClass("1"), ElementClass("2"), ElementClass("3")]
-    runLoop(&anArray)
-  }
-}
-
-ArraySemanticOptzns.test("inout_rule_violated_needsElementTypeCheck")
-  .skip(.Custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))  
-  .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "fatal error: inout rules were violated: the array was overwritten" : "")
-  .code {
-  let v = ViolateInoutSafetyNeedElementTypeCheck()
-  expectCrashLater()
-  v.inoutViolation()
 }
 
 runAllTests()

--- a/test/1_stdlib/ArrayTrapsObjC.swift.gyb
+++ b/test/1_stdlib/ArrayTrapsObjC.swift.gyb
@@ -1,0 +1,197 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %S/../../utils/gyb %s -o %t/ArrayTraps.swift
+// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
+// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O
+//
+// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Debug
+// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Release
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+
+// Also import modules which are used by StdlibUnittest internally. This
+// workaround is needed to link all required libraries in case we compile
+// StdlibUnittest with -sil-serialize-all.
+import SwiftPrivate
+#if _runtime(_ObjC)
+import ObjectiveC
+#endif
+
+import Foundation
+
+var ArrayTraps = TestSuite("ArrayTraps")
+
+class Base { }
+class Derived : Base { }
+class Derived2 : Derived { }
+
+ArrayTraps.test("downcast1")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  let ba: [Base] = [ Derived(), Base() ]
+  let da = ba as! [Derived]
+  let d0 = da[0]
+  expectCrashLater()
+  da[1]
+}
+
+ArrayTraps.test("downcast2")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  let a: [AnyObject] = [ "String", 1 ]
+  let sa = a as! [NSString]
+  let s0 = sa[0]
+  expectCrashLater()
+  sa[1]
+}
+
+ArrayTraps.test("downcast3")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  let ba: [Base] = [ Derived2(), Derived(), Base() ]
+  let d2a = ba as! [Derived2]
+  let d2a0 = d2a[0]
+  let d1a = d2a as [Derived]
+  let d1a0 = d1a[0]
+  let d1a1 = d1a[1]
+  expectCrashLater()
+  d1a[2]
+}
+
+@objc protocol ObjCProto { }
+class ObjCBase : NSObject, ObjCProto { }
+class ObjCDerived : ObjCBase { }
+
+ArrayTraps.test("downcast4")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  let ba: [ObjCProto] = [ ObjCDerived(), ObjCBase() ]
+  let da = ba as! [ObjCDerived]
+  let d0 = da[0]
+  expectCrashLater()
+  da[1]
+}
+
+ArrayTraps.test("bounds_with_downcast")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "fatal error: Index out of range" : "")
+  .code {
+  let ba: [Base] = [ Derived(), Base() ]
+  let da = ba as! [Derived]
+  expectCrashLater()
+  let x = da[2]
+}
+
+var ArraySemanticOptzns = TestSuite("ArraySemanticOptzns")
+
+class BaseClass {
+}
+
+class ElementClass : BaseClass {
+  var val: String
+  init(_ x: String) {
+    val = x
+  }
+}
+
+class ViolateInoutSafetySwitchToObjcBuffer {
+  final var anArray: [ElementClass] = []
+
+  let nsArray = NSArray(
+    objects: ElementClass("a"), ElementClass("b"), ElementClass("c"))
+
+  @inline(never)
+  func accessArrayViaInoutViolation() {
+    anArray = _convertNSArrayToArray(nsArray)
+  }
+
+  @inline(never)
+  func runLoop(inout A: [ElementClass]) {
+    // Simulate what happens if we hoist array properties out of a loop and the
+    // loop calls a function that violates inout safety and overrides the array.
+    let isNativeTypeChecked = A._hoistableIsNativeTypeChecked()
+    for i in 0..<A.count {
+      let t = A._checkSubscript(
+        i, wasNativeTypeChecked: isNativeTypeChecked)
+      _ = A._getElement(
+        i, wasNativeTypeChecked: isNativeTypeChecked, matchingSubscriptCheck: t)
+      accessArrayViaInoutViolation()
+    }
+  }
+
+  @inline(never)
+  func inoutViolation() {
+    anArray = [ ElementClass("1"), ElementClass("2"), ElementClass("3") ]
+    runLoop(&anArray)
+  }
+}
+
+ArraySemanticOptzns.test("inout_rule_violated_isNativeBuffer")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))  
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "fatal error: inout rules were violated: the array was overwritten" : "")
+  .code {
+  let v = ViolateInoutSafetySwitchToObjcBuffer()
+  expectCrashLater()
+  v.inoutViolation()
+}
+
+class ViolateInoutSafetyNeedElementTypeCheck {
+  final var anArray : [ElementClass] = []
+
+  @inline(never)
+  func accessArrayViaInoutViolation() {
+    // Overwrite the array with one that needs an element type check.
+    let ba: [BaseClass] = [ BaseClass(), BaseClass() ]
+    anArray = ba as! [ElementClass]
+  }
+
+  @inline(never)
+  func runLoop(inout A : [ElementClass]) {
+    // Simulate what happens if we hoist array properties out of a loop and the
+    // loop calls a function that violates inout safety and overrides the array.
+    let isNativeTypeChecked = A._hoistableIsNativeTypeChecked()
+    for i in 0..<A.count {
+      let t = A._checkSubscript(
+        i, wasNativeTypeChecked: isNativeTypeChecked)
+      _ = A._getElement(
+        i, wasNativeTypeChecked: isNativeTypeChecked, matchingSubscriptCheck: t)
+      accessArrayViaInoutViolation()
+    }
+  }
+
+  @inline(never)
+  func inoutViolation() {
+    anArray = [ ElementClass("1"), ElementClass("2"), ElementClass("3")]
+    runLoop(&anArray)
+  }
+}
+
+ArraySemanticOptzns.test("inout_rule_violated_needsElementTypeCheck")
+  .skip(.Custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))  
+  .crashOutputMatches(_isDebugAssertConfiguration() ?
+    "fatal error: inout rules were violated: the array was overwritten" : "")
+  .code {
+  let v = ViolateInoutSafetyNeedElementTypeCheck()
+  expectCrashLater()
+  v.inoutViolation()
+}
+
+runAllTests()


### PR DESCRIPTION
This change moves functionality that requires ObjC interop into a new file and removes the XFAIL on Linux. Partially resolves SR-216.
## 

This is tested on Ubuntu 14.04 and OS X 10.10.

As an aside, I've moved any tests that use array downcasting into the ObjC file because it's only supported there. Attempting to downcast an array crashes the compiler on Linux. [SR-236](https://bugs.swift.org/browse/SR-236) covers the compiler crash and **rdar://problem/18881196** covers getting the array functions for downcasting ported to non-objc platforms. 

(Edited to reflect new understanding)
