### PR TITLE
Adjust space in property/subscript declarations

### DIFF
--- a/stdlib/public/core/ArrayBufferType.swift
+++ b/stdlib/public/core/ArrayBufferType.swift
@@ -30,7 +30,7 @@ public protocol _ArrayBufferType : MutableCollectionType {
   ) -> UnsafeMutablePointer<Element>
 
   /// Get or set the index'th element.
-  subscript(index: Int) -> Element { get nonmutating set }
+  subscript(index: Int) -> Element { get nonmutating set}
 
   /// If this buffer is backed by a uniquely-referenced mutable
   /// `_ContiguousArrayBuffer` that can be grown in-place to allow the `self`
@@ -73,7 +73,7 @@ public protocol _ArrayBufferType : MutableCollectionType {
 
   /// Returns a `_SliceBuffer` containing the given `subRange` of values
   /// from this buffer.
-  subscript(subRange: Range<Int>) -> _SliceBuffer<Element> { get }
+  subscript(subRange: Range<Int>) -> _SliceBuffer<Element> {get}
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.  If no such storage exists, it is
@@ -91,34 +91,34 @@ public protocol _ArrayBufferType : MutableCollectionType {
   ) rethrows -> R
 
   /// The number of elements the buffer stores.
-  var count: Int { get set }
+  var count: Int {get set}
 
   /// The number of elements the buffer can store without reallocation.
-  var capacity: Int { get }
+  var capacity: Int {get}
 
   /// An object that keeps the elements stored in this buffer alive.
-  var owner: AnyObject { get }
+  var owner: AnyObject {get}
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  var firstElementAddress: UnsafeMutablePointer<Element> { get }
+  var firstElementAddress: UnsafeMutablePointer<Element> {get}
 
   /// Return a base address to which you can add an index `i` to get the address
   /// of the corresponding element at `i`.
-  var subscriptBaseAddress: UnsafeMutablePointer<Element> { get }
+  var subscriptBaseAddress: UnsafeMutablePointer<Element> {get}
 
   /// Like `subscriptBaseAddress`, but can assume that `self` is a mutable,
   /// uniquely referenced native representation.
   /// - Precondition: `_isNative` is `true`.
   var _unconditionalMutableSubscriptBaseAddress:
-    UnsafeMutablePointer<Element> { get }
+    UnsafeMutablePointer<Element> {get}
 
   /// A value that identifies the storage used by the buffer.  Two
   /// buffers address the same elements when they have the same
   /// identity and count.
-  var identity: UnsafePointer<Void> { get }
+  var identity: UnsafePointer<Void> {get}
 
-  var startIndex: Int { get }
+  var startIndex: Int {get}
 }
 
 extension _ArrayBufferType {

--- a/stdlib/public/core/ArrayBufferType.swift
+++ b/stdlib/public/core/ArrayBufferType.swift
@@ -30,7 +30,7 @@ public protocol _ArrayBufferType : MutableCollectionType {
   ) -> UnsafeMutablePointer<Element>
 
   /// Get or set the index'th element.
-  subscript(index: Int) -> Element { get nonmutating set}
+  subscript(index: Int) -> Element { get nonmutating set }
 
   /// If this buffer is backed by a uniquely-referenced mutable
   /// `_ContiguousArrayBuffer` that can be grown in-place to allow the `self`
@@ -73,7 +73,7 @@ public protocol _ArrayBufferType : MutableCollectionType {
 
   /// Returns a `_SliceBuffer` containing the given `subRange` of values
   /// from this buffer.
-  subscript(subRange: Range<Int>) -> _SliceBuffer<Element> {get}
+  subscript(subRange: Range<Int>) -> _SliceBuffer<Element> { get }
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.  If no such storage exists, it is
@@ -91,34 +91,34 @@ public protocol _ArrayBufferType : MutableCollectionType {
   ) rethrows -> R
 
   /// The number of elements the buffer stores.
-  var count: Int {get set}
+  var count: Int { get set }
 
   /// The number of elements the buffer can store without reallocation.
-  var capacity: Int {get}
+  var capacity: Int { get }
 
   /// An object that keeps the elements stored in this buffer alive.
-  var owner: AnyObject {get}
+  var owner: AnyObject { get }
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  var firstElementAddress: UnsafeMutablePointer<Element> {get}
+  var firstElementAddress: UnsafeMutablePointer<Element> { get }
 
   /// Return a base address to which you can add an index `i` to get the address
   /// of the corresponding element at `i`.
-  var subscriptBaseAddress: UnsafeMutablePointer<Element> {get}
+  var subscriptBaseAddress: UnsafeMutablePointer<Element> { get }
 
   /// Like `subscriptBaseAddress`, but can assume that `self` is a mutable,
   /// uniquely referenced native representation.
   /// - Precondition: `_isNative` is `true`.
   var _unconditionalMutableSubscriptBaseAddress:
-    UnsafeMutablePointer<Element> {get}
+    UnsafeMutablePointer<Element> { get }
 
   /// A value that identifies the storage used by the buffer.  Two
   /// buffers address the same elements when they have the same
   /// identity and count.
-  var identity: UnsafePointer<Void> {get}
+  var identity: UnsafePointer<Void> { get }
 
-  var startIndex: Int {get}
+  var startIndex: Int { get }
 }
 
 extension _ArrayBufferType {

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -21,22 +21,22 @@ protocol _ArrayType
   init(count: Int, repeatedValue: Generator.Element)
 
   /// The number of elements the Array stores.
-  var count: Int {get}
+  var count: Int { get }
 
   /// The number of elements the Array can store without reallocation.
-  var capacity: Int {get}
+  var capacity: Int { get }
 
   /// `true` if and only if the Array is empty.
-  var isEmpty: Bool {get}
+  var isEmpty: Bool { get }
 
   /// An object that guarantees the lifetime of this array's elements.
-  var _owner: AnyObject? {get}
+  var _owner: AnyObject? { get }
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  var _baseAddressIfContiguous: UnsafeMutablePointer<Element> {get}
+  var _baseAddressIfContiguous: UnsafeMutablePointer<Element> { get }
 
-  subscript(index: Int) -> Generator.Element {get set}
+  subscript(index: Int) -> Generator.Element { get set }
 
   //===--- basic mutations ------------------------------------------------===//
 
@@ -77,7 +77,7 @@ protocol _ArrayType
   init(_ buffer: _Buffer)
 
   // For testing.
-  var _buffer: _Buffer {get}
+  var _buffer: _Buffer { get }
 }
 
 internal struct _ArrayTypeMirror<

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -21,22 +21,22 @@ protocol _ArrayType
   init(count: Int, repeatedValue: Generator.Element)
 
   /// The number of elements the Array stores.
-  var count: Int { get }
+  var count: Int {get}
 
   /// The number of elements the Array can store without reallocation.
-  var capacity: Int { get }
+  var capacity: Int {get}
 
   /// `true` if and only if the Array is empty.
-  var isEmpty: Bool { get }
+  var isEmpty: Bool {get}
 
   /// An object that guarantees the lifetime of this array's elements.
-  var _owner: AnyObject? { get }
+  var _owner: AnyObject? {get}
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  var _baseAddressIfContiguous: UnsafeMutablePointer<Element> { get }
+  var _baseAddressIfContiguous: UnsafeMutablePointer<Element> {get}
 
-  subscript(index: Int) -> Generator.Element { get set }
+  subscript(index: Int) -> Generator.Element {get set}
 
   //===--- basic mutations ------------------------------------------------===//
 
@@ -77,7 +77,7 @@ protocol _ArrayType
   init(_ buffer: _Buffer)
 
   // For testing.
-  var _buffer: _Buffer { get }
+  var _buffer: _Buffer {get}
 }
 
 internal struct _ArrayTypeMirror<

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -37,7 +37,7 @@ public protocol Indexable {
   /// In an empty collection, `startIndex == endIndex`.
   ///
   /// - Complexity: O(1)
-  var startIndex: Index { get }
+  var startIndex: Index {get}
 
   /// The collection's "past the end" position.
   ///
@@ -46,7 +46,7 @@ public protocol Indexable {
   /// `successor()`.
   ///
   /// - Complexity: O(1)
-  var endIndex: Index { get }
+  var endIndex: Index {get}
 
   // The declaration of _Element and subscript here is a trick used to
   // break a cyclic conformance/deduction that Swift can't handle.  We
@@ -61,18 +61,18 @@ public protocol Indexable {
   /// Returns the element at the given `position`.
   ///
   /// - Complexity: O(1)
-  subscript(position: Index) -> _Element { get }
+  subscript(position: Index) -> _Element {get}
 }
 
 public protocol MutableIndexable {
   associatedtype Index : ForwardIndexType
 
-  var startIndex: Index { get }
-  var endIndex: Index { get }
+  var startIndex: Index {get}
+  var endIndex: Index {get}
 
   associatedtype _Element
 
-  subscript(position: Index) -> _Element { get set }
+  subscript(position: Index) -> _Element {get set}
 }
 
 /// A *generator* for an arbitrary *collection*.  Provided `C`
@@ -89,7 +89,7 @@ public protocol MutableIndexable {
 ///      }
 public struct IndexingGenerator<Elements : Indexable>
  : GeneratorType, SequenceType {
-
+  
   /// Create a *generator* over the given collection.
   public init(_ elements: Elements) {
     self._elements = elements
@@ -138,11 +138,11 @@ public protocol CollectionType : Indexable, SequenceType {
   // a custom generate() function.  Otherwise we get an
   // IndexingGenerator. <rdar://problem/21539115>
   func generate() -> Generator
-
+  
   // FIXME: should be constrained to CollectionType
   // (<rdar://problem/20715009> Implement recursive protocol
   // constraints)
-
+  
   /// A `SequenceType` that can represent a contiguous subrange of `self`'s
   /// elements.
   ///
@@ -153,13 +153,13 @@ public protocol CollectionType : Indexable, SequenceType {
   associatedtype SubSequence: Indexable, SequenceType = Slice<Self>
 
   /// Returns the element at the given `position`.
-  subscript(position: Index) -> Generator.Element { get }
+  subscript(position: Index) -> Generator.Element {get}
 
   /// Returns a collection representing a contiguous sub-range of
   /// `self`'s elements.
   ///
   /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence { get }
+  subscript(bounds: Range<Index>) -> SubSequence {get}
 
   /// Returns `self[startIndex..<end]`
   ///
@@ -187,10 +187,10 @@ public protocol CollectionType : Indexable, SequenceType {
   /// - Complexity: O(1) if `Index` conforms to `RandomAccessIndexType`;
   ///   O(N) otherwise.
   var count: Index.Distance { get }
-
+  
   // The following requirement enables dispatching for indexOf when
   // the element type is Equatable.
-
+  
   /// Returns `Optional(Optional(index))` if an element was found;
   /// `nil` otherwise.
   ///
@@ -797,7 +797,7 @@ public protocol MutableSliceable : CollectionType, MutableCollectionType {
   subscript(_: Range<Index>) -> SubSequence { get set }
 }
 
-@available(*, unavailable, message="Use the dropFirst() method instead.")
+@available(*, unavailable, message="Use the dropFirst() method instead.") 
 public func dropFirst<Seq : CollectionType>(s: Seq) -> Seq.SubSequence {
   fatalError("unavailable function can't be called")
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -37,7 +37,7 @@ public protocol Indexable {
   /// In an empty collection, `startIndex == endIndex`.
   ///
   /// - Complexity: O(1)
-  var startIndex: Index {get}
+  var startIndex: Index { get }
 
   /// The collection's "past the end" position.
   ///
@@ -46,7 +46,7 @@ public protocol Indexable {
   /// `successor()`.
   ///
   /// - Complexity: O(1)
-  var endIndex: Index {get}
+  var endIndex: Index { get }
 
   // The declaration of _Element and subscript here is a trick used to
   // break a cyclic conformance/deduction that Swift can't handle.  We
@@ -61,18 +61,18 @@ public protocol Indexable {
   /// Returns the element at the given `position`.
   ///
   /// - Complexity: O(1)
-  subscript(position: Index) -> _Element {get}
+  subscript(position: Index) -> _Element { get }
 }
 
 public protocol MutableIndexable {
   associatedtype Index : ForwardIndexType
 
-  var startIndex: Index {get}
-  var endIndex: Index {get}
+  var startIndex: Index { get }
+  var endIndex: Index { get }
 
   associatedtype _Element
 
-  subscript(position: Index) -> _Element {get set}
+  subscript(position: Index) -> _Element { get set }
 }
 
 /// A *generator* for an arbitrary *collection*.  Provided `C`
@@ -89,7 +89,7 @@ public protocol MutableIndexable {
 ///      }
 public struct IndexingGenerator<Elements : Indexable>
  : GeneratorType, SequenceType {
-  
+
   /// Create a *generator* over the given collection.
   public init(_ elements: Elements) {
     self._elements = elements
@@ -138,11 +138,11 @@ public protocol CollectionType : Indexable, SequenceType {
   // a custom generate() function.  Otherwise we get an
   // IndexingGenerator. <rdar://problem/21539115>
   func generate() -> Generator
-  
+
   // FIXME: should be constrained to CollectionType
   // (<rdar://problem/20715009> Implement recursive protocol
   // constraints)
-  
+
   /// A `SequenceType` that can represent a contiguous subrange of `self`'s
   /// elements.
   ///
@@ -153,13 +153,13 @@ public protocol CollectionType : Indexable, SequenceType {
   associatedtype SubSequence: Indexable, SequenceType = Slice<Self>
 
   /// Returns the element at the given `position`.
-  subscript(position: Index) -> Generator.Element {get}
+  subscript(position: Index) -> Generator.Element { get }
 
   /// Returns a collection representing a contiguous sub-range of
   /// `self`'s elements.
   ///
   /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence {get}
+  subscript(bounds: Range<Index>) -> SubSequence { get }
 
   /// Returns `self[startIndex..<end]`
   ///
@@ -187,10 +187,10 @@ public protocol CollectionType : Indexable, SequenceType {
   /// - Complexity: O(1) if `Index` conforms to `RandomAccessIndexType`;
   ///   O(N) otherwise.
   var count: Index.Distance { get }
-  
+
   // The following requirement enables dispatching for indexOf when
   // the element type is Equatable.
-  
+
   /// Returns `Optional(Optional(index))` if an element was found;
   /// `nil` otherwise.
   ///
@@ -797,7 +797,7 @@ public protocol MutableSliceable : CollectionType, MutableCollectionType {
   subscript(_: Range<Index>) -> SubSequence { get set }
 }
 
-@available(*, unavailable, message="Use the dropFirst() method instead.") 
+@available(*, unavailable, message="Use the dropFirst() method instead.")
 public func dropFirst<Seq : CollectionType>(s: Seq) -> Seq.SubSequence {
   fatalError("unavailable function can't be called")
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -37,7 +37,7 @@ public protocol Indexable {
   /// In an empty collection, `startIndex == endIndex`.
   ///
   /// - Complexity: O(1)
-  var startIndex: Index {get}
+  var startIndex: Index { get }
 
   /// The collection's "past the end" position.
   ///
@@ -46,7 +46,7 @@ public protocol Indexable {
   /// `successor()`.
   ///
   /// - Complexity: O(1)
-  var endIndex: Index {get}
+  var endIndex: Index { get }
 
   // The declaration of _Element and subscript here is a trick used to
   // break a cyclic conformance/deduction that Swift can't handle.  We
@@ -61,18 +61,18 @@ public protocol Indexable {
   /// Returns the element at the given `position`.
   ///
   /// - Complexity: O(1)
-  subscript(position: Index) -> _Element {get}
+  subscript(position: Index) -> _Element { get }
 }
 
 public protocol MutableIndexable {
   associatedtype Index : ForwardIndexType
 
-  var startIndex: Index {get}
-  var endIndex: Index {get}
+  var startIndex: Index { get }
+  var endIndex: Index { get }
 
   associatedtype _Element
 
-  subscript(position: Index) -> _Element {get set}
+  subscript(position: Index) -> _Element { get set }
 }
 
 /// A *generator* for an arbitrary *collection*.  Provided `C`
@@ -153,13 +153,13 @@ public protocol CollectionType : Indexable, SequenceType {
   associatedtype SubSequence: Indexable, SequenceType = Slice<Self>
 
   /// Returns the element at the given `position`.
-  subscript(position: Index) -> Generator.Element {get}
+  subscript(position: Index) -> Generator.Element { get }
 
   /// Returns a collection representing a contiguous sub-range of
   /// `self`'s elements.
   ///
   /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence {get}
+  subscript(bounds: Range<Index>) -> SubSequence { get }
 
   /// Returns `self[startIndex..<end]`
   ///

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -312,7 +312,7 @@ extension Any${Kind} {
 //===----------------------------------------------------------------------===//
 
 internal protocol _ForwardIndexBoxType : class {
-  var typeID: ObjectIdentifier {get}
+  var typeID: ObjectIdentifier { get }
 
   @warn_unused_result
   func successor() -> _ForwardIndexBoxType
@@ -564,7 +564,7 @@ internal class _AnyCollectionBox<Element> : _AnyCollectionBoxBase<Element> {
 public protocol AnyCollectionType : CollectionType {
   /// Identifies the underlying collection stored by `self`. Instances
   /// copied from one another have the same `_underlyingCollectionID`.
-  var _underlyingCollectionID: ObjectIdentifier {get}
+  var _underlyingCollectionID: ObjectIdentifier { get }
 }
 
 /// Return true iff `lhs` and `rhs` store the same underlying collection.

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -312,7 +312,7 @@ extension Any${Kind} {
 //===----------------------------------------------------------------------===//
 
 internal protocol _ForwardIndexBoxType : class {
-  var typeID: ObjectIdentifier { get }
+  var typeID: ObjectIdentifier {get}
 
   @warn_unused_result
   func successor() -> _ForwardIndexBoxType
@@ -564,7 +564,7 @@ internal class _AnyCollectionBox<Element> : _AnyCollectionBoxBase<Element> {
 public protocol AnyCollectionType : CollectionType {
   /// Identifies the underlying collection stored by `self`. Instances
   /// copied from one another have the same `_underlyingCollectionID`.
-  var _underlyingCollectionID: ObjectIdentifier { get }
+  var _underlyingCollectionID: ObjectIdentifier {get}
 }
 
 /// Return true iff `lhs` and `rhs` store the same underlying collection.

--- a/stdlib/public/core/Interval.swift.gyb
+++ b/stdlib/public/core/Interval.swift.gyb
@@ -25,17 +25,17 @@ public protocol IntervalType {
   func clamp(intervalToClamp: Self) -> Self
 
   /// `true` iff `self` is empty.
-  var isEmpty: Bool { get }
+  var isEmpty: Bool {get}
 
 
   /// The `Interval`'s lower bound.
   ///
   /// Invariant: `start` <= `end`.
-  var start: Bound { get }
+  var start: Bound {get}
   /// The `Interval`'s upper bound.
   ///
   /// Invariant: `start` <= `end`.
-  var end: Bound { get }
+  var end: Bound {get}
 }
 
 % for Kind, rangeOperator, upperBoundCompare in [

--- a/stdlib/public/core/Interval.swift.gyb
+++ b/stdlib/public/core/Interval.swift.gyb
@@ -25,17 +25,17 @@ public protocol IntervalType {
   func clamp(intervalToClamp: Self) -> Self
 
   /// `true` iff `self` is empty.
-  var isEmpty: Bool {get}
+  var isEmpty: Bool { get }
 
 
   /// The `Interval`'s lower bound.
   ///
   /// Invariant: `start` <= `end`.
-  var start: Bound {get}
+  var start: Bound { get }
   /// The `Interval`'s upper bound.
   ///
   /// Invariant: `start` <= `end`.
-  var end: Bound {get}
+  var end: Bound { get }
 }
 
 % for Kind, rangeOperator, upperBoundCompare in [

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -146,9 +146,9 @@ public protocol LazySequenceType : SequenceType {
   /// Note: this property need not be implemented by conforming types,
   /// it has a default implementation in a protocol extension that
   /// just returns `self`.
-  var elements: Elements {get} 
+  var elements: Elements { get }
   
-  var array: [Generator.Element] {get}
+  var array: [Generator.Element] { get }
 }
 
 extension LazySequenceType {

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -72,7 +72,7 @@
 ///       private var base: Base                  // The underlying generator.
 ///       private let combine: (ResultElement, Base.Element) -> ResultElement
 ///     }
-///     
+///
 ///     struct LazyScanSequence<Base: SequenceType, ResultElement>
 ///       : LazySequenceType // Chained operations on self are lazy, too
 ///     {
@@ -87,7 +87,7 @@
 ///     }
 ///
 /// and finally, we can give all lazy sequences a lazy `scan` method:
-///     
+///
 ///     extension LazySequenceType {
 ///       /// Returns a sequence containing the results of
 ///       ///
@@ -146,9 +146,9 @@ public protocol LazySequenceType : SequenceType {
   /// Note: this property need not be implemented by conforming types,
   /// it has a default implementation in a protocol extension that
   /// just returns `self`.
-  var elements: Elements {get} 
-  
-  var array: [Generator.Element] {get}
+  var elements: Elements { get }
+
+  var array: [Generator.Element] { get }
 }
 
 extension LazySequenceType {
@@ -177,7 +177,7 @@ public struct LazySequence<Base : SequenceType>
   public init(_ base: Base) {
     self._base = base
   }
-  
+
   public var _base: Base
 
   /// The `Base` (presumably non-lazy) sequence from which `self` was created.

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -72,7 +72,7 @@
 ///       private var base: Base                  // The underlying generator.
 ///       private let combine: (ResultElement, Base.Element) -> ResultElement
 ///     }
-///
+///     
 ///     struct LazyScanSequence<Base: SequenceType, ResultElement>
 ///       : LazySequenceType // Chained operations on self are lazy, too
 ///     {
@@ -87,7 +87,7 @@
 ///     }
 ///
 /// and finally, we can give all lazy sequences a lazy `scan` method:
-///
+///     
 ///     extension LazySequenceType {
 ///       /// Returns a sequence containing the results of
 ///       ///
@@ -146,9 +146,9 @@ public protocol LazySequenceType : SequenceType {
   /// Note: this property need not be implemented by conforming types,
   /// it has a default implementation in a protocol extension that
   /// just returns `self`.
-  var elements: Elements { get }
-
-  var array: [Generator.Element] { get }
+  var elements: Elements {get} 
+  
+  var array: [Generator.Element] {get}
 }
 
 extension LazySequenceType {
@@ -177,7 +177,7 @@ public struct LazySequence<Base : SequenceType>
   public init(_ base: Base) {
     self._base = base
   }
-
+  
   public var _base: Base
 
   /// The `Base` (presumably non-lazy) sequence from which `self` was created.

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -12,7 +12,7 @@
 
 public protocol ReverseIndexType : BidirectionalIndexType {
   associatedtype Base : BidirectionalIndexType
-  
+
   /// A type that can represent the number of steps between pairs of
   /// `ReverseIndex` values where one value is reachable from the other.
   associatedtype Distance: _SignedIntegerType = Base.Distance
@@ -22,7 +22,7 @@ public protocol ReverseIndexType : BidirectionalIndexType {
   ///
   /// If `self` is `advance(c.reverse.startIndex, n)`, then:
   /// - `self.base` is `advance(c.endIndex, -n)`.
-  /// - if `n` != `c.count`, then `c.reverse[self]` is 
+  /// - if `n` != `c.count`, then `c.reverse[self]` is
   ///   equivalent to `[self.base.predecessor()]`.
   var base: Base { get }
 
@@ -50,15 +50,15 @@ extension BidirectionalIndexType where Self : ReverseIndexType {
 public struct ReverseIndex<Base: BidirectionalIndexType>
 : BidirectionalIndexType, ReverseIndexType {
   public typealias Distance = Base.Distance
-  
+
   public init(_ base: Base) { self.base = base }
-  
+
   /// The successor position in the underlying (un-reversed)
   /// collection.
   ///
   /// If `self` is `advance(c.reverse.startIndex, n)`, then:
   /// - `self.base` is `advance(c.endIndex, -n)`.
-  /// - if `n` != `c.count`, then `c.reverse[self]` is 
+  /// - if `n` != `c.count`, then `c.reverse[self]` is
   ///   equivalent to `[self.base.predecessor()]`.
   public let base: Base
 
@@ -79,15 +79,15 @@ public struct ReverseRandomAccessIndex<Base: RandomAccessIndexType>
   : RandomAccessIndexType, ReverseIndexType {
 
   public typealias Distance = Base.Distance
-  
+
   public init(_ base: Base) { self.base = base }
-  
+
   /// The successor position in the underlying (un-reversed)
   /// collection.
   ///
   /// If `self` is `advance(c.reverse.startIndex, n)`, then:
   /// - `self.base` is `advance(c.endIndex, -n)`.
-  /// - if `n` != `c.count`, then `c.reverse[self]` is 
+  /// - if `n` != `c.count`, then `c.reverse[self]` is
   ///   equivalent to `[self.base.predecessor()]`.
   public let base: Base
 
@@ -106,7 +106,7 @@ public struct ReverseRandomAccessIndex<Base: RandomAccessIndexType>
 public protocol _ReverseCollectionType : CollectionType {
   associatedtype Index : ReverseIndexType
   associatedtype Base : CollectionType
-  var _base: Base {get}
+  var _base: Base { get }
 }
 
 extension CollectionType
@@ -162,7 +162,7 @@ public struct ReverseCollection<
   /// A type that provides the *sequence*'s iteration interface and
   /// encapsulates its iteration state.
   public typealias Generator = IndexingGenerator<ReverseCollection>
-  
+
   public let _base: Base
 
   @available(*, unavailable, renamed="Base")
@@ -191,7 +191,7 @@ public struct ReverseRandomAccessCollection<
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = ReverseRandomAccessIndex<Base.Index>
-  
+
   /// A type that provides the *sequence*'s iteration interface and
   /// encapsulates its iteration state.
   public typealias Generator = IndexingGenerator<

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -106,7 +106,7 @@ public struct ReverseRandomAccessIndex<Base: RandomAccessIndexType>
 public protocol _ReverseCollectionType : CollectionType {
   associatedtype Index : ReverseIndexType
   associatedtype Base : CollectionType
-  var _base: Base {get}
+  var _base: Base { get }
 }
 
 extension CollectionType

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -12,7 +12,7 @@
 
 public protocol ReverseIndexType : BidirectionalIndexType {
   associatedtype Base : BidirectionalIndexType
-
+  
   /// A type that can represent the number of steps between pairs of
   /// `ReverseIndex` values where one value is reachable from the other.
   associatedtype Distance: _SignedIntegerType = Base.Distance
@@ -22,7 +22,7 @@ public protocol ReverseIndexType : BidirectionalIndexType {
   ///
   /// If `self` is `advance(c.reverse.startIndex, n)`, then:
   /// - `self.base` is `advance(c.endIndex, -n)`.
-  /// - if `n` != `c.count`, then `c.reverse[self]` is
+  /// - if `n` != `c.count`, then `c.reverse[self]` is 
   ///   equivalent to `[self.base.predecessor()]`.
   var base: Base { get }
 
@@ -50,15 +50,15 @@ extension BidirectionalIndexType where Self : ReverseIndexType {
 public struct ReverseIndex<Base: BidirectionalIndexType>
 : BidirectionalIndexType, ReverseIndexType {
   public typealias Distance = Base.Distance
-
+  
   public init(_ base: Base) { self.base = base }
-
+  
   /// The successor position in the underlying (un-reversed)
   /// collection.
   ///
   /// If `self` is `advance(c.reverse.startIndex, n)`, then:
   /// - `self.base` is `advance(c.endIndex, -n)`.
-  /// - if `n` != `c.count`, then `c.reverse[self]` is
+  /// - if `n` != `c.count`, then `c.reverse[self]` is 
   ///   equivalent to `[self.base.predecessor()]`.
   public let base: Base
 
@@ -79,15 +79,15 @@ public struct ReverseRandomAccessIndex<Base: RandomAccessIndexType>
   : RandomAccessIndexType, ReverseIndexType {
 
   public typealias Distance = Base.Distance
-
+  
   public init(_ base: Base) { self.base = base }
-
+  
   /// The successor position in the underlying (un-reversed)
   /// collection.
   ///
   /// If `self` is `advance(c.reverse.startIndex, n)`, then:
   /// - `self.base` is `advance(c.endIndex, -n)`.
-  /// - if `n` != `c.count`, then `c.reverse[self]` is
+  /// - if `n` != `c.count`, then `c.reverse[self]` is 
   ///   equivalent to `[self.base.predecessor()]`.
   public let base: Base
 
@@ -106,7 +106,7 @@ public struct ReverseRandomAccessIndex<Base: RandomAccessIndexType>
 public protocol _ReverseCollectionType : CollectionType {
   associatedtype Index : ReverseIndexType
   associatedtype Base : CollectionType
-  var _base: Base { get }
+  var _base: Base {get}
 }
 
 extension CollectionType
@@ -162,7 +162,7 @@ public struct ReverseCollection<
   /// A type that provides the *sequence*'s iteration interface and
   /// encapsulates its iteration state.
   public typealias Generator = IndexingGenerator<ReverseCollection>
-
+  
   public let _base: Base
 
   @available(*, unavailable, renamed="Base")
@@ -191,7 +191,7 @@ public struct ReverseRandomAccessCollection<
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = ReverseRandomAccessIndex<Base.Index>
-
+  
   /// A type that provides the *sequence*'s iteration interface and
   /// encapsulates its iteration state.
   public typealias Generator = IndexingGenerator<

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -20,8 +20,8 @@ public // @testable
 protocol _SequenceWrapperType {
   associatedtype Base : SequenceType
   associatedtype Generator : GeneratorType = Base.Generator
-
-  var _base: Base { get }
+  
+  var _base: Base {get}
 }
 
 extension SequenceType
@@ -50,13 +50,13 @@ extension SequenceType
   ) rethrows -> [Base.Generator.Element] {
     return try _base.filter(includeElement)
   }
-
+  
   public func _customContainsEquatableElement(
     element: Base.Generator.Element
-  ) -> Bool? {
+  ) -> Bool? { 
     return _base._customContainsEquatableElement(element)
   }
-
+  
   /// If `self` is multi-pass (i.e., a `CollectionType`), invoke
   /// `preprocess` on `self` and return its result.  Otherwise, return
   /// `nil`.

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -21,7 +21,7 @@ protocol _SequenceWrapperType {
   associatedtype Base : SequenceType
   associatedtype Generator : GeneratorType = Base.Generator
   
-  var _base: Base {get}
+  var _base: Base { get }
 }
 
 extension SequenceType

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -20,8 +20,8 @@ public // @testable
 protocol _SequenceWrapperType {
   associatedtype Base : SequenceType
   associatedtype Generator : GeneratorType = Base.Generator
-  
-  var _base: Base {get}
+
+  var _base: Base { get }
 }
 
 extension SequenceType
@@ -50,13 +50,13 @@ extension SequenceType
   ) rethrows -> [Base.Generator.Element] {
     return try _base.filter(includeElement)
   }
-  
+
   public func _customContainsEquatableElement(
     element: Base.Generator.Element
-  ) -> Bool? { 
+  ) -> Bool? {
     return _base._customContainsEquatableElement(element)
   }
-  
+
   /// If `self` is multi-pass (i.e., a `CollectionType`), invoke
   /// `preprocess` on `self` and return its result.  Otherwise, return
   /// `nil`.


### PR DESCRIPTION
This is just a very simple cleanup to maintain consistency with the code style presented at [The Swift Programming Language](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language).
