### PR TITLE
[StdLib] Re-add runAllTests call to Runtime tests

### DIFF
--- a/test/1_stdlib/RuntimeObjC.swift
+++ b/test/1_stdlib/RuntimeObjC.swift
@@ -877,7 +877,10 @@ ObjCConformsToProtocolTestSuite.test("cast/instance") {
   expectTrue(SomeClass() is SomeObjCProto)
   expectTrue(SomeSubclass() is SomeObjCProto)
 }
+
 ObjCConformsToProtocolTestSuite.test("cast/metatype") {
   expectTrue(SomeClass.self is SomeObjCProto.Type)
   expectTrue(SomeSubclass.self is SomeObjCProto.Type)
 }
+
+runAllTests()


### PR DESCRIPTION
I accidentally omitted the call to runAllTests() in 6e0d832 when moving the Objective-C portions to their own file. I will take care to explicitly verify that UnitTests run in the future.

Thank you @gribozavr for spotting this.
