### PR TITLE
[test] ARM-proof assembly check in variables test

### DIFF
--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -3,7 +3,7 @@
 // Ensure that the debug info we're emitting passes the back end verifier.
 // RUN: %target-swift-frontend %s -g -S -o - | FileCheck %s --check-prefix ASM-%target-object-format
 // ASM-macho: .section __DWARF,__debug_info
-// ASM-elf: .section .debug_info,"",@progbits
+// ASM-elf: .section .debug_info,"",{{[@%]}}progbits
 
 // Test variables-interpreter.swift runs this code with `swift -g -i`.
 // Test variables-repl.swift runs this code with `swift -g < variables.swift`.


### PR DESCRIPTION
Assembly generated for ARM uses `%` to prefix section types, as opposed to the typical `@`. On ARM, `@` has historically been used for comments.

Fix the test when run targeting ARM, by accepting both.

---

Thanks to @tienex for the historical context around `%` and `@`! :bow: 

Tested against OS X x86_64, Linux x86_64, and [Android armv7](https://github.com/SwiftAndroid/swift). /cc @hpux735, in case he'd like to test against Linux armv6/armv7.
