### PR TITLE
[SourceKit] Add test case for crash triggered in swift::constraints::ConstraintSystem::resolveOverload(…)

### DIFF
--- a/validation-test/IDE/crashers/067-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/IDE/crashers/067-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,0 +1,4 @@
+// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+struct d{func b
+let g=b<a let a=enum b<j where g:p:#^A^#


### PR DESCRIPTION
Stack trace:

```
found code completion token A at offset 177
swift-ide-test: /path/to/swift/lib/Sema/ConstraintSystem.cpp:1466: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice): Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.
8  swift-ide-test  0x00000000009a656a swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 4074
9  swift-ide-test  0x00000000008e0681 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 897
10 swift-ide-test  0x00000000008eae36 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3142
11 swift-ide-test  0x00000000008e8479 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 313
12 swift-ide-test  0x00000000008e8239 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
13 swift-ide-test  0x000000000090f9f6 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 614
14 swift-ide-test  0x0000000000915db9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
19 swift-ide-test  0x00000000009c7dd8 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 104
20 swift-ide-test  0x00000000009cc68e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
21 swift-ide-test  0x000000000090fa25 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
22 swift-ide-test  0x0000000000915db9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
23 swift-ide-test  0x0000000000916ed0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
24 swift-ide-test  0x0000000000917079 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
26 swift-ide-test  0x000000000092b7f4 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3876
27 swift-ide-test  0x0000000000b71fcc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
28 swift-ide-test  0x0000000000b709dd swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
29 swift-ide-test  0x0000000000951c8b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
32 swift-ide-test  0x000000000097ba3e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
34 swift-ide-test  0x000000000097c944 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
35 swift-ide-test  0x000000000097b94a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
36 swift-ide-test  0x000000000094e08b swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 715
37 swift-ide-test  0x000000000094f79f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
38 swift-ide-test  0x000000000094fb54 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
39 swift-ide-test  0x000000000092aa32 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
43 swift-ide-test  0x0000000000930296 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
44 swift-ide-test  0x00000000008fca42 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
45 swift-ide-test  0x000000000076b4f2 swift::CompilerInstance::performSema() + 2946
46 swift-ide-test  0x0000000000714d83 main + 33379
Stack dump:
0.  Program arguments: swift-ide-test -code-completion -code-completion-token=A -source-filename=<INPUT-FILE>
1.  While type-checking 'd' at <INPUT-FILE>:3:1
2.  While resolving type g at [<INPUT-FILE>:4:32 - line:4:32] RangeText="g"
3.  While type-checking expression at [<INPUT-FILE>:4:7 - line:4:9] RangeText="b<a"
4.  While type-checking expression at [<INPUT-FILE>:4:7 - line:4:7] RangeText="b"
```
