### PR TITLE
[swiftc] Add test case for crash triggered in swift::Expr::propagateLValueAccessKind(…)

### DIFF
--- a/validation-test/compiler_crashers/28216-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers/28216-swift-expr-propagatelvalueaccesskind.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+let e=[[[]_


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/Expr.cpp:204: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind): Assertion `(AllowOverwrite || !E->hasLValueAccessKind()) && "l-value access kind has already been set"' failed.
9  swift           0x0000000000fec937 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) + 23
13 swift           0x0000000000eaeb10 swift::TypeChecker::callWitness(swift::Expr*, swift::DeclContext*, swift::ProtocolDecl*, swift::ProtocolConformance*, swift::DeclName, llvm::MutableArrayRef<swift::Expr*>, swift::Diag<>) + 2688
17 swift           0x0000000000f80c3e swift::Expr::walk(swift::ASTWalker&) + 46
18 swift           0x0000000000eaa826 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
19 swift           0x0000000000e1f62b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
21 swift           0x0000000000ec6dd8 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 5128
22 swift           0x0000000000eca8ee swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
23 swift           0x0000000000e19225 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
24 swift           0x0000000000e1f5b9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
25 swift           0x0000000000e20730 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
26 swift           0x0000000000e208d9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
29 swift           0x0000000000e3a366 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
31 swift           0x0000000000e809c6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
32 swift           0x0000000000e069fd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
33 swift           0x0000000000cb0f4f swift::CompilerInstance::performSema() + 2975
35 swift           0x0000000000775357 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
36 swift           0x000000000076ff35 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28216-swift-expr-propagatelvalueaccesskind.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28216-swift-expr-propagatelvalueaccesskind-2422f6.o
1.  While type-checking declaration 0x596f8a0 at validation-test/compiler_crashers/28216-swift-expr-propagatelvalueaccesskind.swift:8:1
2.  While type-checking expression at [validation-test/compiler_crashers/28216-swift-expr-propagatelvalueaccesskind.swift:8:7 - line:8:11] RangeText="[[[]_"
3.  While type-checking expression at [validation-test/compiler_crashers/28216-swift-expr-propagatelvalueaccesskind.swift:8:7 - line:8:11] RangeText="[[[]_"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
