### PR TITLE
[stdlib] [docs] Modify names of Array's type parameter and Slice in comments.

### DIFF
--- a/docs/Arrays.rst
+++ b/docs/Arrays.rst
@@ -53,34 +53,34 @@ Swift provides three generic array types, all of which have amortized
 O(1) growth.  In this document, statements about **ArrayType** apply
 to all three of the components.
 
-* ``ContiguousArray<T>`` is the fastest and simplest of the three—use this
+* ``ContiguousArray<Element>`` is the fastest and simplest of the three—use this
   when you need "C array" performance.  The elements of a
   ``ContiguousArray`` are always stored contiguously in memory.
 
   .. image:: ContiguousArray.png
 
-* ``Array<T>`` is like ``ContiguousArray<T>``, but optimized for efficient
-  conversions from Cocoa and back—when ``T`` can be a class type,
-  ``Array<T>`` can be backed by the (potentially non-contiguous)
+* ``Array<Element>`` is like ``ContiguousArray<Element>``, but optimized for efficient
+  conversions from Cocoa and back—when ``Element`` can be a class type,
+  ``Array<Element>`` can be backed by the (potentially non-contiguous)
   storage of an arbitrary ``NSArray`` rather than by a Swift
-  ``ContiguousArray``.  ``Array<T>`` also supports up- and down- casts
-  between arrays of related class types.  When ``T`` is known to be a
-  non-class type, the performance of ``Array<T>`` is identical to that
-  of ``ContiguousArray<T>``.
+  ``ContiguousArray``.  ``Array<Element>`` also supports up- and down- casts
+  between arrays of related class types.  When ``Element`` is known to be a
+  non-class type, the performance of ``Array<Element>`` is identical to that
+  of ``ContiguousArray<Element>``.
 
   .. image:: ArrayImplementation.png
 
-* ``Slice<T>`` is a subrange of some ``Array<T>`` or
-  ``ContiguousArray<T>``; it's the result of using slice notation,
+* ``ArraySlice<Element>`` is a subrange of some ``Array<Element>`` or
+  ``ContiguousArray<Element>``; it's the result of using slice notation,
   e.g. ``a[7...21]`` on any Swift array ``a``.  A slice always has
   contiguous storage and "C array" performance.  Slicing an
-  *ArrayType* is O(1) unless the source is an ``Array<T>`` backed by
+  *ArrayType* is O(1) unless the source is an ``Array<Element>`` backed by
   an ``NSArray`` that doesn't supply contiguous storage.
 
-  ``Slice`` is recommended for transient computations but not for
+  ``ArraySlice`` is recommended for transient computations but not for
   long-term storage.  Since it references a sub-range of some shared
-  backing buffer, a ``Slice`` may artificially prolong the lifetime of
-  elements outside the ``Slice`` itself.
+  backing buffer, a ``ArraySlice`` may artificially prolong the lifetime of
+  elements outside the ``ArraySlice`` itself.
 
   .. image:: Slice.png
 

--- a/docs/Arrays.rst
+++ b/docs/Arrays.rst
@@ -53,15 +53,15 @@ Swift provides three generic array types, all of which have amortized
 O(1) growth.  In this document, statements about **ArrayType** apply
 to all three of the components.
 
-* ``ContiguousArray<Element>`` is the fastest and simplest of the three—use this
-  when you need "C array" performance.  The elements of a
+* ``ContiguousArray<Element>`` is the fastest and simplest of the three—use
+  this when you need "C array" performance.  The elements of a
   ``ContiguousArray`` are always stored contiguously in memory.
 
   .. image:: ContiguousArray.png
 
-* ``Array<Element>`` is like ``ContiguousArray<Element>``, but optimized for efficient
-  conversions from Cocoa and back—when ``Element`` can be a class type,
-  ``Array<Element>`` can be backed by the (potentially non-contiguous)
+* ``Array<Element>`` is like ``ContiguousArray<Element>``, but optimized for
+  efficient conversions from Cocoa and back—when ``Element`` can be a class
+  type, ``Array<Element>`` can be backed by the (potentially non-contiguous)
   storage of an arbitrary ``NSArray`` rather than by a Swift
   ``ContiguousArray``.  ``Array<Element>`` also supports up- and down- casts
   between arrays of related class types.  When ``Element`` is known to be a

--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -132,7 +132,7 @@ Array
 The following semantic tags describe Array operations. The operations
 are first described in terms of the Array "state". Relations between the
 operations are formally defined below. 'Array' refers to the standard library
-Array<T>, ContiguousArray<T>, and ArraySlice<T> data-structures.
+Array<Element>, ContiguousArray<Element>, and ArraySlice<Element> data-structures.
 
 We consider the array state to consist of a set of disjoint elements
 and a storage descriptor that encapsulates nonelement data such as the
@@ -156,7 +156,7 @@ array.init
   may act as a guard to other potentially mutating operations, such as
   ``get_element_address``.
 
-array.uninitialized(count: Builtin.Word) -> (Array<T>, Builtin.RawPointer)
+array.uninitialized(count: Builtin.Word) -> (Array<Element>, Builtin.RawPointer)
 
   Creates an array with the specified number of elements. It initializes
   the storage descriptor but not the array elements. The returned tuple

--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -132,7 +132,8 @@ Array
 The following semantic tags describe Array operations. The operations
 are first described in terms of the Array "state". Relations between the
 operations are formally defined below. 'Array' refers to the standard library
-Array<Element>, ContiguousArray<Element>, and ArraySlice<Element> data-structures.
+Array<Element>, ContiguousArray<Element>, and ArraySlice<Element>
+data-structures.
 
 We consider the array state to consist of a set of disjoint elements
 and a storage descriptor that encapsulates nonelement data such as the

--- a/docs/proposals/ArrayBridge.rst
+++ b/docs/proposals/ArrayBridge.rst
@@ -92,7 +92,7 @@ fold this to "0" iff ``T`` is known to be a protocol other than
 AnyObject, if it is known to be a non-\ ``@objc`` class, or if it is
 known to be any struct, enum or tuple.  Otherwise, the builtin is left
 alone, and if it reaches IRGen, IRGen should conservatively fold it to
-"1".  In the common case where ``Array<T>`` is inlined and
+"1".  In the common case where ``Array<Element>`` is inlined and
 specialized, this will allow us to eliminate all of the overhead in
 the important C cases.
 

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -216,11 +216,12 @@ public protocol _FileReferenceLiteralConvertible {
 
 /// A container is destructor safe if whether it may store to memory on
 /// destruction only depends on its type parameters.
-/// For example, whether `Array<Element>` may store to memory on destruction depends
-/// only on `Element`.
-/// If `Element` is an `Int` we know the `Array<Int>` does not store to memory during
-/// destruction. If `Element` is an arbitrary class `Array<MemoryUnsafeDestructorClass>`
-/// then the compiler will deduce may store to memory on destruction because
-/// `MemoryUnsafeDestructorClass`'s destructor may store to memory on destruction.
+/// For example, whether `Array<Element>` may store to memory on destruction
+/// depends only on `Element`.
+/// If `Element` is an `Int` we know the `Array<Int>` does not store to memory
+/// during destruction. If `Element` is an arbitrary class
+/// `Array<MemoryUnsafeDestructorClass>` then the compiler will deduce may
+/// store to memory on destruction because `MemoryUnsafeDestructorClass`'s
+/// destructor may store to memory on destruction.
 public protocol _DestructorSafeContainer {
 }

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -216,10 +216,10 @@ public protocol _FileReferenceLiteralConvertible {
 
 /// A container is destructor safe if whether it may store to memory on
 /// destruction only depends on its type parameters.
-/// For example, whether `Array<T>` may store to memory on destruction depends
-/// only on `T`.
-/// If `T` is an `Int` we know the `Array<Int>` does not store to memory during
-/// destruction. If `T` is an arbitrary class `Array<MemoryUnsafeDestructorClass>`
+/// For example, whether `Array<Element>` may store to memory on destruction depends
+/// only on `Element`.
+/// If `Element` is an `Int` we know the `Array<Int>` does not store to memory during
+/// destruction. If `Element` is an arbitrary class `Array<MemoryUnsafeDestructorClass>`
 /// then the compiler will deduce may store to memory on destruction because
 /// `MemoryUnsafeDestructorClass`'s destructor may store to memory on destruction.
 public protocol _DestructorSafeContainer {


### PR DESCRIPTION
Modify Array's type parameter name and rename Slice to ArraySlice in comments.

In swift 1.2, `Slice` has been renamed  `ArraySlice`.
In swift 2.0, type parameter name of `Array` is changed from `T` to `Element`.
Therefore, modified the names which appear in code comments and a document.
