### PR TITLE
[swiftc] Add test case for crash triggered in swift::NormalProtocolConformance::getWitness(…)

### DIFF
--- a/validation-test/compiler_crashers/28215-swift-normalprotocolconformance-getwitness.swift
+++ b/validation-test/compiler_crashers/28215-swift-normalprotocolconformance-getwitness.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func b<b{class A:A{init(){a{enum B{case
+func w


### PR DESCRIPTION
Stack trace:

```
8  swift           0x000000000101d122 swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const + 610
9  swift           0x0000000001055edb swift::ConformanceLookupTable::getSatisfiedProtocolRequirementsForMember(swift::ValueDecl const*, swift::NominalTypeDecl*, swift::LazyResolver*, bool) + 651
10 swift           0x0000000000fd4025 swift::ValueDecl::getSatisfiedProtocolRequirements(bool) const + 85
14 swift           0x0000000000f5b1a8 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const + 152
24 swift           0x0000000000f5b1a8 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const + 152
33 swift           0x0000000000f7d8d4 swift::Decl::walk(swift::ASTWalker&) + 20
34 swift           0x0000000001007e6e swift::SourceFile::walk(swift::ASTWalker&) + 174
35 swift           0x0000000001036dd4 swift::verify(swift::SourceFile&) + 52
36 swift           0x0000000000e047d2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1922
37 swift           0x0000000000caf3af swift::CompilerInstance::performSema() + 2975
39 swift           0x0000000000775047 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
40 swift           0x000000000076fc35 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28215-swift-normalprotocolconformance-getwitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28215-swift-normalprotocolconformance-getwitness-95a935.o
1.  While walking into decl 'b' at validation-test/compiler_crashers/28215-swift-normalprotocolconformance-getwitness.swift:8:1
2.  While walking into body of 'b' at validation-test/compiler_crashers/28215-swift-normalprotocolconformance-getwitness.swift:8:1
3.  While verifying overridden 'init' at validation-test/compiler_crashers/28215-swift-normalprotocolconformance-getwitness.swift:8:20
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
