### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::addSameTypeRequirementToConcrete(…)

### DIFF
--- a/validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
+++ b/validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+struct c:protocol A{typealias f{}func g:B
+class B<T where f.h:b,f=c


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000efcd50 swift::ArchetypeBuilder::addSameTypeRequirementToConcrete(swift::ArchetypeBuilder::PotentialArchetype*, swift::Type, swift::RequirementSource) + 944
5  swift           0x0000000000efd61f swift::ArchetypeBuilder::addSameTypeRequirement(swift::Type, swift::Type, swift::RequirementSource) + 175
6  swift           0x0000000000efd7a0 swift::ArchetypeBuilder::addRequirement(swift::RequirementRepr const&) + 80
7  swift           0x0000000000e222d8 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 872
8  swift           0x0000000000e2392f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
9  swift           0x0000000000e23ce4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
10 swift           0x0000000000dfeac2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
11 swift           0x0000000000ffbdac swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2908
12 swift           0x0000000000ffa750 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
13 swift           0x0000000000e25e3b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
16 swift           0x0000000000e4f51e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
18 swift           0x0000000000e50484 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift           0x0000000000e4f42a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
21 swift           0x0000000000e224ec swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
26 swift           0x0000000000e041e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000dd0552 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
28 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
30 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
31 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28235-swift-archetypebuilder-addsametyperequirementtoconcrete-e4ca47.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift:7:10
2.  While resolving type B at [validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift:7:41 - line:7:41] RangeText="B"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
