### PR TITLE
[swiftc] Add test case for crash triggered in swift::DeclContext::getProtocolSelf()

### DIFF
--- a/validation-test/compiler_crashers/28210-swift-declcontext-getprotocolself.swift
+++ b/validation-test/compiler_crashers/28210-swift-declcontext-getprotocolself.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+extension{protocol a{class a{protocol C{func<}}func<}}{<T


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000fdeb0e swift::DeclContext::getProtocolSelf() const + 30
6  swift           0x0000000000e32460 swift::configureImplicitSelf(swift::TypeChecker&, swift::AbstractFunctionDecl*) + 160
9  swift           0x0000000000e3288c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 780
12 swift           0x000000000100b642 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
13 swift           0x0000000001012c1a swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3738
14 swift           0x0000000000e5964b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
15 swift           0x0000000000e157d8 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 120
20 swift           0x0000000000f7d50e swift::Expr::walk(swift::ASTWalker&) + 46
21 swift           0x0000000000e16c87 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
22 swift           0x0000000000e1d239 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
24 swift           0x0000000000e7e7d6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
25 swift           0x0000000000e0467d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
26 swift           0x0000000000caf3af swift::CompilerInstance::performSema() + 2975
28 swift           0x0000000000775047 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
29 swift           0x000000000076fc35 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28210-swift-declcontext-getprotocolself.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28210-swift-declcontext-getprotocolself-860fc9.o
1.  While type-checking expression at [validation-test/compiler_crashers/28210-swift-declcontext-getprotocolself.swift:7:55 - line:7:57] RangeText="{<T"
2.  While type-checking '<' at validation-test/compiler_crashers/28210-swift-declcontext-getprotocolself.swift:7:48
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
