### PR TITLE
[SR-560] Remove allowUnboundGenericTypes argument to getTypeEntityInfo()

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1832,8 +1832,7 @@ struct TypeEntityInfo {
 
 static TypeEntityInfo
 getTypeEntityInfo(IRGenModule &IGM,
-                  CanType conformingType,
-                  bool allowUnboundGenericTypes) {
+                  CanType conformingType) {
   TypeMetadataRecordKind typeKind;
   Optional<LinkEntity> entity;
   llvm::Type *defaultTy, *defaultPtrTy;
@@ -1999,8 +1998,7 @@ llvm::Constant *IRGenModule::emitProtocolConformances() {
                   LinkEntity::forProtocolDescriptor(conformance->getProtocol()),
                   getPointerAlignment(), ProtocolDescriptorStructTy);
     auto typeEntity = getTypeEntityInfo(*this,
-                                        conformance->getType()->getCanonicalType(),
-                                        /*allowUnboundGenericTypes*/ false);
+                                        conformance->getType()->getCanonicalType());
     auto flags = typeEntity.flags
         .withConformanceKind(ProtocolConformanceReferenceKind::WitnessTable);
 
@@ -2075,8 +2073,7 @@ llvm::Constant *IRGenModule::emitTypeMetadataRecords() {
 
   SmallVector<llvm::Constant *, 8> elts;
   for (auto type : RuntimeResolvableTypes) {
-    auto typeEntity = getTypeEntityInfo(*this, type,
-                                        /*allowUnboundGenericTypes*/ true);
+    auto typeEntity = getTypeEntityInfo(*this, type);
     auto typeRef = getAddrOfLLVMVariableOrGOTEquivalent(
             typeEntity.entity, getPointerAlignment(), typeEntity.defaultTy);
 


### PR DESCRIPTION
@slavapestov's change in <32bd7705> removed the assert that checked the allowUnboundGenericTypes parameter. This parameter can be removed as it is not used elsewhere.
