### PR TITLE
[gardening] Fix violations of non-controversial PEP8 rules in .gyb files

### DIFF
--- a/test/1_stdlib/Tuple.swift.gyb
+++ b/test/1_stdlib/Tuple.swift.gyb
@@ -68,10 +68,10 @@ TupleTestSuite.test("Tuple/equality") {
 
 TupleTestSuite.test("Tuple/equality/sanity-check") {
   // sanity check all arities
-% for arity in range(2, maxArity+1):
-%   a = str(tuple(range(1, arity+1)))
+% for arity in range(2, maxArity + 1):
+%   a = str(tuple(range(1, arity + 1)))
 %   b = "({}, 0)".format(", ".join([str(i) for i in range(1, arity)]))
-%   c = "(0, {})".format(", ".join([str(i) for i in range(2, arity+1)]))
+%   c = "(0, {})".format(", ".join([str(i) for i in range(2, arity + 1)]))
   expectTrue(${a} == ${a})
   expectTrue(${a} != ${b})
   expectTrue(${b} != ${a})
@@ -147,10 +147,10 @@ TupleTestSuite.test("Tuple/comparison") {
 
 TupleTestSuite.test("Tuple/comparison/sanity-check") {
   // sanity check all arities
-% for arity in range(2, maxArity+1):
-%   a = str(tuple(range(1, arity+1)))
+% for arity in range(2, maxArity + 1):
+%   a = str(tuple(range(1, arity + 1)))
 %   b = "({}, 0)".format(", ".join([str(i) for i in range(1, arity)]))
-%   c = "(0, {})".format(", ".join([str(i) for i in range(2, arity+1)]))
+%   c = "(0, {})".format(", ".join([str(i) for i in range(2, arity + 1)]))
   expectTrue(${b} < ${a})
   expectTrue(${b} <= ${a})
   expectTrue(${a} > ${c})

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -37,7 +37,7 @@ IntLiteral = 'Int%s' % builtinIntLiteralBits
 # 32-bit iOS simulator doesn't have Int128 support, so we stop at
 # double-word.  When we've implemented the arithmetic algorithms
 # for bignum, we can go further.
-fixedBitWidths = [2**x for x in range(3, 8) if 2**x <= 2*word_bits]
+fixedBitWidths = [2 ** x for x in range(3, 8) if 2 ** x <= 2 * word_bits]
 minFixedBits = fixedBitWidths[0]
 maxFixedBits = fixedBitWidths[-1]
   


### PR DESCRIPTION
Follow-up to PR #988: this PR fixes `*.gyb` files too.
