### PR TITLE
[Sema] Fix SR-590 Passing two parameters to a function that takes one…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -542,6 +542,14 @@ matchCallArguments(ConstraintSystem &cs, TypeMatchKind kind,
     if (argType->is<InOutType>()) {
       return ConstraintSystem::SolutionKind::Error;
     }
+    // If the param type is an empty existential composition, the function can
+    // only have one argument. Check if exactly one arguement was passed to this
+    // function, otherwise we obviously have a mismatch
+    if (auto tupleArgType = argType->getAs<TupleType>()) {
+      if (tupleArgType->getNumElements() != 1) {
+        return ConstraintSystem::SolutionKind::Error;
+      }
+    }
     return ConstraintSystem::SolutionKind::Solved;
   }
 

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -75,3 +75,8 @@ A().a(text:"sometext") // expected-error {{argument labels '(text:)' do not matc
 func r22451001() -> AnyObject {}
 print(r22451001(5))  // expected-error {{argument passed to call that takes no arguments}}
 
+
+// SR-590 Passing two parameters to a function that takes one argument of type Any crashes the compiler
+func sr590(x: Any) {}
+sr590(3,4) // expected-error {{extra argument in call}}
+


### PR DESCRIPTION
… argument of type Any crashes the compiler

Since this is my first contribution to the Swift compiler, could someone please have a closer look at the changes ;-)
