### PR TITLE
[gardening] Fix violations of non-controversial PEP8 rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,9 +101,9 @@ html_style = 'swift.css'
 # documentation.
 html_theme_options = {
   # Red links are a bit too garish
-  "linkcolor" : "#577492",
-  "visitedlinkcolor" : "#577492",
-  "hoverlinkcolor" : "#551A8B"
+  "linkcolor": "#577492",
+  "visitedlinkcolor": "#577492",
+  "hoverlinkcolor": "#551A8B"
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -178,14 +178,14 @@ htmlhelp_basename = 'Swiftdoc'
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -18,35 +18,35 @@ usage: nshtml2rst < NSString.html > NSString.rst
 
     # Treat <div class="declaration>...</div> as <pre>...</pre>
     html = re.sub(
-        r'<div\s+class="declaration">(.*?)</div>', 
-        r'<pre>\1</pre>', 
+        r'<div\s+class="declaration">(.*?)</div>',
+        r'<pre>\1</pre>',
         html, flags=re.MULTILINE | re.DOTALL)
 
     # Strip all attributes from <pre>...</pre> containing class="..."
     # The resulting classes confound ReST
     html = re.sub(
-        r'<pre\s[^>]*class=[^>]*>(.*?)</pre>', 
-        r'<pre>\1</pre>', 
+        r'<pre\s[^>]*class=[^>]*>(.*?)</pre>',
+        r'<pre>\1</pre>',
         html, flags=re.MULTILINE | re.DOTALL)
 
     # Remove links from <code>...</code>, which doesn't have a rendering in ReST
     html = re.sub(
-        r'<code>(.*?)<a[^>]*?>(.*?)</a>(.*?)</code>', 
-        r'<code>\1\2\3</code>', 
+        r'<code>(.*?)<a[^>]*?>(.*?)</a>(.*?)</code>',
+        r'<code>\1\2\3</code>',
         html, flags=re.MULTILINE | re.DOTALL)
 
     # Let pandoc do most of the hard work
     p = subprocess.Popen(
-        args=['pandoc', '--reference-links', '-f', 'html', '-t', 'rst']
-        , stdin=subprocess.PIPE
-        , stdout=subprocess.PIPE
+        args=['pandoc', '--reference-links', '-f', 'html', '-t', 'rst'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE
     )
     rst,stderr = p.communicate(html)
 
     # HACKETY HACK HACK: Our html documents apparently contain some
     # bogus heading level nesting.  Just fix up the one we know about
     # so that ReST doesn't complain later.
-    rst = re.sub("(^|\n)('+)($|\n)", 
+    rst = re.sub("(^|\n)('+)($|\n)",
                  lambda m: m.group(1) + len(m.group(2)) * '^' + m.group(3),
                  rst, flags=re.MULTILINE)
 

--- a/stdlib/public/SDK/Darwin/tgmath.swift.gyb
+++ b/stdlib/public/SDK/Darwin/tgmath.swift.gyb
@@ -45,43 +45,51 @@ def cFuncSuffix(bits):
 
 # (T) -> T
 # These functions do not have a corresponding LLVM intrinsic
-UnaryFunctions = ['acos', 'asin', 'atan', 'tan',
-                  'acosh', 'asinh', 'atanh', 'cosh', 'sinh', 'tanh',
-                  'expm1',
-                  'log1p', 'logb',
-                  'cbrt', 'sqrt', 'erf', 'erfc', 'tgamma',
-                  ]
+UnaryFunctions = [
+    'acos', 'asin', 'atan', 'tan',
+    'acosh', 'asinh', 'atanh', 'cosh', 'sinh', 'tanh',
+    'expm1',
+    'log1p', 'logb',
+    'cbrt', 'sqrt', 'erf', 'erfc', 'tgamma',
+]
 
 # These functions have a corresponding LLVM intrinsic
 # We call this intrinsic via the Builtin method so keep this list in
 # sync with core/BuiltinMath.swift.gyb
-UnaryIntrinsicFunctions = ['cos', 'sin',
-                  'exp', 'exp2',
-                  'log', 'log10', 'log2',
-                  'fabs',
-                  'ceil', 'floor', 'nearbyint', 'rint', 'round', 'trunc',
-                  ]
+UnaryIntrinsicFunctions = [
+    'cos', 'sin',
+    'exp', 'exp2',
+    'log', 'log10', 'log2',
+    'fabs',
+    'ceil', 'floor', 'nearbyint', 'rint', 'round', 'trunc',
+]
 
 # (T, T) -> T
-BinaryFunctions = ['atan2', 'hypot', 'pow', 'fmod', 
-                   'remainder', 'copysign', 'nextafter', 'fdim', 'fmax', 'fmin']
+BinaryFunctions = [
+    'atan2', 'hypot', 'pow', 'fmod',
+    'remainder', 'copysign', 'nextafter', 'fdim', 'fmax', 'fmin'
+]
 
 # These functions have special implementations.
-OtherFunctions = ['fpclassify', 
-                  'isnormal', 'isfinite', 'isinf', 'isnan', 'signbit', 
-                  'modf', 'ldexp', 'frexp', 'ilogb', 'scalbn', 'lgamma', 
-                  'remquo', 'nan', 'fma', 
-                  'jn', 'yn']
+OtherFunctions = [
+    'fpclassify',
+    'isnormal', 'isfinite', 'isinf', 'isnan', 'signbit',
+    'modf', 'ldexp', 'frexp', 'ilogb', 'scalbn', 'lgamma',
+    'remquo', 'nan', 'fma',
+    'jn', 'yn'
+]
 
 # These functions are imported correctly as-is.             
 OkayFunctions = ['j0', 'j1', 'y0', 'y1']
 
 # These functions are not supported for various reasons.
-UnhandledFunctions = ['math_errhandling', 'scalbln', 
-                      'lrint', 'lround', 'llrint', 'llround', 'nexttoward', 
-                      'isgreater', 'isgreaterequal', 'isless', 'islessequal', 
-                      'islessgreater', 'isunordered', '__exp10', 
-                      '__sincos', '__cospi', '__sinpi', '__tanpi', '__sincospi']
+UnhandledFunctions = [
+    'math_errhandling', 'scalbln',
+    'lrint', 'lround', 'llrint', 'llround', 'nexttoward',
+    'isgreater', 'isgreaterequal', 'isless', 'islessequal',
+    'islessgreater', 'isunordered', '__exp10',
+    '__sincos', '__cospi', '__sinpi', '__tanpi', '__sincospi'
+]
 
 
 def AllFloatTypes():

--- a/stdlib/public/common/MirrorBoilerplate.gyb
+++ b/stdlib/public/common/MirrorBoilerplate.gyb
@@ -31,10 +31,10 @@
 %sys.path = [os.path.split(inspect.getframeinfo(inspect.currentframe()).filename)[0] or '.'] + sys.path
 %import MirrorCommon
 %genericArgString = MirrorCommon.getGenericArgString(
-%                   genericArgs if 'genericArgs' in locals() else None,
-%                   genericConstraints if 'genericConstraints' in locals() else None)
+%    genericArgs if 'genericArgs' in locals() else None,
+%    genericConstraints if 'genericConstraints' in locals() else None)
 %disposition = MirrorCommon.getDisposition(
-%              disposition if 'disposition' in locals() else None)
+%    disposition if 'disposition' in locals() else None)
 var _value: ${introspecteeType}${genericArgString}
 
 init(_ x: ${introspecteeType}${genericArgString}) {

--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -45,12 +45,13 @@ def cFuncSuffix(bits):
 
 # These functions have a corresponding LLVM intrinsic
 # Note, keep this up to date with Darwin/tgmath.swift.gyb
-UnaryIntrinsicFunctions = ['cos', 'sin',
-                  'exp', 'exp2',
-                  'log', 'log10', 'log2',
-                  'fabs',
-                  'ceil', 'floor', 'nearbyint', 'rint', 'round', 'trunc',
-                  ]
+UnaryIntrinsicFunctions = [
+    'cos', 'sin',
+    'exp', 'exp2',
+    'log', 'log10', 'log2',
+    'fabs',
+    'ceil', 'floor', 'nearbyint', 'rint', 'round', 'trunc',
+]
 
 def TypedUnaryIntrinsicFunctions():
     for ufunc in UnaryIntrinsicFunctions:

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -398,7 +398,7 @@ functionList = [
   	[Response],
   	c_bool),
 
-#  ("sourcekitd_send_request",
+  #  ("sourcekitd_send_request",
 
   ("sourcekitd_send_request_sync",
   	[Object],
@@ -469,19 +469,19 @@ functionList = [
   ("sourcekitd_variant_dictionary_get_int64",
   	[Variant, UIdent],
   	c_int64),
-  
+
   ("sourcekitd_variant_dictionary_get_string",
   	[Variant, UIdent],
   	c_char_p),
-  
+
   ("sourcekitd_variant_dictionary_get_value",
   	[Variant, UIdent],
   	Variant),
-  
+
   ("sourcekitd_variant_dictionary_get_uid",
   	[Variant, UIdent],
   	c_object_p),
-  
+
   ("sourcekitd_variant_get_type",
   	[Variant],
   	VariantType.from_id),

--- a/tools/SourceKit/bindings/python/sourcekitd/request.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/request.py
@@ -27,10 +27,12 @@ class SourceKitError(Exception):
         return "%s (%s)" % (self.msg, self.kind)
 
 def syntax_annotate_text(text):
-    req = { 'key.request': capi.UIdent('source.request.editor.open'),
-            'key.sourcetext': text,
-            'key.name': "annotate-source-text",
-            'key.enablesyntaxmap': True }
+    req = {
+        'key.request': capi.UIdent('source.request.editor.open'),
+        'key.sourcetext': text,
+        'key.name': "annotate-source-text",
+        'key.enablesyntaxmap': True
+    }
     resp = request_sync(req)
     return resp.get_payload().to_python_object()
 

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -37,7 +37,7 @@ class GraphemeClusterBreakPropertyTable(UnicodeProperty):
     # An array of tuples (start_code_point, end_code_point, value).
     property_value_ranges = []
 
-    property_values = [ None for i in range(0, 0x110000) ]
+    property_values = [None for i in range(0, 0x110000)]
 
     # Note: Numeric values should be consistent with
     # '_GraphemeClusterBreakPropertyValue' enum on the Swift side, and with
@@ -64,7 +64,7 @@ class GraphemeClusterBreakPropertyTable(UnicodeProperty):
         # Build 'self.symbolic_values' -- an array that maps numeric property
         # values to symbolic values.
         self.symbolic_values = \
-            [ None ] * (max(self.numeric_value_table.values()) + 1)
+            [None] * (max(self.numeric_value_table.values()) + 1)
         for k,v in self.numeric_value_table.items():
             self.symbolic_values[v] = k
 
@@ -253,7 +253,7 @@ class UnicodeTrieGenerator(object):
                 self.supp_data_offset_bits)
 
         # A mapping from BMP first-level index to BMP data block index.
-        self.BMP_lookup = [ i for i in range(0, 1 << self.BMP_first_level_index_bits) ]
+        self.BMP_lookup = [i for i in range(0, 1 << self.BMP_first_level_index_bits)]
 
         # An array of BMP data blocks.
         self.BMP_data = [
@@ -263,7 +263,7 @@ class UnicodeTrieGenerator(object):
 
         # A mapping from supp first-level index to an index of the second-level
         # lookup table.
-        self.supp_lookup1 = [ i for i in range(0, self.supp_first_level_index_max + 1) ]
+        self.supp_lookup1 = [i for i in range(0, self.supp_first_level_index_max + 1)]
 
         # An array of second-level lookup tables.  Each second-level lookup
         # table is a mapping from a supp second-level index to supp data block
@@ -387,17 +387,17 @@ class UnicodeTrieGenerator(object):
     def _int_to_LE_bytes(self, data, width):
         if width == 1:
             assert(data & ~0xff == 0)
-            return [ data ]
+            return [data]
         if width == 2:
             assert(data & ~0xffff == 0)
-            return [ data & 0xff, data & 0xff00 ]
+            return [data & 0xff, data & 0xff00]
         assert(False)
 
     def _int_list_to_LE_bytes(self, ints, width):
         return [
             byte
             for elt in ints
-            for byte in self._int_to_LE_bytes(elt, width) ]
+            for byte in self._int_to_LE_bytes(elt, width)]
 
     def serialize(self, unicode_property):
         self.BMP_lookup_bytes_per_entry = 1 if len(self.BMP_data) < 256 else 2
@@ -407,18 +407,18 @@ class UnicodeTrieGenerator(object):
         self.supp_lookup2_bytes_per_entry = 1 if len(self.supp_data) < 256 else 2
         self.supp_data_bytes_per_entry = 1
 
-        BMP_lookup_words = [ elt for elt in self.BMP_lookup ]
+        BMP_lookup_words = [elt for elt in self.BMP_lookup]
         BMP_data_words = [
             unicode_property.to_numeric_value(elt)
             for block in self.BMP_data
-            for elt in block ]
+            for elt in block]
 
-        supp_lookup1_words = [ elt for elt in self.supp_lookup1 ]
-        supp_lookup2_words = [ elt for block in self.supp_lookup2 for elt in block ]
+        supp_lookup1_words = [elt for elt in self.supp_lookup1]
+        supp_lookup2_words = [elt for block in self.supp_lookup2 for elt in block]
         supp_data_words = [
             unicode_property.to_numeric_value(elt)
             for block in self.supp_data
-            for elt in block ]
+            for elt in block]
 
         BMP_lookup_bytes = self._int_list_to_LE_bytes(
             BMP_lookup_words, self.BMP_lookup_bytes_per_entry)
@@ -463,17 +463,17 @@ def get_extended_grapheme_cluster_rules_matrix(grapheme_cluster_break_property_t
     # As in the referenced document, the rules are specified in order of
     # decreasing priority.
     rules = [
-      ( [ 'CR' ], 'no_boundary', [ 'LF' ] ),
-      ( [ 'Control', 'CR', 'LF' ], 'boundary', any_value ),
-      ( any_value, 'boundary', [ 'Control', 'CR', 'LF' ] ),
-      ( [ 'L' ], 'no_boundary', [ 'L', 'V', 'LV', 'LVT' ] ),
-      ( [ 'LV', 'V' ], 'no_boundary', [ 'V', 'T' ] ),
-      ( [ 'LVT', 'T' ], 'no_boundary', [ 'T' ] ),
-      ( [ 'Regional_Indicator' ], 'no_boundary', [ 'Regional_Indicator' ] ),
-      ( any_value, 'no_boundary', [ 'Extend' ] ),
-      ( any_value, 'no_boundary', [ 'SpacingMark' ] ),
-      ( [ 'Prepend' ], 'no_boundary', any_value ),
-      ( any_value, 'boundary', any_value ),
+      (['CR'], 'no_boundary', ['LF']),
+      (['Control', 'CR', 'LF'], 'boundary', any_value),
+      (any_value, 'boundary', ['Control', 'CR', 'LF']),
+      (['L'], 'no_boundary', ['L', 'V', 'LV', 'LVT']),
+      (['LV', 'V'], 'no_boundary', ['V', 'T']),
+      (['LVT', 'T'], 'no_boundary', ['T']),
+      (['Regional_Indicator'], 'no_boundary', ['Regional_Indicator']),
+      (any_value, 'no_boundary', ['Extend']),
+      (any_value, 'no_boundary', ['SpacingMark']),
+      (['Prepend'], 'no_boundary', any_value),
+      (any_value, 'boundary', any_value),
     ]
 
     # Expand the rules into a matrix.
@@ -497,13 +497,13 @@ def get_extended_grapheme_cluster_rules_matrix(grapheme_cluster_break_property_t
         row = rules_matrix[first]
 
         # Change strings into bits.
-        bits = [ row[second] == 'no_boundary'
-            for second in any_value ]
+        bits = [row[second] == 'no_boundary'
+            for second in any_value]
 
         # Pack bits into an integer.
-        packed = sum([ bits[i] * pow(2, i) for i in range(0, len(bits)) ])
+        packed = sum([bits[i] * pow(2, i) for i in range(0, len(bits))])
 
-        result += [ packed ]
+        result += [packed]
 
     return result
 
@@ -522,7 +522,7 @@ def get_grapheme_cluster_break_tests_as_UTF8(grapheme_break_test_file_name):
         # Match a list of code points.
         for token in line.split(" "):
             if token == u"÷":
-                boundaries += [ curr_bytes ]
+                boundaries += [curr_bytes]
             elif token == u"×":
                 pass
             else:
@@ -536,17 +536,17 @@ def get_grapheme_cluster_break_tests_as_UTF8(grapheme_break_test_file_name):
                 # and test separately that we handle ill-formed UTF-8 sequences.
                 if code_point >= 0xd800 and code_point <= 0xdfff:
                     code_point = 0x200b
-                code_point = (b'\U%(cp)08x' % { b'cp': code_point }).decode('unicode_escape', 'strict')
+                code_point = (b'\U%(cp)08x' % {b'cp': code_point}).decode('unicode_escape', 'strict')
                 as_UTF8_bytes = bytearray(code_point.encode('utf8', 'strict'))
-                as_UTF8_escaped = ''.join(['\\x%(byte)02x' % { 'byte': byte } for byte in as_UTF8_bytes])
+                as_UTF8_escaped = ''.join(['\\x%(byte)02x' % {'byte': byte} for byte in as_UTF8_bytes])
                 test += as_UTF8_escaped
                 curr_bytes += len(as_UTF8_bytes)
 
         return (test, boundaries)
 
     # Self-test.
-    assert(_convert_line(u'÷ 0903 × 0308 ÷ AC01 ÷ # abc') == ('\\xe0\\xa4\\x83\\xcc\\x88\\xea\\xb0\\x81', [ 0, 5, 8 ]))
-    assert(_convert_line(u'÷ D800 ÷ # abc') == ('\\xe2\\x80\\x8b', [ 0, 3 ]))
+    assert(_convert_line(u'÷ 0903 × 0308 ÷ AC01 ÷ # abc') == ('\\xe0\\xa4\\x83\\xcc\\x88\\xea\\xb0\\x81', [0, 5, 8]))
+    assert(_convert_line(u'÷ D800 ÷ # abc') == ('\\xe2\\x80\\x8b', [0, 3]))
 
     result = []
 
@@ -554,7 +554,7 @@ def get_grapheme_cluster_break_tests_as_UTF8(grapheme_break_test_file_name):
         for line in f:
             test = _convert_line(line)
             if test:
-                result += [ test ]
+                result += [test]
 
     return result
 
@@ -573,7 +573,7 @@ def get_grapheme_cluster_break_tests_as_unicode_scalars(grapheme_break_test_file
         # Match a list of code points.
         for token in line.split(" "):
             if token == "÷":
-                boundaries += [ curr_code_points ]
+                boundaries += [curr_code_points]
             elif token == "×":
                 pass
             else:
@@ -587,14 +587,14 @@ def get_grapheme_cluster_break_tests_as_unicode_scalars(grapheme_break_test_file
                 # and test separately that we handle ill-formed UTF-8 sequences.
                 if code_point >= 0xd800 and code_point <= 0xdfff:
                     code_point = 0x200b
-                test += [ code_point ]
+                test += [code_point]
                 curr_code_points += 1
 
         return (test, boundaries)
 
     # Self-test.
-    assert(_convert_line('÷ 0903 × 0308 ÷ AC01 ÷ # abc') == ([ 0x0903, 0x0308, 0xac01 ], [ 0, 2, 3 ]))
-    assert(_convert_line('÷ D800 ÷ # abc') == ([ 0x200b ], [ 0, 1 ]))
+    assert(_convert_line('÷ 0903 × 0308 ÷ AC01 ÷ # abc') == ([0x0903, 0x0308, 0xac01], [0, 2, 3]))
+    assert(_convert_line('÷ D800 ÷ # abc') == ([0x200b], [0, 1]))
 
     result = []
 
@@ -602,6 +602,6 @@ def get_grapheme_cluster_break_tests_as_unicode_scalars(grapheme_break_test_file
         for line in f:
             test = _convert_line(line)
             if test:
-                result += [ test ]
+                result += [test]
 
     return result

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -67,7 +67,7 @@ def print_with_argv0(message):
 
 
 def quote_shell_command(args):
-    return " ".join([ pipes.quote(a) for a in args ])
+    return " ".join([pipes.quote(a) for a in args])
 
 
 def check_call(args, print_command=False, verbose=False):
@@ -188,13 +188,13 @@ def get_preset_options(substitutions, preset_file_names, preset_name):
                          "': " + ", ".join(missing_opts))
         sys.exit(1)
 
-    return build_script_opts + [ "--" ] + build_script_impl_opts
+    return build_script_opts + ["--"] + build_script_impl_opts
 
 
 def get_all_preset_names(preset_file_names):
     config = _load_preset_files_impl(preset_file_names)
-    return [ name[len(_PRESET_PREFIX):] for name in config.sections()
-             if name.startswith(_PRESET_PREFIX) ]
+    return [name[len(_PRESET_PREFIX):] for name in config.sections()
+            if name.startswith(_PRESET_PREFIX)]
 
 
 # A context manager for changing the current working directory.

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -23,9 +23,9 @@ class SwiftIntegerType(object):
         self.is_signed = is_signed
 
         if is_word:
-            self.possible_bitwidths = [ 32, 64 ]
+            self.possible_bitwidths = [32, 64]
         else:
-            self.possible_bitwidths = [ bits ]
+            self.possible_bitwidths = [bits]
 
         # Derived properties
         self.stdlib_name = \
@@ -48,11 +48,11 @@ class SwiftIntegerType(object):
 
 def all_integer_types(word_bits):
     for bitwidth in _all_integer_type_bitwidths:
-        for is_signed in [ False, True ]:
+        for is_signed in [False, True]:
             yield SwiftIntegerType(is_word=False, bits=bitwidth,
                 is_signed=is_signed)
 
-    for is_signed in [ False, True ]:
+    for is_signed in [False, True]:
         yield SwiftIntegerType(is_word=True, bits=word_bits,
             is_signed=is_signed)
 
@@ -84,21 +84,21 @@ def all_numeric_type_names():
     return all_integer_type_names() + all_real_number_type_names()
 
 def numeric_type_names_Macintosh_only():
-    return ['Float80']  
+    return ['Float80']
 
 # Swift_Programming_Language/Expressions.html
 
 def all_integer_binary_operator_names():
     return ['<<', '>>', '&*', '&', '&+', '&-', '|', '^']
-    
+
 def all_integer_or_real_binary_operator_names():
     return ['*', '/', '%', '+', '-', '..<', '...']
-    
+
 def all_arithmetic_comparison_operator_names():
     return ['<', '<=', '>', '>=', '==', '!=']
-    
+
 def all_integer_assignment_operator_names():
     return ['<<=', '>>=', '&=', '^=', '|=']
-    
+
 def all_integer_or_real_assignment_operator_names():
     return ['=', '*=', '/=', '%=', '+=', '-=']

--- a/utils/build-script
+++ b/utils/build-script
@@ -92,10 +92,10 @@ def main_preset():
     preset_args = get_preset_options(
         args.preset_substitutions, args.preset_file_names, args.preset)
 
-    build_script_args = [ sys.argv[0] ]
+    build_script_args = [sys.argv[0]]
     build_script_args += preset_args
     if args.distcc:
-        build_script_args += [ "--distcc" ]
+        build_script_args += ["--distcc"]
 
     print_with_argv0(
         "using preset '" + args.preset + "', which expands to " +
@@ -792,7 +792,7 @@ the number of parallel build jobs to use""",
     if args.build_foundation:
         build_script_impl_args += [
             "--foundation-build-type", args.foundation_build_variant
-        ]   
+        ]
     build_script_impl_args += build_script_impl_inferred_args
 
     # If we have extra_swift_args, combine all of them together and then add
@@ -803,7 +803,7 @@ the number of parallel build jobs to use""",
     build_script_impl_args += args.build_script_impl_args
 
     # Unset environment variables that might affect how tools behave.
-    for v in [ 'MAKEFLAGS', 'SDKROOT', 'MACOSX_DEPLOYMENT_TARGET', 'IPHONEOS_DEPLOYMENT_TARGET' ]:
+    for v in ['MAKEFLAGS', 'SDKROOT', 'MACOSX_DEPLOYMENT_TARGET', 'IPHONEOS_DEPLOYMENT_TARGET']:
         os.environ.pop(v, None)
 
     check_call(build_script_impl_args)
@@ -824,8 +824,8 @@ def main():
         return 1
 
     # Determine if we are invoked in the preset mode and dispatch accordingly.
-    if any([ (opt.startswith("--preset") or opt == "--show-presets")
-             for opt in sys.argv[1:] ]):
+    if any([(opt.startswith("--preset") or opt == "--show-presets")
+            for opt in sys.argv[1:]]):
         return main_preset()
     else:
         return main_normal()

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -18,31 +18,31 @@ from operator import itemgetter
 
 Prefixes = {
     # Cpp
-    "__Z" : "CPP",
-    "_swift" : "CPP",
-    "__swift" : "CPP",
+    "__Z": "CPP",
+    "_swift": "CPP",
+    "__swift": "CPP",
 
     # Objective-C
-    "+[" : "ObjC",
-    "-[" : "ObjC",
+    "+[": "ObjC",
+    "-[": "ObjC",
 
     # Swift
-    "__TP"  : "Partial Apply",
-    "__TTW" : "Protocol Witness",
-    "__Tw"  : "Value Witness",
-    "__TM"  : "Type Metadata",
-    "__TF"  : "Swift Function",
-    "__TTSg" : "Generic Spec",
-    "__TTSf" : "FuncSig Spec",
-    "__TZF" : "Static Func",
+    "__TP": "Partial Apply",
+    "__TTW": "Protocol Witness",
+    "__Tw": "Value Witness",
+    "__TM": "Type Metadata",
+    "__TF": "Swift Function",
+    "__TTSg": "Generic Spec",
+    "__TTSf": "FuncSig Spec",
+    "__TZF": "Static Func",
     # Function signature specialization of a generic specialization.
-    "__TTSGF" : "FuncSigGen Spec",
-    "__TTo" : "Swift @objc Func",
+    "__TTSGF": "FuncSigGen Spec",
+    "__TTo": "Swift @objc Func",
 }
 
 Infixes = {
   #Swift
-  "q_" : "Generic Function"
+  "q_": "Generic Function"
 }
 
 GenericFunctionPrefix = "__TTSg"
@@ -180,7 +180,7 @@ def compareSizesOfFile(oldFiles, newFiles, allSections, listCategories):
     compareSizes(oldSizes, newSizes, "__text", title)
     if listCategories:
         prev = None
-        for categoryName in sorted(Prefixes.values()) + sorted(Infixes.values())+ ["Unknown"]:
+        for categoryName in sorted(Prefixes.values()) + sorted(Infixes.values()) + ["Unknown"]:
             if categoryName != prev:
                 compareSizes(oldSizes, newSizes, categoryName, "")
             prev = categoryName
@@ -264,7 +264,7 @@ def compareFunctionSizes(oldFiles, newFiles):
                 sizeDecrease -= diff
             if diff == 0:
                 inBothSize += newSize
-            print("%8d %8d %8d %s" %(oldSize, newSize, newSize - oldSize, func))
+            print("%8d %8d %8d %s" % (oldSize, newSize, newSize - oldSize, func))
         print("Total size of functions with the same size in both files: {}".format(inBothSize))
         print("Total size of functions that got smaller: {}".format(sizeDecrease))
         print("Total size of functions that got bigger: {}".format(sizeIncrease))

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -72,11 +72,11 @@ def run():
 
         command = subprocess.Popen(
             sys.argv[dashes + 1:],
-            stderr = subprocess.STDOUT,
-            stdout = subprocess.PIPE,
-            universal_newlines = True
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            universal_newlines=True
         )
-        
+
         error_pattern = re.compile(
             '^(' + '|'.join(re.escape(s) for s in sources) + '):([0-9]+):([0-9]+):(.*)')
 
@@ -85,7 +85,8 @@ def run():
 
         while True:
             line = command.stdout.readline()
-            if line == '': break
+            if line == '':
+                break
             l = line.rstrip('\n')
             m = error_pattern.match(l)
             if m:
@@ -93,12 +94,12 @@ def run():
                 line = '%s:%s:%s:%s\n' % (file, line_num, int(m.group(3)), m.group(4))
             else:
                 m = assertion_pattern.match(l)
-                if m: 
+                if m:
                     file, line_num = map_line(m.group(3), int(m.group(5)))
                     line = '%s%s %s%s%s%s\n' % (m.group(1), m.group(2), file, m.group(4), line_num, m.group(6))
             sys.stdout.write(line)
-        
+
         sys.exit(command.wait())
-        
+
 if __name__ == '__main__':
     run()

--- a/utils/name-compression/CBCGen.py
+++ b/utils/name-compression/CBCGen.py
@@ -15,7 +15,7 @@ def collect_top_entries(val):
   Collect the most frequent substrings and organize them in a table.
   """
   # sort items by hit rate.
-  lst = sorted(hist.items(), key=lambda x: x[1] , reverse=True)[0:val]
+  lst = sorted(hist.items(), key=lambda x: x[1], reverse=True)[0:val]
   # Strip out entries with a small number of hits.
   # These entries are not likely to help the compressor and can extend the compile
   # time of the mangler unnecessarily.
@@ -81,7 +81,8 @@ def addLine(line):
   Extract all of the possible substrings from \p line and insert them into
   the substring dictionary. This method knows to ignore the _T swift prefix.
   """
-  if not line.startswith("__T"): return
+  if not line.startswith("__T"):
+    return
 
   # Strip the "__T" for the prefix calculations.
   line = line[3:]
@@ -113,7 +114,7 @@ index_of_char = ["-1"] * 256
 idx = 0
 for c in charset:
   index_of_char[ord(c)] = str(idx)
-  idx+=1
+  idx += 1
 
 class Trie:
   """
@@ -165,11 +166,12 @@ key_values = [p[0] for p in table]
 # Array of string lengths.
 string_length_table = map(lambda x: str(len(x)), key_values)
 # Stringify the list of words that we use as substrings.
-string_key_list = map(lambda x: "\""+ x + "\"", key_values)
+string_key_list = map(lambda x: "\"" + x + "\"", key_values)
 
 # Add all of the substrings that we'll use for compression into the Trie.
 TrieHead = Trie()
-for i in xrange(len(key_values)): TrieHead.add(key_values[i], i)
+for i in xrange(len(key_values)):
+  TrieHead.add(key_values[i], i)
 
 
 # Generate the header file.

--- a/utils/name-compression/HuffGen.py
+++ b/utils/name-compression/HuffGen.py
@@ -17,7 +17,8 @@ def addLine(line):
   """
   Analyze the frequency of letters in \p line.
   """
-  for c in line: hist[c] += 1
+  for c in line:
+    hist[c] += 1
 
 # Read all of the input files and analyze the content of the files.
 for f in filenames:
@@ -25,11 +26,11 @@ for f in filenames:
     addLine(line.rstrip('\n').strip())
 
 # Sort all of the characters by their appearance frequency.
-sorted_chars = sorted(hist.items(), key=lambda x: x[1] * len(x[0]) , reverse=True)
+sorted_chars = sorted(hist.items(), key=lambda x: x[1] * len(x[0]), reverse=True)
 
 class Node:
   """ This is a node in the Huffman tree """
-  def __init__(self, hits, value = None, l = None, r = None):
+  def __init__(self, hits, value=None, l=None, r=None):
     self.hit = hits  # Number of occurrences for this node.
     self.left = l    # Left subtree.
     self.right = r   # Right subtree.
@@ -76,12 +77,13 @@ class Node:
     Generate the CPP code for the encoder.
     """
     if self.val:
-      sb = "if (ch == '" + str(self.val) +"') {"
+      sb = "if (ch == '" + str(self.val) + "') {"
       sb += "/*" + "".join(map(str, reversed(stack))) + "*/ "
       # Encode the bit stream as a numeric value. Updating the APInt in one go
       # is much faster than inserting one bit at a time.
       numeric_val = 0
-      for bit in reversed(stack): numeric_val = numeric_val * 2 + bit
+      for bit in reversed(stack):
+        numeric_val = numeric_val * 2 + bit
       # num_bits - the number of bits that we use in the bitstream.
       # bits - the numeric value of the bits that we encode in the bitstream.
       sb += "bits = %d; num_bits = %d; " % (numeric_val, len(stack))
@@ -117,7 +119,7 @@ index_of_char = ["-1"] * 256
 idx = 0
 for c in charset:
   index_of_char[ord(c)] = str(idx)
-  idx+=1
+  idx += 1
 
 
 print "#ifndef SWIFT_MANGLER_HUFFMAN_H"

--- a/utils/omit-needless-words.py
+++ b/utils/omit-needless-words.py
@@ -10,13 +10,13 @@ import argparse
 import subprocess
 
 DEFAULT_TARGET_BASED_ON_SDK = {
-    'macosx'              : 'x86_64-apple-macosx10.11',
-    'iphoneos'            : 'arm64-apple-ios9.0',
-    'iphonesimulator'     : 'x86_64-apple-ios9.0',
-    'watchos'             : 'armv7k-apple-watchos2.0',
-    'watchos.simulator'   : 'i386-apple-watchos2.0',
-    'appletvos'           : 'arm64-apple-tvos9',
-    'appletvos.simulator' : 'x86_64-apple-tvos9',
+    'macosx': 'x86_64-apple-macosx10.11',
+    'iphoneos': 'arm64-apple-ios9.0',
+    'iphonesimulator': 'x86_64-apple-ios9.0',
+    'watchos': 'armv7k-apple-watchos2.0',
+    'watchos.simulator': 'i386-apple-watchos2.0',
+    'appletvos': 'arm64-apple-tvos9',
+    'appletvos.simulator': 'x86_64-apple-tvos9',
 }
 
 def create_parser():

--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -98,7 +98,7 @@ def lower_passlist():
         p.SpeculativeDevirtualizer,
         p.FunctionSignatureOpts,
     ])
-        
+
 def normal_passpipelines():
     result = []
 
@@ -106,23 +106,23 @@ def normal_passpipelines():
     x.addPass(ssapass_passlist('high'))
     result.append(x)
 
-    x = ppipe.PassPipeline('EarlyLoopOpt', {'name' : 'run_n_times', 'count' : 1})
+    x = ppipe.PassPipeline('EarlyLoopOpt', {'name': 'run_n_times', 'count': 1})
     x.addPass(highlevel_loopopt_passlist())
     result.append(x)
 
-    x = ppipe.PassPipeline('MidLevelOpt', {'name' : 'run_n_times', 'count' : 2})
+    x = ppipe.PassPipeline('MidLevelOpt', {'name': 'run_n_times', 'count': 2})
     x.addPass(ssapass_passlist('mid'))
     result.append(x)
 
-    x = ppipe.PassPipeline('Lower', {'name' : 'run_to_fixed_point'})
+    x = ppipe.PassPipeline('Lower', {'name': 'run_to_fixed_point'})
     x.addPass(lower_passlist())
     result.append(x)
 
-    x = ppipe.PassPipeline('LowLevel', {'name' : 'run_n_times', 'count' : 1})
+    x = ppipe.PassPipeline('LowLevel', {'name': 'run_n_times', 'count': 1})
     x.addPass(ssapass_passlist('low'))
     result.append(x)
 
-    x = ppipe.PassPipeline('LateLoopOpt', {'name' : 'run_n_times', 'count' : 1})
+    x = ppipe.PassPipeline('LateLoopOpt', {'name': 'run_n_times', 'count': 1})
     x.addPass([lowlevel_loopopt_passlist(), p.DeadFunctionElimination])
     result.append(x)
 

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -33,9 +33,8 @@ import os
 def print_call(*args, **kw):
     if isinstance(args[0], (str, unicode)):
         args = [args]
-        
-    
     print('$ ' + ' '.join(shell_quote(x) for x in args[0]) + '   # %r, %r' % (args[1:], kw))
+
 def check_call(*args, **kw):
     print_call(*args, **kw)
     try:
@@ -44,7 +43,7 @@ def check_call(*args, **kw):
         print('failed command:', args, kw)
         sys.stdout.flush()
         raise
-    
+
 def check_output(*args, **kw):
     print_call(*args, **kw)
     try:
@@ -53,37 +52,37 @@ def check_output(*args, **kw):
         print('failed command:', args, kw)
         sys.stdout.flush()
         raise
-    
+
 def getTreeSha(treeish):
     return check_output(['git', 'show', treeish, '-s', '--format=%t'], cwd=sourceDir).rstrip()
-    
+
 def getWorkTreeSha():
     if check_output(['git', 'status', '--porcelain', '--untracked-files=no'], cwd=sourceDir) == '':
         return getTreeSha('HEAD')
-        
+
     # Create a stash without updating the working tree
     stashId = check_output(['git', 'stash', 'create', 'benchmark stash'], cwd=sourceDir).rstrip()
     check_call(['git', 'update-ref', '-m', 'benchmark stash', 'refs/stash', stashId], cwd=sourceDir)
     sha = getTreeSha('stash@{0}')
     check_call(['git', 'stash', 'drop', '-q'], cwd=sourceDir)
     return sha
-    
+
 def buildBenchmarks(cacheDir, build_script_args):
     print('Building executables...')
-    
+
     configVars = {'SWIFT_INCLUDE_BENCHMARKS':'TRUE', 'SWIFT_INCLUDE_PERF_TESTSUITE':'TRUE', 'SWIFT_STDLIB_BUILD_TYPE':'RelWithDebInfo', 'SWIFT_STDLIB_ASSERTIONS':'FALSE'}
-    
+
     cmakeCache = os.path.join(buildDir, 'CMakeCache.txt')
-    
+
     configArgs = ['-D%s=%s' % i for i in configVars.items()]
-    
+
     # Ensure swift is built with the appropriate options
     if os.path.isfile(cmakeCache):
         check_call(['cmake', '.'] + configArgs, cwd=buildDir)
 
     check_call(
-        [ os.path.join(sourceDir, 'utils', 'build-script'),
-          '-R', '--no-assertions']
+        [os.path.join(sourceDir, 'utils', 'build-script'),
+         '-R', '--no-assertions']
         + build_script_args)
 
     # Doing this requires copying or linking all the libraries to the
@@ -96,11 +95,11 @@ def buildBenchmarks(cacheDir, build_script_args):
     #    shutil.copy(os.path.join(binDir, exe), os.path.join(cacheDir, exe))
     print('done.')
 
-def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = []):
+def collectBenchmarks(exeNames, treeish=None, repeat=3, build_script_args=[]):
     treeSha = getWorkTreeSha() if treeish is None else getTreeSha(treeish)
     cacheDir = os.path.join(benchDir, treeSha)
     print('Collecting benchmarks for %s in %s ' % (treeish if treeish else 'working tree', cacheDir))
-    
+
     if not os.path.isdir(cacheDir):
         os.makedirs(cacheDir)
 
@@ -115,7 +114,7 @@ def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = 
                 check_output(['git', 'branch'], cwd=sourceDir),
                 re.MULTILINE
             )
-            
+
             saveHead = m.group(1) or m.group(2)
 
             if not rebuilt:
@@ -130,7 +129,7 @@ def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = 
                         subprocess.call(['git', 'stash', 'pop'], cwd=sourceDir)
                 else:
                     buildBenchmarks(cacheDir, build_script_args)
-                    
+
                 rebuilt = True
         else:
             with open(timingsFile) as f:
@@ -139,7 +138,7 @@ def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = 
             if oldRepeat < repeat:
                 print('Only %s repeats in existing %s timings file' % (oldRepeat, exe))
                 timingsText = ''
-                
+
         if timingsText == '':
             print('Running new benchmarks...')
             for iteration in range(0, repeat):
@@ -151,18 +150,18 @@ def collectBenchmarks(exeNames, treeish = None, repeat = 3, build_script_args = 
             with open(timingsFile, 'w') as outfile:
                 outfile.write(timingsText)
             print('done.')
-            
+
     return cacheDir
 
 # Parse lines like this
 # #,TEST,SAMPLES,MIN(ms),MAX(ms),MEAN(ms),SD(ms),MEDIAN(ms)
-SCORERE=re.compile(r"(\d+),[ \t]*(\w+),[ \t]*([\d.]+),[ \t]*([\d.]+)")
+SCORERE = re.compile(r"(\d+),[ \t]*(\w+),[ \t]*([\d.]+),[ \t]*([\d.]+)")
 
 # The Totals line would be parsed like this, but we ignore it for now.
-TOTALRE=re.compile(r"()(Totals),[ \t]*([\d.]+),[ \t]*([\d.]+)")
+TOTALRE = re.compile(r"()(Totals),[ \t]*([\d.]+),[ \t]*([\d.]+)")
 
-KEYGROUP=2
-VALGROUP=4
+KEYGROUP = 2
+VALGROUP = 4
 
 def parseFloat(word):
     try:
@@ -209,8 +208,8 @@ def compareScores(key, score1, score2, runs):
         row.append("0.0")
 
     row.append("%.2f" % abs(bestscore1 - bestscore2))
-    Num=float(bestscore1)
-    Den=float(bestscore2)
+    Num = float(bestscore1)
+    Den = float(bestscore2)
     row.append(("%.2f" % (Num / Den)) if Den > 0 else "*")
     return row
 
@@ -242,7 +241,7 @@ def compareTimingsFiles(file1, file2):
             print(key, "not in", file2)
             continue
         rows.append(compareScores(key, scores1[key], scores2[key], runs))
-        
+
     widths = []
     for row in rows:
         for n, x in enumerate(row):
@@ -302,9 +301,9 @@ if __name__ == '__main__':
     # TODO: This name sucks.
     checkAndUpdatePerfTestSuite(sourceDir)
 
-    workCacheDir = collectBenchmarks(exeNames, tree_ish=None, repeat=args.repeat, build_script_args=args.build_script_args)    
+    workCacheDir = collectBenchmarks(exeNames, tree_ish=None, repeat=args.repeat, build_script_args=args.build_script_args)
     baselineCacheDir = collectBenchmarks(exeNames, tree_ish=args.baseline, repeat=args.repeat, build_script_args=args.build_script_args)
-    
+
     if baselineCacheDir == workCacheDir:
         print('No changes between work tree and %s; nothing to compare.' % args.baseline)
     else:

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -30,19 +30,19 @@ class SwiftLexer(RegexLexer):
 
     flags = re.MULTILINE | re.DOTALL
 
-    _isa = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s+)(:)(\s+)([A-Z0-9_][a-zA-Z0-9_]*)' 
+    _isa = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s+)(:)(\s+)([A-Z0-9_][a-zA-Z0-9_]*)'
     _isa_comma = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s+)(:)(\s+)([A-Z0-9_][a-zA-Z0-9_]*)(,\s?)'
     _name = r'[a-zA-Z_][a-zA-Z0-9_?]*'
 
     tokens = {
-   
-        'root' : [
+
+        'root': [
             (r'^', Punctuation, 'root2'),
         ],
- 
-        'root2' : [
+
+        'root2': [
             (r'\n', Text, '#pop'),
-             
+
             (r'//.*?\n', Comment.Single, '#pop'),
             (r'/\*', Comment.Multiline, 'comment'),
 
@@ -60,7 +60,7 @@ class SwiftLexer(RegexLexer):
             (r'(\b[A-Z][a-zA-Z0-9_]*\s?)(\()', bygroups(Name.Constant, Punctuation), 'type-cast'),
             (r'(\b[A-Z][a-zA-Z0-9_]*)(\.)([a-z][a-zA-Z0-9_]*)', bygroups(Name.Constant, Punctuation, Name), 'arg-list'),
             (r'"', String, 'string'),
-            
+
             (r'(\bnew\b\s?)', Keyword.Reserved, 'class-name'),
             (r'\b(true|false)\b', Keyword.Reserved),
             (r'\b(if|else)\s', Keyword.Reserved),
@@ -73,66 +73,66 @@ class SwiftLexer(RegexLexer):
             (r'0x[0-9a-fA-F]+', Number.Hex),
             (r'[0-9]+', Number.Integer),
             (r'\s', Whitespace),
-            
+
             (r'\(', Punctuation, 'tuple'),
-            
+
             include('name'),
-            
+
         ],
 
-        'isa' : [
+        'isa': [
             (_isa, bygroups(Name, Whitespace, Punctuation, Whitespace, Name.Constant)),
         ],
-        
-        'class-isa' : [
+
+        'class-isa': [
             (_isa, bygroups(Name.Class, Whitespace, Punctuation, Whitespace, Name.Constant)),
         ],
 
-        'var-isa' : [
+        'var-isa': [
             (_isa, bygroups(Name.Variable, Whitespace, Punctuation, Whitespace, Name.Constant)),
         ],
 
-        'var-isa-pop' : [
+        'var-isa-pop': [
             (_isa, bygroups(Name.Variable, Whitespace, Punctuation, Whitespace, Name.Constant), '#pop'),
         ],
 
-        'var-isa-comma' : [
+        'var-isa-comma': [
             (_isa_comma, bygroups(Name.Variable, Whitespace, Punctuation, Whitespace, Name.Constant, Punctuation)),
         ],
 
-        'var-name' : [
+        'var-name': [
             (r'[a-zA-Z_][a-zA-Z0-9_?]*', Name.Variable),
         ],
 
-        'tuple' : [
+        'tuple': [
             (r'\(', Punctuation, 'in-tuple'),
         ],
 
-        'in-tuple' : [
+        'in-tuple': [
             (r'\)', Punctuation, '#pop'),
             include('class-name'),
             include('name'),
             include('isa'),
             include('root2'),
         ],
-        
-        'name' : [
+
+        'name': [
             (_name, Name),
         ],
 
-        'comment' : [
+        'comment': [
             (r'[^*/]', Comment.Multiline),
             (r'/\*', Comment.Multiline, '#push'),
             (r'\*/', Comment.Multiline, '#pop'),
             (r'[*/]', Comment.Multiline),
         ],
 
-        'import' : [
+        'import': [
             (_name, Name.Namespace),
             #('\n', Punctuation, '#pop'),
         ],
 
-        'generic-type' : [
+        'generic-type': [
             (r'\s', Whitespace),
             (r'>', Punctuation, '#pop'),
             include('class-name'),
@@ -140,34 +140,34 @@ class SwiftLexer(RegexLexer):
             include('root2'),
         ],
 
-        'class-name' : [
+        'class-name': [
             (r'[A-Z][a-zA-Z0-9_?]*', Name.Constant),
-            (r'(\[)([0-9]+)(\])', bygroups(Operator, Number.Integer, Operator)), 
+            (r'(\[)([0-9]+)(\])', bygroups(Operator, Number.Integer, Operator)),
             (r'<', Punctuation, 'generic-type'),
             (r'\.\(', Punctuation, 'arg-list'),
             (r'\(', Punctuation, 'type-cast'),
             (r'\)', Punctuation, '#pop'),
         ],
 
-        'label' : [
+        'label': [
             (r'[a-zA-Z_][a-zA-Z0-9_]*:(?=\s*\n)', Name.Label),
         ],
 
-        'ws-pop' : [
+        'ws-pop': [
             (r'\s?[\s\n]', Whitespace, '#pop'),
         ],
-            
-        'var-decl' : [ 
+
+        'var-decl': [
             (r'(\[)([\w\s,]*)(\])(\s+)', bygroups(Punctuation, Name.Attribute, Punctuation, Whitespace)),
             include('tuple'),
             include('var-isa-comma'),
             include('var-isa-pop'),
             include('var-name'),
             (r',\s+', Punctuation, 'var-decl'),
-            include('ws-pop'), 
+            include('ws-pop'),
         ],
 
-        'for-loop' : [
+        'for-loop': [
             (r'\sin\s', Keyword.Reserved),
             include('isa'),
             include('name'),
@@ -175,7 +175,7 @@ class SwiftLexer(RegexLexer):
             include('root2'),
         ],
 
-        'func-decl' : [
+        'func-decl': [
             (r'(\[)([\w\s,]*)(\])(\s+)', bygroups(Punctuation, Name.Attribute, Punctuation, Whitespace)),
             (r'\s?\breturn\b', Keyword.Reserved, 'root2'),
             (r'\s?\w', Name.Function),
@@ -185,7 +185,7 @@ class SwiftLexer(RegexLexer):
             (r'\s?\{', Punctuation, '#pop'),
         ],
 
-        'return-type' : [
+        'return-type': [
             include('tuple'),
             include('class-name'),
             (r'\bid\b', Name.Builtin),
@@ -193,16 +193,16 @@ class SwiftLexer(RegexLexer):
             (r'\s?\)', Punctuation),
         ],
 
-        'class-decl' : [
+        'class-decl': [
             (r'\{', Punctuation, '#pop'),
             (r'(\[)([\w\s,]*)(\])(\s+)', bygroups(Punctuation, Name.Attribute, Punctuation, Whitespace)),
             include('class-isa'),
             (r'[A-Z][a-zA-Z0-9_?]*', Name.Class),
             (r'\s', Whitespace),
             (r'<', Punctuation, 'generic-type'),
-        ], 
+        ],
 
-        'arg-list' : [
+        'arg-list': [
             (r',\s?', Punctuation),
             (r'\)', Punctuation, '#pop'),
             include('isa'),
@@ -210,17 +210,17 @@ class SwiftLexer(RegexLexer):
             include('root2'),
         ],
 
-        'type-cast' : [
+        'type-cast': [
             (r'\)', Punctuation, '#pop'),
             include('root2'),
         ],
 
-        'in-interpolated' : [
+        'in-interpolated': [
             ('\)', String.Interpol, '#pop'),
             include('root2'),
         ],
 
-        'string' : [
+        'string': [
             (r'"', String, '#pop'),
             (r'\\([\\abfnrtv"\']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})', String.Escape),
             (r'\\\(', String.Interpol, 'in-interpolated'),
@@ -237,7 +237,7 @@ class SwiftConsoleLexer(RegexLexer):
 
     flags = re.MULTILINE | re.DOTALL
 
-    _isa = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s+)(:)(\s+)([A-Z0-9_][a-zA-Z0-9_]*)' 
+    _isa = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s+)(:)(\s+)([A-Z0-9_][a-zA-Z0-9_]*)'
     _isa_comma = r'([a-zA-Z_][a-zA-Z0-9_]*)(\s+)(:)(\s+)([A-Z0-9_][a-zA-Z0-9_]*)(,\s?)'
     _name = r'[a-zA-Z_][a-zA-Z0-9_?]*'
 

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -56,7 +56,7 @@ def merge_lipo_files(src_root_dirs, file_list, copy_verbatim_subpaths,
                                                                src_root_dirs[0]))
 
         if all([os.path.islink(item) for item in file_paths]):
-            #It's a symlink in all found instances, copy the link.
+            # It's a symlink in all found instances, copy the link.
             print("-- Creating symlink %s" % destPath)
             os.symlink(os.readlink(file_paths[0]), destPath)
         elif all([os.path.isdir(item) for item in file_paths]):

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -2,7 +2,7 @@
 
 # A small utility to take the output of a Swift validation test run
 # where some compiler crashers have been fixed, and move them into the
-# "fixed" testsuite, removing the "--crash" in the process. 
+# "fixed" testsuite, removing the "--crash" in the process.
 
 import re
 import sys
@@ -19,8 +19,8 @@ regex = re.compile('.*Swift :: compiler_crashers(|_2)/(.*\.swift).*')
 for line in sys.stdin:
     match = regex.match(line)
     if match:
-        suffix=match.group(1)
-        filename=match.group(2)
+        suffix = match.group(1)
+        filename = match.group(2)
 
         # Move the test over to the fixed suite.
         from_filename = 'validation-test/compiler_crashers%s/%s' % (suffix, filename)

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -58,16 +58,16 @@ def get_verify_resource_dir_modules_commands(
     print("sil-opt path: " + sil_opt)
 
     known_platforms = [
-      ( 'appletvos', 'arm64', 'arm64-apple-tvos9.0' ),
-      ( 'appletvsimulator', 'x86_64', 'x86_64-apple-tvos9.0' ),
-      ( 'iphoneos', 'armv7', 'armv7-apple-ios7.0' ),
-      ( 'iphoneos', 'armv7s', 'armv7s-apple-ios7.0' ),
-      ( 'iphoneos', 'arm64', 'arm64-apple-ios7.0' ),
-      ( 'iphonesimulator', 'i386', 'i386-apple-ios7.0' ),
-      ( 'iphonesimulator', 'x86_64', 'x86_64-apple-ios7.0' ),
-      ( 'macosx', 'x86_64', 'x86_64-apple-macosx10.9' ),
-      ( 'watchos', 'armv7k', 'armv7k-apple-watchos2.0' ),
-      ( 'watchsimulator', 'i386', 'i386-apple-watchos2.0' ),
+        ('appletvos', 'arm64', 'arm64-apple-tvos9.0'),
+        ('appletvsimulator', 'x86_64', 'x86_64-apple-tvos9.0'),
+        ('iphoneos', 'armv7', 'armv7-apple-ios7.0'),
+        ('iphoneos', 'armv7s', 'armv7s-apple-ios7.0'),
+        ('iphoneos', 'arm64', 'arm64-apple-ios7.0'),
+        ('iphonesimulator', 'i386', 'i386-apple-ios7.0'),
+        ('iphonesimulator', 'x86_64', 'x86_64-apple-ios7.0'),
+        ('macosx', 'x86_64', 'x86_64-apple-macosx10.9'),
+        ('watchos', 'armv7k', 'armv7k-apple-watchos2.0'),
+        ('watchsimulator', 'i386', 'i386-apple-watchos2.0'),
     ]
 
     commands = []
@@ -94,7 +94,7 @@ def get_verify_resource_dir_modules_commands(
 
 
 def quote_shell_command(args):
-    return " ".join([ pipes.quote(a) for a in args ])
+    return " ".join([pipes.quote(a) for a in args])
 
 
 def run_commands_in_parallel(commands):
@@ -148,7 +148,7 @@ def main():
 
     if args.verify_xcode:
         # Find Xcode.
-        swift_path = subprocess.check_output([ 'xcrun', '--find', 'swift' ])
+        swift_path = subprocess.check_output(['xcrun', '--find', 'swift'])
         xcode_path = swift_path
         for _ in range(0, 7):
             xcode_path = os.path.dirname(xcode_path)

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -32,7 +32,7 @@ def capture_with_result(args, include_stderr=False):
         stderr = subprocess.STDOUT
     try:
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=stderr)
-    except OSError,e:
+    except OSError, e:
         if e.errno == errno.ENOENT:
             sys.exit('no such file or directory: %r when running %s.' % (
                 args[0], ' '.join(args)))
@@ -52,8 +52,8 @@ def timestamp():
 
 def submit_results_to_server(results_data, submit_url):
     # Submit the URL encoded data.
-    data = urllib.urlencode({ 'input_data' : results_data,
-                              'commit' : '1' })
+    data = urllib.urlencode({'input_data': results_data,
+                             'commit': '1'})
     response = urllib2.urlopen(urllib2.Request(submit_url, data))
     result_data = response.read()
 
@@ -113,29 +113,29 @@ def main():
    utcnow = datetime.datetime.utcnow()
    start_time = utcnow - datetime.timedelta(seconds=data['elapsed'])
    end_time = utcnow
-   
+
    # Create the LNT report format.
    lnt_results = {}
    lnt_results['Machine'] = {
-      'Name' : machine_name,
-      'Info' : {
-         'hardware' : capture(["uname","-m"], include_stderr=True).strip(),
-         'name' : capture(["uname","-n"], include_stderr=True).strip(),
-         'os' : capture(["uname","-sr"], include_stderr=True).strip(),
-         'uname' : capture(["uname","-a"], include_stderr=True).strip(),
+      'Name': machine_name,
+      'Info': {
+         'hardware': capture(["uname","-m"], include_stderr=True).strip(),
+         'name': capture(["uname","-n"], include_stderr=True).strip(),
+         'os': capture(["uname","-sr"], include_stderr=True).strip(),
+         'uname': capture(["uname","-a"], include_stderr=True).strip(),
       }
    }
 
    # FIXME: Record source versions for LLVM, Swift, etc.?
    lnt_results['Run'] = {
-      'Start Time' : start_time.strftime('%Y-%m-%d %H:%M:%S'),
-      'End Time' : end_time.strftime('%Y-%m-%d %H:%M:%S'),
-      'Info' : {
-         '__report_version__' : '1',
-         'tag' : 'nts',
-         'inferred_run_order' : run_order,
-         'run_order' : run_order,
-         'sw_vers' : capture(['sw_vers'], include_stderr=True).strip(),
+      'Start Time': start_time.strftime('%Y-%m-%d %H:%M:%S'),
+      'End Time': end_time.strftime('%Y-%m-%d %H:%M:%S'),
+      'Info': {
+         '__report_version__': '1',
+         'tag': 'nts',
+         'inferred_run_order': run_order,
+         'run_order': run_order,
+         'sw_vers': capture(['sw_vers'], include_stderr=True).strip(),
       }
    }
 
@@ -161,19 +161,19 @@ def main():
       # FIXME: The XFAIL handling here isn't going to be right.
 
       if not compile_success:
-         lnt_tests.append({ 'Name' : '%s.compile.status' % (test_name,),
-                            'Info' : {},
-                            'Data' : [ FAIL ] })
+         lnt_tests.append({'Name': '%s.compile.status' % (test_name,),
+                           'Info': {},
+                           'Data': [FAIL]})
       if not exec_success:
-         lnt_tests.append({ 'Name' : '%s.exec.status' % (test_name,),
-                            'Info' : {},
-                            'Data' : [ FAIL ] })
-      lnt_tests.append({ 'Name' : '%s.compile' % (test_name,),
-                         'Info' : {},
-                         'Data' : [ compile_time ] })
-      lnt_tests.append({ 'Name' : '%s.exec' % (test_name,),
-                         'Info' : {},
-                         'Data' : [ exec_time ] })
+         lnt_tests.append({'Name': '%s.exec.status' % (test_name,),
+                           'Info': {},
+                           'Data': [FAIL]})
+      lnt_tests.append({'Name': '%s.compile' % (test_name,),
+                        'Info': {},
+                        'Data': [compile_time]})
+      lnt_tests.append({'Name': '%s.exec' % (test_name,),
+                        'Info': {},
+                        'Data': [exec_time]})
 
    # Create the report data.
    lnt_result_data = json.dumps(lnt_results, indent=2) + '\n'
@@ -188,6 +188,6 @@ def main():
    # Submit the results to an LNT server, if requested.
    if opts.submit_url:
       submit_results_to_server(lnt_result_data, opts.submit_url)
-      
+
 if __name__ == '__main__':
    main()

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -180,7 +180,7 @@ main()
         benchName = m.group(1)
         # TODO: Keep track of the line number as well
         self.log("Benchmark found: %s" % benchName, 3)
-        self.tests[name+":"+benchName] = Test(benchName, name, "", "")
+        self.tests[name + ":" + benchName] = Test(benchName, name, "", "")
         testNames.append(benchName)
         if m.group(2):
           output += intoBench
@@ -197,7 +197,7 @@ main()
     with open(processedName, 'w') as f:
       f.write(output)
     for n in testNames:
-      self.tests[name+":"+n].processedSource = processedName
+      self.tests[name + ":" + n].processedSource = processedName
 
 
   def processSources(self):
@@ -219,8 +219,9 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
     self.runCommand(['clang++', 'opaque.cpp', '-o', 'opaque.o', '-c', '-O2'])
 
   compiledFiles = {}
+
   def compileSource(self, name):
-    self.tests[name].binary = "./"+self.tests[name].processedSource.split(os.extsep)[0]
+    self.tests[name].binary = "./" + self.tests[name].processedSource.split(os.extsep)[0]
     if not self.tests[name].processedSource in self.compiledFiles:
       try:
         self.runCommand([self.compiler, self.tests[name].processedSource, "-o", self.tests[name].binary + '.o', '-c'] + self.optFlags)
@@ -330,6 +331,7 @@ class Test:
     self.processedSource = processedSource
     self.binary = binary
     self.status = ""
+
   def Print(self):
     print("NAME: %s" % self.name)
     print("SOURCE: %s" % self.source)
@@ -349,21 +351,23 @@ class TestResults:
     self.samples = samples
     if len(samples) > 0:
       self.Process()
+
   def Process(self):
     self.minimum = min(self.samples)
     self.maximum = max(self.samples)
     self.avg = sum(self.samples)/len(self.samples)
     self.std = pstdev(self.samples)
     self.err = self.std / math.sqrt(len(self.samples))
-    self.int_min = self.avg - self.err*1.96
-    self.int_max = self.avg + self.err*1.96
+    self.int_min = self.avg - self.err * 1.96
+    self.int_max = self.avg + self.err * 1.96
+
   def Print(self):
     print("SAMPLES: %d" % len(self.samples))
     print("MIN: %3.2e" % self.minimum)
     print("MAX: %3.2e" % self.maximum)
     print("AVG: %3.2e" % self.avg)
     print("STD: %3.2e" % self.std)
-    print("ERR: %3.2e (%2.1f%%)" % (self.err, self.err*100/self.avg))
+    print("ERR: %3.2e (%2.1f%%)" % (self.err, self.err * 100 / self.avg))
     print("CONF INT 0.95: (%3.2e, %3.2e)" % (self.int_min, self.int_max))
     print("")
 

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -32,10 +32,10 @@ def update_working_copy(repo_path):
         # Prior to Git 2.6, this is the way to do a "git pull
         # --rebase" that respects rebase.autostash.  See
         # http://stackoverflow.com/a/30209750/125349
-        check_call([ "git", "fetch" ])
-        check_call([ "git", "rebase", "FETCH_HEAD" ])
+        check_call(["git", "fetch"])
+        check_call(["git", "rebase", "FETCH_HEAD"])
 
-def obtain_additional_swift_sources(opts = {'with_ssh': False}):
+def obtain_additional_swift_sources(opts={'with_ssh': False}):
     additional_repos = {
         'llvm': 'apple/swift-llvm',
         'clang': 'apple/swift-clang',

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -89,7 +89,7 @@ def main():
             return
         suffix = sys.argv[1]
 
-    blocks = { }
+    blocks = {}
     curBlock = None
     silBlockPattern = re.compile(r'^(\S+)(\(.*\))?: *(\/\/ *Preds:(.*))?$')
     llvmBlockPattern1 = re.compile(r'^(\S+): *; *preds =(.*)?$')
@@ -128,7 +128,7 @@ def main():
 
     # Add empty blocks which we didn't see, but which are referenced.
 
-    newBlocks = { }
+    newBlocks = {}
     for name, block in blocks.iteritems():
         for adjName in (block.preds + block.getSuccs()):
             if adjName not in blocks:

--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -2,21 +2,21 @@
 
 import itertools
 
-traversal_options = [ 'Forward', 'Bidirectional', 'RandomAccess' ]
-base_kind_options = [ 'Defaulted', 'Minimal' ]
-mutable_options = [ False, True ]
+traversal_options = ['Forward', 'Bidirectional', 'RandomAccess']
+base_kind_options = ['Defaulted', 'Minimal']
+mutable_options = [False, True]
 for traversal, base_kind, mutable in itertools.product(traversal_options,
                                                        base_kind_options,
                                                        mutable_options):
     # Test Slice<Base> and MutableSlice<Base> of various collections using value
     # types as elements.
-    wrapper_types = [ 'Slice', 'MutableSlice' ] if mutable else [ 'Slice' ]
+    wrapper_types = ['Slice', 'MutableSlice'] if mutable else ['Slice']
     for WrapperType in wrapper_types:
         for name, prefix, suffix in [
-          ('FullWidth', '[]', '[]'),
-          ('WithPrefix', '[ -9999, -9998, -9997 ]', '[]'),
-          ('WithSuffix', '[]', '[ -9999, -9998, -9997 ]'),
-          ('WithPrefixAndSuffix', '[ -9999, -9998, -9997, -9996, -9995 ]', '[ -9994, -9993, -9992 ]')
+                ('FullWidth', '[]', '[]'),
+                ('WithPrefix', '[-9999, -9998, -9997]', '[]'),
+                ('WithSuffix', '[]', '[ -9999, -9998, -9997]'),
+                ('WithPrefixAndSuffix', '[-9999, -9998, -9997, -9996, -9995]', '[-9994, -9993, -9992]')
         ]:
             Base = '%s%s%sCollection' % (base_kind, traversal, 'Mutable' if mutable else '')
             testFilename = WrapperType + '_Of_' + Base + '_' + name + '.swift'
@@ -61,12 +61,7 @@ ${{SliceTest}}
 
 runAllTests()
 """.format(
-    testFilename=testFilename,
-    traversal=traversal,
-    base_kind=base_kind,
-    mutable=mutable,
-    WrapperType=WrapperType,
-    name=name,
-    prefix=prefix,
-    suffix=suffix
-))
+                    testFilename=testFilename, traversal=traversal,
+                    base_kind=base_kind, mutable=mutable,
+                    WrapperType=WrapperType, name=name, prefix=prefix,
+                    suffix=suffix))


### PR DESCRIPTION
This is a follow-up to PR #988.

Fixes:
- multiple statements on one line (colon) (E701)
- missing whitespace around arithmetic operator (E226)
- missing whitespace around operator (E225)
- closing bracket does not match visual indentation (E124)
- blank line contains whitespace (W293)
- continuation line missing indentation or outdented (E122)
- continuation line over-indented for hanging indent (E126)
- missing expected blank line (E301)
- trailing whitespace (W291)
- unexpected spaces around keyword / parameter equals (E251)
- whitespace after '(', '[' or '{' (E201)
- whitespace before ')', ']' or '}' (E202)
- whitespace before ',' or ':' (E203)
