### PR TITLE
[Parser] Fix-it for declaration attributes being applied to parameter types (SR-215)

### DIFF
--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -2,6 +2,8 @@
 
 @noescape var fn : () -> Int = { 4 }  // expected-error {{@noescape may only be used on 'parameter' declarations}} {{1-11=}}
 
+func appliedToType(g: @noescape ()->Void) { g() }  // expected-error {{attribute can only be applied to declarations, not types}} {{20-20=@noescape }} {{23-33=}}
+
 func doesEscape(fn : () -> Int) {}
 
 func takesGenericClosure<T>(a : Int, @noescape _ fn : () -> T) {}


### PR DESCRIPTION
Original PR #673 but reverted due to test failures. Test failures should be fixed in this PR. Original description as follows:

As described in [SR-215](https://bugs.swift.org/browse/SR-215), previously the fix-it was suggesting that declaration attributes applied to parameter types be moved to before the function `func` declaration itself. 

This pull request fixes this so that it is instead moved to before the parameter name. 
