### PR TITLE
[gardening] Improve consistency in start of file header comment

### DIFF
--- a/include/swift/AST/ASTVisitor.h
+++ b/include/swift/AST/ASTVisitor.h
@@ -1,4 +1,4 @@
-//===-- ASTVisitor.h - Decl, Expr and Stmt Visitor --------------*- C++ -*-===//
+//===--- ASTVisitor.h - Decl, Expr and Stmt Visitor -------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/CanTypeVisitor.h
+++ b/include/swift/AST/CanTypeVisitor.h
@@ -1,4 +1,4 @@
-//===-- CanTypeVisitor.h - TypeVisitor specialization -----------*- C++ -*-===//
+//===--- CanTypeVisitor.h - TypeVisitor specialization ----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -1,4 +1,4 @@
-//===-- DeclNodes.def - Swift Declaration AST Metaprogramming ---*- C++ -*-===//
+//===--- DeclNodes.def - Swift Declaration AST Metaprogramming --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1,4 +1,4 @@
-//===- DiagnosticEngine.h - Diagnostic Display Engine -----------*- C++ -*-===//
+//===--- DiagnosticEngine.h - Diagnostic Display Engine ---------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsAll.def
+++ b/include/swift/AST/DiagnosticsAll.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsAll.def - Diagnostics Text Index --------------*- C++ -*-===//
+//===--- DiagnosticsAll.def - Diagnostics Text Index ------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsClangImporter.def - Diagnostics Text ----------*- C++ -*-===//
+//===--- DiagnosticsClangImporter.def - Diagnostics Text --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsClangImporter.h
+++ b/include/swift/AST/DiagnosticsClangImporter.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsClangImporter.h - Diagnostic Definitions ------*- C++ -*-===//
+//===--- DiagnosticsClangImporter.h - Diagnostic Definitions ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsCommon.def - Diagnostics Text -----------------*- C++ -*-===//
+//===--- DiagnosticsCommon.def - Diagnostics Text ---------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsCommon.h
+++ b/include/swift/AST/DiagnosticsCommon.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsCommon.h - Shared Diagnostic Definitions ------*- C++ -*-===//
+//===--- DiagnosticsCommon.h - Shared Diagnostic Definitions ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsDriver.def - Diagnostics Text -----------------*- C++ -*-===//
+//===--- DiagnosticsDriver.def - Diagnostics Text ---------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsDriver.h
+++ b/include/swift/AST/DiagnosticsDriver.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsDriver.h - Diagnostic Definitions -------------*- C++ -*-===//
+//===--- DiagnosticsDriver.h - Diagnostic Definitions -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsFrontend.def - Diagnostics Text ---------------*- C++ -*-===//
+//===--- DiagnosticsFrontend.def - Diagnostics Text -------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsFrontend.h
+++ b/include/swift/AST/DiagnosticsFrontend.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsFrontend.h - Diagnostic Definitions -----------*- C++ -*-===//
+//===--- DiagnosticsFrontend.h - Diagnostic Definitions ---------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsIRGen.def - Diagnostics Text ------------------*- C++ -*-===//
+//===--- DiagnosticsIRGen.def - Diagnostics Text ----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsIRGen.h
+++ b/include/swift/AST/DiagnosticsIRGen.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsIRGen.h - Diagnostic Definitions --------------*- C++ -*-===//
+//===--- DiagnosticsIRGen.h - Diagnostic Definitions ------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsParse.def - Diagnostics Text ------------------*- C++ -*-===//
+//===--- DiagnosticsParse.def - Diagnostics Text ----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsParse.h
+++ b/include/swift/AST/DiagnosticsParse.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsParse.h - Diagnostic Definitions --------------*- C++ -*-===//
+//===--- DiagnosticsParse.h - Diagnostic Definitions ------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsSIL.def - Diagnostics Text --------------------*- C++ -*-===//
+//===--- DiagnosticsSIL.def - Diagnostics Text ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsSIL.h
+++ b/include/swift/AST/DiagnosticsSIL.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsSIL.h - Diagnostic Definitions ----------------*- C++ -*-===//
+//===--- DiagnosticsSIL.h - Diagnostic Definitions --------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1,4 +1,4 @@
-//===- DiagnosticsSema.def - Diagnostics Text -------------------*- C++ -*-===//
+//===--- DiagnosticsSema.def - Diagnostics Text -----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsSema.h
+++ b/include/swift/AST/DiagnosticsSema.h
@@ -1,4 +1,4 @@
-//===- DiagnosticsSema.h - Diagnostic Definitions ---------------*- C++ -*-===//
+//===--- DiagnosticsSema.h - Diagnostic Definitions -------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -1,4 +1,4 @@
-//===-- KnownDecls.def - Compiler declaration metaprogramming ---*- C++ -*-===//
+//===--- KnownDecls.def - Compiler declaration metaprogramming --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -1,4 +1,4 @@
-//===- PrettyStackTrace.h - Crash trace information -------------*- C++ -*-===//
+//===--- PrettyStackTrace.h - Crash trace information -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/SubstTypeVisitor.h
+++ b/include/swift/AST/SubstTypeVisitor.h
@@ -1,4 +1,4 @@
-//===-- SubstTypeVisitor.h - Visitor for substituted types ------*- C++ -*-===//
+//===--- SubstTypeVisitor.h - Visitor for substituted types -----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -1,4 +1,4 @@
-//===-- TypeMatcher.h - Recursive Type Matcher------- -----------*- C++ -*-===//
+//===--- TypeMatcher.h - Recursive Type Matcher -----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -1,4 +1,4 @@
-//===-- TypeMemberVisitor.h - ASTVisitor specialization ---------*- C++ -*-===//
+//===--- TypeMemberVisitor.h - ASTVisitor specialization --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/TypeVisitor.h
+++ b/include/swift/AST/TypeVisitor.h
@@ -1,4 +1,4 @@
-//===-- TypeVisitor.h - Type Visitor ----------------------------*- C++ -*-===//
+//===--- TypeVisitor.h - Type Visitor ---------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/AssertImplements.h
+++ b/include/swift/Basic/AssertImplements.h
@@ -1,4 +1,4 @@
-//===- AssertImplements.h - Assert that a class overrides a function ------===//
+//===--- AssertImplements.h - Assert that a class overrides a function ----===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/BlotMapVector.h
+++ b/include/swift/Basic/BlotMapVector.h
@@ -1,4 +1,4 @@
-//===- BlotMapVector.h - Map vector with "blot" operation  ------*- C++ -*-===//
+//===--- BlotMapVector.h - Map vector with "blot" operation  ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/Defer.h
+++ b/include/swift/Basic/Defer.h
@@ -1,4 +1,4 @@
-//===- Defer.h - 'defer' helper macro ---------------------------*- C++ -*-===//
+//===--- Defer.h - 'defer' helper macro -------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/DemangleNodes.def
+++ b/include/swift/Basic/DemangleNodes.def
@@ -1,4 +1,4 @@
-//===-- DemangleNodes.def - Demangling Tree Metaprogramming -----*- C++ -*-===//
+//===--- DemangleNodes.def - Demangling Tree Metaprogramming ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/DiagnosticConsumer.h
+++ b/include/swift/Basic/DiagnosticConsumer.h
@@ -1,4 +1,4 @@
-//===- DiagnosticConsumer.h - Diagnostic Consumer Interface -----*- C++ -*-===//
+//===--- DiagnosticConsumer.h - Diagnostic Consumer Interface ---*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/Fallthrough.h
+++ b/include/swift/Basic/Fallthrough.h
@@ -1,4 +1,4 @@
-//===- Fallthrough.h - switch fallthrough annotation macro ------*- C++ -*-===//
+//===--- Fallthrough.h - switch fallthrough annotation macro ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/FlaggedPointer.h
+++ b/include/swift/Basic/FlaggedPointer.h
@@ -1,4 +1,4 @@
-//===- FlaggedPointer.h - Explicit pointer tagging container ----*- C++ -*-===//
+//===--- FlaggedPointer.h - Explicit pointer tagging container --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/Malloc.h
+++ b/include/swift/Basic/Malloc.h
@@ -1,4 +1,4 @@
-//===- Malloc.h - Aligned malloc interface ----------------------*- C++ -*-===//
+//===--- Malloc.h - Aligned malloc interface --------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/NullablePtr.h
+++ b/include/swift/Basic/NullablePtr.h
@@ -1,4 +1,4 @@
-//===- NullablePtr.h - A pointer that allows null ---------------*- C++ -*-===//
+//===--- NullablePtr.h - A pointer that allows null -------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/OptionSet.h
+++ b/include/swift/Basic/OptionSet.h
@@ -1,4 +1,4 @@
-//===-- OptionSet.h - Sets of boolean options -------------------*- C++ -*-===//
+//===--- OptionSet.h - Sets of boolean options ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/Program.h
+++ b/include/swift/Basic/Program.h
@@ -1,4 +1,4 @@
-//===- Program.h ------------------------------------------------*- C++ -*-===//
+//===--- Program.h ----------------------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/QuotedString.h
+++ b/include/swift/Basic/QuotedString.h
@@ -1,4 +1,4 @@
-//===- QuotedString.h - Print a string in double-quotes ---------*- C++ -*-===//
+//===--- QuotedString.h - Print a string in double-quotes -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -1,4 +1,4 @@
-//===- Range.h - Classes for conveniently working with ranges ---*- C++ -*-===//
+//===--- Range.h - Classes for conveniently working with ranges -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -1,4 +1,4 @@
-//===-- RelativePointer.h - Relative Pointer Support ------------*- C++ -*-===//
+//===--- RelativePointer.h - Relative Pointer Support -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -1,4 +1,4 @@
-//===- STLExtras.h - additions to the STL -----------------------*- C++ -*-===//
+//===--- STLExtras.h - additions to the STL ---------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -1,4 +1,4 @@
-//===- SourceLoc.h - Source Locations and Ranges ----------------*- C++ -*-===//
+//===--- SourceLoc.h - Source Locations and Ranges --------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -1,4 +1,4 @@
-//===- TreeScopedHashTable.h - Hash table with multiple active scopes -----===//
+//===--- TreeScopedHashTable.h - Hash table with multiple active scopes ---===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -1,4 +1,4 @@
-//===- Version.h - Swift Version Number -------------------------*- C++ -*-===//
+//===--- Version.h - Swift Version Number -----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/ClangImporter/ClangImporterOptions.h
+++ b/include/swift/ClangImporter/ClangImporterOptions.h
@@ -1,4 +1,4 @@
-//===-- ClangImporterOptions.h ----------------------------------*- C++ -*-===//
+//===--- ClangImporterOptions.h ---------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -1,4 +1,4 @@
-//===-- Driver.h - Swift compiler driver ------------------------*- C++ -*-===//
+//===--- Driver.h - Swift compiler driver -----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Driver/OutputFileMap.h
+++ b/include/swift/Driver/OutputFileMap.h
@@ -1,4 +1,4 @@
-//===-- OutputFileMap.h - Driver output file map ----------------*- C++ -*-===//
+//===--- OutputFileMap.h - Driver output file map ---------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -1,4 +1,4 @@
-//===- DiagnosticVerifier.h - Diagnostic Verifier (-verify) -----*- C++ -*-===//
+//===--- DiagnosticVerifier.h - Diagnostic Verifier (-verify) ---*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -1,4 +1,4 @@
-//===-- Frontend.h - frontend utility methods -------------------*- C++ -*-===//
+//===--- Frontend.h - frontend utility methods ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -1,4 +1,4 @@
-//===- PrintingDiagnosticConsumer.h - Print Text Diagnostics ----*- C++ -*-===//
+//===--- PrintingDiagnosticConsumer.h - Print Text Diagnostics --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -1,4 +1,4 @@
-//===- SerializedDiagnosticConsumer.h - Serialize Diagnostics ---*- C++ -*-===//
+//===--- SerializedDiagnosticConsumer.h - Serialize Diagnostics -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -1,4 +1,4 @@
-//===- CodeCompletion.h - Routines for code completion --------------------===//
+//===--- CodeCompletion.h - Routines for code completion ------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -1,4 +1,4 @@
-//===- CodeCompletionCache.h - Routines for code completion caching -------===//
+//===--- CodeCompletionCache.h - Routines for code completion caching -----===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -1,4 +1,4 @@
-//===- SourceEntityWalker.h - Routines for semantic source info -----------===//
+//===--- SourceEntityWalker.h - Routines for semantic source info ---------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -1,4 +1,4 @@
-//===- SyntaxModel.h - Routines for IDE syntax model  ---------------------===//
+//===--- SyntaxModel.h - Routines for IDE syntax model  -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -1,4 +1,4 @@
-//===- Utils.h - Misc utilities -------------------------------------------===//
+//===--- Utils.h - Misc utilities -----------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Immediate/Immediate.h
+++ b/include/swift/Immediate/Immediate.h
@@ -1,4 +1,4 @@
-//===-- Immediate.h - Entry point for swift immediate mode ------*- C++ -*-===//
+//===--- Immediate.h - Entry point for swift immediate mode -----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/PrintAsObjC/PrintAsObjC.h
+++ b/include/swift/PrintAsObjC/PrintAsObjC.h
@@ -1,4 +1,4 @@
-//===-- PrintAsObjC.h - Emit a header file for a Swift AST ----------------===//
+//===--- PrintAsObjC.h - Emit a header file for a Swift AST ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SIL/LoopInfo.h
+++ b/include/swift/SIL/LoopInfo.h
@@ -1,4 +1,4 @@
-//===-------------- LoopInfo.h - SIL Loop Analysis --------------*- C++ -*-===//
+//===--- LoopInfo.h - SIL Loop Analysis -------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SIL/PrettyStackTrace.h
+++ b/include/swift/SIL/PrettyStackTrace.h
@@ -1,4 +1,4 @@
-//===- PrettyStackTrace.h - Crash trace information -------------*- C++ -*-===//
+//===--- PrettyStackTrace.h - Crash trace information -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SIL/SILValueProjection.h
+++ b/include/swift/SIL/SILValueProjection.h
@@ -1,4 +1,4 @@
-//===------------------------ SILValueProjection.h ---------------------- -===//
+//===--- SILValueProjection.h ---------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -1,4 +1,4 @@
-//===--------------- ARCAnalysis.h - SIL ARC Analysis -----------*- C++ -*-===//
+//===--- ARCAnalysis.h - SIL ARC Analysis -----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -1,4 +1,4 @@
-//===-------------- AliasAnalysis.h - SIL Alias Analysis --------*- C++ -*-===//
+//===--- AliasAnalysis.h - SIL Alias Analysis -------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -1,4 +1,4 @@
-//===-- Analysis.h  - Swift Analysis ----------------------------*- C++ -*-===//
+//===--- Analysis.h  - Swift Analysis ---------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
+++ b/include/swift/SILOptimizer/Analysis/ColdBlockInfo.h
@@ -1,4 +1,4 @@
-//===-- ColdBlockInfo.h - Fast/slow path analysis for SIL CFG ---*- C++ -*-===//
+//===--- ColdBlockInfo.h - Fast/slow path analysis for SIL CFG --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -1,4 +1,4 @@
-//===----------- EscapeAnalysis.h - SIL Escape Analysis ---------*- C++ -*-===//
+//===--- EscapeAnalysis.h - SIL Escape Analysis -----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/IVAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/IVAnalysis.h
@@ -1,4 +1,4 @@
-//===------------------- IVAnalysis.h - SIL IV Analysis ---------*- C++ -*-===//
+//===--- IVAnalysis.h - SIL IV Analysis -------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
@@ -1,4 +1,4 @@
-//===-------------- LoopAnalysis.h - SIL Loop Analysis ----------*- C++ -*-===//
+//===--- LoopAnalysis.h - SIL Loop Analysis ---------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -1,4 +1,4 @@
-//===------ SideEffectAnalysis.h - SIL Side Effect Analysis -----*- C++ -*-===//
+//===--- SideEffectAnalysis.h - SIL Side Effect Analysis --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/ValueTracking.h
+++ b/include/swift/SILOptimizer/Analysis/ValueTracking.h
@@ -1,4 +1,4 @@
-//===-- ValueTracking.h - SIL Value Tracking Analysis -----------*- C++ -*-===//
+//===--- ValueTracking.h - SIL Value Tracking Analysis ----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -1,4 +1,4 @@
-//===-- PassManager.h  - Swift Pass Manager ---------------------*- C++ -*-===//
+//===--- PassManager.h  - Swift Pass Manager --------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -1,4 +1,4 @@
-//===-------- Passes.h - Swift Compiler SIL Pass Entrypoints ----*- C++ -*-===//
+//===--- Passes.h - Swift Compiler SIL Pass Entrypoints ---------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -1,4 +1,4 @@
-//===-- Transforms.h - Swift Transformations  -------------------*- C++ -*-===//
+//===--- Transforms.h - Swift Transformations  ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -1,4 +1,4 @@
-//===-- Devirtualize.h - Helper for devirtualizing apply --------*- C++ -*-===//
+//===--- Devirtualize.h - Helper for devirtualizing apply -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -1,4 +1,4 @@
-//===-- GenericCloner.h - Specializes generic functions  --------*- C++ -*-===//
+//===--- GenericCloner.h - Specializes generic functions  -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -1,4 +1,4 @@
-//===-- Generics.h - Utilities for transforming generics --------*- C++ -*-===//
+//===--- Generics.h - Utilities for transforming generics -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Utils/SCCVisitor.h
+++ b/include/swift/SILOptimizer/Utils/SCCVisitor.h
@@ -1,4 +1,4 @@
-//===------------------- SCCVisitor.h - SIL SCC Visitor ---------*- C++ -*-===//
+//===--- SCCVisitor.h - SIL SCC Visitor -------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -1,4 +1,4 @@
-//===------ SILSSAUpdater.h - Unstructured SSA Update Tool ------*- C++ -*-===//
+//===--- SILSSAUpdater.h - Unstructured SSA Update Tool ---------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Sema/TypeCheckRequestPayloads.def
+++ b/include/swift/Sema/TypeCheckRequestPayloads.def
@@ -1,4 +1,4 @@
-//===-- TypeCheckRequestPayloads.def - Type Checking Payloads ---*- C++ -*-===//
+//===--- TypeCheckRequestPayloads.def - Type Checking Payloads --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1,4 +1,4 @@
-//===- DiagnosticEngine.cpp - Diagnostic Display Engine ---------*- C++ -*-===//
+//===--- DiagnosticEngine.cpp - Diagnostic Display Engine -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/DiagnosticList.cpp
+++ b/lib/AST/DiagnosticList.cpp
@@ -1,4 +1,4 @@
-//===- DiagnosticList.cpp - Diagnostic Definitions ------------------------===//
+//===--- DiagnosticList.cpp - Diagnostic Definitions ----------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Basic/DiagnosticConsumer.cpp
+++ b/lib/Basic/DiagnosticConsumer.cpp
@@ -1,4 +1,4 @@
-//===- DiagnosticConsumer.cpp - Diagnostic Consumer Impl --------*- C++ -*-===//
+//===--- DiagnosticConsumer.cpp - Diagnostic Consumer Impl ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -1,4 +1,4 @@
-//===-- Platform.cpp - Implement platform-related helpers -------*- C++ -*-===//
+//===--- Platform.cpp - Implement platform-related helpers ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -1,4 +1,4 @@
-//===-- Program.cpp - Implement OS Program Concept --------------*- C++ -*-===//
+//===--- Program.cpp - Implement OS Program Concept -------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1,4 +1,4 @@
-//===-- Driver.cpp - Swift compiler driver --------------------------------===//
+//===--- Driver.cpp - Swift compiler driver -------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Driver/OutputFileMap.cpp
+++ b/lib/Driver/OutputFileMap.cpp
@@ -1,4 +1,4 @@
-//===-- OutputFileMap.cpp - Driver output file map --------------*- C++ -*-===//
+//===--- OutputFileMap.cpp - Driver output file map -------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1,4 +1,4 @@
-//===-- CompilerInvocation.cpp - CompilerInvocation methods ---------------===//
+//===--- CompilerInvocation.cpp - CompilerInvocation methods --------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1,4 +1,4 @@
-//===- DiagnosticVerifier.cpp - Diagnostic Verifier (-verify) -------------===//
+//===--- DiagnosticVerifier.cpp - Diagnostic Verifier (-verify) -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1,4 +1,4 @@
-//===-- Frontend.cpp - frontend utility methods ---------------------------===//
+//===--- Frontend.cpp - frontend utility methods --------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -1,4 +1,4 @@
-//===- PrintingDiagnosticConsumer.cpp - Print Text Diagnostics ------------===//
+//===--- PrintingDiagnosticConsumer.cpp - Print Text Diagnostics ----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1,4 +1,4 @@
-//===- CodeCompletion.cpp - Code completion implementation ----------------===//
+//===--- CodeCompletion.cpp - Code completion implementation --------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -1,4 +1,4 @@
-//===- CodeCompletionResultBuilder.h - Build completion results -----------===//
+//===--- CodeCompletionResultBuilder.h - Build completion results ---------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -1,4 +1,4 @@
-//===- SourceEntityWalker.cpp - Routines for semantic source info ---------===//
+//===--- SourceEntityWalker.cpp - Routines for semantic source info -------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1,4 +1,4 @@
-//===- SyntaxModel.cpp - Routines for IDE syntax model --------------------===//
+//===--- SyntaxModel.cpp - Routines for IDE syntax model ------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/RuntimeFunctions.def
+++ b/lib/IRGen/RuntimeFunctions.def
@@ -1,4 +1,4 @@
-//===-- RuntimeFunctions.def - Runtime Functions Database -------*- C++ -*-===//
+//===--- RuntimeFunctions.def - Runtime Functions Database ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/TypeVisitor.h
+++ b/lib/IRGen/TypeVisitor.h
@@ -1,4 +1,4 @@
-//===-- TypeVisitor.h - IR-gen TypeVisitor specialization -------*- C++ -*-===//
+//===--- TypeVisitor.h - IR-gen TypeVisitor specialization ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -1,4 +1,4 @@
-//===-- Immediate.cpp - the swift immediate mode --------------------------===//
+//===--- Immediate.cpp - the swift immediate mode -------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1,4 +1,4 @@
-//===-- REPL.cpp - the integrated REPL ------------------------------------===//
+//===--- REPL.cpp - the integrated REPL -----------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1,4 +1,4 @@
-//===-- PrintAsObjC.cpp - Emit a header file for a Swift AST --------------===//
+//===--- PrintAsObjC.cpp - Emit a header file for a Swift AST -------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SIL/LoopInfo.cpp
+++ b/lib/SIL/LoopInfo.cpp
@@ -1,4 +1,4 @@
-//===-------------- LoopInfo.cpp - SIL Loop Analysis ------------*- C++ -*-===//
+//===--- LoopInfo.cpp - SIL Loop Analysis -----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SIL/SILValueProjection.cpp
+++ b/lib/SIL/SILValueProjection.cpp
@@ -1,4 +1,4 @@
-//===------------------------- SILValueProjection.cpp ---------------------===//
+//===--- SILValueProjection.cpp -------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILGen/ASTVisitor.h
+++ b/lib/SILGen/ASTVisitor.h
@@ -1,4 +1,4 @@
-//===-- ASTVisitor.h - SILGen ASTVisitor specialization ---------*- C++ -*-===//
+//===--- ASTVisitor.h - SILGen ASTVisitor specialization --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -1,4 +1,4 @@
-//===-------------- ARCAnalysis.cpp - SIL ARC Analysis --------------------===//
+//===--- ARCAnalysis.cpp - SIL ARC Analysis -------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -1,4 +1,4 @@
-//===-------------- AliasAnalysis.cpp - SIL Alias Analysis ----------------===//
+//===--- AliasAnalysis.cpp - SIL Alias Analysis ---------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/Analysis.cpp
+++ b/lib/SILOptimizer/Analysis/Analysis.cpp
@@ -1,4 +1,4 @@
-//===----- Analysis.cpp - Swift Analysis ----------------------------------===//
+//===--- Analysis.cpp - Swift Analysis ------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -1,4 +1,4 @@
-//===- BasicCalleeAnalysis.cpp - Determine callees per call site ----------===//
+//===--- BasicCalleeAnalysis.cpp - Determine callees per call site --------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -1,4 +1,4 @@
-//===----- ColdBlockInfo.cpp - Fast/slow path analysis for the SIL CFG ----===//
+//===--- ColdBlockInfo.cpp - Fast/slow path analysis for the SIL CFG ------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1,4 +1,4 @@
-//===-------------- EscapeAnalysis.cpp - SIL Escape Analysis --------------===//
+//===--- EscapeAnalysis.cpp - SIL Escape Analysis -------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -1,4 +1,4 @@
-//===----- FunctionOrder.cpp - Utility for function ordering --------------===//
+//===--- FunctionOrder.cpp - Utility for function ordering ----------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/IVAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/IVAnalysis.cpp
@@ -1,4 +1,4 @@
-//===----------------- IVAnalysis.cpp - SIL IV Analysis ---------*- C++ -*-===//
+//===--- IVAnalysis.cpp - SIL IV Analysis -----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/LoopAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopAnalysis.cpp
@@ -1,4 +1,4 @@
-//===-------------- LoopAnalysis.cpp - SIL Loop Analysis --------*- C++ -*-===//
+//===--- LoopAnalysis.cpp - SIL Loop Analysis -------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -1,4 +1,4 @@
-//===---------- SideEffectAnalysis.cpp - SIL Side Effect Analysis ---------===//
+//===--- SideEffectAnalysis.cpp - SIL Side Effect Analysis ----------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/TypeExpansionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/TypeExpansionAnalysis.cpp
@@ -1,4 +1,4 @@
-//===---------- TypeExpansionAnalysis.cpp - Type Expansion Analysis -------===//
+//===--- TypeExpansionAnalysis.cpp - Type Expansion Analysis --------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -1,4 +1,4 @@
-//===-- ValueTracking.cpp - SIL Value Tracking Analysis ---------*- C++ -*-===//
+//===--- ValueTracking.cpp - SIL Value Tracking Analysis --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -1,4 +1,4 @@
-//===---- CapturePropagation.cpp - Propagate closure capture constants ----===//
+//===--- CapturePropagation.cpp - Propagate closure capture constants -----===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -1,4 +1,4 @@
-//===---- ClosureSpecializer.cpp ------ Performs Closure Specialization----===//
+//===--- ClosureSpecializer.cpp - Performs Closure Specialization ---------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
@@ -1,4 +1,4 @@
-//===-- FunctionSignatureOpts.cpp - Optimizes function signatures ---------===//
+//===--- FunctionSignatureOpts.cpp - Optimizes function signatures --------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -1,4 +1,4 @@
-//===---------- LetPropertiesOpts.cpp - Optimize let properties -----------===//
+//===--- LetPropertiesOpts.cpp - Optimize let properties ------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -1,4 +1,4 @@
-//===------- UsePrespecialized.cpp - use pre-specialized functions --------===//
+//===--- UsePrespecialized.cpp - use pre-specialized functions ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayBoundsCheckOpts.cpp
@@ -1,4 +1,4 @@
-//===----- ArrayBoundsCheckOpts.cpp - Bounds check elim ---------*- C++ -*-===//
+//===--- ArrayBoundsCheckOpts.cpp - Bounds check elim -----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1,4 +1,4 @@
-//===------- COWArrayOpt.cpp - Optimize Copy-On-Write Array Checks --------===//
+//===--- COWArrayOpt.cpp - Optimize Copy-On-Write Array Checks ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -1,4 +1,4 @@
-//===--------- LICM.cpp - Loop invariant code motion ------------*- C++ -*-===//
+//===--- LICM.cpp - Loop invariant code motion ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -1,4 +1,4 @@
-//===--------- LoopRotate.cpp - Loop structure simplify ---------*- C++ -*-===//
+//===--- LoopRotate.cpp - Loop structure simplify ---------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -1,4 +1,4 @@
-//===--------- LoopUnroll.cpp - Loop unrolling ------------------*- C++ -*-===//
+//===--- LoopUnroll.cpp - Loop unrolling ------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1,4 +1,4 @@
-//===----- PassManager.cpp - Swift Pass Manager ---------------------------===//
+//===--- PassManager.cpp - Swift Pass Manager -----------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -1,4 +1,4 @@
-//===-------- Passes.cpp - Swift Compiler SIL Pass Entrypoints ------------===//
+//===--- Passes.cpp - Swift Compiler SIL Pass Entrypoints -----------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -1,4 +1,4 @@
-//===-------------------------- SILCombine --------------------------------===//
+//===--- SILCombine -------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -1,4 +1,4 @@
-//===-------------------------- SILCombiner.h -------------------*- C++ -*-===//
+//===--- SILCombiner.h ------------------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1,4 +1,4 @@
-//===---- SILCombinerMiscVisitors.cpp -------------------------------------===//
+//===--- SILCombinerMiscVisitors.cpp --------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -1,4 +1,4 @@
-//===------ ArrayCountPropagation.cpp - Propagate the count of arrays -----===//
+//===--- ArrayCountPropagation.cpp - Propagate the count of arrays --------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1,4 +1,4 @@
-//===- CSE.cpp - Simple and fast CSE pass ---------------------------------===//
+//===--- CSE.cpp - Simple and fast CSE pass -------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -1,4 +1,4 @@
-//===-- DeadObjectElimination.cpp - Remove unused objects  ----------------===//
+//===--- DeadObjectElimination.cpp - Remove unused objects  ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -1,4 +1,4 @@
-//===---- DeadStoreElimination.cpp - SIL Dead Store Elimination -----------===//
+//===--- DeadStoreElimination.cpp - SIL Dead Store Elimination ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -1,4 +1,4 @@
-//===-------- Devirtualizer.cpp - Devirtualize indirect calls  ------------===//
+//===--- Devirtualizer.cpp - Devirtualize indirect calls  -----------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -1,4 +1,4 @@
-//===-- GenericSpecializer.cpp - Specialization of generic functions ------===//
+//===--- GenericSpecializer.cpp - Specialization of generic functions -----===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/MergeCondFail.cpp
+++ b/lib/SILOptimizer/Transforms/MergeCondFail.cpp
@@ -1,4 +1,4 @@
-//===-- MergeCondFail.cpp -  Merge cond_fail instructions -------*- C++ -*-===//
+//===--- MergeCondFail.cpp -  Merge cond_fail instructions ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -1,4 +1,4 @@
-//===-------- RedundantLoadElimination.cpp - SIL Load Forwarding ----------===//
+//===--- RedundantLoadElimination.cpp - SIL Load Forwarding ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantOverflowCheckRemoval.cpp
@@ -1,4 +1,4 @@
-//===-- RedundantOverflowCheckRemoval.cpp -----------------------*- C++ -*-===//
+//===--- RedundantOverflowCheckRemoval.cpp ----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -1,4 +1,4 @@
-//===---- ReleaseDevirtualizer.cpp - Devirtualizes release-instructions ---===//
+//===--- ReleaseDevirtualizer.cpp - Devirtualizes release-instructions ----===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/RemovePin.cpp
+++ b/lib/SILOptimizer/Transforms/RemovePin.cpp
@@ -1,4 +1,4 @@
-//===------- RemovePin.cpp -  StrongPin/Unpin removal -----------*- C++ -*-===//
+//===--- RemovePin.cpp -  StrongPin/Unpin removal ---------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/SILCleanup.cpp
+++ b/lib/SILOptimizer/Transforms/SILCleanup.cpp
@@ -1,4 +1,4 @@
-//===-- SILCleanup.cpp - Removes diagnostics instructions -----------------===//
+//===--- SILCleanup.cpp - Removes diagnostics instructions ----------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -1,4 +1,4 @@
-//===- SILCodeMotion.cpp - Code Motion Optimizations ----------------------===//
+//===--- SILCodeMotion.cpp - Code Motion Optimizations --------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -1,4 +1,4 @@
-//===- SILLowerAggregateInstrs.cpp - Aggregate insts to Scalar insts  -----===//
+//===--- SILLowerAggregateInstrs.cpp - Aggregate insts to Scalar insts  ---===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -1,4 +1,4 @@
-//===-- SILSROA.cpp - Scalar Replacement of Aggregates  -------------------===//
+//===--- SILSROA.cpp - Scalar Replacement of Aggregates  ------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/Sink.cpp
+++ b/lib/SILOptimizer/Transforms/Sink.cpp
@@ -1,4 +1,4 @@
-//===-- Sink.cpp ----- Code Sinking -----------------------------*- C++ -*-===//
+//===--- Sink.cpp ----- Code Sinking ----------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -1,4 +1,4 @@
-//===------- StackPromotion.cpp - Promotes allocations to the stack -------===//
+//===--- StackPromotion.cpp - Promotes allocations to the stack -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/AADumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/AADumper.cpp
@@ -1,4 +1,4 @@
-//===-------- AADumper.cpp - Compare all values in Function with AA -------===//
+//===--- AADumper.cpp - Compare all values in Function with AA ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/BasicCalleePrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BasicCalleePrinter.cpp
@@ -1,4 +1,4 @@
-//===-- BasicCalleePrinter.cpp - Callee cache printing pass -----*- C++ -*-===//
+//===--- BasicCalleePrinter.cpp - Callee cache printing pass ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/CFGPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/CFGPrinter.cpp
@@ -1,4 +1,4 @@
-//===-- CFGPrinter.cpp - CFG printer pass ---------------------------------===//
+//===--- CFGPrinter.cpp - CFG printer pass --------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/EscapeAnalysisDumper.cpp
@@ -1,4 +1,4 @@
-//===-------- EscapeAnalysisDumper.cpp - Dumps the escape analysis --------===//
+//===--- EscapeAnalysisDumper.cpp - Dumps the escape analysis -------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/FunctionOrderPrinter.cpp
@@ -1,4 +1,4 @@
-//===-- FunctionOrderPrinter.cpp - Function ordering test pass ------------===//
+//===--- FunctionOrderPrinter.cpp - Function ordering test pass -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/IVInfoPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/IVInfoPrinter.cpp
@@ -1,4 +1,4 @@
-//===------------ IVInfoPrinter.cpp - Print SIL IV Info ---------*- C++ -*-===//
+//===--- IVInfoPrinter.cpp - Print SIL IV Info ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/InstCount.cpp
+++ b/lib/SILOptimizer/UtilityPasses/InstCount.cpp
@@ -1,4 +1,4 @@
-//===-- InstCount.cpp - Collects the count of all instructions ------------===//
+//===--- InstCount.cpp - Collects the count of all instructions -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/LoopInfoPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopInfoPrinter.cpp
@@ -1,4 +1,4 @@
-//===------------ LoopInfoPrinter.cpp - Print SIL Loop Info -----*- C++ -*-===//
+//===--- LoopInfoPrinter.cpp - Print SIL Loop Info --------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/SideEffectsDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SideEffectsDumper.cpp
@@ -1,4 +1,4 @@
-//===------- SideEffectsDumper.cpp - Dumps the side effect analysis -------===//
+//===--- SideEffectsDumper.cpp - Dumps the side effect analysis -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/UtilityPasses/StripDebugInfo.cpp
+++ b/lib/SILOptimizer/UtilityPasses/StripDebugInfo.cpp
@@ -1,4 +1,4 @@
-//===-------- StripDebugInfo.cpp - Strip debug info from SIL --------------===//
+//===--- StripDebugInfo.cpp - Strip debug info from SIL -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1,4 +1,4 @@
-//===-- Devirtualize.cpp - Helper for devirtualizing apply ------*- C++ -*-===//
+//===--- Devirtualize.cpp - Helper for devirtualizing apply -----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -1,4 +1,4 @@
-//===--------- GenericCloner.cpp - Specializes generic functions  ---------===//
+//===--- GenericCloner.cpp - Specializes generic functions  ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1,4 +1,4 @@
-//===- Generics.cpp ---- Utilities for transforming generics ----*- C++ -*-===//
+//===--- Generics.cpp ---- Utilities for transforming generics --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -1,4 +1,4 @@
-//===------ SILSSAUpdater.cpp - Unstructured SSA Update Tool ----*- C++ -*-===//
+//===--- SILSSAUpdater.cpp - Unstructured SSA Update Tool -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SwiftDemangle/MangleHack.cpp
+++ b/lib/SwiftDemangle/MangleHack.cpp
@@ -1,4 +1,4 @@
-//===-- MangleHack.cpp - Swift Mangle Hack for various clients ------------===//
+//===--- MangleHack.cpp - Swift Mangle Hack for various clients -----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -1,4 +1,4 @@
-//===- Range.swift --------------------------------------------*- swift -*-===//
+//===--- Range.swift ------------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/core/RangeMirrors.swift.gyb
+++ b/stdlib/public/core/RangeMirrors.swift.gyb
@@ -1,4 +1,4 @@
-//===- RangeMirrors.swift.gyb ---------------------------------*- swift -*-===//
+//===--- RangeMirrors.swift.gyb -------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
+++ b/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
@@ -1,4 +1,4 @@
-//===- UnicodeExtendedGraphemeClusters.cpp.gyb ------------------*- C++ -*-===//
+//===--- UnicodeExtendedGraphemeClusters.cpp.gyb ----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/SourceKit/include/SourceKit/Support/Logging.h
+++ b/tools/SourceKit/include/SourceKit/Support/Logging.h
@@ -1,4 +1,4 @@
-//===- Logging.h - Logging Interface ----------------------------*- C++ -*-===//
+//===--- Logging.h - Logging Interface --------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/SourceKit/include/SourceKit/Support/Tracing.h
+++ b/tools/SourceKit/include/SourceKit/Support/Tracing.h
@@ -1,4 +1,4 @@
-//===- Tracing.h - Tracing Interface ----------------------------*- C++ -*-===//
+//===--- Tracing.h - Tracing Interface --------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/XpcTracing.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/XpcTracing.h
@@ -1,4 +1,4 @@
-//===- XpcTracing.h - XPC-side Tracing Interface ----------------*- C++ -*-===//
+//===--- XpcTracing.h - XPC-side Tracing Interface --------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -1,4 +1,4 @@
-//===-- autolink_extract_main.cpp - autolink extraction utility -----------===//
+//===--- autolink_extract_main.cpp - autolink extraction utility ----------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -1,4 +1,4 @@
-//===-- driver.cpp - Swift Compiler Driver --------------------------------===//
+//===--- driver.cpp - Swift Compiler Driver -------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/driver/frontend_main.cpp
+++ b/tools/driver/frontend_main.cpp
@@ -1,4 +1,4 @@
-//===-- frontend_main.cpp - Swift Compiler Frontend -----------------------===//
+//===--- frontend_main.cpp - Swift Compiler Frontend ----------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -1,4 +1,4 @@
-//===-- modulewrap_main.cpp - module wrapping utility ---------------------===//
+//===--- modulewrap_main.cpp - module wrapping utility --------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -1,4 +1,4 @@
-//===-- lldb-moduleimport-test.cpp - LLDB moduleimport tester -------------===//
+//===--- lldb-moduleimport-test.cpp - LLDB moduleimport tester ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/sil-extract/SILExtract.cpp
+++ b/tools/sil-extract/SILExtract.cpp
@@ -1,4 +1,4 @@
-//===-- SILExtract.cpp - SIL function extraction utility ------------------===//
+//===--- SILExtract.cpp - SIL function extraction utility -----------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -1,4 +1,4 @@
-//===-- SILOpt.cpp - SIL Optimization Driver ------------------------------===//
+//===--- SILOpt.cpp - SIL Optimization Driver -----------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/swift-compress/swift-compress.cpp
+++ b/tools/swift-compress/swift-compress.cpp
@@ -1,4 +1,4 @@
-//===-- swift-compress.cpp - Swift compression tool  ----------------------===//
+//===--- swift-compress.cpp - Swift compression tool  ---------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -1,4 +1,4 @@
-//===-- swift-demangle.cpp - Swift Demangler app --------------------------===//
+//===--- swift-demangle.cpp - Swift Demangler app -------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/tools/swift-ide-test/XMLValidator.h
+++ b/tools/swift-ide-test/XMLValidator.h
@@ -1,4 +1,4 @@
-//===-- XMLValidator.h - XML validation -----------------------------------===//
+//===--- XMLValidator.h - XML validation ----------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/unittests/Basic/CompressionTests.cpp
+++ b/unittests/Basic/CompressionTests.cpp
@@ -1,4 +1,4 @@
-//===- CompressionTests.cpp - for swift/ABI/Compression.h -----------------===//
+//===--- CompressionTests.cpp - for swift/ABI/Compression.h ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/unittests/Basic/FileSystemTests.cpp
+++ b/unittests/Basic/FileSystemTests.cpp
@@ -1,4 +1,4 @@
-//===- FileSystemTests.cpp - for swift/Basic/FileSystem.h -----------------===//
+//===--- FileSystemTests.cpp - for swift/Basic/FileSystem.h ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/unittests/runtime/Enum.cpp
+++ b/unittests/runtime/Enum.cpp
@@ -1,4 +1,4 @@
-//===- Enum.cpp - Enum tests ----------------------------------------------===//
+//===--- Enum.cpp - Enum tests --------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -1,4 +1,4 @@
-//===- Metadata.cpp - Metadata tests --------------------------------------===//
+//===--- Metadata.cpp - Metadata tests ------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/unittests/runtime/weak.mm
+++ b/unittests/runtime/weak.mm
@@ -1,4 +1,4 @@
-//===- weak.mm - Weak-pointer tests ---------------------------------------===//
+//===--- weak.mm - Weak-pointer tests -------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
Correct format:

```
//===--- Name of file - Description ----------------------------*- Lang -*-===//
```

Notes:
- Padding: Pad with `-` after `Description` to reach 80 columns.
- `Name of file`, `Description` and `Lang` are optional.
- In case of missing `Lang` then `-*-` is dropped too.
