### PR TITLE
[gardening] Conform to LLVM comment formatting guidelines. Avoid multi-line C-style comments. 

### DIFF
--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -77,11 +77,10 @@ EnumPayload EnumPayload::fromBitPattern(IRGenModule &IGM,
   return result;
 }
 
-template<typename Fn /* void(LazyValue &payloadValue,
-                             unsigned payloadBitWidth,
-                             unsigned payloadValueOffset,
-                             unsigned valueBitWidth,
-                             unsigned valueOffset) */>
+// Fn: void(LazyValue &payloadValue, unsigned payloadBitWidth,
+//          unsigned payloadValueOffset, unsigned valueBitWidth,
+//          unsigned valueOffset)
+template<typename Fn>
 static void withValueInPayload(IRGenFunction &IGF,
                                const EnumPayload &payload,
                                llvm::Type *valueType,

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -77,10 +77,9 @@ namespace {
       return getFixedBufferAlignment(IGM);
     }
 
-    /*
-    friend bool operator==(ExistentialLayout a, ExistentialLayout b) {
-      return a.NumTables == b.NumTables;
-    }*/
+    // friend bool operator==(ExistentialLayout a, ExistentialLayout b) {
+    //   return a.NumTables == b.NumTables;
+    // }
 
     /// Given the address of an existential object, drill down to the
     /// buffer.

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -149,8 +149,8 @@ irgen::emitTypeLayoutVerifier(IRGenFunction &IGF,
       
       // Verify that the extra inhabitant representations are consistent.
       
-      /* TODO: Update for EnumPayload implementation changes.
-      
+      // TODO: Update for EnumPayload implementation changes.
+#if 0
       auto xiBuf = IGF.createAlloca(fixedTI->getStorageType(),
                                     fixedTI->getFixedAlignment(),
                                     "extra-inhabitant");
@@ -212,7 +212,7 @@ irgen::emitTypeLayoutVerifier(IRGenFunction &IGF,
                llvm::Twine("extra inhabitant index calculation ")
                  + numberBuf.str());
       }
-       */
+#endif
     }
 
     // TODO: Verify interesting layout properties specific to the kind of type,

--- a/lib/SIL/Verifier.cpp
+++ b/lib/SIL/Verifier.cpp
@@ -1677,8 +1677,9 @@ public:
             || !isa<ExtensionDecl>(CMI->getMember().getDecl()->getDeclContext()),
             "extension method cannot be dispatched natively");
     
-    /* TODO: We should enforce that ObjC methods are dispatched on ObjC
-       metatypes, but IRGen appears not to care right now.
+    // TODO: We should enforce that ObjC methods are dispatched on ObjC
+    // metatypes, but IRGen appears not to care right now.
+#if 0
     if (auto metaTy = operandType.getAs<AnyMetatypeType>()) {
       bool objcMetatype
         = metaTy->getRepresentation() == MetatypeRepresentation::ObjC;
@@ -1686,7 +1687,7 @@ public:
       require(objcMetatype == objcMethod,
               "objc class methods must be invoked on objc metatypes");
     }
-     */
+#endif
   }
 
   void checkSuperMethodInst(SuperMethodInst *CMI) {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1683,12 +1683,11 @@ SILGenModule::emitProtocolWitness(ProtocolConformance *conformance,
   // Lower the witness type with the requirement's abstraction level.
   // FIXME: We should go through TypeConverter::getLoweredType once we settle
   // on interface types.
-  /*
-  SILType witnessSILType = Types.getLoweredType(
-                                              AbstractionPattern(requirementTy),
-                                              witnessSubstTy,
-                                              requirement.uncurryLevel);
-   */
+
+  // SILType witnessSILType = Types.getLoweredType(
+  //                                          AbstractionPattern(requirementTy),
+  //                                          witnessSubstTy,
+  //                                          requirement.uncurryLevel);
   SILType witnessSILType = getWitnessFunctionType(M,
                                               AbstractionPattern(requirementTy),
                                               witnessSubstTy,

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1576,10 +1576,9 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
       InitType = solution.simplifyType(tc, InitType);
 
       // Convert the initializer to the type of the pattern.
+      // ignoreTopLevelInjection = Binding->isConditional()
       expr = solution.coerceToType(expr, InitType, Locator,
-                                   false
-                                   /*ignoreTopLevelInjection=
-                                     Binding->isConditional()*/);
+                                   false /* ignoreTopLevelInjection */);
       if (!expr) {
         return nullptr;
       }

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
@@ -17,14 +17,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-/**
- * \brief The version constants for the sourcekitd API.
- * SOURCEKITD_VERSION_MINOR should increase when there are API additions.
- * SOURCEKITD_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
- *
- * The policy about the sourcekitd API is to keep it source and ABI compatible,
- * thus SOURCEKITD_VERSION_MAJOR is expected to remain stable.
- */
+/// \brief The version constants for the sourcekitd API.
+/// SOURCEKITD_VERSION_MINOR should increase when there are API additions.
+/// SOURCEKITD_VERSION_MAJOR is intended for "major" source/ABI breaking
+/// changes.
+///
+/// The policy about the sourcekitd API is to keep it source and ABI compatible,
+/// thus SOURCEKITD_VERSION_MAJOR is expected to remain stable.
 #define SOURCEKITD_VERSION_MAJOR 0
 #define SOURCEKITD_VERSION_MINOR 3
 
@@ -88,30 +87,26 @@
 
 SOURCEKITD_BEGIN_DECLS
 
-/**
- * \brief Initializes structures needed across the rest of the sourcekitd API.
- *
- * Must be called before any other sourcekitd call.
- * Can be called multiple times as long as it is matched with a
- * \c sourcekitd_shutdown call.
- * Calling \c sourcekitd_initialize a second time without an intervening
- * \c sourcekitd_shutdown is undefined.
- * \c sourcekitd_initialize does not need to be called again even if the service
- * crashes.
- */
+/// \brief Initializes structures needed across the rest of the sourcekitd API.
+///
+/// Must be called before any other sourcekitd call.
+/// Can be called multiple times as long as it is matched with a
+/// \c sourcekitd_shutdown call.
+/// Calling \c sourcekitd_initialize a second time without an intervening
+/// \c sourcekitd_shutdown is undefined.
+/// \c sourcekitd_initialize does not need to be called again even if the
+/// service crashes.
 SOURCEKITD_PUBLIC
 void
 sourcekitd_initialize(void);
 
-/**
- * \brief Deallocates structures needed across the rest of the sourcekitd API.
- *
- * If there are response handlers still waiting for a response, they will
- * receive a SOURCEKITD_ERROR_REQUEST_CANCELLED response.
- *
- * Calling \c sourcekitd_shutdown without a matching \c sourcekitd_initialize is
- * undefined.
- */
+/// \brief Deallocates structures needed across the rest of the sourcekitd API.
+///
+/// If there are response handlers still waiting for a response, they will
+/// receive a SOURCEKITD_ERROR_REQUEST_CANCELLED response.
+///
+/// Calling \c sourcekitd_shutdown without a matching \c sourcekitd_initialize
+/// is undefined.
 SOURCEKITD_PUBLIC
 void
 sourcekitd_shutdown(void);
@@ -120,19 +115,17 @@ sourcekitd_shutdown(void);
 
 typedef void(^sourcekitd_interrupted_connection_handler_t)(void);
 
-/**
- * \brief Sets the handler which should be called whenever the connection to
- * SourceKit is interrupted.
- *
- * The handler should reestablish any necessary state, such as re-opening any
- * documents which were open before the connection was interrupted.
- *
- * It is not necessary to call \c sourcekitd_initialize; the connection will
- * automatically be reestablished when sending the next request.
- *
- * \param handler Interrupted connection handler to use. Pass NULL to remove the
- * handler.
- */
+/// \brief Sets the handler which should be called whenever the connection to
+/// SourceKit is interrupted.
+///
+/// The handler should reestablish any necessary state, such as re-opening any
+/// documents which were open before the connection was interrupted.
+///
+/// It is not necessary to call \c sourcekitd_initialize; the connection will
+/// automatically be reestablished when sending the next request.
+///
+/// \param handler Interrupted connection handler to use. Pass NULL to remove
+/// the handler.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL
 void
 sourcekitd_set_interrupted_connection_handler(
@@ -140,53 +133,39 @@ sourcekitd_set_interrupted_connection_handler(
 
 #endif
 
-/**
- * \brief A "unique identifier" utilized by the request/response protocol.
- *
- * A \c sourcekitd_uid_t object is associated with a string and is uniqued for
- * the lifetime of the process. Its usefulness is in providing an "infinite
- * namespace" of identifiers.
- * A \c sourcekitd_uid_t object remains valid even if the service crashes.
- */
+/// \brief A "unique identifier" utilized by the request/response protocol.
+///
+/// A \c sourcekitd_uid_t object is associated with a string and is uniqued for
+/// the lifetime of the process. Its usefulness is in providing an "infinite
+/// namespace" of identifiers.
+/// A \c sourcekitd_uid_t object remains valid even if the service crashes.
 typedef struct sourcekitd_uid_s *sourcekitd_uid_t;
 
-/**
- * \brief Create a \c sourcekitd_uid_t from a C string.
- */
+/// \brief Create a \c sourcekitd_uid_t from a C string.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 sourcekitd_uid_t
 sourcekitd_uid_get_from_cstr(const char *string);
 
-/**
- * \brief Create a \c sourcekitd_uid_t from a string buffer.
- */
+/// \brief Create a \c sourcekitd_uid_t from a string buffer.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 sourcekitd_uid_t
 sourcekitd_uid_get_from_buf(const char *buf, size_t length);
 
-/**
- * \brief Get the length of the string associated with  a \c sourcekitd_uid_t.
- */
+/// \brief Get the length of the string associated with  a \c sourcekitd_uid_t.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 size_t
 sourcekitd_uid_get_length(sourcekitd_uid_t obj);
 
-/**
- * \brief Get the C string pointer associated with a \c sourcekitd_uid_t.
- */
+/// \brief Get the C string pointer associated with a \c sourcekitd_uid_t.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 const char *
 sourcekitd_uid_get_string_ptr(sourcekitd_uid_t obj);
 
-/**
- * \defgroup Request API
- *
- * @{
- */
-
-/**
- * \brief Used for constructing a request object.
- */
+/// \defgroup Request API
+///
+/// @{
+///
+/// \brief Used for constructing a request object.
 typedef void *sourcekitd_object_t;
 
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
@@ -276,63 +255,49 @@ SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 sourcekitd_object_t
 sourcekitd_request_uid_create(sourcekitd_uid_t uid);
 
-/**
- * \brief Creates a request object by parsing the provided string in YAML
- * format.
- *
- * \param yaml The string in YAML format.
- *
- * \param error A pointer to store a C string of the error description if
- * parsing fails. This string should be disposed of with \c free when done.
- * Can be NULL.
- *
- * \returns A sourcekitd_object_t instance or NULL if parsing fails.
- */
+/// \brief Creates a request object by parsing the provided string in YAML
+/// format.
+///
+/// \param yaml The string in YAML format.
+///
+/// \param error A pointer to store a C string of the error description if
+/// parsing fails. This string should be disposed of with \c free when done.
+/// Can be NULL.
+///
+/// \returns A sourcekitd_object_t instance or NULL if parsing fails.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 sourcekitd_object_t
 sourcekitd_request_create_from_yaml(const char *yaml, char **error);
 
-/**
- * \brief Prints to stderr a string representation of the request object in YAML
- * format.
- */
+/// \brief Prints to stderr a string representation of the request object in
+/// YAML format.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 void
 sourcekitd_request_description_dump(sourcekitd_object_t obj);
 
-/**
- * \brief Copies a string representation of the request object in YAML format.
- * \returns A string representation of the request object. This string should
- * be disposed of with \c free when done.
- */
+/// \brief Copies a string representation of the request object in YAML format.
+/// \returns A string representation of the request object. This string should
+/// be disposed of with \c free when done.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 char *
 sourcekitd_request_description_copy(sourcekitd_object_t obj);
 
-/**
- * @}
- */
+/// @}
 
-/**
- * \defgroup Response API
- *
- * @{
- */
+/// \defgroup Response API
+///
+/// @{
 
-/**
- * \brief The result of a request.
- *
- * If the request failed \c sourcekitd_response_t will be an error response and
- * will contain information about the error, otherwise it will contain the
- * resulting values of the request.
- */
+/// \brief The result of a request.
+///
+/// If the request failed \c sourcekitd_response_t will be an error response and
+/// will contain information about the error, otherwise it will contain the
+/// resulting values of the request.
 typedef void *sourcekitd_response_t;
 
-/**
- * \brief A value of the response object.
- *
- * Its lifetime is tied to the sourcekitd_response_t object that it came from.
- */
+/// \brief A value of the response object.
+///
+/// Its lifetime is tied to the sourcekitd_response_t object that it came from.
 typedef struct {
   uint64_t data[3];
 } sourcekitd_variant_t;
@@ -358,38 +323,30 @@ SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 void
 sourcekitd_response_dispose(sourcekitd_response_t obj);
 
-/**
- * \brief Returns true if the given response is an error.
- */
+/// \brief Returns true if the given response is an error.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 bool
 sourcekitd_response_is_error(sourcekitd_response_t obj);
 
-/**
- * \brief Returns the error kind given a response error.
- *
- * Passing a response object that is not an error will result in undefined
- * behavior.
- */
+/// \brief Returns the error kind given a response error.
+///
+/// Passing a response object that is not an error will result in undefined
+/// behavior.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 sourcekitd_error_t
 sourcekitd_response_error_get_kind(sourcekitd_response_t err);
 
-/**
- * \brief Returns a C string of the error description.
- *
- * Passing a response object that is not an error will result in undefined
- * behavior.
- */
+/// \brief Returns a C string of the error description.
+///
+/// Passing a response object that is not an error will result in undefined
+/// behavior.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 const char *
 sourcekitd_response_error_get_description(sourcekitd_response_t err);
 
-/**
- * \brief Returns the value contained in the response.
- *
- * If the response is an error it will return a null variant.
- */
+/// \brief Returns the value contained in the response.
+///
+/// If the response is an error it will return a null variant.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 sourcekitd_variant_t
 sourcekitd_response_get_value(sourcekitd_response_t resp);
@@ -403,90 +360,75 @@ sourcekitd_variant_t
 sourcekitd_variant_dictionary_get_value(sourcekitd_variant_t dict,
                                         sourcekitd_uid_t key);
 
-/**
- * The underlying C string for the specified key. NULL if the value for the
- * specified key is not a C string value or if there is no value for the
- * specified key.
- */
+/// The underlying C string for the specified key. NULL if the value for the
+/// specified key is not a C string value or if there is no value for the
+/// specified key.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 const char *
 sourcekitd_variant_dictionary_get_string(sourcekitd_variant_t dict,
                                          sourcekitd_uid_t key);
 
-/**
- * The underlying \c int64 value for the specified key. 0 if the
- * value for the specified key is not an integer value or if there is no
- * value for the specified key.
- */
+/// The underlying \c int64 value for the specified key. 0 if the
+/// value for the specified key is not an integer value or if there is no
+/// value for the specified key.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 int64_t
 sourcekitd_variant_dictionary_get_int64(sourcekitd_variant_t dict,
                                         sourcekitd_uid_t key);
 
-/**
- * The underlying \c bool value for the specified key. false if the
- * the value for the specified key is not a Boolean value or if there is no
- * value for the specified key.
- */
+/// The underlying \c bool value for the specified key. false if the
+/// the value for the specified key is not a Boolean value or if there is no
+/// value for the specified key.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 bool
 sourcekitd_variant_dictionary_get_bool(sourcekitd_variant_t dict,
                                        sourcekitd_uid_t key);
 
-/**
- * The underlying \c sourcekitd_uid_t value for the specified key. NULL if the
- * value for the specified key is not a uid value or if there is no
- * value for the specified key.
- */
+/// The underlying \c sourcekitd_uid_t value for the specified key. NULL if the
+/// value for the specified key is not a uid value or if there is no
+/// value for the specified key.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 sourcekitd_uid_t
 sourcekitd_variant_dictionary_get_uid(sourcekitd_variant_t dict,
                                       sourcekitd_uid_t key);
 
 #if SOURCEKITD_HAS_BLOCKS
-/**
- * \brief A block to be invoked for every key/value pair in the dictionary.
- *
- * \param key The current key in the iteration.
- *
- * \param value The current value in the iteration.
- *
- * \returns true to indicate that iteration should continue.
- */
+/// \brief A block to be invoked for every key/value pair in the dictionary.
+///
+/// \param key The current key in the iteration.
+///
+/// \param value The current value in the iteration.
+///
+/// \returns true to indicate that iteration should continue.
 typedef bool (^sourcekitd_variant_dictionary_applier_t)(sourcekitd_uid_t key,
                                                     sourcekitd_variant_t value);
 
-/**
- * \brief Invokes the given block for every key/value pair in the dictionary.
- *
- * \returns true to indicate that iteration of the dictionary completed
- * successfully. Iteration will only fail if the applier block returns false.
- */
+/// \brief Invokes the given block for every key/value pair in the dictionary.
+///
+/// \returns true to indicate that iteration of the dictionary completed
+/// successfully. Iteration will only fail if the applier block returns false.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL
 bool
 sourcekitd_variant_dictionary_apply(sourcekitd_variant_t dict,
                                sourcekitd_variant_dictionary_applier_t applier);
 #endif
 
-/**
- * \brief A function to be invoked for every key/value pair in the dictionary.
- *
- * \param key The current key in the iteration.
- *
- * \param value The current value in the iteration.
- *
- * \returns true to indicate that iteration should continue.
- */
+/// \brief A function to be invoked for every key/value pair in the dictionary.
+///
+/// \param key The current key in the iteration.
+///
+/// \param value The current value in the iteration.
+///
+/// \returns true to indicate that iteration should continue.
 typedef bool (*sourcekitd_variant_dictionary_applier_f_t)(sourcekitd_uid_t key,
                                                     sourcekitd_variant_t value,
                                                     void *context);
 
-/**
- * \brief Invokes the given function for every key/value pair in the dictionary.
- *
- * \returns true to indicate that iteration of the dictionary completed
- * successfully. Iteration will only fail if the applier block returns 0.
- */
+/// \brief Invokes the given function for every key/value pair in the
+/// dictionary.
+///
+/// \returns true to indicate that iteration of the dictionary completed
+/// successfully. Iteration will only fail if the applier block returns 0.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL2
 bool
 sourcekitd_variant_dictionary_apply_f(sourcekitd_variant_t dict,
@@ -518,49 +460,41 @@ sourcekitd_uid_t
 sourcekitd_variant_array_get_uid(sourcekitd_variant_t array, size_t index);
 
 #if SOURCEKITD_HAS_BLOCKS
-/**
- * \brief A block to be invoked for every value in the array.
- *
- * \param index The current index in the iteration.
- *
- * \param value The current value in the iteration.
- *
- * \returns true to indicate that iteration should continue.
- */
+/// \brief A block to be invoked for every value in the array.
+///
+/// \param index The current index in the iteration.
+///
+/// \param value The current value in the iteration.
+///
+/// \returns true to indicate that iteration should continue.
 typedef bool (^sourcekitd_variant_array_applier_t)(size_t index,
                                                    sourcekitd_variant_t value);
 
-/**
- * \brief Invokes the given block for every value in the array.
- *
- * \returns true to indicate that iteration of the array completed
- * successfully. Iteration will only fail if the applier block returns false.
- */
+/// \brief Invokes the given block for every value in the array.
+///
+/// \returns true to indicate that iteration of the array completed
+/// successfully. Iteration will only fail if the applier block returns false.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL
 bool
 sourcekitd_variant_array_apply(sourcekitd_variant_t array,
                                sourcekitd_variant_array_applier_t applier);
 #endif
 
-/**
- * \brief A function to be invoked for every value in the array.
- *
- * \param index The current index in the iteration.
- *
- * \param value The current value in the iteration.
- *
- * \returns true to indicate that iteration should continue.
- */
+/// \brief A function to be invoked for every value in the array.
+///
+/// \param index The current index in the iteration.
+///
+/// \param value The current value in the iteration.
+///
+/// \returns true to indicate that iteration should continue.
 typedef bool (*sourcekitd_variant_array_applier_f_t)(size_t index,
                                                      sourcekitd_variant_t value,
                                                      void *context);
 
-/**
- * \brief Invokes the given function for every value in the array.
- *
- * \returns true to indicate that iteration of the array completed
- * successfully. Iteration will only fail if the applier block returns false.
- */
+/// \brief Invokes the given function for every value in the array.
+///
+/// \returns true to indicate that iteration of the array completed
+/// successfully. Iteration will only fail if the applier block returns false.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL2
 bool
 sourcekitd_variant_array_apply_f(sourcekitd_variant_t array,
@@ -587,95 +521,74 @@ SOURCEKITD_PUBLIC SOURCEKITD_WARN_RESULT
 sourcekitd_uid_t
 sourcekitd_variant_uid_get_value(sourcekitd_variant_t obj);
 
-/**
- * \brief Prints to stderr a string representation of the response object in
- * YAML format.
- */
+/// \brief Prints to stderr a string representation of the response object in
+/// YAML format.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 void
 sourcekitd_response_description_dump(sourcekitd_response_t resp);
 
-/**
- * \brief Prints to the given file descriptor a string representation of the
- * response object.
- */
+/// \brief Prints to the given file descriptor a string representation of the
+/// response object.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 void
 sourcekitd_response_description_dump_filedesc(sourcekitd_response_t resp,
                                               int fd);
 
-/**
- * \brief Copies a string representation of the response object in YAML format.
- * \returns A string representation of the response object. This string should
- * be disposed of with \c free when done.
- */
+/// \brief Copies a string representation of the response object in YAML format.
+/// \returns A string representation of the response object. This string should
+/// be disposed of with \c free when done.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 char *
 sourcekitd_response_description_copy(sourcekitd_response_t resp);
 
-/**
- * \brief Prints to stderr a string representation of the variant object in
- * YAML format.
- */
+/// \brief Prints to stderr a string representation of the variant object in
+/// YAML format.
 SOURCEKITD_PUBLIC
 void
 sourcekitd_variant_description_dump(sourcekitd_variant_t obj);
 
-/**
- * \brief Prints to the given file descriptor a string representation of the
- * variant object.
- */
+/// \brief Prints to the given file descriptor a string representation of the
+/// variant object.
 SOURCEKITD_PUBLIC
 void
 sourcekitd_variant_description_dump_filedesc(sourcekitd_variant_t obj, int fd);
 
-/**
- * \brief Copies a string representation of the variant object in YAML format.
- * \returns A string representation of the variant object. This string should
- * be disposed of with \c free when done.
- */
+/// \brief Copies a string representation of the variant object in YAML format.
+/// \returns A string representation of the variant object. This string should
+/// be disposed of with \c free when done.
 SOURCEKITD_PUBLIC
 char *
 sourcekitd_variant_description_copy(sourcekitd_variant_t obj);
 
-/**
- * @}
- */
+/// @}
 
-/**
- * \brief Invoke a request synchronously.
- *
- * The caller accepts ownership of the returned sourcekitd_response_t object and
- * should invoke \c sourcekitd_response_dispose on it when it is done with it.
- */
+/// \brief Invoke a request synchronously.
+///
+/// The caller accepts ownership of the returned sourcekitd_response_t object
+/// and should invoke \c sourcekitd_response_dispose on it when it is done with
+/// it.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
 sourcekitd_response_t
 sourcekitd_send_request_sync(sourcekitd_object_t req);
 
-/**
- * \brief Used to cancel a request that has been invoked asynchronously.
- */
+/// \brief Used to cancel a request that has been invoked asynchronously.
 typedef void *sourcekitd_request_handle_t;
 
 #if SOURCEKITD_HAS_BLOCKS
-/**
- * \brief Receives the response of an asynchronous request or notification.
- *
- * The receiver accepts ownership of the response object and should invoke
- * \c sourcekitd_response_dispose on it when it is done with it.
- */
+/// \brief Receives the response of an asynchronous request or notification.
+///
+/// The receiver accepts ownership of the response object and should invoke
+/// \c sourcekitd_response_dispose on it when it is done with it.
 typedef void (^sourcekitd_response_receiver_t)(sourcekitd_response_t resp);
 
-/**
- * \brief Invoke a request asynchronously.
- *
- * \param req the request object.
- *
- * \param out_handle the address where the associated
- * \c sourcekitd_request_handle_t will be stored. Can be NULL.
- *
- * \param receiver the block that will receive the response object.
- */
+/// \brief Invoke a request asynchronously.
+///
+/// \param req the request object.
+///
+/// \param out_handle the address where the associated
+/// \c sourcekitd_request_handle_t will be stored. Can be NULL.
+///
+/// \param receiver the block that will receive the response object.
 SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1
 void
 sourcekitd_send_request(sourcekitd_object_t req,
@@ -683,37 +596,33 @@ sourcekitd_send_request(sourcekitd_object_t req,
                         sourcekitd_response_receiver_t receiver);
 #endif
 
-/**
- * \brief Cancel a request using the associated request handle returned by
- * \c sourcekitd_send_request.
- *
- * It is not guaranteed that invoking \c sourcekitd_cancel_request will cancel
- * the request. If the request gets cancelled, the receiver will get a
- * \c SOURCEKITD_ERROR_REQUEST_CANCELLED response error.
- *
- * Calling \c sourcekitd_cancel_request after the response object has been
- * delivered will have no effect.
- */
+/// \brief Cancel a request using the associated request handle returned by
+/// \c sourcekitd_send_request.
+///
+/// It is not guaranteed that invoking \c sourcekitd_cancel_request will cancel
+/// the request. If the request gets cancelled, the receiver will get a
+/// \c SOURCEKITD_ERROR_REQUEST_CANCELLED response error.
+///
+/// Calling \c sourcekitd_cancel_request after the response object has been
+/// delivered will have no effect.
 SOURCEKITD_PUBLIC
 void
 sourcekitd_cancel_request(sourcekitd_request_handle_t handle);
 
 #if SOURCEKITD_HAS_BLOCKS
 
-/**
- * \brief Sets the handler which should be called to receive notifications.
- * The block will be set to be executed in the main thread queue.
- *
- * If the connection to SourceKit is interrupted the handler will receive an
- * error response object of kind \c SOURCEKITD_ERROR_CONNECTION_INTERRUPTED.
- * Any subsequent requests will immediately fail with the same error until
- * the service is restored.
- * When the service is restored the handler will receive an empty response
- * object.
- *
- * \param receiver Notification handler block to use. Pass NULL to remove the
- * previous handler that was set.
- */
+/// \brief Sets the handler which should be called to receive notifications.
+/// The block will be set to be executed in the main thread queue.
+///
+/// If the connection to SourceKit is interrupted the handler will receive an
+/// error response object of kind \c SOURCEKITD_ERROR_CONNECTION_INTERRUPTED.
+/// Any subsequent requests will immediately fail with the same error until
+/// the service is restored.
+/// When the service is restored the handler will receive an empty response
+/// object.
+///
+/// \param receiver Notification handler block to use. Pass NULL to remove the
+/// previous handler that was set.
 SOURCEKITD_PUBLIC
 void
 sourcekitd_set_notification_handler(sourcekitd_response_receiver_t receiver);


### PR DESCRIPTION
`git grep -E '(//|/\*)' -- '*.cpp' '*.h'` now includes all comments in the code base which facilitates proof-reading, etc.
