### PR TITLE
[SR-427][AST] Report DoesNotConform for failed substitutions in a bound generic type.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -910,6 +910,11 @@ LookupConformanceResult Module::lookupConformance(Type type,
       auto substitutions = type->gatherAllSubstitutions(this, substitutionsVec,
                                                         resolver,
                                                         explicitConformanceDC);
+      
+      for (auto sub : substitutions) {
+        if (sub.getReplacement()->is<ErrorType>())
+          return { nullptr, ConformanceKind::DoesNotConform };
+      }
 
       // Create the specialized conformance entry.
       auto result = ctx.getSpecializedConformance(type, conformance,

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -151,3 +151,21 @@ struct V<T> : Fooable {
 // FIXME: <rdar://problem/16123805> Inferred associated types can't be used in expression contexts
 var w = W.AssocType()
 var v = V<String>.AssocType()
+
+//
+// SR-427
+protocol A {
+  func c() // expected-note {{protocol requires function 'c()' with type '() -> ()'}}
+}
+
+protocol B : A {
+  typealias e : A = C<Self> // expected-note {{default type 'C<C<a>>' for associated type 'e' (from protocol 'B') does not conform to 'A'}}
+}
+
+extension B {
+  func c() { // expected-note {{candidate has non-matching type '<Self> () -> ()' (aka '<τ_0_0> () -> ()')}}
+  }
+}
+
+struct C<a : B> : B { // expected-error {{type 'C<a>' does not conform to protocol 'B'}} expected-error {{type 'C<a>' does not conform to protocol 'A'}}
+}


### PR DESCRIPTION
If a BoundGenericType is unable to get a substitution for an archetype it uses ErrorType as the replacement (Module.cpp:705). In such a case we should report DoesNotConform in lookupConformance(), which ends up generating reasonable error messages. Prior to this change the conformance would succeed and then IRGen would crash on emitting an ErrorType during emitForeignTypeMetadataRef().
