### PR TITLE
[build-script] Unify naming: `SIL_VERIFY_ALL`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ option(SWIFT_AST_VERIFIER
     "Enable the AST verifier in the built compiler, and run it on every compilation"
     TRUE)
 
-option(SWIFT_VERIFY_ALL
+option(SWIFT_SIL_VERIFY_ALL
     "Run SIL verification after each transform when building Swift files in the build process"
     FALSE)
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -298,7 +298,7 @@ function(_compile_swift_files dependency_target_out_var_name)
   # Don't include libarclite in any build products by default.
   list(APPEND swift_flags "-no-link-objc-runtime")
 
-  if(SWIFT_VERIFY_ALL)
+  if(SWIFT_SIL_VERIFY_ALL)
     list(APPEND swift_flags "-Xfrontend" "-sil-verify-all")
   endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -173,7 +173,7 @@ KNOWN_SETTINGS=(
     darwin-deployment-version-watchos "2.0"      "minimum deployment target version for watchOS"
 
     extra-swift-args            ""               "Extra arguments to pass to swift modules which match regex. Assumed to be a flattened cmake list consisting of [module_regexp, args, module_regexp, args, ...]"
-    sil-verify-all              "0"              "If enabled, run the sil verifier be run after every SIL pass"
+    sil-verify-all              "0"              "If enabled, run the SIL verifier after each transform when building Swift files during this build process"
     swift-enable-ast-verifier   "1"              "If enabled, and the assertions are enabled, the built Swift compiler will run the AST verifier every time it is invoked"
     swift-runtime-enable-dtrace "0"              "Enable runtime dtrace support"
     swift-runtime-enable-leak-checker   "0"              "Enable leaks checking routines in the runtime"
@@ -1443,7 +1443,7 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
     swift_cmake_options=(
         "${swift_cmake_options[@]}"
         -DSWIFT_AST_VERIFIER:BOOL=$(true_false "${SWIFT_ENABLE_AST_VERIFIER}")
-        -DSWIFT_VERIFY_ALL:BOOL=$(true_false "${SIL_VERIFY_ALL}")
+        -DSWIFT_SIL_VERIFY_ALL:BOOL=$(true_false "${SIL_VERIFY_ALL}")
         -DSWIFT_RUNTIME_ENABLE_DTRACE:BOOL=$(true_false "${SWIFT_RUNTIME_ENABLE_DTRACE}")
         -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=$(true_false "${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")
     )
@@ -2310,10 +2310,3 @@ if [[ "${SYMBOLS_PACKAGE}" ]] ; then
         tar -c -z -f "${SYMBOLS_PACKAGE}" --owner=0 --group=0 "${INSTALL_PREFIX/#\/}")
     fi
 fi
-
-# FIXME(before commit): assertion modes:
-# On:
-#   SWIFT_VERIFY_ALL:BOOL=TRUE
-# Off:
-#   SWIFT_VERIFY_ALL:BOOL=FALSE
-


### PR DESCRIPTION
Although the user sets the option using `--sil-verify-all`, various
build scripts refer to the option as `SWIFT_VERIFY_ALL`. Code comments
indicate that this may have been a separate setting at one time.

Remove the misleading comments and unify naming with
`--sil-verify-all`. This more closely matches what the option actually
does (adds `-Xfrontend -sil-verify-all` to `swiftc` invocations during
the build process).
