### PR TITLE
Fix broken build: Use IsTriviallyCopyable instead of std::is_trivially_copyable

### DIFF
--- a/unittests/Basic/PointerIntEnumTest.cpp
+++ b/unittests/Basic/PointerIntEnumTest.cpp
@@ -1,4 +1,5 @@
 #include "swift/Basic/PointerIntEnum.h"
+#include "swift/Basic/type_traits.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "gtest/gtest.h"
 
@@ -26,7 +27,7 @@ enum class EnumTy : unsigned {
 using PointerIntEnumTy =
     PointerIntEnum<EnumTy, void *, 3, 4, llvm::PointerLikeTypeTraits<void *>>;
 
-static_assert(std::is_trivially_copyable<PointerIntEnumTy>::value,
+static_assert(IsTriviallyCopyable<PointerIntEnumTy>::value,
               "PointerIntEnum type should be trivially copyable");
 
 static constexpr uintptr_t InvalidStorage = uintptr_t(0) - 1;


### PR DESCRIPTION
Use `IsTriviallyCopyable` instead of `std::is_trivially_copyable`.

Before:

```
error: no member named 'is_trivially_copyable' in namespace 'std'
```

After:

```
Builds as expected.
```

Environment:

```
Ubuntu clang version 3.6.0-2ubuntu1~trusty1 (tags/RELEASE_360/final) (based on LLVM 3.6.0)
Target: x86_64-pc-linux-gnu
```

/ping @gottesmm :-)
