### PR TITLE
[utils] Add --{cc,cxx} options to build-script

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -40,6 +40,46 @@ import swift_build_support.cmake
 from swift_build_support.migration import migrate_impl_args
 
 
+# Utility for selecting host compilers.
+class CompilerExecutable(object):
+
+    def __init__(self, args):
+        if args.cc and not args.cxx:
+            self.cc, self.cxx = args.cc, self._suggest_companion(args.cc)
+        elif not args.cc and args.cxx:
+            self.cc, self.cxx = self._suggest_companion(args.cxx), args.cxx
+        elif not args.cc and not args.cxx:
+            host_clang = swift_build_support.clang.host_clang(
+                xcrun_toolchain=args.darwin_xcrun_toolchain)
+            if not host_clang:
+                raise Exception("Can't find clang. "
+                                "Please install clang-3.5 or a later version.")
+            self.cc, self.cxx = host_clang.cc, host_clang.cxx
+        else:
+            self.cc, self.cxx = args.cc, args.cxx
+
+
+    def _suggest_companion(self, cmd):
+        companion = self._find_companion_compiler(cmd)
+        if not companion:
+            raise Exception("Can't infer companion compiler for %s. "
+                            "Please specify --cc and --cxx." % (cmd))
+        return companion
+
+
+    def _find_companion_compiler(self, cmd):
+        suggestions = [
+            ("cc", "c++"),
+            ("gcc", "g++"),
+            ("clang", "clang++"),
+        ]
+        suggestions.extend([(s2, s1) for (s1, s2) in suggestions])
+        suggestions.sort(key=lambda pair: len(pair[0]), reverse=True)
+        for s1, s2 in suggestions:
+            if cmd.endswith(s1):
+                return cmd[:-len(s1)] + s2
+
+
 # Main entry point for the preset mode.
 def main_preset():
     parser = argparse.ArgumentParser(
@@ -516,11 +556,11 @@ placed""",
 
     parser.add_argument("--cc",
         help="specify the C compiler to be used",
-        action="store", dest="cc")
+        action="store")
 
     parser.add_argument("--cxx",
         help="specify the C++ compiler to be used",
-        action="store", dest="cxx")
+        action="store")
 
     parser.add_argument("-j", "--jobs",
         help="""
@@ -670,19 +710,11 @@ the number of parallel build jobs to use""",
             "--skip-test-watchos",
         ]
 
-    if not args.cc or not args.cxx:
-        host_clang = swift_build_support.clang.host_clang(
-            xcrun_toolchain=args.darwin_xcrun_toolchain)
-        if not host_clang:
-            print_with_argv0("Can't find clang. "
-                             "Please install clang-3.5 or a later version.")
-            return 1
-
-        if not args.cc:
-            args.cc = host_clang.cc
-
-        if not args.cxx:
-            args.cxx = host_clang.cxx
+    try:
+        compiler = CompilerExecutable(args)
+    except Exception as e:
+        print_with_argv0(e.message)
+        return 1
 
     if not args.build_lldb:
         build_script_impl_inferred_args += [
@@ -787,8 +819,8 @@ the number of parallel build jobs to use""",
     build_script_impl_args = [
         os.path.join(SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl"),
         "--build-dir", build_dir,
-        "--host-cc", args.cc,
-        "--host-cxx", args.cxx,
+        "--host-cc", compiler.cc,
+        "--host-cxx", compiler.cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
         "--cmake", host_cmake,
         "--cmark-build-type", args.cmark_build_variant,

--- a/utils/build-script
+++ b/utils/build-script
@@ -514,6 +514,14 @@ name of the directory under $SWIFT_BUILD_ROOT where the build products will be
 placed""",
         metavar="PATH")
 
+    parser.add_argument("--cc",
+        help="specify the C compiler to be used",
+        action="store", dest="cc")
+
+    parser.add_argument("--cxx",
+        help="specify the C++ compiler to be used",
+        action="store", dest="cxx")
+
     parser.add_argument("-j", "--jobs",
         help="""
 the number of parallel build jobs to use""",
@@ -662,6 +670,20 @@ the number of parallel build jobs to use""",
             "--skip-test-watchos",
         ]
 
+    if not args.cc or not args.cxx:
+        host_clang = swift_build_support.clang.host_clang(
+            xcrun_toolchain=args.darwin_xcrun_toolchain)
+        if not host_clang:
+            print_with_argv0(
+                "Can't find clang.  Please install clang-3.5 or a later version.")
+            return 1
+
+        if not args.cc:
+            args.cc = host_clang.cc
+
+        if not args.cxx:
+            args.cxx = host_clang.cxx
+
     if not args.build_lldb:
         build_script_impl_inferred_args += [
             "--skip-build-lldb"
@@ -755,13 +777,6 @@ the number of parallel build jobs to use""",
     if args.clean and os.path.isdir(build_dir):
         shutil.rmtree(build_dir)
 
-    host_clang = swift_build_support.clang.host_clang(
-        xcrun_toolchain=args.darwin_xcrun_toolchain)
-    if not host_clang:
-        print_with_argv0(
-            "Can't find clang.  Please install clang-3.5 or a later version.")
-        return 1
-
     host_cmake = args.cmake
     if not host_cmake:
         host_cmake = swift_build_support.cmake.host_cmake(
@@ -772,8 +787,8 @@ the number of parallel build jobs to use""",
     build_script_impl_args = [
         os.path.join(SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl"),
         "--build-dir", build_dir,
-        "--host-cc", host_clang.cc,
-        "--host-cxx", host_clang.cxx,
+        "--host-cc", args.cc,
+        "--host-cxx", args.cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
         "--cmake", host_cmake,
         "--cmark-build-type", args.cmark_build_variant,

--- a/utils/build-script
+++ b/utils/build-script
@@ -64,6 +64,7 @@ class CompilerExecutable(object):
         if not companion:
             raise Exception("Can't infer companion compiler for %s. "
                             "Please specify --cc and --cxx." % (cmd))
+        print("Note: Inferred companion compiler %s for %s." % (companion, cmd))
         return companion
 
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -674,8 +674,8 @@ the number of parallel build jobs to use""",
         host_clang = swift_build_support.clang.host_clang(
             xcrun_toolchain=args.darwin_xcrun_toolchain)
         if not host_clang:
-            print_with_argv0(
-                "Can't find clang.  Please install clang-3.5 or a later version.")
+            print_with_argv0("Can't find clang. "
+                             "Please install clang-3.5 or a later version.")
             return 1
 
         if not args.cc:


### PR DESCRIPTION
Make it a bit easier to use a custom compiler or shim script to build swift & co.

Address review comments: drop the "with" prefix, only grab `host_clang` when it's needed.

This is an updated version of an earlier PR: https://github.com/apple/swift/pull/1037#issuecomment-173693840. I should have reused the PR but accidentally deleted my branch.
