### PR TITLE
[test] Explicitly sign chars to match expectations

### DIFF
--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir | FileCheck %s --check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-frontend -Xcc -fsigned-char -I %S/Inputs/abi %s -emit-ir | FileCheck %s --check-prefix=CHECK-%target-cpu
 
 sil_stage canonical
 import c_layout


### PR DESCRIPTION
`char` is not always signed by default. In fact, the signedness of the `char` datatype in C is undefined. That means that on some architectures, the `c_layout.sil` test fails, because it expects the IR for `char chareth(char a);` to use `signedext`, whereas some architectures treat these types as unsigned, and thus `zeroext` is used.

In order to ensure identical signedness on all platforms the tests run on, explicitly specify the signedness using the compiler flag `-fsigned-char`.

---

More information on `char` signedness can be found here: http://blog.cdleary.com/2012/11/arm-chars-are-unsigned-by-default/

I discovered this failure when targeting [Android armv7](https://github.com/SwiftAndroid/swift). I've tested this change against Android armv7 and Linux x86_64.

@hpux735, I'm curious whether the test is currently failing for you on Linux armv6/armv7, and whether this change fixes things!
