### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::solveSimplified(…)

### DIFF
--- a/validation-test/compiler_crashers/28231-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers/28231-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{func a(a)class a{deinit{a(a{


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000ed21a1 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 11201
5  swift           0x0000000000ecdcc5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
6  swift           0x0000000000ecda79 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
7  swift           0x0000000000de2d96 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 614
8  swift           0x0000000000de9159 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
11 swift           0x0000000000e49d05 swift::TypeChecker::typeCheckDestructorBodyUntil(swift::DestructorDecl*, swift::SourceLoc) + 181
12 swift           0x0000000000e4926b swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 27
13 swift           0x0000000000e49e48 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
15 swift           0x0000000000dd04e2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
16 swift           0x0000000000c7b9cf swift::CompilerInstance::performSema() + 2975
18 swift           0x0000000000775277 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
19 swift           0x000000000076fe55 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28231-swift-constraints-constraintsystem-solvesimplified.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28231-swift-constraints-constraintsystem-solvesimplified-577440.o
1.  While type-checking 'deinit' at validation-test/compiler_crashers/28231-swift-constraints-constraintsystem-solvesimplified.swift:7:19
2.  While type-checking expression at [validation-test/compiler_crashers/28231-swift-constraints-constraintsystem-solvesimplified.swift:7:26 - line:7:29] RangeText="a(a{"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
