### PR TITLE
[Parse][SR-510] emit error for closures outside of a func

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -917,11 +917,13 @@ ERROR(cannot_capture_fields,attribute_parsing,none,
 ERROR(expected_closure_result_type,expr_parsing,none,
       "expected closure result type after '->'", ())
 ERROR(expected_closure_in,expr_parsing,none,
-   "expected 'in' after the closure signature", ())
+      "expected 'in' after the closure signature", ())
 ERROR(unexpected_tokens_before_closure_in,expr_parsing,none,
-   "unexpected tokens prior to 'in'", ())
+      "unexpected tokens prior to 'in'", ())
 ERROR(expected_closure_rbrace,expr_parsing,none,
       "expected '}' at end of closure", ())
+ERROR(closure_not_permitted,expr_parsing,none,
+      "closures cannot appear here", ())
 
 WARNING(trailing_closure_excess_newlines,expr_parsing,none,
         "trailing closure is separated from call site by multiple newlines", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -923,7 +923,7 @@ ERROR(unexpected_tokens_before_closure_in,expr_parsing,none,
 ERROR(expected_closure_rbrace,expr_parsing,none,
       "expected '}' at end of closure", ())
 ERROR(closure_not_permitted,expr_parsing,none,
-      "closures cannot appear here", ())
+      "closures are only allowed inside a function or initializer", ())
 
 WARNING(trailing_closure_excess_newlines,expr_parsing,none,
         "trailing closure is separated from call site by multiple newlines", ())

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1811,13 +1811,14 @@ ParserResult<Expr> Parser::parseExprClosure() {
   parseClosureSignatureIfPresent(captureList, params, throwsLoc, arrowLoc,
                                  explicitResultType, inLoc);
 
-  // If the closure was created in the context of an array type signature's
-  // size expression, there will not be a local context. A parse error will
-  // be reported at the signature's declaration site.
+  // If we get a closure expression without a local context, this is somewhere
+  // a closure cannot appear, such as when trying to parse raw values
+  // for enum cases.
   if (!CurLocalContext) {
     skipUntil(tok::r_brace);
     if (Tok.is(tok::r_brace))
       consumeToken();
+    diagnose(leftBrace, diag::closure_not_permitted);
     return makeParserError();
   }
   

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -371,7 +371,7 @@ struct ErrorTypeInVarDeclArrayType4 {
 }
 
 struct ErrorInFunctionSignatureResultArrayType1 {
-  // expected-error@+1{{closures cannot appear here}}
+  // expected-error@+1{{closures are only allowed inside a function or initializer}}
   func foo() -> Int[ { // expected-error {{expected '{' in body of function declaration}}
     return [0]
   }
@@ -522,7 +522,7 @@ case let (jeb):
 }
 
 // rdar://19605164
-// expected-error@+4{{closures cannot appear here}}
+// expected-error@+4{{closures are only allowed inside a function or initializer}}
 // expected-note@+3{{to match this opening '('}}
 // expected-error@+2{{use of undeclared type 'S'}}
 struct Foo19605164 {

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -371,6 +371,7 @@ struct ErrorTypeInVarDeclArrayType4 {
 }
 
 struct ErrorInFunctionSignatureResultArrayType1 {
+  // expected-error@+1{{closures cannot appear here}}
   func foo() -> Int[ { // expected-error {{expected '{' in body of function declaration}}
     return [0]
   }
@@ -521,6 +522,7 @@ case let (jeb):
 }
 
 // rdar://19605164
+// expected-error@+4{{closures cannot appear here}}
 // expected-note@+3{{to match this opening '('}}
 // expected-error@+2{{use of undeclared type 'S'}}
 struct Foo19605164 {

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -315,3 +315,8 @@ func r21375863() {
     [UInt8](count: width*height, repeatedValue: 0)
   }
 }
+
+// SR-510 `case Foo = {!@#$!@#$}` compiles and drops the case
+enum SR510 {
+  case Foo = {} // expected-error {{closures cannot appear here}}
+}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -318,5 +318,5 @@ func r21375863() {
 
 // SR-510 `case Foo = {!@#$!@#$}` compiles and drops the case
 enum SR510 {
-  case Foo = {} // expected-error {{closures cannot appear here}}
+  case Foo = {} // expected-error {{closures are only allowed inside a function or initializer}}
 }


### PR DESCRIPTION
When there is no local context, we should emit an error rather than
silently eating the closure. This code used to be silent to avoid
double-reporting an error for fixed-size array types, but those
no longer exist.

Resolves https://bugs.swift.org/browse/SR-510
