### PR TITLE
[Sema] Further improvement of diagnoses on args to generic functions

### DIFF
--- a/test/1_stdlib/StringDiagnostics.swift
+++ b/test/1_stdlib/StringDiagnostics.swift
@@ -46,7 +46,7 @@ func testAmbiguousStringComparisons(s: String) {
 func acceptsSequence<S : SequenceType>(sequence: S) {}
 
 func testStringIsNotASequence(s: String) {
-  acceptsSequence(s) // expected-error {{cannot invoke 'acceptsSequence' with an argument list of type '(String)'}} expected-note {{expected an argument list of type '(S)'}}
+  acceptsSequence(s) // expected-error {{argument type 'String' does not conform to expected type 'SequenceType'}}
 }
 
 func testStringDeprecation(hello: String) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -47,8 +47,7 @@ f0(i, i,
 
 
 // Position mismatch
-f5(f4)  // expected-error {{cannot invoke 'f5' with an argument list of type '((Int) -> Int)'}}
-// expected-note @-1 {{expected an argument list of type '(T)'}}
+f5(f4)  // expected-error {{argument type '(Int) -> Int' does not conform to expected type 'P2'}}
 
 // Tuple element not convertible.
 f0(i,
@@ -75,8 +74,7 @@ i.wobble() // expected-error{{value of type 'Int' has no member 'wobble'}}
 "awfawf".doesntExist(0)   // expected-error {{value of type 'String' has no member 'doesntExist'}}
 
 // Does not conform to protocol.
-f5(i)  // expected-error {{cannot invoke 'f5' with an argument list of type '(Int)'}}
-// expected-note @-1 {{expected an argument list of type '(T)'}}
+f5(i)  // expected-error {{argument type 'Int' does not conform to expected type 'P2'}}
 
 // Make sure we don't leave open existentials when diagnosing.
 // <rdar://problem/20598568>

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -205,7 +205,7 @@ extension Int : IsBefore {
 
 func callMin(x: Int, y: Int, a: Float, b: Float) {
   min2(x, y)
-  min2(a, b) // expected-error{{cannot invoke 'min2' with an argument list of type '(Float, Float)'}} expected-note {{expected an argument list of type '(T, T)'}}
+  min2(a, b) // expected-error{{argument type 'Float' does not conform to expected type 'IsBefore'}}
 }
 
 func rangeOfIsBefore<  // expected-note {{in call to function 'rangeOfIsBefore'}}
@@ -294,7 +294,7 @@ func foo() {
     for i in min(1,2) { // expected-error{{type 'Int' does not conform to protocol 'SequenceType'}}
     }
     let j = min(Int(3), Float(2.5)) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
-    let k = min(A(), A()) // expected-error{{cannot invoke 'min' with an argument list of type '(A, A)'}} expected-note{{expected an argument list of type '(T, T)'}}
+    let k = min(A(), A()) // expected-error{{argument type 'A' does not conform to expected type 'Comparable'}}
     let oi : Int? = 5
     let l = min(3, oi) // expected-error{{value of optional type 'Int?' not unwrapped; did you mean to use '!' or '?'?}}
 }

--- a/test/decl/enum/objc_enum_errortype.swift
+++ b/test/decl/enum/objc_enum_errortype.swift
@@ -24,5 +24,4 @@ acceptBridgeableNSError(E2.A)
 }
 
 acceptBridgeableNSError(E3.A)
-// expected-error@-1{{cannot invoke 'acceptBridgeableNSError' with an argument list of type '(E3)'}}
-// expected-note@-2{{expected an argument list of type '(E)'}}
+// expected-error@-1{{argument type 'E3' does not conform to expected type '_ObjectiveCBridgeableErrorType'}}


### PR DESCRIPTION
If the mismatched argument is on an archetype param, check to see whether the argument conforms to all of the protocols on the archetype, using a specific does-not-conform diagnosis if one or more protocols fail.

Also added another closeness class `CC_GenericNonsubstitutableMismatch`, which happens when more than one argument is a mismatch, but all the failing arguments are of the same type and mismatch only because of substitutability. This closeness is farther away than normal `CC_ArgumentMismatch` so that if we note expected matches, we’ll prefer non-generic matches. But if this is the result, we can still produce the specific conforms-to-protocol diagnosis (since, in a sense, it’s only one type of argument that is wrong even though it is multiple arguments).
