### PR TITLE
[test] Mark tests unsupported on all Linux flavors

### DIFF
--- a/test/ClangModules/autolinking.swift
+++ b/test/ClangModules/autolinking.swift
@@ -11,7 +11,11 @@
 // RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -disable-autolink-framework LinkFramework -o %t/with-disabled.ll
 // RUN: FileCheck --check-prefix=CHECK-WITH-DISABLED %s < %t/with-disabled.ll
 
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
 
 import LinkMusket
 import LinkFramework

--- a/test/Frontend/embed-bitcode.swift
+++ b/test/Frontend/embed-bitcode.swift
@@ -4,7 +4,11 @@
 // RUN: llvm-objdump -macho -section="__LLVM,__bitcode" %t.o | FileCheck -check-prefix=MARKER %s
 // RUN: llvm-objdump -macho -section="__LLVM,__swift_cmdline" %t.o | FileCheck -check-prefix=MARKER-CMD %s
 
+// This file tests Mach-O file output, but Linux variants do not produce Mach-O
+// files.
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
 
 // MARKER: Contents of (__LLVM,__bitcode) section
 // MARKER-NEXT: 00

--- a/test/Interpreter/repl_autolinking.swift
+++ b/test/Interpreter/repl_autolinking.swift
@@ -8,6 +8,8 @@
 
 // REQUIRES: swift_repl
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
 
 // This test checks that autolinking works in the REPL.
 

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -20,7 +20,11 @@
 // RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name someModule -module-link-name module %S/../Inputs/empty.swift -autolink-force-load | FileCheck --check-prefix=FORCE-LOAD %s
 // RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name someModule -module-link-name 0module %S/../Inputs/empty.swift -autolink-force-load | FileCheck --check-prefix=FORCE-LOAD-HEX %s
 
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
 // UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
 
 import someModule
 


### PR DESCRIPTION
Autolinking was added to the frontend in 22912bc3b. It was disabled on Linux in 198402dcf, and further constrained to be disabled on "linux-gnu" in 83b4384fa. Since then, more flavors of Linux have become supported by Swift: "linux-gnueabihf" in 4bf81e09d, and "freebsd" in f41b791d4.

Autolinking most likely does not work on any of these platforms, so mark it as unsupported for now.

---

_Why_ this test is not supported on Linux is beyond my depth. Advice on how to support this test in the future would be greatly appreciated!

/cc @hpux735 
