### PR TITLE
[StdlibUnittest] Print termination status description

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -695,9 +695,9 @@ struct _ParentProcess {
           testPassed = false
           print("expecting a crash, but the test did not crash")
 
-        case (.Some(_), false):
+        case (.Some(let status), false):
           testPassed = false
-          print("the test crashed unexpectedly")
+          print("the test crashed unexpectedly with a termination status of '\(status.description)'")
 
         case (.Some(_), true):
           testPassed = !_anyExpectFailed

--- a/validation-test/stdlib/StdlibUnittest.swift
+++ b/validation-test/stdlib/StdlibUnittest.swift
@@ -452,7 +452,7 @@ AssertionsTestSuite.test("UnexpectedCrash/RuntimeTrap") {
 }
 // CHECK: [ RUN      ] Assertions.UnexpectedCrash/RuntimeTrap
 // CHECK: err>>> CRASHED: SIG{{.*}}
-// CHECK: the test crashed unexpectedly
+// CHECK: the test crashed unexpectedly with a termination status of 'Exit(0)'
 // CHECK: [     FAIL ] Assertions.UnexpectedCrash/RuntimeTrap
 
 AssertionsTestSuite.test("UnexpectedCrash/NullPointerDereference") {
@@ -461,7 +461,7 @@ AssertionsTestSuite.test("UnexpectedCrash/NullPointerDereference") {
 }
 // CHECK: [ RUN      ] Assertions.UnexpectedCrash/NullPointerDereference
 // CHECK: err>>> CRASHED: SIG{{.*}}
-// CHECK: the test crashed unexpectedly
+// CHECK: the test crashed unexpectedly with a termination status of 'Exit(0)'
 // CHECK: [     FAIL ] Assertions.UnexpectedCrash/NullPointerDereference
 
 var TestSuiteLifetimeTracked = TestSuite("TestSuiteLifetimeTracked")


### PR DESCRIPTION
When a stdlib unit tests crashes unexpectedly, I'd like to know why. The termination status is readily available: print its description when a crash occurs.

---

I think this is an improvement, but to be honest the test results surprised me. In `validation-test/stdlib/StdlibUnittest.swift`, why do a runtime trap and null pointer dereference result in an exit status of `0`? Shouldn't these child processes have unsuccessful exit codes?
