### PR TITLE
[SR-511][Parse] Add 'associatedtype' keyword and fixit

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -707,6 +707,12 @@ ERROR(expected_close_to_config_stmt,stmt_parsing,none,
 ERROR(expected_close_after_else,stmt_parsing,none,
       "further conditions after #else are unreachable", ())
 
+/// Associatedtype Statement
+WARNING(typealias_inside_protocol,stmt_parsing,none,
+        "use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead", ())
+ERROR(associatedtype_outside_protocol,stmt_parsing,none,
+      "associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement", ())
+
 // Return Statement
 ERROR(expected_expr_return,stmt_parsing,PointsToFirstBadToken,
       "expected expression in 'return' statement", ())

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -387,6 +387,7 @@ enum class CodeCompletionDeclKind {
   Enum,
   EnumElement,
   Protocol,
+  AssociatedType,
   TypeAlias,
   GenericTypeParam,
   Constructor,

--- a/include/swift/Parse/Tokens.def
+++ b/include/swift/Parse/Tokens.def
@@ -63,6 +63,7 @@ DECL_KEYWORD(protocol)
 DECL_KEYWORD(struct)
 DECL_KEYWORD(subscript)
 DECL_KEYWORD(typealias)
+DECL_KEYWORD(associatedtype)
 DECL_KEYWORD(var)
 
 DECL_KEYWORD(internal)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1385,7 +1385,7 @@ void PrintAST::visitAssociatedTypeDecl(AssociatedTypeDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
   if (!Options.SkipIntroducerKeywords)
-    Printer << "typealias ";
+    Printer << "associatedtype ";
   recordDeclLoc(decl,
     [&]{
       Printer.printName(decl->getName());

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -445,8 +445,9 @@ CodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
   case DeclKind::Module:
     return CodeCompletionDeclKind::Module;
   case DeclKind::TypeAlias:
-  case DeclKind::AssociatedType:
     return CodeCompletionDeclKind::TypeAlias;
+  case DeclKind::AssociatedType:
+    return CodeCompletionDeclKind::AssociatedType;
   case DeclKind::GenericTypeParam:
     return CodeCompletionDeclKind::GenericTypeParam;
   case DeclKind::Enum:
@@ -537,6 +538,9 @@ void CodeCompletionResult::print(raw_ostream &OS) const {
       break;
     case CodeCompletionDeclKind::TypeAlias:
       Prefix.append("[TypeAlias]");
+      break;
+    case CodeCompletionDeclKind::AssociatedType:
+      Prefix.append("[AssociatedType]");
       break;
     case CodeCompletionDeclKind::GenericTypeParam:
       Prefix.append("[GenericTypeParam]");
@@ -4735,6 +4739,7 @@ void swift::ide::copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
       case CodeCompletionDeclKind::Enum:
       case CodeCompletionDeclKind::Protocol:
       case CodeCompletionDeclKind::TypeAlias:
+      case CodeCompletionDeclKind::AssociatedType:
       case CodeCompletionDeclKind::GenericTypeParam:
         return true;
       case CodeCompletionDeclKind::EnumElement:

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -111,6 +111,7 @@ static void toDisplayString(CodeCompletionResult *Result,
 
         case CodeCompletionDeclKind::Protocol:
         case CodeCompletionDeclKind::TypeAlias:
+        case CodeCompletionDeclKind::AssociatedType:
         case CodeCompletionDeclKind::GenericTypeParam:
         case CodeCompletionDeclKind::Constructor:
         case CodeCompletionDeclKind::Destructor:

--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 protocol Runcible {
-  typealias Runcee 
+  associatedtype Runcee
 }
 
 class Mince { 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 protocol P {
-  typealias SomeType
+  associatedtype SomeType
 }
 
 protocol P2 { 
@@ -684,4 +684,5 @@ func r23641896() {
   _ = g[12]  // expected-error {{'subscript' is unavailable: cannot subscript String with an Int, see the documentation comment for discussion}}
 
 }
+
 

--- a/test/Constraints/generic_overload.swift
+++ b/test/Constraints/generic_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
-protocol P1 { typealias Assoc }
-protocol P2 : P1 { typealias Assoc }
+protocol P1 { associatedtype Assoc }
+protocol P2 : P1 { associatedtype Assoc }
 protocol P3 { }
 
 struct X1 : P1 { typealias Assoc = X3 }

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -43,7 +43,7 @@ func foo<T : P>(arg: T) -> T {
 
 // Associated types and metatypes
 protocol SomeProtocol {
-  typealias SomeAssociated
+  associatedtype SomeAssociated
 }
 
 func generic_metatypes<T : SomeProtocol>(x: T)
@@ -101,7 +101,7 @@ func foo2(p1: P1) -> P2 {
 
 // <rdar://problem/14005696>
 protocol BinaryMethodWorkaround {
-  typealias MySelf
+  associatedtype MySelf
 }
 
 protocol Squigglable : BinaryMethodWorkaround {

--- a/test/Constraints/invalid_archetype_constraint.swift
+++ b/test/Constraints/invalid_archetype_constraint.swift
@@ -3,7 +3,7 @@
 protocol Empty {}
 
 protocol P {
-  typealias Element
+  associatedtype Element
   init()
 }
 

--- a/test/Constraints/invalid_constraint_lookup.swift
+++ b/test/Constraints/invalid_constraint_lookup.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 protocol P {
-  typealias A
+  associatedtype A
   func generate() -> Int
 }
 func f<U: P>(rhs: U) -> X<U.A> { // expected-error {{use of undeclared type 'X'}}
@@ -19,8 +19,8 @@ struct Zzz<T> {
 }
 
 protocol _CollectionType {
-  typealias Index
-  typealias _Element
+  associatedtype Index
+  associatedtype _Element
   subscript(i: Index) -> _Element {get}
 }
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -181,7 +181,7 @@ let (var z) = 42  // expected-error {{'var' cannot appear nested inside another 
 // at least we don't crash anymore.
 
 protocol PP {
-  typealias E
+  associatedtype E
 }
 
 struct A<T> : PP {

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -1,13 +1,13 @@
 // RUN: %target-parse-verify-swift
 
 protocol Fooable {
-  typealias Foo
+  associatedtype Foo
 
   var foo: Foo { get }
 }
 
 protocol Barrable {
-  typealias Bar: Fooable
+  associatedtype Bar: Fooable
   var bar: Bar { get }
 }
 

--- a/test/Generics/Inputs/associated_types_multi_file_helper.swift
+++ b/test/Generics/Inputs/associated_types_multi_file_helper.swift
@@ -1,5 +1,5 @@
 protocol Fooable {
-  typealias AssocType
+  associatedtype AssocType
   func foo(x : AssocType)
 }
 

--- a/test/Generics/associated_self_constraints.swift
+++ b/test/Generics/associated_self_constraints.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 protocol Observer {
-    typealias Value
+    associatedtype Value
     
     func onNext(item: Value) -> Void
     func onCompleted() -> Void
@@ -9,7 +9,7 @@ protocol Observer {
 }
 
 protocol Observable {
-    typealias Value
+    associatedtype Value
 
     func subscribe<O: Observer where O.Value == Value>(observer: O) -> Any
 }
@@ -64,7 +64,7 @@ struct X<T> {
 }
 
 protocol P {
-    typealias A
+    associatedtype A
     
     func onNext(item: A) -> Void
 }

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -4,11 +4,11 @@
 // RUN: FileCheck -check-prefix CHECK-GENERIC %s < %t.dump
 
 protocol P1 {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 protocol P2 {
-  typealias AssocP2 : P1
+  associatedtype AssocP2 : P1
 }
 
 protocol P3 { }

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -2,7 +2,7 @@
 
 // Deduction of associated types.
 protocol Fooable {
-  typealias AssocType
+  associatedtype AssocType
   func foo(x : AssocType)
 }
 
@@ -39,7 +39,7 @@ var d : Double
 d = yd
 
 protocol P1 {
-  typealias Assoc1
+  associatedtype Assoc1
   func foo() -> Assoc1
 }
 
@@ -50,7 +50,7 @@ struct S1 : P1 {
 prefix operator % {}
 
 protocol P2 {
-  typealias Assoc2
+  associatedtype Assoc2
   prefix func %(target: Self) -> Assoc2
 }
 
@@ -63,12 +63,12 @@ extension S1 : P2 {
 
 // <rdar://problem/14418181>
 protocol P3 {
-  typealias Assoc3
+  associatedtype Assoc3
   func foo() -> Assoc3
 }
 
 protocol P4 : P3 {
-  typealias Assoc4
+  associatedtype Assoc4
   func bar() -> Assoc4
 }
 
@@ -93,7 +93,7 @@ protocol P6 {
 }
 
 protocol P7 : P6 {
-  typealias Assoc : P6
+  associatedtype Assoc : P6
   func ~> (x: Self, _: S7a) -> Assoc
 }
 
@@ -116,12 +116,12 @@ struct zip<A: GeneratorType, B: GeneratorType> : GeneratorType, SequenceType {
 protocol P8 { }
 
 protocol P9 {
-  typealias A1 : P8
+  associatedtype A1 : P8
 }
 
 protocol P10 {
-  typealias A1b : P8
-  typealias A2 : P9
+  associatedtype A1b : P8
+  associatedtype A2 : P9
 
   func f()
   func g(a: A1b)
@@ -159,7 +159,7 @@ protocol A {
 }
 
 protocol B : A {
-  typealias e : A = C<Self> // expected-note {{default type 'C<C<a>>' for associated type 'e' (from protocol 'B') does not conform to 'A'}}
+  associatedtype e : A = C<Self> // expected-note {{default type 'C<C<a>>' for associated type 'e' (from protocol 'B') does not conform to 'A'}}
 }
 
 extension B {
@@ -169,3 +169,11 @@ extension B {
 
 struct C<a : B> : B { // expected-error {{type 'C<a>' does not conform to protocol 'B'}} expected-error {{type 'C<a>' does not conform to protocol 'A'}}
 }
+
+// SR-511
+protocol sr511 {
+  typealias Foo // expected-warning {{use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead}} {{3-12=associatedtype}}
+}
+
+associatedtype Foo = Int // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}}
+

--- a/test/Generics/associated_types_inherit.swift
+++ b/test/Generics/associated_types_inherit.swift
@@ -10,7 +10,7 @@ class D : C {
 class E { }
 
 protocol P { // expected-note{{requirement specified as 'Self.Assoc' : 'C' [with Self = X2]}}
-  typealias Assoc : C
+  associatedtype Assoc : C
   func getAssoc() -> Assoc
 }
 

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -266,7 +266,7 @@ func testGetVectorSize(vi: MyVector<Int>, vf: MyVector<Float>) {
 postfix operator <*> {}
 
 protocol MetaFunction {
-  typealias Result
+  associatedtype Result
   postfix func <*> (_: Self) -> Result?
 }
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -72,8 +72,8 @@ func testRuncible(x: Runcible) { // expected-error{{protocol 'Runcible' can only
 //===----------------------------------------------------------------------===//
 
 protocol Overload {
-  typealias A
-  typealias B
+  associatedtype A
+  associatedtype B
   func getA() -> A
   func getB() -> B
   func f1(_: A) -> A
@@ -128,8 +128,8 @@ func testOverload<Ovl : Overload, OtherOvl : Overload>(ovl: Ovl, ovl2: Ovl,
 // Subscripting
 //===----------------------------------------------------------------------===//
 protocol Subscriptable {
-  typealias Index
-  typealias Value
+  associatedtype Index
+  associatedtype Value
 
   func getIndex() -> Index
   func getValue() -> Value
@@ -138,7 +138,7 @@ protocol Subscriptable {
 }
 
 protocol IntSubscriptable {
-  typealias ElementType
+  associatedtype ElementType
 
   func getElement() -> ElementType
 
@@ -200,12 +200,12 @@ func conformanceViaRequires<T
 }
 
 protocol GeneratesAnElement {
-  typealias Element : EqualComparable
+  associatedtype Element : EqualComparable
   func generate() -> Element
 }
 
 protocol AcceptsAnElement {
-  typealias Element : MethodLessComparable
+  associatedtype Element : MethodLessComparable
   func accept(e : Element)
 }
 
@@ -218,12 +218,12 @@ func impliedSameType<T : GeneratesAnElement where T : AcceptsAnElement>(t: T) {
 }
 
 protocol GeneratesAssoc1 {
-  typealias Assoc1 : EqualComparable
+  associatedtype Assoc1 : EqualComparable
   func get() -> Assoc1
 }
 
 protocol GeneratesAssoc2 {
-  typealias Assoc2 : MethodLessComparable
+  associatedtype Assoc2 : MethodLessComparable
   func get() -> Assoc2
 }
 
@@ -235,12 +235,12 @@ func simpleSameType
 }
 
 protocol GeneratesMetaAssoc1 {
-  typealias MetaAssoc1 : GeneratesAnElement
+  associatedtype MetaAssoc1 : GeneratesAnElement
   func get() -> MetaAssoc1
 }
 
 protocol GeneratesMetaAssoc2 {
-  typealias MetaAssoc2 : AcceptsAnElement
+  associatedtype MetaAssoc2 : AcceptsAnElement
   func get() -> MetaAssoc2
 }
 
@@ -258,11 +258,11 @@ func recursiveSameType
 
 // <rdar://problem/13985164>
 protocol P1 {
-  typealias Element
+  associatedtype Element
 }
 
 protocol P2 {
-  typealias AssocP1 : P1
+  associatedtype AssocP1 : P1
   func getAssocP1() -> AssocP1
 }
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -292,11 +292,11 @@ class X3 { }
 var x2 : X2<X3> // expected-error{{'X2' requires that 'X3' inherit from 'X1'}}
 
 protocol P {
-  typealias AssocP
+  associatedtype AssocP
 }
 
 protocol Q {
-  typealias AssocQ
+  associatedtype AssocQ
 }
 
 struct X4 : P, Q {

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -91,23 +91,23 @@ func inferSuperclassRequirement2<T : Canidae>(v: U<T>) {}
 // ----------------------------------------------------------------------------
 
 protocol P3 {
-  typealias P3Assoc : P2
+  associatedtype P3Assoc : P2
 }
 
 protocol P4 {
-  typealias P4Assoc : P1
+  associatedtype P4Assoc : P1
 }
 
 protocol PCommonAssoc1 {
-  typealias CommonAssoc
+  associatedtype CommonAssoc
 }
 
 protocol PCommonAssoc2 {
-  typealias CommonAssoc
+  associatedtype CommonAssoc
 }
 
 protocol PAssoc {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 struct Model_P3_P4_Eq<T : P3, U : P4 where T.P3Assoc == U.P4Assoc> { }
@@ -119,8 +119,8 @@ struct Model_P3_P4_Eq<T : P3, U : P4 where T.P3Assoc == U.P4Assoc> { }
 // CHECK-NEXT:   U witness marker
 // CHECK-NEXT:   U : P4 [inferred @ {{.*}}:30]
 // CHECK-NEXT:   T[.P3].P3Assoc witness marker
-// CHECK-NEXT:   T[.P3].P3Assoc : P1 [protocol @ {{.*}}:13]
-// CHECK-NEXT:   T[.P3].P3Assoc : P2 [protocol @ {{.*}}:13]
+// CHECK-NEXT:   T[.P3].P3Assoc : P1 [protocol @ {{.*}}:18]
+// CHECK-NEXT:   T[.P3].P3Assoc : P2 [protocol @ {{.*}}:18]
 // CHECK-NEXT:   U[.P4].P4Assoc == T[.P3].P3Assoc [inferred @ {{.*}}30]
 func inferSameType1<T, U>(x: Model_P3_P4_Eq<T, U>) { }
 
@@ -131,7 +131,7 @@ func inferSameType1<T, U>(x: Model_P3_P4_Eq<T, U>) { }
 // CHECK-NEXT:   U witness marker
 // CHECK-NEXT:   U : P4 [explicit @ {{.*}}requirement_inference.swift:{{.*}}:33]
 // CHECK-NEXT:   T[.P3].P3Assoc witness marker
-// CHECK-NEXT:   T[.P3].P3Assoc : P1 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:13]
+// CHECK-NEXT:   T[.P3].P3Assoc : P1 [protocol @ {{.*}}requirement_inference.swift:{{.*}}:18]
 // CHECK-NEXT:   T[.P3].P3Assoc : P2 [redundant @ {{.*}}requirement_inference.swift:{{.*}}:54]
 // CHECK-NEXT:   U[.P4].P4Assoc == T[.P3].P3Assoc [explicit @ {{.*}}requirement_inference.swift:{{.*}}:68]
 func inferSameType2<T : P3, U : P4 where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc>(_: T) { }
@@ -148,15 +148,15 @@ func inferSameType2<T : P3, U : P4 where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc>
 func inferSameType3<T : PCommonAssoc1 where T.CommonAssoc : P1, T : PCommonAssoc2>(_: T) { }
 
 protocol P5 {
-  typealias Element
+  associatedtype Element
 }
 
 protocol P6 {
-  typealias AssocP6 : P5
+  associatedtype AssocP6 : P5
 }
 
 protocol P7 : P6 {
-  typealias AssocP7: P6
+  associatedtype AssocP7: P6
 }
 
 // CHECK-LABEL: P7.nestedSameType1()@

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -1,13 +1,13 @@
 // RUN: %target-parse-verify-swift
 
 protocol Fooable {
-  typealias Foo
+  associatedtype Foo
 
   var foo: Foo { get }
 }
 
 protocol Barrable {
-  typealias Bar: Fooable
+  associatedtype Bar: Fooable
   var bar: Bar { get }
 }
 
@@ -29,7 +29,7 @@ struct SatisfySameTypeRequirement : TestSameTypeRequirement {
 }
 
 protocol TestSameTypeAssocTypeRequirement {
-  typealias Assoc
+  associatedtype Assoc
   func foo<F1: Fooable where F1.Foo == Assoc>(f: F1)
 }
 struct SatisfySameTypeAssocTypeRequirement : TestSameTypeAssocTypeRequirement {
@@ -104,12 +104,12 @@ public final class IterateGenerator<A> : GeneratorType {
 
 // rdar://problem/18475138
 public protocol Observable : class {
-    typealias Output
+    associatedtype Output
     func addObserver(obj : Output -> Void)
 }
 
 public protocol Bindable : class {
-    typealias Input
+    associatedtype Input
     func foo()
 }
 
@@ -135,7 +135,7 @@ struct Pair<T, U> {
 }
 
 protocol Seq {
-  typealias Element
+  associatedtype Element
 
   func zip<OtherSeq: Seq, ResultSeq: Seq where ResultSeq.Element == Pair<Element, OtherSeq.Element>.Type_> (otherSeq: OtherSeq) -> ResultSeq
 }
@@ -153,7 +153,7 @@ extension Dictionary {
 
 // rdar://problem/19245317
 protocol P {
-	typealias T: P // expected-error{{type may not reference itself as a requirement}}
+	associatedtype T: P // expected-error{{type may not reference itself as a requirement}}
 }
 
 struct S<A: P> {
@@ -165,7 +165,7 @@ protocol Food { }
 class Grass : Food { }
 
 protocol Animal {
-    typealias EdibleFood:Food
+    associatedtype EdibleFood:Food
     func eat(f:EdibleFood)
 }
 class Cow : Animal {
@@ -226,12 +226,12 @@ func testSameTypeTuple(a: Array<(Int,Int)>, s: ArraySlice<(Int,Int)>) {
 
 // rdar://problem/20256475
 protocol FooType {
-  typealias Element
+  associatedtype Element
 
   func getElement() -> Element
 }
 protocol BarType {
-  typealias Foo : FooType
+  associatedtype Foo : FooType
 
   func getFoo() -> Foo
 
@@ -248,7 +248,7 @@ protocol P1 { }
 protocol P2Base { }
 
 protocol P2 : P2Base {
-  typealias Q : P1
+  associatedtype Q : P1
 
   func getQ() -> Q
 }
@@ -263,11 +263,11 @@ func sameTypeParameterizedConcrete<C : P2 where C.Q == XP1<C>>(c: C) {
 
 // rdar://problem/21621421
 protocol P3 {
-  typealias AssocP3 : P1
+  associatedtype AssocP3 : P1
 }
 
 protocol P4 {
-  typealias AssocP4 : P3
+  associatedtype AssocP4 : P3
 }
 
 struct X1 : P1 { }
@@ -292,12 +292,12 @@ struct X6<T> { }
 protocol P6 { }
 
 protocol P7 {
-  typealias AssocP7
+  associatedtype AssocP7
 }
 
 protocol P8 {
-  typealias AssocP8 : P7
-  typealias AssocOther
+  associatedtype AssocP8 : P7
+  associatedtype AssocOther
 }
 
 func testP8<C : P8 where C.AssocOther == X6<C.AssocP8.AssocP7>>(c: C) { }
@@ -306,7 +306,7 @@ func testP8<C : P8 where C.AssocOther == X6<C.AssocP8.AssocP7>>(c: C) { }
 struct Ghost<T> {}
 
 protocol Timewarp {
-  typealias Wormhole
+  associatedtype Wormhole
 }
 
 struct Teleporter<A, B where A : Timewarp, A.Wormhole == Ghost<B>> {}

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -23,28 +23,28 @@
 // FIXME: extensions that introduce conformances?
 
 protocol FooBaseProtocolWithAssociatedTypes {
-  typealias DefaultedTypeCommonA = Int
-  typealias DefaultedTypeCommonB = Int
-  typealias DefaultedTypeCommonC = Int
-  typealias DefaultedTypeCommonD = Int
+  associatedtype DefaultedTypeCommonA = Int
+  associatedtype DefaultedTypeCommonB = Int
+  associatedtype DefaultedTypeCommonC = Int
+  associatedtype DefaultedTypeCommonD = Int
 
-  typealias FooBaseDefaultedTypeA = Int
-  typealias FooBaseDefaultedTypeB = Int
-  typealias FooBaseDefaultedTypeC = Int
+  associatedtype FooBaseDefaultedTypeA = Int
+  associatedtype FooBaseDefaultedTypeB = Int
+  associatedtype FooBaseDefaultedTypeC = Int
 
-  typealias DeducedTypeCommonA
-  typealias DeducedTypeCommonB
-  typealias DeducedTypeCommonC
-  typealias DeducedTypeCommonD
+  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonB
+  associatedtype DeducedTypeCommonC
+  associatedtype DeducedTypeCommonD
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonB() -> DeducedTypeCommonB
   func deduceCommonC() -> DeducedTypeCommonC
   func deduceCommonD() -> DeducedTypeCommonD
 
-  typealias FooBaseDeducedTypeA
-  typealias FooBaseDeducedTypeB
-  typealias FooBaseDeducedTypeC
-  typealias FooBaseDeducedTypeD
+  associatedtype FooBaseDeducedTypeA
+  associatedtype FooBaseDeducedTypeB
+  associatedtype FooBaseDeducedTypeC
+  associatedtype FooBaseDeducedTypeD
   func deduceFooBaseA() -> FooBaseDeducedTypeA
   func deduceFooBaseB() -> FooBaseDeducedTypeB
   func deduceFooBaseC() -> FooBaseDeducedTypeC
@@ -52,35 +52,35 @@ protocol FooBaseProtocolWithAssociatedTypes {
 }
 protocol FooProtocolWithAssociatedTypes : FooBaseProtocolWithAssociatedTypes {
   // From FooBase.
-  typealias DefaultedTypeCommonA = Int
-  typealias DefaultedTypeCommonB = Int
+  associatedtype DefaultedTypeCommonA = Int
+  associatedtype DefaultedTypeCommonB = Int
 
-  typealias FooBaseDefaultedTypeB = Double
+  associatedtype FooBaseDefaultedTypeB = Double
 
-  typealias DeducedTypeCommonA
-  typealias DeducedTypeCommonB
+  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonB
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonB() -> DeducedTypeCommonB
 
   func deduceFooBaseB() -> Int
 
   // New decls.
-  typealias FooDefaultedType = Int
+  associatedtype FooDefaultedType = Int
 
-  typealias FooDeducedTypeB
-  typealias FooDeducedTypeC
-  typealias FooDeducedTypeD
+  associatedtype FooDeducedTypeB
+  associatedtype FooDeducedTypeC
+  associatedtype FooDeducedTypeD
   func deduceFooB() -> FooDeducedTypeB
   func deduceFooC() -> FooDeducedTypeC
   func deduceFooD() -> FooDeducedTypeD
 }
 protocol BarBaseProtocolWithAssociatedTypes {
   // From FooBase.
-  typealias DefaultedTypeCommonA = Int
-  typealias DefaultedTypeCommonC = Int
+  associatedtype DefaultedTypeCommonA = Int
+  associatedtype DefaultedTypeCommonC = Int
 
-  typealias DeducedTypeCommonA
-  typealias DeducedTypeCommonC
+  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonC
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonC() -> DeducedTypeCommonC
 
@@ -90,20 +90,20 @@ protocol BarBaseProtocolWithAssociatedTypes {
   func deduceFooC() -> Int
 
   // New decls.
-  typealias BarBaseDefaultedType = Int
+  associatedtype BarBaseDefaultedType = Int
 
-  typealias BarBaseDeducedTypeC
-  typealias BarBaseDeducedTypeD
+  associatedtype BarBaseDeducedTypeC
+  associatedtype BarBaseDeducedTypeD
   func deduceBarBaseC() -> BarBaseDeducedTypeC
   func deduceBarBaseD() -> BarBaseDeducedTypeD
 }
 protocol BarProtocolWithAssociatedTypes : BarBaseProtocolWithAssociatedTypes {
   // From FooBase.
-  typealias DefaultedTypeCommonA = Int
-  typealias DefaultedTypeCommonD = Int
+  associatedtype DefaultedTypeCommonA = Int
+  associatedtype DefaultedTypeCommonD = Int
 
-  typealias DeducedTypeCommonA
-  typealias DeducedTypeCommonD
+  associatedtype DeducedTypeCommonA
+  associatedtype DeducedTypeCommonD
   func deduceCommonA() -> DeducedTypeCommonA
   func deduceCommonD() -> DeducedTypeCommonD
 
@@ -116,9 +116,9 @@ protocol BarProtocolWithAssociatedTypes : BarBaseProtocolWithAssociatedTypes {
   func deduceBarBaseD() -> Int
 
   // New decls.
-  typealias BarDefaultedTypeA = Int
+  associatedtype BarDefaultedTypeA = Int
 
-  typealias BarDeducedTypeD
+  associatedtype BarDeducedTypeD
   func deduceBarD() -> BarDeducedTypeD
 }
 
@@ -234,30 +234,30 @@ class MoreDerivedFromClassWithAssociatedTypes : DerivedFromClassWithAssociatedTy
   }
 }
 // ASSOCIATED_TYPES_UNQUAL: Begin completions
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DefaultedTypeCommonA[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DefaultedTypeCommonD[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DeducedTypeCommonA[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DeducedTypeCommonD[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: BarDefaultedTypeA[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: BarDeducedTypeD[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DefaultedTypeCommonC[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DeducedTypeCommonC[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: BarBaseDefaultedType[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: BarBaseDeducedTypeC[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: BarBaseDeducedTypeD[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DefaultedTypeCommonB[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG-FIXME: Decl[TypeAlias]/Super: FooBaseDefaultedTypeB[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: DeducedTypeCommonB[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooDefaultedType[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooDeducedTypeB[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooDeducedTypeC[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooDeducedTypeD[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooBaseDefaultedTypeA[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooBaseDefaultedTypeC[#Double#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooBaseDeducedTypeA[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooBaseDeducedTypeB[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooBaseDeducedTypeC[#Int#]{{; name=.+$}}
-// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[TypeAlias]/Super: FooBaseDeducedTypeD[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DefaultedTypeCommonA[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DefaultedTypeCommonD[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DeducedTypeCommonA[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DeducedTypeCommonD[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: BarDefaultedTypeA[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: BarDeducedTypeD[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DefaultedTypeCommonC[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DeducedTypeCommonC[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: BarBaseDefaultedType[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: BarBaseDeducedTypeC[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: BarBaseDeducedTypeD[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DefaultedTypeCommonB[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG-FIXME: Decl[AssociatedType]/Super: FooBaseDefaultedTypeB[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: DeducedTypeCommonB[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooDefaultedType[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooDeducedTypeB[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooDeducedTypeC[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooDeducedTypeD[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooBaseDefaultedTypeA[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooBaseDefaultedTypeB[#Double#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooBaseDeducedTypeA[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooBaseDeducedTypeB[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooBaseDeducedTypeC[#Int#]{{; name=.+$}}
+// ASSOCIATED_TYPES_UNQUAL-DAG: Decl[AssociatedType]/Super: FooBaseDeducedTypeD[#Int#]{{; name=.+$}}
 // ASSOCIATED_TYPES_UNQUAL: End completions
 
 struct StructWithBrokenConformance : FooProtocolWithAssociatedTypes {

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -236,14 +236,14 @@ enum QuxEnum : Int {
 // QUX_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Qux1[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Qux2[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:   ({#rawValue: Int#})[#QuxEnum?#]{{; name=.+$}}
-// QUX_ENUM_NO_DOT-NEXT: Decl[TypeAlias]/Super:            .RawValue[#Int#]{{; name=.+$}}
+// QUX_ENUM_NO_DOT-NEXT: Decl[AssociatedType]/Super:            .RawValue[#Int#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: End completions
 
 // QUX_ENUM_DOT: Begin completions, 4 items
 // QUX_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Qux1[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_DOT-NEXT: Decl[EnumElement]/CurrNominal:    Qux2[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_DOT-NEXT: Decl[Constructor]/CurrNominal: init({#rawValue: Int#})[#QuxEnum?#]{{; name=.+$}}
-// QUX_ENUM_DOT-NEXT: Decl[TypeAlias]/Super:            RawValue[#Int#]{{; name=.+$}}
+// QUX_ENUM_DOT-NEXT: Decl[AssociatedType]/Super:            RawValue[#Int#]{{; name=.+$}}
 // QUX_ENUM_DOT-NEXT: End completions
 
 func freeFunc() {}

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1683,7 +1683,7 @@ func testTypealias1<S: P4 where S.T == WillConformP1>() {
   S.#^PROTOCOL_EXT_TA_2^#
 }
 // PROTOCOL_EXT_TA: Begin completions
-// PROTOCOL_EXT_TA-DAG: Decl[TypeAlias]/{{Super|CurrNominal}}: T
+// PROTOCOL_EXT_TA_2-DAG: Decl[AssociatedType]/{{Super|CurrNominal}}: T
 // PROTOCOL_EXT_TA: End completions
 
 func testProtExtInit1() {

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -91,7 +91,7 @@ protocol FooProtocol {}
 protocol BarProtocol {}
 protocol BazProtocol { func baz() }
 protocol QuxProtocol {
-  typealias Qux
+  associatedtype Qux
 }
 
 protocol SubFooProtocol : FooProtocol { }
@@ -470,8 +470,8 @@ class d0121_TestClassDerived : d0120_TestClassBase {
 protocol d0130_TestProtocol {
 // PASS_COMMON-LABEL: {{^}}protocol d0130_TestProtocol {{{$}}
 
-  typealias NestedTypealias
-// PASS_COMMON-NEXT: {{^}}  typealias NestedTypealias{{$}}
+  associatedtype NestedTypealias
+// PASS_COMMON-NEXT: {{^}}  associatedtype NestedTypealias{{$}}
 
   var property1: Int { get }
 // PASS_COMMON-NEXT: {{^}}  var property1: Int { get }{{$}}
@@ -879,14 +879,14 @@ typealias SimpleTypealias1 = FooProtocol
 // Associated types.
 
 protocol AssociatedType1 {
-  typealias AssociatedTypeDecl1 = Int
-// PASS_ONE_LINE-DAG: {{^}}  typealias AssociatedTypeDecl1 = Int{{$}}
+  associatedtype AssociatedTypeDecl1 = Int
+// PASS_ONE_LINE-DAG: {{^}}  associatedtype AssociatedTypeDecl1 = Int{{$}}
 
-  typealias AssociatedTypeDecl2 : FooProtocol
-// PASS_ONE_LINE-DAG: {{^}}  typealias AssociatedTypeDecl2 : FooProtocol{{$}}
+  associatedtype AssociatedTypeDecl2 : FooProtocol
+// PASS_ONE_LINE-DAG: {{^}}  associatedtype AssociatedTypeDecl2 : FooProtocol{{$}}
 
-  typealias AssociatedTypeDecl3 : FooProtocol, BarProtocol
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  typealias AssociatedTypeDecl3 : FooProtocol, BarProtocol{{$}}
+  associatedtype AssociatedTypeDecl3 : FooProtocol, BarProtocol
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl3 : FooProtocol, BarProtocol{{$}}
 }
 
 //===---
@@ -1157,12 +1157,12 @@ infix operator %%<> {
 //===---
 
 protocol d2700_ProtocolWithAssociatedType1 {
-  typealias TA1
+  associatedtype TA1
   func returnsTA1() -> TA1
 }
 
 // PASS_COMMON: {{^}}protocol d2700_ProtocolWithAssociatedType1 {{{$}}
-// PASS_COMMON-NEXT: {{^}}  typealias TA1{{$}}
+// PASS_COMMON-NEXT: {{^}}  associatedtype TA1{{$}}
 // PASS_COMMON-NEXT: {{^}}  func returnsTA1() -> Self.TA1{{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
@@ -1336,7 +1336,7 @@ public func ParamAttrs3(@noescape a : () -> ()) {
 // Protocol extensions
 
 protocol ProtocolToExtend {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 extension ProtocolToExtend where Self.Assoc == Int {}

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -21,7 +21,7 @@ protocol FooProtocol {}
 protocol BarProtocol {}
 protocol BazProtocol { func baz() }
 protocol QuxProtocol {
-  typealias Qux
+  associatedtype Qux
 }
 
 class FooProtocolImpl : FooProtocol {}
@@ -176,22 +176,22 @@ func foo(bar: Typealias1<Int>) {} // Should not generate error "cannot specializ
 protocol AssociatedType1 {
 // CHECK-LABEL: AssociatedType1 {
 
-  typealias AssociatedTypeDecl1 : FooProtocol = FooClass
-// CHECK: {{^}}  typealias AssociatedTypeDecl1 : FooProtocol = FooClass{{$}}
+  associatedtype AssociatedTypeDecl1 : FooProtocol = FooClass
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl1 : FooProtocol = FooClass{{$}}
 
-  typealias AssociatedTypeDecl2 : BazProtocol = FooClass
-// CHECK: {{^}}  typealias AssociatedTypeDecl2 : BazProtocol = FooClass{{$}}
+  associatedtype AssociatedTypeDecl2 : BazProtocol = FooClass
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl2 : BazProtocol = FooClass{{$}}
 
-  typealias AssociatedTypeDecl3 : FooNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
-// NO-TYREPR: {{^}}  typealias AssociatedTypeDecl3 : <<error type>>{{$}}
-// TYREPR: {{^}}  typealias AssociatedTypeDecl3 : FooNonExistentProtocol{{$}}
+  associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}}
+// NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl3 : <<error type>>{{$}}
+// TYREPR: {{^}}  associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol{{$}}
 
-  typealias AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}}
-// NO-TYREPR: {{^}}  typealias AssociatedTypeDecl4 : <<error type>>, <<error type>>{{$}}
-// TYREPR: {{^}}  typealias AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol{{$}}
+  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol // expected-error {{use of undeclared type 'FooNonExistentProtocol'}} expected-error {{use of undeclared type 'BarNonExistentProtocol'}}
+// NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : <<error type>>, <<error type>>{{$}}
+// TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol{{$}}
 
-  typealias AssociatedTypeDecl5 : FooClass
-// CHECK: {{^}}  typealias AssociatedTypeDecl5 : FooClass{{$}}
+  associatedtype AssociatedTypeDecl5 : FooClass
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl5 : FooClass{{$}}
 }
 
 //===---

--- a/test/IDE/print_types.swift
+++ b/test/IDE/print_types.swift
@@ -105,7 +105,7 @@ func testCurriedFuncType1(a: Int)(b: Float) {} // expected-warning{{curried func
 
 protocol FooProtocol {}
 protocol BarProtocol {}
-protocol QuxProtocol { typealias Qux }
+protocol QuxProtocol { associatedtype Qux }
 
 struct GenericStruct<A, B : FooProtocol> {}
 

--- a/test/IDE/print_usrs.swift
+++ b/test/IDE/print_usrs.swift
@@ -68,8 +68,8 @@ class GenericClass {
 
 // CHECK: [[@LINE+1]]:10 s:P14swift_ide_test4Prot{{$}}
 protocol Prot {
-  // CHECK: [[@LINE+1]]:13 s:P14swift_ide_test4Prot5Blarg{{$}}
-  typealias Blarg
+  // CHECK: [[@LINE+1]]:18 s:P14swift_ide_test4Prot5Blarg{{$}}
+  associatedtype Blarg
   // CHECK: [[@LINE+1]]:8 s:FP14swift_ide_test4Prot8protMethFwx5BlargwxS1_{{$}}
   func protMeth(x: Blarg) -> Blarg
   // CHECK: [[@LINE+2]]:7 s:vP14swift_ide_test4Prot17protocolProperty1Si{{$}}

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -104,7 +104,7 @@ extension Foo : MethodProto {} // expected-error {{type 'Foo' does not conform t
 
 
 protocol TypeProto {
-  typealias TheType // expected-note * {{protocol requires nested type 'TheType'}}
+  associatedtype TheType // expected-note * {{protocol requires nested type 'TheType'}}
 }
 
 extension OriginallyEmpty {}

--- a/test/NameBinding/name_lookup.swift
+++ b/test/NameBinding/name_lookup.swift
@@ -450,7 +450,7 @@ func useProto<R : MyProto>(value: R) -> R.Element {
 }
 
 protocol MyProto {
-  typealias Element
+  associatedtype Element
   func get() -> Element
 }
 

--- a/test/NameBinding/stdlib.swift
+++ b/test/NameBinding/stdlib.swift
@@ -14,6 +14,6 @@ protocol _BuiltinFloatLiteralConvertible {
 }
 
 protocol FloatLiteralConvertible {
-  typealias FloatLiteralType : _BuiltinFloatLiteralConvertible
+  associatedtype FloatLiteralType : _BuiltinFloatLiteralConvertible
   static func convertFromFloatLiteral(value: FloatLiteralType) -> Self
 }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -17,7 +17,7 @@ struct Foo {
 }
 
 protocol Zim {
-  typealias Zang
+  associatedtype Zang
 
   init()
   // TODO class var prop: Int { get }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -474,7 +474,7 @@ protocol Supportable {
   mutating func support() throws
 }
 protocol Buildable {
-  typealias Structure : Supportable
+  associatedtype Structure : Supportable
   var firstStructure: Structure { get set }
   subscript(name: String) -> Structure { get set }
 }

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -171,7 +171,7 @@ typealias GenericArgs = Optional<PrivateStruct> // expected-error {{type alias m
 
 
 public protocol HasAssocType {
-  typealias Inferred
+  associatedtype Inferred
   func test(input: Inferred)
 }
 
@@ -238,20 +238,20 @@ internal class InternalClass {}
 private class PrivateClass {}
 
 public protocol AssocTypes {
-  typealias Foo
+  associatedtype Foo
 
-  typealias Internal: InternalClass // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
-  typealias InternalConformer: InternalProto // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
-  typealias PrivateConformer: PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  typealias PI: PrivateProto, InternalProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  typealias IP: InternalProto, PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype Internal: InternalClass // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
+  associatedtype InternalConformer: InternalProto // expected-error {{associated type in a public protocol uses an internal type in its requirement}}
+  associatedtype PrivateConformer: PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype PI: PrivateProto, InternalProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype IP: InternalProto, PrivateProto // expected-error {{associated type in a public protocol uses a private type in its requirement}}
 
-  typealias PrivateDefault = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
-  typealias PublicDefault = PublicStruct
-  typealias PrivateDefaultConformer: PublicProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
-  typealias PublicDefaultConformer: PrivateProto = PublicStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  typealias PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
-  typealias PublicPublicDefaultConformer: PublicProto = PublicStruct
+  associatedtype PrivateDefault = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
+  associatedtype PublicDefault = PublicStruct
+  associatedtype PrivateDefaultConformer: PublicProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its default definition}}
+  associatedtype PublicDefaultConformer: PrivateProto = PublicStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype PrivatePrivateDefaultConformer: PrivateProto = PrivateStruct // expected-error {{associated type in a public protocol uses a private type in its requirement}}
+  associatedtype PublicPublicDefaultConformer: PublicProto = PublicStruct
 }
 
 public protocol RequirementTypes {

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1395,7 +1395,7 @@ protocol ProtocolWithRequirementMentioningUnavailable {
 }
 
 protocol HasMethodF {
-  typealias T
+  associatedtype T
   func f(p: T) // expected-note 5{{protocol requirement here}}
 }
 

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -44,14 +44,14 @@ var TopLevelVar: TopLevelVar? { return nil } // expected-error 2 {{use of undecl
 
 
 protocol AProtocol {
-  typealias e : e  // expected-error {{inheritance from non-protocol, non-class type 'Self.e'}}
+  associatedtype e : e  // expected-error {{inheritance from non-protocol, non-class type 'Self.e'}}
 }
 
 
 
 // <rdar://problem/15604574> Protocol conformance checking needs to be delayed
 protocol P15604574 {
-  typealias FooResult
+  associatedtype FooResult
   func foo() -> FooResult
 }
 

--- a/test/Sema/diag_values_of_module_type.swift
+++ b/test/Sema/diag_values_of_module_type.swift
@@ -30,7 +30,7 @@ enum GoodEnum {
 }
 
 protocol GoodProtocol1 : diag_values_of_module_type_foo.SomeProtocol {
-  typealias GoodTypealias1 : diag_values_of_module_type_foo.SomeProtocol
+  associatedtype GoodTypealias1 : diag_values_of_module_type_foo.SomeProtocol
 }
 
 typealias GoodTypealias1 = Swift.Int

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -2,6 +2,15 @@
   key.results: [
     {
       key.kind: source.lang.swift.keyword,
+      key.name: "associatedtype",
+      key.sourcetext: "associatedtype",
+      key.description: "associatedtype",
+      key.typename: "",
+      key.context: source.codecompletion.context.none,
+      key.num_bytes_to_erase: 0
+    },
+    {
+      key.kind: source.lang.swift.keyword,
       key.name: "class",
       key.sourcetext: "class",
       key.description: "class",

--- a/test/SourceKit/DocSupport/Inputs/cake.swift
+++ b/test/SourceKit/DocSupport/Inputs/cake.swift
@@ -1,5 +1,5 @@
 public protocol Prot {
-  typealias Element
+  associatedtype Element
   var p : Int { get }
   func foo()
 }

--- a/test/SourceKit/DocSupport/Inputs/main.swift
+++ b/test/SourceKit/DocSupport/Inputs/main.swift
@@ -137,7 +137,7 @@ func test3(c: SB1, s: S2) {
 func test4(inout a: Int) {}
 
 protocol Prot2 {
-  typealias Element
+  associatedtype Element
   var p : Int { get }
   func foo()
 }

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -1560,223 +1560,223 @@
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1724,
-    key.length: 9
+    key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1734,
+    key.offset: 1739,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1744,
+    key.offset: 1749,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1748,
+    key.offset: 1753,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1752,
+    key.offset: 1757,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1758,
+    key.offset: 1763,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1766,
+    key.offset: 1771,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1771,
+    key.offset: 1776,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1780,
+    key.offset: 1785,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1787,
+    key.offset: 1792,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot2",
     key.usr: "s:P8__main__5Prot2",
-    key.offset: 1792,
+    key.offset: 1797,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1802,
+    key.offset: 1807,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1812,
+    key.offset: 1817,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1822,
+    key.offset: 1827,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1828,
+    key.offset: 1833,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1832,
+    key.offset: 1837,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1836,
+    key.offset: 1841,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1842,
+    key.offset: 1847,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1846,
+    key.offset: 1851,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1851,
+    key.offset: 1856,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1863,
+    key.offset: 1868,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1868,
+    key.offset: 1873,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1875,
+    key.offset: 1880,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot2",
     key.usr: "s:P8__main__5Prot2",
-    key.offset: 1879,
+    key.offset: 1884,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1885,
+    key.offset: 1890,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:tF8__main__6genfoouRxS_5Prot2wx7ElementzSirFxT_L_1TMx",
-    key.offset: 1891,
+    key.offset: 1896,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.ref.typealias,
+    key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:P8__main__5Prot27Element",
-    key.offset: 1893,
+    key.offset: 1898,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1904,
+    key.offset: 1909,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1909,
+    key.offset: 1914,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1909,
+    key.offset: 1914,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:tF8__main__6genfoouRxS_5Prot2wx7ElementzSirFxT_L_1TMx",
-    key.offset: 1912,
+    key.offset: 1917,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1919,
+    key.offset: 1924,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1928,
+    key.offset: 1933,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1938,
+    key.offset: 1943,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1945,
+    key.offset: 1950,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1945,
+    key.offset: 1950,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:tP8__main__5Prot34SelfMx",
-    key.offset: 1948,
+    key.offset: 1953,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1954,
+    key.offset: 1959,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1954,
+    key.offset: 1959,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:tP8__main__5Prot34SelfMx",
-    key.offset: 1957,
+    key.offset: 1962,
     key.length: 4
   }
 ]
@@ -2413,14 +2413,14 @@
     key.name: "Prot2",
     key.usr: "s:P8__main__5Prot2",
     key.offset: 1705,
-    key.length: 72,
+    key.length: 77,
     key.entities: [
       {
-        key.kind: source.lang.swift.decl.typealias,
+        key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:P8__main__5Prot27Element",
         key.offset: 1724,
-        key.length: 10
+        key.length: 15
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
@@ -2435,7 +2435,7 @@
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:FP8__main__5Prot23fooFT_T_",
-        key.offset: 1766,
+        key.offset: 1771,
         key.length: 9
       }
     ]
@@ -2444,7 +2444,7 @@
     key.kind: source.lang.swift.decl.struct,
     key.name: "S1",
     key.usr: "s:V8__main__2S1",
-    key.offset: 1780,
+    key.offset: 1785,
     key.length: 80,
     key.conforms: [
       {
@@ -2458,11 +2458,11 @@
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Element",
         key.usr: "s:V8__main__2S17Element",
-        key.offset: 1802,
+        key.offset: 1807,
         key.length: 20,
         key.conforms: [
           {
-            key.kind: source.lang.swift.ref.typealias,
+            key.kind: source.lang.swift.ref.associatedtype,
             key.name: "Element",
             key.usr: "s:P8__main__5Prot27Element"
           }
@@ -2484,7 +2484,7 @@
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:FV8__main__2S13fooFT_T_",
-        key.offset: 1846,
+        key.offset: 1851,
         key.length: 12,
         key.conforms: [
           {
@@ -2511,14 +2511,14 @@
         key.description: "T.Element == Int"
       }
     ],
-    key.offset: 1863,
+    key.offset: 1868,
     key.length: 53,
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "x",
-        key.offset: 1912,
+        key.offset: 1917,
         key.length: 1
       }
     ]
@@ -2527,28 +2527,28 @@
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot3",
     key.usr: "s:P8__main__5Prot3",
-    key.offset: 1919,
+    key.offset: 1924,
     key.length: 44,
     key.entities: [
       {
         key.kind: source.lang.swift.decl.function.operator.infix,
         key.name: "+(_:_:)",
         key.usr: "s:ZFP8__main__5Prot3oi1pFTxx_T_",
-        key.offset: 1938,
+        key.offset: 1943,
         key.length: 23,
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "x",
-            key.offset: 1948,
+            key.offset: 1953,
             key.length: 4
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "y",
-            key.offset: 1957,
+            key.offset: 1962,
             key.length: 4
           }
         ]

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -15,7 +15,7 @@ enum MyEnum : Int {
 }
 
 protocol Prot {
-    typealias Element
+    associatedtype Element
     var p: Int { get }
     func foo()
 }
@@ -229,214 +229,214 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 255,
-    key.length: 9
+    key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 265,
+    key.offset: 270,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 277,
+    key.offset: 282,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 281,
+    key.offset: 286,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 284,
+    key.offset: 289,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 290,
+    key.offset: 295,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 300,
+    key.offset: 305,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 305,
+    key.offset: 310,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 314,
+    key.offset: 319,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
-    key.offset: 324,
+    key.offset: 329,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 329,
+    key.offset: 334,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 335,
+    key.offset: 340,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 340,
+    key.offset: 345,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 351,
+    key.offset: 356,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 361,
+    key.offset: 366,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 366,
+    key.offset: 371,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 378,
+    key.offset: 383,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 383,
+    key.offset: 388,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 390,
+    key.offset: 395,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
-    key.offset: 395,
+    key.offset: 400,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 401,
+    key.offset: 406,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 406,
+    key.offset: 411,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:C4cake2C1",
-    key.offset: 411,
+    key.offset: 416,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 414,
+    key.offset: 419,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 420,
+    key.offset: 425,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 423,
+    key.offset: 428,
     key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 434,
-    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 439,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 444,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 442,
+    key.offset: 447,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 453,
+    key.offset: 458,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 456,
+    key.offset: 461,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 465,
+    key.offset: 470,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 467,
+    key.offset: 472,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 465,
+    key.offset: 470,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 467,
+    key.offset: 472,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 471,
+    key.offset: 476,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 475,
+    key.offset: 480,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 477,
+    key.offset: 482,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 475,
+    key.offset: 480,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 477,
+    key.offset: 482,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 481,
+    key.offset: 486,
     key.length: 2
   }
 ]
@@ -463,7 +463,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.length: 23,
         key.conforms: [
           {
-            key.kind: source.lang.swift.ref.typealias,
+            key.kind: source.lang.swift.ref.associatedtype,
             key.name: "Element",
             key.usr: "s:P4cake4Prot7Element"
           }
@@ -576,27 +576,27 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
     key.offset: 235,
-    key.length: 77,
+    key.length: 82,
     key.entities: [
       {
-        key.kind: source.lang.swift.decl.typealias,
+        key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:P4cake4Prot7Element",
         key.offset: 255,
-        key.length: 17
+        key.length: 22
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
         key.usr: "s:vP4cake4Prot1pSi",
-        key.offset: 277,
+        key.offset: 282,
         key.length: 18
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:FP4cake4Prot3fooFT_T_",
-        key.offset: 300,
+        key.offset: 305,
         key.length: 10
       }
     ]
@@ -608,7 +608,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.description: "Self.Element == Int"
       }
     ],
-    key.offset: 314,
+    key.offset: 319,
     key.length: 62,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -620,7 +620,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "extfoo()",
         key.usr: "s:Fe4cakeRxS_4Protwx7ElementzSirS0_6extfooFT_T_",
-        key.offset: 361,
+        key.offset: 366,
         key.length: 13
       }
     ]
@@ -647,21 +647,21 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.description: "T2.Element == T1.Element"
       }
     ],
-    key.offset: 378,
+    key.offset: 383,
     key.length: 106,
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "ix",
-        key.offset: 471,
+        key.offset: 476,
         key.length: 2
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "y",
         key.name: "iy",
-        key.offset: 481,
+        key.offset: 486,
         key.length: 2
       }
     ]

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -78,7 +78,7 @@ private enum TestEnum {
 }
 
 private protocol TestProtocol {
-  private typealias Foo // expected-error {{'private' modifier cannot be applied to this declaration}} {{3-11=}}
+  private associatedtype Foo // expected-error {{'private' modifier cannot be applied to this declaration}} {{3-11=}}
   internal var Bar: Int { get } // expected-error {{'internal' modifier cannot be used in protocols}} {{3-12=}}
   public func baz() // expected-error {{'public' modifier cannot be used in protocols}} {{3-10=}}
 }
@@ -148,7 +148,7 @@ internal struct InternalStruct {} // expected-note * {{declared here}}
 private struct PrivateStruct {} // expected-note * {{declared here}}
 
 protocol InternalProto { // expected-note * {{declared here}}
-  typealias Assoc // expected-note {{type declared here}}
+  associatedtype Assoc // expected-note {{type declared here}}
 }
 public extension InternalProto {} // expected-error {{extension of internal protocol cannot be declared public}} {{1-8=}}
 internal extension InternalProto where Assoc == PublicStruct {}
@@ -159,7 +159,7 @@ private extension InternalProto where Assoc == InternalStruct {}
 private extension InternalProto where Assoc == PrivateStruct {}
 
 public protocol PublicProto {
-  typealias Assoc // expected-note * {{type declared here}}
+  associatedtype Assoc // expected-note * {{type declared here}}
 }
 public extension PublicProto {}
 public extension PublicProto where Assoc == PublicStruct {}
@@ -190,7 +190,7 @@ extension GenericStruct where Param: InternalProto {
 
 
 public protocol ProtoWithReqs {
-  typealias Assoc
+  associatedtype Assoc
   func foo()
 }
 

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -110,8 +110,8 @@ public enum DC_PublicEnum {
 
 // CHECK-LABEL: private{{(\*/)?}} protocol EA_PrivateProtocol {
 private protocol EA_PrivateProtocol {
-  // CHECK: {{^}} typealias Foo
-  typealias Foo
+  // CHECK: {{^}} associatedtype Foo
+  associatedtype Foo
   // CHECK: private var Bar
   var Bar: Int { get }
   // CHECK: private func baz()
@@ -120,8 +120,8 @@ private protocol EA_PrivateProtocol {
 
 // CHECK-LABEL: public{{(\*/)?}} protocol EB_PublicProtocol {
 public protocol EB_PublicProtocol {
-  // CHECK: {{^}} typealias Foo
-  typealias Foo
+  // CHECK: {{^}} associatedtype Foo
+  associatedtype Foo
   // CHECK: public var Bar
   var Bar: Int { get }
   // CHECK: public func baz()
@@ -241,13 +241,13 @@ private struct GC_NestedOuterPrivate {
 
 
 public protocol HA_PublicProtocol {
-  typealias Assoc
+  associatedtype Assoc
 }
 internal protocol HB_InternalProtocol {
-  typealias Assoc
+  associatedtype Assoc
 }
 private protocol HC_PrivateProtocol {
-  typealias Assoc
+  associatedtype Assoc
 }
 public struct HA_PublicStruct {}
 internal struct HB_InternalStruct {}

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -44,10 +44,10 @@ class DerivedClass {
 }
 
 protocol P1 {
-  typealias Element
+  associatedtype Element
 }
 protocol P2 : P1 {
-  typealias Element
+  associatedtype Element
 }
 
 func overloadedEach<O: P1>(source: O, _ closure: () -> ()) {

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -172,10 +172,10 @@ func redundant(@noescape  // expected-error {{@noescape is implied by @autoclosu
 
 
 protocol P1 {
-  typealias Element
+  associatedtype Element
 }
 protocol P2 : P1 {
-  typealias Element
+  associatedtype Element
 }
 
 func overloadedEach<O: P1, T>(source: O, _ transform: O.Element -> (), _: T) {}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -86,7 +86,7 @@ var x = c.p1
 c.p1 = 1
 
 protocol P3 {
-  typealias Assoc
+  associatedtype Assoc
   func foo() -> Assoc
 }
 

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift
 
-protocol P1 { typealias AssocType }
+protocol P1 { associatedtype AssocType }
 protocol P2 : P1 { }
 protocol P3 { }
 
@@ -43,7 +43,7 @@ extension LValueCheck {
 struct MemberTypeCheckA<T> { }
 
 protocol MemberTypeProto {
-  typealias AssocType
+  associatedtype AssocType
 
   func foo(a: AssocType)
   init(_ assoc: MemberTypeCheckA<AssocType>)
@@ -148,7 +148,7 @@ extension GenericClass where Self : P3 { }
 // expected-error@-2{{type 'GenericClass' in conformance requirement does not refer to a generic parameter or associated type}}
 
 protocol P4 {
-  typealias T
+  associatedtype T
   init(_: T)
 }
 

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -20,7 +20,7 @@ extension P1 {
 }
 
 protocol P2 {
-  typealias AssocP2 : P1
+  associatedtype AssocP2 : P1
 
   func reqP2a() -> AssocP2
 }
@@ -36,7 +36,7 @@ extension P2 {
 }
 
 protocol P3 {
-  typealias AssocP3 : P2
+  associatedtype AssocP3 : P2
 
   func reqP3a() -> AssocP3
 }
@@ -48,7 +48,7 @@ extension P3 {
 }
 
 protocol P4 {
-  typealias AssocP4
+  associatedtype AssocP4
 
   func reqP4a() -> AssocP4
 }
@@ -71,7 +71,7 @@ extension P2 {
 
 // Use of 'Self' as a return type within a protocol extension.
 protocol SelfP1 {
-  typealias AssocType
+  associatedtype AssocType
 }
 
 protocol SelfP2 {
@@ -269,7 +269,7 @@ extension S6d : P5 {
 }
 
 protocol P7 {
-  typealias P7Assoc
+  associatedtype P7Assoc
 
   func getP7Assoc() -> P7Assoc
 }
@@ -277,7 +277,7 @@ protocol P7 {
 struct P7FromP8<T> { }
 
 protocol P8 {
-  typealias P8Assoc
+  associatedtype P8Assoc
   func getP8Assoc() -> P8Assoc
 }
 
@@ -337,17 +337,17 @@ struct SConforms2b : PConforms2 {
 protocol _MySeq { }
 
 protocol MySeq : _MySeq {
-  typealias Generator : GeneratorType
+  associatedtype Generator : GeneratorType
   func myGenerate() -> Generator
 }
 
 protocol _MyCollection : _MySeq {
-  typealias Index : ForwardIndexType
+  associatedtype Index : ForwardIndexType
 
   var myStartIndex : Index { get }
   var myEndIndex : Index { get }
 
-  typealias _Element
+  associatedtype _Element
   subscript (i: Index) -> _Element { get }
 }
 
@@ -465,7 +465,7 @@ extension PConforms7 {
 struct SConforms7a : PConforms7 { }
 
 protocol PConforms8 {
-  typealias Assoc
+  associatedtype Assoc
 
   func method() -> Assoc
   var property: Assoc { get }
@@ -510,7 +510,7 @@ extension String : DefaultInitializable { }
 extension Int : DefaultInitializable { }
 
 protocol PConforms9 {
-  typealias Assoc : DefaultInitializable // expected-note{{protocol requires nested type 'Assoc'}}
+  associatedtype Assoc : DefaultInitializable // expected-note{{protocol requires nested type 'Assoc'}}
 
   func method() -> Assoc
   var property: Assoc { get }
@@ -571,7 +571,7 @@ struct SConforms11 : PConforms10, PConforms11 {}
 
 // Basic support
 protocol PTypeAlias1 {
-  typealias AssocType1
+  associatedtype AssocType1
 }
 
 extension PTypeAlias1 {
@@ -605,7 +605,7 @@ extension PTypeAliasSuper2 {
 }
 
 protocol PTypeAliasSub2 : PTypeAliasSuper2 {
-  typealias Helper
+  associatedtype Helper
   func foo() -> Helper
 }
 
@@ -688,7 +688,7 @@ func testPInherit(si2 : SInherit2, si3: SInherit3, si4: SInherit4) {
 }
 
 protocol PConstrained1 {
-  typealias AssocTypePC1
+  associatedtype AssocTypePC1
 }
 
 extension PConstrained1 {
@@ -731,7 +731,7 @@ func testPConstrained1(sc1: SConstrained1, sc2: SConstrained2,
 }
 
 protocol PConstrained2 {
-  typealias AssocTypePC2
+  associatedtype AssocTypePC2
 }
 
 protocol PConstrained3 : PConstrained2 {
@@ -791,7 +791,7 @@ extension PConstrained4 where Self : Superclass {
 
 protocol PConstrained5 { }
 protocol PConstrained6 {
-  typealias Assoc
+  associatedtype Assoc
 
   func foo()
 }

--- a/test/decl/nested.swift
+++ b/test/decl/nested.swift
@@ -30,7 +30,7 @@ struct OuterGeneric<D> {
   }
 
   protocol InnerProtocol { // expected-error{{declaration is only valid at file scope}}
-    typealias Rooster
+    associatedtype Rooster
     func flip(r: Rooster)
     func flop(t: D)
   }
@@ -93,7 +93,7 @@ class OuterGenericClass<T> {
   } 
 
   protocol InnerProtocol { // expected-error{{declaration is only valid at file scope}}
-    typealias Rooster
+    associatedtype Rooster
     func flip(r: Rooster)
     func flop(t: T)
   }
@@ -160,16 +160,16 @@ class OuterGenericClass<T> {
 }
 
 protocol OuterProtocol {
-  typealias Hen
+  associatedtype Hen
   protocol InnerProtocol { // expected-error{{type not allowed here}}
-    typealias Rooster
+    associatedtype Rooster
     func flip(r: Rooster)
     func flop(h: Hen)
   }
 }
 
 protocol Racoon {
-  typealias Stripes
+  associatedtype Stripes
   class Claw<T> { // expected-error{{type not allowed here}}
     func mangle(s: Stripes) {}
   }

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -3,7 +3,7 @@
 class C { }
 
 protocol P { // expected-note{{requirement specified as 'Self.AssocP' : 'C' [with Self = X]}}
-  typealias AssocP : C
+  associatedtype AssocP : C
 }
 
 struct X : P { // expected-error{{'P' requires that 'AssocP' (aka 'Int') inherit from 'C'}}

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -29,7 +29,7 @@ protocol P3 {
   func foo() // expected-note {{protocol requires function 'foo()'}}
   func bar() // okay
   func baz() -> Baz
-  typealias Baz
+  associatedtype Baz
 }
 
 extension P3 {
@@ -45,7 +45,7 @@ protocol P4 {
   func foo() // expected-note {{protocol requires function 'foo()'}}
   func bar() // expected-note {{protocol requires function 'bar()'}}
   func baz() -> Baz // okay
-  typealias Baz
+  associatedtype Baz
 }
 protocol P4Helper {}
 
@@ -59,7 +59,7 @@ struct P4Conformer : P4 { // expected-error {{does not conform}}
 
 
 protocol P5 {
-  typealias Foo
+  associatedtype Foo
   func foo() -> Foo // expected-note {{protocol requires function 'foo()'}}
   func bar() -> Foo // okay
   func baz() -> Foo // okay
@@ -75,14 +75,14 @@ struct P5Conformer : P5 { // expected-error {{does not conform}}
 
 
 protocol P6Base {
-  typealias Foo
+  associatedtype Foo
   func foo()
   func bar() -> Foo // expected-note{{protocol requires function 'bar()' }}
 }
 extension P6Base {
 }
 protocol P6 : P6Base {
-  typealias Bar // expected-note {{protocol requires nested type 'Bar'}}
+  associatedtype Bar // expected-note {{protocol requires nested type 'Bar'}}
 }
 extension P6 {
   func bar() -> Bar? { return nil } // expected-note{{candidate has non-matching type}}

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -32,7 +32,7 @@ protocol P6 {
 
 // Inheritable: method involving associated type.
 protocol P7 {
-  typealias Assoc
+  associatedtype Assoc
   func f7() -> Assoc
 }
 

--- a/test/decl/protocol/indirectly_recursive_requirement.swift
+++ b/test/decl/protocol/indirectly_recursive_requirement.swift
@@ -5,7 +5,7 @@ protocol Incrementable  {
 }
 
 protocol _ForwardIndexType  {
-  typealias Distance  = MyInt
+  associatedtype Distance  = MyInt
 }
 
 protocol ForwardIndexType : _ForwardIndexType {
@@ -19,7 +19,7 @@ protocol BidirectionalIndexType : ForwardIndexType, _BidirectionalIndexType {
 }
 
 protocol _RandomAccessIndexType : _BidirectionalIndexType {
-  typealias Distance
+  associatedtype Distance
 }
 
 protocol RandomAccessIndexType 

--- a/test/decl/protocol/protocol_overload_selection.swift
+++ b/test/decl/protocol/protocol_overload_selection.swift
@@ -13,9 +13,9 @@ func f<C : P2> (elements: C) {
 }
 
 protocol _CollectionType  {
-  typealias Index
+  associatedtype Index
 
-  typealias _Element
+  associatedtype _Element
   subscript(i: Index) -> _Element {get}
 }
 
@@ -38,7 +38,7 @@ C: MutableCollectionType
 
 // rdar://problem/21322215
 protocol FactoryType {
-  typealias Item
+  associatedtype Item
 }
 
 protocol MyCollectionType : Swift.CollectionType {}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -24,8 +24,8 @@ protocol Test2 {
   var title: String = "The Art of War" { get } // expected-error{{initial value is not allowed here}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
   static var title2: String = "The Art of War" // expected-error{{initial value is not allowed here}} expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{static stored properties not yet supported in generic types}}
 
-  typealias mytype
-  typealias mybadtype = Int
+  associatedtype mytype
+  associatedtype mybadtype = Int
 }
 
 func test1() {
@@ -114,7 +114,7 @@ protocol disallownesto { enum O {} } // expected-error {{type not allowed here}}
 //===----------------------------------------------------------------------===//
 
 protocol SimpleAssoc {
-  typealias Associated // expected-note{{protocol requires nested type 'Associated'}}
+  associatedtype Associated // expected-note{{protocol requires nested type 'Associated'}}
 }
 
 struct IsSimpleAssoc : SimpleAssoc {
@@ -124,7 +124,7 @@ struct IsSimpleAssoc : SimpleAssoc {
 struct IsNotSimpleAssoc : SimpleAssoc {} // expected-error{{type 'IsNotSimpleAssoc' does not conform to protocol 'SimpleAssoc'}}
 
 protocol StreamWithAssoc {
-  typealias Element
+  associatedtype Element
   func get() -> Element // expected-note{{protocol requires function 'get()' with type '() -> Element'}}
 }
 
@@ -150,7 +150,7 @@ struct StreamTypeWithInferredAssociatedTypes : StreamWithAssoc {
 }
 
 protocol SequenceViaStream {
-  typealias SequenceStreamTypeType : GeneratorType // expected-note{{protocol requires nested type 'SequenceStreamTypeType'}}
+  associatedtype SequenceStreamTypeType : GeneratorType // expected-note{{protocol requires nested type 'SequenceStreamTypeType'}}
   func generate() -> SequenceStreamTypeType
 }
 
@@ -183,7 +183,7 @@ struct NotSequence : SequenceViaStream { // expected-error{{type 'NotSequence' d
 }
 
 protocol GetATuple {
-  typealias Tuple
+  associatedtype Tuple
   func getATuple() -> Tuple
 }
 
@@ -249,7 +249,7 @@ func existentialSequence(e: SequenceType) { // expected-error{{has Self or assoc
 }
 
 protocol HasSequenceAndStream {
-  typealias R : GeneratorType, SequenceType
+  associatedtype R : GeneratorType, SequenceType
   func getR() -> R
 }
 
@@ -270,7 +270,7 @@ protocol IntIntSubscriptable {
 }
 
 protocol IntSubscriptable {
-  typealias Element
+  associatedtype Element
   subscript (i: Int) -> Element { get }
 }
 
@@ -415,7 +415,7 @@ class DoesntConformToObjCProtocol : ObjCProtocol { // expected-error{{type 'Does
 
 // <rdar://problem/16079878>
 protocol P1 {
-  typealias Assoc // expected-note 2{{protocol requires nested type 'Assoc'}}
+  associatedtype Assoc // expected-note 2{{protocol requires nested type 'Assoc'}}
 }
 
 protocol P2 {

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -3,7 +3,7 @@
 // -----
 
 protocol Foo {
-  typealias Bar : Foo // expected-error{{type may not reference itself as a requirement}}
+  associatedtype Bar : Foo // expected-error{{type may not reference itself as a requirement}}
 }
 
 struct Oroborous : Foo {
@@ -13,7 +13,7 @@ struct Oroborous : Foo {
 // -----
 
 protocol P {
- typealias A : P // expected-error{{type may not reference itself as a requirement}}
+ associatedtype A : P // expected-error{{type may not reference itself as a requirement}}
 }
 
 struct X<T: P> {
@@ -26,11 +26,11 @@ func f<T : P>(z: T) {
 // -----
 
 protocol PP2 {
-  typealias A : P2 = Self // expected-error{{type may not reference itself as a requirement}}
+  associatedtype A : P2 = Self // expected-error{{type may not reference itself as a requirement}}
 }
 
 protocol P2 : PP2 {
-  typealias A = Self
+  associatedtype A = Self
 }
 
 struct X2<T: P2> {
@@ -47,7 +47,7 @@ func f<T : P2>(z: T) {
 // -----
 
 protocol P3 {
- typealias A: P4 = Self // expected-error{{type may not reference itself as a requirement}}
+ associatedtype A: P4 = Self // expected-error{{type may not reference itself as a requirement}}
 }
 
 protocol P4 : P3 {}
@@ -68,11 +68,11 @@ f2(Y3())
 // -----
 
 protocol Alpha {
-  typealias Beta: Gamma // expected-error{{type may not reference itself as a requirement}}
+  associatedtype Beta: Gamma // expected-error{{type may not reference itself as a requirement}}
 }
 
 protocol Gamma {
-  typealias Delta: Alpha // expected-error{{type may not reference itself as a requirement}}
+  associatedtype Delta: Alpha // expected-error{{type may not reference itself as a requirement}}
 }
 
 struct Epsilon<T: Alpha, U: Gamma where T.Beta == U, U.Delta == T> { }
@@ -91,12 +91,12 @@ protocol AsExistentialAssocTypeA {
 }
 protocol AsExistentialAssocTypeB {
   func aMethod(object : AsExistentialAssocTypeA)
-  typealias Bar
+  associatedtype Bar
 }
 
 protocol AsExistentialAssocTypeAgainA {
   var delegate : AsExistentialAssocTypeAgainB? { get }
-  typealias Bar
+  associatedtype Bar
 }
 protocol AsExistentialAssocTypeAgainB {
   func aMethod(object : AsExistentialAssocTypeAgainA) // expected-error * {{protocol 'AsExistentialAssocTypeAgainA' can only be used as a generic constraint because it has Self or associated type requirements}}

--- a/test/decl/protocol/req/associated_type_default.swift
+++ b/test/decl/protocol/req/associated_type_default.swift
@@ -4,7 +4,7 @@ struct X { }
 
 // Simple default definition for associated types.
 protocol P1 {
-  typealias AssocType1 = Int
+  associatedtype AssocType1 = Int
 }
 
 extension X : P1 { }
@@ -13,7 +13,7 @@ var i: X.AssocType1 = 17
 
 // Dependent default definition for associated types
 protocol P2 {
-  typealias AssocType2 = Self
+  associatedtype AssocType2 = Self
 }
 
 extension X : P2 { }
@@ -22,7 +22,7 @@ var xAssoc2: X.AssocType2 = X()
 // Dependent default definition for associated types that doesn't meet
 // requirements.
 protocol P3 {
-  typealias AssocType3 : P1 = Self // expected-note{{default type 'X2' for associated type 'AssocType3' (from protocol 'P3') does not conform to 'P1'}}
+  associatedtype AssocType3 : P1 = Self // expected-note{{default type 'X2' for associated type 'AssocType3' (from protocol 'P3') does not conform to 'P1'}}
 }
 
 extension X : P3 { } // okay

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 protocol P0 {
-  typealias Assoc1 : PSimple // expected-note{{ambiguous inference of associated type 'Assoc1': 'Double' vs. 'Int'}}
+  associatedtype Assoc1 : PSimple // expected-note{{ambiguous inference of associated type 'Assoc1': 'Double' vs. 'Int'}}
   // expected-note@-1{{ambiguous inference of associated type 'Assoc1': 'Double' vs. 'Int'}}
   // expected-note@-2{{unable to infer associated type 'Assoc1' for protocol 'P0'}}
   // expected-note@-3{{unable to infer associated type 'Assoc1' for protocol 'P0'}}
@@ -87,7 +87,7 @@ extension P1 {
 struct X0j : P0, P1 { }
 
 protocol P2 {
-  typealias P2Assoc
+  associatedtype P2Assoc
 
   func h0(x: P2Assoc)
 }
@@ -114,7 +114,7 @@ struct X0m : P0, P2 {
 
 // Inference from properties.
 protocol PropertyP0 {
-  typealias Prop : PSimple // expected-note{{unable to infer associated type 'Prop' for protocol 'PropertyP0'}}
+  associatedtype Prop : PSimple // expected-note{{unable to infer associated type 'Prop' for protocol 'PropertyP0'}}
   var property: Prop { get }
 }
 
@@ -128,8 +128,8 @@ struct XProp0b : PropertyP0 { // expected-error{{type 'XProp0b' does not conform
 
 // Inference from subscripts
 protocol SubscriptP0 {
-  typealias Index
-  typealias Element : PSimple // expected-note{{unable to infer associated type 'Element' for protocol 'SubscriptP0'}}
+  associatedtype Index
+  associatedtype Element : PSimple // expected-note{{unable to infer associated type 'Element' for protocol 'SubscriptP0'}}
 
   subscript (i: Index) -> Element { get }
 }
@@ -144,8 +144,8 @@ struct XSubP0b : SubscriptP0 { // expected-error{{type 'XSubP0b' does not confor
 
 // Inference from properties and subscripts
 protocol CollectionLikeP0 {
-  typealias Index
-  typealias Element
+  associatedtype Index
+  associatedtype Element
 
   var startIndex: Index { get }
   var endIndex: Index { get }
@@ -166,7 +166,7 @@ struct XCollectionLikeP0a<T> : CollectionLikeP0 {
 
 // rdar://problem/21304164
 public protocol Thenable {
-    typealias T // expected-note{{protocol requires nested type 'T'}}
+    associatedtype T // expected-note{{protocol requires nested type 'T'}}
     func then(success: (_: T) -> T) -> Self
 }
 
@@ -180,8 +180,8 @@ public class CorePromise<T> : Thenable { // expected-error{{type 'CorePromise<T>
 
 // rdar://problem/21559670
 protocol P3 {
-  typealias Assoc = Int
-  typealias Assoc2
+  associatedtype Assoc = Int
+  associatedtype Assoc2
   func foo(x: Assoc2) -> Assoc?
 }
 
@@ -200,7 +200,7 @@ struct X4 : P4 { }
 
 // rdar://problem/21738889
 protocol P5 {
-  typealias A = Int
+  associatedtype A = Int
 }
 
 struct X5<T : P5> : P5 {
@@ -208,15 +208,15 @@ struct X5<T : P5> : P5 {
 }
 
 protocol P6 : P5 {
-  typealias A : P5 = X5<Self>
+  associatedtype A : P5 = X5<Self>
 }
 
 extension P6 where A == X5<Self> { }
 
 // rdar://problem/21774092
 protocol P7 {
-  typealias A
-  typealias B
+  associatedtype A
+  associatedtype B
   func f() -> A
   func g() -> B
 }
@@ -243,12 +243,12 @@ struct MyAnyGenerator<T> : MyGeneratorType {
 }
 
 protocol MyGeneratorType {
-  typealias Element
+  associatedtype Element
 }
 
 protocol MySequenceType {
-  typealias Generator : MyGeneratorType
-  typealias SubSequence
+  associatedtype Generator : MyGeneratorType
+  associatedtype SubSequence
 
   func foo() -> SubSequence
   func generate() -> Generator
@@ -279,7 +279,7 @@ protocol P9 : P8 {
 }
 
 protocol P10 {
-  typealias A
+  associatedtype A
 
   func foo() -> A
 }
@@ -306,8 +306,8 @@ func testZ10() -> Z10.A {
 
 // rdar://problem/21926788
 protocol P11 {
-  typealias A
-  typealias B
+  associatedtype A
+  associatedtype B
   func foo() -> B
 }
 

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -21,7 +21,7 @@ struct X1b : P1 {
 
 // Function with an associated type
 protocol P2 {
-  typealias Assoc : P1 // expected-note{{ambiguous inference of associated type 'Assoc': 'X1a' vs. 'X1b'}}
+  associatedtype Assoc : P1 // expected-note{{ambiguous inference of associated type 'Assoc': 'X1a' vs. 'X1b'}}
   // expected-note@-1{{protocol requires nested type 'Assoc'}}
   func f1(x: Assoc) // expected-note{{protocol requires function 'f1' with type 'Assoc -> ()'}} expected-note{{protocol requires function 'f1' with type 'Assoc -> ()'}}
 }
@@ -87,7 +87,7 @@ struct X2z : P2 { // expected-error{{type 'X2z' does not conform to protocol 'P2
 prefix operator ~~ {}
 
 protocol P3 {
-  typealias Assoc : P1
+  associatedtype Assoc : P1
   prefix func ~~(_: Self) -> Assoc // expected-note{{protocol requires function '~~' with type 'X3z -> Assoc'}}
 }
 
@@ -110,7 +110,7 @@ postfix func ~~(_: X3z) -> X1a {} // expected-note{{candidate is postfix, not pr
 // Protocol with postfix unary function
 postfix operator ~~ {}
 protocol P4 {
-  typealias Assoc : P1
+  associatedtype Assoc : P1
   postfix func ~~ (_: Self) -> Assoc // expected-note{{protocol requires function '~~' with type 'X4z -> Assoc'}}
 }
 
@@ -222,7 +222,7 @@ struct X9 : P9 {
 prefix func %%%(x: X9) -> X9 { }
 
 protocol P10 {
-  typealias Assoc
+  associatedtype Assoc
   func bar(x: Assoc)
 }
 
@@ -237,7 +237,7 @@ protocol P11 {
 }
 
 protocol P12 {
-  typealias Index : P1 // expected-note{{unable to infer associated type 'Index' for protocol 'P12'}}
+  associatedtype Index : P1 // expected-note{{unable to infer associated type 'Index' for protocol 'P12'}}
   func getIndex() -> Index
 }
 

--- a/test/decl/protocol/req/optional.swift
+++ b/test/decl/protocol/req/optional.swift
@@ -201,7 +201,7 @@ optional class optErrorClass { // expected-error{{'optional' modifier cannot be 
   
 protocol optErrorProtocol {
   optional func foo(x: Int) // expected-error{{'optional' can only be applied to members of an @objc protocol}}
-  optional typealias Assoc  // expected-error{{'optional' modifier cannot be applied to this declaration}} {{3-12=}}
+  optional associatedtype Assoc  // expected-error{{'optional' modifier cannot be applied to this declaration}} {{3-12=}}
 }
 
 @objc protocol optionalInitProto {

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -1,14 +1,14 @@
 // RUN: %target-parse-verify-swift
 
 protocol SomeProtocol {
-	typealias T
+	associatedtype T
 }
 
 extension SomeProtocol where T == Optional<T> { } // expected-error{{same-type constraint 'Self.T' == 'Optional<Self.T>' is recursive}}
 
 // rdar://problem/20000145
 public protocol P {
-  typealias T
+  associatedtype T
 }
 public struct S<A: P where A.T == S<A>> {}
 
@@ -18,5 +18,5 @@ class X<T where T == X> { // expected-error{{same-type requirement makes generic
 }
 
 protocol Y {
-  typealias Z = Z // expected-error{{type alias 'Z' circularly references itself}}
+  associatedtype Z = Z // expected-error{{type alias 'Z' circularly references itself}}
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -274,7 +274,7 @@ class Foo {
 
 // <rdar://problem/23952125> QoI: Subscript in protocol with missing {}, better diagnostic please
 protocol r23952125 {
-  typealias ItemType
+  associatedtype ItemType
   var count: Int { get }
   subscript(index: Int) -> ItemType  // expected-error {{subscript in protocol must have explicit { get } or { get set } specifier}} {{36-36= { get set \}}}
   

--- a/test/decl/typealias/associated_types.swift
+++ b/test/decl/typealias/associated_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift -parse-as-library
 
 protocol BaseProto {
-  typealias AssocTy
+  associatedtype AssocTy
 }
 var a: BaseProto.AssocTy = 4 // expected-error{{cannot use associated type 'AssocTy' outside of its protocol}}
 

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 protocol P {
-  typealias Assoc = Self
+  associatedtype Assoc = Self
 }
 
 struct X : P {
@@ -15,7 +15,7 @@ func f<T: P>(x: T, y: Y<T>.Assoc) {
 }
 
 protocol P1 {
-  typealias A = Int
+  associatedtype A = Int
 }
 
 struct X1<T> : P1 {

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -944,7 +944,7 @@ var didSetPropertyTakingOldValue : Int = 0 {
 
 // rdar://16280138 - synthesized getter is defined in terms of archetypes, not interface types
 protocol AbstractPropertyProtocol {
-  typealias Index
+  associatedtype Index
   var a : Index { get }
 }
 struct AbstractPropertyStruct<T> : AbstractPropertyProtocol {

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -48,7 +48,7 @@ struct CompoAliasTypeWhereRequirement<T where T: Compo> {}
 
 // rdar://problem/20593294
 protocol HasAssoc {
-  typealias Assoc
+  associatedtype Assoc
   func foo()
 }
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -394,6 +394,7 @@ static bool matchesExpectedStyle(Completion *completion, NameStyle style) {
   case CodeCompletionDeclKind::Enum:
   case CodeCompletionDeclKind::Protocol:
   case CodeCompletionDeclKind::TypeAlias:
+  case CodeCompletionDeclKind::AssociatedType:
     return style.possiblyUpperCamelCase();
 
   case CodeCompletionDeclKind::StaticMethod:

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -115,6 +115,8 @@ static UIdent KindDeclExtensionStruct("source.lang.swift.decl.extension.struct")
 static UIdent KindDeclExtensionClass("source.lang.swift.decl.extension.class");
 static UIdent KindDeclExtensionEnum("source.lang.swift.decl.extension.enum");
 static UIdent KindDeclExtensionProtocol("source.lang.swift.decl.extension.protocol");
+static UIdent KindDeclAssociatedType("source.lang.swift.decl.associatedtype");
+static UIdent KindRefAssociatedType("source.lang.swift.ref.associatedtype");
 static UIdent KindDeclTypeAlias("source.lang.swift.decl.typealias");
 static UIdent KindRefTypeAlias("source.lang.swift.ref.typealias");
 static UIdent KindDeclGenericTypeParam("source.lang.swift.decl.generic_type_param");
@@ -163,7 +165,7 @@ public:
   UIdent visitVarDecl(const VarDecl *D);
   UIdent visitExtensionDecl(const ExtensionDecl *D);
   UIdent visitAssociatedTypeDecl(const AssociatedTypeDecl *D) {
-    return IsRef ? KindRefTypeAlias : KindDeclTypeAlias;
+    return IsRef ? KindRefAssociatedType : KindDeclAssociatedType;
   }
 
 #define UID_FOR(CLASS) \
@@ -312,6 +314,7 @@ UIdent SwiftLangSupport::getUIDForCodeCompletionDeclKind(
     case CodeCompletionDeclKind::Enum: return KindRefEnum;
     case CodeCompletionDeclKind::EnumElement: return KindRefEnumElement;
     case CodeCompletionDeclKind::Protocol: return KindRefProtocol;
+    case CodeCompletionDeclKind::AssociatedType: return KindRefAssociatedType;
     case CodeCompletionDeclKind::TypeAlias: return KindRefTypeAlias;
     case CodeCompletionDeclKind::GenericTypeParam: return KindRefGenericTypeParam;
     case CodeCompletionDeclKind::Constructor: return KindRefConstructor;
@@ -337,6 +340,7 @@ UIdent SwiftLangSupport::getUIDForCodeCompletionDeclKind(
   case CodeCompletionDeclKind::Enum: return KindDeclEnum;
   case CodeCompletionDeclKind::EnumElement: return KindDeclEnumElement;
   case CodeCompletionDeclKind::Protocol: return KindDeclProtocol;
+  case CodeCompletionDeclKind::AssociatedType: return KindDeclAssociatedType;
   case CodeCompletionDeclKind::TypeAlias: return KindDeclTypeAlias;
   case CodeCompletionDeclKind::GenericTypeParam: return KindDeclGenericTypeParam;
   case CodeCompletionDeclKind::Constructor: return KindDeclConstructor;


### PR DESCRIPTION
Adds an associatedtype keyword to the parser tokens, and accepts either
typealias or associatedtype to create an AssociatedTypeDecl, warning
that the former is deprecated. The ASTPrinter now emits associatedtype
for AssociatedTypeDecls.

Separated AssociatedType from TypeAlias as two different kinds of
CodeCompletionDeclKinds. This part probably doesn’t turn out to be
absolutely necessary currently, but it is nice cleanup from formerly
specifically glomming the two together.

And then many, many changes to tests. The actual new test for the fixit
is at the end of Generics/associated_types.swift.

There is one open question at the moment, which is what should happen
with using associatedtype in a non-Protocol context:

```
protocol P9 {
  associatedtype A1 : P8
}
struct Y9 : P9 {
  typealias A1 = X8
}
```

Currently the code still expects typealias in the struct, and it _is_ a
typealias as far as the compiler is concerned. But I can certainly
imagine users mistakenly thinking that they are ‘assigning’ a specific type to an
associatedtype instead. With this current commit, using the
associatedtype keyword there will assert an unexpected token. It should
either accept it or have a nice error, and I’m not sure which.
