### PR TITLE
Add backtrace reporting on fatalError

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -18,9 +18,9 @@
 #define _SWIFT_RUNTIME_DEBUG_HELPERS_
 
 #include <llvm/Support/Compiler.h>
+#include <stdint.h>
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
-#include <stdint.h>
 
 #define CRASH_REPORTER_CLIENT_HIDDEN __attribute__((visibility("hidden")))
 #define CRASHREPORTER_ANNOTATIONS_VERSION 5
@@ -81,7 +81,7 @@ static inline void crash(const char *message) {
 // but makes no attempt to preserve register state.
 LLVM_ATTRIBUTE_NORETURN
 extern void
-fatalError(const char *format, ...);
+fatalError(uint32_t flags, const char *format, ...);
 
 struct Metadata;
 
@@ -102,7 +102,7 @@ swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                          const char *message = nullptr);
 
 extern "C"
-void swift_reportError(const char *message);
+void swift_reportError(uint32_t flags, const char *message);
 
 // namespace swift
 }

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -36,7 +36,8 @@ public func assert(
   // Only assert in debug mode.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), true) {
-      _assertionFailed("assertion failed", message(), file, line)
+      _assertionFailed("assertion failed", message(), file, line,
+        flags: _fatalErrorFlags())
     }
   }
 }
@@ -66,7 +67,8 @@ public func precondition(
   // Only check in debug and release mode.  In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), true) {
-      _assertionFailed("precondition failed", message(), file, line)
+      _assertionFailed("precondition failed", message(), file, line,
+        flags: _fatalErrorFlags())
     }
   } else if _isReleaseAssertConfiguration() {
     let error = !condition()
@@ -98,7 +100,8 @@ public func assertionFailure(
   file: StaticString = __FILE__, line: UInt = __LINE__
 ) {
   if _isDebugAssertConfiguration() {
-    _assertionFailed("fatal error", message(), file, line)
+    _assertionFailed("fatal error", message(), file, line,
+      flags: _fatalErrorFlags())
   }
   else if _isFastAssertConfiguration() {
     _conditionallyUnreachable()
@@ -127,7 +130,8 @@ public func preconditionFailure(
 ) {
   // Only check in debug and release mode.  In release mode just trap.
   if _isDebugAssertConfiguration() {
-    _assertionFailed("fatal error", message(), file, line)
+    _assertionFailed("fatal error", message(), file, line,
+      flags: _fatalErrorFlags())
   } else if _isReleaseAssertConfiguration() {
     Builtin.int_trap()
   }
@@ -140,7 +144,8 @@ public func fatalError(
   @autoclosure message: () -> String = String(),
   file: StaticString = __FILE__, line: UInt = __LINE__
 ) {
-  _assertionFailed("fatal error", message(), file, line)
+  _assertionFailed("fatal error", message(), file, line,
+    flags: _fatalErrorFlags())
 }
 
 /// Library precondition checks.
@@ -157,7 +162,8 @@ public func _precondition(
   // Only check in debug and release mode. In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), true) {
-      _fatalErrorMessage("fatal error", message, file, line)
+      _fatalErrorMessage("fatal error", message, file, line,
+        flags: _fatalErrorFlags())
     }
   } else if _isReleaseAssertConfiguration() {
     let error = !condition()
@@ -186,7 +192,8 @@ public func _overflowChecked<T>(
   let (result, error) = args
   if _isDebugAssertConfiguration() {
     if _branchHint(error, false) {
-      _fatalErrorMessage("fatal error", "Overflow/underflow", file, line)
+      _fatalErrorMessage("fatal error", "Overflow/underflow", file, line,
+        flags: _fatalErrorFlags())
     }
   } else {
     Builtin.condfail(error._value)
@@ -210,7 +217,8 @@ public func _debugPrecondition(
   // Only check in debug mode.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), true) {
-      _fatalErrorMessage("fatal error", message, file, line)
+      _fatalErrorMessage("fatal error", message, file, line,
+        flags: _fatalErrorFlags())
     }
   }
 }
@@ -238,7 +246,8 @@ public func _sanityCheck(
 ) {
 #if INTERNAL_CHECKS_ENABLED
   if !_branchHint(condition(), true) {
-    _fatalErrorMessage("fatal error", message, file, line)
+    _fatalErrorMessage("fatal error", message, file, line,
+      flags: _fatalErrorFlags())
   }
 #endif
 }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -395,7 +395,8 @@ swift::swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                                 const char *message) {
   asm("");
 
-  swift::fatalError("Could not cast value of type '%s' (%p) to '%s' (%p)%s%s\n",
+  swift::fatalError(/* flags = */ 0,
+                    "Could not cast value of type '%s' (%p) to '%s' (%p)%s%s\n",
                     sourceName, sourceType, 
                     targetName, targetType, 
                     message ? ": " : ".", 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -22,10 +22,125 @@
 #include <pthread.h>
 #include <stdarg.h>
 #include "swift/Runtime/Debug.h"
+#include "swift/Basic/Demangle.h"
+#include <cxxabi.h>
+#include <execinfo.h>
 
 #ifdef __APPLE__
 #include <asl.h>
 #endif
+
+namespace FatalErrorFlags {
+enum: uint32_t {
+  ReportBacktrace = 1 << 0
+};
+} // end namespace FatalErrorFlags
+
+LLVM_ATTRIBUTE_ALWAYS_INLINE
+static bool
+isIdentifier(char c)
+{
+  return isalnum(c) || c == '_' || c == '$';
+}
+
+static bool
+demangledLinePrefix(std::string line, std::string prefix,
+                    std::string &out,
+                    bool (*demangle)(std::string, std::string &))
+{
+  int symbolStart = -1;
+  int symbolEnd = -1;
+  
+  for (size_t i = 0; i < line.size(); i++) {
+    char c = line[i];
+    
+    bool hasBegun = symbolStart != -1;
+    bool isIdentifierChar = isIdentifier(c);
+    bool isEndOfSymbol = hasBegun && !isIdentifierChar;
+    bool isEndOfLine = i == line.size() - 1;
+    
+    if (isEndOfLine || isEndOfSymbol) {
+      symbolEnd = i;
+      break;
+    }
+
+    bool canFindPrefix = (line.size() - 2) - i > prefix.size();
+    if (!hasBegun && canFindPrefix && !isIdentifierChar &&
+        line.substr(i + 1, prefix.size()) == prefix) {
+      symbolStart = i + 1;
+      continue;
+    }
+  }
+  
+  if (symbolStart == -1 || symbolEnd == -1) {
+    out = line;
+    return false;
+  } else {
+    auto symbol = line.substr(symbolStart, symbolEnd - symbolStart);
+    
+    std::string demangled;
+    bool success = demangle(symbol, demangled);
+    
+    if (success) {
+      line.replace(symbolStart, symbolEnd - symbolStart, demangled);
+    }
+    
+    out = line;
+    
+    return success;
+  }
+}
+
+static std::string
+demangledLine(std::string line) {
+  std::string res;
+  bool success = false;
+  auto cppPrefix = "_Z"; // not sure how to check for DARWIN's __Z here.
+  success = demangledLinePrefix(line, cppPrefix, res,
+                                [](std::string symbol, std::string &out) {
+    int status;
+    auto demangled = abi::__cxa_demangle(symbol.c_str(), 0, 0, &status);
+    if (demangled == NULL || status != 0) {
+      out = symbol;
+      return false;
+    } else {
+      out = demangled;
+      return true;
+    }
+  });
+  if (success) return res;
+  success = demangledLinePrefix(line, "_T", res,
+                                [](std::string symbol, std::string &out) {
+    out = swift::Demangle::demangleSymbolAsString(symbol);
+    return true;
+  });
+  if (success) return res;
+  return line;
+}
+
+const int STACK_DEPTH = 128;
+
+static char **
+reportBacktrace(int *count)
+{
+  void **addrs = (void **)malloc(sizeof(void *) * STACK_DEPTH);
+  if (addrs == NULL) {
+    if (count) *count = 0;
+    return NULL;
+  }
+  int symbolCount = backtrace(addrs, STACK_DEPTH);
+  if (count) *count = symbolCount;
+
+  char **symbols = backtrace_symbols(addrs, symbolCount);
+  free(addrs);
+  if (symbols == NULL) {
+    if (count) *count = 0;
+    return NULL;
+  }
+
+  return symbols;
+}
+
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
 #include <malloc/malloc.h>
@@ -44,7 +159,7 @@ struct crashreporter_annotations_t gCRAnnotations
 
 // Report a message to any forthcoming crash log.
 static void
-reportOnCrash(const char *message)
+reportOnCrash(uint32_t flags, const char *message)
 {
   static pthread_mutex_t crashlogLock = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&crashlogLock);
@@ -67,7 +182,7 @@ reportOnCrash(const char *message)
 #else
 
 static void
-reportOnCrash(const char *message)
+reportOnCrash(uint32_t flags, const char *message)
 {
   // empty
 }
@@ -77,25 +192,35 @@ reportOnCrash(const char *message)
 
 // Report a message to system console and stderr.
 static void
-reportNow(const char *message)
+reportNow(uint32_t flags, const char *message)
 {
   write(STDERR_FILENO, message, strlen(message));
 #ifdef __APPLE__
   asl_log(NULL, NULL, ASL_LEVEL_ERR, "%s", message);
 #endif
+  if (flags & FatalErrorFlags::ReportBacktrace) {
+    fputs("Current stack trace:\n", stderr);
+    int count = 0;
+    char **trace = reportBacktrace(&count);
+    for (int i = 0; i < count; i++) {
+      fprintf(stderr, "%s\n", demangledLine(trace[i]).c_str());
+    }
+    free(trace);
+  }
 }
 
 /// Report a fatal error to system console, stderr, and crash logs.
 /// Does not crash by itself.
-void swift::swift_reportError(const char *message) {
-  reportNow(message);
-  reportOnCrash(message);
+void swift::swift_reportError(uint32_t flags,
+                              const char *message) {
+  reportNow(flags, message);
+  reportOnCrash(flags, message);
 }
 
 // Report a fatal error to system console, stderr, and crash logs, then abort.
 LLVM_ATTRIBUTE_NORETURN
 void
-swift::fatalError(const char *format, ...)
+swift::fatalError(uint32_t flags, const char *format, ...)
 {
   va_list args;
   va_start(args, format);
@@ -103,7 +228,7 @@ swift::fatalError(const char *format, ...)
   char *log;
   vasprintf(&log, format, args);
 
-  swift_reportError(log);
+  swift_reportError(flags, log);
   abort();
 }
 
@@ -111,5 +236,6 @@ swift::fatalError(const char *format, ...)
 LLVM_ATTRIBUTE_NORETURN
 extern "C" void
 swift_deletedMethodError() {
-  swift::fatalError("fatal error: call of deleted method\n");
+  swift::fatalError(/* flags = */ 0,
+                    "fatal error: call of deleted method\n");
 }

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -80,10 +80,12 @@ swift::swift_initStackObject(HeapMetadata const *metadata,
 void
 swift::swift_verifyEndOfLifetime(HeapObject *object) {
   if (object->refCount.getCount() != 0)
-    swift::fatalError("fatal error: stack object escaped\n");
-
+    swift::fatalError(/* flags = */ 0,
+                      "fatal error: stack object escaped\n");
+  
   if (object->weakRefCount.getCount() != 1)
-    swift::fatalError("fatal error: weak/unowned reference to stack object\n");
+    swift::fatalError(/* flags = */ 0,
+                      "fatal error: weak/unowned reference to stack object\n");
 }
 
 /// \brief Allocate a reference-counted object on the heap that

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -318,7 +318,8 @@ swift::swift_getObjCClassMetadata(const ClassMetadata *theClass) {
 
   return entry->getData();
 #else
-  fatalError("swift_getObjCClassMetadata: no Objective-C interop");
+  fatalError(/* flags = */ 0,
+             "swift_getObjCClassMetadata: no Objective-C interop");
 #endif
 }
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -238,7 +238,8 @@ static NSString *_getClassDescription(Class cls) {
 
 - (void)doesNotRecognizeSelector: (SEL) sel {
   Class cls = (Class) _swift_getClassOfAllocated(self);
-  fatalError("Unrecognized selector %c[%s %s]\n", 
+  fatalError(/* flags = */ 0,
+             "Unrecognized selector %c[%s %s]\n",
              class_isMetaClass(cls) ? '+' : '-', 
              class_getName(cls), sel_getName(sel));
 }

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -28,13 +28,14 @@ extern "C" void
 _swift_stdlib_reportFatalErrorInFile(const char *prefix, intptr_t prefixLength,
                                    const char *message, intptr_t messageLength,
                                    const char *file, intptr_t fileLength,
-                                   uintptr_t line) {
+                                   uintptr_t line,
+                                     uint32_t flags) {
   char *log;
   asprintf(&log, "%.*s: %.*s%sfile %.*s, line %zu\n", (int)prefixLength, prefix,
            (int)messageLength, message, (messageLength ? ": " : ""),
            (int)fileLength, file, (size_t)line);
   
-  swift_reportError(log);
+  swift_reportError(flags, log);
   free(log);
 }
 
@@ -45,12 +46,13 @@ extern "C" void
 _swift_stdlib_reportFatalError(const char *prefix,
                                intptr_t prefixLength,
                                const char *message,
-                               intptr_t messageLength) {
+                               intptr_t messageLength,
+                               uint32_t flags) {
   char *log;
   asprintf(&log, "%.*s: %.*s\n", (int)prefixLength, prefix,
            (int)messageLength, message);
   
-  swift_reportError(log);
+  swift_reportError(flags, log);
   free(log);
 }
 
@@ -61,14 +63,14 @@ extern "C" void
 _swift_stdlib_reportUnimplementedInitializerInFile(
          const char *className, intptr_t classNameLength, const char *initName,
          intptr_t initNameLength, const char *file, intptr_t fileLength,
-         uintptr_t line, uintptr_t column) {
+         uintptr_t line, uintptr_t column, uint32_t flags) {
   char *log;
   asprintf(&log, "%.*s: %zu: %zu: fatal error: use of unimplemented "
            "initializer '%.*s' for class '%.*s'\n",
            (int)fileLength, file, (size_t)line, (size_t)column,
            (int)initNameLength, initName, (int)classNameLength, className);
 
-  swift_reportError(log);
+  swift_reportError(flags, log);
   free(log);
 }
 
@@ -79,13 +81,14 @@ extern "C" void
 _swift_stdlib_reportUnimplementedInitializer(const char *className,
                                              intptr_t classNameLength,
                                              const char *initName,
-                                             intptr_t initNameLength) {
+                                             intptr_t initNameLength,
+                                             uint32_t flags) {
   char *log;
   asprintf(&log, "fatal error: use of unimplemented "
            "initializer '%.*s' for class '%.*s'\n",
            (int)initNameLength, initName, (int)classNameLength, className);
 
-  swift_reportError(log);
+  swift_reportError(flags, log);
   free(log);
 }
 

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -30,7 +30,8 @@ static NSDictionary *systemVersionDictionaryFromPlist() {
   // not pick up the host OS version.
   const char *simulatorRoot = getenv("IPHONE_SIMULATOR_ROOT");
   if (!simulatorRoot) {
-    fatalError("Unable to check API availability: "
+    fatalError(/* flags = */ 0,
+               "Unable to check API availability: "
                "IPHONE_SIMULATOR_ROOT not set when running under simulator");
   }
 
@@ -45,13 +46,15 @@ static NSDictionary *systemVersionDictionaryFromPlist() {
 static NSOperatingSystemVersion operatingSystemVersionFromPlist() {
   NSDictionary *plistDictionary = systemVersionDictionaryFromPlist();
   if (!plistDictionary) {
-    fatalError("Unable to check API availability: "
+    fatalError(/* flags = */ 0,
+               "Unable to check API availability: "
                "system version dictionary not found");
   }
 
   NSString *versionString = [plistDictionary objectForKey:@"ProductVersion"];
   if (!versionString) {
-    fatalError("Unable to check API availability: "
+    fatalError(/* flags = */ 0,
+               "Unable to check API availability: "
                "ProductVersion not present in system version dictionary");
   }
 


### PR DESCRIPTION
Backtraces are symbolicated and reported on builds with
`-assert-config=Debug`
