### PR TITLE
Revert "[StdLib] Extend ReflectionHashing test to pass on Linux"

### DIFF
--- a/test/1_stdlib/ReflectionHashing.swift
+++ b/test/1_stdlib/ReflectionHashing.swift
@@ -2,6 +2,8 @@
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 
+// XFAIL: linux
+
 //
 // This file contains reflection tests that depend on hash values.
 // Don't add other tests here.
@@ -36,7 +38,7 @@ Reflection.test("Dictionary") {
   var output = ""
   dump(dict, &output)
 
-#if _runtime(_ObjC) && (arch(i386) || arch(arm))
+#if arch(i386) || arch(arm)
   var expected = ""
   expected += "▿ 5 key/value pairs\n"
   expected += "  ▿ [0]: (2 elements)\n"
@@ -54,7 +56,7 @@ Reflection.test("Dictionary") {
   expected += "  ▿ [4]: (2 elements)\n"
   expected += "    - .0: Three\n"
   expected += "    - .1: 3\n"
-#elseif _runtime(_ObjC) && (arch(x86_64) || arch(arm64))
+#elseif arch(x86_64) || arch(arm64)
   var expected = ""
   expected += "▿ 5 key/value pairs\n"
   expected += "  ▿ [0]: (2 elements)\n"
@@ -72,24 +74,6 @@ Reflection.test("Dictionary") {
   expected += "  ▿ [4]: (2 elements)\n"
   expected += "    - .0: Four\n"
   expected += "    - .1: 4\n"
-#elseif !_runtime(_ObjC) && arch(x86_64)
-  var expected = ""
-  expected += "▿ 5 key/value pairs\n"
-  expected += "  ▿ [0]: (2 elements)\n"
-  expected += "    - .0: One\n"
-  expected += "    - .1: 1\n"
-  expected += "  ▿ [1]: (2 elements)\n"
-  expected += "    - .0: Five\n"
-  expected += "    - .1: 5\n"
-  expected += "  ▿ [2]: (2 elements)\n"
-  expected += "    - .0: Two\n"
-  expected += "    - .1: 2\n"
-  expected += "  ▿ [3]: (2 elements)\n"
-  expected += "    - .0: Four\n"
-  expected += "    - .1: 4\n"
-  expected += "  ▿ [4]: (2 elements)\n"
-  expected += "    - .0: Three\n"
-  expected += "    - .1: 3\n"
 #else
   fatalError("unimplemented")
 #endif


### PR DESCRIPTION
This test expects consistent hash code generation on any given platform.
However String instance generate different values on Linux depending on which
version of libicu is installed, causing environment-specific test failures.

This reverts commit def419b57fbce2391eb16c4c203c4db996dc5b97.
## 

The specific situation here is that we're relying on libicu's collation elements to hash strings on platforms without objective-c interop. The values for collection elements returned by icu vary depending upon the specific version of ICU, the internal collation algorithm, and the version of Unicode that's being implemented. As a result, I don't seem to be able to mimic the other tests by checking for a static answer.

I've validated this in versions 52 (in Ubuntu 14.04) and 54 (in Fedora 23). I haven't yet tried on Ubuntu 15.10, but I expect it to be from 14.04.

@moiseev @gribozavr Can either of you tell me more about this test? Is reliance on stable hashing instrumental in this test's intent or just an implementation side effect?
