### PR TITLE
[gardening] Fix violations of non-controversial PEP8 rules (follow-up)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,10 +100,10 @@ html_style = 'swift.css'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  # Red links are a bit too garish
-  "linkcolor": "#577492",
-  "visitedlinkcolor": "#577492",
-  "hoverlinkcolor": "#551A8B"
+    # Red links are a bit too garish
+    "linkcolor": "#577492",
+    "visitedlinkcolor": "#577492",
+    "hoverlinkcolor": "#551A8B"
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -191,8 +191,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('contents', 'Swift.tex', u'Swift Documentation',
-   u'LLVM project', 'manual'),
+    ('contents', 'Swift.tex', u'Swift Documentation',
+     u'LLVM project', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -235,9 +235,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('contents', 'Swift', u'Swift Documentation',
-   u'LLVM project', 'Swift', 'One line description of project.',
-   'Miscellaneous'),
+    ('contents', 'Swift', u'Swift Documentation',
+     u'LLVM project', 'Swift', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -41,7 +41,7 @@ usage: nshtml2rst < NSString.html > NSString.rst
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE
     )
-    rst,stderr = p.communicate(html)
+    rst, stderr = p.communicate(html)
 
     # HACKETY HACK HACK: Our html documents apparently contain some
     # bogus heading level nesting.  Just fix up the one we know about

--- a/stdlib/public/common/MirrorCommon.py
+++ b/stdlib/public/common/MirrorCommon.py
@@ -25,7 +25,7 @@ def getDisposition(disp=None):
 
 def _getGenericArgStrings(genericArgs=None, genericConstraints=None):
   if genericArgs is None:
-    return ('','')
+    return ('', '')
   genericArgString = ''
   first = True
   for arg in genericArgs:

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -21,7 +21,8 @@ import sys
 assert len(sys.argv) >= 2
 timeVal = int(sys.argv[1])
 
-timeVal += 946684800 # offset between Unix and LLVM epochs
+# offset between Unix and LLVM epochs
+timeVal += 946684800
 
 # Update the output file mtime, or create it if necessary.
 # From http://stackoverflow.com/a/1160227.

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -64,7 +64,7 @@ class Object(object):
     def __init__(self, obj):
         if isinstance(obj, Object):
             self._obj = conf.lib.sourcekitd_request_retain(obj)
-        elif isinstance(obj, (int,long,bool)):
+        elif isinstance(obj, (int, long, bool)):
             self._obj = conf.lib.sourcekitd_request_int64_create(obj)
         elif isinstance(obj, str):
             self._obj = conf.lib.sourcekitd_request_string_create(obj)
@@ -74,10 +74,10 @@ class Object(object):
             self._obj = conf.lib.sourcekitd_request_dictionary_create(
                 POINTER(c_void_p)(), POINTER(c_void_p)(), 0)
             self._as_parameter_ = self._obj
-            for k,v in obj.iteritems():
+            for k, v in obj.iteritems():
                 conf.lib.sourcekitd_request_dictionary_set_value(self,
                     UIdent(k), Object(v))
-        elif isinstance(obj, (list,tuple)):
+        elif isinstance(obj, (list, tuple)):
             self._obj = conf.lib.sourcekitd_request_array_create(
                 POINTER(c_void_p)(), 0)
             self._as_parameter_ = self._obj
@@ -182,8 +182,8 @@ class ErrorKind(object):
         """Get the enumeration name of this error kind."""
         if self._name_map is None:
             self._name_map = {}
-            for key,value in ErrorKind.__dict__.items():
-                if isinstance(value,ErrorKind):
+            for key, value in ErrorKind.__dict__.items():
+                if isinstance(value, ErrorKind):
                     self._name_map[value] = key
         return self._name_map[self]
 
@@ -265,8 +265,8 @@ class VariantType(object):
         """Get the enumeration name of this variant type."""
         if self._name_map is None:
             self._name_map = {}
-            for key,value in VariantType.__dict__.items():
-                if isinstance(value,VariantType):
+            for key, value in VariantType.__dict__.items():
+                if isinstance(value, VariantType):
                     self._name_map[value] = key
         return self._name_map[self]
 

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -295,7 +295,9 @@ callbacks['dictionary_applier'] = CFUNCTYPE(c_int, c_object_p, Variant, py_objec
 
 # Functions strictly alphabetical order.
 functionList = [
-  ("sourcekitd_cancel_request",
+  # FIXME: Fix PEP8 violation "continuation line under-indented for hanging
+  #        indent" (E121) and remove "noqa" marker.
+  ("sourcekitd_cancel_request", # noqa
   	[c_void_p]),
 
   ("sourcekitd_initialize",

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -226,7 +226,8 @@ class Variant(Structure):
     def to_python_array(self):
         def applier(index, value, arr):
             arr.append(value.to_python_object())
-            return 1 # continue
+            # continue
+            return 1
         arr = []
         conf.lib.sourcekitd_variant_array_apply_f(self, callbacks['array_applier'](applier), arr)
         return arr
@@ -234,7 +235,8 @@ class Variant(Structure):
     def to_python_dictionary(self):
         def applier(cobj, value, d):
             d[str(UIdent(cobj))] = value.to_python_object()
-            return 1 # continue
+            # continue
+            return 1
         d = {}
         conf.lib.sourcekitd_variant_dictionary_apply_f(self, callbacks['dictionary_applier'](applier), d)
         return d
@@ -297,7 +299,7 @@ callbacks['dictionary_applier'] = CFUNCTYPE(c_int, c_object_p, Variant, py_objec
 functionList = [
   # FIXME: Fix PEP8 violation "continuation line under-indented for hanging
   #        indent" (E121) and remove "noqa" marker.
-  ("sourcekitd_cancel_request", # noqa
+  ("sourcekitd_cancel_request",  # noqa
   	[c_void_p]),
 
   ("sourcekitd_initialize",

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -65,7 +65,7 @@ class GraphemeClusterBreakPropertyTable(UnicodeProperty):
         # values to symbolic values.
         self.symbolic_values = \
             [None] * (max(self.numeric_value_table.values()) + 1)
-        for k,v in self.numeric_value_table.items():
+        for k, v in self.numeric_value_table.items():
             self.symbolic_values[v] = k
 
         # Load the data file.
@@ -96,7 +96,7 @@ class GraphemeClusterBreakPropertyTable(UnicodeProperty):
         for cp in range(0, 0x110000):
             self.property_values[cp] = self.get_default_value()
 
-        for start_code_point,end_code_point,value in self.property_value_ranges:
+        for start_code_point, end_code_point, value in self.property_value_ranges:
             for cp in range(start_code_point, end_code_point + 1):
                 self.property_values[cp] = value
 
@@ -483,7 +483,7 @@ def get_extended_grapheme_cluster_rules_matrix(grapheme_cluster_break_property_t
             dict.fromkeys(any_value, None)
 
     # Iterate over rules in the order of increasing priority.
-    for firstList,action,secondList in reversed(rules):
+    for firstList, action, secondList in reversed(rules):
         for first in firstList:
             for second in secondList:
                 rules_matrix[first][second] = action

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -45,19 +45,19 @@ class GraphemeClusterBreakPropertyTable(UnicodeProperty):
     # reason for either of those to differ, then this mapping can be overridden
     # after an instance of this class is created.
     numeric_value_table = {
-      'Other': 0,
-      'CR': 1,
-      'LF': 2,
-      'Control': 3,
-      'Extend': 4,
-      'Regional_Indicator': 5,
-      'Prepend': 6,
-      'SpacingMark': 7,
-      'L': 8,
-      'V': 9,
-      'T': 10,
-      'LV': 11,
-      'LVT': 12,
+        'Other': 0,
+        'CR': 1,
+        'LF': 2,
+        'Control': 3,
+        'Extend': 4,
+        'Regional_Indicator': 5,
+        'Prepend': 6,
+        'SpacingMark': 7,
+        'L': 8,
+        'V': 9,
+        'T': 10,
+        'LV': 11,
+        'LVT': 12,
     }
 
     def __init__(self, grapheme_break_property_file_name):
@@ -463,17 +463,17 @@ def get_extended_grapheme_cluster_rules_matrix(grapheme_cluster_break_property_t
     # As in the referenced document, the rules are specified in order of
     # decreasing priority.
     rules = [
-      (['CR'], 'no_boundary', ['LF']),
-      (['Control', 'CR', 'LF'], 'boundary', any_value),
-      (any_value, 'boundary', ['Control', 'CR', 'LF']),
-      (['L'], 'no_boundary', ['L', 'V', 'LV', 'LVT']),
-      (['LV', 'V'], 'no_boundary', ['V', 'T']),
-      (['LVT', 'T'], 'no_boundary', ['T']),
-      (['Regional_Indicator'], 'no_boundary', ['Regional_Indicator']),
-      (any_value, 'no_boundary', ['Extend']),
-      (any_value, 'no_boundary', ['SpacingMark']),
-      (['Prepend'], 'no_boundary', any_value),
-      (any_value, 'boundary', any_value),
+        (['CR'], 'no_boundary', ['LF']),
+        (['Control', 'CR', 'LF'], 'boundary', any_value),
+        (any_value, 'boundary', ['Control', 'CR', 'LF']),
+        (['L'], 'no_boundary', ['L', 'V', 'LV', 'LVT']),
+        (['LV', 'V'], 'no_boundary', ['V', 'T']),
+        (['LVT', 'T'], 'no_boundary', ['T']),
+        (['Regional_Indicator'], 'no_boundary', ['Regional_Indicator']),
+        (any_value, 'no_boundary', ['Extend']),
+        (any_value, 'no_boundary', ['SpacingMark']),
+        (['Prepend'], 'no_boundary', any_value),
+        (any_value, 'boundary', any_value),
     ]
 
     # Expand the rules into a matrix.

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -11,9 +11,11 @@
 from __future__ import print_function
 
 try:
-    import ConfigParser # Python 2
+    # Python 2
+    import ConfigParser
 except ImportError:
-    import configparser as ConfigParser # Python 3
+    # Python 3
+    import configparser as ConfigParser
 
 import os
 import pipes

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -78,7 +78,8 @@ def all_integer_type_names():
     return [self_ty.stdlib_name for self_ty in all_integer_types(0)]
 
 def all_real_number_type_names():
-    return ['Float', 'Double'] # FIXME , 'Float80' Revert until I figure out a test failure  # Float80 for i386 & x86_64
+    # FIXME , 'Float80' Revert until I figure out a test failure  # Float80 for i386 & x86_64
+    return ['Float', 'Double']
 
 def all_numeric_type_names():
     return all_integer_type_names() + all_real_number_type_names()

--- a/utils/build-script
+++ b/utils/build-script
@@ -720,25 +720,25 @@ the number of parallel build jobs to use""",
 
         # FIXME: mangle LLDB build configuration into the directory name.
         if (llvm_build_dir_label == swift_build_dir_label and
-            llvm_build_dir_label == swift_stdlib_build_dir_label and
-            llvm_build_dir_label == cmark_build_dir_label):
+                llvm_build_dir_label == swift_stdlib_build_dir_label and
+                llvm_build_dir_label == cmark_build_dir_label):
             # Use a simple directory name if all projects use the same build type.
             args.build_subdir += "-" + llvm_build_dir_label
         elif (llvm_build_dir_label != swift_build_dir_label and
-            llvm_build_dir_label == swift_stdlib_build_dir_label and
-            llvm_build_dir_label == cmark_build_dir_label):
+                llvm_build_dir_label == swift_stdlib_build_dir_label and
+                llvm_build_dir_label == cmark_build_dir_label):
             # Swift build type differs.
             args.build_subdir += "-" + llvm_build_dir_label
             args.build_subdir += "+swift-" + swift_build_dir_label
         elif (llvm_build_dir_label == swift_build_dir_label and
-            llvm_build_dir_label != swift_stdlib_build_dir_label and
-            llvm_build_dir_label == cmark_build_dir_label):
+                llvm_build_dir_label != swift_stdlib_build_dir_label and
+                llvm_build_dir_label == cmark_build_dir_label):
             # Swift stdlib build type differs.
             args.build_subdir += "-" + llvm_build_dir_label
             args.build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
         elif (llvm_build_dir_label == swift_build_dir_label and
-            llvm_build_dir_label == swift_stdlib_build_dir_label and
-            llvm_build_dir_label != cmark_build_dir_label):
+                llvm_build_dir_label == swift_stdlib_build_dir_label and
+                llvm_build_dir_label != cmark_build_dir_label):
             # cmark build type differs.
             args.build_subdir += "-" + llvm_build_dir_label
             args.build_subdir += "+cmark-" + cmark_build_dir_label

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -41,8 +41,8 @@ Prefixes = {
 }
 
 Infixes = {
-  #Swift
-  "q_": "Generic Function"
+    #Swift
+    "q_": "Generic Function"
 }
 
 GenericFunctionPrefix = "__TTSg"

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -128,7 +128,7 @@ def tokenizePythonToUnmatchedCloseCurly(sourceText, start, lineStarts):
 
     try:
         for kind, text, tokenStart, tokenEnd, lineText \
-            in tokenize.generate_tokens(stream.readline):
+                in tokenize.generate_tokens(stream.readline):
 
             if text == '{':
                 nesting += 1
@@ -225,7 +225,7 @@ def tokenizeTemplate(templateText):
 
         # pull out the one matched key (ignoring internal patterns starting with _)
         ((kind, text), ) = (
-            (kind,text) for (kind,text) in m.groupdict().items()
+            (kind, text) for (kind, text) in m.groupdict().items()
             if text is not None and kind[0] != '_')
 
         if kind in ('literal', 'symbol'):
@@ -301,13 +301,13 @@ def splitGybLines(sourceLines):
     >>> src[s[1]]
     '        print 1\n'
     """
-    lastTokenText,lastTokenKind = None,None
+    lastTokenText, lastTokenKind = None, None
     unmatchedIndents = []
 
     dedents = 0
     try:
         for tokenKind, tokenText, tokenStart, (tokenEndLine, tokenEndCol), lineText \
-            in tokenize.generate_tokens(lambda i=iter(sourceLines): next(i)):
+                in tokenize.generate_tokens(lambda i=iter(sourceLines): next(i)):
 
             if tokenKind in (tokenize.COMMENT, tokenize.ENDMARKER):
                 continue
@@ -350,7 +350,7 @@ def codeStartsWithDedentKeyword(sourceLines):
     """
     tokenText = None
     for tokenKind, tokenText, _, _, _ \
-        in tokenize.generate_tokens(lambda i=iter(sourceLines): next(i)):
+            in tokenize.generate_tokens(lambda i=iter(sourceLines): next(i)):
 
         if tokenKind != tokenize.COMMENT and tokenText.strip() != '':
             break
@@ -533,7 +533,7 @@ class ExecutionContext:
     def appendText(self, text, file, line):
         # see if we need to inject a line marker
         if self.lineDirective:
-            if (file,line) != self.lastFileLine:
+            if (file, line) != self.lastFileLine:
                 # We can only insert the line directive at a line break
                 if len(self.resultText) == 0 \
                    or self.resultText[-1].endswith('\n'):

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -513,7 +513,6 @@ class ParseContext:
             else:
                 yield self.tokenKind
 
-
     def nextToken(self):
         """Move to the next token"""
         for kind in self.tokens:

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -231,7 +231,8 @@ def tokenizeTemplate(templateText):
         if kind in ('literal', 'symbol'):
             if len(savedLiteral) == 0:
                 literalFirstMatch = m
-            savedLiteral.append(text) # literals and symbols get batched together
+            # literals and symbols get batched together
+            savedLiteral.append(text)
             pos = None
         else:
             # found a non-literal.  First yield any literal we've accumulated
@@ -248,7 +249,8 @@ def tokenizeTemplate(templateText):
         if pos is None:
             pos = m.end(0)
         else:
-            yield # Client is not yet ready to process next token
+            # Client is not yet ready to process next token
+            yield
 
     if savedLiteral != []:
         yield 'literal', ''.join(savedLiteral), literalFirstMatch
@@ -328,7 +330,8 @@ def splitGybLines(sourceLines):
             lastTokenText, lastTokenKind = tokenText, tokenKind
 
     except tokenize.TokenError:
-        return [] # Let the later compile() call report the error
+        # Let the later compile() call report the error
+        return []
 
     if lastTokenText == ':':
         unmatchedIndents.append(len(sourceLines))
@@ -459,7 +462,8 @@ class ParseContext:
             # Do we need to close the current lines?
             self.closeLines = kind == 'gybLinesClose'
 
-            if kind.endswith('Open'): # %{...}% and ${...} constructs
+            # %{...}% and ${...} constructs
+            if kind.endswith('Open'):
 
                 # Tokenize text that follows as Python up to an unmatched '}'
                 codeStart = self.tokenMatch.end(kind)
@@ -478,7 +482,8 @@ class ParseContext:
                     nextPos = m2.end(0)
                 else:
                     assert kind == 'substitutionOpen'
-                    nextPos = closePos + 1 # skip past the closing '}'
+                    # skip past the closing '}'
+                    nextPos = closePos + 1
 
                 # Resume tokenizing after the end of the code.
                 baseTokens.send(nextPos)

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -58,7 +58,7 @@ def fline_map(filename):
 def map_line(filename, line_num):
     assert(line_num > 0)
     map = fline_map(filename)
-    index = bisect.bisect_left(map, (line_num,'',0))
+    index = bisect.bisect_left(map, (line_num, '', 0))
     base = map[index - 1]
     return base[1], base[2] + (line_num - base[0] - 1)
 

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -21,8 +21,7 @@ import re
 import bisect
 import subprocess
 
-line_pattern = re.compile(
- r'^// ###line ([0-9]+) "([^"]+)"\s*')
+line_pattern = re.compile(r'^// ###line ([0-9]+) "([^"]+)"\s*')
 
 def _make_line_map(filename, stream=None):
     """

--- a/utils/name-compression/CBCGen.py
+++ b/utils/name-compression/CBCGen.py
@@ -104,7 +104,8 @@ escape_char1 = 'J'
 
 # notice that Y and J are missing because they are escape chars:
 charset = r"0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIKLMNOPQRSTUVWXZ$"
-encoders = [c for c in charset] # alphabet without the escape chars.
+# alphabet without the escape chars.
+encoders = [c for c in charset]
 enc_len = len(encoders)
 
 # Take the most frequent entries from the table that fit into the range of

--- a/utils/name-compression/CBCGen.py
+++ b/utils/name-compression/CBCGen.py
@@ -10,6 +10,8 @@ if len(filenames) == 0:
   sys.exit(1)
 
 hist = defaultdict(int)
+
+
 def collect_top_entries(val):
   """
   Collect the most frequent substrings and organize them in a table.
@@ -153,7 +155,7 @@ class Trie:
     """
     sb = ""
     space = " " * depth
-    for opt,node in self.children.iteritems():
+    for opt, node in self.children.iteritems():
       sb += space + "if ((%d < n) && (str[%d] == '%s')) {\n" % (depth, depth, opt)
       sb += space + node.generate(depth + 1)
       sb += space + "}\n"
@@ -186,13 +188,13 @@ print "namespace CBC {"
 print "// The charset that the fragment indices can use:"
 print "const unsigned CharsetLength = %d;" % len(charset)
 print "const char *Charset = \"%s\";" % charset
-print "const int IndexOfChar[] =  {", ",".join(index_of_char),"};"
+print "const int IndexOfChar[] =  {", ",".join(index_of_char), "};"
 print "const char EscapeChar0 = '%s';" % escape_char0
 print "const char EscapeChar1 = '%s';" % escape_char1
 print "// The Fragments:"
 print "const unsigned NumFragments = ", len(string_key_list), ";"
-print "const char* CodeBook[] = {", ",".join(string_key_list),"};"
-print "const unsigned CodeBookLen[] = {", ",".join(string_length_table),"};"
+print "const char* CodeBook[] = {", ",".join(string_key_list), "};"
+print "const unsigned CodeBookLen[] = {", ",".join(string_length_table), "};"
 print TrieHead.generateHeader()
 print TrieHead.generate(0)
 print TrieHead.generateFooter()

--- a/utils/name-compression/HuffGen.py
+++ b/utils/name-compression/HuffGen.py
@@ -31,10 +31,14 @@ sorted_chars = sorted(hist.items(), key=lambda x: x[1] * len(x[0]), reverse=True
 class Node:
   """ This is a node in the Huffman tree """
   def __init__(self, hits, value=None, l=None, r=None):
-    self.hit = hits  # Number of occurrences for this node.
-    self.left = l    # Left subtree.
-    self.right = r   # Right subtree.
-    self.val = value # Character value for leaf nodes.
+    # Number of occurrences for this node.
+    self.hit = hits
+    # Left subtree.
+    self.left = l
+    # Right subtree.
+    self.right = r
+    # Character value for leaf nodes.
+    self.val = value
 
   def merge(Left, Right):
     """ This is the merge phase of the huffman encoding algorithm

--- a/utils/name-compression/HuffGen.py
+++ b/utils/name-compression/HuffGen.py
@@ -104,7 +104,7 @@ charset = r"0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$"
 nodes = []
 for c in sorted_chars:
   if c[0] in charset:
-    n = Node(c[1],c[0])
+    n = Node(c[1], c[0])
     heappush(nodes, n)
 
 # This is the Merge phase of the Huffman algorithm:
@@ -135,8 +135,8 @@ print "// The charset that the fragment indices can use:"
 print "const unsigned CharsetLength = %d;" % len(charset)
 print "const unsigned LongestEncodingLength = %d;" % (nodes[0].getMaxEncodingLength())
 print "const char *Charset = \"%s\";" % charset
-print "const int IndexOfChar[] =  {", ",".join(index_of_char),"};"
+print "const int IndexOfChar[] =  {", ",".join(index_of_char), "};"
 print "std::pair<char, unsigned> variable_decode(uint64_t tailbits) {\n", nodes[0].generate_decoder(0), "\n assert(false); return {0, 0};\n}"
-print "void variable_encode(uint64_t &bits, uint64_t &num_bits, char ch) {\n", nodes[0].generate_encoder([]),"assert(false);\n}"
+print "void variable_encode(uint64_t &bits, uint64_t &num_bits, char ch) {\n", nodes[0].generate_encoder([]), "assert(false);\n}"
 print "} // namespace"
 print "#endif /* SWIFT_MANGLER_HUFFMAN_H */"

--- a/utils/pass-pipeline/src/pass_pipeline.py
+++ b/utils/pass-pipeline/src/pass_pipeline.py
@@ -6,6 +6,8 @@ class Pass(object):
         return "<pass name=%s>" % self.name
 
 PassListId = 0
+
+
 class PassList(object):
     def __init__(self, transforms):
         global PassListId

--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -78,7 +78,8 @@ def ssapass_passlist(optlevel):
         p.SILCombine,
         simplifycfg_silcombine_passlist(),
         p.GlobalLoadStoreOpts,
-        p.CodeMotion, # Need to add proper argument here
+        # Need to add proper argument here
+        p.CodeMotion,
         p.GlobalARCOpts,
         p.SpeculativeDevirtualizer,
         p.SILLinker,

--- a/utils/pre-commit-benchmark
+++ b/utils/pre-commit-benchmark
@@ -70,7 +70,12 @@ def getWorkTreeSha():
 def buildBenchmarks(cacheDir, build_script_args):
     print('Building executables...')
 
-    configVars = {'SWIFT_INCLUDE_BENCHMARKS':'TRUE', 'SWIFT_INCLUDE_PERF_TESTSUITE':'TRUE', 'SWIFT_STDLIB_BUILD_TYPE':'RelWithDebInfo', 'SWIFT_STDLIB_ASSERTIONS':'FALSE'}
+    configVars = {
+        'SWIFT_INCLUDE_BENCHMARKS': 'TRUE',
+        'SWIFT_INCLUDE_PERF_TESTSUITE': 'TRUE',
+        'SWIFT_STDLIB_BUILD_TYPE': 'RelWithDebInfo',
+        'SWIFT_STDLIB_ASSERTIONS': 'FALSE'
+    }
 
     cmakeCache = os.path.join(buildDir, 'CMakeCache.txt')
 
@@ -227,9 +232,9 @@ def compareTimingsFiles(file1, file2):
         print(file1, "/", file2)
 
     rows = [["benchmark"]]
-    for i in range(0,runs):
+    for i in range(0, runs):
         rows[0].append("baserun%d" % i)
-    for i in range(0,runs):
+    for i in range(0, runs):
         rows[0].append("optrun%d" % i)
     rows[0] += ["delta", "speedup"]
 

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -134,7 +134,8 @@ for m in re.finditer(protocolsAndOperators, sourceSansComments, reFlags):
 
 # Find clusters of protocols that have the same name when underscores
 # are stripped
-clusterBuilder = {} # map from potential cluster name to nodes in the cluster
+# map from potential cluster name to nodes in the cluster
+clusterBuilder = {}
 for n in graph:
     clusterBuilder.setdefault(n.translate(None, '_'), set()).add(n)
 
@@ -148,7 +149,8 @@ clusterEdges = set(
     for t in graph[s] if t in elements)
 
 print('digraph ProtocolHierarchies {')
-print('  mclimit = 100; ranksep=1.5; ') # ; packmode="array1"
+# ; packmode="array1"
+print('  mclimit = 100; ranksep=1.5; ')
 print('  edge [dir="back"];')
 print('  node [shape = box, fontname = Helvetica, fontsize = 10];')
 

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -43,7 +43,7 @@ def merge_lipo_files(src_root_dirs, file_list, copy_verbatim_subpaths,
     corresponding subdirectory in dest_root_dir. If the subdirectory path matches
     copy_verbatim_subpaths, the whole subdirectory is recursively copied verbatim.
     """
-    lipo_cmd = [lipo_executable,"-create"]
+    lipo_cmd = [lipo_executable, "-create"]
 
     for file in file_list:
         file_paths = [os.path.join(dir, file) for dir in src_root_dirs

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -142,7 +142,6 @@ def main():
         print("--verify-build-dir and --verify-xcode can't be used together")
         return 1
 
-
     if args.verify_build_dir is not None:
         commands = get_verify_build_dir_commands(args.verify_build_dir)
 

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -37,8 +37,8 @@ def capture_with_result(args, include_stderr=False):
             sys.exit('no such file or directory: %r when running %s.' % (
                 args[0], ' '.join(args)))
         raise
-    out,_ = p.communicate()
-    return out,p.wait()
+    out, _ = p.communicate()
+    return out, p.wait()
 
 def capture(args, include_stderr=False):
     """capture(command) - Run the given command (or argv list) in a shell and
@@ -119,10 +119,10 @@ def main():
    lnt_results['Machine'] = {
       'Name': machine_name,
       'Info': {
-         'hardware': capture(["uname","-m"], include_stderr=True).strip(),
-         'name': capture(["uname","-n"], include_stderr=True).strip(),
-         'os': capture(["uname","-sr"], include_stderr=True).strip(),
-         'uname': capture(["uname","-a"], include_stderr=True).strip(),
+         'hardware': capture(["uname", "-m"], include_stderr=True).strip(),
+         'name': capture(["uname", "-n"], include_stderr=True).strip(),
+         'os': capture(["uname", "-sr"], include_stderr=True).strip(),
+         'uname': capture(["uname", "-a"], include_stderr=True).strip(),
       }
    }
 
@@ -149,7 +149,7 @@ def main():
          continue
 
       # Extract the test name, which is encoded as 'suite :: name'.
-      test_name = 'nts.%s' % (test['name'].split('::',1)[1][1:],)
+      test_name = 'nts.%s' % (test['name'].split('::', 1)[1][1:],)
 
       # Convert this test to the 'nts' schema.
       compile_success = test['metrics'].get('compile_success', 1)

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -117,26 +117,26 @@ def main():
    # Create the LNT report format.
    lnt_results = {}
    lnt_results['Machine'] = {
-      'Name': machine_name,
-      'Info': {
-         'hardware': capture(["uname", "-m"], include_stderr=True).strip(),
-         'name': capture(["uname", "-n"], include_stderr=True).strip(),
-         'os': capture(["uname", "-sr"], include_stderr=True).strip(),
-         'uname': capture(["uname", "-a"], include_stderr=True).strip(),
-      }
+       'Name': machine_name,
+       'Info': {
+           'hardware': capture(["uname", "-m"], include_stderr=True).strip(),
+           'name': capture(["uname", "-n"], include_stderr=True).strip(),
+           'os': capture(["uname", "-sr"], include_stderr=True).strip(),
+           'uname': capture(["uname", "-a"], include_stderr=True).strip(),
+       }
    }
 
    # FIXME: Record source versions for LLVM, Swift, etc.?
    lnt_results['Run'] = {
-      'Start Time': start_time.strftime('%Y-%m-%d %H:%M:%S'),
-      'End Time': end_time.strftime('%Y-%m-%d %H:%M:%S'),
-      'Info': {
-         '__report_version__': '1',
-         'tag': 'nts',
-         'inferred_run_order': run_order,
-         'run_order': run_order,
-         'sw_vers': capture(['sw_vers'], include_stderr=True).strip(),
-      }
+       'Start Time': start_time.strftime('%Y-%m-%d %H:%M:%S'),
+       'End Time': end_time.strftime('%Y-%m-%d %H:%M:%S'),
+       'Info': {
+           '__report_version__': '1',
+           'tag': 'nts',
+           'inferred_run_order': run_order,
+           'run_order': run_order,
+           'sw_vers': capture(['sw_vers'], include_stderr=True).strip(),
+       }
    }
 
    lnt_results['Tests'] = lnt_tests = []

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -59,18 +59,15 @@ class SwiftBenchHarness:
   minIterTime = 1
   optFlags = []
 
-
   def log(self, str, level):
     if self.verboseLevel >= level:
       for _ in range(1, level):
         sys.stdout.write('  ')
       print(str)
 
-
   def runCommand(self, cmd):
     self.log('    Executing: ' + ' '.join(cmd), 1)
     return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-
 
   def parseArguments(self):
     self.log("Parsing arguments.", 2)
@@ -101,7 +98,6 @@ class SwiftBenchHarness:
     self.log("Verbosity: %s." % self.verboseLevel, 3)
     self.log("Time limit: %s." % self.timeLimit, 3)
     self.log("Min sample time: %s." % self.minSampleTime, 3)
-
 
   def processSource(self, name):
     self.log("Processing source file: %s." % name, 2)
@@ -199,12 +195,10 @@ main()
     for n in testNames:
       self.tests[name + ":" + n].processedSource = processedName
 
-
   def processSources(self):
     self.log("Processing sources: %s." % self.sources, 2)
     for s in self.sources:
       self.processSource(s)
-
 
   def compileOpaqueCFile(self):
     self.log("Generating and compiling C file with opaque functions.", 3)
@@ -234,19 +228,16 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
     self.tests[name].status = status
     self.tests[name].output = output
 
-
   def compileSources(self):
     self.log("Compiling processed sources.", 2)
     self.compileOpaqueCFile()
     for t in self.tests:
       self.compileSource(t)
 
-
   def runBenchmarks(self):
     self.log("Running benchmarks.", 2)
     for t in self.tests:
       self.runBench(t)
-
 
   def parseBenchmarkOutput(self, res):
     # Parse lines like
@@ -257,7 +248,6 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
     if not m:
       return ("", 0, 0)
     return (m.group(1), m.group(2), m.group(3))
-
 
   def computeItersNumber(self, name):
     scale = 1
@@ -290,7 +280,6 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
       samples = 1
     return (samples, scale)
 
-
   def runBench(self, name):
     if not self.tests[name].status == "":
       return
@@ -315,7 +304,6 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
         break
     res = TestResults(name, samples)
     self.tests[name].results = res
-
 
   def reportResults(self):
     self.log("\nReporting results.", 2)

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -259,7 +259,8 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
         r = self.runCommand([self.tests[name].binary, str(scale),
                              self.tests[name].name])
         (testName, itersComputed, execTime) = self.parseBenchmarkOutput(r)
-        spent = int(execTime) / 1000000 # Convert ns to ms
+        # Convert ns to ms
+        spent = int(execTime) / 1000000
         if spent <= self.minIterTime:
           scale *= 2
         if scale > sys.maxint:

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -125,9 +125,7 @@ def main():
             curBlock.addLine(line)
             blocks[blockName] = curBlock
 
-
     # Add empty blocks which we didn't see, but which are referenced.
-
     newBlocks = {}
     for name, block in blocks.iteritems():
         for adjName in (block.preds + block.getSuccs()):


### PR DESCRIPTION
This is a follow-up to PR #1003.

The Python code in the project is now in fairly good shape PEP8-wise. This PR fixes the last violation classes that can be fixed without introducing large diffs that would span many lines of code and hence mess up `git blame`, etc.

After the merge of this PR only six violation classes are left in the code base :+1: 

Fixed in this PR:
- continuation line under-indented for hanging indent (E121)
- continuation line with same indent as next logical line (E125)
- missing whitespace after ',' or ':' (E231)
- at least two spaces before inline comment (E261)
- too many blank lines (E303)
