### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintGraph::addConstraint(…)

### DIFF
--- a/validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift
+++ b/validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift
@@ -1,0 +1,12 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{
+func a
+class
+a{
+func b{{}{a

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision 471695aa9bd443649ff0f6e0a1cef34af05a0d08
+Tests updated as of revision a4124ed94080ff07b6cd55afe57970272fb52c2f


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:50: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *): Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.
9  swift           0x0000000000f068df swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) + 111
10 swift           0x0000000000e81f42 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 258
11 swift           0x0000000000e02ca3 swift::TypeChecker::typesSatisfyConstraint(swift::Type, swift::Type, swift::constraints::ConstraintKind, swift::DeclContext*) + 131
12 swift           0x0000000000ea8f97 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 919
13 swift           0x0000000000ead51e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
14 swift           0x0000000000dfa275 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
15 swift           0x0000000000e00609 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
18 swift           0x0000000000ea8c68 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 104
19 swift           0x0000000000ead51e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
20 swift           0x0000000000dfa275 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
21 swift           0x0000000000e00609 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
25 swift           0x0000000000ea8c68 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 104
26 swift           0x0000000000ead51e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
27 swift           0x0000000000dfa275 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
28 swift           0x0000000000e00609 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
31 swift           0x0000000000e6084a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
32 swift           0x0000000000e6069e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
33 swift           0x0000000000e61268 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
35 swift           0x0000000000de75ab swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1771
36 swift           0x0000000000c9eed2 swift::CompilerInstance::performSema() + 2946
38 swift           0x0000000000764692 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
39 swift           0x000000000075f271 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28196-swift-constraints-constraintgraph-addconstraint-42f46f.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift:12:1
2.  While type-checking expression at [validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift:12:8 - line:12:11] RangeText="{}{a"
3.  While type-checking expression at [validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift:12:10 - line:12:11] RangeText="{a"
4.  While type-checking expression at [validation-test/compiler_crashers/28196-swift-constraints-constraintgraph-addconstraint.swift:12:10 - line:12:11] RangeText="{a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
