### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::resolveTypeInContext(…)

### DIFF
--- a/validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift
@@ -1,0 +1,12 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+struct B{let f= <a
+extension{
+protocol A{
+extension{
+protocol A:A{func<


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckType.cpp:247: swift::Type swift::TypeChecker::resolveTypeInContext(swift::TypeDecl *, swift::DeclContext *, TypeResolutionOptions, bool, swift::GenericTypeResolver *, UnsatisfiedDependency *): Assertion `(ownerNominal || nonTypeOwner) && "Owner must be a nominal type or a non type context"' failed.
8  swift           0x0000000000e51e17 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 2151
12 swift           0x0000000000e5288e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000e537f4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000e5279a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
16 swift           0x0000000000dffb5a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
17 swift           0x0000000000e25125 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 373
18 swift           0x0000000000e269e0 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 256
19 swift           0x0000000000e26d24 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
20 swift           0x0000000000e01e70 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
21 swift           0x0000000000fff69d swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2237
22 swift           0x0000000000e28e7b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
25 swift           0x0000000000e5288e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
27 swift           0x0000000000e537f4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
28 swift           0x0000000000e5279a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
29 swift           0x0000000000ee2982 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
30 swift           0x0000000000ee1c0d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
31 swift           0x0000000000ee1d99 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
32 swift           0x0000000000dfe750 swift::TypeChecker::resolveInheritedProtocols(swift::ProtocolDecl*) + 64
33 swift           0x0000000000f00621 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 225
36 swift           0x0000000000f021bf swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
37 swift           0x0000000000f0038b swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 603
38 swift           0x0000000000f0010c swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
39 swift           0x0000000000e25137 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 391
40 swift           0x0000000000e2696f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
41 swift           0x0000000000e26d24 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
42 swift           0x0000000000e01e70 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1248
43 swift           0x0000000000e01a50 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 192
46 swift           0x0000000000ff86a2 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
47 swift           0x0000000000fffd57 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3959
48 swift           0x0000000000e28e7b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
49 swift           0x0000000000de4746 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 102
53 swift           0x0000000000f6a21e swift::Expr::walk(swift::ASTWalker&) + 46
54 swift           0x0000000000de5d27 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
55 swift           0x0000000000dec2d9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
56 swift           0x0000000000ded450 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
57 swift           0x0000000000ded5f9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
62 swift           0x0000000000e07226 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
63 swift           0x0000000000dd34a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
64 swift           0x0000000000c7d3df swift::CompilerInstance::performSema() + 2975
66 swift           0x0000000000775927 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
67 swift           0x0000000000770505 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28212-swift-typechecker-resolvetypeincontext-6ff8d4.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift:1:1
2.  While type-checking expression at [validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift:1:17 - line:1:18] RangeText="<a"
3.  While resolving type A at [validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift:5:12 - line:5:12] RangeText="A"
4.  While resolving type A at [validation-test/compiler_crashers/28212-swift-typechecker-resolvetypeincontext.swift:3:10 - line:3:10] RangeText="A"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
