### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getDesugaredType()

### DIFF
--- a/validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class a{protocol P{typealias e:d:let a}var d={class b:P


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000001019520 swift::TypeBase::getDesugaredType() + 32
9  swift           0x0000000001026b95 swift::Type::walk(swift::TypeWalker&) const + 21
10 swift           0x000000000101651f swift::Type::findIf(std::function<bool (swift::Type)> const&) const + 31
14 swift           0x0000000000e453bf swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 1279
17 swift           0x0000000000e1b266 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
20 swift           0x0000000000e61b2a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
21 swift           0x0000000000e8dc6c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
22 swift           0x0000000000e0067b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
23 swift           0x0000000000e01780 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
24 swift           0x0000000000e01929 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
26 swift           0x0000000000e168a4 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3876
27 swift           0x000000000100544c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
28 swift           0x0000000001003e5d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
29 swift           0x0000000000e3ca8b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
32 swift           0x0000000000e6617e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
34 swift           0x0000000000e67084 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
35 swift           0x0000000000e6608a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
36 swift           0x0000000000ef6242 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
37 swift           0x0000000000ef54cd swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
38 swift           0x0000000000e127b9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
39 swift           0x0000000000e15d91 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
44 swift           0x0000000000e1b266 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
45 swift           0x0000000000de7482 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
46 swift           0x0000000000c9eed2 swift::CompilerInstance::performSema() + 2946
48 swift           0x0000000000764692 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
49 swift           0x000000000075f271 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28197-swift-typebase-getdesugaredtype-7a0037.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift:7:1
2.  While resolving type d at [validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift:7:32 - line:7:32] RangeText="d"
3.  While type-checking expression at [validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift:7:46 - line:7:55] RangeText="{class b:P"
4.  While type-checking 'b' at validation-test/compiler_crashers/28197-swift-typebase-getdesugaredtype.swift:7:47
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
