### PR TITLE
[Coverage] Fix crash when assigning counter to orphan if_expr

### DIFF
--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -564,8 +564,11 @@ public:
       assignCounter(E);
     } else if (auto *IE = dyn_cast<IfExpr>(E)) {
       CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
-      assignCounter(IE->getElseExpr(),
-                    CounterExpr::Sub(getCurrentCounter(), ThenCounter));
+      if (Parent.isNull())
+        assignCounter(IE->getElseExpr());
+      else
+        assignCounter(IE->getElseExpr(),
+                      CounterExpr::Sub(getCurrentCounter(), ThenCounter));
     }
 
     if (hasCounter(E))

--- a/test/SILGen/coverage_ternary.swift
+++ b/test/SILGen/coverage_ternary.swift
@@ -10,3 +10,11 @@ func foo(x : Int32) -> Int32 {
 foo(1)
 foo(2)
 foo(3)
+
+// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_ternary.bar.__allocating_init
+class bar {
+  var m1 = 0 == 1
+             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 1
+             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : 0
+}


### PR DESCRIPTION
When visited by an ASTWalker, an if_expr nested within a
patter_binding_decl has no Parent. This leads to a crash while assigning
counters for the if_expr's "else" branch: there is no enclosing region,
so grabbing the current region is impossible.

We can handle this case safely by using a new leaf counter for the
"else" branch.

rdar://problem/23256795
