### PR TITLE
[SR-610][Stdlib] Use for-in to iterate over CollectionType elements

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -3963,7 +3963,13 @@ public struct Defaulted${traversal}RangeReplaceableSlice<Element>
   }
 
   public func generate() -> MinimalGenerator<Element> {
-    return MinimalGenerator(Array(self))
+    var array: [Element] = []
+    var index = startIndex
+    while index != endIndex {
+      array.append(self[index])
+      index = index.successor()
+    }
+    return MinimalGenerator(array)
   }
 
   public subscript(index: Index) -> Element {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -603,16 +603,7 @@ internal func _copyCollectionToNativeArrayBuffer<
     count: numericCast(count),
     minimumCapacity: 0
   )
-
-  var p = result.firstElementAddress
-  var i = source.startIndex
-  for _ in 0..<count {
-    // FIXME(performance): use _initializeTo().
-    p.initialize(source[i])
-    i._successorInPlace()
-    p._successorInPlace()
-  }
-  _expectEnd(i, source)
+  source._initializeTo(result.firstElementAddress)
   return result
 }
 


### PR DESCRIPTION
The Generator interface is specialized for iteration and is often faster than indexing.

https://bugs.swift.org/browse/SR-610
