### PR TITLE
[AST] Fix inconsistent handling of generic args & params during BoundGenericType::getSubstitutions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2827,12 +2827,12 @@ public:
   /// Set the generic signature of this type.
   void setGenericSignature(GenericSignature *sig);
 
-  /// Retrieve the generic parameter types.
-  ArrayRef<GenericTypeParamType *> getGenericParamTypes() const {
+  /// Retrieve the innermost generic parameter types.
+  ArrayRef<GenericTypeParamType *> getInnermostGenericParamTypes() const {
     if (!GenericSig)
       return { };
 
-    return GenericSig->getGenericParams();
+    return GenericSig->getInnermostGenericParams();
   }
 
   /// Retrieve the generic requirements.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1746,9 +1746,9 @@ Type ValueDecl::getInterfaceType() const {
     auto proto = cast<ProtocolDecl>(getDeclContext());
     (void)proto->getType(); // make sure we've computed the type.
     // FIXME: the generic parameter types list should never be empty.
-    auto selfTy = proto->getGenericParamTypes().empty()
+    auto selfTy = proto->getInnermostGenericParamTypes().empty()
                     ? proto->getProtocolSelf()->getType()
-                    : proto->getGenericParamTypes().back();
+                    : proto->getInnermostGenericParamTypes().back();
     auto &ctx = getASTContext();
     InterfaceTy = DependentMemberType::get(
                     selfTy,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1258,7 +1258,7 @@ ArchetypeTransformer::ArchetypeTransformer(DeclContext *DC, Type Ty) :
   if (!D)
     return;
   SmallVector<Type, 3> Scrach;
-  auto Params = D->getGenericParamTypes();
+  auto Params = D->getInnermostGenericParamTypes();
   auto Args = BaseTy->getAllGenericArgs(Scrach);
   assert(Params.size() == Args.size());
   for (unsigned I = 0, N = Params.size(); I < N; I ++) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2883,7 +2883,8 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
   SmallVector<Type, 3> Scratch;
   auto genericArgs = BaseTy->getAllGenericArgs(Scratch);
   TypeSubstitutionMap substitutions;
-  auto genericParams = BaseTy->getNominalOrBoundGenericNominal()->getGenericParamTypes();
+  auto genericParams = BaseTy->getNominalOrBoundGenericNominal()
+                         ->getInnermostGenericParamTypes();
   assert(genericParams.size() == genericArgs.size());
   for (unsigned i = 0, n = genericParams.size(); i != n; ++i) {
     auto gp = genericParams[i]->getCanonicalType()->castTo<GenericTypeParamType>();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -603,7 +603,7 @@ namespace {
 
         // Open up the generic type.
         cs.openGeneric(unboundDecl,
-                       unboundDecl->getGenericParamTypes(),
+                       unboundDecl->getInnermostGenericParamTypes(),
                        unboundDecl->getGenericRequirements(),
                        /*skipProtocolSelfConstraint=*/false,
                        minOpeningDepth,
@@ -612,7 +612,7 @@ namespace {
 
         // Map the generic parameters to their corresponding type variables.
         llvm::SmallVector<Type, 4> arguments;
-        for (auto gp : unboundDecl->getGenericParamTypes()) {
+        for (auto gp : unboundDecl->getInnermostGenericParamTypes()) {
           assert(replacements.count(gp->getCanonicalType()) && 
                  "Missing generic parameter?");
           arguments.push_back(replacements[gp->getCanonicalType()]);

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -317,7 +317,7 @@ class Bottom<T : Bottom<Top>> {} // expected-error 2{{type may not reference its
 class X6<T> {
   let d: D<T>
   init(_ value: T) {
-    d = D(value) // expected-error{{cannot invoke initializer for type 'X6<T>.D<_, _>' with an argument list of type '(T)'}} expected-note{{expected an argument list of type '(T2)'}}
+    d = D(value)
   }
   class D<T2> { // expected-error{{generic type 'D' nested in type 'X6' is not allowed}}
     init(_ value: T2) {}

--- a/validation-test/IDE/crashers/043-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/IDE/crashers/043-swift-boundgenerictype-getsubstitutions.swift
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-class A<h{#^A^#class B<a{let:AnyObject.Type=B

--- a/validation-test/IDE/crashers_fixed/043-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/IDE/crashers_fixed/043-swift-boundgenerictype-getsubstitutions.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+class A<h{#^A^#class B<a{let:AnyObject.Type=B

--- a/validation-test/compiler_crashers_fixed/24558-swift-typebase-gatherallsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/24558-swift-typebase-gatherallsubstitutions.swift
@@ -1,7 +1,9 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-struct B<g{class B<T var:AnyObject.Type=B
+enum S<b{
+let:AnyObject.Type=B
+class B<T

--- a/validation-test/compiler_crashers_fixed/24624-swift-module-lookupconformance.swift
+++ b/validation-test/compiler_crashers_fixed/24624-swift-module-lookupconformance.swift
@@ -1,9 +1,7 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-enum S<b{
-let:AnyObject.Type=B
-class B<T
+struct B<B{let f=e()enum e<T>:String

--- a/validation-test/compiler_crashers_fixed/24800-swift-constraints-constraintsystem-matchsuperclasstypes.swift
+++ b/validation-test/compiler_crashers_fixed/24800-swift-constraints-constraintsystem-matchsuperclasstypes.swift
@@ -1,8 +1,8 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-{struct d<T{var _=0 as a
-class a<T>:a
+class B<w{class C{func c
+class B<T>:C{let s=c

--- a/validation-test/compiler_crashers_fixed/27367-swift-boundgenerictype-getsubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/27367-swift-boundgenerictype-getsubstitutions.swift
@@ -1,8 +1,7 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-class B<w{class C{func c
-class B<T>:C{let s=c
+struct B<g{class B<T var:AnyObject.Type=B

--- a/validation-test/compiler_crashers_fixed/27426-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/27426-swift-typechecker-validatedecl.swift
@@ -1,10 +1,10 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-let a{
-enum b:Any}enum S<T{enum b<d>:a
-let a{
-var d=b{
+enum s{class A{
+class c<T{
+enum B<T>:Q
+let e=B{

--- a/validation-test/compiler_crashers_fixed/27499-llvm-bitstreamcursor-read.swift
+++ b/validation-test/compiler_crashers_fixed/27499-llvm-bitstreamcursor-read.swift
@@ -1,7 +1,8 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-struct B<B{let f=e()enum e<T>:String
+enum S<e{struct A
+class A?enum A<e>:d{let f=A{

--- a/validation-test/compiler_crashers_fixed/27743-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/27743-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,8 +1,8 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-enum S<e{struct A
-class A?enum A<e>:d{let f=A{
+{struct d<T{var _=0 as a
+class a<T>:a

--- a/validation-test/compiler_crashers_fixed/27800-swift-protocoltype-canonicalizeprotocols.swift
+++ b/validation-test/compiler_crashers_fixed/27800-swift-protocoltype-canonicalizeprotocols.swift
@@ -1,10 +1,10 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-enum s{class A{
-class c<T{
-enum B<T>:Q
-let e=B{
+let a{
+enum b:Any}enum S<T{enum b<d>:a
+let a{
+var d=b{


### PR DESCRIPTION
#### Summary

A decl’s full `GenericSignature` is set during `validateGenericTypeSignature()`.

Then during `ConstraintSystem::openTypes()`, in `ReplaceDependentTypes`, the GenericArgs list is built from the generic signature (via `getGenericParamTypes()`) and passed into a new BoundGenericType.

In `BoundGenericType::getSubstitutions()`, the `GenericArgs` are assumed to match `getGenericParamsOfContext()->getParams()`.

However, in reality, the GenericArgs include all levels of generic args, whereas `getGenericParamsOfContext()` are the params of the innermost context only, so the params array is accessed past its end.

This commit changes `NominalTypeDecl::getGenericParamTypes()` to return the innermost params, in order to match the output of `BoundGenericType::getGenericArgs()`. For clarity and to hopefully prevent future confusion, we also rename `getGenericParamTypes()` to `getInnermostGenericParamTypes()`.
#### Notes for reviewers

I'm not sure if using "innermost" is really the right thing to do here (note that `getGenericArgs()`'s comment says "Retrieve the set of generic arguments provided _at this level_"), but it seems there are very few places where nested generics actually do anything interesting/useful, so I think it's safe right now. The function rename should help future maintainers understand what's going on.

Fixes 8 compiler_crashers and 1 IDE/crasher. :cat2:
Also removes what appear to have been some spurious diagnostics in `test/Generics/generic_type.swift`.
