### PR TITLE
[crash triaging] Add AddressSanitizer (ASan) output to crash cases

### DIFF
--- a/validation-test/IDE/crashers/001-swift-ide-removecodecompletiontokens.swift
+++ b/validation-test/IDE/crashers/001-swift-ide-removecodecompletiontokens.swift
@@ -1,2 +1,5 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+// ASAN Output: heap-buffer-overflow on address 0x610000007ffd at pc 0x0000009c9913 bp 0x7fff8de8ba90 sp 0x7fff8de8ba88
+
 #^

--- a/validation-test/compiler_crashers/08008-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers/08008-swift-typechecker-typecheckexpression.swift
@@ -4,4 +4,6 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// ASAN Output: stack-overflow on address 0x7fffe2a98fd8 (pc 0x000001e12adb bp 0x7fffe2a992d0 sp 0x7fffe2a98f60 T0)
+
 class A:A.b{let b=Void{

--- a/validation-test/compiler_crashers/21765-vtable.swift
+++ b/validation-test/compiler_crashers/21765-vtable.swift
@@ -4,6 +4,8 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// ASAN Output: stack-overflow on address 0x7ffe8def3f70 (pc 0x000001cf1268 bp 0x7ffe8def48f0 sp 0x7ffe8def3f00 T0)
+
 func b<T {
 class A : A.e {
 func e: T.e

--- a/validation-test/compiler_crashers/24797-no-stacktrace.swift
+++ b/validation-test/compiler_crashers/24797-no-stacktrace.swift
@@ -4,6 +4,8 @@
 // Test case found by https://github.com/neilpa (neilpa)
 // http://www.openradar.me/20220559
 
+// ASAN Output: stack-overflow on address 0x7ffe14a39f08 (pc 0x0000008b75dd bp 0x7ffe14a3a770 sp 0x7ffe14a39f10 T0)
+
 let values = [
     0x0000,
     0x0001,

--- a/validation-test/compiler_crashers/24798-no-stacktrace.swift
+++ b/validation-test/compiler_crashers/24798-no-stacktrace.swift
@@ -4,6 +4,8 @@
 // Test case found by https://github.com/neilpa (neilpa)
 // http://www.openradar.me/20220559
 
+// ASAN Output: stack-overflow on address 0x7ffc82319f20 (pc 0x000001e54411 bp 0x7ffc8231a050 sp 0x7ffc82319ee0 T0)
+
 let records = [
     0x0000: "",
     0x0001: "",

--- a/validation-test/compiler_crashers/24887-no-stack-trace.swift
+++ b/validation-test/compiler_crashers/24887-no-stack-trace.swift
@@ -2,6 +2,8 @@
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/codafi (Robert Widmann)
 
+// ASAN Output: stack-overflow on address 0x7ffc688c8fa8 (pc 0x0000008b75dd bp 0x7ffc688c9810 sp 0x7ffc688c8fb0 T0)
+
 struct X<T> {
-	let s : X<X>
+    let s : X<X>
 }

--- a/validation-test/compiler_crashers/27636-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers/27636-swift-typechecker-resolvetypeincontext.swift
@@ -4,6 +4,8 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// ASAN Output: stack-overflow on address 0x7ffdcd2b1fd0 (pc 0x0000008ecf9e bp 0x7ffdcd2b2810 sp 0x7ffdcd2b1fc0 T0)
+
 enum A
 protocol A{
 typealias f:a

--- a/validation-test/compiler_crashers/27832-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers/27832-swift-typechecker-resolvetypeincontext.swift
@@ -4,6 +4,8 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// ASAN Output: stack-overflow on address 0x7ffd2c334fb0 (pc 0x0000008ecf9e bp 0x7ffd2c3357f0 sp 0x7ffd2c334fa0 T0)
+
 enum A
 protocol A{
 typealias f:a

--- a/validation-test/compiler_crashers/27939-vtable.swift
+++ b/validation-test/compiler_crashers/27939-vtable.swift
@@ -4,6 +4,8 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
+// ASAN Output: stack-overflow on address 0x7ffdad0b1cd0 (pc 0x000001cf1268 bp 0x7ffdad0b2650 sp 0x7ffdad0b1c60 T0)
+
 func b<T {
 class A : A.e {
 func e: T.e

--- a/validation-test/compiler_crashers/28180-rawrepresentable-extension-with-initializer.swift
+++ b/validation-test/compiler_crashers/28180-rawrepresentable-extension-with-initializer.swift
@@ -1,5 +1,7 @@
 // RUN: not --crash %target-swift-frontend %s -parse
 
+// ASAN Output: stack-overflow on address 0x7fff31bf3ff8 (pc 0x0000022f8f44 bp 0x7fff31bf49d0 sp 0x7fff31bf4000 T0)
+
 extension RawRepresentable {
     init?(rawValue optionalRawValue: RawValue?) {
         guard let rawValue = optionalRawValue, value = Self(rawValue: rawValue) else { return nil }


### PR DESCRIPTION
Swift built with:

```
ASAN_OPTIONS="detect_leaks=0" utils/build-script --test --validation-test --release --assertions -- --enable-asan
```
