### PR TITLE
[build-script-impl][SR-58] When bootstrapping ninja, set CMAKE_MAKE_COMMAND

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1327,8 +1327,7 @@ if [[ "${BUILD_NINJA}" ]] ; then
           { set +x; } 2>/dev/null
         fi
     fi
-    export PATH="${build_dir}:${PATH}"
-    export NINJA_BIN="${build_dir}/ninja"
+    NINJA_BIN="${build_dir}/ninja"
     COMMON_CMAKE_OPTIONS=(
         "${COMMON_CMAKE_OPTIONS[@]}"
         -DCMAKE_MAKE_PROGRAM=${NINJA_BIN}

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1328,6 +1328,11 @@ if [[ "${BUILD_NINJA}" ]] ; then
         fi
     fi
     export PATH="${build_dir}:${PATH}"
+    export NINJA_BIN="${build_dir}/ninja"
+    COMMON_CMAKE_OPTIONS=(
+        "${COMMON_CMAKE_OPTIONS[@]}"
+        -DCMAKE_MAKE_PROGRAM=${NINJA_BIN}
+    )
 fi
 
 #


### PR DESCRIPTION
Works around problem where CMake has already cached the nonexistence
of ninja.

Ref #SR-58 https://bugs.swift.org/browse/SR-58
