### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getCanonicalType()

### DIFF
--- a/validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol a:A.e
+protocol A{typealias e:a
+class A:e
+func b:A

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision 75c8eac27530ed891be4104485129820572c3fd1
+Tests updated as of revision e823a5d05b386975c98b5cdd7045e4d8474bff60


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000001013ef4 swift::TypeBase::getCanonicalType() + 20
5  swift           0x0000000000e13176 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5078
6  swift           0x0000000000e15649 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
7  swift           0x00000000010048dc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
8  swift           0x00000000010032ed swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
9  swift           0x0000000000e3bf0b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
12 swift           0x0000000000e6593e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000e66844 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000e6584a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
17 swift           0x0000000000e385dc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
22 swift           0x0000000000e16671 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 5969
23 swift           0x00000000010048dc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
24 swift           0x0000000000e3cbba swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 282
26 swift           0x0000000000e6593e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
28 swift           0x0000000000e66844 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
29 swift           0x0000000000e6584a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
30 swift           0x0000000000ef58d2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
31 swift           0x0000000000ef4b5d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
32 swift           0x0000000000ef4ce9 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
33 swift           0x0000000000e11cb0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
34 swift           0x0000000000f1f191 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
37 swift           0x0000000000f20aaf swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
38 swift           0x0000000000f1eefb swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
39 swift           0x0000000000f1f2b7 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 519
42 swift           0x0000000000f20aaf swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
43 swift           0x0000000000f1eefb swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
44 swift           0x0000000000f1ec7c swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
45 swift           0x0000000000e381c7 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
46 swift           0x0000000000e39a1f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
47 swift           0x0000000000e39dd4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
48 swift           0x0000000000e15400 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
53 swift           0x0000000000e6593e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
55 swift           0x0000000000e66844 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
56 swift           0x0000000000e6584a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
57 swift           0x0000000000ef58d2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
58 swift           0x0000000000ef4b5d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
59 swift           0x0000000000ef4ce9 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
60 swift           0x0000000000e11cb0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
61 swift           0x0000000000f1f191 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
64 swift           0x0000000000f20aaf swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
65 swift           0x0000000000f1eefb swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
66 swift           0x0000000000f1ec7c swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
67 swift           0x0000000000e381c7 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
68 swift           0x0000000000e39a1f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
69 swift           0x0000000000e39dd4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
70 swift           0x0000000000e15400 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
73 swift           0x0000000000e1a816 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
74 swift           0x0000000000de6ab2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
75 swift           0x0000000000c9c702 swift::CompilerInstance::performSema() + 2946
77 swift           0x0000000000763402 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
78 swift           0x000000000075dfe1 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28191-swift-typebase-getcanonicaltype-ad7dcd.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift:7:1
2.  While resolving type A.e at [validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift:7:12 - line:7:14] RangeText="A.e"
3.  While resolving type A.e at [validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift:7:12 - line:7:14] RangeText="A.e"
4.  While type-checking 'A' at validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift:8:1
5.  While resolving type A at [validation-test/compiler_crashers/28191-swift-typebase-getcanonicaltype.swift:10:8 - line:10:8] RangeText="A"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
