### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::resolveOverload(…)

### DIFF
--- a/validation-test/compiler_crashers/28195-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers/28195-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+enum a{
+func b
+var h=b
+enum b<T where h=a

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision 5c11d98523cf4dd2ea1a7946083b8d56f1c641de
+Tests updated as of revision 471695aa9bd443649ff0f6e0a1cef34af05a0d08


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintSystem.cpp:1399: void swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator *, swift::Type, swift::constraints::OverloadChoice): Assertion `!refType->hasTypeParameter() && "Cannot have a dependent type here"' failed.
8  swift           0x0000000000e8a1da swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 4058
9  swift           0x0000000000ee45c1 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 897
10 swift           0x0000000000eeda26 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3142
11 swift           0x0000000000eeb4c9 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 313
12 swift           0x0000000000eeb289 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
13 swift           0x0000000000dfe2a6 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 614
14 swift           0x0000000000e04669 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
15 swift           0x0000000000e057e0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
16 swift           0x0000000000e05989 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
18 swift           0x0000000000e1a904 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3876
19 swift           0x00000000010097dc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
20 swift           0x00000000010081ed swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
21 swift           0x0000000000e40aeb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
24 swift           0x0000000000e6a36e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
26 swift           0x0000000000e6b274 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
27 swift           0x0000000000e6a27a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
28 swift           0x0000000000e3ce7f swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 607
29 swift           0x0000000000e3e5ff swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
30 swift           0x0000000000e3e9b4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
31 swift           0x0000000000e19b42 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
35 swift           0x0000000000e1f2c6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
36 swift           0x0000000000deb4e2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
37 swift           0x0000000000ca2572 swift::CompilerInstance::performSema() + 2946
39 swift           0x0000000000764552 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
40 swift           0x000000000075f131 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28195-swift-constraints-constraintsystem-resolveoverload.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28195-swift-constraints-constraintsystem-resolveoverload-3b9977.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28195-swift-constraints-constraintsystem-resolveoverload.swift:8:1
2.  While resolving type h at [validation-test/compiler_crashers/28195-swift-constraints-constraintsystem-resolveoverload.swift:11:16 - line:11:16] RangeText="h"
3.  While type-checking expression at [validation-test/compiler_crashers/28195-swift-constraints-constraintsystem-resolveoverload.swift:10:7 - line:10:7] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
