### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::isInstanceMember()

### DIFF
--- a/validation-test/compiler_crashers/28244-swift-valuedecl-isinstancemember.swift
+++ b/validation-test/compiler_crashers/28244-swift-valuedecl-isinstancemember.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A{let i:Bool,b}let a{struct S<>:A{let i:Bool


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000fbfa81 swift::ValueDecl::isInstanceMember() const + 1
9  swift           0x0000000000e31bdf swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2063
13 swift           0x0000000000e07226 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000e4cbaa swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
17 swift           0x0000000000e4c9fe swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
18 swift           0x0000000000e4d5c8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
20 swift           0x0000000000dd35a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
21 swift           0x0000000000c7d3df swift::CompilerInstance::performSema() + 2975
23 swift           0x0000000000775927 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
24 swift           0x0000000000770505 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28244-swift-valuedecl-isinstancemember.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28244-swift-valuedecl-isinstancemember-b5b6a9.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28244-swift-valuedecl-isinstancemember.swift:8:30
2.  While type-checking 'S' at validation-test/compiler_crashers/28244-swift-valuedecl-isinstancemember.swift:8:31
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
