### PR TITLE
[swiftc] Add test case for crash triggered in swift::DiagnosticEngine::emitDiagnostic(…)

### DIFF
--- a/validation-test/compiler_crashers/28217-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers/28217-swift-diagnosticengine-emitdiagnostic.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+var b{enum b:String{case=nil


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/DiagnosticEngine.cpp:463: void formatDiagnosticText(llvm::StringRef, ArrayRef<swift::DiagnosticArgument>, llvm::raw_ostream &): Assertion `ArgIndex < Args.size() && "Out-of-range argument index"' failed.
9  swift           0x0000000000fe725b swift::DiagnosticEngine::emitDiagnostic(swift::Diagnostic const&) + 2891
10 swift           0x0000000000fe64ef swift::DiagnosticEngine::flushActiveDiagnostic() + 319
11 swift           0x0000000000ec5b20 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 336
12 swift           0x0000000000eca8ee swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
13 swift           0x0000000000e19225 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
14 swift           0x0000000000e1f5b9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
18 swift           0x0000000000e3a366 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000e7f59a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
22 swift           0x0000000000e7f3ee swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
23 swift           0x0000000000e7ffb8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
25 swift           0x0000000000e06a92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
26 swift           0x0000000000cb0f4f swift::CompilerInstance::performSema() + 2975
28 swift           0x0000000000775357 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
29 swift           0x000000000076ff35 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28217-swift-diagnosticengine-emitdiagnostic.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28217-swift-diagnosticengine-emitdiagnostic-78c825.o
1.  While type-checking getter for b at validation-test/compiler_crashers/28217-swift-diagnosticengine-emitdiagnostic.swift:8:6
2.  While type-checking 'b' at validation-test/compiler_crashers/28217-swift-diagnosticengine-emitdiagnostic.swift:8:7
3.  While type-checking expression at [validation-test/compiler_crashers/28217-swift-diagnosticengine-emitdiagnostic.swift:8:26 - line:8:26] RangeText="n"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
