### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28238-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28238-swift-typechecker-validatedecl.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class B<T:B{class B<class b{}func b(T.B


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:3989: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
10 swift           0x0000000000dfec6c swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 780
14 swift           0x0000000000e041e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000dd0552 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
16 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
18 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
19 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28238-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28238-swift-typechecker-validatedecl-7b74ed.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28238-swift-typechecker-validatedecl.swift:8:1
2.  While type-checking 'b' at validation-test/compiler_crashers/28238-swift-typechecker-validatedecl.swift:8:30
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
