### PR TITLE
[swiftc] Add test case for crash triggered in swift::ConformanceLookupTable::expandImpliedConformances(…)

### DIFF
--- a/validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A:A
+protocol a:A
+struct c:a{
+let h=D


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ConformanceLookupTable.cpp:497: void swift::ConformanceLookupTable::expandImpliedConformances(swift::NominalTypeDecl *, swift::DeclContext *, swift::LazyResolver *): Assertion `i <= 16384 && "Infinite loop due to circular protocol inheritance?"' failed.
8  swift           0x0000000001044d15 swift::ConformanceLookupTable::expandImpliedConformances(swift::NominalTypeDecl*, swift::DeclContext*, swift::LazyResolver*) + 821
9  swift           0x0000000001042f15 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 1109
10 swift           0x000000000104655e swift::ConformanceLookupTable::getAllProtocols(swift::NominalTypeDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolDecl*>&) + 30
11 swift           0x000000000100f67f swift::NominalTypeDecl::getAllProtocols() const + 95
12 swift           0x0000000001004b49 swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 3529
13 swift           0x00000000010032ed swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
14 swift           0x0000000000e3bf0b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
15 swift           0x0000000000df81e8 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 120
17 swift           0x0000000000f6dd83 swift::Expr::walk(swift::ASTWalker&) + 19
18 swift           0x0000000000df9697 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
19 swift           0x0000000000dffc49 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
20 swift           0x0000000000e00d60 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
21 swift           0x0000000000e00f09 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
26 swift           0x0000000000e1a816 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000de6ab2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
28 swift           0x0000000000c9c702 swift::CompilerInstance::performSema() + 2946
30 swift           0x0000000000763402 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
31 swift           0x000000000075dfe1 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28190-swift-conformancelookuptable-expandimpliedconformances-582f15.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift:11:7 - line:11:7] RangeText="D"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
