### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func b{for c:a
+protocol a{typealias d:d
+var T:d


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2191: swift::Type swift::ValueDecl::getType() const: Assertion `hasType() && "declaration has no type set yet"' failed.
12 swift           0x0000000000e17a01 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 5969
13 swift           0x00000000010048ec swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
14 swift           0x00000000010032fd swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
15 swift           0x0000000000e3d3bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
18 swift           0x0000000000e66bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
20 swift           0x0000000000e67b14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
21 swift           0x0000000000e66aea swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
22 swift           0x0000000000e3fb17 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 967
27 swift           0x0000000000e17a01 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 5969
28 swift           0x00000000010048ec swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
29 swift           0x00000000010032fd swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
30 swift           0x0000000000e3d3bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
33 swift           0x0000000000e66bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
35 swift           0x0000000000e67b14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
36 swift           0x0000000000e66aea swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
37 swift           0x0000000000ef50b2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
38 swift           0x0000000000ef433d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
39 swift           0x0000000000e13119 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
40 swift           0x0000000000e166c1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
44 swift           0x0000000000e66bde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
46 swift           0x0000000000e67b14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
47 swift           0x0000000000e66aea swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
48 swift           0x0000000000e3fb17 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 967
52 swift           0x0000000000e6111a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
53 swift           0x0000000000e60f6e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
54 swift           0x0000000000e61b38 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
56 swift           0x0000000000de8282 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
57 swift           0x0000000000c9f9b2 swift::CompilerInstance::performSema() + 2946
59 swift           0x0000000000764ccf frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2463
60 swift           0x000000000075f8d5 main + 2741
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28206-swift-typechecker-validatedecl-bdf4a1.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift:8:1
2.  While resolving type a at [validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift:8:14 - line:8:14] RangeText="a"
3.  While resolving type d at [validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift:9:24 - line:9:24] RangeText="d"
4.  While type-checking 'a' at validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift:9:1
5.  While resolving type d at [validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift:10:7 - line:10:7] RangeText="d"
6.  While type-checking 'a' at validation-test/compiler_crashers/28206-swift-typechecker-validatedecl.swift:9:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
