### PR TITLE
Invoke "/usr/bin/env bash" instead of "/bin/bash" also in print-var.sh

### DIFF
--- a/test/Driver/Inputs/print-var.sh
+++ b/test/Driver/Inputs/print-var.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 last_arg=${@: -1}
 echo ${!last_arg}


### PR DESCRIPTION
Prior to this commit:

```
$ git grep '#!/usr/bin/env bash' | wc -l
8
$ git grep '#!/bin/bash' | wc -l
1
```

After this commit:

```
$ git grep '#!/usr/bin/env bash' | wc -l
9
$ git grep '#!/bin/bash' | wc -l
0
```
