### PR TITLE
[AST] Formatting consistency in conditional compilation output

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -952,7 +952,7 @@ namespace {
       OS.indent(Indent) << "(#if_decl\n";
       Indent += 2;
       for (auto &Clause : ICD->getClauses()) {
-        OS.indent(Indent) << (Clause.Cond ? "(#if:\n" : "#else");
+        OS.indent(Indent) << (Clause.Cond ? "(#if:\n" : "\n(#else:\n");
         if (Clause.Cond)
           printRec(Clause.Cond);
         
@@ -960,6 +960,8 @@ namespace {
           OS << '\n';
           printRec(D);
         }
+
+        OS << ')';
       }
     
       Indent -= 2;


### PR DESCRIPTION
Before:

```
(#if_stmt
  (#if:
    (stuff)     #else
    (stuff))
```

After:

```
(#if_stmt
  (#if:
    (stuff))
  (#else:
    (stuff)))
```

Notable differences:
- #if block is closed
- #else block is treated same as #if block, starts on new line, token terminated with `:`
- #else block is closed
