### PR TITLE
[tests][ast] Obj-C related tests require Obj-C

### DIFF
--- a/test/DebugInfo/ASTSection_ObjC.swift
+++ b/test/DebugInfo/ASTSection_ObjC.swift
@@ -11,7 +11,7 @@
 // RUN: %lldb-moduleimport-test %t/ASTSection | FileCheck %s --allow-empty --check-prefix=LINETABLE-CHECK
 
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=linux-gnu
+// REQUIRES: objc_interop
 
 // CHECK: Loaded module ASTSection from
 // CHECK: - Target: {{.+}}-{{.+}}-{{.+}}


### PR DESCRIPTION
`ASTSection_ObjC` tests may be run on any number of operating systems,
not just Linux. No matter the OS, these tests rely on Objective-C being available.
Check for that instead of the OS.
