### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::checkConformance(…)

### DIFF
--- a/validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func e{enum k:A}protocol A{typealias B:A
+typealias n


### PR DESCRIPTION
Stack trace:

```
6  swift           0x0000000000e2f88d swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 1293
10 swift           0x0000000000e05766 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
13 swift           0x0000000000e4ab3a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
14 swift           0x0000000000e4a98e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
15 swift           0x0000000000e4b558 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
17 swift           0x0000000000dd1c12 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1730
18 swift           0x0000000000c7d14f swift::CompilerInstance::performSema() + 2975
20 swift           0x00000000007751c7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
21 swift           0x000000000076fda5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28225-swift-typechecker-checkconformance-39d6d8.o
1.  While type-checking 'e' at validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift:7:1
2.  While type-checking 'k' at validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift:7:8
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
