### PR TITLE
[AST] Resolved name quotation inconsistency

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2322,7 +2322,7 @@ public:
   void visitNamedTypeRepr(NamedTypeRepr *T) {
     printCommon(T, "type_named");
     if (T->hasName())
-      OS << " id='" << T->getName();
+      OS << " id=" << T->getName();
     if (T->getTypeRepr()) {
       OS << '\n';
       printRec(T->getTypeRepr());


### PR DESCRIPTION
Prior to this change, the AST would look something like this, note `id='incoming` missing the closing quote.

``` swift
(type_named id='incoming
    (type_ident
        (component id='UIImage' bind=type)))
```

In reviewing conventions used throughout this class, it appears that this identifier should not need to be quoted at all, so I removed the leading quote. If I am wrong in my understanding, then perhaps the trailing quote should be introduced.
