### PR TITLE
[build-script] Print unknown target

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -783,7 +783,7 @@ for t in ${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS} ; do
             )
             ;;
         *)
-            echo "Unknown deployment target"
+            echo "Unknown deployment target: ${t}"
             exit 1
             ;;
     esac


### PR DESCRIPTION
Most other parts of `build-script-impl` print the unknown argument when
a switch statement fails to pattern match. Do the same for unknown
arguments passed to `--cross-compile-tools-deployment-targets`.
