### PR TITLE
[swiftc] Add test case for crash triggered in swift::Expr::propagateLValueAccessKind(…)

### DIFF
--- a/validation-test/compiler_crashers/28246-swift-expr-propagatelvalueaccesskind.swift
+++ b/validation-test/compiler_crashers/28246-swift-expr-propagatelvalueaccesskind.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class g{deinit{{&.T

--- a/validation-test/compiler_crashers/README
+++ b/validation-test/compiler_crashers/README
@@ -1,7 +1,7 @@
 These test cases under MIT License: 
 The MIT License (MIT)
 
-Copyright (c) 2014 practicalswift
+Copyright (c) 2014-2016 practicalswift
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,4 +24,4 @@ SOFTWARE.
 Repository: https://github.com/practicalswift/swift-compiler-crashes.git
 Web URL: https://github.com/practicalswift/swift-compiler-crashes
 
-Tests updated as of revision 50f86f4f26c78587dbc37ccff04ae95c8285beca
+Tests updated as of revision a98b6a75b8622dfc44dd56ddea633a9254ac7f1a


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/AST/Expr.cpp:207: void swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool)::PropagateAccessKind::visit(swift::Expr *, swift::AccessKind): Assertion `E->getType()->isAssignableType() && "setting access kind on non-l-value"' failed.
9  swift           0x0000000000fe9127 swift::Expr::propagateLValueAccessKind(swift::AccessKind, bool) + 23
12 swift           0x0000000000f7cda5 swift::Expr::walk(swift::ASTWalker&) + 69
13 swift           0x0000000000e86d26 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
14 swift           0x0000000000dfb2fb swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
17 swift           0x0000000000ea1969 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
18 swift           0x0000000000ea640e swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 3934
19 swift           0x0000000000df4ef5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
20 swift           0x0000000000dfb289 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
23 swift           0x0000000000e5ca15 swift::TypeChecker::typeCheckDestructorBodyUntil(swift::DestructorDecl*, swift::SourceLoc) + 181
24 swift           0x0000000000e5bf7b swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 27
25 swift           0x0000000000e5cb58 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
27 swift           0x0000000000de2532 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1746
28 swift           0x0000000000c8b0ff swift::CompilerInstance::performSema() + 2975
30 swift           0x00000000007766d7 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2487
31 swift           0x00000000007712b5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28246-swift-expr-propagatelvalueaccesskind.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28246-swift-expr-propagatelvalueaccesskind-47a5b0.o
1.  While type-checking 'deinit' at validation-test/compiler_crashers/28246-swift-expr-propagatelvalueaccesskind.swift:8:9
2.  While type-checking expression at [validation-test/compiler_crashers/28246-swift-expr-propagatelvalueaccesskind.swift:8:16 - line:8:19] RangeText="{&.T"
3.  While type-checking expression at [validation-test/compiler_crashers/28246-swift-expr-propagatelvalueaccesskind.swift:8:17 - line:8:19] RangeText="&.T"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
