### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::addRequirement(…)

### DIFF
--- a/validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+struct B<g:a{}protocol a{typealias e:a{}typealias f:a


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1235: void swift::ArchetypeBuilder::addRequirement(const swift::Requirement &, swift::RequirementSource): Assertion `!invalid && "Re-introducing invalid requirement"' failed.
8  swift           0x0000000000efdff3 swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) + 595
9  swift           0x0000000000eff843 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, bool, bool) + 531
10 swift           0x0000000000e21fbd swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 77
12 swift           0x0000000000e224ec swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
15 swift           0x0000000000e041e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000e601e1 swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 1265
17 swift           0x0000000000e0a88e swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) + 334
18 swift           0x0000000000e099a0 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1440
21 swift           0x0000000000e041e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift           0x0000000000dd0552 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
23 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
25 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
26 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28240-swift-archetypebuilder-addrequirement-8229a1.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift:8:1
2.  While defining default constructor for 'B' at validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift:8:1
3.  While type-checking 'init' at validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift:8:8
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
