### PR TITLE
[Sema] Improve diagnoses on args to generic members

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1066,6 +1066,8 @@ CalleeCandidateInfo::evaluateCloseness(Type candArgListType,
       // FIXME: Use TC.isConvertibleTo?
       if (rArgType->isEqual(paramType))
         continue;
+      if (auto genericParam = paramType->getAs<GenericTypeParamType>())
+        paramType = genericParam->getDecl()->getArchetype();
       if (paramType->is<ArchetypeType>() && !rArgType->hasTypeVariable()) {
         if (singleArchetype) {
           if (!paramType->isEqual(singleArchetype))
@@ -1662,6 +1664,10 @@ bool CalleeCandidateInfo::diagnoseGenericParameterErrors(Expr *badArgExpr) {
   bool foundFailure = false;
   Type paramType = failedArgument.parameterType;
   Type argType = badArgExpr->getType();
+
+  if (auto genericParam = paramType->getAs<GenericTypeParamType>())
+    paramType = genericParam->getDecl()->getArchetype();
+  
   if (paramType->is<ArchetypeType>() && !argType->hasTypeVariable() &&
       // FIXME: For protocol argument types, could add specific error
       // similar to could_not_use_member_on_existential.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -68,6 +68,20 @@ f4(i, d) // expected-error {{extra argument in call}}
 // Missing member.
 i.wobble() // expected-error{{value of type 'Int' has no member 'wobble'}}
 
+// Generic member does not conform.
+extension Int {
+  func wibble<T: P2>(x: T, _ y: T) -> T { return x }
+}
+i.wibble(3, 4) // expected-error {{argument type 'Int' does not conform to expected type 'P2'}}
+
+// Generic member args correct, but return type doesn't match.
+struct A : P2 {
+  func wonka() {}
+}
+let a = A()
+for j in i.wibble(a, a) { // expected-error {{type 'A' does not conform to protocol 'SequenceType'}}
+}
+
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}
 [1, 2, 3].doesntExist(0)  // expected-error {{value of type '[Int]' has no member 'doesntExist'}}
@@ -596,7 +610,7 @@ func r22470302(c: r22470302Class) {
 // <rdar://problem/21928143> QoI: Pointfree reference to generic initializer in generic context does not compile
 extension String {
   @available(*, unavailable, message="calling this is unwise")
-  func unavail<T : SequenceType where T.Generator.Element == String> // expected-note {{'unavail' has been explicitly marked unavailable here}}
+  func unavail<T : SequenceType where T.Generator.Element == String> // expected-note 2 {{'unavail' has been explicitly marked unavailable here}}
     (a : T) -> String {}
 }
 extension Array {
@@ -605,8 +619,7 @@ extension Array {
   }
   
   func h() -> String {
-    return "foo".unavail([0])  // expected-error {{cannot invoke 'unavail' with an argument list of type '([Int])'}}
-    // expected-note @-1 {{expected an argument list of type '(T)'}}
+    return "foo".unavail([0])  // expected-error {{'unavail' is unavailable: calling this is unwise}}
   }
 }
 


### PR DESCRIPTION
In both figuring out candidate closeness and in diagnosing generic parameter errors, if the parameter is a GenericTypeParamType, get its decl’s archetype to perform archetype substitutability checking upon.

This extends https://github.com/apple/swift/pull/1089 to apply to generic member methods to act the same as with the previous generic free functions.

Added tests, all tests pass.
