### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::lookupMemberType(…)

### DIFF
--- a/validation-test/compiler_crashers/28193-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers/28193-swift-typechecker-lookupmembertype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+var d:CollectionType{for c d in

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision 123e5e159549b3b82e97926b8ed077f6172441e4
+Tests updated as of revision c4404e3d4d4e3a39a771530a59d9ec13405a7e9f


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckNameLookup.cpp:320: swift::LookupTypeResult swift::TypeChecker::lookupMemberType(swift::DeclContext *, swift::Type, swift::Identifier, NameLookupOptions): Assertion `!type->isTypeParameter()' failed.
8  swift           0x0000000000e3e889 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1433
10 swift           0x0000000000dfb061 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 385
11 swift           0x0000000000e01509 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
12 swift           0x0000000000e0296c swift::TypeChecker::typeCheckForEachBinding(swift::DeclContext*, swift::ForEachStmt*) + 76
16 swift           0x0000000000e6161a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
17 swift           0x0000000000e6146e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
18 swift           0x0000000000e62038 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
20 swift           0x0000000000de84ab swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1771
21 swift           0x0000000000c9deb2 swift::CompilerInstance::performSema() + 2946
23 swift           0x0000000000763472 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
24 swift           0x000000000075e051 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28193-swift-typechecker-lookupmembertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28193-swift-typechecker-lookupmembertype-5af868.o
1.  While type-checking getter for d at validation-test/compiler_crashers/28193-swift-typechecker-lookupmembertype.swift:8:21
2.  While type-checking expression at [validation-test/compiler_crashers/28193-swift-typechecker-lookupmembertype.swift:8:28 - line:8:28] RangeText="d"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
