### PR TITLE
[swiftc] Add test case for crash triggered in swift::DependentGenericTypeResolver::resolveSelfAssociatedType(…)

### DIFF
--- a/validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+struct g
+struct c{}protocol c{typealias e:d
+class d<T where g:e.T


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:34: virtual swift::Type swift::DependentGenericTypeResolver::resolveDependentMemberType(swift::Type, swift::DeclContext *, swift::SourceRange, swift::ComponentIdentTypeRepr *): Assertion `archetype && "Bad generic context nesting?"' failed.
8  swift           0x0000000000e228a0 swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 0
10 swift           0x0000000000e5076e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift           0x0000000000e516d4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
13 swift           0x0000000000e5067a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
14 swift           0x0000000000e2326c swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 748
15 swift           0x0000000000e2493f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
16 swift           0x0000000000e24cf4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
17 swift           0x0000000000e00042 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
18 swift           0x0000000000ff9a1c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
19 swift           0x0000000000ff83c0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
20 swift           0x0000000000e26e4b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
23 swift           0x0000000000e5076e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
25 swift           0x0000000000e516d4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
26 swift           0x0000000000e5067a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
27 swift           0x0000000000edc802 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
28 swift           0x0000000000edba8d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
29 swift           0x0000000000dfcd49 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
30 swift           0x0000000000e002f1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
32 swift           0x0000000000e05766 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000dd1b12 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1474
34 swift           0x0000000000c7d14f swift::CompilerInstance::performSema() + 2975
36 swift           0x00000000007751c7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
37 swift           0x000000000076fda5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype-a5a67f.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:9:1
2.  While resolving type d at [validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:9:34 - line:9:34] RangeText="d"
3.  While resolving type e.T at [validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:10:19 - line:10:21] RangeText="e.T"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
