### PR TITLE
[swiftc] Add two crash cases (previously timeouts, now assertion failures)

### DIFF
--- a/validation-test/compiler_crashers/22725-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers/22725-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case found by https://github.com/robrix (Rob Rix)
+// http://www.openradar.me/19343997
+
+func b<T>(String -> (T, String)?
+func |<T>(c: String -> (T, String)?
+a:String > (())) -> String -> (T?, String)?
+b("" | "" | "" | "")

--- a/validation-test/compiler_crashers/24245-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers/24245-swift-constraints-constraintsystem-solve.swift
@@ -1,0 +1,13 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case found by https://github.com/robrix (Rob Rix)
+// http://www.openradar.me/19924870
+
+func unit<T>(x: T) -> T? {
+    return x
+}
+func f() -> Int? {
+    return unit(1) ?? unit(2).map { 1 } ?? nil
+}


### PR DESCRIPTION
These two assertion crash cases were previously timeout cases (infinite running time) and hence not included in `validation-test/compiler_crashers/`.
