### PR TITLE
API to suppress warnings

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -388,8 +388,8 @@ namespace swift {
       Unspecified,
       Ignore,
       Note,
-      Warn,
-      Err,
+      Warning,
+      Error,
       Fatal,
     };
 
@@ -483,7 +483,7 @@ namespace swift {
     
   public:
     explicit DiagnosticEngine(SourceManager &SourceMgr)
-      : SourceMgr(SourceMgr), state(), ActiveDiagnostic() {
+      : SourceMgr(SourceMgr), ActiveDiagnostic() {
     }
 
     /// hadAnyError - return true if any *error* diagnostics have been emitted.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -398,6 +398,9 @@ namespace swift {
     /// fatal error
     bool showDiagnosticsAfterFatalError = false;
 
+    /// \brief Don't emit any warnings
+    bool ignoreAllWarnings = false;
+
     /// \brief Whether a fatal error has occurred
     bool fatalErrorOccurred = false;
 
@@ -419,6 +422,10 @@ namespace swift {
     void setShowDiagnosticsAfterFatalError(bool val = true) {
       showDiagnosticsAfterFatalError = val;
     }
+
+    /// \brief Whether to skip emitting warnings
+    void setIgnoreAllWarnings(bool val) { ignoreAllWarnings = val; }
+    bool getIgnoreAllWarnings() const { return ignoreAllWarnings; }
 
     void resetHadAnyError() {
       anyErrorOccurred = false;
@@ -482,6 +489,12 @@ namespace swift {
 
     void setShowDiagnosticsAfterFatalError(bool val = true) {
       state.setShowDiagnosticsAfterFatalError(val);
+    }
+
+    /// \brief Whether to skip emitting warnings
+    void setIgnoreAllWarnings(bool val) { state.setIgnoreAllWarnings(val); }
+    bool getIgnoreAllWarnings() const {
+      return state.getIgnoreAllWarnings();
     }
 
     void resetHadAnyError() {

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -398,18 +398,14 @@ namespace swift {
     /// fatal error
     bool showDiagnosticsAfterFatalError = false;
 
+    /// \brief Whether a fatal error has occurred
+    bool fatalErrorOccurred = false;
+
     /// \brief Whether any error diagnostics have been emitted.
     bool anyErrorOccurred = false;
 
-    /// Fatal error tracking
-    enum class FatalErrorState {
-      None,
-      JustEmitted,
-      Fatal
-    };
-
-    /// Sticky flag set to \c true when a fatal error is emitted.
-    FatalErrorState fatalState = FatalErrorState::None;
+    /// \brief Track the previous emitted Behavior, useful for notes
+    Behavior previousBehavior = Behavior::Unspecified;
 
   public:
     DiagnosticState() {}
@@ -418,9 +414,7 @@ namespace swift {
     Behavior getBehavior(const Diagnostic &);
 
     bool hadAnyError() const { return anyErrorOccurred; }
-    bool hasFatalErrorOccurred() const {
-      return fatalState != FatalErrorState::None;
-    }
+    bool hasFatalErrorOccurred() const { return fatalErrorOccurred; }
 
     void setShowDiagnosticsAfterFatalError(bool val = true) {
       showDiagnosticsAfterFatalError = val;
@@ -428,7 +422,7 @@ namespace swift {
 
     void resetHadAnyError() {
       anyErrorOccurred = false;
-      fatalState = FatalErrorState::None;
+      fatalErrorOccurred = false;
     }
 
   private:

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -378,6 +378,70 @@ namespace swift {
       return fixItReplaceChars(Start, End, {});
     }
   };
+
+  /// \brief Class to track, map, and remap diagnostic severity and fatality
+  ///
+  class DiagnosticState {
+  public:
+    /// \brief Describes the current behavior to take with a diagnostic
+    enum class Behavior {
+      Unspecified,
+      Ignore,
+      Note,
+      Warn,
+      Err,
+      Fatal,
+    };
+
+  private:
+    /// \brief Whether we should continue to emit diagnostics, even after a
+    /// fatal error
+    bool showDiagnosticsAfterFatalError = false;
+
+    /// \brief Whether any error diagnostics have been emitted.
+    bool anyErrorOccurred = false;
+
+    /// Fatal error tracking
+    enum class FatalErrorState {
+      None,
+      JustEmitted,
+      Fatal
+    };
+
+    /// Sticky flag set to \c true when a fatal error is emitted.
+    FatalErrorState fatalState = FatalErrorState::None;
+
+  public:
+    DiagnosticState() {}
+
+    /// \brief Figure out the Behavior for the given diagnostic
+    Behavior getBehavior(const Diagnostic &);
+
+    bool hadAnyError() const { return anyErrorOccurred; }
+    bool hasFatalErrorOccurred() const {
+      return fatalState != FatalErrorState::None;
+    }
+
+    void setShowDiagnosticsAfterFatalError(bool val = true) {
+      showDiagnosticsAfterFatalError = val;
+    }
+
+    void resetHadAnyError() {
+      anyErrorOccurred = false;
+      fatalState = FatalErrorState::None;
+    }
+
+  private:
+    /// \returns true if diagnostic is marked as fatal.
+    bool isDiagnosticFatal(DiagID ID) const;
+
+    // Make the state movable only
+    DiagnosticState(const DiagnosticState &) = delete;
+    const DiagnosticState &operator=(const DiagnosticState &) = delete;
+
+    DiagnosticState(DiagnosticState &&) = default;
+    DiagnosticState &operator=(DiagnosticState &&) = default;
+  };
     
   /// \brief Class responsible for formatting diagnostics and presenting them
   /// to the user.
@@ -390,19 +454,7 @@ namespace swift {
     /// emitting diagnostics.
     SmallVector<DiagnosticConsumer *, 2> Consumers;
 
-    /// HadAnyError - True if any error diagnostics have been emitted.
-    bool HadAnyError;
-
-    enum class FatalErrorState {
-      None,
-      JustEmitted,
-      Fatal
-    };
-
-    /// Sticky flag set to \c true when a fatal error is emitted.
-    FatalErrorState FatalState = FatalErrorState::None;
-
-    bool ShowDiagnosticsAfterFatalError = false;
+    DiagnosticState state;
 
     /// \brief The currently active diagnostic, if there is one.
     Optional<Diagnostic> ActiveDiagnostic;
@@ -424,25 +476,22 @@ namespace swift {
     
   public:
     explicit DiagnosticEngine(SourceManager &SourceMgr)
-      : SourceMgr(SourceMgr), HadAnyError(false), ActiveDiagnostic() {
+      : SourceMgr(SourceMgr), state(), ActiveDiagnostic() {
     }
 
     /// hadAnyError - return true if any *error* diagnostics have been emitted.
-    bool hadAnyError() const {
-      return HadAnyError;
-    }
+    bool hadAnyError() const { return state.hadAnyError(); }
 
     bool hasFatalErrorOccurred() const {
-      return FatalState != FatalErrorState::None;
+      return state.hasFatalErrorOccurred();
     }
 
-    void setShowDiagnosticsAfterFatalError(bool Val = true) {
-      ShowDiagnosticsAfterFatalError = Val;
+    void setShowDiagnosticsAfterFatalError(bool val = true) {
+      state.setShowDiagnosticsAfterFatalError(val);
     }
 
     void resetHadAnyError() {
-      HadAnyError = false;
-      FatalState = FatalErrorState::None;
+      state.resetHadAnyError();
     }
 
     /// \brief Add an additional DiagnosticConsumer to receive diagnostics.
@@ -572,10 +621,7 @@ namespace swift {
 
     /// \returns true if diagnostic is marked with PointsToFirstBadToken
     /// option.
-    bool isDiagnosticPointsToFirstBadToken(DiagID ID) const;
-
-    /// \returns true if diagnostic is marked as fatal.
-    bool isDiagnosticFatal(DiagID ID) const;
+    bool isDiagnosticPointsToFirstBadToken(DiagID id) const;
 
   private:
     /// \brief Flush the active diagnostic.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -82,9 +82,9 @@ DiagnosticState::DiagnosticState() {
 #define ERROR(ID, Category, Options, Text, Signature)                          \
   perDiagnosticState[LocalDiagID::ID] =                                        \
       DiagnosticOptions::Options == DiagnosticOptions::Fatal ? Behavior::Fatal \
-                                                             : Behavior::Err;
+                                                             : Behavior::Error;
 #define WARNING(ID, Category, Options, Text, Signature)                        \
-  perDiagnosticState[LocalDiagID::ID] = Behavior::Warn;
+  perDiagnosticState[LocalDiagID::ID] = Behavior::Warning;
 #define NOTE(ID, Category, Options, Text, Signature)                           \
   perDiagnosticState[LocalDiagID::ID] = Behavior::Note;
 #include "swift/AST/DiagnosticsAll.def"
@@ -468,12 +468,12 @@ static DiagnosticKind toDiagnosticKind(DiagnosticState::Behavior behavior) {
     llvm_unreachable("unspecified behavior");
   case DiagnosticState::Behavior::Ignore:
     llvm_unreachable("trying to map an ignored diagnostic");
-  case DiagnosticState::Behavior::Err:
+  case DiagnosticState::Behavior::Error:
   case DiagnosticState::Behavior::Fatal:
     return DiagnosticKind::Error;
   case DiagnosticState::Behavior::Note:
     return DiagnosticKind::Note;
-  case DiagnosticState::Behavior::Warn:
+  case DiagnosticState::Behavior::Warning:
     return DiagnosticKind::Warning;
   }
 }
@@ -483,7 +483,7 @@ DiagnosticState::Behavior DiagnosticState::determineBehavior(DiagID id) {
     if (lvl == Behavior::Fatal) {
       fatalErrorOccurred = true;
       anyErrorOccurred = true;
-    } else if (lvl == Behavior::Err) {
+    } else if (lvl == Behavior::Error) {
       anyErrorOccurred = true;
     }
 
@@ -507,7 +507,7 @@ DiagnosticState::Behavior DiagnosticState::determineBehavior(DiagID id) {
       return set(Behavior::Ignore);
   }
 
-  if (behavior == Behavior::Warn && ignoreAllWarnings)
+  if (behavior == Behavior::Warning && ignoreAllWarnings)
     return set(Behavior::Ignore);
 
   return set(behavior);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -485,7 +485,7 @@ DiagnosticState::Behavior DiagnosticState::getBehavior(const Diagnostic &diag) {
   case DiagnosticKind::Error:
     return set(Behavior::Err);
   case DiagnosticKind::Warning:
-    return set(Behavior::Warn);
+    return set(ignoreAllWarnings ? Behavior::Ignore : Behavior::Warn);
   case DiagnosticKind::Note:
     return set(Behavior::Note);
   }


### PR DESCRIPTION
Hello, I am interested in extending the underlying diagnostics infrastructure to support such things as suppressing warnings, categorization of warnings, and other finer grained control.

Here is a series of patches that lay some of the ground work.

The first refactors some diagnostic-state out of DiagnosticsEngine into a helper class, DiagnosticState. This helps separate concerns and keeps DiagnosticsEngine nimble. In the future, if Swift ever has scoped diagnostic state (e.g. #pragma or equivalent), then DiagnosticsEngine can have a stack of these states.

The second replaces the fatal-state-machine with a previous-state-machine, so that when we add suppressing of diagnostics, we can also suppress notes attached to suppressed diagnostics.

The third introduces an API on DiagnosticEngine to suppress all warnings.

If this approach is approved, and there’s interest, I can continue with categorization of warnings and additional plumbing.

There will need to be additional plumbing when it comes time to communicate levels through to the consumers (e.g. treat warnings as errors).
