### PR TITLE
[AST] Fix argument to diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -257,7 +257,7 @@ ERROR(cannot_throw_nil,none,
 ERROR(cannot_convert_raw_initializer_value,none,
       "cannot convert value of type %0 to raw type %1", (Type,Type))
 ERROR(cannot_convert_raw_initializer_value_nil,none,
-      "cannot convert nil to raw type %1", (Type))
+      "cannot convert nil to raw type %0", (Type))
 
 ERROR(cannot_convert_default_arg_value,none,
       "default argument value of type %0 cannot be converted to type %1",

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -429,3 +429,7 @@ public protocol RawValueB
 enum RawValueBTest: Double, RawValueB {
   case A, B
 }
+
+enum foo : String {
+  case bar = nil // expected-error {{cannot convert nil to raw type 'String'}}
+}


### PR DESCRIPTION
A simple “%1” to “%0” for a diagnosis with just one arg.

This is a fix for the crash here: https://github.com/apple/swift/pull/1013
