### PR TITLE
Emit static dispatch for super methods of same-module implementations

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -108,6 +108,13 @@ static CanSILFunctionType getDynamicMethodLoweredType(SILGenFunction &gen,
   return replaceSelfTypeForDynamicLookup(ctx, methodTy, selfTy, methodName);
 }
 
+static bool canUseStaticDispatch(SILGenFunction &gen,
+                                 SILDeclRef constant) {
+  auto *funcDecl = cast<AbstractFunctionDecl>(constant.getDecl());
+  auto thisModule = gen.SGM.M.getSwiftModule();
+  return funcDecl->isFinal() || (thisModule == funcDecl->getModuleContext());
+}
+
 namespace {
 
 /// Abstractly represents a callee, which may be a constant or function value,
@@ -1291,8 +1298,7 @@ public:
                  apply);
 
     SILValue superMethod;
-    auto *funcDecl = cast<AbstractFunctionDecl>(constant.getDecl());
-    if (constant.isForeign || !funcDecl->isFinal()) {
+    if (constant.isForeign || !canUseStaticDispatch(SGF, constant)) {
       // All Objective-C methods and
       // non-final native Swift methods use dynamic dispatch.
       SILValue Input = super.getValue();
@@ -3784,7 +3790,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &gen,
   while (auto *upcast = dyn_cast<UpcastInst>(self))
     self = upcast->getOperand();
 
-  if (constant.isForeign || !decl->isFinal())
+  if (constant.isForeign || !canUseStaticDispatch(gen, constant))
     return Callee::forSuperMethod(gen, self, constant, substAccessorType,loc);
 
   return Callee::forDirect(gen, constant, substAccessorType, loc);

--- a/test/SILGen/auto_closures.swift
+++ b/test/SILGen/auto_closures.swift
@@ -40,7 +40,7 @@ public class Sub : Base {
   // CHECK: }
 
   // CHECK-LABEL: sil shared [transparent] @_TFFC13auto_closures3Subg1xVS_4Boolu_KT_S1_ : $@convention(thin) (@owned Sub) -> Bool {
-  // CHECK: [[SUPER:%[0-9]+]] = super_method %{{[0-9]+}} : $Sub, #Base.x!getter.1 : (Base) -> () -> Bool , $@convention(method) (@guaranteed Base) -> Bool
+  // CHECK: [[SUPER:%[0-9]+]] = function_ref @_TFC13auto_closures4Baseg1xVS_4Bool : $@convention(method) (@guaranteed Base) -> Bool
   // CHECK: [[RET:%.*]] = apply [[SUPER]]({{%.*}})
   // CHECK: return [[RET]]
   override var x: Bool { return call_auto_closure(super.x) }

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -16,7 +16,7 @@ class SomeDerivedClass : Parent {
 // CHECK: integer_literal $Builtin.Int2048, 42
 // CHECK: [[SELFLOAD:%[0-9]+]] = load [[SELF:%[0-9]+]] : $*SomeDerivedClass
 // CHECK-NEXT: [[PARENT:%[0-9]+]] = upcast [[SELFLOAD]] : $SomeDerivedClass to $Parent
-// CHECK-NEXT: [[INITCALL1:%[0-9]+]] = super_method [[SELFLOAD]] : $SomeDerivedClass, #Parent.init!initializer.1
+// CHECK: [[INITCALL1:%[0-9]+]] = function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent
 // CHECK-NEXT: [[RES1:%[0-9]+]] = apply [[INITCALL1]]([[PARENT]])
 // CHECK-NEXT: [[DOWNCAST:%[0-9]+]] = unchecked_ref_cast [[RES1]] : $Parent to $SomeDerivedClass
 // CHECK-NEXT: store [[DOWNCAST]] to [[SELF]] : $*SomeDerivedClass 
@@ -25,7 +25,7 @@ class SomeDerivedClass : Parent {
   init(x: Int) {
     y = x
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call16SomeDerivedClassc{{.*}} : $@convention(method) (Int, @owned SomeDerivedClass) -> @owned SomeDerivedClass
-// CHECK: super_method {{%[0-9]+}} : $SomeDerivedClass, #Parent.init!initializer.1 : Parent.Type -> () -> Parent , $@convention(method) (@owned Parent) -> @owned Parent
+// CHECK: function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent
   }
 
   init(b: Bool) {
@@ -41,7 +41,7 @@ class SomeDerivedClass : Parent {
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call16SomeDerivedClassc{{.*}} : $@convention(method) (Bool, @owned SomeDerivedClass) -> @owned SomeDerivedClass    
 // CHECK: bb4:
 // CHECK: [[SELFLOAD:%[0-9]+]] = load [[SELF:%[0-9]+]] : $*SomeDerivedClass
-// CHECK: super_method [[SELFLOAD]] : $SomeDerivedClass, #Parent.init!initializer.1 : Parent.Type -> () -> Parent , $@convention(method) (@owned Parent) -> @owned Parent
+// CHECK: function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent /
 // CHECK-NEXT: apply
 // CHECK-NEXT: unchecked_ref_cast
 // CHECK-NEXT: store
@@ -61,8 +61,7 @@ class SomeDerivedClass : Parent {
       
     super.init()
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call16SomeDerivedClassc{{.*}} : $@convention(method) (Bool, Int, @owned SomeDerivedClass) -> @owned SomeDerivedClass    
-// CHECK: super_method {{%[0-9]+}} : $SomeDerivedClass, #Parent.init!initializer.1 : Parent.Type -> () -> Parent , $@convention(method) (@owned Parent) -> @owned Parent
-// CHECK-NOT: function_ref @_TFC30auto_generated_super_init_call6Parentc
+// CHECK: function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent
 // CHECK: return
   }
 }
@@ -71,7 +70,7 @@ class SomeDerivedClass : Parent {
 class HasNoIVars : Parent {
   override init() {
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call10HasNoIVarsc{{.*}} : $@convention(method) (@owned HasNoIVars) -> @owned HasNoIVars
-// CHECK: super_method {{%[0-9]+}} : $HasNoIVars, #Parent.init!initializer.1
+// CHECK: function_ref @_TFC30auto_generated_super_init_call6ParentcfT_S0_ : $@convention(method) (@owned Parent) -> @owned Parent
   }
 }
 
@@ -95,7 +94,7 @@ class ChildOfParentWithNoExplicitInit : ParentWithNoExplicitInit {
   override init() {
     y = 10
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call31ChildOfParentWithNoExplicitInitc
-// CHECK: super_method {{%[0-9]+}} : $ChildOfParentWithNoExplicitInit, #ParentWithNoExplicitInit.init!initializer.1 : ParentWithNoExplicitInit.Type -> () -> ParentWithNoExplicitInit , $@convention(method) (@owned ParentWithNoExplicitInit) -> @owned ParentWithNoExplicitInit
+// CHECK: function_ref @_TFC30auto_generated_super_init_call24ParentWithNoExplicitInitcfT_S0_ : $@convention(method) (@owned ParentWithNoExplicitInit) -> @owned ParentWithNoExplicitInit
   }
 }
 
@@ -109,7 +108,7 @@ class ChildOfParentWithNoExplicitInit2 : ParentWithNoExplicitInit2 {
   override init() {
     y = 10
 // CHECK-LABEL: sil hidden @_TFC30auto_generated_super_init_call32ChildOfParentWithNoExplicitInit2c
-// CHECK: super_method {{%[0-9]+}} : $ChildOfParentWithNoExplicitInit2, #ParentWithNoExplicitInit2.init!initializer.1 : ParentWithNoExplicitInit2.Type -> () -> ParentWithNoExplicitInit2 , $@convention(method) (@owned ParentWithNoExplicitInit2) -> @owned ParentWithNoExplicitInit2
+// CHECK: function_ref @_TFC30auto_generated_super_init_call25ParentWithNoExplicitInit2cfT_S0_ : $@convention(method) (@owned ParentWithNoExplicitInit2) -> @owned ParentWithNoExplicitInit2
   }
 }
 

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -360,7 +360,7 @@ class SuperSub : SuperBase {
     // CHECK: [[CLASS_METHOD:%.*]] = class_method %0 : $SuperSub, #SuperSub.boom!1
     // CHECK: = apply [[CLASS_METHOD]](%0)
     // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-    // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+    // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
     // CHECK: return
     func a1() {
@@ -384,7 +384,7 @@ class SuperSub : SuperBase {
       // CHECK: [[CLASS_METHOD:%.*]] = class_method %0 : $SuperSub, #SuperSub.boom!1
       // CHECK: = apply [[CLASS_METHOD]](%0)
       // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
       // CHECK: return
       func b2() {
@@ -405,7 +405,7 @@ class SuperSub : SuperBase {
     // CHECK: [[CLASS_METHOD:%.*]] = class_method %0 : $SuperSub, #SuperSub.boom!1
     // CHECK: = apply [[CLASS_METHOD]](%0)
     // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-    // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+    // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
     // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
     // CHECK: return
     let c1 = { () -> Void in
@@ -427,7 +427,7 @@ class SuperSub : SuperBase {
     let d1 = { () -> Void in
       // CHECK-LABEL: sil shared @_TFFFC8closures8SuperSub1d
       // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
       // CHECK: return
       func d2() {
@@ -450,7 +450,7 @@ class SuperSub : SuperBase {
     func e1() {
       // CHECK-LABEL: sil shared @_TFFFC8closures8SuperSub1e
       // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
       // CHECK: return
       let e2 = {
@@ -473,7 +473,7 @@ class SuperSub : SuperBase {
     let f1 = {
       // CHECK-LABEL: sil shared [transparent] @_TFFFC8closures8SuperSub1f
       // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
       // CHECK: return
       nil ?? super.boom()
@@ -492,7 +492,7 @@ class SuperSub : SuperBase {
     func g1() {
       // CHECK-LABEL: sil shared [transparent] @_TFFFC8closures8SuperSub1g
       // CHECK: [[SUPER:%.*]] = upcast %0 : $SuperSub to $SuperBase
-      // CHECK: [[SUPER_METHOD:%.*]] = super_method %0 : $SuperSub, #SuperBase.boom!1
+      // CHECK: [[SUPER_METHOD:%.*]] = function_ref @_TFC8closures9SuperBase4boomfT_T_ : $@convention(method) (@guaranteed SuperBase) -> ()
       // CHECK: = apply [[SUPER_METHOD]]([[SUPER]])
       // CHECK: return
       nil ?? super.boom()

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -53,7 +53,7 @@ class F : E { }
 // CHECK-NEXT: store [[ORIGSELF]] to [[SELF]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [[SELF]] : $*F
 // CHECK-NEXT: [[E:%[0-9]]] = upcast [[SELFP]] : $F to $E
-// CHECK: [[E_CTOR:%[0-9]+]] = super_method [[SELFP]] : $F, #E.init!initializer.1 : E.Type -> () -> E , $@convention(method) (@owned E) -> @owned E
+// CHECK: [[E_CTOR:%[0-9]+]] = function_ref @_TFC19default_constructor1EcfT_S0_ : $@convention(method) (@owned E) -> @owned E
 // CHECK-NEXT: [[ESELF:%[0-9]]] = apply [[E_CTOR]]([[E]]) : $@convention(method) (@owned E) -> @owned E
 
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -148,54 +148,54 @@ class Subclass: Foo {
     super.nativeMethod()
   }
   // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclass12nativeMethod
-  // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.nativeMethod!1
+  // CHECK:         function_ref @_TFC7dynamic3Foo12nativeMethodfT_T_ : $@convention(method) (@guaranteed Foo) -> ()
 
   override var nativeProp: Int {
     get { return super.nativeProp }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclassg10nativePropSi
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.nativeProp!getter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foog10nativePropSi : $@convention(method) (@guaranteed Foo) -> Int
     set { super.nativeProp = newValue }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclasss10nativePropSi
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.nativeProp!setter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foos10nativePropSi : $@convention(method) (Int, @guaranteed Foo) -> ()
   }
 
   override subscript(native native: Int) -> Int {
     get { return super[native: native] }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclassg9subscriptFT6nativeSi_Si
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.subscript!getter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foog9subscriptFT6nativeSi_Si : $@convention(method) (Int, @guaranteed Foo) -> Int
     set { super[native: native] = newValue }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclasss9subscriptFT6nativeSi_Si
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.subscript!setter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foos9subscriptFT6nativeSi_Si : $@convention(method) (Int, Int, @guaranteed Foo) -> ()
   }
 
   override init(objc: Int) {
     super.init(objc: objc)
   }
-  // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclassc
-  // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.init!initializer.1
+  // CHECK-LABEL: sil hidden @_TFC7dynamic8SubclasscfT4objcSi_S0_
+  // CHECK:         function_ref @_TFC7dynamic3FoocfT4objcSi_S0_ : $@convention(method) (Int, @owned Foo) -> @owned Foo
 
   override func objcMethod() {
     super.objcMethod()
   }
   // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclass10objcMethod
-  // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.objcMethod!1
+  // CHECK:         function_ref @_TFC7dynamic3Foo10objcMethodfT_T_ : $@convention(method) (@guaranteed Foo) -> ()
 
   override var objcProp: Int {
     get { return super.objcProp }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclassg8objcPropSi
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.objcProp!getter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foog8objcPropSi : $@convention(method) (@guaranteed Foo) -> Int
     set { super.objcProp = newValue }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclasss8objcPropSi
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.objcProp!setter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foos8objcPropSi : $@convention(method) (Int, @guaranteed Foo) -> ()
   }
 
   override subscript(objc objc: AnyObject) -> Int {
     get { return super[objc: objc] }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclassg9subscriptFT4objcPs9AnyObject__Si
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.subscript!getter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foog9subscriptFT4objcPs9AnyObject__Si : $@convention(method) (@owned AnyObject, @guaranteed Foo) -> Int
     set { super[objc: objc] = newValue }
     // CHECK-LABEL: sil hidden @_TFC7dynamic8Subclasss9subscriptFT4objcPs9AnyObject__Si
-    // CHECK:         super_method {{%[0-9]+}} : $Subclass, #Foo.subscript!setter.1
+    // CHECK:         function_ref @_TFC7dynamic3Foos9subscriptFT4objcPs9AnyObject__Si : $@convention(method) (Int, @owned AnyObject, @guaranteed Foo) -> ()
   }
 
   // Dynamic methods are super-dispatched by objc_msgSend

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -466,7 +466,7 @@ class BaseThrowingInit : HasThrowingInit {
 //   Super delegation.
 // CHECK-NEXT: [[T0:%.*]] = load [[MARKED_BOX]]
 // CHECK-NEXT: [[T2:%.*]] = upcast [[T0]] : $BaseThrowingInit to $HasThrowingInit
-// CHECK-NEXT: [[T3:%[0-9]+]] = super_method [[T0]] : $BaseThrowingInit, #HasThrowingInit.init!initializer.1
+// CHECK: [[T3:%[0-9]+]] = function_ref @_TFC6errors15HasThrowingInitcfzT5valueSi_S0_ : $@convention(method) (Int, @owned HasThrowingInit) -> (@owned HasThrowingInit, @error ErrorType)
 // CHECK-NEXT: apply [[T3]](%0, [[T2]])
 
 // Cleanups for writebacks.

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -636,7 +636,7 @@ class D : B {
     super.init(y: y)
     // CHECK: [[THIS1:%[0-9]+]] = load [[THISADDR]]
     // CHECK: [[THIS1_SUP:%[0-9]+]] = upcast [[THIS1]] : ${{.*}} to $B
-    // CHECK: [[SUPER_CTOR:%[0-9]+]] = super_method %{{[0-9]*}} : $D, #B.init!initializer.1
+    // CHECK: [[SUPER_CTOR:%[0-9]+]] = function_ref @_TFC8lifetime1BcfT1ySi_S0_ : $@convention(method) (Int, @owned B) -> @owned B
     // CHECK: [[Y:%[0-9]+]] = load [[YADDR]]
     // CHECK: [[THIS2_SUP:%[0-9]+]] = apply [[SUPER_CTOR]]([[Y]], [[THIS1_SUP]])
     // CHECK: [[THIS2:%[0-9]+]] = unchecked_ref_cast [[THIS2_SUP]] : $B to $D

--- a/test/SILGen/objc_super.swift
+++ b/test/SILGen/objc_super.swift
@@ -42,7 +42,7 @@ class Wotsit : Hoozit {
 class NonObjCSuperInit : Wotsit {
   // CHECK-LABEL: sil hidden @_TFC10objc_super16NonObjCSuperInitc{{.*}} : $@convention(method) (@owned NonObjCSuperInit) -> @owned NonObjCSuperInit
   init() {
-    // CHECK: super_method {{%[0-9]+}} : $NonObjCSuperInit, #Wotsit.init!initializer.1 : Wotsit.Type -> (nope: NotInObjC<Int>) -> Wotsit , $@convention(method) (NotInObjC<Int>, @owned Wotsit) -> @owned Wotsit
+    // CHECK: function_ref @_TFV10objc_super9NotInObjCCfT_GS0_x_ : $@convention(thin) <τ_0_0> (@thin NotInObjC<τ_0_0>.Type) -> NotInObjC<τ_0_0>
     super.init(nope: NotInObjC<Int>())
   }
 }

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -1,0 +1,229 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend -I %t -emit-module -emit-module-path=%t/resilient_struct.swiftmodule -module-name resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -I %t -emit-module -emit-module-path=%t/resilient_class.swiftmodule -module-name resilient_class %S/../Inputs/resilient_class.swift
+// RUN: %target-swift-frontend -enable-resilience -emit-silgen -parse-as-library -I %t %s | FileCheck %s
+
+import resilient_class
+
+func doFoo(f: () -> ()) {
+  f()
+}
+
+public class Parent {
+  public init() {}
+  public func method() {}
+  public final func finalMethod() {}
+  public class func classMethod() {}
+  public final class func finalClassMethod() {}
+}
+
+public class GenericParent<A> {
+  let a: A
+  public init(a: A) {
+    self.a = a
+  }
+  public func method() {}
+  public final func finalMethod() {}
+  public class func classMethod() {}
+  public final class func finalClassMethod() {}
+}
+
+class Child : Parent {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super5Child6methodfT_T_ : $@convention(method) (@guaranteed Child) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdFC19partial_apply_super6Parent6methodFT_T_ : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super5Child11classMethodfT_T_ : $@convention(thin) (@thick Child.Type) -> () {
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick Child.Type to $@thick Parent.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdZFC19partial_apply_super6Parent11classMethodFT_T_ : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super5Child20callFinalSuperMethodfT_T_ : $@convention(method) (@guaranteed Child) -> () 
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC19partial_apply_super6Parent11finalMethodFT_T_ : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK: [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@owned Parent) -> @owned @callee_owned () -> ()
+  // CHECK:  apply [[DOFOO]]([[APPLIED_SELF]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  func callFinalSuperMethod() {
+    doFoo(super.finalMethod)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super5Child25callFinalSuperClassMethodfT_T_ : $@convention(thin) (@thick Child.Type) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick Child.Type to $@thick Parent.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TZFC19partial_apply_super6Parent16finalClassMethodFT_T_ : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
+  // CHECK: [[APPLIED_SELF:%[0-9]+]] = apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick Parent.Type) -> @owned @callee_owned () -> ()
+  // CHECK: apply [[DOFOO]]([[APPLIED_SELF]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  class func callFinalSuperClassMethod() {
+    doFoo(super.finalClassMethod)
+  }
+}
+
+class GenericChild<A> : GenericParent<A> {
+  override init(a: A) {
+    super.init(a: a)
+  }
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super12GenericChild6methodfT_T_ : $@convention(method) <A> (@guaranteed GenericChild<A>) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChild<A> to $GenericParent<A>
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdFC19partial_apply_super13GenericParent6methodFT_T_ : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@owned GenericParent<τ_0_0>) -> @owned @callee_owned () -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super12GenericChild11classMethodfT_T_ : $@convention(thin) <A> (@thick GenericChild<A>.Type) -> ()
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChild<A>.Type to $@thick GenericParent<A>.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = function_ref @_TTdZFC19partial_apply_super13GenericParent11classMethodFT_T_ : $@convention(thin) <τ_0_0> (@thick GenericParent<τ_0_0>.Type) -> @owned @callee_owned () -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = apply %4<A>(%3) : $@convention(thin) <τ_0_0> (@thick GenericParent<τ_0_0>.Type) -> @owned @callee_owned () -> ()
+  // CHECK: apply %2(%5) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}
+
+class ChildToFixedOutsideParent : OutsideParent {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super25ChildToFixedOutsideParent6methodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $ChildToFixedOutsideParent to $OutsideParent
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $ChildToFixedOutsideParent, #OutsideParent.method!1 : (OutsideParent) -> () -> () , $@convention(method) (@guaranteed OutsideParent) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@guaranteed OutsideParent) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super25ChildToFixedOutsideParent11classMethodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick ChildToFixedOutsideParent.Type to $@thick OutsideParent.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToFixedOutsideParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> () , $@convention(thin) (@thick OutsideParent.Type) -> () // user: %5
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick OutsideParent.Type) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}
+
+class ChildToResilientOutsideParent : ResilientOutsideParent {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super29ChildToResilientOutsideParent6methodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $ChildToResilientOutsideParent to $ResilientOutsideParent
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $ChildToResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super29ChildToResilientOutsideParent11classMethodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick ChildToResilientOutsideParent.Type to $@thick ResilientOutsideParent.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick ChildToResilientOutsideParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> () , $@convention(thin) (@thick ResilientOutsideParent.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick ResilientOutsideParent.Type) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}
+
+class GrandchildToFixedOutsideChild : OutsideChild {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super29GrandchildToFixedOutsideChild6methodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GrandchildToFixedOutsideChild to $OutsideChild
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GrandchildToFixedOutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> () , $@convention(method) (@guaranteed OutsideChild) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply %5(%4) : $@convention(method) (@guaranteed OutsideChild) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super29GrandchildToFixedOutsideChild11classMethodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GrandchildToFixedOutsideChild.Type to $@thick OutsideChild.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToFixedOutsideChild.Type, #OutsideChild.classMethod!1 : (OutsideChild.Type) -> () -> () , $@convention(thin) (@thick OutsideChild.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply %4(%3) : $@convention(thin) (@thick OutsideChild.Type) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}
+
+class GrandchildToResilientOutsideChild : ResilientOutsideChild {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super33GrandchildToResilientOutsideChild6methodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GrandchildToResilientOutsideChild to $ResilientOutsideChild
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GrandchildToResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> () , $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super33GrandchildToResilientOutsideChild11classMethodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GrandchildToResilientOutsideChild.Type to $@thick ResilientOutsideChild.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GrandchildToResilientOutsideChild.Type, #ResilientOutsideChild.classMethod!1 : (ResilientOutsideChild.Type) -> () -> () , $@convention(thin) (@thick ResilientOutsideChild.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]([[CASTED_SELF]]) : $@convention(thin) (@thick ResilientOutsideChild.Type) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}
+
+class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super39GenericChildToFixedGenericOutsideParent6methodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChildToFixedGenericOutsideParent<A> to $GenericOutsideParent<A>
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super39GenericChildToFixedGenericOutsideParent11classMethodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type to $@thick GenericOutsideParent<A>.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type, #GenericOutsideParent.classMethod!1 : <A> (GenericOutsideParent<A>.Type) -> () -> () , $@convention(thin) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}
+
+class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsideParent<A> {
+  // CHECK-LABEL: sil hidden @_TFC19partial_apply_super43GenericChildToResilientGenericOutsideParent6methodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChildToResilientGenericOutsideParent<A> to $ResilientGenericOutsideParent<A>
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override func method() {
+    doFoo(super.method)
+  }
+
+  // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super43GenericChildToResilientGenericOutsideParent11classMethodfT_T_
+  // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type to $@thick ResilientGenericOutsideParent<A>.Type
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type, #ResilientGenericOutsideParent.classMethod!1 : <A> (ResilientGenericOutsideParent<A>.Type) -> () -> () , $@convention(thin) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  override class func classMethod() {
+    doFoo(super.classMethod)
+  }
+}

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -654,7 +654,7 @@ class rdar16151899Derived : rdar16151899Base {
     override init() {
         super.init()
         // CHECK: upcast {{.*}} : $rdar16151899Derived to $rdar16151899Base
-        // CHECK-NEXT: super_method {{%[0-9]+}} : $rdar16151899Derived, #rdar16151899Base.init!initializer.1
+        // CHECK: function_ref @_TFC10properties16rdar16151899BasecfT_S0_ : $@convention(method) (@owned rdar16151899Base) -> @owned rdar16151899Base
 
         // This should not be a direct access, it should call the setter in the
         // base.
@@ -718,7 +718,7 @@ class DerivedProperty : BaseProperty {
 // CHECK: sil hidden @_TFC10properties15DerivedProperty24super_property_reference
 // CHECK: bb0(%0 : $DerivedProperty):
 // CHECK:  [[BASEPTR:%[0-9]+]] = upcast %0 : $DerivedProperty to $BaseProperty
-// CHECK:  [[FN:%[0-9]+]] = super_method %0 : $DerivedProperty, #BaseProperty.x!getter.1
+// CHECK:  [[FN:%[0-9]+]] = function_ref @_TFC10properties12BasePropertyg1xSi : $@convention(method) (@guaranteed BaseProperty) -> Int 
 // CHECK:  apply [[FN]]([[BASEPTR]]) : $@convention(method) (@guaranteed BaseProperty) -> Int // user: %7
 
 

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -34,7 +34,7 @@ public class Parent {
 public class Child : Parent {
   // CHECK-LABEL: sil @_TFC5super5Childg8propertySS
   // CHECK:         [[CASTED_SELF:%[0-9]+]] = upcast %0 : $Child to $Parent
-  // CHECK:         [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $Child, #Parent.property!getter.1
+  // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @_TFC5super6Parentg8propertySS : $@convention(method) (@guaranteed Parent) -> @owned String
   public override var property: String {
     return super.property
   }
@@ -50,7 +50,7 @@ public class Child : Parent {
 public class Grandchild : Child {
   // CHECK-LABEL: sil @_TFC5super10Grandchild16onlyInGrandchildfT_T_
   public func onlyInGrandchild() {
-    // CHECK: super_method %0 : $Grandchild, #Parent.methodOnlyInParent!1 : (Parent) -> () -> ()
+    // CHECK: function_ref @_TFC5super6Parent18methodOnlyInParentfT_T_ : $@convention(method) (@guaranteed Parent) -> ()
     super.methodOnlyInParent()
     // CHECK: function_ref @_TFC5super6Parent23finalMethodOnlyInParentfT_T_
     super.finalMethodOnlyInParent()
@@ -58,7 +58,7 @@ public class Grandchild : Child {
 
   // CHECK-LABEL: sil @_TFC5super10Grandchild6methodfT_T_
   public override func method() {
-    // CHECK: super_method %0 : $Grandchild, #Parent.method!1 : (Parent) -> () -> ()
+    // CHECK: function_ref @_TFC5super6Parent6methodfT_T_ : $@convention(method) (@guaranteed Parent) -> ()
     super.method()
   }
 }
@@ -66,7 +66,7 @@ public class Grandchild : Child {
 public class GreatGrandchild : Grandchild {
   // CHECK-LABEL: sil @_TFC5super15GreatGrandchild6methodfT_T_
   public override func method() {
-    // CHECK: super_method {{%[0-9]+}} : $GreatGrandchild, #Grandchild.method!1 : (Grandchild) -> () -> () , $@convention(method) (@guaranteed Grandchild) -> ()
+    // CHECK: function_ref @_TFC5super10Grandchild6methodfT_T_ : $@convention(method) (@guaranteed Grandchild) -> ()
     super.method()
   }
 }

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -15,7 +15,7 @@ class Bar: Foo {
   // CHECK-NOT:     strong_retain [[ORIG_SELF]]
   // CHECK:         [[ORIG_SELF_UP:%.*]] = upcast [[ORIG_SELF]]
   // CHECK-NOT:     strong_retain [[ORIG_SELF_UP]]
-  // CHECK:         [[SUPER_INIT:%[0-9]+]] = super_method [[ORIG_SELF]] : $Bar, #Foo.init!initializer.1
+  // CHECK:         [[SUPER_INIT:%[0-9]+]] = function_ref @_TFC22super_init_refcounting3FoocfT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SUPER_INIT]]([[ORIG_SELF_UP]])
   // CHECK:         [[NEW_SELF_DOWN:%.*]] = unchecked_ref_cast [[NEW_SELF]]
   // CHECK:         store [[NEW_SELF_DOWN]] to [[SELF_MUI]]
@@ -44,7 +44,7 @@ class Zim: Foo {
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting3Zimc
   // CHECK-NOT:     strong_retain
   // CHECK-NOT:     strong_release
-  // CHECK:         super_method {{%[0-9]+}} : $Zim, #Foo.init!initializer.1
+  // CHECK:         function_ref @_TFC22super_init_refcounting3FoocfT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo
 }
 
 class Zang: Foo {
@@ -57,7 +57,7 @@ class Zang: Foo {
   // CHECK-LABEL: sil hidden @_TFC22super_init_refcounting4Zangc
   // CHECK-NOT:     strong_retain
   // CHECK-NOT:     strong_release
-  // CHECK:         super_method {{%[0-9]+}} : $Zang, #Foo.init!initializer.1
+  // CHECK:         function_ref @_TFC22super_init_refcounting3FoocfT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo
 }
 
 class Bad: Foo {
@@ -81,7 +81,7 @@ class Good: Foo {
   // CHECK:         assign {{.*}} to [[X_ADDR]] : $*Int
   // CHECK:         [[SELF_OBJ:%.*]] = load [[SELF]] : $*Good
   // CHECK:         [[SUPER_OBJ:%.*]] = upcast [[SELF_OBJ]] : $Good to $Foo
-  // CHECK:         [[SUPER_INIT:%.*]] = super_method [[SELF_OBJ]] : $Good, #Foo.init!initializer.1
+  // CHECK:         [[SUPER_INIT:%.*]] = function_ref @_TFC22super_init_refcounting3FoocfSiS0_ : $@convention(method) (Int, @owned Foo) -> @owned Foo
   // CHECK:         [[SELF_OBJ:%.*]] = load [[SELF]]
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[SELF_OBJ]] : $Good, #Good.x
   // CHECK:         [[X:%.*]] = load [[X_ADDR]] : $*Int

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -946,7 +946,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:       bb1([[RESULT:%.*]] : $Int)
 // CHECK-NEXT:    [[BASE_SELF:%.*]] = upcast %2
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_TFC35definite_init_failable_initializers14ThrowBaseClasscfzT_S0_
-// CHECK-NEXT:    try_apply [[INIT_FN]]([[BASE_SELF]])
+// CHECK:         try_apply [[INIT_FN]]([[BASE_SELF]])
 // CHECK:       bb2([[NEW_SELF:%.*]] : $ThrowBaseClass):
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]
@@ -1012,7 +1012,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:         store %2 to [[SELF_BOX]]
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = upcast %2
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_TFC35definite_init_failable_initializers14ThrowBaseClasscfzT_S0_
-// CHECK-NEXT:    try_apply [[INIT_FN]]([[DERIVED_SELF]])
+// CHECK:    try_apply [[INIT_FN]]([[DERIVED_SELF]])
 // CHECK:       bb1([[NEW_SELF:%.*]] : $ThrowBaseClass):
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]
@@ -1060,7 +1060,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
 // CHECK-NEXT:    [[BASE_SELF:%.*]] = upcast %2
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_TFC35definite_init_failable_initializers14ThrowBaseClasscfT6noFailT__S0_
-// CHECK-NEXT:    [[NEW_SELF:%.*]] = apply [[INIT_FN]]([[BASE_SELF]])
+// CHECK:    [[NEW_SELF:%.*]] = apply [[INIT_FN]]([[BASE_SELF]])
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]
 // CHECK:         [[UNWRAP_FN:%.*]] = function_ref @_TF35definite_init_failable_initializers6unwrapFzSiSi
@@ -1106,7 +1106,7 @@ class ThrowDerivedClass : ThrowBaseClass {
 // CHECK:       bb1([[RESULT:%.*]] : $Int):
 // CHECK-NEXT:    [[BASE_SELF:%.*]] = upcast %3
 // CHECK:         [[INIT_FN:%.*]] = function_ref @_TFC35definite_init_failable_initializers14ThrowBaseClasscfzT_S0_
-// CHECK-NEXT:    try_apply [[INIT_FN]]([[BASE_SELF]])
+// CHECK:    try_apply [[INIT_FN]]([[BASE_SELF]])
 // CHECK:       bb2([[NEW_SELF:%.*]] : $ThrowBaseClass):
 // CHECK-NEXT:    [[DERIVED_SELF:%.*]] = unchecked_ref_cast [[NEW_SELF]]
 // CHECK-NEXT:    store [[DERIVED_SELF]] to [[SELF_BOX]]

--- a/test/SILOptimizer/super_method.swift
+++ b/test/SILOptimizer/super_method.swift
@@ -75,7 +75,7 @@ class ConcreteChild : GenericParent<String> {
   override init(a: String) {
     // CHECK-NOT: super_method {{%[0-9]+}} : $ConcreteChild, #GenericParent.init!initializer.1
     // CHECK: [[INIT_FN_REF:%[0-9]+]] = function_ref @_TFC12super_method13GenericParentcfT1ax_GS0_x_ : $@convention(method) <τ_0_0> (@in τ_0_0, @owned GenericParent<τ_0_0>) -> @owned GenericParent<τ_0_0> // user: %10
-    // CHECK-NEXT: apply [[INIT_FN_REF]]
+    // CHECK: apply [[INIT_FN_REF]]
     super.init(a: a)
   }
 }


### PR DESCRIPTION
When the nearest implementation of a superclass's implementation of a
method is in the same module, eagerly emit a direct call to the method
instead of relying on the devirtualizer for these, since this is a very
lightweight check and can make -Onone builds faster.
