### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::getInterfaceType()

### DIFF
--- a/validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol c{typealias e:a:protocol a{typealias a}func b:e.c


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2191: swift::Type swift::ValueDecl::getType() const: Assertion `hasType() && "declaration has no type set yet"' failed.
8  swift           0x0000000000fbb008 swift::ValueDecl::getInterfaceType() const + 472
9  swift           0x0000000000fbb886 swift::TypeDecl::getDeclaredInterfaceType() const + 6
10 swift           0x0000000000e4e857 swift::TypeChecker::substMemberTypeWithBase(swift::ModuleDecl*, swift::ValueDecl const*, swift::Type, bool) + 55
12 swift           0x0000000000e4f05e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000e4ffc4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000e4ef6a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
20 swift           0x0000000000e04076 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
21 swift           0x0000000000dd03e2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
22 swift           0x0000000000c7b9cf swift::CompilerInstance::performSema() + 2975
24 swift           0x0000000000775277 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
25 swift           0x000000000076fe55 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28229-swift-valuedecl-getinterfacetype-9ca3a6.o
1.  While type-checking 'c' at validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift:8:1
2.  While resolving type e.a at [validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift:8:56 - line:8:58] RangeText="e.c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
