### PR TITLE
[Python] Remove unused import (recently introduced PEP8 regression)

### DIFF
--- a/lib/ClangImporter/SortedCFDatabase.def.gyb
+++ b/lib/ClangImporter/SortedCFDatabase.def.gyb
@@ -17,7 +17,6 @@
 %{
 
 import re
-import sys
 import codecs
 
 prologueLines = ""

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -11,7 +11,6 @@
 ##===----------------------------------------------------------------------===##
 
 import re
-import sys
 import codecs
 
 class UnicodeProperty(object):


### PR DESCRIPTION
PEP8 regressions can be found by running:

```
flake8 --ignore=E101,E111,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E201,E202,E203,E222,E225,E226,E227,E231,E241,E251,E261,E262,E265,E301,E302,E303,E401,E501,E701,W191,W291,W293,W391 .
```

The ignores are minor PEP8 violations currently found in the repo. We ignore those.
