### PR TITLE
Make String validation tests runnable on Linux

### DIFF
--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 
 // XFAIL: interpret
-// XFAIL: linux
 
 import StdlibUnittest
 
@@ -12,9 +11,8 @@ import StdlibUnittest
 import SwiftPrivate
 #if _runtime(_ObjC)
 import ObjectiveC
-#endif
-
 import Foundation
+#endif
 
 extension String {
   var bufferID: UInt {
@@ -244,7 +242,10 @@ StringTests.test("_splitFirst") {
   expectEqual("bar", after)
 }
 
-StringTests.test("hasPrefix") {
+StringTests.test("hasPrefix")
+  .skip(.LinuxAny(reason: "hasPrefix unavailable"))
+  .code {
+#if _runtime(_ObjC)
   expectFalse("".hasPrefix(""))
   expectFalse("".hasPrefix("a"))
   expectFalse("a".hasPrefix(""))
@@ -256,6 +257,9 @@ StringTests.test("hasPrefix") {
   expectFalse("a\u{0301}bc".hasPrefix("a"))
   expectTrue("\u{00e1}bc".hasPrefix("a\u{0301}"))
   expectTrue("a\u{0301}bc".hasPrefix("\u{00e1}"))
+#else
+  expectUnreachable()
+#endif
 }
 
 StringTests.test("literalConcatenation") {
@@ -609,7 +613,10 @@ func asciiString<
   return s
 }
 
-StringTests.test("stringCoreExtensibility") {
+StringTests.test("stringCoreExtensibility")
+  .skip(.LinuxAny(reason: "Foundation dependency"))
+  .code {
+#if _runtime(_ObjC)
   let ascii = UTF16.CodeUnit(UnicodeScalar("X").value)
   let nonAscii = UTF16.CodeUnit(UnicodeScalar("é").value)
 
@@ -642,9 +649,15 @@ StringTests.test("stringCoreExtensibility") {
       }
     }
   }
+#else
+  expectUnreachable()
+#endif
 }
 
-StringTests.test("stringCoreReserve") {
+StringTests.test("stringCoreReserve")
+  .skip(.LinuxAny(reason: "Foundation dependency"))
+  .code {
+#if _runtime(_ObjC)
   for k in 0...5 {
     var base: String
     var startedNative: Bool
@@ -699,6 +712,9 @@ StringTests.test("stringCoreReserve") {
     }
     expectEqual(expected, base)
   }
+#else
+  expectUnreachable()
+#endif
 }
 
 func makeStringCore(base: String) -> _StringCore {
@@ -895,12 +911,22 @@ StringTests.test("Conversions") {
 
 // Check the internal functions are correct for ASCII values
 StringTests.test(
-  "forall x: Int8, y: Int8 . x < 128 ==> x <ascii y == x <unicode y") {
+  "forall x: Int8, y: Int8 . x < 128 ==> x <ascii y == x <unicode y")
+  .skip(.LinuxAny(reason: "String._compareASCII defined when _runtime(_ObjC)"))
+  .code {
+#if _runtime(_ObjC)
   let asciiDomain = (0..<128).map({ String(UnicodeScalar($0)) })
   expectEqualMethodsForDomain(
     asciiDomain, asciiDomain, 
     String._compareDeterministicUnicodeCollation, String._compareASCII)
+#else
+  expectUnreachable()
+#endif
 }
+
+#if os(Linux)
+import Glibc
+#endif
 
 StringTests.test("lowercaseString") {
   // Use setlocale so tolower() is correct on ASCII.
@@ -1038,7 +1064,10 @@ StringTests.test("unicodeViews") {
 
 // Validate that index conversion does something useful for Cocoa
 // programmers.
-StringTests.test("indexConversion") {
+StringTests.test("indexConversion")
+  .skip(.LinuxAny(reason: "Foundation dependency"))
+  .code {
+#if _runtime(_ObjC)
   let re : NSRegularExpression
   do {
     re = try NSRegularExpression(
@@ -1061,6 +1090,9 @@ StringTests.test("indexConversion") {
   }
 
   expectEqual(["furth", "lard", "bart"], matches)
+#else
+  expectUnreachable()
+#endif
 }
 
 StringTests.test("String.append(_: UnicodeScalar)") {


### PR DESCRIPTION
Foundation-dependent tests are skipped.
