### PR TITLE
[swiftc] Add test case for crash triggered in swift::LValueType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28219-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers/28219-swift-lvaluetype-get.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+struct c}println(c
+_


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:3218: static swift::LValueType *swift::LValueType::get(swift::Type): Assertion `!objectTy->is<LValueType>() && !objectTy->is<InOutType>() && "cannot have 'inout' or @lvalue wrapped inside an @lvalue"' failed.
8  swift           0x0000000000f4b682 swift::LValueType::get(swift::Type) + 546
9  swift           0x000000000102fb4b swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 3899
10 swift           0x0000000000ea1f3d swift::constraints::ConstraintSystem::simplifyType(swift::Type, llvm::SmallPtrSet<swift::TypeVariableType*, 16u>&) + 77
11 swift           0x0000000000eff165 swift::constraints::ConstraintSystem::finalize(swift::FreeTypeVariableBinding) + 2037
12 swift           0x0000000000f03fc6 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 374
13 swift           0x0000000000f071b9 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 6425
14 swift           0x0000000000f03f89 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 313
15 swift           0x0000000000f065bc swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3356
16 swift           0x0000000000f03f89 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 313
17 swift           0x0000000000f03d49 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
18 swift           0x0000000000e17f76 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 614
19 swift           0x0000000000e1e339 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
24 swift           0x0000000000ec495a swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 106
25 swift           0x0000000000ec980e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4046
26 swift           0x0000000000e17fa5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
27 swift           0x0000000000e1e339 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
29 swift           0x0000000000e7f8e6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
30 swift           0x0000000000e0576d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
31 swift           0x0000000000cafccf swift::CompilerInstance::performSema() + 2975
33 swift           0x0000000000775367 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
34 swift           0x000000000076ff45 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28219-swift-lvaluetype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28219-swift-lvaluetype-get-50f344.o
1.  While type-checking expression at [validation-test/compiler_crashers/28219-swift-lvaluetype-get.swift:8:10 - line:9:1] RangeText="println(c
2.  While type-checking expression at [validation-test/compiler_crashers/28219-swift-lvaluetype-get.swift:9:1 - line:9:1] RangeText="_"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
