### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintGraph::addConstraint(…)

### DIFF
--- a/validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift
+++ b/validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift
@@ -1,0 +1,17 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+let a{
+var f=[[
+map class d
+{
+protocol A:A
+{
+typealias d
+class A:A
+func a
+class A:d


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:50: std::pair<ConstraintGraphNode &, unsigned int> swift::constraints::ConstraintGraph::lookupNode(swift::TypeVariableType *): Assertion `impl.getGraphIndex() < TypeVariables.size() && "Out-of-bounds index"' failed.
9  swift           0x0000000000ef02cf swift::constraints::ConstraintGraph::addConstraint(swift::constraints::Constraint*) + 111
10 swift           0x0000000000e69082 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 258
11 swift           0x0000000000ebdfcd swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 3869
12 swift           0x0000000000ebcc0b swift::constraints::ConstraintSystem::matchTupleTypes(swift::TupleType*, swift::TupleType*, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 443
13 swift           0x0000000000ec1eec swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 620
14 swift           0x0000000000ebfa00 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 10576
15 swift           0x0000000000ec11e0 swift::constraints::ConstraintSystem::matchFunctionTypes(swift::FunctionType*, swift::FunctionType*, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 400
16 swift           0x0000000000ec06c4 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 13844
17 swift           0x0000000000ebd99a swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 2282
18 swift           0x0000000000ec963c swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 652
19 swift           0x0000000000e68f97 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
20 swift           0x0000000000e787af swift::TypeChecker::callWitness(swift::Expr*, swift::DeclContext*, swift::ProtocolDecl*, swift::ProtocolConformance*, swift::DeclName, llvm::MutableArrayRef<swift::Expr*>, swift::Diag<>) + 1839
24 swift           0x0000000000f6705e swift::Expr::walk(swift::ASTWalker&) + 46
25 swift           0x0000000000e74806 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
26 swift           0x0000000000de91ab swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
28 swift           0x0000000000e90a86 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 7734
29 swift           0x0000000000e9375e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
30 swift           0x0000000000de2da5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
31 swift           0x0000000000de9139 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
32 swift           0x0000000000dea2b0 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
33 swift           0x0000000000dea459 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
36 swift           0x0000000000e04076 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
39 swift           0x0000000000e499fa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
40 swift           0x0000000000e4984e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
41 swift           0x0000000000e4a418 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
43 swift           0x0000000000dd0402 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
44 swift           0x0000000000c7aeef swift::CompilerInstance::performSema() + 2975
46 swift           0x00000000007755f7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
47 swift           0x00000000007701d5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/23445-swift-constraints-constraintgraph-unbindtypevariable-651080.o
1.  While type-checking getter for a at validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift:5:6
2.  While type-checking declaration 0x4ceff98 at validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift:6:1
3.  While type-checking expression at [validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift:6:7 - line:7:1] RangeText="[[
4.  While type-checking expression at [validation-test/compiler_crashers/23445-swift-constraints-constraintgraph-unbindtypevariable.swift:6:7 - line:7:1] RangeText="[[
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
