### PR TITLE
[swiftc] Add test case for crash triggered in swift::AbstractStorageDecl::isGetterMutating()

### DIFF
--- a/validation-test/compiler_crashers/28194-swift-abstractstoragedecl-isgettermutating.swift
+++ b/validation-test/compiler_crashers/28194-swift-abstractstoragedecl-isgettermutating.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class A
+struct Q{{}let a:A{set{a{

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision c4404e3d4d4e3a39a771530a59d9ec13405a7e9f
+Tests updated as of revision 5c11d98523cf4dd2ea1a7946083b8d56f1c641de


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/Decl.cpp:2663: bool swift::AbstractStorageDecl::isGetterMutating() const: Assertion `getGetter()' failed.
8  swift           0x0000000000fcd29a swift::AbstractStorageDecl::isGetterMutating() const + 154
13 swift           0x0000000000f72a35 swift::Expr::walk(swift::ASTWalker&) + 69
14 swift           0x0000000000e91d46 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
15 swift           0x0000000000e046db swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
19 swift           0x0000000000eacf58 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 104
20 swift           0x0000000000eb180e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
21 swift           0x0000000000dfe2d5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
22 swift           0x0000000000e04669 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
25 swift           0x0000000000e64a2a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
26 swift           0x0000000000e6487e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
27 swift           0x0000000000e65448 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
29 swift           0x0000000000deb60b swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1771
30 swift           0x0000000000ca2572 swift::CompilerInstance::performSema() + 2946
32 swift           0x0000000000764552 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
33 swift           0x000000000075f131 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28194-swift-abstractstoragedecl-isgettermutating.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28194-swift-abstractstoragedecl-isgettermutating-e7cbe7.o
1.  While type-checking setter for a at validation-test/compiler_crashers/28194-swift-abstractstoragedecl-isgettermutating.swift:9:20
2.  While type-checking expression at [validation-test/compiler_crashers/28194-swift-abstractstoragedecl-isgettermutating.swift:9:24 - line:9:25] RangeText="a{"
3.  While type-checking expression at [validation-test/compiler_crashers/28194-swift-abstractstoragedecl-isgettermutating.swift:9:24 - line:9:24] RangeText="a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
