### PR TITLE
[swiftc] Add test case for crash triggered in swift::Type::transform(…)

### DIFF
--- a/validation-test/compiler_crashers/28223-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28223-swift-type-transform.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class B<T{class b<h:B<T.b>{func b{b


### PR DESCRIPTION
Stack trace:

```
5  swift           0x00000000010122bc swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 44
6  swift           0x0000000001012543 swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 691
7  swift           0x0000000000e6b8dd swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, unsigned int, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 1293
9  swift           0x00000000010122bc swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 44
10 swift           0x0000000000e6c23a swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, bool, bool, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >*) + 778
11 swift           0x0000000000e6d537 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 519
12 swift           0x0000000000ec6f93 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 931
13 swift           0x0000000000e69fd7 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
14 swift           0x0000000000e6d2c7 swift::constraints::ConstraintSystem::addOverloadSet(swift::Type, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::constraints::ConstraintLocator*, swift::constraints::OverloadChoice*) + 327
15 swift           0x0000000000ec5448 swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::Constraint const&) + 600
16 swift           0x0000000000ec6c34 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 68
17 swift           0x0000000000e69fd7 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
20 swift           0x0000000000f63515 swift::Expr::walk(swift::ASTWalker&) + 69
21 swift           0x0000000000ea75d8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
22 swift           0x0000000000de42c0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
23 swift           0x0000000000dea7e9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
26 swift           0x0000000000e4ab3a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
27 swift           0x0000000000e4a98e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift           0x0000000000e4b558 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
30 swift           0x0000000000dd1c12 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
31 swift           0x0000000000c7d14f swift::CompilerInstance::performSema() + 2975
33 swift           0x00000000007751c7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
34 swift           0x000000000076fda5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28223-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28223-swift-type-transform-1612ec.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28223-swift-type-transform.swift:7:28
2.  While type-checking expression at [validation-test/compiler_crashers/28223-swift-type-transform.swift:7:35 - line:7:35] RangeText="b"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
