### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::performMemberLookup(…)

### DIFF
--- a/validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift
+++ b/validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class A{
+struct S<>:A var e=A.e
+class A:e{typealias e=s

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision a4124ed94080ff07b6cd55afe57970272fb52c2f
+Tests updated as of revision bfdd23326150a4ff1804e8810a0cbd5a254c5613


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2191: swift::Type swift::ValueDecl::getType() const: Assertion `hasType() && "declaration has no type set yet"' failed.
9  swift           0x0000000000edd28f swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::constraints::ConstraintLocator*) + 3119
10 swift           0x0000000000ede9fa swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 458
11 swift           0x0000000000ee0235 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 69
12 swift           0x0000000000e81d47 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
15 swift           0x0000000000f6eb55 swift::Expr::walk(swift::ASTWalker&) + 69
16 swift           0x0000000000ec0898 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
17 swift           0x0000000000dfa110 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
18 swift           0x0000000000e00639 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
19 swift           0x0000000000e017b0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
20 swift           0x0000000000e01959 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
22 swift           0x0000000000e168a4 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3876
23 swift           0x000000000100595c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
24 swift           0x000000000100436d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
25 swift           0x0000000000e3ca8b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
28 swift           0x0000000000e6611e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
30 swift           0x0000000000e67024 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
31 swift           0x0000000000e6602a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
32 swift           0x0000000000e13b4a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
33 swift           0x0000000000e160a9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
34 swift           0x000000000100595c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
35 swift           0x000000000100436d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
36 swift           0x0000000000e3ca8b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
39 swift           0x0000000000e6611e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
41 swift           0x0000000000e67024 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
42 swift           0x0000000000e6602a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
43 swift           0x0000000000e13b4a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
44 swift           0x0000000000e160a9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
49 swift           0x0000000000e1b266 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
50 swift           0x0000000000de77a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
51 swift           0x0000000000c9f042 swift::CompilerInstance::performSema() + 2946
53 swift           0x00000000007645a2 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
54 swift           0x000000000075f181 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28199-swift-constraints-constraintsystem-performmemberlookup-bedf87.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift:8:1
2.  While resolving type A at [validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift:9:12 - line:9:12] RangeText="A"
3.  While resolving type e at [validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift:10:9 - line:10:9] RangeText="e"
4.  While type-checking expression at [validation-test/compiler_crashers/28199-swift-constraints-constraintsystem-performmemberlookup.swift:9:20 - line:9:22] RangeText="A.e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
