### PR TITLE
[swiftc] Add test case for crash triggered in swift::Expr::walk(…)

### DIFF
--- a/validation-test/compiler_crashers/28213-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28213-swift-expr-walk.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{{{l->Void in{


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/PointerUnion.h:297: T llvm::PointerUnion3<swift::Expr *, swift::Stmt *, swift::Decl *>::get() const [PT1 = swift::Expr *, PT2 = swift::Stmt *, PT3 = swift::Decl *, T = swift::Stmt *]: Assertion `is<T>() && "Invalid accessor called"' failed.
9  swift           0x0000000000f7d4f3 swift::Expr::walk(swift::ASTWalker&) + 19
10 swift           0x0000000000ea84e6 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
11 swift           0x0000000000e1d2ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
14 swift           0x0000000000ec4f70 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 6448
15 swift           0x0000000000ec854e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
16 swift           0x0000000000e16ea5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
17 swift           0x0000000000e1d239 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
19 swift           0x0000000000e7e7d6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
20 swift           0x0000000000e0467d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
21 swift           0x0000000000caf3af swift::CompilerInstance::performSema() + 2975
23 swift           0x0000000000775047 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
24 swift           0x000000000076fc35 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28213-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28213-swift-expr-walk-e0f871.o
1.  While type-checking expression at [validation-test/compiler_crashers/28213-swift-expr-walk.swift:8:1 - line:8:14] RangeText="{{{l->Void in{"
2.  While type-checking expression at [validation-test/compiler_crashers/28213-swift-expr-walk.swift:8:3 - line:8:14] RangeText="{l->Void in{"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
