### PR TITLE
[SR-392][Runtime] Avoid overrelease when failing cast to protocol

### DIFF
--- a/test/1_stdlib/Casts.swift
+++ b/test/1_stdlib/Casts.swift
@@ -54,4 +54,23 @@ CastsTests.test("No leak for failed tuple casts") {
     expectTrue(deinitRan)
 }
 
+protocol P {}
+class ErrClass : ErrorType { }
+
+CastsTests.test("No overrelease of existential boxes in failed casts") {
+    // Test for crash from SR-392
+    // We fail casts of an existential box repeatedly
+    // to ensure it does not get over-released.
+    func bar<T>(t: T) {
+        for i in 0..<10 {
+            if case let a as P = t {
+                _ = a
+            }
+        }
+    }
+    
+    let err: ErrorType = ErrClass()
+    bar(err)
+}
+
 runAllTests()


### PR DESCRIPTION
Fixes a regression introduced in e09027ca which causes us to release the wrong value when a cast fails.

I added the additional `srcDynamicType` argument to `_fail` (rather than just passing it for the `srcType` argument) because I was unsure if it was safe to use the dynamic type's version of `vw_destroy` on the `srcValue` (or in general use the dynamic type as a substitute for the `srcType` in possible future modifications to `_fail`). If it is always safe to substitute the dynamic type, we could simply pass the dynamic type for the srcType to `_fail` whenever it is available. 
