### PR TITLE
[Stdlib] Remove all redundant stdout locking when printing

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -39,7 +39,7 @@ typedef long int __swift_ssize_t;
 void _swift_stdlib_free(void *ptr);
 
 // Input/output <stdio.h>
-int _swift_stdlib_putchar(int c);
+int _swift_stdlib_putchar_unlocked(int c);
 
 // String handling <string.h>
 __attribute__((pure))

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -805,7 +805,7 @@ extension String {
   /// - SeeAlso: `String.init<T>(T)`
   public init<T>(reflecting subject: T) {
     self.init()
-    debugPrint(subject, terminator: "", toStream: &self)
+    _debugPrint_unlocked(subject, &self)
   }
 }
 

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -123,13 +123,13 @@ internal func _print<Target: OutputStreamType>(
 ) {
   var prefix = ""
   output._lock()
+  defer { output._unlock() }
   for item in items {
     output.write(prefix)
     _print_unlocked(item, &output)
     prefix = separator
   }
   output.write(terminator)
-  output._unlock()
 }
 
 @inline(never)
@@ -142,13 +142,13 @@ internal func _debugPrint<Target: OutputStreamType>(
 ) {
   var prefix = ""
   output._lock()
+  defer { output._unlock() }
   for item in items {
     output.write(prefix)
     _debugPrint_unlocked(item, &output)
     prefix = separator
   }
   output.write(terminator)
-  output._unlock()
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -28,7 +28,7 @@ namespace swift {
 
 void _swift_stdlib_free(void *ptr) { free(ptr); }
 
-int _swift_stdlib_putchar(int c) { return putchar(c); }
+int _swift_stdlib_putchar_unlocked(int c) { return putchar_unlocked(c); }
 
 __swift_size_t _swift_stdlib_strlen(const char *s) { return strlen(s); }
 


### PR DESCRIPTION
- Switch to calling `putchar_unlocked()` instead of `putchar()` for
  actual printing. We're already locking stdout with `flockfile()`, so
  there's no need for the redundant lock that `putchar()` uses.
- Add an explicit lock to the output stream in `dump()`. This means the
  entire dump is printed with the lock held, which will prevent the
  output of `dump()` from mixing with prints on other threads.
- Use `_debugPrint_unlocked()` instead of `debugPrint()` in
  `_adHocPrint()`. The output stream is already locked while this
  function is executing. Rename the function to `_adHocPrint_unlocked()`
  to make this explicit.
- Use `targetStream.write()` and `_print_unlocked()` instead of
  `print()` in `_dumpWithMirror()`. This removes the redundant locking,
  and also eliminates the creation of intermediate strings. Rename the
  function to `_dumpWithMirror_unlocked()` to make this explicit.
- Use `_debugPrint_unlocked()` instead of `debugPrint()` in
  `String.init(reflecting:)`. This shouldn't really make much of a
  difference but it matches the usage of `_print_unlocked()` in
  `String.init(_:)`.

The net result is that all printing is still covered under locks like
before, but stdout is never recursively locked. This should result in
slightly faster printing. In addition, `dump()` is now covered under a
single lock so it can't mix its output with prints from other threads.
