### PR TITLE
[AST] Enclose value of writtenType attribute in quotes

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2098,9 +2098,9 @@ public:
     printCommon(E, name) << ' ';
     if (auto checkedCast = dyn_cast<CheckedCastExpr>(E))
       OS << getCheckedCastKindName(checkedCast->getCastKind()) << ' ';
-    OS << "writtenType=";
+    OS << "writtenType='";
     E->getCastTypeLoc().getType().print(OS);
-    OS << '\n';
+    OS << "'\n";
     printRec(E->getSubExpr());
     OS << ')';
   }


### PR DESCRIPTION
Prior to this change, writtentType value was not enclosed in single quotes and could contain spaces (e.g. `writtenType='[[String : String]]'`). With this change, the value is enclosed in quotes matching the rendering of the `type` attribute.
