### PR TITLE
[swiftc] Add test case for crash triggered in swift::DependentGenericTypeResolver::resolveSelfAssociatedType(…)

### DIFF
--- a/validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A{typealias e
+func f:A
+protocol A{typealias A:f func f:e


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:46: virtual swift::Type swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext *, swift::AssociatedTypeDecl *): Assertion `archetype && "Bad generic context nesting?"' failed.
8  swift           0x0000000000e5511d swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 125
9  swift           0x0000000000e821b9 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 729
13 swift           0x0000000000e82e6e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
15 swift           0x0000000000e83dd4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
16 swift           0x0000000000e82d7a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
18 swift           0x0000000000e55cfc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
21 swift           0x0000000000e3288c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 780
22 swift           0x0000000001013c4c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
23 swift           0x000000000101265d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
24 swift           0x0000000000e5964b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
27 swift           0x0000000000e82e6e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
29 swift           0x0000000000e83dd4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
30 swift           0x0000000000e82d7a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
31 swift           0x0000000000f11292 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
32 swift           0x0000000000f1051d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
33 swift           0x0000000000e2f3e9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
34 swift           0x0000000000e32991 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
35 swift           0x0000000001013c4c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
36 swift           0x000000000101265d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2269
37 swift           0x0000000000e5964b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
40 swift           0x0000000000e82e6e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
42 swift           0x0000000000e83dd4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
43 swift           0x0000000000e82d7a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
45 swift           0x0000000000e55cfc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
50 swift           0x0000000000e37dc6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
51 swift           0x0000000000e04612 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
52 swift           0x0000000000caf3af swift::CompilerInstance::performSema() + 2975
54 swift           0x0000000000775047 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
55 swift           0x000000000076fc35 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype-2cf8ca.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:8:1
2.  While resolving type A at [validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:9:8 - line:9:8] RangeText="A"
3.  While resolving type f at [validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:10:24 - line:10:24] RangeText="f"
4.  While type-checking 'f' at validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:10:26
5.  While resolving type e at [validation-test/compiler_crashers/28207-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:10:33 - line:10:33] RangeText="e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
