### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::addGenericParameter(…)

### DIFF
--- a/validation-test/compiler_crashers/28237-swift-archetypebuilder-addgenericparameter.swift
+++ b/validation-test/compiler_crashers/28237-swift-archetypebuilder-addgenericparameter.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{<f}class B<a{protocol a{enum S<A{extension{protocol a{func<


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:721: swift::ArchetypeBuilder::PotentialArchetype *swift::ArchetypeBuilder::addGenericParameter(swift::GenericTypeParamType *, swift::ProtocolDecl *, swift::Identifier): Assertion `!Impl->PotentialArchetypes[Key]' failed.
9  swift           0x0000000000efb4f6 swift::ArchetypeBuilder::addGenericParameter(swift::GenericTypeParamDecl*) + 246
10 swift           0x0000000000e22071 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 257
11 swift           0x0000000000e2392f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
12 swift           0x0000000000e23ce4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
13 swift           0x0000000000dfee40 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
14 swift           0x0000000000dfea20 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 192
17 swift           0x0000000000ff36c2 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
18 swift           0x0000000000ffad77 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3959
19 swift           0x0000000000e25e3b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
20 swift           0x0000000000de17f4 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 100
25 swift           0x0000000000f6578e swift::Expr::walk(swift::ASTWalker&) + 46
26 swift           0x0000000000de2d17 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
27 swift           0x0000000000de92c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
29 swift           0x0000000000e4af86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
30 swift           0x0000000000dd05bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1597
31 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
33 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
34 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28237-swift-archetypebuilder-addgenericparameter.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28237-swift-archetypebuilder-addgenericparameter-cd9b72.o
1.  While type-checking expression at [validation-test/compiler_crashers/28237-swift-archetypebuilder-addgenericparameter.swift:8:1 - line:8:4] RangeText="{<f}"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
