### PR TITLE
[StdlibUnittest] Fix "'++' is deprecated" warning

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -57,8 +57,8 @@ func findSubstring(string: String, _ substring: String) -> String.Index? {
       }
       if needle[needleIndex] == haystack[matchIndex] {
         // keep advancing through both the string and search string on match
-        ++matchIndex
-        ++needleIndex
+        matchIndex = matchIndex.successor()
+        needleIndex = needleIndex.successor()
       } else {
         // no match, go back to finding a starting match in the string.
         break


### PR DESCRIPTION
`++` operators were being used for the implementation of a StdlibUnittest helper function, in environments where the Objective-C runtime was unavailable. Replace these with successor functions.

---

Output when compiling before making this change:

```
[337/339] Compiling /home/modocache/GitHub/apple/build/Ninja-ReleaseAssert/swift-linux-x86_64/stdlib/private/StdlibUnittest/linux/x86_64/StdlibUnittest.o
/home/modocache/GitHub/apple/swift/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift:60:9: warning: '++' is deprecated: it will be removed in Swift 3
        ++matchIndex
        ^~
                     = matchIndex.successor()
/home/modocache/GitHub/apple/swift/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift:61:9: warning: '++' is deprecated: it will be removed in Swift 3
        ++needleIndex
        ^~
                      = needleIndex.successor()
```

After making the change, the warnings are no longer emitted.
