### PR TITLE
[gardening] Replace left/right quotation marks

### DIFF
--- a/docs/ARCOptimization.rst
+++ b/docs/ARCOptimization.rst
@@ -137,7 +137,7 @@ lower directly to is_unique instructions in SIL.
 The is_unique instruction takes the address of a reference, and
 although it does not actually change the reference, the reference must
 appear mutable to the optimizer. This forces the optimizer to preserve
-a retain distinct from what’s required to maintain lifetime for any of
+a retain distinct from what's required to maintain lifetime for any of
 the reference's source-level copies, because the called function is
 allowed to replace the reference, thereby releasing the
 referent. Consider the following sequence of rules:
@@ -225,7 +225,7 @@ these cases:
 - isUniqueOrPinned_native : <T> (inout T[?]) -> Int1
 
 These builtins perform an implicit cast to NativeObject before
-checking uniqueness. There’s no way at SIL level to cast the address
+checking uniqueness. There's no way at SIL level to cast the address
 of a reference, so we need to encapsulate this operation as part of
 the builtin.
 

--- a/docs/ErrorHandlingRationale.rst
+++ b/docs/ErrorHandlingRationale.rst
@@ -1359,7 +1359,7 @@ declaration or type::
     return try stream.readInt()
   }
 
-  // ‘throws’ is written before the arrow to give a sensible and
+  // 'throws' is written before the arrow to give a sensible and
   // consistent grammar for function types and implicit () result types.
   func baz() throws {
     if let byte = try stream.getOOB() where byte == PROTO_RESET {
@@ -1367,7 +1367,7 @@ declaration or type::
     }
   }
 
-  // ‘throws’ appears in a consistent position in function types.
+  // 'throws' appears in a consistent position in function types.
   func fred(callback: (UInt8) throws -> ()) throws {
      while true {
        let code = try stream.readByte()
@@ -1380,7 +1380,7 @@ declaration or type::
   // this function has type:
   //   (Int) -> (Int) throws -> Int
   func jerry(i: Int)(j: Int) throws -> Int {
-    // It’s not an error to use ‘throws’ on a function that can’t throw.
+    // It's not an error to use 'throws' on a function that can't throw.
     return i + j
   }
 

--- a/docs/GitWorkflows.rst
+++ b/docs/GitWorkflows.rst
@@ -11,7 +11,7 @@ transition to Git this document helps to address questions about how common SVN
 workflows we use today translate to their Git counterparts as well as to discuss
 Git workflow practices we plan on having — at least initially — after the Git
 transition.  Notably we will follow a model where commits to trunk — which is
-the ‘master’ branch in Git — has commits land (in the common case) via rebasing
+the 'master' branch in Git — has commits land (in the common case) via rebasing
 instead of merging.  This model is open to evolution later, but this mimics the
 workflow we have today with SVN.
 

--- a/docs/MutationModel.rst
+++ b/docs/MutationModel.rst
@@ -40,7 +40,7 @@ Consider::
   w.title += " (parenthesized remark)”
 
 What do we do with this?  Since ``+=`` has an ``inout`` first
-argument, we detect this situation statically (hopefully one day we’ll
+argument, we detect this situation statically (hopefully one day we'll
 have a better error message): 
 
 ::
@@ -53,7 +53,7 @@ Great.  Now what about this? [#append]_ ::
 
   w.title.append(" (fool the compiler)")
 
-Today, we allow it, but since there’s no way to implement the
+Today, we allow it, but since there's no way to implement the
 write-back onto ``w.title``, the changes are silently dropped.
 
 Unsatisfying Approaches

--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -157,7 +157,7 @@ do not have any overriding declarations in the same file:
   func usingE(e: E) {
     e.doSomething() // There is no sub class in the file that declares this class.
                     // The compiler can remove virtual calls to doSomething()
-                    // and directly call A’s doSomething method.
+                    // and directly call A's doSomething method.
   }
 
   func usingF(f: F) -> Int {

--- a/docs/OptimizerDesign.md
+++ b/docs/OptimizerDesign.md
@@ -180,7 +180,7 @@ This is an example of the *@_semantics* attribute as used by Swift Array:
 
 Notice that as soon as we inline functions that have the @_semantics attribute
 the attribute is lost and the optimizer can't analyze the content of the
-function. For example, the optimizer can identify the array ‘count' method (that
+function. For example, the optimizer can identify the array 'count' method (that
 returns the size of the array) and can hoist this method out of loops. However,
 as soon as this method is inlined, the code looks to the optimizer like a memory
 read from an undetermined memory location, and the optimizer can't optimize the

--- a/docs/proposals/CompressedMangledNames.md
+++ b/docs/proposals/CompressedMangledNames.md
@@ -7,7 +7,7 @@ compiler and make an effort to optimize and shrink the generated binaries. One
 of the problems that we have today is that swift symbols are mangled into
 extremely long strings. This is especially a problem for libraries, and almost
 half of the size of libswiftCore.dylib (the swift runtime library on x86_64 OSX)
-is string tables. On MacOSX you can use the command ’size -m file.dylib’ to read
+is string tables. On MacOSX you can use the command "size -m file.dylib" to read
 the size of the string table. C++ also suffers from the problem of long names,
 but since we control the Swift ABI we can do better than C++.
 
@@ -99,7 +99,7 @@ the top 63 frequent substrings in our dictionary using two characters (escape + 
 The second escape character encodes a two-character reference that can access 63 x 63 entries in the table.
 Less common substrings can be encoded using this three character sequence (escape + index0 + index1).
 
-One interesting bit of information is that the character ‘Y’ is only used 4
+One interesting bit of information is that the character "Y" is only used 4
 times in the entire standard library! The letter J, and a few other letters are
 also not used very frequently. We use Y and J as escape characters.
 
@@ -107,7 +107,7 @@ The dictionary-based encoding uses the following rules:
 
 1. We use two escape characters that are not frequently used in names (Y and Z).
 These characters are escape character and cannot be used as part of the text
-without escaping. ‘Y’ is encoded as ‘YY’, and ‘Z’ would be encoded as ‘YZ’.
+without escaping. "Y" is encoded as "YY", and "Z" would be encoded as "YZ".
 
 2. The most commonly used sub-strings (calculated as length of substring times
 number of occurrences) is encoded with a single escape character and a
@@ -216,7 +216,7 @@ Error handling
 The compression routines only handle characters that are in the list of valid
 characters.  It is possible to compress every string that uses the valid
 character set. However, now all incoming strings are legal. For example the
-string "Y" is illegal because 'Y' is an escape character and the decoded expects
+string "Y" is illegal because "Y" is an escape character and the decoded expects
 another character to follow the escape character.
 
 There are a few users that will use the compression routines: The

--- a/docs/proposals/InitializerInheritance.rst
+++ b/docs/proposals/InitializerInheritance.rst
@@ -50,16 +50,16 @@ We can also distinguish two ways to originally invoke an initializer:
 Either kind of dispatched initialization poses a soundness problem
 because there may not be a sound initializer with any given signature
 in the most-derived class.  In ObjC, initializers are normal instance
-methods and are therefore inherited like normal, but this isn’t really
+methods and are therefore inherited like normal, but this isn't really
 quite right; initialization is different from a normal method in that
-it’s not inherently sensible to require subclasses to provide
+it's not inherently sensible to require subclasses to provide
 initializers at all the signatures that their superclasses provide.
 
 Subobject initializers
 ~~~~~~~~~~~~~~~~~~~~~~
 The defining class of a subobject initializer is central to its
 behavior.  It can be soundly inherited by a class C only if is trivial
-to initialize the ivars of C, but it’s convenient to ignore that and
+to initialize the ivars of C, but it's convenient to ignore that and
 assume that subobjects will always trivially wrap and delegate to
 superclass subobject initializers. 
 
@@ -75,7 +75,7 @@ initializer of a class C if and only if it is defined by C.
 
 Complete object initializers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The defining class of a complete object initializer doesn’t really
+The defining class of a complete object initializer doesn't really
 matter.  In principle, complete object initializers could just as well
 be freestanding functions to which a metatype is passed.  It can make
 sense to inherit a complete object initializer.
@@ -90,11 +90,11 @@ A complete object initializer soundly acts like a complete object
 initializer of a class C if and only if it delegates to an initializer
 which soundly acts like a complete object initializer of C.
 
-These rules are not obvious to check statically because they’re
+These rules are not obvious to check statically because they're
 dependent on the dynamic value of the most-derived class C.  Therefore
 any ability to check them depends on restricting C somehow relative to
 the defining class of the initializer.  Since, statically, we only
-know the defining class of the initializer, we can’t establish
+know the defining class of the initializer, we can't establish
 soundness solely at the definition site; instead we have to prevent
 unsound initializers from being called.
 
@@ -116,7 +116,7 @@ Virtual initializers
 The above condition is not sufficient to make indirect initialization
 sound, because it relies on the ability to simply not use an
 initializer in cases where its delegation behavior isn't known to be
-sound, and we can’t do that to arbitrary code.  For that, we would
+sound, and we can't do that to arbitrary code.  For that, we would
 need true virtual initializers.
 
 A virtual initializer is a contract much more like that of a standard

--- a/docs/proposals/ValueSemantics.rst
+++ b/docs/proposals/ValueSemantics.rst
@@ -175,7 +175,7 @@ pseudo-random number generator).  It needs to make one copy and do
 in-place mutation of the state, rather than wholesale value
 replacement via assignment, which might be expensive.
 
-Here’s a version of cycle_length that works when state is a mutable
+Here's a version of cycle_length that works when state is a mutable
 value type::
 
  func cycle_length<State>(

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -291,7 +291,7 @@ BUILTIN_SIL_OPERATION(FixLifetime, "fixLifetime", Special)
 ///
 /// This builtin takes an inout object reference and returns a boolean. Passing
 /// the reference inout forces the optimizer to preserve a retain distinct from
-/// what’s required to maintain lifetime for any of the reference's source-level
+/// what's required to maintain lifetime for any of the reference's source-level
 /// copies, because the called function is allowed to replace the reference,
 /// thereby releasing the referent.
 ///

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -134,7 +134,7 @@ extension String {
   // + (const NSStringEncoding *)availableStringEncodings
 
   /// Returns an Array of the encodings string objects support
-  /// in the application’s environment.
+  /// in the application's environment.
   @warn_unused_result
   public static func availableStringEncodings() -> [NSStringEncoding] {
     var result = [NSStringEncoding]()
@@ -302,7 +302,7 @@ extension String {
 
   /// Returns a string containing characters the `String` and a
   /// given string have in common, starting from the beginning of each
-  /// up to the first characters that aren’t equivalent.
+  /// up to the first characters that aren't equivalent.
   @warn_unused_result
   public func commonPrefixWithString(
     aString: String, options: NSStringCompareOptions) -> String {
@@ -452,7 +452,7 @@ extension String {
 
   // @property NSString* decomposedStringWithCanonicalMapping;
 
-  /// Returns a string made by normalizing the `String`’s
+  /// Returns a string made by normalizing the `String`'s
   /// contents using Form D.
   public var decomposedStringWithCanonicalMapping: String {
     return _ns.decomposedStringWithCanonicalMapping
@@ -460,7 +460,7 @@ extension String {
 
   // @property NSString* decomposedStringWithCompatibilityMapping;
 
-  /// Returns a string made by normalizing the `String`’s
+  /// Returns a string made by normalizing the `String`'s
   /// contents using Form KD.
   public var decomposedStringWithCompatibilityMapping: String {
     return _ns.decomposedStringWithCompatibilityMapping
@@ -605,7 +605,7 @@ extension String {
   /// - Parameter encoding: The encoding to use for the returned bytes.
   ///
   /// - Parameter options: A mask to specify options to use for
-  ///   converting the receiver’s contents to `encoding` (if conversion
+  ///   converting the receiver's contents to `encoding` (if conversion
   ///   is necessary).
   ///
   /// - Parameter range: The range of characters in the receiver to get.
@@ -645,7 +645,7 @@ extension String {
   //     maxLength:(NSUInteger)maxBufferCount
   //     encoding:(NSStringEncoding)encoding
 
-  /// Converts the `String`’s content to a given encoding and
+  /// Converts the `String`'s content to a given encoding and
   /// stores them in a buffer.
   /// - Note: will store a maximum of `min(buffer.count, maxLength)` bytes.
   public func getCString(
@@ -923,7 +923,7 @@ extension String {
 
   /// Returns a `String` object initialized by using a given
   /// format string as a template into which the remaining argument
-  /// values are substituted according to the user’s default locale.
+  /// values are substituted according to the user's default locale.
   public init(format: String, arguments: [CVarArgType]) {
     self = String(format: format, locale: nil, arguments: arguments)
   }
@@ -1120,7 +1120,7 @@ extension String {
   // @property NSString* pathExtension;
 
   /// Interprets the `String` as a path and returns the
-  /// `String`’s extension, if any.
+  /// `String`'s extension, if any.
   @available(*, unavailable, message="Use pathExtension on NSURL instead.")
   public var pathExtension: String {
     return _ns.pathExtension
@@ -1128,7 +1128,7 @@ extension String {
 
   // @property NSString* precomposedStringWithCanonicalMapping;
 
-  /// Returns a string made by normalizing the `String`’s
+  /// Returns a string made by normalizing the `String`'s
   /// contents using Form C.
   public var precomposedStringWithCanonicalMapping: String {
     return _ns.precomposedStringWithCanonicalMapping
@@ -1136,7 +1136,7 @@ extension String {
 
   // @property NSString * precomposedStringWithCompatibilityMapping;
 
-  /// Returns a string made by normalizing the `String`’s
+  /// Returns a string made by normalizing the `String`'s
   /// contents using Form KC.
   public var precomposedStringWithCompatibilityMapping: String {
     return _ns.precomposedStringWithCompatibilityMapping

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3398,7 +3398,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorageType {
     var nativeStorage = native
 
     // FIXME(performance): if the storage is non-uniquely referenced, we
-    // shouldn’t be copying the elements into new storage and then immediately
+    // shouldn't be copying the elements into new storage and then immediately
     // deleting the elements. We should detect that the storage is not uniquely
     // referenced and allocate new empty storage of appropriate capacity.
 

--- a/test/IDE/complete_lazy_initialized_var.swift
+++ b/test/IDE/complete_lazy_initialized_var.swift
@@ -7,7 +7,7 @@ func lazyInClass1(a: FooClass1) {
  a.#^LAZY_IN_CLASS_1^#
 }
 
-// This test checks that we don’t include extra hidden declarations into code completion results.  If you add more declarations to the type, update this test properly.
+// This test checks that we don't include extra hidden declarations into code completion results.  If you add more declarations to the type, update this test properly.
 // LAZYVAR1:       Begin completions, 1 items
 // LAZYVAR1-NEXT:  Decl[InstanceVar]/CurrNominal:      lazyVar1[#Int#]{{; name=.+$}}
 // LAZYVAR1-NEXT:  End completions

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1227,7 +1227,7 @@ function cmark_c_flags() {
 }
 
 function swift_c_flags() {
-    # Don’t pass common_cross_c_flags to Swift because CMake code in the Swift
+    # Don't pass common_cross_c_flags to Swift because CMake code in the Swift
     # project is itself aware of cross-compilation for the host tools and
     # standard library.
     echo -n "${COMMON_C_FLAGS}"


### PR DESCRIPTION
In quote contexts:
- `LEFT SINGLE QUOTATION MARK (U+2018)` → `QUOTATION MARK (U+0022)`
- `RIGHT SINGLE QUOTATION MARK (U+2019)` → `QUOTATION MARK (U+0022)`

In non-quote contexts:
- `LEFT SINGLE QUOTATION MARK (U+2018)` → `APOSTROPHE (U+0027)`
- `RIGHT SINGLE QUOTATION MARK (U+2019)` → `APOSTROPHE (U+0027)`
