### PR TITLE
[SR-510][Parser] complain for invalid enum raw value

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -584,8 +584,6 @@ ERROR(throw_in_function_type,type_parsing,none,
 // Enum Types
 ERROR(expected_expr_enum_case_raw_value,type_parsing,PointsToFirstBadToken,
       "expected expression after '=' in 'case'", ())
-ERROR(not_a_proper_raw_value_expression,type_parsing,none,
-      "not a proper raw value expression", ())
 ERROR(nonliteral_enum_case_raw_value,type_parsing,PointsToFirstBadToken,
       "raw value for enum case must be a literal", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -584,6 +584,8 @@ ERROR(throw_in_function_type,type_parsing,none,
 // Enum Types
 ERROR(expected_expr_enum_case_raw_value,type_parsing,PointsToFirstBadToken,
       "expected expression after '=' in 'case'", ())
+ERROR(not_a_proper_raw_value_expression,type_parsing,none,
+      "not a proper raw value expression", ())
 ERROR(nonliteral_enum_case_raw_value,type_parsing,PointsToFirstBadToken,
       "raw value for enum case must be a literal", ())
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4404,6 +4404,7 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         return Status;
       }
       if (RawValueExpr.isNull()) {
+        diagnose(EqualsLoc, diag::not_a_proper_raw_value_expression);
         Status.setIsParseError();
         return Status;
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4390,6 +4390,7 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     
     // See if there's a raw value expression.
     SourceLoc EqualsLoc;
+    auto NextLoc = peekToken().getLoc();
     ParserResult<Expr> RawValueExpr;
     LiteralExpr *LiteralRawValueExpr = nullptr;
     if (Tok.is(tok::equal)) {
@@ -4404,7 +4405,7 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         return Status;
       }
       if (RawValueExpr.isNull()) {
-        diagnose(EqualsLoc, diag::not_a_proper_raw_value_expression);
+        diagnose(NextLoc, diag::not_a_proper_raw_value_expression);
         Status.setIsParseError();
         return Status;
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4405,7 +4405,7 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         return Status;
       }
       if (RawValueExpr.isNull()) {
-        diagnose(NextLoc, diag::not_a_proper_raw_value_expression);
+        diagnose(NextLoc, diag::nonliteral_enum_case_raw_value);
         Status.setIsParseError();
         return Status;
       }

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -290,5 +290,9 @@ func testSimpleEnum() {
   let _ : SimpleEnum=.X    // expected-error {{'=' must have consistent whitespace on both sides}}
 }
 
+enum SR510: String {
+    case Thing = "thing"
+    case Bob = {"test"} // expected-error {{not a proper raw value expression}}
+}
 
 


### PR DESCRIPTION
Instead of fail silently, issue a diagosis when a valid expression can not
be parsed for enum raw value.

Resolves [SR-510](https://bugs.swift.org/browse/SR-510).
