### PR TITLE
[parser][SR-510] add diagnose for non-expr case raw value

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4400,6 +4400,7 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         return Status;
       }
       if (RawValueExpr.isNull()) {
+        diagnose(EqualsLoc, diag::expected_expr_enum_case_raw_value);
         Status.setIsParseError();
         return Status;
       }

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -290,5 +290,7 @@ func testSimpleEnum() {
   let _ : SimpleEnum=.X    // expected-error {{'=' must have consistent whitespace on both sides}}
 }
 
-
-
+enum TestingSR510: String {
+    case Thing = "thing"
+    case Bob = {"test"} // expected-error {{expected expression after '=' in 'case'}}
+}


### PR DESCRIPTION
When a `case`'s raw value is not considered as a valid expression, generate a diagnose instead of silently quite.

This resolves [SR-510](https://bugs.swift.org/browse/SR-510)
