### PR TITLE
[swiftc] Add test case for crash triggered in swift::GenericFunctionType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28192-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers/28192-swift-genericfunctiontype-get.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{struct Q<I{struct A:OptionSetType{let rawValue=""let rawValue=0

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision e823a5d05b386975c98b5cdd7045e4d8474bff60
+Tests updated as of revision 123e5e159549b3b82e97926b8ed077f6172441e4


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:2868: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &): Assertion `sig && "no generic signature for generic function type?!"' failed.
8  swift           0x0000000000f3950e swift::GenericFunctionType::get(swift::GenericSignature*, swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) + 574
11 swift           0x0000000000eccae9 swift::TypeChecker::compareDeclarations(swift::DeclContext*, swift::ValueDecl*, swift::ValueDecl*) + 25
14 swift           0x0000000000e465d1 swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 193
15 swift           0x000000000100e216 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
16 swift           0x000000000100e158 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
17 swift           0x000000000100e8f6 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
20 swift           0x000000000101e0ec swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 44
21 swift           0x00000000010174ef swift::Type::subst(swift::ModuleDecl*, llvm::DenseMap<swift::TypeBase*, swift::Type, llvm::DenseMapInfo<swift::TypeBase*>, llvm::detail::DenseMapPair<swift::TypeBase*, swift::Type> >&, swift::OptionSet<swift::SubstFlags, unsigned int>) const + 111
22 swift           0x0000000000e3b838 swift::TypeChecker::checkGenericArguments(swift::DeclContext*, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature*, llvm::ArrayRef<swift::Type>) + 408
23 swift           0x0000000000e461a7 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 1399
29 swift           0x0000000000e1c0c6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
32 swift           0x0000000000e628fa swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
33 swift           0x0000000000e8e98c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
34 swift           0x0000000000e0157b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
36 swift           0x0000000000e62a46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
37 swift           0x0000000000de83ed swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
38 swift           0x0000000000c9deb2 swift::CompilerInstance::performSema() + 2946
40 swift           0x0000000000763472 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
41 swift           0x000000000075e051 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28192-swift-genericfunctiontype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28192-swift-genericfunctiontype-get-81d34c.o
1.  While type-checking expression at [validation-test/compiler_crashers/28192-swift-genericfunctiontype-get.swift:8:1 - line:8:64] RangeText="{struct Q<I{struct A:OptionSetType{let rawValue=""let rawValue=0"
2.  While type-checking 'Q' at validation-test/compiler_crashers/28192-swift-genericfunctiontype-get.swift:8:2
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
