### PR TITLE
Adding ARMv6 in swift_build_support

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -25,6 +25,9 @@ def host_target():
         elif machine.startswith('armv7'):
             # linux-armv7* is canonicalized to 'linux-armv7'
             return 'linux-armv7'
+        elif machine.startswith('armv6'):
+            # linux-armv6* is canonicalized to 'linux-armv6'
+            return 'linux-armv6'
         elif machine == 'aarch64':
             return 'linux-aarch64'
         elif machine == 'ppc64':


### PR DESCRIPTION
I'm compiling Swift on an Armv6 Raspberry Pi and i've noticed that the ARMv6 platform has not been included yet among the ones listed in swift_build_support.targets.host_target() (and it needs to be specified manually with --host-target to compile), this commit updates the list.
