### PR TITLE
[validation-test][FreeBSD] xfail Foundation check

### DIFF
--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -82,6 +82,7 @@ Algorithm.test("min,max") {
 
 Algorithm.test("sorted/strings")
   .xfail(.LinuxAny(reason: "String comparison: ICU vs. Foundation"))
+  .xfail(.FreeBSDAny(reason: "String comparison: ICU vs. Foundation"))
   .code {
   expectEqual(
     [ "Banana", "apple", "cherry" ],


### PR DESCRIPTION
The "sorted/strings" test compares string sorting between Foundation and ICU. Foundation is only available on OS X, so the test is expected to fail on Linux. Foundation isn't available on FreeBSD either, so disable it for that platform as well.

---

This should fix one of the failing tests for FreeBSD. /cc @dcci, in case you'd like to confirm :smiley: 
