### PR TITLE
[Parser] Missed signed cast of CurPtr

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1464,7 +1464,7 @@ Restart:
   // Remember the start of the token so we can form the text range.
   const char *TokStart = CurPtr;
   
-  switch (*CurPtr++) {
+  switch ((signed char)*CurPtr++) {
   default: {
     char const *tmp = CurPtr-1;
     if (advanceIfValidStartOfIdentifier(tmp, BufferEnd))


### PR DESCRIPTION
A char is unsigned by default on PowerPC. CurPtr is cast
to a signed char whenever a signed comparison is required,
but we are missing one place.

This fixes a testcase failure in Parse/BOM.swift
