### PR TITLE
[ASTDumper] Dump the trailing newline on the given stream

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1028,7 +1028,7 @@ void Decl::dump(raw_ostream &OS, unsigned Indent) const {
   llvm::SaveAndRestore<bool> X(getASTContext().LangOpts.DebugConstraintSolver,
                                true);
   PrintDecl(OS, Indent).visit(const_cast<Decl *>(this));
-  llvm::errs() << '\n';
+  OS << '\n';
 }
 
 /// Print the given declaration context (with its parents).


### PR DESCRIPTION
No more phantom newlines appearing when dumping to a different stream than `llvm::errs()`.
