### PR TITLE
[SR-628][Sema] Improved handling of mixed lvalues & rvalues in tuple exprs

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1385,7 +1385,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     } else {
       // When the base is a tuple rvalue, the member is always an rvalue.
       auto tuple = choice.getBaseType()->castTo<TupleType>();
-      refType = tuple->getElementType(choice.getTupleIndex());
+      refType = tuple->getElementType(choice.getTupleIndex())->getRValueType();
     }
     break;
   }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -842,3 +842,5 @@ let _ = (x, 3).1
 (x,y) = (2,3)
 (x,4) = (1,2) // expected-error {{cannot assign to value: function call returns immutable value}}
 (x,y).1 = 7 // expected-error {{cannot assign to immutable expression of type 'Int'}}
+x = (x,(3,y)).1.1
+


### PR DESCRIPTION
My previous commit here didn’t work correctly for nested tuples, both because it didn’t recurse into them to propagate access kind correctly and because an outer TupleIndex overload (when indexing into the nested tuple) could still be expecting an lvalue type. 

This fix is much better. ConstraintSystem::resolveOverload now correctly always expects rvalue types from rvalue tuples. And during applyMemberRefExpr, if the overload expects an rvalue but the tuple contains lvalues, coerceToType() can correctly do any recursive munging of the tuple expr required. Note the small change to coerceToType: it knows how to handle lvalue to rvalue tuple conversions correctly, but it was performing it incorrectly (too simplistically) for tuples if the solver recorded a knownRestriction.

Test added, tests pass. Could still use a better diagnosis for `(3,x).1 = 7` - will look at that next.
