### PR TITLE
[StdLib] Extend ReflectionHashing test to pass on Linux

### DIFF
--- a/test/1_stdlib/ReflectionHashing.swift
+++ b/test/1_stdlib/ReflectionHashing.swift
@@ -2,8 +2,6 @@
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 
-// XFAIL: linux
-
 //
 // This file contains reflection tests that depend on hash values.
 // Don't add other tests here.
@@ -38,7 +36,7 @@ Reflection.test("Dictionary") {
   var output = ""
   dump(dict, &output)
 
-#if arch(i386) || arch(arm)
+#if _runtime(_ObjC) && (arch(i386) || arch(arm))
   var expected = ""
   expected += "▿ 5 key/value pairs\n"
   expected += "  ▿ [0]: (2 elements)\n"
@@ -56,7 +54,7 @@ Reflection.test("Dictionary") {
   expected += "  ▿ [4]: (2 elements)\n"
   expected += "    - .0: Three\n"
   expected += "    - .1: 3\n"
-#elseif arch(x86_64) || arch(arm64)
+#elseif _runtime(_ObjC) && (arch(x86_64) || arch(arm64))
   var expected = ""
   expected += "▿ 5 key/value pairs\n"
   expected += "  ▿ [0]: (2 elements)\n"
@@ -74,6 +72,24 @@ Reflection.test("Dictionary") {
   expected += "  ▿ [4]: (2 elements)\n"
   expected += "    - .0: Four\n"
   expected += "    - .1: 4\n"
+#elseif !_runtime(_ObjC) && arch(x86_64)
+  var expected = ""
+  expected += "▿ 5 key/value pairs\n"
+  expected += "  ▿ [0]: (2 elements)\n"
+  expected += "    - .0: One\n"
+  expected += "    - .1: 1\n"
+  expected += "  ▿ [1]: (2 elements)\n"
+  expected += "    - .0: Five\n"
+  expected += "    - .1: 5\n"
+  expected += "  ▿ [2]: (2 elements)\n"
+  expected += "    - .0: Two\n"
+  expected += "    - .1: 2\n"
+  expected += "  ▿ [3]: (2 elements)\n"
+  expected += "    - .0: Four\n"
+  expected += "    - .1: 4\n"
+  expected += "  ▿ [4]: (2 elements)\n"
+  expected += "    - .0: Three\n"
+  expected += "    - .1: 3\n"
 #else
   fatalError("unimplemented")
 #endif


### PR DESCRIPTION
Add a test case for X86_64 platforms that do not use Objective-C interop
and removes the XFAIL on Linux. Partially resolves [SR-216](https://bugs.swift.org/browse/SR-216).
## 

This change passes the normal test suite on OS X 10.10 and Unbuntu 14.04.

The core reason the tests fail is because String is hashed differently depending on whether or not the platform supports the Obj-C runtime. Foundation's hashcode is used when the runtime is present and the built-in hashcode function is used otherwise. This seems reasonable, so I've extended the test with a new case.
