### PR TITLE
[test] Add an end-to-end test for code coverage.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -376,6 +376,14 @@ if run_cpu == "i386" or run_cpu == "x86_64":
 if "optimized_stdlib" in config.available_features:
   config.available_features.add("optimized_stdlib_" + run_cpu)
 
+# Check to see if there's a compiler_rt directory.
+# FIXME: We should really plumb this through build-script and CMake instead of
+# guessing.
+compiler_rt_base_dir = os.path.join(test_resource_dir, 'clang', 'lib')
+compiler_rt_name = 'darwin' if platform.system() == 'Darwin' else run_os
+if os.path.exists(os.path.join(test_resource_dir, compiler_rt_name)):
+  config.available_features.add('compiler_rt')
+
 swift_test_mode = lit_config.params.get('swift_test_mode', 'optimize_none')
 swift_execution_tests_extra_flags = ''
 if swift_test_mode == 'optimize_none':

--- a/validation-test/Driver/coverage.swift
+++ b/validation-test/Driver/coverage.swift
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: %target-build-swift %s -profile-generate -o %t/main
+// RUN: (cd %t && %target-run %t/main)
+
+// RUN: llvm-profdata show -function=thisFunctionIsRun %t/*.profraw | FileCheck %s -check-prefix=CHECK-RUN-FN
+// RUN: llvm-profdata show -function=thisFunctionIsNotRun %t/*.profraw | FileCheck %s -check-prefix=CHECK-NOT-RUN-FN
+
+// REQUIRES: compiler_rt
+
+func thisFunctionIsRun() {
+  // CHECK-RUN-FN: Counters: 1
+  // CHECK-RUN-FN: Function count: 1
+  print("hello")
+}
+
+func thisFunctionIsNotRun() {
+  // CHECK-NOT-RUN-FN: Counters: 1
+  // CHECK-NOT-RUN-FN: Function count: 0
+  print("goodbye")
+}
+
+thisFunctionIsRun()


### PR DESCRIPTION
This requires building compiler-rt alongside Swift, which isn't supported yet, but if/when we get that up and running it will help catch problems like 9c6cdd3.

@vedantk, mind reviewing, since I imagine you'll be doing a fair bit more in this space?

Also testing that the REQUIRES clause is sufficient to not cause trouble for any buildbots at the moment.
