### PR TITLE
[gardening] Fix violations of non-controversial PEP8 rules

### DIFF
--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-import sys, re, subprocess
+import re
+import subprocess
+import sys
 
 def run():
     if len(sys.argv) > 1:
@@ -18,20 +20,20 @@ usage: nshtml2rst < NSString.html > NSString.rst
     html = re.sub(
         r'<div\s+class="declaration">(.*?)</div>', 
         r'<pre>\1</pre>', 
-        html, flags=re.MULTILINE|re.DOTALL)
+        html, flags=re.MULTILINE | re.DOTALL)
 
     # Strip all attributes from <pre>...</pre> containing class="..."
     # The resulting classes confound ReST
     html = re.sub(
         r'<pre\s[^>]*class=[^>]*>(.*?)</pre>', 
         r'<pre>\1</pre>', 
-        html, flags=re.MULTILINE|re.DOTALL)
+        html, flags=re.MULTILINE | re.DOTALL)
 
     # Remove links from <code>...</code>, which doesn't have a rendering in ReST
     html = re.sub(
         r'<code>(.*?)<a[^>]*?>(.*?)</a>(.*?)</code>', 
         r'<code>\1\2\3</code>', 
-        html, flags=re.MULTILINE|re.DOTALL)
+        html, flags=re.MULTILINE | re.DOTALL)
 
     # Let pandoc do most of the hard work
     p = subprocess.Popen(
@@ -45,7 +47,7 @@ usage: nshtml2rst < NSString.html > NSString.rst
     # bogus heading level nesting.  Just fix up the one we know about
     # so that ReST doesn't complain later.
     rst = re.sub("(^|\n)('+)($|\n)", 
-                 lambda m: m.group(1) + len(m.group(2))*'^' +m.group(3), 
+                 lambda m: m.group(1) + len(m.group(2)) * '^' + m.group(3),
                  rst, flags=re.MULTILINE)
 
     sys.stdout.write(rst)

--- a/stdlib/public/common/MirrorCommon.py
+++ b/stdlib/public/common/MirrorCommon.py
@@ -55,4 +55,3 @@ def getGenericArgString(genericArgs=None, genericConstraints=None):
 
 def getGenericConstraintString(genericArgs=None, genericConstraints=None):
   return _getGenericArgStrings(genericArgs, genericConstraints)[1]
-

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -30,7 +30,7 @@ if '-primary-file' in sys.argv:
   # Modify all files after the primary file.
   # Ideally this would modify every non-primary file, but that's harder to
   # infer without actually parsing the arguments.
-  for file in sys.argv[primaryFileIndex+1:]:
+  for file in sys.argv[primaryFileIndex + 1:]:
     if file.startswith('-'):
       break
     os.utime(file, None)

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -400,9 +400,9 @@ functionList = [
 
 #  ("sourcekitd_send_request",
 
-   ("sourcekitd_send_request_sync",
-    [Object],
-    c_object_p),
+  ("sourcekitd_send_request_sync",
+  	[Object],
+  	c_object_p),
 
   # ("sourcekitd_set_interrupted_connection_handler",
 
@@ -426,8 +426,8 @@ functionList = [
   	c_char_p),
 
   ("sourcekitd_variant_array_apply_f",
-    [Variant, callbacks['array_applier'], py_object],
-    c_bool),
+  	[Variant, callbacks['array_applier'], py_object],
+  	c_bool),
 
 
   ("sourcekitd_variant_array_get_bool",
@@ -459,8 +459,8 @@ functionList = [
   	c_bool),
 
   ("sourcekitd_variant_dictionary_apply_f",
-    [Variant, callbacks['dictionary_applier'], py_object],
-    c_bool),
+  	[Variant, callbacks['dictionary_applier'], py_object],
+  	c_bool),
 
   ("sourcekitd_variant_dictionary_get_bool",
   	[Variant, UIdent],
@@ -501,7 +501,7 @@ functionList = [
   ("sourcekitd_variant_uid_get_value",
   	[Variant],
   	c_object_p),
-  ]
+]
 
 
 class LibsourcekitdError(Exception):

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -257,8 +257,9 @@ class UnicodeTrieGenerator(object):
 
         # An array of BMP data blocks.
         self.BMP_data = [
-            [ -1 for i in range(0, 1 << self.BMP_data_offset_bits) ]
-                for i in range(0, 1 << self.BMP_first_level_index_bits) ]
+            [-1 for i in range(0, 1 << self.BMP_data_offset_bits)]
+            for i in range(0, 1 << self.BMP_first_level_index_bits)
+        ]
 
         # A mapping from supp first-level index to an index of the second-level
         # lookup table.
@@ -268,13 +269,15 @@ class UnicodeTrieGenerator(object):
         # table is a mapping from a supp second-level index to supp data block
         # index.
         self.supp_lookup2 = [
-            [ j for j in range(i << self.supp_second_level_index_bits, (i + 1) << self.supp_second_level_index_bits) ]
-                for i in range(0, self.supp_first_level_index_max + 1) ]
+            [j for j in range(i << self.supp_second_level_index_bits, (i + 1) << self.supp_second_level_index_bits)]
+            for i in range(0, self.supp_first_level_index_max + 1)
+        ]
 
         # An array of supp data blocks.
         self.supp_data = [
-            [ -1 for i in range(0, 1 << self.supp_data_offset_bits) ]
-                for i in range(0, (self.supp_first_level_index_max + 1) * (1 << self.supp_second_level_index_bits)) ]
+            [-1 for i in range(0, 1 << self.supp_data_offset_bits)]
+            for i in range(0, (self.supp_first_level_index_max + 1) * (1 << self.supp_second_level_index_bits))
+        ]
 
     def splat(self, value):
         for i in range(0, len(self.BMP_data)):
@@ -602,4 +605,3 @@ def get_grapheme_cluster_break_tests_as_unicode_scalars(grapheme_break_test_file
                 result += [ test ]
 
     return result
-

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -78,7 +78,7 @@ def all_integer_type_names():
     return [self_ty.stdlib_name for self_ty in all_integer_types(0)]
 
 def all_real_number_type_names():
-    return ['Float', 'Double'] #FIXME , 'Float80' Revert until I figure out a test failure  # Float80 for i386 & x86_64
+    return ['Float', 'Double'] # FIXME , 'Float80' Revert until I figure out a test failure  # Float80 for i386 & x86_64
 
 def all_numeric_type_names():
     return all_integer_type_names() + all_real_number_type_names()
@@ -102,4 +102,3 @@ def all_integer_assignment_operator_names():
     
 def all_integer_or_real_assignment_operator_names():
     return ['=', '*=', '/=', '%=', '+=', '-=']
-    

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -49,7 +49,7 @@ def apply_edits(path):
         if fname not in edits_per_file:
             edits_per_file[fname] = []
         edits_per_file[fname].append((ed[1], ed[2], ed[3]))
-    
+
     for fname, edits in edits_per_file.iteritems():
         print('Updating', fname)
         edits.sort(reverse=True)
@@ -59,7 +59,8 @@ def apply_edits(path):
             offset = ed[0]
             length = ed[1]
             text = ed[2]
-            file_data = file_data[:offset] + str(text) + file_data[offset+length:]
+            file_data = file_data[:offset] + str(text) + \
+                file_data[offset + length:]
         with open(fname, 'w') as f:
             f.write(file_data)
     return 0
@@ -70,7 +71,7 @@ def main():
         description="""Finds all .remap files in a directory and applies their
 edits to the source files.""")
     parser.add_argument("build_dir_path",
-        help="path to index info")
+                        help="path to index info")
 
     args = parser.parse_args()
     return apply_edits(args.build_dir_path)

--- a/utils/build-script
+++ b/utils/build-script
@@ -531,9 +531,8 @@ the number of parallel build jobs to use""",
         args.build_cmark = True
 
     # Build LLDB if any LLDB-related options were specified.
-    if (args.lldb_build_variant is not None or
-        args.lldb_assertions is not None):
-       args.build_lldb = True
+    if (args.lldb_build_variant is not None or args.lldb_assertions is not None):
+        args.build_lldb = True
 
     # Set the default build variant.
     if args.build_variant is None:
@@ -805,4 +804,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -43,7 +43,7 @@ def _make_line_map(filename, stream=None):
     for i, l in enumerate(input.readlines()):
         m = line_pattern.match(l)
         if m:
-            result.append((i+1, m.group(2), int(m.group(1))))
+            result.append((i + 1, m.group(2), int(m.group(1))))
     return result
 
 _line_maps = {}
@@ -60,7 +60,7 @@ def map_line(filename, line_num):
     map = fline_map(filename)
     index = bisect.bisect_left(map, (line_num,'',0))
     base = map[index - 1]
-    return base[1], base[2] + (line_num - base[0]-1)
+    return base[1], base[2] + (line_num - base[0] - 1)
 
 def run():
     if len(sys.argv) <= 1:

--- a/utils/name-compression/CBCGen.py
+++ b/utils/name-compression/CBCGen.py
@@ -142,6 +142,7 @@ class Trie:
   def generateHeader(self):
     return "// Returns the index of the longest substring in \p str that's shorter than \p n.\n" +\
            "int matchStringSuffix(const char* str, int n) {"
+
   def generateFooter(self):
     return "return -1; \n}"
 

--- a/utils/name-compression/HuffGen.py
+++ b/utils/name-compression/HuffGen.py
@@ -48,8 +48,10 @@ class Node:
   def getMaxEncodingLength(self):
     """ Return the length of the longest possible encoding word"""
     v = 0
-    if self.left:  v = max(v, 1 + self.left .getMaxEncodingLength())
-    if self.right: v = max(v, 1 + self.right.getMaxEncodingLength())
+    if self.left:
+      v = max(v, 1 + self.left .getMaxEncodingLength())
+    if self.right:
+      v = max(v, 1 + self.right.getMaxEncodingLength())
     return v
 
   def generate_decoder(self, depth):
@@ -63,8 +65,10 @@ class Node:
 
     T = """{0}if ((tailbits & 1) == {1}) {{\n{0} tailbits/=2;\n{2}\n{0}}}"""
     sb = ""
-    if self.left:  sb += T.format(space, 0, self.left .generate_decoder(depth + 1)) + "\n"
-    if self.right: sb += T.format(space, 1, self.right.generate_decoder(depth + 1))
+    if self.left:
+      sb += T.format(space, 0, self.left .generate_decoder(depth + 1)) + "\n"
+    if self.right:
+      sb += T.format(space, 1, self.right.generate_decoder(depth + 1))
     return sb
 
   def generate_encoder(self, stack):
@@ -73,7 +77,7 @@ class Node:
     """
     if self.val:
       sb = "if (ch == '" + str(self.val) +"') {"
-      sb += "/*" +  "".join(map(str, reversed(stack))) + "*/ "
+      sb += "/*" + "".join(map(str, reversed(stack))) + "*/ "
       # Encode the bit stream as a numeric value. Updating the APInt in one go
       # is much faster than inserting one bit at a time.
       numeric_val = 0
@@ -84,8 +88,10 @@ class Node:
       sb += "return; }\n"
       return sb
     sb = ""
-    if (self.left):  sb += self.left .generate_encoder(stack + [0])
-    if (self.right): sb += self.right.generate_encoder(stack + [1])
+    if self.left:
+      sb += self.left .generate_encoder(stack + [0])
+    if self.right:
+      sb += self.right.generate_encoder(stack + [1])
     return sb
 
 # Only accept these characters into the tree.
@@ -132,4 +138,3 @@ print "std::pair<char, unsigned> variable_decode(uint64_t tailbits) {\n", nodes[
 print "void variable_encode(uint64_t &bits, uint64_t &num_bits, char ch) {\n", nodes[0].generate_encoder([]),"assert(false);\n}"
 print "} // namespace"
 print "#endif /* SWIFT_MANGLER_HUFFMAN_H */"
-

--- a/utils/omit-needless-words.py
+++ b/utils/omit-needless-words.py
@@ -86,4 +86,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -49,7 +49,7 @@ def build_disable_slice_pipelines(**kwargs):
         return result
 
     for i in pipeline_range:
-        pipeline_args = get_pipeline_args(kwargs['pipeline_script'], pipeline_range[:i+1])
+        pipeline_args = get_pipeline_args(kwargs['pipeline_script'], pipeline_range[:i + 1])
         data_file = os.path.join(kwargs['output_dir'], "pipeline-slice-%.2d-disabled-pipeline.json" % i)
         with open(data_file, 'w') as f:
             f.write(subprocess.check_output(pipeline_args))

--- a/utils/pass-pipeline/src/pass_pipeline.py
+++ b/utils/pass-pipeline/src/pass_pipeline.py
@@ -1,6 +1,7 @@
 class Pass(object):
     def __init__(self, name):
         self.name = name
+
     def __repr__(self):
         return "<pass name=%s>" % self.name
 

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -208,10 +208,10 @@ def compareScores(key, score1, score2, runs):
     while r < runs:
         row.append("0.0")
 
-    row.append("%.2f" % abs(bestscore1-bestscore2))
+    row.append("%.2f" % abs(bestscore1 - bestscore2))
     Num=float(bestscore1)
     Den=float(bestscore2)
-    row.append(("%.2f" % (Num/Den)) if Den > 0 else "*")
+    row.append(("%.2f" % (Num / Den)) if Den > 0 else "*")
     return row
 
 def compareTimingsFiles(file1, file2):
@@ -227,7 +227,7 @@ def compareTimingsFiles(file1, file2):
         print("comparing ", file1, "vs", file2, "=", end='')
         print(file1, "/", file2)
 
-    rows =  [["benchmark"]]
+    rows = [["benchmark"]]
     for i in range(0,runs):
         rows[0].append("baserun%d" % i)
     for i in range(0,runs):

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -60,7 +60,7 @@ def bodyLines(bodyText):
     return [
         cgi.escape(b.group(0)) for b in
         re.finditer(
-            r'(typealias\s*'+identifier+r'(\s*[:,]\s*'+identifier + ')?|' + operator + '.*)',
+            r'(typealias\s*' + identifier + r'(\s*[:,]\s*' + identifier + ')?|' + operator + '.*)',
             bodyText, reFlags)
     ]
 

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -67,7 +67,7 @@ class SwiftLexer(RegexLexer):
             (r'\b(return|break)\b', Keyword.Reserved),
 
             (r'[\^\*!%&<>+=/?-]|\.{2}', Operator),
-            (r'\$([0-9]+)', Name.Variable),   #Tokens
+            (r'\$([0-9]+)', Name.Variable),   # Tokens
             (r'[\[\]\(\)\{\}\|:;,.#]', Punctuation),
             (r'[0-9]+\.[0-9]+', Number.Float),
             (r'0x[0-9a-fA-F]+', Number.Hex),

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -20,7 +20,7 @@ def merge_file_lists(src_root_dirs, skip_files, skip_subpaths):
     for src_root_dir in src_root_dirs:
         for src_dir, dirs, files in os.walk(src_root_dir):
             rel_dir = os.path.relpath(src_dir, src_root_dir)
-            rel_files = [os.path.join(rel_dir, file) for file in files+dirs
+            rel_files = [os.path.join(rel_dir, file) for file in files + dirs
                         if file not in skip_files]
             file_list.extend(filter(lambda file:
                                     file not in file_list, rel_files))
@@ -94,8 +94,8 @@ def merge_lipo_files(src_root_dirs, file_list, copy_verbatim_subpaths,
 
 def main():
     parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description="""
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
 This script merges and applies 'lipo' to directories. For each file present in
 any source directory, it will create a file in the destination directory.
 

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -52,7 +52,7 @@ def get_verify_build_dir_commands(build_dir, toolchain_name='XcodeDefault'):
 
 
 def get_verify_resource_dir_modules_commands(
-    resource_dir, sil_opt, toolchain_name):
+        resource_dir, sil_opt, toolchain_name):
     print("================================================================")
     print("Resource dir: " + resource_dir)
     print("sil-opt path: " + sil_opt)

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -35,7 +35,7 @@ def capture_with_result(args, include_stderr=False):
     except OSError,e:
         if e.errno == errno.ENOENT:
             sys.exit('no such file or directory: %r when running %s.' % (
-                  args[0], ' '.join(args)))
+                args[0], ' '.join(args)))
         raise
     out,_ = p.communicate()
     return out,p.wait()
@@ -123,7 +123,8 @@ def main():
          'name' : capture(["uname","-n"], include_stderr=True).strip(),
          'os' : capture(["uname","-sr"], include_stderr=True).strip(),
          'uname' : capture(["uname","-a"], include_stderr=True).strip(),
-         } }
+      }
+   }
 
    # FIXME: Record source versions for LLVM, Swift, etc.?
    lnt_results['Run'] = {
@@ -135,7 +136,8 @@ def main():
          'inferred_run_order' : run_order,
          'run_order' : run_order,
          'sw_vers' : capture(['sw_vers'], include_stderr=True).strip(),
-         } }
+      }
+   }
 
    lnt_results['Tests'] = lnt_tests = []
    for test in data['tests']:
@@ -143,7 +145,7 @@ def main():
       code = test['code']
       if code not in ('PASS', 'XPASS', 'FAIL', 'XFAIL'):
          sys.stderr.write("ignoring test %r with result code %r" % (
-               test['name'], code))
+             test['name'], code))
          continue
 
       # Extract the test name, which is encoded as 'suite :: name'.
@@ -179,7 +181,7 @@ def main():
    # Write the results, if requested.
    if opts.output:
       sys.stderr.write('%s: generating report: %r\n' % (
-            timestamp(), opts.output))
+          timestamp(), opts.output))
       with open(opts.output, 'w') as f:
          f.write(lnt_result_data)
 

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -104,4 +104,3 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -55,7 +55,7 @@ class Block:
         self.succs = None
         self.lastLine = None
         self.index = Block.currentIndex
-        Block.currentIndex +=  1
+        Block.currentIndex += 1
         if preds is not None:
             for pred in re.split("[, %]", preds):
                 canPred = pred.strip()

--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -5,8 +5,9 @@ import itertools
 traversal_options = [ 'Forward', 'Bidirectional', 'RandomAccess' ]
 base_kind_options = [ 'Defaulted', 'Minimal' ]
 mutable_options = [ False, True ]
-for traversal, base_kind, mutable in itertools.product(
-    traversal_options, base_kind_options, mutable_options):
+for traversal, base_kind, mutable in itertools.product(traversal_options,
+                                                       base_kind_options,
+                                                       mutable_options):
     # Test Slice<Base> and MutableSlice<Base> of various collections using value
     # types as elements.
     wrapper_types = [ 'Slice', 'MutableSlice' ] if mutable else [ 'Slice' ]


### PR DESCRIPTION
Fixes:
- multiple imports on one line
- closing bracket does not match indentation of opening bracket's line
- continuation line over-indented for hanging indent
- continuation line over-indented for visual indent
- continuation line unaligned for hanging indent
- inline comment should start with '# '
- missing whitespace around bitwise or shift operator
- missing whitespace around arithmetic operator
- multiple spaces after ':'
- multiple spaces after operator
