### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::applyUnboundGenericArguments(…)

### DIFF
--- a/validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class B<T{func a{{func g:A}protocol A{typealias e=c<T>struct c<a]typealias d:e


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:835: bool swift::TypeChecker::checkGenericArguments(swift::DeclContext *, swift::SourceLoc, swift::SourceLoc, swift::Type, swift::GenericSignature *, ArrayRef<swift::Type>): Assertion `count == genericArgs.size()' failed.
9  swift           0x0000000000e66a1d swift::TypeChecker::applyUnboundGenericArguments(swift::UnboundGenericType*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) + 589
10 swift           0x0000000000e66680 swift::TypeChecker::applyGenericArguments(swift::Type, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, bool, swift::GenericTypeResolver*) + 448
14 swift           0x0000000000e66bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift           0x0000000000e67b14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
17 swift           0x0000000000e66aea swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
22 swift           0x0000000000e17a01 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 5969
23 swift           0x00000000010048ec swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
24 swift           0x00000000010032fd swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
25 swift           0x0000000000e3d3bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
28 swift           0x0000000000e66bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
30 swift           0x0000000000e67b14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
31 swift           0x0000000000e66aea swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
32 swift           0x0000000000ef50b2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
33 swift           0x0000000000ef433d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
34 swift           0x0000000000e13119 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
35 swift           0x0000000000e166c1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
39 swift           0x0000000000e66bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
41 swift           0x0000000000e67b14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
42 swift           0x0000000000e66aea swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
45 swift           0x0000000000e1bb96 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
48 swift           0x0000000000e623fa swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
49 swift           0x0000000000e8c2cc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
50 swift           0x0000000000e00fdb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
53 swift           0x0000000000e6111a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
54 swift           0x0000000000e60f6e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
55 swift           0x0000000000e61b38 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
57 swift           0x0000000000de8282 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
58 swift           0x0000000000c9f9b2 swift::CompilerInstance::performSema() + 2946
60 swift           0x0000000000764ccf frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2463
61 swift           0x000000000075f8d5 main + 2741
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28202-swift-typechecker-applygenericarguments-c0e012.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:11
2.  While type-checking expression at [validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:18 - line:8:27] RangeText="{func g:A}"
3.  While type-checking 'g' at validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:19
4.  While resolving type A at [validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:26 - line:8:26] RangeText="A"
5.  While resolving type e at [validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:78 - line:8:78] RangeText="e"
6.  While type-checking 'A' at validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:28
7.  While resolving type c<T> at [validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift:8:51 - line:8:54] RangeText="c<T>"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
