### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::getGenericSignature(…)

### DIFF
--- a/validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class A{
+var f=F>
+struct B<d{extension{enum S<T where h:A{extension{protocol A:a{func>


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1942: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
8  swift           0x0000000000effbe4 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 1620
9  swift           0x0000000000e2346c swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 332
10 swift           0x0000000000e23764 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
11 swift           0x0000000000dfeab2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
12 swift           0x0000000000ffa25d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2237
13 swift           0x0000000000e258bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
16 swift           0x0000000000e4f1be swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
18 swift           0x0000000000e50124 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift           0x0000000000e4f0ca swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
20 swift           0x0000000000eddff2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
21 swift           0x0000000000edd27d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
22 swift           0x0000000000edd409 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
23 swift           0x0000000000dfb710 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
24 swift           0x0000000000efb811 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
27 swift           0x0000000000efd3af swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
28 swift           0x0000000000efb57b swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
29 swift           0x0000000000efb2fc swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
30 swift           0x0000000000e21b77 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
31 swift           0x0000000000e233af swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
32 swift           0x0000000000e23764 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
33 swift           0x0000000000dfee30 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
34 swift           0x0000000000dfea10 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 192
37 swift           0x0000000000ff3262 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
38 swift           0x0000000000ffa917 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3959
39 swift           0x0000000000e258bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
40 swift           0x0000000000de17e4 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 100
44 swift           0x0000000000f6542e swift::Expr::walk(swift::ASTWalker&) + 46
45 swift           0x0000000000de2d07 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
46 swift           0x0000000000de92b9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
47 swift           0x0000000000dea430 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
48 swift           0x0000000000dea5d9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
53 swift           0x0000000000e041d6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
54 swift           0x0000000000dd0542 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
55 swift           0x0000000000c7bb2f swift::CompilerInstance::performSema() + 2975
57 swift           0x00000000007753d7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
58 swift           0x000000000076ffb5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28234-swift-archetypebuilder-getgenericsignature-17b60f.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift:8:1
2.  While type-checking expression at [validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift:9:7 - line:9:8] RangeText="F>"
3.  While resolving type a at [validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift:10:62 - line:10:62] RangeText="a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
