### PR TITLE
[stdlib] Remove confusing `incIfSigned` control flow

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -158,12 +158,6 @@ def getMinFloat(floatBits, intBits):
     minFloat = negativePrefix(floatBits) + negativeExponent(floatBits, intBits)
     return "0x%0.x" % minFloat
 
-def incIfSigned(bits, signed):
-    if not(signed):
-        return bits + 1
-    else:
-        return bits
-
 }%
 
 % for bits in allFloatBits:
@@ -649,6 +643,7 @@ public func ${op}= (inout lhs: ${Self}, rhs: ${Self}) { lhs = lhs ${op} rhs }
 %   sign = 's' if signed else 'u'
 %   Self = intName(bits, signed)
 %   BuiltinName = builtinIntName(bits)
+%   intBits = intFormatFix(bits)
 @_transparent
 extension ${Self} {
 %   for srcBits in allFloatBits:
@@ -670,19 +665,24 @@ extension ${Self} {
 %      if signed:
     // FIXME: Float80 doesn't have a _fromBitPattern
     // ${That}(roundTowardsZero: ${Self}.min)
-    // > ${getMinFloat(srcBits, incIfSigned(intFormatFix(bits), signed))}
-    _precondition(other >= ${That}._fromBitPattern(${getMinFloat(srcBits,
-      incIfSigned(intFormatFix(bits), signed))}),
+    // > ${getMinFloat(srcBits, intBits)}
+    _precondition(other >= ${That}._fromBitPattern(${getMinFloat(srcBits, intBits)}),
       "floating point value cannot be converted to ${Self} because it is less than ${Self}.min")
+    // ${That}(roundTowardsZero: ${Self}.max)
+    // > ${getMaxFloat(srcBits, intBits)}
+    _precondition(other <= ${That}._fromBitPattern(${getMaxFloat(srcBits, intBits)}),
+      "floating point value cannot be converted to ${Self} because it is greater than ${Self}.max")
 %      else:
     _precondition(other >= (0.0 as ${That}),
       "floating point value cannot be converted to ${Self} because it is less than ${Self}.min")
-%      end
+%          # NOTE: Since unsigned ints effectively have one more bit than signed ints
+%          # for storing positive numbers, we use `intBits + 1` when calculating the
+%          # max acceptable float value in the following lines.
     // ${That}(roundTowardsZero: ${Self}.max)
-    // > ${getMaxFloat(srcBits, incIfSigned(intFormatFix(bits), signed))}
-    _precondition(other <= ${That}._fromBitPattern(${getMaxFloat(srcBits,
-      incIfSigned(intFormatFix(bits), signed))}),
+    // > ${getMaxFloat(srcBits, intBits + 1)}
+    _precondition(other <= ${That}._fromBitPattern(${getMaxFloat(srcBits, intBits + 1)}),
       "floating point value cannot be converted to ${Self} because it is greater than ${Self}.max")
+%      end
 
 %     end
     self._value =


### PR DESCRIPTION
#### What's this PR do?

Updates the Python logic in the foating-point-to-integer conversion initializers to remove some misleading code.
#### Discussion

I started out looking to fix the name of this function (formerly lines 161-166):

``` python
def incIfSigned(bits, signed):
    if not(signed):
        return bits + 1
    else:
        return bits
```

> Increment if … wait, what?

This function was named exactly backwards (it incremented only when _not_ signed).

Investigating this naming error revealed that the call site was also unclear. The function was only used twice, and one of those uses was inside an `if signed:` code block that effectively made it a (misleading) no-op. Also, the name of the function did nothing to help indicate _why_ the value needed to be incremented for signed types.

My assessment of this function was that its purpose was to allow one line of Python code to generate bounds-checking Swift code for both signed and unsigned integers (lines 681-684 of the old file).

My solution was to separate the signed and unsigned bounds checks into separate `gyb` lines (671-674 and 681-683) in order to clarify the intent of the code, and to add a comment explaining why the increment was needed.
#### How should this be manually tested?

As they say, the proof is in the pudding with this one. The easiest way to test it is to compare the `gyb` output from this version with that of the old version, like:

```
utils/gyb -D CMAKE_SIZEOF_VOID_P=8 < stdlib/public/core/FloatingPoint.swift.gyb
```

Note: There will be a lot of noise in the diff due to line number changes (source file line numbers are included as comments in the output). You can easily omit these comments by piping the output into `grep -v '^// ###line'`.

There should be no differences between the output from the old and new versions of the file.

---

P.S. I noticed a handful of (minor) inconsistencies in this file while putting together this PR. It might be worth having someone give this entire file a once-over to give it a uniform style.
