### PR TITLE
[build-presets] Remove unknown tvOS build param

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -142,22 +142,6 @@ mixin-preset=
 mixin-preset=
     mixin_buildbot_tools_RA_stdlib_RDA
 
-[preset: buildbot,tools=RA,stdlib=DA,NotvOS]
-mixin-preset=
-    mixin_buildbot_tools_RA_stdlib_DA
-    mixin_NotvOS
-
-[preset: buildbot,tools=RA,stdlib=RD,NotvOS]
-mixin-preset=
-    mixin_buildbot_tools_RA_stdlib_RD
-    mixin_NotvOS
-
-
-[preset: buildbot,tools=RA,stdlib=RDA,NotvOS]
-mixin-preset=
-    mixin_buildbot_tools_RA_stdlib_RDA
-    mixin_NotvOS
-
 
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes
@@ -183,15 +167,6 @@ build-ninja
 build-swift-static-stdlib=0
 
 compiler-vendor=apple
-
-
-[preset: mixin_NotvOS]
-dash-dash
-
-swift-sdks=OSX;IOS;IOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR
-skip-build-tvos
-skip-test-tvos
-swift-enable-target-appletvos=0
 
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA]
@@ -232,13 +207,6 @@ dash-dash
 skip-test-osx
 skip-test-ios
 skip-test-watchos
-
-[preset: buildbot_incremental,tools=RA,stdlib=RA,NotvOS]
-mixin-preset=
-    buildbot_incremental,tools=RA,stdlib=RA
-    mixin_NotvOS
-
-build-subdir=buildbot_incremental_NotvOS
 
 
 [preset: buildbot_incremental_asan,tools=RDA,stdlib=RDA]


### PR DESCRIPTION
The parameter `swift-enable-target-appletvos` is not recognized by `build-script-impl`. Running the build-script with this preset results in the error:

```
Error: Unknown setting: swift-enable-target-appletvos
```

Remove the unknown parameter.
