### PR TITLE
[StdLib] Update requirements for UnicodeUTFEncoders test

### DIFF
--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
-// FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import SwiftPrivate
 import StdlibUnittest


### PR DESCRIPTION
All of the tests in this file need the Objective-C runtime. This change removes
the XFAIL on linux and replaces it with a runtime requirement.
## 

Tested on OS X 10.10 and Ubuntu 14.04
