### PR TITLE
[SR-558] Only build _swift_buildDemanglingForMetadata() for ObjC

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -4,8 +4,8 @@
 #include "Private.h"
 
 #if SWIFT_OBJC_INTEROP
+
 #include <objc/runtime.h>
-#endif
 
 // Build a demangled type tree for a nominal type.
 static Demangle::NodePointer
@@ -227,3 +227,5 @@ Demangle::NodePointer swift::_swift_buildDemanglingForMetadata(const Metadata *t
   // Not a type.
   return nullptr;
 }
+
+#endif

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -119,7 +119,10 @@ namespace swift {
   const Metadata *
   _searchConformancesByMangledTypeName(const llvm::StringRef typeName);
 
+#if SWIFT_OBJC_INTEROP
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type);
+#endif
+
 } // end namespace swift
 
 #endif /* SWIFT_RUNTIME_PRIVATE_H */


### PR DESCRIPTION
`_swift_buildDemanglingForMetadata()` is being built for the non-ObjC interop case as a result of a change introduced in an earlier version #834 that was not correctly backed out.

Of course, if we do eventually want to support a `swift_getMangledTypeName()` API (which #834 originally implemented), then it could be left in.
