### PR TITLE
[SIL] Add test case for crash triggered in swift::Expr::walk(…): UNREACHABLE executed at /path/to/swift/lib/Sema/CSApply.cpp:4913

### DIFF
--- a/validation-test/SIL/crashers/024-swift-expr-walk.sil
+++ b/validation-test/SIL/crashers/024-swift-expr-walk.sil
@@ -1,0 +1,3 @@
+// RUN: not --crash %target-sil-opt %s
+// REQUIRES: asserts
+{(x:(x:(


### PR DESCRIPTION
Stack trace:

```
Unhandled coercion
UNREACHABLE executed at /path/to/swift/lib/Sema/CSApply.cpp:4913!
6  sil-opt         0x0000000002c115cd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
11 sil-opt         0x0000000000ccfdd3 swift::Expr::walk(swift::ASTWalker&) + 19
12 sil-opt         0x0000000000b15286 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
13 sil-opt         0x0000000000a8730b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
15 sil-opt         0x0000000000ae8f46 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
16 sil-opt         0x0000000000a6de0d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
17 sil-opt         0x0000000000739912 swift::CompilerInstance::performSema() + 2946
18 sil-opt         0x00000000007241dc main + 1916
Stack dump:
0.  Program arguments: sil-opt -enable-sil-verify-all
1.  While type-checking expression at [<stdin>:3:1 - line:3:8] RangeText="{(x:(x:("
```
