### PR TITLE
[CMake] Spell freebsd correctly.

### DIFF
--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -13,7 +13,7 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
   list(APPEND swift_stdlib_unittest_framework_depends
     Foundation)
 endif()
-if(SWIFT_HOST_VARIANT STREQUAL "linux" OR SWIFT_HOST_VARIANT STREQUAL "FreeBSD")
+if(SWIFT_HOST_VARIANT STREQUAL "linux" OR SWIFT_HOST_VARIANT STREQUAL "freebsd")
   list(APPEND swift_stdlib_unittest_module_depends
     Glibc)
 endif()

--- a/stdlib/private/SwiftPrivateDarwinExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateDarwinExtras/CMakeLists.txt
@@ -4,7 +4,7 @@ set(swift_private_darwin_extras_module_depends
 if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
   list(APPEND swift_private_darwin_extras_module_depends
     Darwin)
-elseif(SWIFT_HOST_VARIANT STREQUAL "linux" OR SWIFT_HOST_VARIANT STREQUAL "FreeBSD")
+elseif(SWIFT_HOST_VARIANT STREQUAL "linux" OR SWIFT_HOST_VARIANT STREQUAL "freebsd")
   list(APPEND swift_private_darwin_extras_module_depends
     Glibc)
 endif()

--- a/stdlib/private/SwiftPrivatePthreadExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivatePthreadExtras/CMakeLists.txt
@@ -3,7 +3,7 @@ set(swift_private_pthread_extras_module_depends)
 if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
   list(APPEND swift_private_pthread_extras_module_depends
     Darwin)
-elseif(SWIFT_HOST_VARIANT STREQUAL "linux" OR SWIFT_HOST_VARIANT STREQUAL "FreeBSD")
+elseif(SWIFT_HOST_VARIANT STREQUAL "linux" OR SWIFT_HOST_VARIANT STREQUAL "freebsd")
   list(APPEND swift_private_pthread_extras_module_depends
     Glibc)
 endif()


### PR DESCRIPTION
Case sensitiveness matters in this case.
