### PR TITLE
[SR-426][Runtime] Use _fail to ensure src is deallocated in cast

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1906,10 +1906,7 @@ static bool _dynamicCastToExistentialMetatype(OpaqueValue *dest,
   case MetadataKind::Opaque:
   case MetadataKind::Struct:
   case MetadataKind::Tuple:
-    if (flags & DynamicCastFlags::Unconditional) {
-      swift_dynamicCastFailure(srcType, targetType);
-    }
-    return false;
+    return _fail(src, srcType, targetType, flags);
   }
   _failCorruptType(srcType);
 }

--- a/test/1_stdlib/Casts.swift
+++ b/test/1_stdlib/Casts.swift
@@ -1,0 +1,50 @@
+// Casts.swift - Tests for conversion between types.
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2015 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Contains tests for conversions between types which shouldn't trap.
+///
+// -----------------------------------------------------------------------------
+// RUN: %target-run-stdlib-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+let CastsTests = TestSuite("Casts")
+
+// Test for SR-426: missing release for some types after failed conversion
+class DeinitTester {
+    private let onDeinit: () -> ()
+    
+    init(onDeinit: () -> ()) {
+        self.onDeinit = onDeinit
+    }
+    deinit {
+        onDeinit()
+    }
+}
+
+func testFailedTupleCast(onDeinit: () -> ()) {
+    // This function is to establish a scope for t to 
+    // be deallocated at the end of.
+    let t: Any = (1, DeinitTester(onDeinit: onDeinit))
+    _ = t is Any.Type
+}
+
+CastsTests.test("No leak for failed tuple casts") {
+    var deinitRan = false
+    testFailedTupleCast {
+        deinitRan = true
+    }
+    expectTrue(deinitRan)
+}
+
+runAllTests()


### PR DESCRIPTION
This case was previously ignoring the DestroyOnFailure flag, so
we had a leak if a cast to an existential metatype failed for
certain types (tuples, structs, etc).
