### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::getTypeOfRValue(…)

### DIFF
--- a/validation-test/compiler_crashers/28227-swift-typechecker-gettypeofrvalue.swift
+++ b/validation-test/compiler_crashers/28227-swift-typechecker-gettypeofrvalue.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+struct c{struct A:a{var d}let a=A{}protocol A


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2191: swift::Type swift::ValueDecl::getType() const: Assertion `hasType() && "declaration has no type set yet"' failed.
8  swift           0x0000000000df720d swift::TypeChecker::getTypeOfRValue(swift::ValueDecl*, bool) + 221
9  swift           0x0000000000e6114d swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 525
10 swift           0x0000000000e0abac swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1404
11 swift           0x0000000000ff998b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2763
13 swift           0x0000000000e27892 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 386
14 swift           0x0000000000e28189 swift::TypeChecker::lookupConstructors(swift::DeclContext*, swift::Type, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 41
15 swift           0x0000000000ec1abf swift::constraints::ConstraintSystem::simplifyConstructionConstraint(swift::Type, swift::FunctionType*, unsigned int, swift::constraints::ConstraintLocator*) + 207
16 swift           0x0000000000ec670f swift::constraints::ConstraintSystem::simplifyApplicableFnConstraint(swift::constraints::Constraint const&) + 943
17 swift           0x0000000000ec6f60 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 880
18 swift           0x0000000000e69fd7 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
21 swift           0x0000000000f63515 swift::Expr::walk(swift::ASTWalker&) + 69
22 swift           0x0000000000ea75d8 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
23 swift           0x0000000000de42c0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
24 swift           0x0000000000dea7e9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
25 swift           0x0000000000deb960 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
26 swift           0x0000000000debb09 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
28 swift           0x0000000000e00d7c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3740
29 swift           0x0000000000ff9a1c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
30 swift           0x0000000000ff83c0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
31 swift           0x0000000000e26e4b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
34 swift           0x0000000000e5076e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
36 swift           0x0000000000e516d4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
37 swift           0x0000000000e5067a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
38 swift           0x0000000000dfe0aa swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
39 swift           0x0000000000e00605 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1829
44 swift           0x0000000000e05766 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
45 swift           0x0000000000dd1b12 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
46 swift           0x0000000000c7d14f swift::CompilerInstance::performSema() + 2975
48 swift           0x00000000007751c7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
49 swift           0x000000000076fda5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28227-swift-typechecker-gettypeofrvalue.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28227-swift-typechecker-gettypeofrvalue-c6b32f.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28227-swift-typechecker-gettypeofrvalue.swift:8:1
2.  While resolving type a at [validation-test/compiler_crashers/28227-swift-typechecker-gettypeofrvalue.swift:8:19 - line:8:19] RangeText="a"
3.  While type-checking expression at [validation-test/compiler_crashers/28227-swift-typechecker-gettypeofrvalue.swift:8:33 - line:8:35] RangeText="A{}"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
