### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::checkConformance(…)

### DIFF
--- a/validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+var _{struct B<a:CollectionType{var _={struct B<a{enum B{case


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:148: swift::Type swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &) const: Assertion `(conforms || firstArchetype->getIsRecursive() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.
13 swift           0x0000000000e2f7f3 swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2083
19 swift           0x0000000000e053b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift           0x0000000000e4baba swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
23 swift           0x0000000000e7557c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
24 swift           0x0000000000dea4ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
25 swift           0x0000000000deb5b0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
26 swift           0x0000000000deb759 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
31 swift           0x0000000000e053b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
34 swift           0x0000000000e4a78a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
35 swift           0x0000000000e4a5de swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
36 swift           0x0000000000e4b1a8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
38 swift           0x0000000000dd1862 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
39 swift           0x0000000000c7d15f swift::CompilerInstance::performSema() + 2975
41 swift           0x0000000000775137 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
42 swift           0x000000000076fd15 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28222-swift-typechecker-checkconformance-e1d9f6.o
1.  While type-checking declaration 0x47c2e80 at validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift:8:6
2.  While type-checking 'B' at validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift:8:7
3.  While type-checking expression at [validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift:8:39 - line:8:58] RangeText="{struct B<a{enum B{c"
4.  While type-checking 'B' at validation-test/compiler_crashers/28222-swift-typechecker-checkconformance.swift:8:40
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
