### PR TITLE
[Coverage] Fix function mapping record emission

### DIFF
--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -82,7 +82,7 @@ void IRGenModule::emitCoverageMapping() {
     W.write(OS);
 
     auto *NameVal =
-        llvm::ConstantDataArray::getString(LLVMContext, M.getName(), true);
+        llvm::ConstantDataArray::getString(LLVMContext, M.getName(), false);
     auto *NameVar =
         new llvm::GlobalVariable(*getModule(), NameVal->getType(), true,
                                  llvm::GlobalValue::LinkOnceAnyLinkage, NameVal,

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -92,9 +92,7 @@ void IRGenModule::emitCoverageMapping() {
     // Create a record for this function.
     llvm::Constant *FunctionRecordVals[] = {
         llvm::ConstantExpr::getBitCast(NameVar, Int8PtrTy),
-        // TODO: We're including the null to match the profile, but we should
-        // really skip the null in the profile instead.
-        llvm::ConstantInt::get(Int32Ty, M.getName().size() + 1),
+        llvm::ConstantInt::get(Int32Ty, M.getName().size()),
         llvm::ConstantInt::get(Int32Ty, CurrentSize - PrevSize),
         llvm::ConstantInt::get(Int64Ty, M.getHash())};
     FunctionRecords.push_back(llvm::ConstantStruct::get(


### PR DESCRIPTION
We emit an extra byte in the name field of function mapping records,
expecting it to be a null byte (it isn't, it's a dirty byte hanging past
the end of a StringRef). A comment states that the "null" byte is
included to match the suffix of the corresponding "__llvm_profile_name_"
GV, but that has never been true.

We need execution tests to prevent this sort of issue from arising in
the future. Before that can happen, swift needs to start maintaining its
own branches of compiler-rt (this is SR-601).

rdar://problem/24267336
