### PR TITLE
[gardening] Use consistent formatting of header comments

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -1,4 +1,4 @@
-//===-- KnownProtocols.def - Compiler protocol metaprogramming --*- C++ -*-===//
+//===--- KnownProtocols.def - Compiler protocol metaprogramming -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/IDE/REPLCodeCompletion.h
+++ b/include/swift/IDE/REPLCodeCompletion.h
@@ -1,4 +1,4 @@
-//===--- REPLCodeCompletion.h - Code completion for REPL ----------* C++ *-===//
+//===--- REPLCodeCompletion.h - Code completion for REPL --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -1,4 +1,4 @@
-//===- CodeCompletionCallbacks.h - Parser's interface to code completion --===//
+//===--- CodeCompletionCallbacks.h - Parser's interface to code completion ===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Parse/DelayedParsingCallbacks.h
+++ b/include/swift/Parse/DelayedParsingCallbacks.h
@@ -1,4 +1,4 @@
-//===- DelayedParsingCallbacks.h - Callbacks for Parser's delayed parsing -===//
+//===--- DelayedParsingCallbacks.h - Delayed parsing callbacks ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -1,4 +1,4 @@
-//===-- ClassHierarchyAnalysis.h - Analysis of Class Hierarchy --*- C++ -*-===//
+//===--- ClassHierarchyAnalysis.h - Analysis of Class Hierarchy -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SILOptimizer/Utils/ConstantFolding.h
+++ b/include/swift/SILOptimizer/Utils/ConstantFolding.h
@@ -1,4 +1,4 @@
-//===-- ConstantFolding.h - Utilities for SIL constant folding --*- C++ -*-===//
+//===--- ConstantFolding.h - Utilities for SIL constant folding -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Sema/TypeCheckRequestKinds.def
+++ b/include/swift/Sema/TypeCheckRequestKinds.def
@@ -1,4 +1,4 @@
-//===-- TypeCheckRequestKinds.def - Type Checking Request Kinds -*- C++ -*-===//
+//===--- TypeCheckRequestKinds.def - Type Check Request Kinds ---*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1,4 +1,4 @@
-//===--- ASTDumper.cpp - Swift Language AST Dumper-------------------------===//
+//===--- ASTDumper.cpp - Swift Language AST Dumper ------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1,4 +1,4 @@
-//===--- ASTPrinter.cpp - Swift Language AST Printer-----------------------===//
+//===--- ASTPrinter.cpp - Swift Language AST Printer ----------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1,4 +1,4 @@
-//===--- ImporterImpl.h - Import Clang Modules - Implementation------------===//
+//===--- ImporterImpl.h - Import Clang Modules: Implementation ------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -1,4 +1,4 @@
-//===--- EnumPayload.h - Payload management for 'enum' Types ------* C++ *-===//
+//===--- EnumPayload.h - Payload management for 'enum' Types ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -1,4 +1,4 @@
-//===--- GenEnum.h - Swift IR Generation For 'enum' Types ---------* C++ *-===//
+//===--- GenEnum.h - Swift IR Generation For 'enum' Types -------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1,4 +1,4 @@
-//===--- IRGenDebugInfo.cpp - Debug Info Support---------------------------===//
+//===--- IRGenDebugInfo.cpp - Debug Info Support --------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -1,4 +1,4 @@
-//===--- IRGenDebugInfo.h - Debug Info Support-------------------*- C++ -*-===//
+//===--- IRGenDebugInfo.h - Debug Info Support ------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Immediate/ImmediateImpl.h
+++ b/lib/Immediate/ImmediateImpl.h
@@ -1,4 +1,4 @@
-//===-- ImmediateImpl.h - Support functions for immediate mode --*- C++ -*-===//
+//===--- ImmediateImpl.h - Support functions for immediate mode -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/LLVMPasses/LLVMARCOpts.h
+++ b/lib/LLVMPasses/LLVMARCOpts.h
@@ -1,4 +1,4 @@
-//===- LLVMARCOpts.h - LLVM level ARC Opts Utility Declarations -*- C++ -*-===//
+//===--- LLVMARCOpts.h - LLVM level ARC Opts Util. Declarations -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -1,4 +1,4 @@
-//===--- ArgumentSource.h - Abstracted source of an argument 000-*- C++ -*-===//
+//===--- ArgumentSource.h - Abstracted source of an argument ----*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/ARC/GlobalARCPairingAnalysis.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCPairingAnalysis.cpp
@@ -1,4 +1,4 @@
-//===-- GlobalARCPairingAnalysis.cpp - Global ARC Retain Release Pairing --===//
+//===--- GlobalARCPairingAnalysis.cpp - Global ARC Retain Release Pairing -===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -1,4 +1,4 @@
-//===- ClassHierarchyAnalysis.cpp - Analysis of class hierarchy -*- C++ -*-===//
+//===--- ClassHierarchyAnalysis.cpp - Class hierarchy analysis --*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/IPO/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/IPO/PerformanceInliner.cpp
@@ -1,4 +1,4 @@
-//===- PerformanceInliner.cpp - Basic cost based inlining for performance -===//
+//===--- PerformanceInliner.cpp - Basic cost based performance inlining ---===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -1,4 +1,4 @@
-//===-- DataflowDiagnostics.cpp - Emits diagnostics based on SIL analysis -===//
+//===--- DataflowDiagnostics.cpp - Emits diagnostics based on SIL analysis ===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -1,4 +1,4 @@
-//===-- SpeculativeDevirtualizer.cpp -- Speculatively devirtualize calls --===//
+//===--- SpeculativeDevirtualizer.cpp - Speculatively devirtualize calls --===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1,4 +1,4 @@
-//===- ConstantFolding.cpp - Utilities for SIL constant folding -*- C++ -*-===//
+//===--- ConstantFolding.cpp - Utils for SIL constant folding ---*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/Sema/ConstraintGraphScope.h
+++ b/lib/Sema/ConstraintGraphScope.h
@@ -1,4 +1,4 @@
-//===--- ConstraintGraphScope.h - Constraint Graph Scope---------*- C++ -*-===//
+//===--- ConstraintGraphScope.h - Constraint Graph Scope --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -1,4 +1,4 @@
-//===--- Availability.mm - Swift Language API Availability Support---------===//
+//===--- Availability.mm - Swift Language API Availability Support --------===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
After this commit all header comments in the repo will be line with to the rules below.

Hopefully this should be the last gardening PR pertaining to header comments :-)

Correct format:

```
//===--- Name of file - Description ----------------------------*- Lang -*-===//
```

Notes:
- The comment line should be exactly 80 chars.
- Padding: Pad with dashes after "Description" to reach 80 chars.
- "Name of file", "Description" and "Lang" are all optional.
- In case of missing "Lang": drop the "-*-" markers.
- In case of missing space: drop one, two or three dashes before "Name of file".
