### PR TITLE
[stdlib] Fix conversion from (signed) int to float in default float initializers

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -181,7 +181,7 @@ public struct ${Self} {
   @_transparent public
   init() {
     let zero: Int64 = 0
-    self._value = Builtin.uitofp_Int64_FPIEEE${bits}(zero._value)
+    self._value = Builtin.sitofp_Int64_FPIEEE${bits}(zero._value)
   }
 
   @_transparent 


### PR DESCRIPTION
#### What does this PR do?

Fixes a (benign) error in the `gyb` file for floating point types: the default initializer converted a signed integer to a float using a builtin function that expected an unsigned integer.
#### Discussion

Note: This is a change to a `gyb` file, so to see the full result, you need to run the file through the `gyb` tool. From the root of the Swift repo: `utils/gyb < stdlib/public/core/FloatingPoint.swift.gyb > stdlib/public/core/FloatingPoint.swift`.

It's easier to explain with a concrete example, so I'll use the `Double` type. Previously, the default initializer for `Double` was generated as:

``` swift
init() {
  let zero: Int64 = 0
  self._value = Builtin.uitofp_Int64_FPIEEE64(zero._value)
}
```

Note the use of the _unsigned_-int-to-float function. Compare this to the `Int64` conversion initializer (edited slightly to remove irrelevant differences):

``` swift
init(_ v: Int64) {
  self._value = Builtin.sitofp_Int64_FPIEEE64(v._value)
}
```

Both start with an signed 64-bit integer value, but the default initializer calls the builtin function for converting from an _unsigned_ integer to a float (`Builtin.uitofp_Int64_FPIEEE64`).

Since there is no difference in the bit patterns for signed or unsigned `0`s, the previous code functioned correctly even though it was technically incorrect.

With the change in this PR, the default initializer is now generated as:

``` swift
init() {
  let zero: Int64 = 0
  self._value = Builtin.sitofp_Int64_FPIEEE64(zero._value)
}
```
