### PR TITLE
[crash triaging] Add crash type annotations and Valgrind output for memory errors

### DIFF
--- a/validation-test/compiler_crashers/16694-swift-constraints-constraintsystem-opentype.swift
+++ b/validation-test/compiler_crashers/16694-swift-constraints-constraintsystem-opentype.swift
@@ -4,4 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 4")
 var a{class d{var b=B{}let c=(x:d<T{{}}class B<T where h=d>:a

--- a/validation-test/compiler_crashers/24394-swift-typevariabletype-implementation-getrepresentative.swift
+++ b/validation-test/compiler_crashers/24394-swift-typevariabletype-implementation-getrepresentative.swift
@@ -4,6 +4,7 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 8")
 [Void{}}struct A
 protocol A{typealias b:A func b
 class A<S:e

--- a/validation-test/compiler_crashers/25458-swift-archetypetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers/25458-swift-archetypetype-getnestedtype.swift
@@ -4,6 +4,7 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 8")
 class a{
 class c
 class B:A

--- a/validation-test/compiler_crashers/27203-swift-typeloc-iserror.swift
+++ b/validation-test/compiler_crashers/27203-swift-typeloc-iserror.swift
@@ -4,4 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 4")
 class n{protocol a:d var d={class b:a

--- a/validation-test/compiler_crashers/27443-matchwitness.swift
+++ b/validation-test/compiler_crashers/27443-matchwitness.swift
@@ -4,6 +4,7 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 8")
 {e
 struct B:a{let t:a}
 protocol a{let t:a

--- a/validation-test/compiler_crashers/27754-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers/27754-swift-typechecker-resolvetypeincontext.swift
@@ -4,4 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 8")
 class d{let f=a< class a{extension{struct Q<h:a{protocol P{func<

--- a/validation-test/compiler_crashers/28155-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers/28155-swift-typechecker-validategenericfuncsignature.swift
@@ -4,4 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// Crash type: memory error ("Invalid read of size 2")
 class A{func b->Self{{{}}class B<n{let a=self


### PR DESCRIPTION
Valgrind output:

```
$ valgrind swift -frontend -c validation-test/compiler_crashers/16694-swift-constraints-constraintsystem-opentype.swift
Invalid read of size 4
   at 0x1016C00: swift::TypeBase::getDesugaredType() (in /path/to/swift/bin/swift)

$ valgrind swift -frontend -c validation-test/compiler_crashers/24394-swift-typevariabletype-implementation-getrepresentative.swift
Invalid read of size 8
   at 0x10121C4: swift::TypeBase::getCanonicalType() (in /path/to/swift/bin/swift)

$ valgrind swift -frontend -c validation-test/compiler_crashers/25458-swift-archetypetype-getnestedtype.swift
Invalid read of size 8
   at 0xE52866: (anonymous namespace)::ConformanceChecker::recordTypeWitness(swift::AssociatedTypeDecl*, swift::Type, swift::TypeDecl*, swift::DeclContext*, bool, bool) (in /path/to/swift/bin/swift)

$ valgrind swift -frontend -c validation-test/compiler_crashers/27203-swift-typeloc-iserror.swift
Invalid read of size 4
   at 0xE42CD5: swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) (in /path/to/swift/bin/swift)

$ valgrind swift -frontend -c validation-test/compiler_crashers/27443-matchwitness.swift
Invalid read of size 8
   at 0xE4BAD1: checkMutating(swift::FuncDecl*, swift::FuncDecl*, swift::ValueDecl*) (in /path/to/swift/bin/swift)

$ valgrind swift -frontend -c validation-test/compiler_crashers/27754-swift-typechecker-resolvetypeincontext.swift
Invalid read of size 8
   at 0x10121C4: swift::TypeBase::getCanonicalType() (in /path/to/swift/bin/swift)

$ valgrind swift -frontend -c validation-test/compiler_crashers/28155-swift-typechecker-validategenericfuncsignature.swift
Invalid read of size 2
   at 0xF35D76: swift::FunctionType::get(swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) (in /path/to/swift/bin/swift)
```
