### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::typeCheckDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28236-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers/28236-swift-typebase-getmembersubstitutions.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class d<T:d{class B{let A{protocol a{func i(T.B


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:3989: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
12 swift           0x0000000000e041e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000e49b0a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
16 swift           0x0000000000e4995e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
17 swift           0x0000000000e4a528 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
19 swift           0x0000000000dd0652 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
20 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
22 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
23 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28236-swift-typebase-getmembersubstitutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28236-swift-typebase-getmembersubstitutions-699297.o
1.  While type-checking getter for A at validation-test/compiler_crashers/28236-swift-typebase-getmembersubstitutions.swift:8:26
2.  While type-checking 'a' at validation-test/compiler_crashers/28236-swift-typebase-getmembersubstitutions.swift:8:27
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
