### PR TITLE
Fixes improving source ranges and implicit flags of AST nodes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4198,6 +4198,7 @@ public:
 class ParamDecl : public VarDecl {
   Identifier ArgumentName;
   SourceLoc ArgumentNameLoc;
+  SourceLoc LetVarInOutLoc;
 
   /// This is the type specified, including location information.
   TypeLoc typeLoc;
@@ -4216,7 +4217,7 @@ class ParamDecl : public VarDecl {
   DefaultArgumentKind defaultArgumentKind = DefaultArgumentKind::None;
   
 public:
-  ParamDecl(bool isLet, SourceLoc argumentNameLoc, 
+  ParamDecl(bool isLet, SourceLoc letVarInOutLoc, SourceLoc argumentNameLoc,
             Identifier argumentName, SourceLoc parameterNameLoc,
             Identifier parameterName, Type ty, DeclContext *dc);
 
@@ -4233,6 +4234,8 @@ public:
   /// The resulting source location will be valid if the argument name
   /// was specified separately from the parameter name.
   SourceLoc getArgumentNameLoc() const { return ArgumentNameLoc; }
+
+  SourceLoc getLetVarInOutLoc() const { return LetVarInOutLoc; }
   
   TypeLoc &getTypeLoc() { return typeLoc; }
   TypeLoc getTypeLoc() const { return typeLoc; }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -752,7 +752,7 @@ public:
     return Segments.front()->getStartLoc();
   }
   SourceLoc getEndLoc() const {
-    return Segments.front()->getEndLoc();
+    return Segments.back()->getEndLoc();
   }
   
   static bool classof(const Expr *E) {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -993,8 +993,7 @@ public:
   // Create an implicit TypeExpr, with location information even though it
   // shouldn't have one.  This is presently used to work around other location
   // processing bugs.  If you have an implicit location, use createImplicit.
-  static TypeExpr *createImplicitHack(SourceLoc StartLoc, Type Ty,
-                                      ASTContext &C, SourceLoc EndLoc);
+  static TypeExpr *createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C);
 
   
   /// Return a TypeExpr for a TypeDecl and the specified location.

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -993,7 +993,8 @@ public:
   // Create an implicit TypeExpr, with location information even though it
   // shouldn't have one.  This is presently used to work around other location
   // processing bugs.  If you have an implicit location, use createImplicit.
-  static TypeExpr *createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C);
+  static TypeExpr *createImplicitHack(SourceLoc StartLoc, Type Ty,
+                                      ASTContext &C, SourceLoc EndLoc);
 
   
   /// Return a TypeExpr for a TypeDecl and the specified location.

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -717,18 +717,14 @@ private:
 /// that cannot be spelled in the language proper.
 class FixedTypeRepr : public TypeRepr {
   Type Ty;
-  SourceLoc StartLoc;
-  SourceLoc EndLoc;
+  SourceLoc Loc;
 
 public:
   FixedTypeRepr(Type Ty, SourceLoc Loc)
-    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), StartLoc(Loc), EndLoc(Loc) {}
-
-  FixedTypeRepr(Type Ty, SourceLoc StartLoc, SourceLoc EndLoc)
-    : TypeRepr(TypeReprKind::Fixed), Ty(Ty),StartLoc(StartLoc),EndLoc(EndLoc) {}
+    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc) {}
 
   /// Retrieve the location.
-  SourceLoc getLoc() const { return StartLoc; }
+  SourceLoc getLoc() const { return Loc; }
 
   /// Retrieve the fixed type.
   Type getType() const { return Ty; }
@@ -739,8 +735,8 @@ public:
   static bool classof(const FixedTypeRepr *T) { return true; }
 
 private:
-  SourceLoc getStartLocImpl() const { return StartLoc; }
-  SourceLoc getEndLocImpl() const { return EndLoc; }
+  SourceLoc getStartLocImpl() const { return Loc; }
+  SourceLoc getEndLocImpl() const { return Loc; }
   void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
   friend class TypeRepr;
 };

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -717,14 +717,18 @@ private:
 /// that cannot be spelled in the language proper.
 class FixedTypeRepr : public TypeRepr {
   Type Ty;
-  SourceLoc Loc;
+  SourceLoc StartLoc;
+  SourceLoc EndLoc;
 
 public:
   FixedTypeRepr(Type Ty, SourceLoc Loc)
-    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), Loc(Loc) {}
+    : TypeRepr(TypeReprKind::Fixed), Ty(Ty), StartLoc(Loc), EndLoc(Loc) {}
+
+  FixedTypeRepr(Type Ty, SourceLoc StartLoc, SourceLoc EndLoc)
+    : TypeRepr(TypeReprKind::Fixed), Ty(Ty),StartLoc(StartLoc),EndLoc(EndLoc) {}
 
   /// Retrieve the location.
-  SourceLoc getLoc() const { return Loc; }
+  SourceLoc getLoc() const { return StartLoc; }
 
   /// Retrieve the fixed type.
   Type getType() const { return Ty; }
@@ -735,8 +739,8 @@ public:
   static bool classof(const FixedTypeRepr *T) { return true; }
 
 private:
-  SourceLoc getStartLocImpl() const { return Loc; }
-  SourceLoc getEndLocImpl() const { return Loc; }
+  SourceLoc getStartLocImpl() const { return StartLoc; }
+  SourceLoc getEndLocImpl() const { return EndLoc; }
   void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
   friend class TypeRepr;
 };

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -71,6 +71,7 @@ class Parser {
 
   bool IsInputIncomplete = false;
   SourceLoc DelayedDeclEnd;
+  std::vector<Token> SplitTokens;
 
 public:
   SourceManager &SourceMgr;
@@ -154,6 +155,8 @@ public:
   bool allowTopLevelCode() const {
     return SF.isScriptMode();
   }
+
+  std::vector<Token> &getSplitTokens() { return SplitTokens; }
 
   /// Returns true if the parser reached EOF with incomplete source input, due
   /// for example, a missing right brace.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -156,7 +156,9 @@ public:
     return SF.isScriptMode();
   }
 
-  std::vector<Token> &getSplitTokens() { return SplitTokens; }
+  const std::vector<Token> &getSplitTokens() { return SplitTokens; }
+
+  void markSplitToken(tok Kind, StringRef Txt);
 
   /// Returns true if the parser reached EOF with incomplete source input, due
   /// for example, a missing right brace.

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -261,6 +261,9 @@ public:
     return SourceLoc(llvm::SMLoc::getFromPointer(trimComment().begin()));
   }
 
+  StringRef getFullText() const {
+    return Text;
+  }
 
   StringRef getText() const {
     if (EscapedIdentifier) {

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -261,7 +261,7 @@ public:
     return SourceLoc(llvm::SMLoc::getFromPointer(trimComment().begin()));
   }
 
-  StringRef getFullText() const {
+  StringRef getRawText() const {
     return Text;
   }
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -123,7 +123,8 @@ namespace swift {
                               const SourceManager &SM, unsigned BufferID,
                               unsigned Offset = 0, unsigned EndOffset = 0,
                               bool KeepComments = true,
-                              bool TokenizeInterpolatedString = true);
+                              bool TokenizeInterpolatedString = true,
+                              ArrayRef<Token> SplitTokens = ArrayRef<Token>());
 
   /// Once parsing is complete, this walks the AST to resolve imports, record
   /// operators, and do other top-level validation.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2675,6 +2675,20 @@ struct ASTNodeBase {};
                         [&]{ P->print(Out); });
     }
 
+    void assertValidRegion(Decl *D) {
+      auto R = D->getSourceRange();
+      if (R.isValid() && Ctx.SourceMgr.isBeforeInBuffer(R.End, R.Start)) {
+        Out << "invalid type source range for decl: ";
+        D->print(Out);
+        Out << "\n";
+        abort();
+      }
+    }
+
+    void checkSourceRanges(ParamDecl *PD) {
+      assertValidRegion(PD);
+    }
+
     void checkSourceRanges(Decl *D) {
       PrettyStackTraceDecl debugStack("verifying ranges", D);
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -291,6 +291,14 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   bool visitEnumElementDecl(EnumElementDecl *ED) {
+    if (ED->hasArgumentType()) {
+      if (auto TR = ED->getArgumentTypeLoc().getTypeRepr()) {
+        if (doIt(TR)) {
+          return true;
+        }
+      }
+    }
+
     // The getRawValueExpr should remain the untouched original LiteralExpr for
     // serialization and validation purposes. We only traverse the type-checked
     // form, unless we haven't populated it yet.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -148,7 +148,7 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
 
   SmallVector<ParamDecl*, 4> params;
   for (Type argType : argTypes) {
-    auto PD = new (Context) ParamDecl(/*IsLet*/true, SourceLoc(),
+    auto PD = new (Context) ParamDecl(/*IsLet*/true, SourceLoc(), SourceLoc(),
                                       Identifier(), SourceLoc(),
                                       Identifier(), argType,
                                       DC);
@@ -206,7 +206,7 @@ getBuiltinGenericFunction(Identifier Id,
 
   SmallVector<ParamDecl*, 4> params;
   for (auto paramType : ArgBodyTypes) {
-    auto PD = new (Context) ParamDecl(/*IsLet*/true, SourceLoc(),
+    auto PD = new (Context) ParamDecl(/*IsLet*/true, SourceLoc(), SourceLoc(),
                                       Identifier(), SourceLoc(),
                                       Identifier(), paramType, DC);
     PD->setImplicit();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3487,7 +3487,7 @@ SourceRange ParamDecl::getSourceRange() const {
   // If the typeloc has a valid location, use it to end the range.
   if (auto typeRepr = getTypeLoc().getTypeRepr()) {
     auto endLoc = typeRepr->getEndLoc();
-    if (endLoc.isValid())
+    if (endLoc.isValid() && !isTypeLocImplicit())
       return SourceRange(range.Start, endLoc);
   }
   

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1022,6 +1022,18 @@ PatternBindingDecl *
 PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
                            StaticSpellingKind StaticSpelling,
                            SourceLoc VarLoc,
+                           Pattern *Pat, Expr *E,
+                           DeclContext *Parent) {
+  return create(Ctx, StaticLoc, StaticSpelling, VarLoc,
+                PatternBindingEntry(Pat, E,
+                                    E ? E->getSourceRange() : SourceRange()),
+                Parent);
+}
+
+PatternBindingDecl *
+PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
+                           StaticSpellingKind StaticSpelling,
+                           SourceLoc VarLoc,
                            ArrayRef<PatternBindingEntry> PatternList,
                            DeclContext *Parent) {
   size_t Size = sizeof(PatternBindingDecl) +
@@ -1037,7 +1049,7 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
   for (auto pe : PatternList) {
     ++elt;
     auto &newEntry = entries[elt];
-    newEntry = { nullptr, pe.getInit() };
+    newEntry = { nullptr, pe.getInit(), pe.getOrigInitRange() };
     PBD->setPattern(elt, pe.getPattern());
   }
   return PBD;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3404,12 +3404,14 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
   }
 }
 
-ParamDecl::ParamDecl(bool isLet, SourceLoc argumentNameLoc,
+ParamDecl::ParamDecl(bool isLet,
+                     SourceLoc letVarInOutLoc, SourceLoc argumentNameLoc,
                      Identifier argumentName, SourceLoc parameterNameLoc,
                      Identifier parameterName, Type ty, DeclContext *dc)
   : VarDecl(DeclKind::Param, /*IsStatic=*/false, isLet, parameterNameLoc,
             parameterName, ty, dc),
-  ArgumentName(argumentName), ArgumentNameLoc(argumentNameLoc) {
+  ArgumentName(argumentName), ArgumentNameLoc(argumentNameLoc),
+  LetVarInOutLoc(letVarInOutLoc) {
 }
 
 /// Clone constructor, allocates a new ParamDecl identical to the first.
@@ -3420,6 +3422,7 @@ ParamDecl::ParamDecl(ParamDecl *PD)
             PD->getDeclContext()),
     ArgumentName(PD->getArgumentName()),
     ArgumentNameLoc(PD->getArgumentNameLoc()),
+    LetVarInOutLoc(PD->getLetVarInOutLoc()),
     typeLoc(PD->getTypeLoc()),
     DefaultValueAndIsVariadic(PD->DefaultValueAndIsVariadic),
     IsTypeLocImplicit(PD->IsTypeLocImplicit),
@@ -3465,7 +3468,7 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
       selfType = InOutType::get(selfType);
   }
     
-  auto *selfDecl = new (C) ParamDecl(/*IsLet*/!isInOut, SourceLoc(),
+  auto *selfDecl = new (C) ParamDecl(/*IsLet*/!isInOut, SourceLoc(),SourceLoc(),
                                      Identifier(), loc, C.Id_self, selfType,DC);
   selfDecl->setImplicit();
   return selfDecl;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1025,8 +1025,7 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
                            Pattern *Pat, Expr *E,
                            DeclContext *Parent) {
   return create(Ctx, StaticLoc, StaticSpelling, VarLoc,
-                PatternBindingEntry(Pat, E,
-                                    E ? E->getSourceRange() : SourceRange()),
+                PatternBindingEntry(Pat, E),
                 Parent);
 }
 
@@ -1049,7 +1048,7 @@ PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
   for (auto pe : PatternList) {
     ++elt;
     auto &newEntry = entries[elt];
-    newEntry = { nullptr, pe.getInit(), pe.getOrigInitRange() };
+    newEntry = pe; // This should take care of initializer with flags
     PBD->setPattern(elt, pe.getPattern());
   }
   return PBD;
@@ -1084,6 +1083,20 @@ unsigned PatternBindingDecl::getPatternEntryIndexForVarDecl(const VarDecl *VD) c
   return ~0U;
 }
 
+SourceRange PatternBindingEntry::getOrigInitRange() const {
+  auto Init = InitCheckedAndRemoved.getPointer();
+  return Init ? Init->getSourceRange() : SourceRange();
+}
+
+void PatternBindingEntry::setInit(Expr *E) {
+  auto F = InitCheckedAndRemoved.getInt();
+  if (E) {
+    InitCheckedAndRemoved.setInt(F - Flags::Removed);
+    InitCheckedAndRemoved.setPointer(E);
+  } else {
+    InitCheckedAndRemoved.setInt(F | Flags::Removed);
+  }
+}
 
 SourceRange PatternBindingDecl::getSourceRange() const {
   SourceLoc startLoc = getStartLoc();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1187,11 +1187,10 @@ TypeExpr *TypeExpr::createForSpecializedDecl(SourceLoc Loc, TypeDecl *D,
 // Create an implicit TypeExpr, with location information even though it
 // shouldn't have one.  This is presently used to work around other location
 // processing bugs.  If you have an implicit location, use createImplicit.
-TypeExpr *TypeExpr::createImplicitHack(SourceLoc StartLoc, Type Ty,
-                                       ASTContext &C, SourceLoc EndLoc) {
+TypeExpr *TypeExpr::createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C) {
   // FIXME: This is horrible.
-  if (StartLoc.isInvalid()) return createImplicit(Ty, C);
-  auto *Repr = new (C) FixedTypeRepr(Ty, StartLoc, EndLoc);
+  if (Loc.isInvalid()) return createImplicit(Ty, C);
+  auto *Repr = new (C) FixedTypeRepr(Ty, Loc);
   auto *Res = new (C) TypeExpr(TypeLoc(Repr, Ty));
   Res->setImplicit();
   Res->setType(MetatypeType::get(Ty, C));

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1187,10 +1187,11 @@ TypeExpr *TypeExpr::createForSpecializedDecl(SourceLoc Loc, TypeDecl *D,
 // Create an implicit TypeExpr, with location information even though it
 // shouldn't have one.  This is presently used to work around other location
 // processing bugs.  If you have an implicit location, use createImplicit.
-TypeExpr *TypeExpr::createImplicitHack(SourceLoc Loc, Type Ty, ASTContext &C) {
+TypeExpr *TypeExpr::createImplicitHack(SourceLoc StartLoc, Type Ty,
+                                       ASTContext &C, SourceLoc EndLoc) {
   // FIXME: This is horrible.
-  if (Loc.isInvalid()) return createImplicit(Ty, C);
-  auto *Repr = new (C) FixedTypeRepr(Ty, Loc);
+  if (StartLoc.isInvalid()) return createImplicit(Ty, C);
+  auto *Repr = new (C) FixedTypeRepr(Ty, StartLoc, EndLoc);
   auto *Res = new (C) TypeExpr(TypeLoc(Repr, Ty));
   Res->setImplicit();
   Res->setType(MetatypeType::get(Ty, C));

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -353,7 +353,7 @@ static FuncDecl *makeRawValueTrivialSetter(ClangImporter::Implementation &Impl,
 
   auto *selfDecl = ParamDecl::createSelf(SourceLoc(), importedDecl,
                                          /*static*/false, /*inout*/true);
-  auto *newValueDecl = new (C) ParamDecl(/*IsLet*/true, SourceLoc(),
+  auto *newValueDecl = new (C) ParamDecl(/*IsLet*/true, SourceLoc(),SourceLoc(),
                                          Identifier(), SourceLoc(),
                                          C.Id_value, rawType, importedDecl);
   newValueDecl->setImplicit();
@@ -416,7 +416,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   auto selfDecl = ParamDecl::createSelf(SourceLoc(), enumDecl,
                                         /*static*/false, /*inout*/true);
 
-  auto param = new (C) ParamDecl(/*let*/ true,
+  auto param = new (C) ParamDecl(/*let*/ true, SourceLoc(),
                                  SourceLoc(), C.Id_rawValue,
                                  SourceLoc(), C.Id_rawValue,
                                  enumDecl->getRawType(),
@@ -551,7 +551,7 @@ static FuncDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
   auto &C = Impl.SwiftContext;
   auto selfDecl = ParamDecl::createSelf(SourceLoc(), importedDecl,
                                         /*isStatic*/false, /*isInOut*/true);
-  auto newValueDecl = new (C) ParamDecl(/*isLet */ true, SourceLoc(),
+  auto newValueDecl = new (C) ParamDecl(/*isLet */ true,SourceLoc(),SourceLoc(),
                                         Identifier(), SourceLoc(), C.Id_value,
                                         importedFieldDecl->getType(),
                                         importedDecl);
@@ -1591,7 +1591,7 @@ namespace {
       for (auto var : members) {
         Identifier argName = wantCtorParamNames ? var->getName()
                                                 : Identifier();
-        auto param = new (context) ParamDecl(/*IsLet*/ true,
+        auto param = new (context) ParamDecl(/*IsLet*/ true, SourceLoc(),
                                              SourceLoc(), argName,
                                              SourceLoc(), var->getName(),
                                              var->getType(), structDecl);
@@ -3561,7 +3561,7 @@ namespace {
       auto selfDecl = ParamDecl::createSelf(SourceLoc(), dc);
 
       auto paramVarDecl = new (context) ParamDecl(/*isLet=*/false, SourceLoc(),
-                                                  Identifier(), loc,
+                                                  SourceLoc(), Identifier(),loc,
                                                   valueIndex->get(0)->getName(),
                                                   elementTy, dc);
       

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1448,7 +1448,7 @@ importFunctionType(const clang::FunctionDecl *clangDecl,
     auto bodyVar
       = createDeclWithClangNode<ParamDecl>(param,
                                      /*IsLet*/ true,
-                                     SourceLoc(), name,
+                                     SourceLoc(), SourceLoc(), name,
                                      importSourceLoc(param->getLocation()),
                                      bodyName, swiftParamTy, 
                                      ImportedHeaderUnit);
@@ -1466,10 +1466,10 @@ importFunctionType(const clang::FunctionDecl *clangDecl,
     auto paramTy =  BoundGenericType::get(SwiftContext.getArrayDecl(), Type(),
       {SwiftContext.getAnyDecl()->getDeclaredType()});
     auto name = SwiftContext.getIdentifier("varargs");
-    auto param = new (SwiftContext) ParamDecl(true, SourceLoc(),
-                                                Identifier(),
-                                                SourceLoc(), name, paramTy,
-                                                ImportedHeaderUnit);
+    auto param = new (SwiftContext) ParamDecl(true, SourceLoc(), SourceLoc(),
+                                              Identifier(),
+                                              SourceLoc(), name, paramTy,
+                                              ImportedHeaderUnit);
 
     param->setVariadic();
     parameters.push_back(param);
@@ -2093,7 +2093,7 @@ Type ClangImporter::Implementation::importMethodType(
     // It doesn't actually matter which DeclContext we use, so just
     // use the imported header unit.
     auto type = TupleType::getEmpty(SwiftContext);
-    auto var = new (SwiftContext) ParamDecl(/*IsLet*/ true,
+    auto var = new (SwiftContext) ParamDecl(/*IsLet*/ true, SourceLoc(),
                                             SourceLoc(), argName,
                                             SourceLoc(), argName, type,
                                             ImportedHeaderUnit);
@@ -2205,8 +2205,8 @@ Type ClangImporter::Implementation::importMethodType(
     // It doesn't actually matter which DeclContext we use, so just use the
     // imported header unit.
     auto bodyVar
-      = createDeclWithClangNode<ParamDecl>(param,
-                                     /*IsLet*/ true, SourceLoc(), name,
+      = createDeclWithClangNode<ParamDecl>(param, /*IsLet*/ true,
+                                     SourceLoc(), SourceLoc(), name,
                                      importSourceLoc(param->getLocation()),
                                      bodyName, swiftParamTy, 
                                      ImportedHeaderUnit);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2923,7 +2923,7 @@ createSetterAccessorArgument(SourceLoc nameLoc, Identifier name,
     name = P.Context.getIdentifier(implName);
   }
 
-  auto result = new (P.Context) ParamDecl(/*IsLet*/true, SourceLoc(),
+  auto result = new (P.Context) ParamDecl(/*IsLet*/true,SourceLoc(),SourceLoc(),
                                           Identifier(), nameLoc, name,
                                           Type(), P.CurDeclContext);
   if (isNameImplicit)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4053,6 +4053,7 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     Tok.setKind(tok::oper_prefix);
   }
   Identifier SimpleName;
+  Token NameTok = Tok;
   SourceLoc NameLoc = Tok.getLoc();
   Token NonglobalTok = Tok;
   bool NonglobalError = false;
@@ -4100,6 +4101,13 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     auto Result = parseGenericParameters(LAngleLoc);
     GenericParams = Result.getPtrOrNull();
     GPHasCodeCompletion |= Result.hasCodeCompletion();
+
+    auto NameTokText = NameTok.getRawText();
+    markSplitToken(tok::identifier,
+                   NameTokText.substr(0, NameTokText.size() - 1));
+    markSplitToken(tok::oper_binary_unspaced,
+                   NameTokText.substr(NameTokText.size() - 1));
+
   } else {
     auto Result = maybeParseGenericParams();
     GenericParams = Result.getPtrOrNull();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3832,7 +3832,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
 
     // Remember this pattern/init pair for our ultimate PatternBindingDecl. The
     // Initializer will be added later when/if it is parsed.
-    PBDEntries.push_back({pattern, nullptr, SourceRange()});
+    PBDEntries.push_back({pattern, nullptr});
     
     Expr *PatternInit = nullptr;
     
@@ -3892,9 +3892,6 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
       // Remember this init for the PatternBindingDecl.
       PatternInit = init.getPtrOrNull();
       PBDEntries.back().setInit(PatternInit);
-      if (PatternInit) {
-        PBDEntries.back().setOrigInitRange(PatternInit->getSourceRange());
-      }
 
       // If we allocated an initContext and the expression had a closure in it,
       // we'll need to keep the initContext around.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3832,7 +3832,7 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
 
     // Remember this pattern/init pair for our ultimate PatternBindingDecl. The
     // Initializer will be added later when/if it is parsed.
-    PBDEntries.push_back({pattern, nullptr});
+    PBDEntries.push_back({pattern, nullptr, SourceRange()});
     
     Expr *PatternInit = nullptr;
     
@@ -3892,6 +3892,9 @@ ParserStatus Parser::parseDeclVar(ParseDeclOptions Flags,
       // Remember this init for the PatternBindingDecl.
       PatternInit = init.getPtrOrNull();
       PBDEntries.back().setInit(PatternInit);
+      if (PatternInit) {
+        PBDEntries.back().setOrigInitRange(PatternInit->getSourceRange());
+      }
 
       // If we allocated an initContext and the expression had a closure in it,
       // we'll need to keep the initContext around.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -40,8 +40,10 @@ static Expr *createArgWithTrailingClosure(ASTContext &context,
   // If there are no elements, just build a parenthesized expression around
   // the closure.
   if (elementsIn.empty()) {
-    return new (context) ParenExpr(leftParen, closure, rightParen,
-                                   /*hasTrailingClosure=*/true);
+    auto PE = new (context) ParenExpr(leftParen, closure, rightParen,
+                                      /*hasTrailingClosure=*/true);
+    PE->setImplicit();
+    return PE;
   }
 
   // Create the list of elements, and add the trailing closure to the end.
@@ -1191,9 +1193,10 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
         Expr *arg = createArgWithTrailingClosure(Context, SourceLoc(), { },
                                                  { }, { }, SourceLoc(), 
                                                  closure.get());
+        // The call node should still be marked as explicit
         Result = makeParserResult(
             ParserStatus(closure),
-            new (Context) CallExpr(Result.get(), arg, /*Implicit=*/true));
+            new (Context) CallExpr(Result.get(), arg, /*Implicit=*/false));
       }
 
       if (Result.hasCodeCompletion())
@@ -2027,6 +2030,7 @@ Expr *Parser::parseExprAnonClosureArg() {
     auto *var = new (Context) ParamDecl(/*IsLet*/ true, SourceLoc(),
                                         Identifier(), varLoc, ident, Type(),
                                         closure);
+    var->setImplicit();
     decls.push_back(var);
   }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1784,8 +1784,8 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
         Identifier name = Tok.is(tok::identifier) ?
             Context.getIdentifier(Tok.getText()) : Identifier();
         auto var = new (Context) ParamDecl(/*IsLet*/ true, SourceLoc(),
-                                           Identifier(), Tok.getLoc(), name,
-                                           Type(), nullptr);
+                                           SourceLoc(), Identifier(),
+                                           Tok.getLoc(), name, Type(), nullptr);
         elements.push_back(var);
         consumeToken();
  
@@ -2027,7 +2027,7 @@ Expr *Parser::parseExprAnonClosureArg() {
     StringRef varName = ("$" + Twine(nextIdx)).toStringRef(StrBuf);
     Identifier ident = Context.getIdentifier(varName);
     SourceLoc varLoc = leftBraceLoc;
-    auto *var = new (Context) ParamDecl(/*IsLet*/ true, SourceLoc(),
+    auto *var = new (Context) ParamDecl(/*IsLet*/ true, SourceLoc(),SourceLoc(),
                                         Identifier(), varLoc, ident, Type(),
                                         closure);
     var->setImplicit();

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -338,7 +338,8 @@ mapParsedParameters(Parser &parser,
   -> ParamDecl * {
     auto specifierKind = paramInfo.SpecifierKind;
     bool isLet = specifierKind == Parser::ParsedParameter::Let;
-    auto param = new (ctx) ParamDecl(isLet, argNameLoc, argName,
+    auto param = new (ctx) ParamDecl(isLet, paramInfo.LetVarInOutLoc,
+                                     argNameLoc, argName,
                                      paramNameLoc, paramName, Type(),
                                      parser.CurDeclContext);
     param->getAttrs() = paramInfo.Attrs;
@@ -834,8 +835,8 @@ Pattern *Parser::createBindingFromPattern(SourceLoc loc, Identifier name,
                                           bool isLet) {
   VarDecl *var;
   if (ArgumentIsParameter) {
-    var = new (Context) ParamDecl(isLet, loc, name, loc, name, Type(),
-                                  CurDeclContext);
+    var = new (Context) ParamDecl(isLet, SourceLoc(), loc, name, loc, name,
+                                  Type(), CurDeclContext);
   } else {
     var = new (Context) VarDecl(/*static*/ false, /*IsLet*/ isLet,
                                 loc, name, Type(), CurDeclContext);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -228,7 +228,8 @@ std::vector<Token> swift::tokenize(const LangOptions &LangOpts,
                                    const SourceManager &SM, unsigned BufferID,
                                    unsigned Offset, unsigned EndOffset,
                                    bool KeepComments,
-                                   bool TokenizeInterpolatedString) {
+                                   bool TokenizeInterpolatedString,
+                                   ArrayRef<Token> SplitTokens) {
   if (Offset == 0 && EndOffset == 0)
     EndOffset = SM.getRangeForBuffer(BufferID).getByteLength();
 
@@ -236,10 +237,34 @@ std::vector<Token> swift::tokenize(const LangOptions &LangOpts,
           KeepComments ? CommentRetentionMode::ReturnAsTokens
                        : CommentRetentionMode::AttachToNextToken,
           Offset, EndOffset);
+
+  auto TokComp = [&] (const Token &A, const Token &B) {
+    return SM.isBeforeInBuffer(A.getLoc(), B.getLoc());
+  };
+
+  std::set<Token, decltype(TokComp)> ResetTokens(TokComp);
+  for (auto C = SplitTokens.begin(), E = SplitTokens.end(); C != E; ++C) {
+    ResetTokens.insert(*C);
+  }
+
   std::vector<Token> Tokens;
   do {
     Tokens.emplace_back();
     L.lex(Tokens.back());
+
+    // If the token has the same location as a reset location,
+    // reset the token stream
+    auto F = ResetTokens.find(Tokens.back());
+    if (F != ResetTokens.end()) {
+      Tokens.back() = *F;
+      assert(Tokens.back().isNot(tok::string_literal));
+
+      auto NewState = L.getStateForBeginningOfTokenLoc(
+                                    F->getLoc().getAdvancedLoc(F->getLength()));
+      L.restoreState(NewState);
+      continue;
+    }
+
     if (Tokens.back().is(tok::string_literal) && TokenizeInterpolatedString) {
       Token StrTok = Tokens.back();
       Tokens.pop_back();
@@ -334,6 +359,9 @@ SourceLoc Parser::consumeStartingCharacterOfCurrentToken() {
   if (Tok.getLength() == 1) {
     return consumeToken();
   }
+
+  SplitTokens.emplace_back();
+  SplitTokens.back().setToken(tok::oper_postfix, Tok.getText().substr(0, 1));
 
   // ... or a multi-character token with the first character being the one that
   // we want to consume as a separate token.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -360,13 +360,17 @@ SourceLoc Parser::consumeStartingCharacterOfCurrentToken() {
     return consumeToken();
   }
 
-  SplitTokens.emplace_back();
-  SplitTokens.back().setToken(tok::oper_postfix, Tok.getText().substr(0, 1));
+  markSplitToken(tok::oper_binary_unspaced, Tok.getText().substr(0, 1));
 
   // ... or a multi-character token with the first character being the one that
   // we want to consume as a separate token.
   restoreParserPosition(getParserPositionAfterFirstCharacter(Tok));
   return PreviousLoc;
+}
+
+void Parser::markSplitToken(tok Kind, StringRef Txt) {
+  SplitTokens.emplace_back();
+  SplitTokens.back().setToken(Kind, Txt);
 }
 
 SourceLoc Parser::consumeStartingLess() {

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -30,7 +30,7 @@ static SILValue emitConstructorMetatypeArg(SILGenFunction &gen,
   // the metatype as its first argument, like a static function.
   Type metatype = ctor->getType()->castTo<AnyFunctionType>()->getInput();
   auto &AC = gen.getASTContext();
-  auto VD = new (AC) ParamDecl(/*IsLet*/ true, SourceLoc(),
+  auto VD = new (AC) ParamDecl(/*IsLet*/ true, SourceLoc(), SourceLoc(),
                                AC.getIdentifier("$metatype"), SourceLoc(),
                                AC.getIdentifier("$metatype"), metatype,
                                ctor->getDeclContext());
@@ -52,7 +52,7 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &gen,
     return tuple;
   } else {
     auto &AC = gen.getASTContext();
-    auto VD = new (AC) ParamDecl(/*IsLet*/ true, SourceLoc(),
+    auto VD = new (AC) ParamDecl(/*IsLet*/ true, SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$implicit_value"),
                                  SourceLoc(),
                                  AC.getIdentifier("$implicit_value"), ty, DC);
@@ -76,7 +76,7 @@ static void emitImplicitValueConstructor(SILGenFunction &gen,
   SILValue resultSlot;
   if (selfTy.isAddressOnly(gen.SGM.M)) {
     auto &AC = gen.getASTContext();
-    auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(),
+    auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
                                  SourceLoc(),
                                  AC.getIdentifier("$return_value"), selfTyCan,
@@ -353,7 +353,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
   std::unique_ptr<Initialization> dest;
   if (enumTI.isAddressOnly()) {
     auto &AC = getASTContext();
-    auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(),
+    auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
                                  SourceLoc(),
                                  AC.getIdentifier("$return_value"),

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -436,7 +436,7 @@ unsigned SILGenFunction::emitProlog(ArrayRef<ParameterList*> paramLists,
   const TypeLowering &returnTI = getTypeLowering(resultType);
   if (returnTI.isReturnedIndirectly()) {
     auto &AC = getASTContext();
-    auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(),
+    auto VD = new (AC) ParamDecl(/*IsLet*/ false, SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"), SourceLoc(),
                                  AC.getIdentifier("$return_value"), resultType,
                                  DeclCtx);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -379,7 +379,7 @@ namespace {
         auto openedFnType = openedType->castTo<FunctionType>();
         auto baseTy = simplifyType(openedFnType->getInput())
                         ->getRValueInstanceType();
-        Expr *base = TypeExpr::createImplicitHack(loc, baseTy, ctx, loc);
+        Expr *base = TypeExpr::createImplicitHack(loc, baseTy, ctx);
         auto result = buildMemberRef(base, openedType, SourceLoc(), decl,
                                      loc, openedFnType->getResult(),
                                      locator, locator, implicit, semantics,
@@ -1419,10 +1419,9 @@ namespace {
       Expr *args[2] = {
         object,
         new (tc.Context) DotSelfExpr(
-                           TypeExpr::createImplicitHack(object->getStartLoc(),
+                           TypeExpr::createImplicitHack(object->getLoc(),
                                                         valueType,
-                                                        tc.Context,
-                                                        object->getEndLoc()),
+                                                        tc.Context),
                            object->getLoc(), object->getLoc(),
                            MetatypeType::get(valueType))
       };
@@ -1918,8 +1917,7 @@ namespace {
       // Build a reference to the init(stringInterpolation:) initializer.
       // FIXME: This location info is bogus.
       auto typeRef = TypeExpr::createImplicitHack(expr->getStartLoc(),
-                                                  type, tc.Context,
-                                                  expr->getEndLoc());
+                                                  type, tc.Context);
       Expr *memberRef = new (tc.Context) MemberRefExpr(typeRef,
                                                        expr->getStartLoc(),
                                                        member,
@@ -2045,9 +2043,8 @@ namespace {
         
       DeclName constrName(tc.getObjectLiteralConstructorName(expr));
       Expr *arg = expr->getArg();
-      Expr *base = TypeExpr::createImplicitHack(expr->getStartLoc(),
-                                                conformingType, ctx,
-                                                expr->getEndLoc());
+      Expr *base = TypeExpr::createImplicitHack(expr->getLoc(), conformingType,
+                                                ctx);
       Expr *semanticExpr = tc.callWitness(base, dc, proto, conformance,
                                           constrName, arg,
                                           diag::object_literal_broken_proto);
@@ -2203,8 +2200,7 @@ namespace {
       // The base expression is simply the metatype of the base type.
       // FIXME: This location info is bogus.
       auto base = TypeExpr::createImplicitHack(expr->getDotLoc(),
-                                               baseTy, tc.Context,
-                                               expr->getDotLoc());
+                                               baseTy, tc.Context);
 
       // Build the member reference.
       bool isDynamic
@@ -2361,8 +2357,8 @@ namespace {
                                              baseMetaTy->getInstanceType());
           
           // FIXME: We're dropping side effects in the base here!
-          base = TypeExpr::createImplicitHack(base->getStartLoc(), classTy,
-                                              tc.Context, base->getEndLoc());
+          base = TypeExpr::createImplicitHack(base->getLoc(), classTy, 
+                                              tc.Context);
         } else {
           // Bridge the base to its corresponding Objective-C object.
           base = bridgeToObjectiveC(base);
@@ -2480,9 +2476,8 @@ namespace {
       // be nicer to re-use them.
 
       // FIXME: This location info is bogus.
-      Expr *typeRef = TypeExpr::createImplicitHack(expr->getStartLoc(),
-                                                   arrayTy, tc.Context,
-                                                   expr->getEndLoc());
+      Expr *typeRef = TypeExpr::createImplicitHack(expr->getLoc(),
+                                                   arrayTy, tc.Context);
       DeclName name(tc.Context, tc.Context.Id_init,
                     { tc.Context.Id_arrayLiteral });
 
@@ -2546,9 +2541,8 @@ namespace {
       // It would be nicer to re-use them.
       // FIXME: Cache the name.
       // FIXME: This location info is bogus.
-      Expr *typeRef = TypeExpr::createImplicitHack(expr->getStartLoc(),
-                                                   dictionaryTy, tc.Context,
-                                                   expr->getEndLoc());
+      Expr *typeRef = TypeExpr::createImplicitHack(expr->getLoc(),
+                                                   dictionaryTy, tc.Context);
 
       DeclName name(tc.Context, tc.Context.Id_init,
                     { tc.Context.Id_dictionaryLiteral });
@@ -5160,8 +5154,8 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
 
     // Call the builtin conversion operation.
     // FIXME: Bogus location info.
-    Expr *base = TypeExpr::createImplicitHack(literal->getStartLoc(), type,
-                                              tc.Context, literal->getEndLoc());
+    Expr *base = TypeExpr::createImplicitHack(literal->getLoc(), type,
+                                              tc.Context);
     Expr *result = tc.callWitness(base, dc,
                                   builtinProtocol, builtinConformance,
                                   builtinLiteralFuncName,
@@ -5220,8 +5214,8 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
 
   // Convert the resulting expression to the final literal type.
   // FIXME: Bogus location info.
-  Expr *base = TypeExpr::createImplicitHack(literal->getStartLoc(), type,
-                                            tc.Context, literal->getEndLoc());
+  Expr *base = TypeExpr::createImplicitHack(literal->getLoc(), type,
+                                            tc.Context);
   literal = tc.callWitness(base, dc,
                            protocol, conformance, literalFuncName,
                            literal, brokenProtocolDiag);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -941,6 +941,9 @@ namespace {
         assert((!baseIsInstance || member->isInstanceMember()) &&
                "can't call a static method on an instance");
         apply = new (context) DotSyntaxCallExpr(ref, dotLoc, base);
+        if (Implicit) {
+          apply->setImplicit();
+        }
       }
       return finishApply(apply, openedType, nullptr);
     }
@@ -1422,6 +1425,7 @@ namespace {
                            object->getLoc(), object->getLoc(),
                            MetatypeType::get(valueType))
       };
+      args[1]->setImplicit();
 
       // Form the argument tuple.
       Expr *argTuple = TupleExpr::createImplicit(tc.Context, args, {});
@@ -4353,6 +4357,9 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, Type paramType,
                                             argParen->getRParenLoc(),
                                             argParen->hasTrailingClosure(),
                                             fromTupleExpr[0]->getType());
+      if (argParen->isImplicit()) {
+        argParen->setImplicit();
+      }
       arg = argParen;
     } else {
       // coerceToType may have updated the element type of the ParenExpr in
@@ -5173,7 +5180,8 @@ Expr *ExprRewriter::convertLiteral(Expr *literal,
     // If there is no argument to the constructor function, then just pass in
     // the empty tuple.
     literal = TupleExpr::createEmpty(tc.Context, literal->getLoc(),
-                                     literal->getLoc(), /*implicit*/true);
+                                     literal->getLoc(),
+                                     /*implicit*/!literal->getLoc().isValid());
   } else {
     // Otherwise, figure out the type of the constructor function and coerce to
     // it.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4359,12 +4359,13 @@ Expr *ExprRewriter::coerceCallArguments(Expr *arg, Type paramType,
     // If the element changed, rebuild a new ParenExpr.
     assert(fromTupleExpr.size() == 1 && fromTupleExpr[0]);
     if (fromTupleExpr[0] != argParen->getSubExpr()) {
+      bool argParenImplicit = argParen->isImplicit();
       argParen = new (tc.Context) ParenExpr(argParen->getLParenLoc(),
                                             fromTupleExpr[0],
                                             argParen->getRParenLoc(),
                                             argParen->hasTrailingClosure(),
                                             fromTupleExpr[0]->getType());
-      if (argParen->isImplicit()) {
+      if (argParenImplicit) {
         argParen->setImplicit();
       }
       arg = argParen;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3024,12 +3024,13 @@ namespace {
           tc.diagnose(expr->getLoc(), diag::forced_downcast_noop, toType)
             .fixItRemove(SourceRange(expr->getLoc(),
                                  expr->getCastTypeLoc().getSourceRange().End));
-          return sub;
+
+        } else {
+          tc.diagnose(expr->getLoc(), diag::forced_downcast_coercion,
+                      sub->getType(), toType)
+            .fixItReplace(SourceRange(expr->getLoc(), expr->getExclaimLoc()),
+                          "as");
         }
-        tc.diagnose(expr->getLoc(), diag::forced_downcast_coercion,
-                    sub->getType(), toType)
-          .fixItReplace(SourceRange(expr->getLoc(), expr->getExclaimLoc()),
-                        "as");
 
         // Convert the subexpression.
         bool failed = tc.convertToType(sub, toType, cs.DC);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6388,12 +6388,25 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
       ++i;
     }
 
+    // The tuple should have the source range enclosing its arguments unless
+    // they are invalid or there are no arguments.
+    SourceLoc TupleStartLoc = base->getStartLoc();
+    SourceLoc TupleEndLoc = base->getEndLoc();
+    if (arguments.size() > 0) {
+      SourceLoc AltStartLoc = arguments.front()->getStartLoc();
+      SourceLoc AltEndLoc = arguments.back()->getEndLoc();
+      if (AltStartLoc.isValid() && AltEndLoc.isValid()) {
+        TupleStartLoc = AltStartLoc;
+        TupleEndLoc = AltEndLoc;
+      }
+    }
+
     arg = TupleExpr::create(Context,
-                            base->getStartLoc(),
+                            TupleStartLoc,
                             arguments,
                             names,
                             { },
-                            base->getEndLoc(),
+                            TupleEndLoc,
                             /*hasTrailingClosure=*/false,
                             /*Implicit=*/true,
                             TupleType::get(elementTypes, Context));

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1483,8 +1483,10 @@ static void createStubBody(TypeChecker &tc, ConstructorDecl *ctor) {
                                "." +
                                classDecl->getName().str()).toStringRef(buffer));
 
-  Expr *className = new (tc.Context) StringLiteralExpr(fullClassName, loc);
+  Expr *className = new (tc.Context) StringLiteralExpr(fullClassName, loc,
+                                                       /*Implicit=*/true);
   className = new (tc.Context) ParenExpr(loc, className, loc, false);
+  className->setImplicit();
   Expr *call = new (tc.Context) CallExpr(fn, className, /*Implicit=*/true);
   ctor->setBody(BraceStmt::create(tc.Context, SourceLoc(),
                                   ASTNode(call),

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -58,9 +58,9 @@ static VarDecl *getFirstParamDecl(FuncDecl *fn) {
 static ParamDecl *buildArgument(SourceLoc loc, DeclContext *DC,
                                StringRef name, Type type, bool isLet) {
   auto &context = DC->getASTContext();
-  auto *param = new (context) ParamDecl(isLet, SourceLoc(), Identifier(),
-                                        loc, context.getIdentifier(name),
-                                        Type(), DC);
+  auto *param = new (context) ParamDecl(isLet, SourceLoc(), SourceLoc(),
+                                        Identifier(), loc,
+                                        context.getIdentifier(name),Type(), DC);
   param->setImplicit();
   param->getTypeLoc().setType(type);
   return param;
@@ -1419,7 +1419,8 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
         varType = OptionalType::get(varType);
 
       // Create the parameter.
-      auto *arg = new (context) ParamDecl(/*IsLet*/true, Loc, var->getName(),
+      auto *arg = new (context) ParamDecl(/*IsLet*/true, SourceLoc(), 
+                                          Loc, var->getName(),
                                           Loc, var->getName(), varType, decl);
       arg->setImplicit();
       params.push_back(arg);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -195,9 +195,9 @@ deriveEquatable_enum_eq(TypeChecker &tc, Decl *parentDecl, EnumDecl *enumDecl) {
   auto enumTy = parentDC->getDeclaredTypeInContext();
   
   auto getParamDecl = [&](StringRef s) -> ParamDecl* {
-    return new (C) ParamDecl(/*isLet*/true, SourceLoc(), Identifier(),
-                             SourceLoc(), C.getIdentifier(s), enumTy,
-                             parentDC);
+    return new (C) ParamDecl(/*isLet*/true, SourceLoc(), SourceLoc(),
+                             Identifier(), SourceLoc(), C.getIdentifier(s),
+                             enumTy, parentDC);
   };
   
   auto params = ParameterList::create(C, {

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -268,7 +268,7 @@ static ConstructorDecl *deriveRawRepresentable_init(TypeChecker &tc,
   auto *selfDecl = ParamDecl::createSelf(SourceLoc(), parentDC,
                                          /*static*/false, /*inout*/true);
 
-  auto *rawDecl = new (C) ParamDecl(/*IsLet*/true, SourceLoc(),
+  auto *rawDecl = new (C) ParamDecl(/*IsLet*/true, SourceLoc(), SourceLoc(),
                                     C.Id_rawValue, SourceLoc(),
                                     C.Id_rawValue, rawType, parentDC);
   rawDecl->setImplicit();

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -313,7 +313,7 @@ static Expr *makeBinOp(TypeChecker &TC, Expr *Op, Expr *LHS, Expr *RHS,
                                      SourceLoc(), 
                                      ArgElts2, { }, { }, SourceLoc(),
                                      /*hasTrailingClosure=*/false,
-                                     LHS->isImplicit() && RHS->isImplicit());
+                                     /*Implicit=*/true);
 
   
   

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -225,7 +225,7 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   TopLevelCodeDecl *newTopLevel = new (Context) TopLevelCodeDecl(&SF);
 
   // Build function of type T->() which prints the operand.
-  auto *Arg = new (Context) ParamDecl(/*isLet=*/true,
+  auto *Arg = new (Context) ParamDecl(/*isLet=*/true, SourceLoc(),
                                          SourceLoc(), Identifier(),
                                          Loc, Context.getIdentifier("arg"),
                                          E->getType(), /*DC*/ newTopLevel);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2478,7 +2478,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     if (declOrOffset.isComplete())
       return declOrOffset;
 
-    auto param = createDecl<ParamDecl>(isLet, SourceLoc(),
+    auto param = createDecl<ParamDecl>(isLet, SourceLoc(), SourceLoc(),
                                        getIdentifier(argNameID), SourceLoc(),
                                        getIdentifier(paramNameID), type, DC);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2639,7 +2639,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     SmallVector<PatternBindingEntry, 2> patterns;
     patterns.reserve(numPatterns);
     for (unsigned i = 0; i != numPatterns; ++i) {
-      patterns.push_back({ maybeReadPattern(), nullptr, SourceRange() });
+      patterns.push_back({ maybeReadPattern(), nullptr });
       assert(patterns.back().getPattern());
     }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2639,7 +2639,7 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
     SmallVector<PatternBindingEntry, 2> patterns;
     patterns.reserve(numPatterns);
     for (unsigned i = 0; i != numPatterns; ++i) {
-      patterns.push_back({ maybeReadPattern(), nullptr });
+      patterns.push_back({ maybeReadPattern(), nullptr, SourceRange() });
       assert(patterns.back().getPattern());
     }
 

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -32,7 +32,7 @@ func passClosure() {
   }
   
   takeClosure {
-    $0 = 42     // expected-error{{cannot assign to value: '$0' is a 'let' constant}}
+    $0 = 42     // expected-error{{cannot assign to value: '$0' is immutable}}
     return 42
   }
   

--- a/unittests/Parse/CMakeLists.txt
+++ b/unittests/Parse/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_unittest(SwiftParseTests
   BuildConfigTests.cpp
   LexerTests.cpp
+  TokenizerTests.cpp
 )
 
 target_link_libraries(SwiftParseTests

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -1,0 +1,179 @@
+#include "swift/Basic/LangOptions.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Parse/Lexer.h"
+#include "swift/Parse/Parser.h"
+#include "swift/Subsystems.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace llvm;
+
+// The test fixture.
+class TokenizerTest : public ::testing::Test {
+public:
+  LangOptions LangOpts;
+  SourceManager SM;
+
+  unsigned makeBuffer(StringRef Source) {
+    return SM.addMemBufferCopy(Source);
+  }
+
+  static void replaceNewLines(std::string &S) {
+    size_t Index = 0;
+    while (true) {
+      Index = S.find("\n", Index);
+      if (Index == std::string::npos) break;
+      S.erase(Index, 1);
+      S.insert(Index, "\\n");
+      Index += 3;
+    }
+  }
+
+  static StringRef tokToString(swift::tok T) {
+    switch (T) {
+  #define KEYWORD(X) \
+    case swift::tok::kw_##X: return "kw_" #X; break;
+  #define PUNCTUATOR(X, Y) \
+    case swift::tok::X: return #X; break;
+  #include "swift/Parse/Tokens.def"
+
+  #define OTHER(X) \
+  case swift::tok::X: return #X; break;
+        OTHER(unknown)
+        OTHER(eof)
+        OTHER(code_complete)
+        OTHER(identifier)
+        OTHER(oper_binary_unspaced)
+        OTHER(oper_binary_spaced)
+        OTHER(oper_postfix)
+        OTHER(oper_prefix)
+        OTHER(dollarident)
+        OTHER(integer_literal)
+        OTHER(floating_literal)
+        OTHER(string_literal)
+        OTHER(sil_local_name)
+        OTHER(pound_if)
+        OTHER(pound_else)
+        OTHER(pound_elseif)
+        OTHER(pound_endif)
+        OTHER(pound_line)
+        OTHER(pound_available)
+        OTHER(comment)
+
+      default:
+        return "??? (" + std::to_string(static_cast<int>(tok())) + ")";
+        break;
+    }
+  }
+  
+  void assertTokens(std::vector<Token> Ts, StringRef Expected) {
+    std::string Actual;
+    for (auto C = Ts.begin(), E = Ts.end(); C != E; ++C) {
+      Actual += tokToString(C->getKind());
+      Actual += ": ";
+      
+      std::string Txt(C->getRawText());
+      replaceNewLines(Txt);
+      Actual += Txt;
+      
+      Actual += "\n";
+    }
+    EXPECT_EQ(Expected, Actual)
+      << "---- Expected: \n" << Expected << "\n" 
+      << "---- Actual: \n" << Actual << "\n";
+  }
+  
+  std::vector<Token> parseAndGetSplitTOkens(unsigned BufID) {
+    swift::ParserUnit PU(SM, BufID, LangOpts, "unknown");
+
+    bool Done = false;
+    while (!Done) {
+      PU.getParser().parseTopLevel();
+      Done = PU.getParser().Tok.is(tok::eof);
+    }
+    
+    return PU.getParser().getSplitTokens();
+  }
+  
+  std::vector<Token> tokenize(unsigned BufID, const std::vector<Token> &SplitTokens = {}) {
+    return swift::tokenize(LangOpts, 
+                           SM, 
+                           BufID, 
+                           /* Offset = */ 0,
+                           /* EndOffset = */ 0,
+                           /* KeepComments = */ true,
+                           /* TokenizeInterpolatedString = */ true,
+                           SplitTokens);
+  }
+};
+
+TEST_F(TokenizerTest, ProperlySplitTokens) {
+  auto BufID = makeBuffer(
+    "infix operator ⊕ { associativity left precedence 100 }\n"
+    "func ⊕<T>(t1: T, t2: T) {}\n"
+  );
+  
+  // Tokenize w/o fixing split tokens
+  auto Tokens = tokenize(BufID);
+  assertTokens(Tokens,
+    "identifier: infix\n"
+    "kw_operator: operator\n"
+    "oper_binary_spaced: ⊕\n"
+    "l_brace: {\n"
+    "identifier: associativity\n"
+    "identifier: left\n"
+    "identifier: precedence\n"
+    "integer_literal: 100\n"
+    "r_brace: }\n"
+    "kw_func: func\n"
+    "oper_prefix: ⊕<\n"
+    "identifier: T\n"
+    "oper_binary_unspaced: >\n"
+    "l_paren: (\n"
+    "identifier: t1\n"
+    "colon: :\n"
+    "identifier: T\n"
+    "comma: ,\n"
+    "identifier: t2\n"
+    "colon: :\n"
+    "identifier: T\n"
+    "r_paren: )\n"
+    "l_brace: {\n"
+    "r_brace: }\n"
+  );
+
+  // Parse the input and get split tokens info
+  auto SplitTokens = parseAndGetSplitTOkens(BufID);
+
+  // Tokenize with fixing split tokens
+  Tokens = tokenize(BufID, SplitTokens);
+  assertTokens(Tokens,
+     "identifier: infix\n"
+     "kw_operator: operator\n"
+     "oper_binary_spaced: ⊕\n"
+     "l_brace: {\n"
+     "identifier: associativity\n"
+     "identifier: left\n"
+     "identifier: precedence\n"
+     "integer_literal: 100\n"
+     "r_brace: }\n"
+     "kw_func: func\n"
+     "identifier: ⊕\n"
+     "oper_binary_unspaced: <\n"
+     "identifier: T\n"
+     "oper_binary_unspaced: >\n"
+     "l_paren: (\n"
+     "identifier: t1\n"
+     "colon: :\n"
+     "identifier: T\n"
+     "comma: ,\n"
+     "identifier: t2\n"
+     "colon: :\n"
+     "identifier: T\n"
+     "r_paren: )\n"
+     "l_brace: {\n"
+     "r_brace: }\n"
+  );
+}
+


### PR DESCRIPTION
This is a series of fixes intended to improve the quality of references to source code from AST, it includes:
  a) fixes in source ranges stored on AST nodes
  b) fixes of few missed 'implicit' flags for generated nodes
  c) fix for swift::tokenize(...) method to handle tokens split by the parser
