### PR TITLE
[stdlib] Failing string ordering on linux test

### DIFF
--- a/test/1_stdlib/StringOrderRelation.swift
+++ b/test/1_stdlib/StringOrderRelation.swift
@@ -13,7 +13,10 @@ import ObjectiveC
 
 var StringOrderRelationTestSuite = TestSuite("StringOrderRelation")
 
-StringOrderRelationTestSuite.test("StringOrderRelation/ASCII/NullByte") {
+StringOrderRelationTestSuite.test("StringOrderRelation/ASCII/NullByte")
+  .xfail(.LinuxAny(reason: "String comparison: ICU vs. Foundation"))
+  .xfail(.FreeBSDAny(reason: "String comparison: ICU vs. Foundation"))
+  .code {
   let baseString = "a"
   let nullbyteString = "a\0"
   expectTrue(baseString < nullbyteString)

--- a/test/1_stdlib/StringOrderRelation.swift
+++ b/test/1_stdlib/StringOrderRelation.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+// Also import modules which are used by StdlibUnittest internally. This
+// workaround is needed to link all required libraries in case we compile
+// StdlibUnittest with -sil-serialize-all.
+import SwiftPrivate
+#if _runtime(_ObjC)
+import ObjectiveC
+#endif
+
+var StringOrderRelationTestSuite = TestSuite("StringOrderRelation")
+
+StringOrderRelationTestSuite.test("StringOrderRelation/ASCII/NullByte") {
+  let baseString = "a"
+  let nullbyteString = "a\0"
+  expectTrue(baseString < nullbyteString)
+  expectTrue(baseString <= nullbyteString)
+  expectFalse(baseString > nullbyteString)
+  expectFalse(baseString >= nullbyteString)
+  expectFalse(baseString == nullbyteString)
+  expectTrue(baseString != nullbyteString)
+}
+
+runAllTests()
+


### PR DESCRIPTION
This testcase illustrates a problem on linux: the strings "a" and "a\0" satisfy

```
"a" <= "a\0"
"a" >= "a\0"
"a" != "a\0"
```

The testcase should succeed on OS X (@Lvt send me the OS X output of the compares - it's basically "a" < "a\0", which is reasonable).

Here is a sample output of the failure on linux (swift trunk with this pull request, ubuntu 15.10):

```
Command Output (stdout):
--
[ RUN      ] StringOrderRelation.StringOrderRelation/ASCII/NullByte
out>>> check failed at /home/rtreffer/work/swift/test/1_stdlib/StringOrderRelation.swift, line 19
out>>> expected: true
out>>> check failed at /home/rtreffer/work/swift/test/1_stdlib/StringOrderRelation.swift, line 22
out>>> expected: false
[     FAIL ] StringOrderRelation.StringOrderRelation/ASCII/NullByte
StringOrderRelation: Some tests failed, aborting
UXPASS: []
FAIL: ["StringOrderRelation/ASCII/NullByte"]
SKIP: []
```

 [SR-530](https://bugs.swift.org/browse/SR-530) reports another inconsistent ordering on linux but is related to case sensitive vs. insensitive ordering. This might be another nice addition for an ordering testcase.
