### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getCanonicalType()

### DIFF
--- a/validation-test/compiler_crashers/28243-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/28243-swift-typebase-getcanonicaltype.swift
@@ -1,0 +1,17 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+extension String{
+func b{
+{
+a<
+}}
+class A
+extension{
+struct B{
+struct B<T where T:A{
+protocol a{func<


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000001010564 swift::TypeBase::getCanonicalType() + 20
5  swift           0x0000000000e2499f swift::DependentGenericTypeResolver::resolveTypeOfContext(swift::DeclContext*) + 47
6  swift           0x0000000000e51908 swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 856
10 swift           0x0000000000e5288e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift           0x0000000000e537f4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
13 swift           0x0000000000e5279a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
14 swift           0x0000000000e2529c swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 748
15 swift           0x0000000000e2696f swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
16 swift           0x0000000000e26d24 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
17 swift           0x0000000000e01af2 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
18 swift           0x0000000000e01a50 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 192
19 swift           0x0000000000e01a50 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 192
22 swift           0x0000000000ff86a2 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
23 swift           0x0000000000fffd57 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3959
24 swift           0x0000000000e28e7b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
25 swift           0x0000000000de4746 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 102
30 swift           0x0000000000f6a21e swift::Expr::walk(swift::ASTWalker&) + 46
31 swift           0x0000000000de5d27 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
32 swift           0x0000000000dec2d9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
35 swift           0x0000000000e4cbaa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
36 swift           0x0000000000e4c9fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
37 swift           0x0000000000e4d5c8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
39 swift           0x0000000000dd35a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
40 swift           0x0000000000c7d3df swift::CompilerInstance::performSema() + 2975
42 swift           0x0000000000775927 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
43 swift           0x0000000000770505 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28243-swift-typebase-getcanonicaltype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28243-swift-typebase-getcanonicaltype-a30a37.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28243-swift-typebase-getcanonicaltype.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28243-swift-typebase-getcanonicaltype.swift:10:1 - line:12:1] RangeText="{
3.  While resolving type A at [validation-test/compiler_crashers/28243-swift-typebase-getcanonicaltype.swift:16:20 - line:16:20] RangeText="A"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
