### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getDesugaredType()

### DIFF
--- a/validation-test/compiler_crashers/28200-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28200-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+enum S<T:CollectionType where B:A{func c
+var _=c<T

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision bfdd23326150a4ff1804e8810a0cbd5a254c5613
+Tests updated as of revision 50f86f4f26c78587dbc37ccff04ae95c8285beca


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000001019a40 swift::TypeBase::getDesugaredType() + 32
5  swift           0x0000000000e89d9c swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext*, swift::Type, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<swift::Substitution>&) const + 828
9  swift           0x0000000000f6eb55 swift::Expr::walk(swift::ASTWalker&) + 69
10 swift           0x0000000000e8db66 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
11 swift           0x0000000000e006ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
16 swift           0x0000000000ea8d28 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 104
17 swift           0x0000000000ead62e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
18 swift           0x0000000000dfa2a5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
19 swift           0x0000000000e00639 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
20 swift           0x0000000000e017b0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
21 swift           0x0000000000e01959 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
26 swift           0x0000000000e1b266 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000de77a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
28 swift           0x0000000000c9f042 swift::CompilerInstance::performSema() + 2946
30 swift           0x00000000007645a2 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
31 swift           0x000000000075f181 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28200-swift-typebase-getdesugaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28200-swift-typebase-getdesugaredtype-20fee1.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28200-swift-typebase-getdesugaredtype.swift:7:1
2.  While type-checking expression at [validation-test/compiler_crashers/28200-swift-typebase-getdesugaredtype.swift:8:7 - line:8:9] RangeText="c<T"
3.  While type-checking expression at [validation-test/compiler_crashers/28200-swift-typebase-getdesugaredtype.swift:8:7 - line:8:7] RangeText="c"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
