### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::setType(…)

### DIFF
--- a/validation-test/compiler_crashers/28189-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers/28189-swift-valuedecl-settype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func f{{for b{}{String($0


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/Decl.cpp:1728: void swift::ValueDecl::setType(swift::Type): Assertion `!hasType() && "changing type of declaration"' failed.
8  swift           0x0000000000fc370c swift::ValueDecl::setType(swift::Type) + 92
10 swift           0x0000000000ea80d9 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 6649
11 swift           0x0000000000eaaffe swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
12 swift           0x0000000000df7c55 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
13 swift           0x0000000000dfdfe9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
14 swift           0x0000000000dffbc1 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 145
18 swift           0x0000000000e5f29a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
19 swift           0x0000000000e8b85c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
20 swift           0x0000000000dfe05b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
23 swift           0x0000000000e5dfaa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
24 swift           0x0000000000e5ddfe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
25 swift           0x0000000000e5e9d8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
27 swift           0x0000000000de4f7b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1771
28 swift           0x0000000000c9ab42 swift::CompilerInstance::performSema() + 2946
30 swift           0x00000000007631e2 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
31 swift           0x000000000075ddc1 main + 2705
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28189-swift-valuedecl-settype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28189-swift-valuedecl-settype-5823eb.o
1.  While type-checking 'f' at validation-test/compiler_crashers/28189-swift-valuedecl-settype.swift:8:1
2.  While type-checking expression at [validation-test/compiler_crashers/28189-swift-valuedecl-settype.swift:8:8 - line:8:24] RangeText="{for b{}{String($"
3.  While type-checking expression at [validation-test/compiler_crashers/28189-swift-valuedecl-settype.swift:8:16 - line:8:24] RangeText="{String($"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
