### PR TITLE
[SIL] Add test case for crash triggered in swift::Parser::parseExprIdentifier()

### DIFF
--- a/validation-test/SIL/crashers/023-swift-parser-parseexpridentifier.sil
+++ b/validation-test/SIL/crashers/023-swift-parser-parseexpridentifier.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+enum n{func p<p{p<@convention()>


### PR DESCRIPTION
Stack trace:

```
<stdin>:3:16: error: expected '>' to complete generic parameter list
enum n{func p<p{p<@convention()>
               ^
<stdin>:3:14: note: to match this opening '<'
enum n{func p<p{p<@convention()>
             ^
<stdin>:3:16: error: expected '(' in argument list of function declaration
enum n{func p<p{p<@convention()>
               ^
<stdin>:3:31: error: expected convention name identifier in 'convention' attribute
enum n{func p<p{p<@convention()>
                              ^
<stdin>:3:32: error: expected type
enum n{func p<p{p<@convention()>
                               ^
<stdin>:3:18: note: while parsing this '<' as a type parameter bracket
enum n{func p<p{p<@convention()>
                 ^
sil-opt: /path/to/swift/include/swift/Basic/SourceLoc.h:93: swift::SourceRange::SourceRange(swift::SourceLoc, swift::SourceLoc): Assertion `Start.isValid() == End.isValid() && "Start and end should either both be valid or both be invalid!"' failed.
8  sil-opt         0x0000000000a2049a swift::Parser::parseExprIdentifier() + 1722
9  sil-opt         0x0000000000a1c363 swift::Parser::parseExprPostfix(swift::Diag<>, bool) + 515
10 sil-opt         0x0000000000a1afaa swift::Parser::parseExprSequence(swift::Diag<>, bool, bool) + 170
11 sil-opt         0x0000000000a1ae9f swift::Parser::parseExprImpl(swift::Diag<>, bool) + 191
12 sil-opt         0x0000000000a51054 swift::Parser::parseExprOrStmt(swift::ASTNode&) + 420
13 sil-opt         0x0000000000a52c56 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 1974
14 sil-opt         0x0000000000a573e0 swift::Parser::parseBraceItemList(swift::Diag<>) + 96
15 sil-opt         0x0000000000a11d61 swift::Parser::parseDeclFunc(swift::SourceLoc, swift::StaticSpellingKind, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 3041
16 sil-opt         0x0000000000a093ba swift::Parser::parseDecl(llvm::SmallVectorImpl<swift::Decl*>&, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>) + 3306
18 sil-opt         0x00000000009fc0a3 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 723
19 sil-opt         0x0000000000a0d28e swift::Parser::parseDeclEnum(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1678
20 sil-opt         0x0000000000a0936b swift::Parser::parseDecl(llvm::SmallVectorImpl<swift::Decl*>&, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>) + 3227
21 sil-opt         0x0000000000a52c0e swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 1902
22 sil-opt         0x00000000009fde5c swift::Parser::parseTopLevel() + 156
23 sil-opt         0x00000000009f931f swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 207
24 sil-opt         0x00000000007398f6 swift::CompilerInstance::performSema() + 2918
25 sil-opt         0x00000000007241dc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  With parser at source location: <stdin>:3:33
```
