### PR TITLE
[docs] Replace old-style array type annotations.

### DIFF
--- a/docs/Arrays.rst
+++ b/docs/Arrays.rst
@@ -169,43 +169,43 @@ conforms to ``_BridgedToObjectiveC``:
 
 .. _trivial bridging:
 
-* **Trivial bridging** implicitly converts ``Base[]`` to
+* **Trivial bridging** implicitly converts ``[Base]`` to
   ``NSArray`` in O(1). This is simply a matter of returning the
   Array's internal buffer, which is-a ``NSArray``.
 
 .. _trivial bridging back:
 
 * **Trivial bridging back** implicitly converts ``NSArray`` to
-  ``AnyObject[]`` in O(1) plus the cost of calling ``copy()`` on
+  ``[AnyObject]`` in O(1) plus the cost of calling ``copy()`` on
   the ``NSArray``. [#nocopy]_
 
 * **Implicit conversions** between ``Array`` types
 
-  - **Implicit upcasting** implicitly converts ``Derived[]`` to
-    ``Base[]`` in O(1).
-  - **Implicit bridging** implicitly converts ``X[]`` to
-    ``X._ObjectiveCType[]`` in O(N).
+  - **Implicit upcasting** implicitly converts ``[Derived]`` to
+    ``[Base]`` in O(1).
+  - **Implicit bridging** implicitly converts ``[X]`` to
+    ``[X._ObjectiveCType]`` in O(N).
 
   .. Note:: Either type of implicit conversion may be combined with
      `trivial bridging`_ in an implicit conversion to ``NSArray``.
 
-* **Checked conversions** convert ``T[]`` to ``U[]?`` in O(N)
-  via ``a as U[]``.
+* **Checked conversions** convert ``[T]`` to ``[U]?`` in O(N)
+  via ``a as [U]``.
 
-  - **Checked downcasting** converts ``Base[]`` to ``Derived[]?``.
-  - **Checked bridging back** converts ``T[]`` to ``X[]?`` where
+  - **Checked downcasting** converts ``[Base]`` to ``[Derived]?``.
+  - **Checked bridging back** converts ``[T]`` to ``[X]?`` where
     ``X._ObjectiveCType`` is ``T`` or a trivial subtype thereof.
 
-* **Forced conversions** convert ``AnyObject[]`` or ``NSArray`` to
-  ``T[]`` implicitly, in bridging thunks between Swift and Objective-C.
+* **Forced conversions** convert ``[AnyObject]`` or ``NSArray`` to
+  ``[T]`` implicitly, in bridging thunks between Swift and Objective-C.
 
-  For example, when a user writes a Swift method taking ``NSView[]``,
+  For example, when a user writes a Swift method taking ``[NSView]``,
   it is exposed to Objective-C as a method taking ``NSArray``, which
-  is force-converted to ``NSView[]`` when called from Objective-C.
+  is force-converted to ``[NSView]`` when called from Objective-C.
 
-  - **Forced downcasting** converts ``AnyObject[]`` to ``Derived[]`` in
+  - **Forced downcasting** converts ``[AnyObject]`` to ``[Derived]`` in
     O(1)
-  - **Forced bridging back** converts ``AnyObject[]`` to ``X[]`` in O(N).
+  - **Forced bridging back** converts ``[AnyObject]`` to ``[X]`` in O(N).
 
   A forced conversion where any element fails to convert is considered
   a user programming error that may trap.  In the case of forced
@@ -225,7 +225,7 @@ Upcasts
 
 TODO: this section is outdated.
 
-When up-casting an ``Derived[]`` to ``Base[]``, a buffer of
+When up-casting an ``[Derived]`` to ``[Base]``, a buffer of
 ``Derived`` object can simply be ``unsafeBitCast``\ 'ed to a buffer
 of elements of type ``Base``—as long as the resulting buffer is never
 mutated.  For example, we cannot allow a ``Base`` element to be
@@ -234,11 +234,11 @@ the elements with the (incorrect) static presumption that they have
 ``Derived`` type.
 
 Furthermore, we can't (logically) copy the buffer just prior to
-mutation, since the ``Base[]`` may be copied prior to mutation,
+mutation, since the ``[Base]`` may be copied prior to mutation,
 and our shared subscript assignment semantics imply that all copies
 must observe its subscript assignments.
 
-Therefore, converting ``T[]`` to ``U[]`` is akin to
+Therefore, converting ``[T]`` to ``[U]`` is akin to
 resizing: the new ``Array`` becomes logically independent.  To avoid
 an immediate O(N) conversion cost, and preserve shared subscript
 assignment semantics, we use a layer of indirection in the data

--- a/docs/StringDesign.rst
+++ b/docs/StringDesign.rst
@@ -219,7 +219,7 @@ passes you a string *you own it*.  Nobody can change a string value
   `// s: String =` :look:`"Hey"`\ :aside:`…and it doesn't.`
   |swift| :look1:`t.addEcho()`\ :aside:`this call can't change c.lastSound…`
   |swift| [s, c.lastSound, t]
-  `// r0: String[] = ["Hey",` :look:`"HeyHey"`\ :aside:`…and it doesn't.`\ `, "HeyHeyHeyHey"]`
+  `// r0: [String] = ["Hey",` :look:`"HeyHey"`\ :aside:`…and it doesn't.`\ `, "HeyHeyHeyHey"]`
 
 Strings are **Unicode-Aware**
 -----------------------------
@@ -1021,8 +1021,8 @@ Splitting
 
 :Swift:
   .. parsed-literal::
-     func split(maxSplit: Int = Int.max()) -> String[]
-     func split(separator: Character, maxSplit: Int = Int.max()) -> String[]
+     func split(maxSplit: Int = Int.max()) -> [String]
+     func split(separator: Character, maxSplit: Int = Int.max()) -> [String]
 
   The semantics of these functions were taken from Python, which seems
   to be a fairly good representative of what modern languages are
@@ -1038,7 +1038,7 @@ Splitting
     func **split**\ <Seq: Sliceable, IsSeparator: Predicate 
         where IsSeparator.Arguments == Seq.Element
     >(seq: Seq, isSeparator: IsSeparator, maxSplit: Int = Int.max(),
-      allowEmptySlices: Bool = false  ) -> Seq[]
+      allowEmptySlices: Bool = false  ) -> [Seq]
 
 Splitting
 ~~~~~~~~~

--- a/docs/archive/LangRefNew.rst
+++ b/docs/archive/LangRefNew.rst
@@ -1123,7 +1123,7 @@ label if it is a named pattern or a type annotation of a named pattern.
 
 A tuple pattern whose body ends in ``'...'`` is a varargs tuple.  The last
 element of such a tuple must be a typed pattern, and the type of that pattern
-is changed from ``T`` to ``T[]``.  The corresponding tuple type for a varargs
+is changed from ``T`` to ``[T]``.  The corresponding tuple type for a varargs
 tuple is a varargs tuple type.
 
 As a special case, a tuple pattern with one element that has no label, has no
@@ -1150,7 +1150,7 @@ appear in declarations.
   class D1 : B {}
   class D2 : B {}
 
-  var bs : B[] = [B(), D1(), D2()]
+  var bs : [B] = [B(), D1(), D2()]
 
   for b in bs {
     switch b {

--- a/docs/proposals/ArrayBridge.rst
+++ b/docs/proposals/ArrayBridge.rst
@@ -34,11 +34,11 @@ Being "great for Cocoa" means this must work and be efficient::
   var a = [cocoaObject1, cocoaObject2]
   someCocoaObject.takesAnNSArray(a)
 
-  func processViews(views: AnyObject[]) { ... }
+  func processViews(views: [AnyObject]) { ... }
   var b = someNSWindow.views // views is an NSArray
   processViews(b)
 
-  var c: AnyObject[] = someNSWindow.views
+  var c: [AnyObject] = someNSWindow.views
 
 Being "great For C" means that an array created in Swift must have
 C-like performance and be representable as a base pointer and
@@ -47,18 +47,18 @@ length, for interaction with C APIs, at zero cost.
 Proposed Solution
 =================
 
-``Array<T>``, a.k.a. ``T[]``, is notionally an ``enum`` with two
+``Array<T>``, a.k.a. ``[T]``, is notionally an ``enum`` with two
 cases; call them ``Native`` and ``Cocoa``.  The ``Native`` case stores
 a ``ContiguousArray``, which has a known, contiguous buffer
 representation and O(1) access to the address of any element.  The
 ``Cocoa`` case stores an ``NSArray``.
 
 ``NSArray`` bridges bidirectionally in O(1) [#copy]_ to
-``AnyObject[]``.  It also implicitly converts in to ``T[]``, where T
+``[AnyObject]``.  It also implicitly converts in to ``[T]``, where T
 is any class declared to be ``@objc``.  No dynamic check of element
 types is ever performed for arrays of ``@objc`` elements; instead we
 simply let ``objc_msgSend`` fail when ``T``\ 's API turns out to be
-unsupported by the object.  Any ``T[]``, where T is an ``@objc``
+unsupported by the object.  Any ``[T]``, where T is an ``@objc``
 class, converts implicitly to NSArray.
 
 Optimization
@@ -114,7 +114,7 @@ We considered an approach where conversions between ``NSArray`` and
 native Swift ``Array`` were entirely manual and quickly ruled it out
 as failing to satisfy the requirements.
 
-We considered another promising proposal that would make ``T[]`` a
+We considered another promising proposal that would make ``[T]`` a
 (hand-rolled) existential wrapper type.  Among other things, we felt
 this approach would expose multiple array types too prominently and
 would tend to "bless" an inappropriately-specific protocol as the

--- a/docs/proposals/C Pointer Argument Interop.rst
+++ b/docs/proposals/C Pointer Argument Interop.rst
@@ -141,7 +141,7 @@ known, so a copy-on-write array buffer must be eagerly uniqued prior to the
 address of the array being taken::
 
   func loadFloatsFromData(data: NSData) {
-    var a: Float[] = [0.0, 0.0, 0.0, 0.0]
+    var a: [Float] = [0.0, 0.0, 0.0, 0.0]
     var b = a
 
     // Should only mutate 'b' without affecting 'a', so its backing store

--- a/docs/proposals/C Pointer Interop Language Model.rst
+++ b/docs/proposals/C Pointer Interop Language Model.rst
@@ -72,7 +72,7 @@ You can call it as any of::
 
   var x: Float = 0.0
   var p: UnsafeMutablePointer<Float> = nil
-  var a: Float[] = [1.0, 2.0, 3.0]
+  var a: [Float] = [1.0, 2.0, 3.0]
   foo(nil)
   foo(p)
   foo(&x)
@@ -86,7 +86,7 @@ You can call it as any of::
 
   var x: Float = 0.0, y: Int = 0
   var p: UnsafeMutablePointer<Float> = nil, q: UnsafeMutablePointer<Int> = nil
-  var a: Float[] = [1.0, 2.0, 3.0], b: Int = [1, 2, 3]
+  var a: [Float] = [1.0, 2.0, 3.0], b: Int = [1, 2, 3]
   bar(nil)
   bar(p)
   bar(q)

--- a/docs/proposals/valref.rst
+++ b/docs/proposals/valref.rst
@@ -290,7 +290,7 @@ type parameter, as follows::
 parameters::
 
   // Fill an array with independent copies of x
-  func fill<T:val>(array:T[], x:T) {
+  func fill<T:val>(array:[T], x:T) {
     for i in 0...array.length {
       array[i] = x
     }


### PR DESCRIPTION
I found some old-style array type annotations in documents. 
I replaced them to current style.
