### PR TITLE
[swiftc] Add test case for crash triggered in swift::GenericFunctionType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{enum S<T where S.c:A{case c


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ASTContext.cpp:2918: static swift::GenericFunctionType *swift::GenericFunctionType::get(swift::GenericSignature *, swift::Type, swift::Type, const swift::AnyFunctionType::ExtInfo &): Assertion `sig && "no generic signature for generic function type?!"' failed.
8  swift           0x0000000000f134de swift::GenericFunctionType::get(swift::GenericSignature*, swift::Type, swift::Type, swift::AnyFunctionType::ExtInfo const&) + 574
10 swift           0x0000000000e001ec swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 780
11 swift           0x0000000000ff9a1c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
12 swift           0x0000000000e27bca swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 282
14 swift           0x0000000000e5076e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift           0x0000000000e516d4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
17 swift           0x0000000000e5067a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
18 swift           0x0000000000e23242 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 706
19 swift           0x0000000000e2493f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
20 swift           0x0000000000e24cf4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
21 swift           0x0000000000e00042 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
24 swift           0x0000000000e05766 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000e4be6a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
28 swift           0x0000000000e758fc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
29 swift           0x0000000000dea85b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
31 swift           0x0000000000e4bfb6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
32 swift           0x0000000000dd1b7d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1581
33 swift           0x0000000000c7d14f swift::CompilerInstance::performSema() + 2975
35 swift           0x00000000007751c7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
36 swift           0x000000000076fda5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28224-swift-genericfunctiontype-get-d82d73.o
1.  While type-checking expression at [validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift:8:1 - line:8:28] RangeText="{enum S<T where S.c:A{case c"
2.  While type-checking 'S' at validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift:8:2
3.  While resolving type S.c at [validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift:8:17 - line:8:19] RangeText="S.c"
4.  While type-checking 'c' at validation-test/compiler_crashers/28224-swift-genericfunctiontype-get.swift:8:28
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
