### PR TITLE
[sema] forbid struct as type argument in type of its property

### DIFF
--- a/validation-test/compiler_crashers_fixed/24887-no-stack-trace.swift
+++ b/validation-test/compiler_crashers_fixed/24887-no-stack-trace.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// RUN: not %target-swift-frontend %s -emit-silgen
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/codafi (Robert Widmann)
 


### PR DESCRIPTION
When property type with generic argument is declared similar to type of
`s` in the following, complain.

```
struct X<T> {
    let s: X<X>
}
```

A complier crash is thus resolved.

This change can be further developed to check recursive value type, which
is currently checked after SILGen.

(build-script -RT passes, I also removed some local trailing whitespaces).
