### PR TITLE
[SR-560] reinstate bound generic type assert

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1840,6 +1840,15 @@ getTypeEntityInfo(IRGenModule &IGM,
 
   auto nom = conformingType->getAnyNominal();
   if (IGM.hasMetadataPattern(nom)) {
+    // This assert is to maintain the convention that the protocol conformance
+    // record path only emits generic patterns for bound generic types. It may
+    // be safe to remove this check.
+    //
+    // (The type metadata record path emits patterns for unbound generic types
+    // in order to allow the runtime to dynamically instantiate a generic type
+    // that was not bound at compile time.)
+    assert(allowUnboundGenericTypes || isa<BoundGenericType>(conformingType));
+
     // Conformances for generics, concrete subclasses of generics, and
     // resiliently-sized types are represented by referencing the
     // metadata pattern.


### PR DESCRIPTION
This assertion was accidentally removed in the commit below:

https://github.com/apple/swift/commit/32bd7705bffb24c11b6b04ecd635a8f6c7586744

The original purpose of the check was to ensure that unbound generic patterns are never added to protocol conformance records, only to type metadata records (where they are present for a future implementation of dynamic type specialization).
