### PR TITLE
[build-script] Call rmdir(build_dir) only if build_dir exists (-c option)

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -725,7 +725,7 @@ the number of parallel build jobs to use""",
 
     build_dir = os.path.join(SWIFT_BUILD_ROOT, args.build_subdir)
 
-    if args.clean:
+    if args.clean and os.path.isdir(build_dir):
         shutil.rmtree(build_dir)
 
     host_clang = swift_build_support.clang.host_clang(


### PR DESCRIPTION
Before (in case of missing `build_dir`):

```
Traceback (most recent call last):
  File "utils/build-script", line 809, in <module>
    sys.exit(main())
  File "utils/build-script", line 805, in main
    return main_normal()
  File "utils/build-script", line 730, in main_normal
    shutil.rmtree(build_dir)
  File "/usr/lib/python2.7/shutil.py", line 239, in rmtree
    onerror(os.listdir, path, sys.exc_info())
  File "/usr/lib/python2.7/shutil.py", line 237, in rmtree
    names = os.listdir(path)
OSError: [Errno 2] No such file or directory: '/path/to/build/Ninja-ReleaseAssert'
```

After:

```
Builds as expected :-)
```
