### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getDesugaredType()

### DIFF
--- a/validation-test/compiler_crashers/28203-swift-typebase-getdesugaredtype.swift
+++ b/validation-test/compiler_crashers/28203-swift-typebase-getdesugaredtype.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol P{
+func f:P
+protocol P{func b:e
+typealias B:P
+typealias e


### PR DESCRIPTION
Stack trace:

```
4  swift           0x00000000010189d0 swift::TypeBase::getDesugaredType() + 32
9  swift           0x0000000001026074 swift::Type::walk(swift::TypeWalker&) const + 52
10 swift           0x00000000010159cf swift::Type::findIf(std::function<bool (swift::Type)> const&) const + 31
19 swift           0x0000000000f6da94 swift::Decl::walk(swift::ASTWalker&) + 20
20 swift           0x0000000000ff8b0e swift::SourceFile::walk(swift::ASTWalker&) + 174
21 swift           0x0000000001027a54 swift::verify(swift::SourceFile&) + 52
22 swift           0x0000000000de8342 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1922
23 swift           0x0000000000c9f9b2 swift::CompilerInstance::performSema() + 2946
25 swift           0x0000000000764ccf frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2463
26 swift           0x000000000075f8d5 main + 2741
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28203-swift-typebase-getdesugaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28203-swift-typebase-getdesugaredtype-5179cc.o
1.  While walking into decl 'P' at validation-test/compiler_crashers/28203-swift-typebase-getdesugaredtype.swift:7:1
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
