### PR TITLE
[stdlib] Adding zipWithNilPadding

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -130,6 +130,7 @@ set(SWIFTLIB_SOURCES
   Tuple.swift.gyb
   VarArgs.swift
   Zip.swift
+  ZipWithNilPadding.swift
   Prespecialized.swift
   )
 

--- a/stdlib/public/core/ZipWithNilPadding.swift
+++ b/stdlib/public/core/ZipWithNilPadding.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A sequence of pairs built out of two underlying sequences, where
+/// the elements of the `i`th pair are the `i`th elements of each
+/// underlying sequence. Passes nil instead of element of underlying sequence
+/// when there is no `i`th element.  Finishes when both of sequences finish.
+/// For example: zipWithNilPadding(["one", "two", "three", "four"], (1, 2, 3))
+/// returns a sequence ("one", 1), ("two", 2), ("three", 3), ("four", nil).
+public func zipWithNilPadding<Sequence1 : SequenceType, Sequence2 : SequenceType>(
+  sequence1: Sequence1, _ sequence2: Sequence2
+) -> Zip2SequenceWithNilPadding<Sequence1, Sequence2> {
+  return Zip2SequenceWithNilPadding(sequence1, sequence2)
+}
+
+/// A generator for `Zip2SequenceWithNilPadding`.
+public struct Zip2GeneratorWithNilPadding<
+  Generator1 : GeneratorType, Generator2 : GeneratorType
+> : GeneratorType {
+  /// The type of element returned by `next()`.
+  public typealias Element = (Generator1.Element?, Generator2.Element?)
+
+  /// Construct around a pair of underlying generators.
+  public init(_ generator1: Generator1, _ generator2: Generator2) {
+    (_baseStream1, _baseStream2) = (generator1, generator2)
+  }
+
+  /// Advance to the next element and return it, or `nil` if no next
+  /// element exists.
+  ///
+  /// - Requires: `next()` has not been applied to a copy of `self`
+  ///   since the copy was made, and no preceding call to `self.next()`
+  ///   has returned `nil`.
+  public mutating func next() -> Element? {
+    let element1 = self._baseStream1.next()
+    let element2 = self._baseStream2.next()
+
+    if nil == element1 && nil == element2 {
+        return nil
+    } else {
+        return (element1, element2)
+    }
+  }
+
+  internal var _baseStream1: Generator1
+  internal var _baseStream2: Generator2
+}
+
+/// A sequence of pairs built out of two underlying sequences, where
+/// the elements of the `i`th pair are the `i`th elements of each
+/// underlying sequence.  Finishes when both of sequences finish.
+/// For example: Zip2SequenceWithNilPadding(["one", "two", "three", "four"], (1, 2, 3))
+/// returns a sequence ("one", 1), ("two", 2), ("three", 3), ("four", nil).
+public struct Zip2SequenceWithNilPadding<Sequence1 : SequenceType, Sequence2 : SequenceType>
+  : SequenceType {
+
+  public typealias Stream1 = Sequence1.Generator
+  public typealias Stream2 = Sequence2.Generator
+
+  /// A type whose instances can produce the elements of this
+  /// sequence, in order.
+  public typealias Generator = Zip2GeneratorWithNilPadding<Stream1, Stream2>
+
+  /// Construct an instance that makes pairs of elements from `sequence1` and
+  /// `sequence2`.
+  public init(_ sequence1: Sequence1, _ sequence2: Sequence2) {
+    (_sequence1, _sequence2) = (sequence1, sequence2)
+  }
+
+  /// Return a *generator* over the elements of this *sequence*.
+  ///
+  /// - Complexity: O(1).
+  public func generate() -> Generator {
+    return Generator(
+      _sequence1.generate(),
+      _sequence2.generate())
+  }
+
+  internal let _sequence1: Sequence1
+  internal let _sequence2: Sequence2
+}

--- a/test/1_stdlib/ZipWithNilPadding.swift
+++ b/test/1_stdlib/ZipWithNilPadding.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift | FileCheck %s
+// REQUIRES: executable_test
+
+// FIXME(prext): remove this file when protocol extensions land.
+
+var n = [2, 3, 5, 7, 11]
+var s = ["two", "three", "five", "seven", "eleven", "thirteen"]
+
+func stringValue<T>(valueOrNil: T?, defaultValue: String = "nil") -> String {
+    if let value = valueOrNil {
+        return "\(value)"
+    } else {
+        return defaultValue
+    }
+}
+
+var i = 0
+var prefix = ""
+for p in zipWithNilPadding(n, s) {
+    print("\(prefix)\(stringValue(p.0)) => \(stringValue(p.1))", terminator: "")
+    i += 1
+    prefix = ", "
+}
+print(" (\(i) items)")
+// CHECK: 2 => two, 3 => three, 5 => five, 7 => seven, 11 => eleven, nil => thirteen (6 items)
+
+i = 0
+prefix = ""
+for p in zipWithNilPadding(s, n) {
+    print("\(prefix)\(stringValue(p.0)) => \(stringValue(p.1))", terminator: "")
+    i += 1
+    prefix = ", "
+}
+print(" (\(i) items)")
+// CHECK: two => 2, three => 3, five => 5, seven => 7, eleven => 11, thirteen => nil (6 items)
+
+print("done.")
+


### PR DESCRIPTION
zipWithNilPadding builds a sequence of pairs built out of two underlying sequences,
where the elements of the `i`th pair are the `i`th elements of each underlying sequence.
Unlike regular zip zipWithNilPadding finishes when longer underlying sequence finishes.
For example: zipWithNilPadding(["one", "two", "three", "four"], (1, 2, 3)) returns
a sequence: ("one", 1), ("two", 2), ("three", 3), ("four", nil).
This function is useful for merging or comparing elements two sequences.
