### PR TITLE
[SR-433][Sema] Don't produce vararg tuples outside of arglists

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1593,12 +1593,16 @@ ConstraintSystem::matchTypes(Type type1, Type type2, TypeMatchKind kind,
       // containing a single element if the scalar type is a subtype of
       // the type of that tuple's element.
       //
-      // A scalar type can be converted to a tuple so long as there is at
-      // most one non-defaulted element.
+      // A scalar type can be converted to an argument tuple so long as
+      // there is at most one non-defaulted element.
+      // For non-argument tuples, we can do the same conversion but not
+      // to a tuple with varargs.
       if ((tuple2->getNumElements() == 1 &&
            !tuple2->getElement(0).isVararg()) ||
           (kind >= TypeMatchKind::Conversion &&
-           tuple2->getElementForScalarInit() >= 0)) {
+           tuple2->getElementForScalarInit() >= 0 &&
+           (isArgumentTupleConversion ||
+            !tuple2->getVarArgsBaseType()))) {
         conversionsOrFixes.push_back(
           ConversionRestrictionKind::ScalarToTuple);
 

--- a/validation-test/compiler_crashers_fixed/26298-llvm-densemapbase.swift
+++ b/validation-test/compiler_crashers_fixed/26298-llvm-densemapbase.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// RUN: %target-swift-frontend %s -emit-silgen
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/airspeedswift (airspeedswift)
 


### PR DESCRIPTION
Previously, we could produce such a tuple shuffle for non-arg
tuples, which would trigger an assert in SILGen.

There are lots of ways to solve this -- for example, perhaps it makes more sense to constrain non-arg tuple types themselves to be non-vararg rather than trying to enforce this as part of matching the types. Happy to take another pass if there's a better approach here.
