### PR TITLE
Revert "Remove unnecessary 'visitDecl' default cases."

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -156,6 +156,9 @@ class UIdentVisitor : public ASTVisitor<UIdentVisitor,
 public:
   explicit UIdentVisitor(bool IsRef) : IsRef(IsRef) { }
 
+  /// TODO: reconsider whether having a default case is a good idea.
+  UIdent visitDecl(const Decl *D) { return UIdent(); }
+
   UIdent visitFuncDecl(const FuncDecl *D);
   UIdent visitVarDecl(const VarDecl *D);
   UIdent visitExtensionDecl(const ExtensionDecl *D);

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -782,6 +782,10 @@ public:
     return Result;
   }
 
+  void visitDecl(Decl *D) {
+    // FIXME: maybe don't have a default case
+  }
+
   void visitStructDecl(StructDecl *SD) {
     auto ResultSD = std::make_shared<sma::StructDecl>();
     ResultSD->Name = convertToIdentifier(SD->getName());


### PR DESCRIPTION
Reverts apple/swift#244; this breaks the build.
