### PR TITLE
Revert "[Parser] Fix-it for declaration attributes being applied to parameter types (SR-215)"

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -235,21 +235,6 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       if (Tok.is(tok::colon)) {
         param.ColonLoc = consumeToken();
 
-        // Check if token is @ sign ergo an attribute
-        if (Tok.is(tok::at_sign)) {
-          Token nextToken = peekToken();
-          // Check if attribute is invalid type attribute
-          // and actually a declaration attribute
-          if (TypeAttributes::getAttrKindFromString(nextToken.getText()) == TAK_Count 
-              && DeclAttribute::getAttrKindFromString(nextToken.getText()) != DAK_Count) { 
-            SourceLoc AtLoc = consumeToken(tok::at_sign);
-            SourceLoc AttrLoc = consumeToken(tok::identifier);
-            diagnose(AtLoc, diag::decl_attribute_applied_to_type)
-              .fixItRemove(SourceRange(AtLoc, AttrLoc))
-              .fixItInsert(StartLoc, "@" + nextToken.getText().str()+" ");
-          }
-        }
-
         auto type = parseType(diag::expected_parameter_type);
         status |= type;
         param.Type = type.getPtrOrNull();

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -2,8 +2,6 @@
 
 @noescape var fn : () -> Int = { 4 }  // expected-error {{@noescape may only be used on 'parameter' declarations}} {{1-11=}}
 
-func appliedToType(g: @noescape ()->Void) { g() }  // expected-error {{attribute can only be applied to declarations, not types}} {{20-20=@noescape }} {{23-33=}}
-
 func doesEscape(fn : () -> Int) {}
 
 func takesGenericClosure<T>(a : Int, @noescape _ fn : () -> T) {}


### PR DESCRIPTION
Reverts apple/swift#673, it caused test failures.
