### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getMemberSubstitutions(…)

### DIFF
--- a/validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{struct d<h:d.d{struct d struct d:d


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/Type.cpp:2465: TypeSubstitutionMap swift::TypeBase::getMemberSubstitutions(swift::DeclContext *): Assertion `baseTy && "Couldn't find appropriate context"' failed.
8  swift           0x000000000103021a swift::TypeBase::getMemberSubstitutions(swift::DeclContext*) + 458
9  swift           0x000000000103051a swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext*) + 58
10 swift           0x0000000000e85547 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1591
14 swift           0x0000000000e85f5e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift           0x0000000000e86ec4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
17 swift           0x0000000000e85e6a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
18 swift           0x0000000000e33a6a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
19 swift           0x0000000000e35fc5 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1829
20 swift           0x0000000001015e7c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
21 swift           0x0000000000e5d2aa swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 282
23 swift           0x0000000000e85f5e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
25 swift           0x0000000000e86ec4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
26 swift           0x0000000000e85e6a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
27 swift           0x0000000000e33a6a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
28 swift           0x0000000000e58885 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 373
29 swift           0x0000000000e5a0cf swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
30 swift           0x0000000000e5a484 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
31 swift           0x0000000000e35a02 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
34 swift           0x0000000000e3b126 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
37 swift           0x0000000000e8165a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
38 swift           0x0000000000eaafcc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
39 swift           0x0000000000e2024b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
41 swift           0x0000000000e817a6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
42 swift           0x0000000000e0760d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
43 swift           0x0000000000cb1f5f swift::CompilerInstance::performSema() + 2975
45 swift           0x0000000000775447 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
46 swift           0x0000000000770025 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28221-swift-typebase-getmembersubstitutions-17ebef.o
1.  While type-checking expression at [validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift:8:1 - line:8:35] RangeText="{struct d<h:d.d{struct d struct d:d"
2.  While type-checking 'd' at validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift:8:2
3.  While resolving type d.d at [validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift:8:13 - line:8:15] RangeText="d.d"
4.  While resolving type d at [validation-test/compiler_crashers/28221-swift-typebase-getmembersubstitutions.swift:8:35 - line:8:35] RangeText="d"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
