### PR TITLE
[SR-589] Plumbing for dynamic instantiation of generic types

### DIFF
--- a/docs/ABI.rst
+++ b/docs/ABI.rst
@@ -647,8 +647,14 @@ layout is as follows:
   * For each type parameter **n**, the following fields are stored:
 
     + The **number of witnesses** for the type parameter is stored at
-      **offset 10+n**. This is the number of witness table pointers that are
-      stored for the type parameter in the generic parameter vector.
+      **offset 10+p**. This is the number of witness table pointers that are
+      stored for the type parameter in the generic parameter vector. The
+      inner offset **p** is advanced by **1+w** for each parameter, where
+      **w** is the number of witness tables for the type. This accounts for
+      the variable length protocol descriptor references below.
+    + For each type parameter with protocol contraints that require a witness
+      table, **n** references to the **protocol descriptors**. References are
+      stored as an offset relative to the start of the nominal type descriptor.
 
 Note that there is no nominal type descriptor for protocols or protocol types.
 See the `protocol descriptor`_ description below.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2270,8 +2270,6 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(CanType concreteType,
   if (!section.empty())
     var->setSection(section);
 
-  // Keep type metadata around for all types, although the runtime can currently
-  // only perform name lookup of non-generic types.
   addRuntimeResolvableType(concreteType);
 
   // For metadata patterns, we're done.
@@ -2477,15 +2475,15 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   return result;
 }
 
-/// Return the address of a nominal type descriptor.  Right now, this
-/// must always be for purposes of defining it.
+/// Return the address of a nominal type descriptor.
 llvm::Constant *IRGenModule::getAddrOfNominalTypeDescriptor(NominalTypeDecl *D,
                                                   llvm::Type *definitionType) {
-  assert(definitionType && "not defining nominal type descriptor?");
   auto entity = LinkEntity::forNominalTypeDescriptor(D);
-  return getAddrOfLLVMVariable(entity, getPointerAlignment(),
-                               definitionType, definitionType,
-                               DebugTypeInfo());
+  DebugTypeInfo DbgTy(D->getDeclaredType(), NominalTypeDescriptorPtrTy,
+                      getPointerSize(), getPointerAlignment(),
+                      nullptr);
+  return getAddrOfLLVMVariable(entity, getPointerAlignment(), definitionType,
+                               NominalTypeDescriptorPtrTy, DbgTy);
 }
 
 llvm::Constant *IRGenModule::getAddrOfProtocolDescriptor(ProtocolDecl *D,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -839,6 +839,10 @@ public:
   /// the binary.
   void setTrueConstGlobal(llvm::GlobalVariable *var);
 
+  std::pair<llvm::Constant *, DirectOrGOT>
+  getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity, Alignment alignment,
+                                       llvm::Type *defaultType);
+
 private:
   llvm::Constant *getAddrOfLLVMVariable(LinkEntity entity,
                                         Alignment alignment,
@@ -850,10 +854,6 @@ private:
                                         ForDefinition_t forDefinition,
                                         llvm::Type *defaultType,
                                         DebugTypeInfo debugType);
-
-  std::pair<llvm::Constant *, DirectOrGOT>
-  getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity, Alignment alignment,
-                                       llvm::Type *defaultType);
 
   void emitLazyPrivateDefinitions();
   void addRuntimeResolvableType(CanType type);

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -27,7 +27,6 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
   set(swift_runtime_objc_sources
       ErrorObject.mm
       SwiftObject.mm
-      Remangle.cpp
       Reflection.mm)
 else()
 endif()
@@ -46,6 +45,7 @@ add_swift_library(swiftRuntime IS_STDLIB IS_STDLIB_CORE
   Once.cpp
   ProtocolConformance.cpp
   Reflection.cpp
+  Remangle.cpp
   SwiftObject.cpp
   ${swift_runtime_objc_sources}
   ${swift_runtime_leaks_sources}

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1474,9 +1474,9 @@ static void _swift_initializeSuperclass(ClassMetadata *theClass,
     if (genericParams.hasGenericParams()) {
       unsigned numParamWords = 0;
       for (unsigned i = 0; i < genericParams.NumParams; ++i) {
+        auto param = genericParams.getParameterAt(i);
         // 1 word for the type metadata, and 1 for every protocol witness
-        numParamWords +=
-            1 + genericParams.Parameters[i].NumWitnessTables;
+        numParamWords += 1 + param->NumWitnessTables;
       }
       memcpy(classWords + genericParams.Offset,
              superWords + genericParams.Offset,

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/Demangle.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Compiler.h"
 
 namespace swift {
@@ -112,12 +113,14 @@ namespace swift {
   void installCommonValueWitnesses(ValueWitnessTable *vwtable);
 
   const Metadata *
-  _matchMetadataByMangledTypeName(const llvm::StringRef metadataNameRef,
-                                  const Metadata *metadata,
-                                  const NominalTypeDescriptor *ntd);
-
-  const Metadata *
-  _searchConformancesByMangledTypeName(const llvm::StringRef typeName);
+  _iterateConformances(
+    const llvm::StringRef name,
+    const Demangle::NodePointer node,
+    llvm::function_ref<const Metadata *(const llvm::StringRef,
+                                        const Demangle::NodePointer,
+                                        const Metadata *,
+                                        const NominalTypeDescriptor *
+                                        )> match);
 
 #if SWIFT_OBJC_INTEROP
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type);

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -64,8 +64,12 @@ import Builtin
 // CHECK:   i32 add ({{.*}}@_TMPV15generic_structs23DynamicWithRequirements{{.*}}, i32 1)
 // --       generic parameter vector offset
 // CHECK:   i32 5,
-// --       generic parameter count; primary count; generic parameter witness counts
-// CHECK:   i32 3, i32 2, i32 1, i32 1, i32 0
+// --       generic parameter count; primary count;
+// CHECK:   i32 3, i32 2,
+//          generic parameter witness counts and protocols
+// CHECK:   i32 1, i32 trunc (i64 sub (i64 ptrtoint (%swift.protocol* @_TMp15generic_structs4Req1 to i64), i64 add (i64 ptrtoint ({{.*}}* @_TMnV15generic_structs23DynamicWithRequirements to i64), i64 40)) to i32),
+// CHECK:   i32 1, i32 trunc (i64 sub (i64 ptrtoint (%swift.protocol* @_TMp15generic_structs4Req2 to i64), i64 add (i64 ptrtoint ({{.*}}* @_TMnV15generic_structs23DynamicWithRequirements to i64), i64 48)) to i32),
+// CHECK:   i32 0
 // CHECK: }
 
 // CHECK: @_TMPV15generic_structs23DynamicWithRequirements = global { {{.*}}* } {


### PR DESCRIPTION
This extends b5880f38 with the infrastructure necessary to dynamically instantiate generic types by name. In order to do so it extends GenericParameterDescriptor::Parameter with a list of ProtocolDescriptors for primary associated type requirements.

Some notes:
- This is "plumbing" as we have not defined a Swift API yet to lookup anything beyond a top-level non-generic class. The test suite uses private API taking a mangled type name in order to exercise this path.
- There is no support for associated types, i.e. where NumParams != NumPrimaryParams. Still investigating how to implement this.
- A recursive lock is used on the protocol conformance table, this may be unacceptable.
