### PR TITLE
[Sema] diagnose unsupported generic arguments

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -45,6 +45,12 @@ ERROR(not_implemented,none,
 ERROR(error_opening_output,none,
       "error opening '%0' for output: %1", (StringRef, StringRef))
 
+ERROR(unsupported_recursive_type,none,
+      "recursive value type %0 is not allowed", (Type))
+
+ERROR(recursive_enum_not_indirect,none,
+      "recursive enum %0 is not marked 'indirect'", (Type))
+
 
 NOTE(previous_decldef,none,
      "previous %select{declaration|definition}0 of %1 is here", 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -78,12 +78,6 @@ ERROR(inout_argument_alias,none,
 NOTE(previous_inout_alias,none,
       "previous aliasing argument", ())
 
-ERROR(unsupported_recursive_type,none,
-      "recursive value type %0 is not allowed", (Type))
-
-ERROR(recursive_enum_not_indirect,none,
-      "recursive enum %0 is not marked 'indirect'", (Type))
-
 ERROR(unsupported_c_function_pointer_conversion,none,
       "C function pointer signature %0 is not compatible with expected type %1",
       (Type, Type))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -435,6 +435,35 @@ Type TypeChecker::applyUnboundGenericArguments(
   BoundGenericType *BGT = BoundGenericType::get(unbound->getDecl(),
                                                 unbound->getParent(),
                                                 genericArgTypes);
+
+  // Check for self referencing generic argument types.
+  // To meet this condition, a member's overall type must be same as the
+  // struct or enum it belongs to. Then it must have the same type as one
+  // of its type's arugment. See 'X' in the following example:
+  //   struct X<T> { let s: X<X> }
+  //   enum X<T> { case s(X<X>) }
+  bool SelfReferencingGenArgType = false;
+  auto DCT = dc->getDeclaredTypeInContext();
+  auto BGTN = BGT->getNominalOrBoundGenericNominal();
+  auto DCTN = DCT ? DCT->getNominalOrBoundGenericNominal() : nullptr;
+  auto BGTNI = BGTN ? BGTN->getDeclaredInterfaceType() : nullptr;
+  auto DCTNI = DCTN ? DCTN->getDeclaredInterfaceType() : nullptr;
+  if (BGTNI && DCTNI && BGTNI->isEqual(DCTNI)) {
+    for (auto GAT: genericArgTypes) {
+      if (GAT->isEqual(DCT)) {
+        SelfReferencingGenArgType = true;
+      }
+    }
+  }
+
+  if (SelfReferencingGenArgType) {
+    if (isa<StructDecl>(BGTN)) {
+      diagnose(BGTN->getLoc(), diag::unsupported_recursive_type, DCT);
+    } else if (isa<EnumDecl>(BGTN)) {
+      diagnose(BGTN->getLoc(), diag::recursive_enum_not_indirect, DCT);
+    }
+  }
+
   // Check protocol conformance.
   if (!BGT->hasTypeParameter()) {
     SourceLoc noteLoc = unbound->getDecl()->getLoc();

--- a/test/Sema/diag_unsupported_generic_argument.swift
+++ b/test/Sema/diag_unsupported_generic_argument.swift
@@ -1,0 +1,8 @@
+// RUN: %target-parse-verify-swift
+struct X<T> { // expected-error {{recursive value type 'X<T>' is not allowed}}
+    let s: X<X>
+}
+
+enum Y<T> { // expected-error {{recursive enum 'Y<T>' is not marked 'indirect'}}
+    case S(Y<Y>)
+}

--- a/validation-test/compiler_crashers_fixed/24887-no-stack-trace.swift
+++ b/validation-test/compiler_crashers_fixed/24887-no-stack-trace.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-silgen
+// RUN: not %target-swift-frontend %s -emit-silgen
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/codafi (Robert Widmann)
 


### PR DESCRIPTION
Declaration such as `struct X { let s: X<X> }` should be invalid. The _recursive
value type_ check in SILGen doesn't catch this specific case. So we catch it in
Sema and issue the diagnosis that would've been issued.

A known compiler crash is resolved as a result.
