### PR TITLE
Add cases .ObjCRuntime and .NativeRuntime to StdlibUnittest's TestPredicate

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -1162,6 +1162,9 @@ public enum TestRunPredicate : CustomStringConvertible {
 
   case FreeBSDAny(reason: String)
 
+  case ObjCRuntime(/*reason:*/ String)
+  case NativeRuntime(/*reason:*/ String)
+
   public var description: String {
     switch self {
     case Custom(_, let reason):
@@ -1232,6 +1235,11 @@ public enum TestRunPredicate : CustomStringConvertible {
 
     case FreeBSDAny(reason: let reason):
       return "FreeBSDAny(*, reason: \(reason))"
+
+    case ObjCRuntime(let reason):
+      return "Objective-C runtime, reason: \(reason))"
+    case NativeRuntime(let reason):
+      return "Native runtime (no ObjC), reason: \(reason))"
     }
   }
 
@@ -1471,6 +1479,20 @@ public enum TestRunPredicate : CustomStringConvertible {
       default:
         return false
       }
+
+    case ObjCRuntime:
+#if _runtime(_ObjC)
+      return true
+#else
+      return false
+#endif
+
+    case NativeRuntime:
+#if _runtime(_ObjC)
+      return false
+#else
+      return true
+#endif
     }
   }
 }


### PR DESCRIPTION
This predicate case evaluates to `false` #if `_runtime(_ObjC)`, `true` otherwise.
