### PR TITLE
[swiftc] Add test case for crash triggered in swift::DependentGenericTypeResolver::resolveSelfAssociatedType(…)

### DIFF
--- a/validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{struct A<T:A.B{class B<U:T.u


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckGeneric.cpp:34: virtual swift::Type swift::DependentGenericTypeResolver::resolveDependentMemberType(swift::Type, swift::DeclContext *, swift::SourceRange, swift::ComponentIdentTypeRepr *): Assertion `archetype && "Bad generic context nesting?"' failed.
8  swift           0x0000000000e27a20 swift::DependentGenericTypeResolver::resolveSelfAssociatedType(swift::Type, swift::DeclContext*, swift::AssociatedTypeDecl*) + 0
10 swift           0x0000000000e559be swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
12 swift           0x0000000000e56924 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
13 swift           0x0000000000e558ca swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
14 swift           0x0000000000e026ba swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
15 swift           0x0000000000e28275 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 373
16 swift           0x0000000000e29abf swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
17 swift           0x0000000000e29e74 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
18 swift           0x0000000000e04652 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
19 swift           0x0000000001006fdc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2892
20 swift           0x0000000000e2cd55 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 293
22 swift           0x0000000000e559be swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
24 swift           0x0000000000e56924 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
25 swift           0x0000000000e558ca swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
26 swift           0x0000000000e026ba swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4890
27 swift           0x0000000000e28275 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::DeclContext*, bool, swift::GenericTypeResolver*) + 373
28 swift           0x0000000000e29abf swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 143
29 swift           0x0000000000e29e74 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
30 swift           0x0000000000e04652 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 354
33 swift           0x0000000000e09e06 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
36 swift           0x0000000000e5102a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
37 swift           0x0000000000e7aa0c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
38 swift           0x0000000000deeefb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
40 swift           0x0000000000e51176 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
41 swift           0x0000000000dd609d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1597
42 swift           0x0000000000c7ed3f swift::CompilerInstance::performSema() + 2975
44 swift           0x00000000007766a7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
45 swift           0x0000000000771285 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype-aaad08.o
1.  While type-checking expression at [validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:8:1 - line:8:29] RangeText="{struct A<T:A.B{class B<U:T.u"
2.  While type-checking 'A' at validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:8:2
3.  While resolving type A.B at [validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:8:13 - line:8:15] RangeText="A.B"
4.  While resolving type T.u at [validation-test/compiler_crashers/28245-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift:8:27 - line:8:29] RangeText="T.u"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
