### PR TITLE
[swiftc] Add test case for crash triggered in swift::IterativeTypeChecker::processInheritedProtocols(…)

### DIFF
--- a/validation-test/compiler_crashers/28226-swift-iterativetypechecker-processinheritedprotocols.swift
+++ b/validation-test/compiler_crashers/28226-swift-iterativetypechecker-processinheritedprotocols.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A{typealias e:A protocol A:a
+protocol a:c}struct c<I:A


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:3495: void swift::ProtocolDecl::setInheritedProtocols(ArrayRef<swift::ProtocolDecl *>): Assertion `!InheritedProtocolsSet && "protocols already set"' failed.
8  swift           0x0000000000edd252 swift::IterativeTypeChecker::processInheritedProtocols(swift::ProtocolDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 1602
9  swift           0x0000000000edba8d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
10 swift           0x0000000000dfcca0 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
11 swift           0x0000000000ef98e1 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
14 swift           0x0000000000efb47f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
15 swift           0x0000000000ef964b swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
16 swift           0x0000000000ef9a07 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 519
19 swift           0x0000000000efb47f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
20 swift           0x0000000000ef964b swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
21 swift           0x0000000000ef93cc swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
22 swift           0x0000000000e23107 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
23 swift           0x0000000000e2493f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
24 swift           0x0000000000e24cf4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
25 swift           0x0000000000e003c0 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
28 swift           0x0000000000e05766 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
29 swift           0x0000000000dd1b12 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
30 swift           0x0000000000c7d14f swift::CompilerInstance::performSema() + 2975
32 swift           0x00000000007751c7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
33 swift           0x000000000076fda5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28226-swift-iterativetypechecker-processinheritedprotocols.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28226-swift-iterativetypechecker-processinheritedprotocols-2a895f.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28226-swift-iterativetypechecker-processinheritedprotocols.swift:8:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
