### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::typeCheckFunctionBodyUntil(…)

### DIFF
--- a/validation-test/compiler_crashers/28232-swift-typechecker-typecheckfunctionbodyuntil.swift
+++ b/validation-test/compiler_crashers/28232-swift-typechecker-typecheckfunctionbodyuntil.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func a(.,Int={}){


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckStmt.cpp:1103: void checkDefaultArguments(swift::TypeChecker &, swift::ParameterList *, unsigned int &, swift::DeclContext *): Assertion `initContext->getIndex() == curArgIndex' failed.
9  swift           0x0000000000e494a1 swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 129
10 swift           0x0000000000e493de swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
11 swift           0x0000000000e49fa8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
13 swift           0x0000000000dd0642 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
14 swift           0x0000000000c7bb2f swift::CompilerInstance::performSema() + 2975
16 swift           0x00000000007753d7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
17 swift           0x000000000076ffb5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28232-swift-typechecker-typecheckfunctionbodyuntil.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28232-swift-typechecker-typecheckfunctionbodyuntil-ab7ced.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28232-swift-typechecker-typecheckfunctionbodyuntil.swift:8:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
