### PR TITLE
[SR-533] Improve C-style for fixits by also removing 'var' keyword from loop var decl.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1820,6 +1820,7 @@ static void checkCStyleForLoop(TypeChecker &TC, const ForStmt *FS) {
   SourceLoc endOfIncrementLoc = Lexer::getLocForEndOfToken(TC.Context.SourceMgr, FS->getIncrement().getPtrOrNull()->getEndLoc());
     
   diagnostic
+   .fixItRemoveChars(loopVarDecl->getLoc(), loopVar->getLoc())
    .fixItReplaceChars(loopPatternEnd, startValue->getStartLoc(), " in ")
    .fixItReplaceChars(FS->getFirstSemicolonLoc(), endValue->getStartLoc(), " ..< ")
    .fixItRemoveChars(FS->getSecondSemicolonLoc(), endOfIncrementLoc);

--- a/test/Sema/diag_c_style_for.swift
+++ b/test/Sema/diag_c_style_for.swift
@@ -1,19 +1,19 @@
 // RUN: %target-parse-verify-swift
 
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for var a = 0; a < 10; a++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-13= in }} {{14-20= ..< }} {{22-27=}}
+for var a = 0; a < 10; a++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{5-9=}} {{10-13= in }} {{14-20= ..< }} {{22-27=}}
 }
 
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for var b = 0; b < 10; ++b { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-13= in }} {{14-20= ..< }} {{22-27=}}
+for var b = 0; b < 10; ++b { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{5-9=}} {{10-13= in }} {{14-20= ..< }} {{22-27=}}
 }
 
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for var c=1;c != 5 ;++c { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-11= in }} {{12-18= ..< }} {{20-24=}}
+for var c=1;c != 5 ;++c { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{5-9=}} {{10-11= in }} {{12-18= ..< }} {{20-24=}}
 }
 
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for var d=100;d<5;d++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-11= in }} {{14-17= ..< }} {{18-22=}}
+for var d=100;d<5;d++ { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{5-9=}} {{10-11= in }} {{14-17= ..< }} {{18-22=}}
 }
 
 // next three aren't auto-fixable
@@ -35,7 +35,7 @@ for ; other<count; other++ { // expected-warning {{C-style for statement is depr
 
 // this should be fixable, and keep the type
 // expected-warning @+1 {{'++' is deprecated: it will be removed in Swift 3}}
-for (var number : Int8 = start; number < count; number++) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{23-26= in }} {{31-42= ..< }} {{47-57=}}
+for (var number : Int8 = start; number < count; number++) { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{6-10=}} {{23-26= in }} {{31-42= ..< }} {{47-57=}}
   print(number)
 }
 
@@ -45,7 +45,7 @@ for (var m : Int8 = start; m < count; ++m) { // expected-warning {{C-style for s
   m += 3
 }
 
-for var o = 2; o < 888; o += 1 { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{10-13= in }} {{14-20= ..< }} {{23-31=}}
+for var o = 2; o < 888; o += 1 { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{5-9=}} {{10-13= in }} {{14-20= ..< }} {{23-31=}}
 }
 
 for var o = 2; o < 888; o += 11 { // expected-warning {{C-style for statement is deprecated and will be removed in a future version of Swift}} {{none}}


### PR DESCRIPTION
Sorry I missed this part originally! You’d get to the correct code eventually because after switching to a for/in the next compile would suggest replacing the ‘var’ with ‘let’ and then the ‘let’ with nothing, but better to save a couple steps.
