### PR TITLE
[gardening] Remove unreachable/unused/redundant code

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -64,8 +64,6 @@ struct ASTNodeBase {};
     };
 #include "swift/AST/PatternNodes.def"
 
-  enum ShouldHalt { Continue, Halt };
-
   class Verifier : public ASTWalker {
     PointerUnion<Module *, SourceFile *> M;
     ASTContext &Ctx;

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -197,12 +197,6 @@ public:
     return true;
   }
 
-  bool nextIfNot(char c) {
-    if (isEmpty() || peek() == c) return false;
-    advanceOffset(1);
-    return true;
-  }
-
   /// Claim the next few characters if they exactly match the given string.
   bool nextIf(StringRef str) {
     if (!Text.startswith(str)) return false;
@@ -376,10 +370,6 @@ public:
   }
   
 private:
-  enum class IsProtocol {
-    yes = true, no = false
-  };
-
   enum class IsVariadic {
     yes = true, no = false
   };

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1494,40 +1494,6 @@ static bool isObjCMethodResultAudited(const clang::Decl *decl) {
           decl->hasAttr<clang::ObjCReturnsInnerPointerAttr>());
 }
 
-namespace {
-  struct ErrorImportInfo {
-    ForeignErrorConvention::Kind Kind;
-    ForeignErrorConvention::IsOwned_t IsOwned;
-    ForeignErrorConvention::IsReplaced_t ReplaceParamWithVoid;
-    unsigned ParamIndex;
-    CanType ParamType;
-    CanType OrigResultType;
-
-    ForeignErrorConvention asForeignErrorConvention() const {
-      assert(ParamType && "not fully initialized!");
-      using FEC = ForeignErrorConvention;
-      switch (Kind) {
-      case FEC::ZeroResult:
-        return FEC::getZeroResult(ParamIndex, IsOwned, ReplaceParamWithVoid,
-                                  ParamType, OrigResultType);
-      case FEC::NonZeroResult:
-        return FEC::getNonZeroResult(ParamIndex, IsOwned, ReplaceParamWithVoid,
-                                     ParamType, OrigResultType);
-      case FEC::ZeroPreservedResult:
-        return FEC::getZeroPreservedResult(ParamIndex, IsOwned,
-                                           ReplaceParamWithVoid, ParamType);
-      case FEC::NilResult:
-        return FEC::getNilResult(ParamIndex, IsOwned, ReplaceParamWithVoid,
-                                 ParamType);
-      case FEC::NonNilError:
-        return FEC::getNonNilError(ParamIndex, IsOwned, ReplaceParamWithVoid,
-                                   ParamType);
-      }
-      llvm_unreachable("bad error convention");
-    }
-  };
-}
-
 /// Determine whether this is the name of an Objective-C collection
 /// with a single element type.
 static bool isObjCCollectionName(StringRef typeName) {

--- a/lib/IDE/ReconstructType.cpp
+++ b/lib/IDE/ReconstructType.cpp
@@ -102,10 +102,6 @@ struct MemberInfo {
   }
 };
 
-struct CachedMemberInfo {
-  std::vector<MemberInfo> member_infos;
-};
-
 struct EnumElementInfo {
   swift::Type clang_type;
   ConstString name;
@@ -560,24 +556,11 @@ struct VisitNodeResult {
     return _types.size() == 1 && _types.front();
   }
 
-  bool
-  HasSingleDecl ()
-  {
-    return _decls.size() == 1 && _decls.front();
-  }
-
   swift::Type
   GetFirstType ()
   {
     // Must ensure there is a type prior to calling this
     return _types.front();
-  }
-
-  swift::Decl*
-  GetFirstDecl ()
-  {
-    // Must ensure there is a decl prior to calling this
-    return _decls.front();
   }
 
   void

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -150,10 +150,6 @@ class ExistentialTypeInfoBase : public Base {
   }
 
 protected:
-  const ExistentialTypeInfoBase<Derived, Base> &asExistentialTI() const {
-    return *this;
-  }
-
   const Derived &asDerived() const {
     return *static_cast<const Derived*>(this);
   }

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -266,40 +266,9 @@ namespace {
     CallResult() : CurState(State::Invalid) {}
     ~CallResult() { reset(); }
 
-    /// Configure this result to carry a number of direct values at
-    /// the given explosion level.
-    Explosion &initForDirectValues() {
-      assert(CurState == State::Invalid);
-      CurState = State::Direct;
-      return *new (&CurValue.Direct) Explosion();
-    }
-
-    /// As a potential efficiency, set that this is a direct result
-    /// with no values.
-    void setAsEmptyDirect() {
-      initForDirectValues();
-    }
-
-    /// Set this result so that it carries a single directly-returned
-    /// maximally-fragile value without management.
-    void setAsSingleDirectUnmanagedFragileValue(llvm::Value *value) {
-      initForDirectValues().add(value);
-    }
-
-    void setAsIndirectAddress(Address address) {
-      assert(CurState == State::Invalid);
-      CurState = State::Indirect;
-      CurValue.Indirect = address;
-    }
-
     bool isInvalid() const { return CurState == State::Invalid; } 
     bool isDirect() const { return CurState == State::Direct; }
     bool isIndirect() const { return CurState == State::Indirect; }
-
-    Explosion &getDirectValues() {
-      assert(isDirect());
-      return CurValue.Direct;
-    }
 
     Address getIndirectAddress() const {
       assert(isIndirect());

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1791,12 +1791,6 @@ namespace {
   protected:
     Size getNextOffset() const { return NextOffset; }
 
-    /// Add a uintptr_t value that represents the given offset, but
-    /// scaled to a number of words.
-    void addConstantWordInWords(Size value) {
-      addConstantWord(getOffsetInWords(IGM, value));
-    }
-
     /// Add a constant word-sized value.
     void addConstantWord(int64_t value) {
       addWord(llvm::ConstantInt::get(IGM.SizeTy, value));

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -388,12 +388,6 @@ public:
     (void)inserted;
   }
   
-  void overwriteLoweredValue(SILValue v, LoweredValue &&lv) {
-    auto it = LoweredValues.find(v);
-    assert(it != LoweredValues.end() && "no existing entry for overwrite?");
-    it->second = std::move(lv);
-  }
-  
   /// Create a new Address corresponding to the given SIL address value.
   void setLoweredAddress(SILValue v, const Address &address) {
     assert(v.getType().isAddress() && "address for non-address value?!");
@@ -434,17 +428,6 @@ public:
     setLoweredValue(v, LoweredValue(box));
   }
 
-  void overwriteLoweredExplosion(SILValue v, Explosion &e) {
-    assert(v.getType().isObject() && "explosion for address value?!");
-    overwriteLoweredValue(v, LoweredValue(e));
-  }
-
-  void setLoweredSingleValue(SILValue v, llvm::Value *scalar) {
-    Explosion e;
-    e.add(scalar);
-    setLoweredExplosion(v, e);
-  }
-  
   /// Create a new StaticFunction corresponding to the given SIL value.
   void setLoweredStaticFunction(SILValue v,
                                 llvm::Function *f,

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -2143,8 +2143,8 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
   case ValueKind::CheckedCastBranchInst: {
     SILType ty;
     SILValue destVal;
-    Identifier kindToken, toToken;
-    SourceLoc kindLoc, toLoc;
+    Identifier toToken;
+    SourceLoc toLoc;
 
     bool isExact = false;
     if (Opcode == ValueKind::CheckedCastBranchInst &&

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1592,30 +1592,6 @@ public:
   ~NominalTypeMemberRefRValueEmitter() = default;
 
 private:
-  bool hasStructWithAtMostOneNonTrivialField(SILGenFunction &SGF) const {
-    auto *S = dyn_cast<StructDecl>(Base);
-    if (!S)
-      return false;
-
-    bool FoundNonTrivialField = false;
-
-    for (auto Field : S->getStoredProperties()) {
-      SILType Ty = SGF.getLoweredType(Field->getType()->getCanonicalType());
-      if (Ty.isTrivial(SGF.F.getModule()))
-        continue;
-
-      // We already found a non-trivial field, so we have two. Return false.
-      if (FoundNonTrivialField)
-        return false;
-
-      // We found one non-trivial field.
-      FoundNonTrivialField = true;
-    }
-
-    // We found at most one non-trivial field.
-    return true;
-  }
-
   RValue emitStructDecl(SILGenFunction &SGF) {
     ManagedValue base =
       SGF.emitRValueAsSingleValue(Expr->getBase(),

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -450,7 +450,7 @@ private:
 
   void bindVariable(SILLocation loc, VarDecl *var,
                     ConsumableManagedValue value, CanType formalValueType,
-                    bool isForSuccess);
+                    bool isIrrefutable);
 
   void emitSpecializedDispatch(ClauseMatrix &matrix, ArgArray args,
                                unsigned &lastRow, unsigned column,
@@ -525,11 +525,6 @@ public:
   }
   MutableArrayRef<Pattern *> getColumns() {
     return Columns;
-  }
-
-  /// Remove a column.
-  void removeColumn(unsigned index) {
-    Columns.erase(Columns.begin() + index);
   }
 
   /// Add new columns to the end of the row.

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -916,16 +916,6 @@ struct alledge_iterator
     return SuccIter->getValue().IsNonLocal;
   }
 
-  Optional<unsigned> getSuccIndex() const {
-    if (isSubregion())
-      return None;
-    // Since we have a bidirectional iterator, this will perform increments
-    // until we get to SuccIter. This is the behavior we want so that we ensure
-    // that we skip over any dead successor edges. We are just performing
-    // graphing, so performance is not a concern.
-    return std::distance(Wrapper->Region->succ_begin(), SuccIter);
-  }
-
   LoopRegionWrapper *operator*() const {
     if (SubregionIter != Wrapper->Region->subregion_end()) {
       return &Wrapper->FuncInfo.Data[*SubregionIter];

--- a/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
@@ -414,11 +414,6 @@ unsigned ArgumentDescriptor::updateOptimizedBBArgs(SILBuilder &Builder,
 
 namespace {
 
-template <typename T1, typename T2>
-inline T1 getFirstPairElt(const std::pair<T1, T2> &P) {
-  return P.first;
-}
-
 /// A class that contains all analysis information we gather about our
 /// function. Also provides utility methods for creating the new empty function.
 class FunctionAnalyzer {

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -370,7 +370,7 @@ public:
 
 private:
   void addStore(StoreInst *Store, IndexTrieNode *AddressNode);
-  bool recursivelyCollectInteriorUses(ValueBase *defInst,
+  bool recursivelyCollectInteriorUses(ValueBase *DefInst,
                                       IndexTrieNode *AddressNode,
                                       bool IsInteriorAddress);
 

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -1068,9 +1068,6 @@ public:
   using iterator = decltype(ValueToCaseMap)::iterator;
   iterator begin() { return ValueToCaseMap.getItems().begin(); }
   iterator end() { return ValueToCaseMap.getItems().begin(); }
-  iterator_range<iterator> currentTrackedState() {
-    return ValueToCaseMap.getItems();
-  }
 
   void clear() { ValueToCaseMap.clear(); }
 

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -86,15 +86,3 @@ void GenericCloner::populateCloned() {
     visit(BI->first->getTerminator());
   }
 }
-
-void dumpTypeSubstitutionMap(const TypeSubstitutionMap &map) {
-  llvm::errs() << "{\n";
-  for (auto &kv : map) {
-    llvm::errs() << "  ";
-    kv.first->print(llvm::errs());
-    llvm::errs() << " => ";
-    kv.second->print(llvm::errs());
-    llvm::errs() << "\n";
-  }
-  llvm::errs() << "}\n";
-}

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2048,26 +2048,6 @@ namespace {
       return expr;
     }
 
-    /// \brief Retrieve the type of a reference to the given declaration.
-    Type getTypeOfDeclReference(ValueDecl *decl, bool isSpecialized) {
-      if (auto typeDecl = dyn_cast<TypeDecl>(decl)) {
-        // Resolve the reference to this type declaration in our
-        // current context.
-        auto type = cs.getTypeChecker().resolveTypeInContext(typeDecl, dc,
-                                                             TR_InExpression,
-                                                             isSpecialized);
-        if (!type)
-          return nullptr;
-
-        // Refer to the metatype of this type.
-        return MetatypeType::get(type);
-      }
-
-      return cs.TC.getUnopenedTypeOfReference(decl, Type(), dc,
-                                              /*base=*/nullptr,
-                                              /*wantInterfaceType=*/true);
-    }
-
     Expr *visitDeclRefExpr(DeclRefExpr *expr) {
       auto locator = cs.getConstraintLocator(expr);
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2181,22 +2181,6 @@ void TypeChecker::checkOmitNeedlessWords(VarDecl *var) {
     .fixItReplace(var->getLoc(), newName->str());
 }
 
-namespace {
-  struct CallEdit {
-    enum {
-      RemoveDefaultArg,
-      Rename,
-    } Kind;
-
-    // The source range affected by this change.
-    SourceRange Range;
-
-    // The replacement text, for a rename.
-    std::string Name;
-  };
-
-}
-
 /// Find the source ranges of extraneous default arguments within a
 /// call to the given function.
 static bool hasExtraneousDefaultArguments(AbstractFunctionDecl *afd,

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -82,9 +82,6 @@ public:
   /// Whether the function is marked 'rethrows'.
   bool isBodyRethrows() const { return IsRethrows; }
 
-  /// The uncurry level that 'rethrows' applies to.
-  unsigned getNumBodyParameters() const { return ParamCount; }
-
   unsigned getNumArgumentsForFullApply() const {
     return (ParamCount - unsigned(IsProtocolMethod));
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -24,9 +24,6 @@
 using namespace swift;
 using namespace swift::serialization;
 
-using ConformancePair = std::pair<ProtocolDecl *, ProtocolConformance *>;
-
-
 namespace {
   struct IDAndKind {
     const Decl *D;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2446,7 +2446,7 @@ ImmutableTextSnapshotRef SwiftEditorDocument::replaceText(
 }
 
 void SwiftEditorDocument::updateSemaInfo() {
-  if (auto SemaInfo = Impl.SemanticInfo) {
+  if (Impl.SemanticInfo) {
     Impl.SemanticInfo->processLatestSnapshotAsync(Impl.EditableBuffer);
   }
 }

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/tracer.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/tracer.cpp
@@ -219,7 +219,7 @@ public:
     S->Operations.erase(OpId);
   }
 
-  static void persistAsync(bool WithActions) {
+  static void persistAsync() {
     llvm::sys::ScopedLock L(GlobalMutex);
     auto S = CurrentState;
     Queue.dispatch([S] {S->persist();});
@@ -380,7 +380,7 @@ void handleTraceMessageRequest(uint64_t Session, xpc_object_t Msg) {
 
 void persistTracingData() {
   if (isTracingEnabled()) {
-    State::persistAsync(true);
+    State::persistAsync();
   }
 }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1517,10 +1517,6 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
       while (node->getKind() != NodeKind::LocalDeclName)
         node = node->getChild(1); // local decl name
 
-      // Now simulate the remangling process directly on the
-      // LocalDeclName node.
-      auto localDeclNameNode = node;
-
       auto remangled = Demangle::mangleNode(typeNode);
 
       auto LTD = M->lookupLocalType(remangled);


### PR DESCRIPTION
Cleanups include:
- Remove unused enums
- Remove unused functions
- Remove unused methods
- Remove unused structs
- Remove unused variables
- Bring parameter naming in forward declaration in sync with parameter naming in definition
