### PR TITLE
[Sema] Skip ErrorTypes in potential bindings during constraint solving

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1094,7 +1094,9 @@ static bool tryTypeVariableBindings(
 
     // Enumerate the supertypes of each of the types we tried.
     for (auto binding : bindings) {
-      auto type = binding.BindingType;
+      const auto type = binding.BindingType;
+      if (type->is<ErrorType>())
+        continue;
 
       // After our first pass, note that we've explored these
       // types.

--- a/validation-test/compiler_crashers_fixed/25750-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers_fixed/25750-swift-lvaluetype-get.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
When ErrorTypes were not skipped, they'd cause an assertion failure in `LValueType::get`.

Fixes 1 compiler_crasher.
