### PR TITLE
[SR-547][Sema] Invalidate more parts of protocols involved in recursive definitions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2596,7 +2596,7 @@ public:
   SourceLoc getStartLoc() const { return KeywordLoc; }
   SourceRange getSourceRange() const;
 
-  void setIsRecursive() { AssociatedTypeDeclBits.Recursive = true; }
+  void setIsRecursive();
   bool isRecursive() { return AssociatedTypeDeclBits.Recursive; }
 
   /// Whether the declaration is currently being validated.

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1061,10 +1061,17 @@ bool ArchetypeBuilder::addAbstractTypeParamRequirements(
   auto markRecursive = [&](AssociatedTypeDecl *assocType,
                            ProtocolDecl *proto,
                            SourceLoc loc) {
-    if (!pa->isRecursive() && !assocType->isRecursive())
+    if (!pa->isRecursive() && !assocType->isRecursive()) {
       Diags.diagnose(assocType->getLoc(),
                      diag::recursive_requirement_reference);
-    assocType->setIsRecursive();
+        
+      // Mark all associatedtypes in this protocol as recursive (and error-type) to avoid later
+      // crashes dealing with this invalid protocol in other contexts.
+      auto containingProto = assocType->getDeclContext()->isProtocolOrProtocolExtensionContext();
+      for (auto member : containingProto->getMembers())
+        if (auto assocType = dyn_cast<AssociatedTypeDecl>(member))
+          assocType->setIsRecursive();
+    }
     pa->setIsRecursive();
 
     // FIXME: Drop this protocol.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2171,6 +2171,11 @@ SourceRange AssociatedTypeDecl::getSourceRange() const {
   return SourceRange(KeywordLoc, endLoc);
 }
 
+void AssociatedTypeDecl::setIsRecursive() {
+  AssociatedTypeDeclBits.Recursive = true;
+  overwriteType(ErrorType::get(this->getASTContext()));
+}
+
 EnumDecl::EnumDecl(SourceLoc EnumLoc,
                      Identifier Name, SourceLoc NameLoc,
                      MutableArrayRef<TypeLoc> Inherited,

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -20,7 +20,7 @@ struct X<T: P> {
 }
 
 func f<T : P>(z: T) {
- _ = X<T.A>()
+ _ = X<T.A>() // expected-error{{type 'X<T.A>' has no member 'A'}}
 }
 
 // -----
@@ -60,7 +60,7 @@ struct Y3 : DeclaredP {
 struct X3<T:P4> {}
 
 func f2<T:P4>(a: T) {
- _ = X3<T.A>()
+ _ = X3<T.A>() // expected-error{{type 'X3<T.A>' has no member 'A'}}
 }
 
 f2(Y3())
@@ -101,4 +101,24 @@ protocol AsExistentialAssocTypeAgainA {
 protocol AsExistentialAssocTypeAgainB {
   func aMethod(object : AsExistentialAssocTypeAgainA) // expected-error * {{protocol 'AsExistentialAssocTypeAgainA' can only be used as a generic constraint because it has Self or associated type requirements}}
 }
+
+// SR-547
+protocol A {
+    associatedtype B1: B // expected-error{{type may not reference itself as a requirement}}
+    associatedtype C1: C
+    
+    mutating func addObserver(observer: B1, forProperty: C1)
+}
+
+protocol C {
+    
+}
+
+protocol B {
+    associatedtype BA: A // expected-error{{type may not reference itself as a requirement}}
+    associatedtype BC: C
+    
+    func observeChangeOfProperty(property: BC, observable: BA)
+}
+
 


### PR DESCRIPTION
The idea here is to do more marking of the generic parts of the
protocol as being invalid as soon as the recursiveness is diagnosed in
order to simplify checking (and avoid infinite loops) down the line.

When an associatedtype is discovered to be recursive, all associated types in the protocol are marked as recursive and are set to be error-type[1], and later when validating decls, any decl referencing a recursive associatedtype is marked invalid.

This avoids the infinite loop in SR-547 where typeCheckDecl() get called recursively on the protocol because it never has a valid type, and also (once that is fixed) crashing later in a similar spot to 28203-swift-typebase-getdesugaredtype.swift in verification since the associatedtype would never get a valid type.

All tests pass. Ideally the additional errors in test/decl/protocol/recursive_requirement.swift wouldn't be emitted, because they are extra noise caused by the extra protocol invalidation, but that seems like it can be improved later.

@lattner This removes some of the associated type checking that you put in yesterday[2], but hopefully it does so in a way that you'll approve of, since it's essentially doing what your TODO comment was talking about there. 

[1] This has to happen via overwriteType() directly because just calling setType() would assert that the type is already set.

[2] The crashes you fixed are still fixed by this, but this commit needs to go farther (with the bit that marks ALL associated types as errors) since SR-547 was still broken.
