### PR TITLE
Revert "[SR-610][Stdlib] Use for-in to iterate over CollectionType elements"

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -3963,13 +3963,7 @@ public struct Defaulted${traversal}RangeReplaceableSlice<Element>
   }
 
   public func generate() -> MinimalGenerator<Element> {
-    var array: [Element] = []
-    var index = startIndex
-    while index != endIndex {
-      array.append(self[index])
-      index = index.successor()
-    }
-    return MinimalGenerator(array)
+    return MinimalGenerator(Array(self))
   }
 
   public subscript(index: Index) -> Element {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -603,7 +603,16 @@ internal func _copyCollectionToNativeArrayBuffer<
     count: numericCast(count),
     minimumCapacity: 0
   )
-  source._initializeTo(result.firstElementAddress)
+
+  var p = result.firstElementAddress
+  var i = source.startIndex
+  for _ in 0..<count {
+    // FIXME(performance): use _initializeTo().
+    p.initialize(source[i])
+    i._successorInPlace()
+    p._successorInPlace()
+  }
+  _expectEnd(i, source)
   return result
 }
 


### PR DESCRIPTION
Reverts apple/swift#1084

It broke the `stdlib/ArrayNew.swift.gyb` test by removing the `_expectEnd` call, that ensured memory safety.
