### PR TITLE
Initial integration of libdispatch into build-script

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -154,11 +154,12 @@ SWIFT_SOURCE_ROOT: a directory containing the source for LLVM, Clang, Swift.
    $SWIFT_SOURCE_ROOT/llvm
                      /clang
                      /swift
-                     /lldb                      (optional)
-                     /llbuild                   (optional)
-                     /swiftpm                   (optional, requires llbuild)
-                     /swift-corelibs-xctest     (optional)
-                     /swift-corelibs-foundation (optional)
+                     /lldb                       (optional)
+                     /llbuild                    (optional)
+                     /swiftpm                    (optional, requires llbuild)
+                     /swift-corelibs-xctest      (optional)
+                     /swift-corelibs-foundation  (optional)
+                     /swift-corelibs-libdispatch (optional)
 
 SWIFT_BUILD_ROOT: a directory in which to create out-of-tree builds.
                   Defaults to "$SWIFT_SOURCE_ROOT/build/".
@@ -309,6 +310,10 @@ details of the setups of other systems or automated environments.""")
         help="build foundation",
         action="store_true",
         dest="build_foundation")
+    projects_group.add_argument("--libdispatch",
+        help="build libdispatch",
+        action="store_true",
+        dest="build_libdispatch")
 
     extra_actions_group = parser.add_argument_group(
         title="Extra actions to perform before or in addition to building")
@@ -373,6 +378,11 @@ build the Debug variant of the Swift standard library and SDK overlay""",
         action="store_const",
         const="Debug",
         dest="foundation_build_variant")
+    build_variant_override_group.add_argument("--debug-libdispatch",
+        help="build the Debug variant of libdispatch",
+        action="store_const",
+        const="Debug",
+        dest="libdispatch_build_variant")
 
     assertions_group = parser.add_mutually_exclusive_group(required=False)
     assertions_group.add_argument("--assertions",
@@ -564,6 +574,9 @@ the number of parallel build jobs to use""",
     if args.foundation_build_variant is None:
         args.foundation_build_variant = args.build_variant
 
+    if args.libdispatch_build_variant is None:
+        args.libdispatch_build_variant = args.build_variant
+
     # Assertions are enabled by default.
     if args.assertions is None:
         args.assertions = True
@@ -615,6 +628,7 @@ the number of parallel build jobs to use""",
             "--skip-test-swiftpm",
             "--skip-test-xctest",
             "--skip-test-foundation",
+            "--skip-test-libdispatch",
             "--skip-test-ios",
             "--skip-test-tvos",
             "--skip-test-watchos",
@@ -671,6 +685,11 @@ the number of parallel build jobs to use""",
     if not args.build_foundation:
         build_script_impl_inferred_args += [
             "--skip-build-foundation"
+        ]
+
+    if not args.build_libdispatch:
+        build_script_impl_inferred_args += [
+            "--skip-build-libdispatch"
         ]
 
     if args.skip_build:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -119,6 +119,7 @@ KNOWN_SETTINGS=(
     skip-build-swiftpm          ""               "set to skip building swiftpm"
     skip-build-xctest           ""               "set to skip building xctest"
     skip-build-foundation       ""               "set to skip building foundation"
+    skip-build-libdispatch      ""               "set to skip building libdispatch"
     skip-test-cmark             ""               "set to skip testing CommonMark"
     skip-test-lldb              ""               "set to skip testing lldb"
     skip-test-swift             ""               "set to skip testing Swift"
@@ -126,6 +127,7 @@ KNOWN_SETTINGS=(
     skip-test-swiftpm           ""               "set to skip testing swiftpm"
     skip-test-xctest            ""               "set to skip testing xctest"
     skip-test-foundation        ""               "set to skip testing foundation"
+    skip-test-libdispatch       ""               "set to skip testing libdispatch"
     skip-test-osx               ""               "set to skip testing Swift stdlibs for OSX"
     skip-test-ios               ""               "set to skip testing Swift stdlibs for iOS"
     skip-test-ios-simulator     ""               "set to skip testing Swift stdlibs for iOS simulators (i.e. test devices only)"
@@ -165,6 +167,7 @@ KNOWN_SETTINGS=(
     install-swiftpm             ""               "whether to install swiftpm"
     install-xctest              ""               "whether to install xctest"
     install-foundation          ""               "whether to install foundation"
+    install-libdispatch         ""               "whether to install libdispatch"
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
     cross-compile-tools-deployment-targets ""    "space-separated list of targets to cross-compile host Swift tools for"
     skip-merge-lipo-cross-compile-tools ""       "set to skip running merge-lipo after installing cross-compiled host Swift tools"
@@ -542,6 +545,7 @@ if [[ "${SKIP_BUILD}" ]]; then
     SKIP_BUILD_SWIFTPM=1
     SKIP_BUILD_XCTEST=1
     SKIP_BUILD_FOUNDATION=1
+    SKIP_BUILD_LIBDISPATCH=1
 fi
 
 if [[ "${SKIP_IOS}" ]] ; then
@@ -886,6 +890,7 @@ LLBUILD_SOURCE_DIR="${WORKSPACE}/llbuild"
 SWIFTPM_SOURCE_DIR="${WORKSPACE}/swiftpm"
 XCTEST_SOURCE_DIR="${WORKSPACE}/swift-corelibs-xctest"
 FOUNDATION_SOURCE_DIR="${WORKSPACE}/swift-corelibs-foundation"
+LIBDISPATCH_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 
 if [[ ! -d ${CMARK_SOURCE_DIR} ]]; then
     echo "Couldn't find cmark source directory."
@@ -926,6 +931,11 @@ if [[ ! "${SKIP_BUILD_FOUNDATION}" && ! -d ${FOUNDATION_SOURCE_DIR} ]]; then
     exit 1
 fi
 
+if [[ ! "${SKIP_BUILD_LIBDISPATCH}" && ! -d ${LIBDISPATCH_SOURCE_DIR} ]]; then
+    echo "Couldn't find libdispatch source directory."
+    exit 1
+fi
+
 # Symlink clang into the llvm tree.
 CLANG_SOURCE_DIR="${LLVM_SOURCE_DIR}/tools/clang"
 if [ ! -e "${WORKSPACE}/clang" ] ; then
@@ -954,6 +964,9 @@ if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
 fi
 if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" foundation)
+fi
+if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+     PRODUCTS=("${PRODUCTS[@]}" libdispatch)
 fi
 
 SWIFT_STDLIB_TARGETS=()
@@ -1184,6 +1197,9 @@ function build_directory_bin() {
             foundation)
                 echo "${root}/${FOUNDATION_BUILD_TYPE}/bin"
                 ;;
+            libdispatch)
+                echo "${root}/bin"
+                ;;
             *)
                 echo "error: unknown product: ${product}"
                 exit 1
@@ -1284,6 +1300,8 @@ function cmake_config_opt() {
             foundation)
                 echo "--config ${FOUNDATION_BUILD_TYPE}"
                 ;;            
+            libdispatch)
+                ;;
             *)
                 echo "error: unknown product: ${product}"
                 exit 1
@@ -1826,6 +1844,28 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 # Foundation builds itself and doesn't use cmake
                 continue
                 ;;
+            libdispatch)
+                LIBDISPATCH_BUILD_DIR=$(build_directory ${deployment_target} ${product})
+
+                set -x
+                if [[ ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
+                    # First time building; need to run autotools and configure
+                    mkdir -p "${LIBDISPATCH_BUILD_DIR}"
+                    pushd "${LIBDISPATCH_SOURCE_DIR}"
+                    autoreconf -fvi
+                    popd
+                    pushd "${LIBDISPATCH_BUILD_DIR}"
+                    "${LIBDISPATCH_SOURCE_DIR}"/configure --prefix="${INSTALL_DESTDIR}"/"${INSTALL_PREFIX}"
+                    popd
+                fi
+                pushd "${LIBDISPATCH_BUILD_DIR}"
+                make
+                popd
+                { set +x; } 2>/dev/null
+
+                # libdispatch builds itself and doesn't use cmake
+                continue
+                ;;
             *)
                 echo "error: unknown product: ${product}"
                 exit 1
@@ -2013,6 +2053,20 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
+            libdispatch)
+                if [[ "${SKIP_TEST_LIBDISPATCH}" ]]; then
+                    continue
+                fi
+                LIBDISPATCH_BUILD_DIR=$(build_directory ${deployment_target} ${product})
+                echo "--- Running tests for ${product} ---"
+                set -x
+                pushd "${LIBDISPATCH_BUILD_DIR}"
+                make check
+                popd
+                { set +x; } 2>/dev/null
+                echo "--- Finished tests for ${product} ---"
+                continue
+                ;;
             *)
                 echo "error: unknown product: ${product}"
                 exit 1
@@ -2156,6 +2210,21 @@ for deployment_target in "${NATIVE_TOOLS_DEPLOYMENT_TARGETS[@]}" "${CROSS_TOOLS_
                 { set +x; } 2>/dev/null
 
                 # As foundation installation is self-contained, we break early here.
+                continue
+                ;;
+            libdispatch)
+                if [[ -z "${INSTALL_LIBDISPATCH}" ]] ; then
+                    continue
+                fi
+                echo "--- Installing ${product} ---"
+                LIBDISPATCH_BUILD_DIR=$(build_directory ${deployment_target} ${product})
+                set -x
+                pushd "${LIBDISPATCH_BUILD_DIR}"
+                make install
+                popd
+                { set +x; } 2>/dev/null
+
+                # As libdispatch installation is self-contained, we break early here.
                 continue
                 ;;
             *)

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -45,6 +45,7 @@ def obtain_additional_swift_sources(opts = {'with_ssh': False}):
         'swiftpm': 'apple/swift-package-manager',
         'swift-corelibs-xctest': 'apple/swift-corelibs-xctest',
         'swift-corelibs-foundation': 'apple/swift-corelibs-foundation',
+        'swift-corelibs-libdispatch': 'apple/swift-corelibs-libdispatch',
         'swift-integration-tests': 'apple/swift-integration-tests',
     }
     for dir_name, repo in additional_repos.items():
@@ -95,6 +96,7 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "cmark"))
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "lldb"))
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "swiftpm"))
+    update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "swift-corelibs-libdispatch"))
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "swift-corelibs-foundation"))
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "swift-corelibs-xctest"))
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "swift-integration-tests"))


### PR DESCRIPTION
Extend build-script, build-script-impl, and update-checkout
to include libdispatch.  For now, libdispatch is not
built by default (user must enable via command line
argument).

Integration of testing is functional, but should be improved
in a later pull request.  The basic autotools based test
harness does not give the nice high-level progress output
as the rest of the test suite.

A related pull request to libdispatch (#34) has some fixes
to the autotools build that are needed to enable the test
target to succeed when run in an external directory.
