### PR TITLE
[CMake] Pass -lpthread on FreeBSD.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -161,7 +161,7 @@ function(_add_variant_link_flags
   if("${sdk}" STREQUAL "LINUX")
     list(APPEND result "-lpthread" "-ldl")
   elseif("${sdk}" STREQUAL "FREEBSD")
-    # No extra libraries required.
+    list(APPEND result "-lpthread")
   else()
     list(APPEND result "-lobjc")
   endif()


### PR DESCRIPTION
At the time this code was originally written, Swift standard
library hasn't been ported to FreeBSD, so we didn't need any
additional library. This is not true anymore, so fix it.
