### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::isAccessibleFrom(…)

### DIFF
--- a/validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift
+++ b/validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class B<T,T where k:a{func b{var _=B<T{


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2211: swift::Accessibility swift::ValueDecl::getFormalAccess() const: Assertion `hasAccessibility() && "accessibility not computed yet"' failed.
8  swift           0x0000000000ff7f66 swift::ValueDecl::isAccessibleFrom(swift::DeclContext const*) const + 102
13 swift           0x0000000000e8e459 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
14 swift           0x0000000000e92e9e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
15 swift           0x0000000000de2f35 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
16 swift           0x0000000000de92c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
21 swift           0x0000000000e8e459 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
22 swift           0x0000000000e92e9e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
23 swift           0x0000000000de2f35 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
24 swift           0x0000000000de92c9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
25 swift           0x0000000000dea440 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
26 swift           0x0000000000dea5e9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
29 swift           0x0000000000e041e6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
32 swift           0x0000000000e49b0a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
33 swift           0x0000000000e4995e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
34 swift           0x0000000000e4a528 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
36 swift           0x0000000000dd0652 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
37 swift           0x0000000000c7bb3f swift::CompilerInstance::performSema() + 2975
39 swift           0x0000000000775527 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
40 swift           0x0000000000770105 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28241-swift-valuedecl-isaccessiblefrom-be322e.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift:8:23
2.  While type-checking declaration 0x4ab1398 at validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift:8:30
3.  While type-checking expression at [validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift:8:36 - line:8:39] RangeText="B<T{"
4.  While type-checking expression at [validation-test/compiler_crashers/28241-swift-valuedecl-isaccessiblefrom.swift:8:38 - line:8:39] RangeText="T{"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
