### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeRepr::walk(…)

### DIFF
--- a/validation-test/compiler_crashers/28198-swift-typerepr-walk.swift
+++ b/validation-test/compiler_crashers/28198-swift-typerepr-walk.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+private class B
+class d<T where B<T>:w


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2211: swift::Accessibility swift::ValueDecl::getFormalAccess() const: Assertion `hasAccessibility() && "accessibility not computed yet"' failed.
10 swift           0x0000000000f6a34a swift::TypeRepr::walk(swift::ASTWalker&) + 42
16 swift           0x0000000000e07226 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
17 swift           0x0000000000dd352a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1626
18 swift           0x0000000000c7d3df swift::CompilerInstance::performSema() + 2975
20 swift           0x0000000000775927 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
21 swift           0x0000000000770505 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28198-swift-typerepr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28198-swift-typerepr-walk-f511c7.o
1.  While type-checking 'd' at validation-test/compiler_crashers/28198-swift-typerepr-walk.swift:9:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
