### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::setType(…)

### DIFF
--- a/validation-test/compiler_crashers/28218-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers/28218-swift-valuedecl-settype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+let a{{enum a{case c(c(class c]func c


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/Decl.cpp:1753: void swift::ValueDecl::setType(swift::Type): Assertion `!hasType() && "changing type of declaration"' failed.
8  swift           0x0000000000fd680c swift::ValueDecl::setType(swift::Type) + 92
9  swift           0x0000000000fdfbf5 swift::EnumElementDecl::computeType() + 277
13 swift           0x0000000000e39286 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000e7f79a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
17 swift           0x0000000000ea987c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
18 swift           0x0000000000e1e3ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
21 swift           0x0000000000e7e4ba swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
22 swift           0x0000000000e7e30e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
23 swift           0x0000000000e7eed8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
25 swift           0x0000000000e05802 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
26 swift           0x0000000000cafccf swift::CompilerInstance::performSema() + 2975
28 swift           0x0000000000775367 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
29 swift           0x000000000076ff45 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28218-swift-valuedecl-settype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28218-swift-valuedecl-settype-de68ab.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28218-swift-valuedecl-settype.swift:8:6
2.  While type-checking expression at [validation-test/compiler_crashers/28218-swift-valuedecl-settype.swift:8:7 - line:8:37] RangeText="{enum a{case c(c(class c]func c"
3.  While type-checking 'a' at validation-test/compiler_crashers/28218-swift-valuedecl-settype.swift:8:8
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
