### PR TITLE
[build-script] There can only be one host target

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -37,6 +37,7 @@ from SwiftBuildSupport import (
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 import swift_build_support.clang
 import swift_build_support.cmake
+import swift_build_support.targets
 from swift_build_support.migration import migrate_impl_args
 
 
@@ -287,6 +288,15 @@ to build Swift.  This is not a technical limitation of the Swift build system.
 It is a policy decision aimed at making the builds uniform across all
 environments and easily reproducible by engineers who are not familiar with the
 details of the setups of other systems or automated environments.""")
+
+    targets_group = parser.add_argument_group(
+        title="Host and cross-compilation targets.")
+    targets_group.add_argument(
+        "--host-target",
+        help="The host target. LLVM, Clang, and Swift will be built for this "
+             "target. The built LLVM and Clang will be used to compile Swift "
+             "for the cross-compilation targets.",
+        default=swift_build_support.targets.host_target())
 
     projects_group = parser.add_argument_group(
         title="Options to select projects")
@@ -541,7 +551,12 @@ the number of parallel build jobs to use""",
     args = parser.parse_args(migrate_impl_args(sys.argv[1:], [
         '--darwin-xcrun-toolchain',
         '--cmake',
+        '--host-target',
     ]))
+
+    if args.host_target is None:
+        print_with_argv0("Unknown operating system.")
+        return 1
 
     # Build cmark if any cmark-related options were specified.
     if (args.cmark_build_variant is not None):
@@ -772,6 +787,7 @@ the number of parallel build jobs to use""",
     build_script_impl_args = [
         os.path.join(SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl"),
         "--build-dir", build_dir,
+        "--host-target", args.host_target,
         "--host-cc", host_clang.cc,
         "--host-cxx", host_clang.cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -170,6 +170,7 @@ KNOWN_SETTINGS=(
     install-foundation          ""               "whether to install foundation"
     install-libdispatch         ""               "whether to install libdispatch"
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
+    host-target                 ""               "The host target. LLVM, Clang, and Swift will be built for this target. The built LLVM and Clang will be used to compile Swift for the cross-compilation targets. **This argument is required**"
     cross-compile-tools-deployment-targets ""    "space-separated list of targets to cross-compile host Swift tools for"
     skip-merge-lipo-cross-compile-tools ""       "set to skip running merge-lipo after installing cross-compiled host Swift tools"
     darwin-deployment-version-osx     "10.9"     "minimum deployment target version for OS X"
@@ -739,59 +740,10 @@ if [[ "$(uname -s)" == "Darwin" ]] ; then
     TOOLCHAIN_PREFIX=$(echo ${INSTALL_PREFIX} | sed -E 's/\/usr$//')
 fi
 
-# A list of deployment targets to compile the Swift host tools for, in cases
-# where we can run the resulting binaries natively on the build machine.
-NATIVE_TOOLS_DEPLOYMENT_TARGETS=()
 
 # A list of deployment targets to cross-compile the Swift host tools for.
 # We can't run the resulting binaries on the build machine.
 CROSS_TOOLS_DEPLOYMENT_TARGETS=()
-
-# Determine the native deployment target for the build machine, that will be
-# used to jumpstart the standard library build when cross-compiling.
-case "$(uname -s -m)" in
-    Linux\ x86_64)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "linux-x86_64"
-        )
-        ;;
-    Linux\ armv7*)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "linux-armv7"
-        )
-        ;;
-    Linux\ aarch64)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "linux-aarch64"
-        )
-        ;;
-    Linux\ ppc64)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "linux-powerpc64"
-        )
-        ;;
-    Linux\ ppc64le)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "linux-powerpc64le"
-        )
-        ;;
-    Darwin\ x86_64)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "macosx-x86_64"
-        )
-        ;;
-
-    FreeBSD\ amd64)
-        NATIVE_TOOLS_DEPLOYMENT_TARGETS=(
-            "freebsd-x86_64"
-        )
-        ;;
-
-    *)
-        echo "Unknown operating system"
-        exit 1
-        ;;
-esac
 
 # Sanitize the list of cross-compilation targets.
 for t in ${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS} ; do
@@ -1376,7 +1328,7 @@ fi
 # Configure and build each product
 #
 # Start with native deployment targets because the resulting tools are used during cross-compilation.
-for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
+for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
     set_deployment_target_based_options
 
     case "${COMPILER_VENDOR}" in
@@ -1561,11 +1513,10 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                     "${LLVM_SOURCE_DIR}"
                 )
                 if [[ $(is_cross_tools_deployment_target ${deployment_target}) ]] ; then
-                    # FIXME: don't hardcode macosx-x86_64.
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DLLVM_TABLEGEN=$(build_directory macosx-x86_64 llvm)/bin/llvm-tblgen
-                        -DCLANG_TABLEGEN=$(build_directory macosx-x86_64 llvm)/bin/clang-tblgen
+                        -DLLVM_TABLEGEN=$(build_directory "${HOST_TARGET}" llvm)/bin/llvm-tblgen
+                        -DCLANG_TABLEGEN=$(build_directory "${HOST_TARGET}" llvm)/bin/clang-tblgen
                     )
                 fi
 
@@ -1592,10 +1543,9 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                     build_perf_testsuite_this_time=false
                     build_tests_this_time=false
 
-                    # FIXME: don't hardcode macosx-x86_64.
-                    native_llvm_tools_path="$(build_directory macosx-x86_64 llvm)/bin"
-                    native_clang_tools_path="$(build_directory macosx-x86_64 llvm)/bin"
-                    native_swift_tools_path="$(build_directory macosx-x86_64 swift)/bin"
+                    native_llvm_tools_path="$(build_directory "${HOST_TARGET}" llvm)/bin"
+                    native_clang_tools_path="$(build_directory "${HOST_TARGET}" llvm)/bin"
+                    native_swift_tools_path="$(build_directory "${HOST_TARGET}" swift)/bin"
 
                     cmake_options=(
                         "${cmake_options[@]}"
@@ -2111,7 +2061,7 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
     done
 done
 
-for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
+for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
     set_deployment_target_based_options
 
     for product in "${PRODUCTS[@]}"; do

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -1,0 +1,43 @@
+# swift_build_support/targets.py - Build target helpers -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import platform
+
+
+def host_target():
+    """
+    Return the build target for the current host machine, if it is one of the
+    recognized targets. Otherwise, return None.
+    """
+    system = platform.system()
+    machine = platform.machine()
+
+    if system == 'Linux':
+        if machine == 'x86_64':
+            return 'linux-x86_64'
+        elif machine.startswith('armv7'):
+            # linux-armv7* is canonicalized to 'linux-armv7'
+            return 'linux-armv7'
+        elif machine == 'aarch64':
+            return 'linux-aarch64'
+        elif machine == 'ppc64':
+            return 'linux-powerpc64'
+        elif machine == 'ppc64le':
+            return 'linux-powerpc64le'
+
+    elif system == 'Darwin':
+        if machine == 'x86_64':
+            return 'macosx-x86_64'
+
+    elif system == 'FreeBSD':
+        if machine == 'amd64':
+            return 'freebsd-x86_64'
+
+    return None

--- a/utils/swift_build_support/tests/test_targets.py
+++ b/utils/swift_build_support/tests/test_targets.py
@@ -1,0 +1,22 @@
+# test_targets.py - Unit tests for swift_build_support.targets -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import unittest
+
+from swift_build_support.targets import host_target
+
+
+class HostTargetTestCase(unittest.TestCase):
+    def test_is_not_none_on_this_platform(self):
+        self.assertIsNotNone(host_target())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What's in this pull request?

`build-script-impl` currently maintains a list of `NATIVE_TOOLS_DEPLOYMENT_TARGETS` -- host machine targets, for which the resulting binaries can be run on the current machine.

However, there is only ever _one_ host machine. This commit:
- Changes the `NATIVE_TOOLS_DEPLOYMENT_TARGETS` list parameter into a single string parameter, `HOST_TARGET`.
- Promotes the logic to detect the host target to Python, and places it in the `swift_build_support` module.
- Removes the hard-coded "macosx_x86_64" path to the LLVM and Clang TableGen -- thereby unblocking future work to make cross-compilation possible on platforms other than OS X.
- Also promotes cross-compilation target validation to Python, placing it in the `swift_build_support` module.
## Why merge this pull request?
1. It continues work on [SR-237](https://bugs.swift.org/browse/SR-237) by pulling more of the `build-script-impl` logic out of the shellscript and into Python.
2. It removes hardcoded "macosx-x86-64" parameters from the build script. This is useful if we ever want the build script to allow cross-compilation from host machines other than OS X--which I think is indeed something we do want in the near future.
## What downsides are there to merging this pull request?
- It changes `NATIVE_TOOLS_DEPLOYMENT_TARGETS` from a list to a single element. I don't think there is any need multiple host targets, but I may be misunderstanding something.
