### PR TITLE
[swiftc] Add test case for crash triggered in swift::LValueType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28220-swift-lvaluetype-get.swift
+++ b/validation-test/compiler_crashers/28220-swift-lvaluetype-get.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+var d:d=struct d<h:let{d


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:3216: static swift::LValueType *swift::LValueType::get(swift::Type): Assertion `!objectTy->is<ErrorType>() && "cannot have ErrorType wrapped inside LValueType"' failed.
8  swift           0x0000000000f4b6df swift::LValueType::get(swift::Type) + 639
9  swift           0x000000000102fb4b swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 3899
10 swift           0x0000000000e9ea6c swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl*, bool, bool, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*) + 1820
11 swift           0x0000000000ea0ea1 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 689
12 swift           0x0000000000efd081 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 897
13 swift           0x0000000000e9d927 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
14 swift           0x0000000000ea0b87 swift::constraints::ConstraintSystem::addOverloadSet(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::constraints::ConstraintLocator*, swift::constraints::OverloadChoice*) + 327
18 swift           0x0000000000f7fc1e swift::Expr::walk(swift::ASTWalker&) + 46
19 swift           0x0000000000edcfd8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
20 swift           0x0000000000e17e10 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
21 swift           0x0000000000e1e339 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
23 swift           0x0000000000e7f8e6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
24 swift           0x0000000000e0576d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
25 swift           0x0000000000cafccf swift::CompilerInstance::performSema() + 2975
27 swift           0x0000000000775367 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
28 swift           0x000000000076ff45 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28220-swift-lvaluetype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28220-swift-lvaluetype-get-a71661.o
1.  While type-checking expression at [validation-test/compiler_crashers/28220-swift-lvaluetype-get.swift:8:23 - line:8:24] RangeText="{d"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
