### PR TITLE
[swiftc] Add test case for crash triggered in swift::VarDecl::emitLetToVarNoteIfSimple(…)

### DIFF
--- a/validation-test/compiler_crashers/24969-swift-vardecl-emitlettovarnoteifsimple.swift
+++ b/validation-test/compiler_crashers/24969-swift-vardecl-emitlettovarnoteifsimple.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class n{func f{func b<class A{var _=f=b


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::FuncDecl, const swift::AbstractFunctionDecl *>::doit(const From *) [To = swift::FuncDecl, From = const swift::AbstractFunctionDecl *]: Assertion `Val && "isa<> used on a null pointer"' failed.
8  swift           0x0000000000fc74ba swift::VarDecl::emitLetToVarNoteIfSimple(swift::DeclContext*) const + 586
10 swift           0x0000000000dedb84 swift::constraints::ConstraintSystem::computeAssignDestType(swift::Expr*, swift::SourceLoc) + 964
13 swift           0x0000000000f6a235 swift::Expr::walk(swift::ASTWalker&) + 69
14 swift           0x0000000000eab468 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
15 swift           0x0000000000de5db0 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
16 swift           0x0000000000dec2d9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
17 swift           0x0000000000ded450 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
18 swift           0x0000000000ded5f9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
23 swift           0x0000000000e07226 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 swift           0x0000000000e4cbaa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
27 swift           0x0000000000e4c9fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift           0x0000000000e4d5c8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
30 swift           0x0000000000dd35a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
31 swift           0x0000000000c7d3df swift::CompilerInstance::performSema() + 2975
33 swift           0x0000000000775927 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
34 swift           0x0000000000770505 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/24969-swift-vardecl-emitlettovarnoteifsimple.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/24969-swift-vardecl-emitlettovarnoteifsimple-816fda.o
1.  While type-checking 'f' at validation-test/compiler_crashers/24969-swift-vardecl-emitlettovarnoteifsimple.swift:5:9
2.  While type-checking 'A' at validation-test/compiler_crashers/24969-swift-vardecl-emitlettovarnoteifsimple.swift:5:23
3.  While type-checking expression at [validation-test/compiler_crashers/24969-swift-vardecl-emitlettovarnoteifsimple.swift:5:37 - line:5:39] RangeText="f=b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
