### PR TITLE
Fix exit bugs of some python scripts

### DIFF
--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -10,7 +10,7 @@ ns-html2rst - Convert Cocoa HTML documentation into ReST
 
 usage: nshtml2rst < NSString.html > NSString.rst
         """)
-        exit(0)
+        sys.exit(0)
 
     html = sys.stdin.read()
 

--- a/test/Driver/Dependencies/Inputs/fail.py
+++ b/test/Driver/Dependencies/Inputs/fail.py
@@ -9,4 +9,5 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-exit(1)
+import sys
+sys.exit(1)

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -27,7 +27,7 @@ primaryFile = sys.argv[sys.argv.index('-primary-file') + 1]
 
 if os.path.basename(primaryFile) == 'bad.swift':
     print("Handled", os.path.basename(primaryFile))
-    exit(1)
+    sys.exit(1)
 
 dir = os.path.dirname(os.path.abspath(__file__))
 execfile(os.path.join(dir, "update-dependencies.py"))

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1058,7 +1058,7 @@ def main():
     if args.test or args.verbose_test:
         import doctest
         if doctest.testmod(verbose=args.verbose_test).failed:
-            exit(1)
+            sys.exit(1)
         
     bindings = dict( x.split('=', 1) for x in args.defines )
     ast = parseTemplate(args.file.name, args.file.read())


### PR DESCRIPTION
Make sure that the system uses `sys.exit()` rather than just `exit()` because `exit()` should not be used in production.

`exit()` should not be used in production code. This is because it only works if the `site` module is loaded. Instead, this function should only be used in the interpreter.

Unlike `exit()` or `quit()` however, `sys.exit()` is considered good to use in production code. This is because the `sys` module will always be there. 

Updates old PR: https://github.com/apple/swift/pull/546
