### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::resolveTypeWitness(…)

### DIFF
--- a/validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{class A:a protocol a{typealias e:A}class A:A.e


### PR DESCRIPTION
Stack trace:

```
6  swift           0x0000000000e45801 swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 193
7  swift           0x000000000100e286 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
8  swift           0x000000000100e1c8 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
9  swift           0x000000000100e996 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
10 swift           0x0000000000e3da4e swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1070
12 swift           0x0000000000e6611e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000e67024 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000e6602a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
16 swift           0x0000000000e13b4a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
17 swift           0x0000000000e160a9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
21 swift           0x0000000000e6611e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
23 swift           0x0000000000e67024 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
24 swift           0x0000000000e6602a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
25 swift           0x0000000000ef64d2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
26 swift           0x0000000000ef575d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
27 swift           0x0000000000e127e9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
28 swift           0x0000000000e15d91 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
32 swift           0x0000000000e6611e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
34 swift           0x0000000000e67024 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
35 swift           0x0000000000e6602a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
36 swift           0x0000000000e13b4a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
37 swift           0x0000000000e160a9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1833
40 swift           0x0000000000e1b266 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
43 swift           0x0000000000e61aca swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
44 swift           0x0000000000e8dc9c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
45 swift           0x0000000000e006ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
47 swift           0x0000000000e61c16 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
48 swift           0x0000000000de780d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
49 swift           0x0000000000c9f042 swift::CompilerInstance::performSema() + 2946
51 swift           0x00000000007645a2 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2482
52 swift           0x000000000075f181 main + 2705
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28201-swift-typechecker-resolvetypewitness-0de291.o
1.  While type-checking expression at [validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift:7:1 - line:7:47] RangeText="{class A:a protocol a{typealias e:A}class A:A.e"
2.  While type-checking 'A' at validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift:7:2
3.  While resolving type a at [validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift:7:10 - line:7:10] RangeText="a"
4.  While resolving type A at [validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift:7:35 - line:7:35] RangeText="A"
5.  While resolving type A.e at [validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift:7:45 - line:7:47] RangeText="A.e"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
