### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getMemberSubstitutions(…)

### DIFF
--- a/validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A{class A}protocol a:A{protocol P{typealias e:A}}a


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000001015b37 swift::TypeBase::getMemberSubstitutions(swift::DeclContext*) + 23
5  swift           0x0000000001015fea swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext*) + 58
6  swift           0x0000000000e4e7a7 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 1591
10 swift           0x0000000000e4f1be swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift           0x0000000000e50124 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
13 swift           0x0000000000e4f0ca swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
14 swift           0x0000000000eddff2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
15 swift           0x0000000000edd27d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
16 swift           0x0000000000dfb7b9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
17 swift           0x0000000000dfed61 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1041
18 swift           0x0000000000fbeeda swift::ProtocolDecl::existentialTypeSupportedSlow(swift::LazyResolver*) + 186
23 swift           0x0000000000f6549e swift::Stmt::walk(swift::ASTWalker&) + 78
24 swift           0x0000000000e54f6a swift::TypeChecker::checkUnsupportedProtocolType(swift::Stmt*) + 138
25 swift           0x0000000000ee0e2c swift::performStmtDiagnostics(swift::TypeChecker&, swift::Stmt const*) + 28
26 swift           0x0000000000e4aa23 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 163
27 swift           0x0000000000dd05ad swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1597
28 swift           0x0000000000c7bb2f swift::CompilerInstance::performSema() + 2975
30 swift           0x00000000007753d7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
31 swift           0x000000000076ffb5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28233-swift-typebase-getmembersubstitutions-f57c4c.o
1.  While resolving type A at [validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift:7:56 - line:7:56] RangeText="A"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
