### PR TITLE
[SR-510] diagnose enum raw value in closure parsing

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4398,7 +4398,6 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     
     // See if there's a raw value expression.
     SourceLoc EqualsLoc;
-    auto NextLoc = peekToken().getLoc();
     ParserResult<Expr> RawValueExpr;
     LiteralExpr *LiteralRawValueExpr = nullptr;
     if (Tok.is(tok::equal)) {
@@ -4413,7 +4412,6 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         return Status;
       }
       if (RawValueExpr.isNull()) {
-        diagnose(NextLoc, diag::nonliteral_enum_case_raw_value);
         Status.setIsParseError();
         return Status;
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4405,7 +4405,16 @@ ParserStatus Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       {
         CodeCompletionCallbacks::InEnumElementRawValueRAII
             InEnumElementRawValue(CodeCompletion);
-        RawValueExpr = parseExpr(diag::expected_expr_enum_case_raw_value);
+        if (!CurLocalContext) {
+          // A local context is needed for parsing closures. We want to parse
+          // them anyways for proper diagnosis.
+          LocalContext tempContext{};
+          CurLocalContext = &tempContext;
+          RawValueExpr = parseExpr(diag::expected_expr_enum_case_raw_value);
+          CurLocalContext = nullptr;
+        } else {
+          RawValueExpr = parseExpr(diag::expected_expr_enum_case_raw_value);
+        }
       }
       if (RawValueExpr.hasCodeCompletion()) {
         Status.setHasCodeCompletion();

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -290,9 +290,4 @@ func testSimpleEnum() {
   let _ : SimpleEnum=.X    // expected-error {{'=' must have consistent whitespace on both sides}}
 }
 
-enum SR510: String {
-    case Thing = "thing"
-    case Bob = {"test"} // expected-error {{raw value for enum case must be a literal}}
-}
-
 

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -290,4 +290,9 @@ func testSimpleEnum() {
   let _ : SimpleEnum=.X    // expected-error {{'=' must have consistent whitespace on both sides}}
 }
 
+enum SR510: String {
+    case Thing = "thing"
+    case Bob = {"test"} // expected-error {{raw value for enum case must be a literal}}
+}
+
 


### PR DESCRIPTION
This reverts the previous fix "complain for invalid enum raw value" and fixes
SR-510 with a different approach:

~~enum raw value is parsed as a normal expression. When a closure is encountered
as the expression, a proper context will be absent. If we pass a diagnosis
from raw value to `parseExprClosure`, it will get properly issued.~~

enum raw value is parsed as a normal expression using `parseExpr()`. However,
for a closure, the parser expects a local context that doesn't exist for raw
values.

We create a temporary context to ensure the closure gets parsed as normal.
As a consequence, `parseExpr()` returns normally for closure and correct
diagnosis for raw value gets issued.

@jrose-apple 
