### PR TITLE
[swiftc] Add test case for crash triggered in swift::DeclContext::lookupQualified(…)

### DIFF
--- a/validation-test/compiler_crashers/28239-swift-declcontext-lookupqualified.swift
+++ b/validation-test/compiler_crashers/28239-swift-declcontext-lookupqualified.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+for in.f=Swift.dynamicType.e.n


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/NameLookup.cpp:1095: bool swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver *, SmallVectorImpl<swift::ValueDecl *> &) const: Assertion `!(options & NL_IgnoreAccessibility) && "accessibility always enforced for module-level lookup"' failed.
8  swift           0x0000000000ffcc0b swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 6603
10 swift           0x0000000000e26882 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclName, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 386
11 swift           0x0000000000ec4f9a swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclName, swift::Type, swift::constraints::ConstraintLocator*, bool) + 4058
12 swift           0x0000000000e8fca0 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 6320
13 swift           0x0000000000e92e9e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
14 swift           0x0000000000de2f35 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
15 swift           0x0000000000de92c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
20 swift           0x0000000000f6577e swift::Expr::walk(swift::ASTWalker&) + 46
21 swift           0x0000000000fd1aeb swift::Expr::forEachImmediateChildExpr(std::function<swift::Expr* (swift::Expr*)> const&) + 43
23 swift           0x0000000000e8e459 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
24 swift           0x0000000000e92e9e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
25 swift           0x0000000000de2f35 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
26 swift           0x0000000000de92c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
29 swift           0x0000000000e8e459 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
30 swift           0x0000000000e92e9e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
31 swift           0x0000000000de2f35 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
32 swift           0x0000000000de92c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
33 swift           0x0000000000dea78c swift::TypeChecker::typeCheckForEachBinding(swift::DeclContext*, swift::ForEachStmt*) + 76
36 swift           0x0000000000e4af86 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
37 swift           0x0000000000dd05bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1597
38 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
40 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
41 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28239-swift-declcontext-lookupqualified.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28239-swift-declcontext-lookupqualified-f99ef7.o
1.  While type-checking expression at [validation-test/compiler_crashers/28239-swift-declcontext-lookupqualified.swift:8:7 - line:8:30] RangeText=".f=Swift.dynamicType.e.n"
2.  While type-checking expression at [validation-test/compiler_crashers/28239-swift-declcontext-lookupqualified.swift:8:10 - line:8:30] RangeText="Swift.dynamicType.e.n"
3.  While type-checking expression at [validation-test/compiler_crashers/28239-swift-declcontext-lookupqualified.swift:8:10 - line:8:28] RangeText="Swift.dynamicType.e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
