### PR TITLE
[Sema] Fix crash in addCurriedSelfType

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -320,9 +320,9 @@ static Type addCurriedSelfType(ASTContext &ctx, Type type, DeclContext *dc) {
   auto nominal = dc->getDeclaredTypeOfContext()->getAnyNominal();
   auto selfTy = nominal->getInterfaceType()->castTo<MetatypeType>()
                   ->getInstanceType();
-  if (nominal->isGenericContext())
-    return GenericFunctionType::get(nominal->getGenericSignature(),
-                                    selfTy, type, AnyFunctionType::ExtInfo());
+  if (auto sig = nominal->getGenericSignatureOfContext())
+    return GenericFunctionType::get(sig, selfTy, type,
+                                    AnyFunctionType::ExtInfo());
   return FunctionType::get(selfTy, type);
 }
 

--- a/validation-test/compiler_crashers_fixed/28192-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28192-swift-genericfunctiontype-get.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 
 // Distributed under the terms of the MIT license


### PR DESCRIPTION
`isGenericContext()` returning true doesn’t necessarily imply that `getGenericSignature()` returns non-null. `getGenericSignatureOfContext()` performs a traversal equivalent to `isGenericContext()`, so we use it instead.

Fixes 1 compiler_crasher. :trumpet: :confused: 
