### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::simplify(…)

### DIFF
--- a/validation-test/compiler_crashers/28242-swift-constraints-constraintsystem-simplify.swift
+++ b/validation-test/compiler_crashers/28242-swift-constraints-constraintsystem-simplify.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{struct b{let a{struct D{let a=b([print{}}}}struct b


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000ecfd73 swift::constraints::ConstraintSystem::simplify(bool) + 163
5  swift           0x0000000000ed30b0 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 48
6  swift           0x0000000000ed6c1a swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 8506
7  swift           0x0000000000ed3d19 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3225
8  swift           0x0000000000ed5813 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3379
9  swift           0x0000000000ed3d19 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3225
10 swift           0x0000000000ed5813 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3379
11 swift           0x0000000000ed3d19 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3225
12 swift           0x0000000000ed2f79 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
13 swift           0x0000000000de5f16 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 614
14 swift           0x0000000000dec2d9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
15 swift           0x0000000000ded450 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 112
16 swift           0x0000000000ded5f9 swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 265
21 swift           0x0000000000e07226 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
24 swift           0x0000000000e4cbaa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
25 swift           0x0000000000e4c9fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
26 swift           0x0000000000e4d5c8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
28 swift           0x0000000000dd35a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
29 swift           0x0000000000c7d3df swift::CompilerInstance::performSema() + 2975
31 swift           0x0000000000775927 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
32 swift           0x0000000000770505 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28242-swift-constraints-constraintsystem-simplify.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28242-swift-constraints-constraintsystem-simplify-fda504.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28242-swift-constraints-constraintsystem-simplify.swift:7:16
2.  While type-checking 'D' at validation-test/compiler_crashers/28242-swift-constraints-constraintsystem-simplify.swift:7:17
3.  While type-checking expression at [validation-test/compiler_crashers/28242-swift-constraints-constraintsystem-simplify.swift:7:32 - line:7:41] RangeText="b([print{}"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
