### PR TITLE
Move SIL parser to GenericFunctionTypes

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -324,6 +324,24 @@ public:
   /// list.
   ArrayRef<ArchetypeType *> getAllArchetypes();
   
+  /// Map an interface type to a contextual type.
+  static Type mapTypeIntoContext(DeclContext *dc, Type type,
+                                 LazyResolver *resolver = nullptr);
+
+  /// Map an interface type to a contextual type.
+  static Type mapTypeIntoContext(ModuleDecl *M,
+                                 GenericParamList *genericParams,
+                                 Type type,
+                                 LazyResolver *resolver = nullptr);
+
+  /// Map a contextual type to an interface type.
+  static Type mapTypeOutOfContext(DeclContext *dc, Type type);
+
+  /// Map a contextual type to an interface type.
+  static Type mapTypeOutOfContext(ModuleDecl *M,
+                                  GenericParamList *genericParams,
+                                  Type type);
+
   using SameTypeRequirement
     = std::pair<PotentialArchetype *,
                 PointerUnion<Type, PotentialArchetype*>>;
@@ -335,18 +353,6 @@ public:
   // FIXME: Compute the set of 'extra' witness tables needed to express this
   // requirement set.
 
-  /// Map the given type, which is based on an interface type and may therefore
-  /// be dependent, to a type based on the archetypes of the given declaration
-  /// context.
-  ///
-  /// \param dc The declaration context in which we should perform the mapping.
-  /// \param type The type to map into the given declaration context.
-  ///
-  /// \returns the mapped type, which will involve archetypes rather than
-  /// dependent types.
-  static Type mapTypeIntoContext(DeclContext *dc, Type type,
-                                 LazyResolver *resolver = nullptr);
-  
   /// \brief Dump all of the requirements, both specified and inferred.
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump(),
@@ -354,12 +360,6 @@ public:
 
   /// Dump all of the requirements to the given output stream.
   void dump(llvm::raw_ostream &out);
-
-  /// FIXME: Share the guts of our mapTypeIntoContext implementation with
-  static Type mapTypeIntoContext(ModuleDecl *M,
-                                 GenericParamList *genericParams,
-                                 Type type,
-                                 LazyResolver *resolver = nullptr);
 
   // In SILFunction.cpp:
   

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1098,19 +1098,11 @@ class GenericParamList {
   SourceLoc TrailingWhereLoc;
   unsigned FirstTrailingWhereArg;
 
-  /// The builder used to build archetypes for this list.
-  ArchetypeBuilder *Builder;
-
   GenericParamList(SourceLoc LAngleLoc,
                    ArrayRef<GenericTypeParamDecl *> Params,
                    SourceLoc WhereLoc,
                    MutableArrayRef<RequirementRepr> Requirements,
                    SourceLoc RAngleLoc);
-  
-  void getAsGenericSignatureElements(ASTContext &C,
-                         llvm::DenseMap<ArchetypeType*, Type> &archetypeMap,
-                         SmallVectorImpl<GenericTypeParamType*> &genericParams,
-                         SmallVectorImpl<Requirement> &requirements) const;
   
   // Don't copy.
   GenericParamList(const GenericParamList &) = delete;
@@ -1262,11 +1254,6 @@ public:
     return getAllArchetypes().slice(0, getNumPrimaryArchetypes());
   }
   
-  /// \brief Retrieves the list containing only the associated archetypes.
-  ArrayRef<ArchetypeType *> getAssociatedArchetypes() const {
-    return getAllArchetypes().slice(getNumPrimaryArchetypes());
-  }
-
   /// \brief Sets all archetypes *without* copying the source array.
   void setAllArchetypes(ArrayRef<ArchetypeType *> AA) {
     assert(AA.size() >= size()
@@ -1344,17 +1331,7 @@ public:
       ++depth;
     return depth;
   }
-  
-  /// Get the generic parameter list as a GenericSignature in which the generic
-  /// parameters have been canonicalized.
-  ///
-  /// \param archetypeMap   This DenseMap is populated with a mapping of
-  ///                       context primary archetypes to dependent generic
-  ///                       types.
-  GenericSignature *getAsCanonicalGenericSignature(
-                           llvm::DenseMap<ArchetypeType*, Type> &archetypeMap,
-                           ASTContext &C) const;
-  
+
   /// Derive a type substitution map for this generic parameter list from a
   /// matching substitution vector.
   TypeSubstitutionMap getSubstitutionMap(ArrayRef<Substitution> Subs) const;
@@ -1366,14 +1343,6 @@ public:
                       SmallVectorImpl<ArchetypeType*> &archetypes);
 
   ArrayRef<Substitution> getForwardingSubstitutions(ASTContext &C);
-
-  void setBuilder(ArchetypeBuilder *builder) {
-    Builder = builder;
-  }
-
-  ArchetypeBuilder *getBuilder() const {
-    return Builder;
-  }
 
   /// Collect the nested archetypes of an archetype into the given
   /// collection.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -54,6 +54,12 @@ enum class SubstFlags {
   /// If a type cannot be produced because some member type is
   /// missing, return the identity type rather than a null type.
   IgnoreMissing = 0x01,
+  /// Allow substitutions to recurse into SILFunctionTypes.
+  /// Normally, SILType::subst() should be used for lowered
+  /// types, however in special cases where the substitution
+  /// is just changing between contextual and interface type
+  /// representations, using Type::subst() is allowed.
+  AllowLoweredTypes = 0x02,
 };
 
 /// Options for performing substitutions into a type.

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -351,21 +351,33 @@ inline IdentTypeRepr::ComponentRange IdentTypeRepr::getComponentRange() {
 ///   Foo -> Bar
 /// \endcode
 class FunctionTypeRepr : public TypeRepr {
-  GenericParamList *Generics;
+  // These two are only used in SIL mode, which is the only time
+  // we can have polymorphic function values.
+  GenericParamList *GenericParams;
+  GenericSignature *GenericSig;
+
   TypeRepr *ArgsTy;
   TypeRepr *RetTy;
   SourceLoc ArrowLoc;
   SourceLoc ThrowsLoc;
 
 public:
-  FunctionTypeRepr(GenericParamList *generics, TypeRepr *argsTy,
+  FunctionTypeRepr(GenericParamList *genericParams, TypeRepr *argsTy,
                    SourceLoc throwsLoc, SourceLoc arrowLoc, TypeRepr *retTy)
     : TypeRepr(TypeReprKind::Function),
-      Generics(generics), ArgsTy(argsTy), RetTy(retTy),
+      GenericParams(genericParams), GenericSig(nullptr),
+      ArgsTy(argsTy), RetTy(retTy),
       ArrowLoc(arrowLoc), ThrowsLoc(throwsLoc) {
   }
 
-  GenericParamList *getGenericParams() const { return Generics; }
+  GenericParamList *getGenericParams() const { return GenericParams; }
+  GenericSignature *getGenericSignature() const { return GenericSig; }
+
+  void setGenericSignature(GenericSignature *genericSig) {
+    assert(GenericSig == nullptr);
+    GenericSig = genericSig;
+  }
+
   TypeRepr *getArgsTypeRepr() const { return ArgsTy; }
   TypeRepr *getResultTypeRepr() const { return RetTy; }
   bool throws() const { return ThrowsLoc.isValid(); }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3734,11 +3734,6 @@ public:
     return T->getKind() == TypeKind::Archetype;
   }
   
-  /// Convert an archetype to a dependent generic parameter type using the
-  /// given mapping of primary archetypes to generic parameter types.
-  Type getAsDependentType(
-                    const llvm::DenseMap<ArchetypeType *, Type> &archetypeMap);
-  
   /// getIsRecursive - The archetype type refers back to itself.
   bool getIsRecursive() { return this->isRecursive; }
   

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -776,16 +776,6 @@ public:
   /// interface to this function. There must be an active generic context.
   void popGenericContext(CanGenericSignature sig);
   
-  // Map a type involving context archetypes out of its context into a
-  // dependent type.
-  CanType getInterfaceTypeOutOfContext(CanType contextTy,
-                                    DeclContext *context) const;
-  
-  // Map a type involving context archetypes out of its context into a
-  // dependent type.
-  CanType getInterfaceTypeOutOfContext(CanType contextTy,
-                                    GenericParamList *contextParams) const;
-
   /// Known types for bridging.
 #define BRIDGING_KNOWN_TYPE(BridgedModule,BridgedType) \
   CanType get##BridgedType##Type();

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -44,6 +44,7 @@ namespace swift {
   class DiagnosticEngine;
   class FileUnit;
   class GenericParamList;
+  class GenericSignature;
   class IRGenOptions;
   class LangOptions;
   class ModuleDecl;
@@ -187,13 +188,9 @@ namespace swift {
                               bool ProduceDiagnostics = true);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  /// We pass in a vector of nested GenericParamLists and a vector of
-  /// ArchetypeBuilders with the innermost GenericParamList in the beginning
-  /// of the vector.
-  bool handleSILGenericParams(ASTContext &Ctx,
-                              SmallVectorImpl<GenericParamList *> &gps,
-                              DeclContext *DC,
-                              SmallVectorImpl<ArchetypeBuilder *> &builders);
+  GenericSignature *handleSILGenericParams(ASTContext &Ctx,
+                                           GenericParamList *genericParams,
+                                           DeclContext *DC);
 
   /// Turn the given module into SIL IR.
   ///

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2360,7 +2360,8 @@ Type Type::subst(Module *module, TypeSubstitutionMap &substitutions,
   };
   
   return transform([&](Type type) -> Type {
-    assert(!isa<SILFunctionType>(type.getPointer()) &&
+    assert((options.contains(SubstFlags::AllowLoweredTypes) ||
+            !isa<SILFunctionType>(type.getPointer())) &&
            "should not be doing AST type-substitution on a lowered SIL type;"
            "use SILType::subst");
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -588,8 +588,8 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
       auto *VD = capture.getDecl();
       auto type = VD->getType()->getCanonicalType();
       
-      type = Types.getInterfaceTypeOutOfContext(type,
-                                                function->getAsDeclContext());
+      type = ArchetypeBuilder::mapTypeOutOfContext(
+          function->getAsDeclContext(), type)->getCanonicalType();
       
       auto &loweredTL = Types.getTypeLowering(
                                     AbstractionPattern(genericSig, type), type);

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1183,13 +1183,13 @@ public:
   
   void visitClassMethodInst(ClassMethodInst *AMI) {
     printMethodInst(AMI, AMI->getOperand(), "class_method");
-    *this << " : " << AMI->getMember().getDecl()->getType();
+    *this << " : " << AMI->getMember().getDecl()->getInterfaceType();
     *this << " , ";
     *this << AMI->getType();
   }
   void visitSuperMethodInst(SuperMethodInst *AMI) {
     printMethodInst(AMI, AMI->getOperand(), "super_method");
-    *this << " : " << AMI->getMember().getDecl()->getType();
+    *this << " : " << AMI->getMember().getDecl()->getInterfaceType();
     *this << " , ";
     *this << AMI->getType();
   }
@@ -1206,7 +1206,7 @@ public:
   }
   void visitDynamicMethodInst(DynamicMethodInst *DMI) {
     printMethodInst(DMI, DMI->getOperand(), "dynamic_method");
-    *this << " : " << DMI->getMember().getDecl()->getType();
+    *this << " : " << DMI->getMember().getDecl()->getInterfaceType();
     *this << ", ";
     *this << DMI->getType();
   }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1689,9 +1689,13 @@ getOrCreateReabstractionThunk(GenericParamList *thunkContextParams,
 
     // Substitute context parameters out of the "from" and "to" types.
     auto fromInterfaceType
-      = Types.getInterfaceTypeOutOfContext(fromType, thunkContextParams);
+        = ArchetypeBuilder::mapTypeOutOfContext(
+            M.getSwiftModule(), thunkContextParams, fromType)
+                ->getCanonicalType();
     auto toInterfaceType
-      = Types.getInterfaceTypeOutOfContext(toType, thunkContextParams);
+        = ArchetypeBuilder::mapTypeOutOfContext(
+            M.getSwiftModule(), thunkContextParams, toType)
+                ->getCanonicalType();
 
     mangler.mangleType(fromInterfaceType, /*uncurry*/ 0);
     mangler.mangleType(toInterfaceType, /*uncurry*/ 0);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1433,21 +1433,28 @@ CanSILFunctionType SILGenFunction::buildThunkType(
   // type of the thunk.
   SmallVector<SILParameterInfo, 4> interfaceParams;
   interfaceParams.reserve(params.size());
-  auto &Types = SGM.M.Types;
+  auto *moduleDecl = SGM.M.getSwiftModule();
   for (auto &param : params) {
     interfaceParams.push_back(
-      SILParameterInfo(Types.getInterfaceTypeOutOfContext(param.getType(), generics),
-                       param.getConvention()));
+      SILParameterInfo(
+          ArchetypeBuilder::mapTypeOutOfContext(
+              moduleDecl, generics, param.getType())
+                ->getCanonicalType(),
+          param.getConvention()));
   }
   
   auto interfaceResult = SILResultInfo(
-    Types.getInterfaceTypeOutOfContext(expectedType->getResult().getType(), generics),
-    expectedType->getResult().getConvention());
+      ArchetypeBuilder::mapTypeOutOfContext(
+          moduleDecl, generics, expectedType->getResult().getType())
+              ->getCanonicalType(),
+      expectedType->getResult().getConvention());
 
   Optional<SILResultInfo> interfaceErrorResult;
   if (expectedType->hasErrorResult()) {
     interfaceErrorResult = SILResultInfo(
-      Types.getInterfaceTypeOutOfContext(expectedType->getErrorResult().getType(), generics),
+      ArchetypeBuilder::mapTypeOutOfContext(
+        moduleDecl, generics, expectedType->getErrorResult().getType())
+            ->getCanonicalType(),
       expectedType->getErrorResult().getConvention());
   }
   

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -372,7 +372,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
 
     // Retrieve the interface type for this inherited type.
     if (DC->isGenericContext() && DC->isTypeContext()) {
-      inheritedTy = getInterfaceTypeFromInternalType(DC, inheritedTy);
+      inheritedTy = ArchetypeBuilder::mapTypeOutOfContext(DC, inheritedTy);
     }
 
     // Check whether we inherited from the same type twice.
@@ -1243,7 +1243,7 @@ static void validatePatternBindingDecl(TypeChecker &tc,
     if (dc->isGenericContext() && dc->isTypeContext()) {
       binding->getPattern(entryNumber)->forEachVariable([&](VarDecl *var) {
         var->setInterfaceType(
-          tc.getInterfaceTypeFromInternalType(dc, var->getType()));
+          ArchetypeBuilder::mapTypeOutOfContext(dc, var->getType()));
       });
     }
 
@@ -2998,9 +2998,9 @@ public:
 
       // If we're in a generic context, set the interface type.
       if (dc->isGenericContext()) {
-        auto indicesTy = TC.getInterfaceTypeFromInternalType(
+        auto indicesTy = ArchetypeBuilder::mapTypeOutOfContext(
                            dc, indicesType);
-        auto elementTy = TC.getInterfaceTypeFromInternalType(
+        auto elementTy = ArchetypeBuilder::mapTypeOutOfContext(
                            dc, SD->getElementType());
         SD->setInterfaceType(FunctionType::get(indicesTy, elementTy));
       }
@@ -3114,8 +3114,8 @@ public:
         TAD->getUnderlyingTypeLoc().setInvalidType(TC.Context);
       } else if (TAD->getDeclContext()->isGenericContext()) {
         TAD->setInterfaceType(
-          TC.getInterfaceTypeFromInternalType(TAD->getDeclContext(),
-                                              TAD->getType()));
+          ArchetypeBuilder::mapTypeOutOfContext(TAD->getDeclContext(),
+                                                TAD->getType()));
       }
 
       // We create TypeAliasTypes with invalid underlying types, so we
@@ -5067,10 +5067,10 @@ public:
 
     // Build the generic function type.
     auto funcTy = elt->getType()->castTo<AnyFunctionType>();
-    auto inputTy = TC.getInterfaceTypeFromInternalType(enumDecl,
-                                                       funcTy->getInput());
-    auto resultTy = TC.getInterfaceTypeFromInternalType(enumDecl,
-                                                        funcTy->getResult());
+    auto inputTy = ArchetypeBuilder::mapTypeOutOfContext(enumDecl,
+                                                         funcTy->getInput());
+    auto resultTy = ArchetypeBuilder::mapTypeOutOfContext(enumDecl,
+                                                          funcTy->getResult());
     auto interfaceTy
       = GenericFunctionType::get(enumDecl->getGenericSignatureOfContext(),
                                  inputTy, resultTy, funcTy->getExtInfo());

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3945,7 +3945,8 @@ public:
         // Create a fresh archetype builder.
         ArchetypeBuilder builder =
           TC.createArchetypeBuilder(FD->getModuleContext());
-        TC.checkGenericParamList(&builder, gp, FD->getDeclContext());
+        auto *parentSig = FD->getDeclContext()->getGenericSignatureOfContext();
+        TC.checkGenericParamList(&builder, gp, parentSig);
 
         // Infer requirements from parameter patterns.
         for (auto pattern : FD->getParameterLists()) {
@@ -5310,7 +5311,8 @@ public:
       } else {
         ArchetypeBuilder builder =
           TC.createArchetypeBuilder(CD->getModuleContext());
-        TC.checkGenericParamList(&builder, gp, CD->getDeclContext());
+        auto *parentSig = CD->getDeclContext()->getGenericSignatureOfContext();
+        TC.checkGenericParamList(&builder, gp, parentSig);
 
         // Infer requirements from the parameters of the constructor.
         builder.inferRequirements(CD->getParameterList(1), gp);
@@ -5763,7 +5765,8 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
 
         ArchetypeBuilder builder =
           createArchetypeBuilder(nominal->getModuleContext());
-        checkGenericParamList(&builder, gp, nominal->getDeclContext());
+        auto *parentSig = nominal->getDeclContext()->getGenericSignatureOfContext();
+        checkGenericParamList(&builder, gp, parentSig);
         finalizeGenericParamList(builder, gp, nominal, *this);
       }
     }
@@ -5822,7 +5825,8 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
 
     ArchetypeBuilder builder =
       createArchetypeBuilder(proto->getModuleContext());
-    checkGenericParamList(&builder, gp, proto->getDeclContext());
+    auto *parentSig = proto->getDeclContext()->getGenericSignatureOfContext();
+    checkGenericParamList(&builder, gp, parentSig);
     finalizeGenericParamList(builder, gp, proto, *this);
 
     // Record inherited protocols.
@@ -6189,7 +6193,8 @@ static Type checkExtensionGenericParams(
   // Validate the generic parameters for the last time.
   tc.revertGenericParamList(genericParams);
   ArchetypeBuilder builder = tc.createArchetypeBuilder(ext->getModuleContext());
-  tc.checkGenericParamList(&builder, genericParams, ext->getDeclContext());
+  auto *parentSig = ext->getDeclContext()->getGenericSignatureOfContext();
+  tc.checkGenericParamList(&builder, genericParams, parentSig);
   inferExtendedTypeReqs(builder);
   finalizeGenericParamList(builder, genericParams, ext, tc);
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -220,16 +220,15 @@ Type CompleteGenericTypeResolver::resolveTypeOfContext(DeclContext *dc) {
 /// parent generic parameter lists) according to the given resolver.
 bool TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
                                         GenericParamList *genericParams,
-                                        DeclContext *parentDC,
+                                        GenericSignature *parentSig,
                                         bool adoptArchetypes,
                                         GenericTypeResolver *resolver) {
   bool invalid = false;
 
   // If there is a parent context, add the generic parameters and requirements
   // from that context.
-  if (builder && parentDC)
-    if (auto sig = parentDC->getGenericSignatureOfContext())
-      builder->addGenericSignature(sig, adoptArchetypes);
+  if (builder)
+    builder->addGenericSignature(parentSig, adoptArchetypes);
 
   // If there aren't any generic parameters at this level, we're done.
   if (!genericParams)
@@ -343,10 +342,10 @@ bool TypeChecker::checkGenericParamList(ArchetypeBuilder *builder,
 /// parameter list.
 static void collectGenericParamTypes(
               GenericParamList *genericParams,
-              DeclContext *parentDC,
+              GenericSignature *parentSig,
               SmallVectorImpl<GenericTypeParamType *> &allParams) {
   // If the parent context has a generic signature, add its generic parameters.
-  if (auto parentSig = parentDC->getGenericSignatureOfContext()) {
+  if (parentSig) {
     allParams.append(parentSig->getGenericParams().begin(),
                      parentSig->getGenericParams().end());
   }
@@ -372,7 +371,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   auto genericParams = func->getGenericParams();
 
   tc.checkGenericParamList(builder, genericParams,
-                           func->getDeclContext(),
+                           func->getDeclContext()->getGenericSignatureOfContext(),
                            false, &resolver);
 
   // Check the parameter patterns.
@@ -489,7 +488,7 @@ bool TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   // Collect the complete set of generic parameter types.
   SmallVector<GenericTypeParamType *, 4> allGenericParams;
   collectGenericParamTypes(func->getGenericParams(),
-                           func->getDeclContext(),
+                           func->getDeclContext()->getGenericSignatureOfContext(),
                            allGenericParams);
 
   auto sig = builder.getGenericSignature(allGenericParams);
@@ -686,13 +685,14 @@ GenericSignature *TypeChecker::validateGenericSignature(
   // Create the archetype builder.
   Module *module = dc->getParentModule();
   ArchetypeBuilder builder = createArchetypeBuilder(module);
-  if (outerSignature)
-    builder.addGenericSignature(outerSignature, true);
+  auto *parentSig = (outerSignature
+                     ? outerSignature
+                     : dc->getGenericSignatureOfContext());
 
   // Type check the generic parameters, treating all generic type
   // parameters as dependent, unresolved.
   DependentGenericTypeResolver dependentResolver(builder);  
-  if (checkGenericParamList(&builder, genericParams, dc,
+  if (checkGenericParamList(&builder, genericParams, parentSig,
                             false, &dependentResolver)) {
     invalid = true;
   }
@@ -710,7 +710,7 @@ GenericSignature *TypeChecker::validateGenericSignature(
   // and type-check it again, completely.
   revertGenericParamList(genericParams);
   CompleteGenericTypeResolver completeResolver(*this, builder);
-  if (checkGenericParamList(nullptr, genericParams, dc,
+  if (checkGenericParamList(nullptr, genericParams, parentSig,
                             false, &completeResolver)) {
     invalid = true;
   }
@@ -718,7 +718,7 @@ GenericSignature *TypeChecker::validateGenericSignature(
   // The generic signature is complete and well-formed. Gather the
   // generic parameter types at all levels.
   SmallVector<GenericTypeParamType *, 4> allGenericParams;
-  collectGenericParamTypes(genericParams, dc, allGenericParams);
+  collectGenericParamTypes(genericParams, parentSig, allGenericParams);
 
   // Record the generic type parameter types and the requirements.
   auto sig = builder.getGenericSignature(allGenericParams);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1669,7 +1669,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
   if (fromDC != DC && DC->getGenericSignatureOfContext() &&
       fromDC->getGenericSignatureOfContext() && !isa<ProtocolDecl>(fromDC)) {
     // Map the type to an interface type.
-    type = TC.getInterfaceTypeFromInternalType(fromDC, type);
+    type = ArchetypeBuilder::mapTypeOutOfContext(fromDC, type);
 
     // Map the type into the conformance's context.
     type = Adoptee->getTypeOfMember(DC->getParentModule(), type, fromDC);
@@ -1739,7 +1739,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
       aliasDecl->setInvalid();
     if (metaType->hasArchetype()) {
       aliasDecl->setInterfaceType(
-        TC.getInterfaceTypeFromInternalType(DC, metaType));
+        ArchetypeBuilder::mapTypeOutOfContext(DC, metaType));
     }
     
     // Inject the typealias into the nominal decl that conforms to the protocol.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -652,14 +652,10 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
 }
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-/// We pass in a vector of nested GenericParamLists and a vector of
-/// ArchetypeBuilders with the innermost GenericParamList in the beginning
-/// of the vector.
-bool swift::handleSILGenericParams(ASTContext &Ctx,
-              SmallVectorImpl<GenericParamList *> &gps,
-              DeclContext *DC,
-              SmallVectorImpl<ArchetypeBuilder *> &builders) {
-  return TypeChecker(Ctx).handleSILGenericParams(builders, gps, DC);
+GenericSignature *swift::handleSILGenericParams(ASTContext &Ctx,
+                                                GenericParamList *genericParams,
+                                                DeclContext *DC) {
+  return TypeChecker(Ctx).handleSILGenericParams(genericParams, DC);
 }
 
 bool swift::typeCheckCompletionDecl(Decl *D) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -976,17 +976,6 @@ public:
                              GenericSignature *genericSig,
                              ArrayRef<Type> genericArgs);
 
-  /// Given a type that was produced within the given generic declaration
-  /// context, produce the corresponding interface type.
-  ///
-  /// \param dc The declaration context in which the type was produced.
-  ///
-  /// \param type The type, which involves archetypes but not dependent types.
-  ///
-  /// \returns the type after mapping all archetypes to their corresponding
-  /// dependent types.
-  Type getInterfaceTypeFromInternalType(DeclContext *dc, Type type);
-
   /// Resolve the superclass of the given class.
   void resolveSuperclass(ClassDecl *classDecl) override;
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -636,12 +636,8 @@ public:
   void checkUnsupportedProtocolType(Stmt *stmt);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  /// We pass in a vector of nested GenericParamLists and a vector of
-  /// ArchetypeBuilders with the innermost GenericParamList in the beginning
-  /// of the vector.
-  bool handleSILGenericParams(SmallVectorImpl<ArchetypeBuilder *> &builders,
-                              SmallVectorImpl<GenericParamList *> &gps,
-                              DeclContext *DC);
+  GenericSignature *handleSILGenericParams(GenericParamList *genericParams,
+                                           DeclContext *DC);
 
   /// \brief Resolves a TypeRepr to a type.
   ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -955,7 +955,7 @@ public:
   /// parent generic parameter lists) according to the given resolver.
   bool checkGenericParamList(ArchetypeBuilder *builder,
                              GenericParamList *genericParams,
-                             DeclContext *parentDC,
+                             GenericSignature *parentSig,
                              bool adoptArchetypes = true,
                              GenericTypeResolver *resolver = nullptr);
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -32,7 +32,7 @@ func direct_to_class(obj: AnyObject) {
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup18direct_to_protocol
 func direct_to_protocol(obj: AnyObject) {
   // CHECK: [[OBJ_SELF:%[0-9]+]] = open_existential_ref [[EX:%[0-9]+]] : $AnyObject to $@opened({{.*}}) AnyObject
-  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <`Self` : P> (Self) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
+  // CHECK: [[METHOD:%[0-9]+]] = dynamic_method [volatile] [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <Self where Self : P> Self -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK: apply [[METHOD]]([[OBJ_SELF]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   obj.g!()
 }

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -36,7 +36,7 @@ func testDynamicSelfDispatch(y: Y) {
 // CHECK: bb0([[Y:%[0-9]+]] : $Y):
 // CHECK:   strong_retain [[Y]]
 // CHECK:   [[Y_AS_X:%[0-9]+]] = upcast [[Y]] : $Y to $X  
-// CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X]] : $X, #X.f!1 : (Self) -> () -> Self , $@convention(method) (@guaranteed X) -> @owned X
+// CHECK:   [[X_F:%[0-9]+]] = class_method [[Y_AS_X]] : $X, #X.f!1 : X -> () -> Self , $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   [[X_RESULT:%[0-9]+]] = apply [[X_F]]([[Y_AS_X]]) : $@convention(method) (@guaranteed X) -> @owned X
 // CHECK:   strong_release [[Y_AS_X]]
 // CHECK:   [[Y_RESULT:%[0-9]+]] = unchecked_ref_cast [[X_RESULT]] : $X to $Y
@@ -50,7 +50,7 @@ func testDynamicSelfDispatchGeneric(gy: GY<Int>) {
   // CHECK: bb0([[GY:%[0-9]+]] : $GY<Int>):
   // CHECK:   strong_retain [[GY]]
   // CHECK:   [[GY_AS_GX:%[0-9]+]] = upcast [[GY]] : $GY<Int> to $GX<Array<Int>>
-  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX]] : $GX<Array<Int>>, #GX.f!1 : <T> (Self) -> () -> Self , $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
+  // CHECK:   [[GX_F:%[0-9]+]] = class_method [[GY_AS_GX]] : $GX<Array<Int>>, #GX.f!1 : <T> GX<T> -> () -> Self , $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   [[GX_RESULT:%[0-9]+]] = apply [[GX_F]]<[Int]>([[GY_AS_GX]]) : $@convention(method) <τ_0_0> (@guaranteed GX<τ_0_0>) -> @owned GX<τ_0_0>
   // CHECK:   strong_release [[GY_AS_GX]]
   // CHECK:   [[GY_RESULT:%[0-9]+]] = unchecked_ref_cast [[GX_RESULT]] : $GX<Array<Int>> to $GY<Int>
@@ -145,7 +145,7 @@ func testOptionalResult(v : OptionalResultInheritor) {
   v.foo()?.bar()
 }
 // CHECK-LABEL: sil hidden @_TF12dynamic_self18testOptionalResult{{.*}} : $@convention(thin) (@owned OptionalResultInheritor) -> ()
-// CHECK:      [[T0:%.*]] = class_method [[V:%.*]] : $OptionalResult, #OptionalResult.foo!1 : (Self) -> () -> Self? , $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
+// CHECK:      [[T0:%.*]] = class_method [[V:%.*]] : $OptionalResult, #OptionalResult.foo!1 : OptionalResult -> () -> Self? , $@convention(method) (@guaranteed OptionalResult) -> @owned Optional<OptionalResult>
 // CHECK-NEXT: [[RES:%.*]] = apply [[T0]]([[V]])
 // CHECK:      select_enum [[RES]]
 // CHECK:      [[T1:%.*]] = unchecked_enum_data [[RES]]

--- a/test/SILGen/objc_generic_class.swift
+++ b/test/SILGen/objc_generic_class.swift
@@ -32,7 +32,7 @@ class Generic<T>: NSObject {
 
 // CHECK-LABEL: sil hidden @_TFC18objc_generic_class11SubGeneric1D : $@convention(method) <U, V> (@owned SubGeneric1<U, V>) -> () {
 // CHECK:       bb0([[SELF:%.*]] : $SubGeneric1<U, V>):
-// CHECK:         [[SUPER_DEALLOC:%.*]] = super_method [[SELF]] : $SubGeneric1<U, V>, #Generic.deinit!deallocator.foreign : <T> Generic<T> -> () , $@convention(objc_method) <τ_0_0> (Generic<τ_0_0>) -> ()
+// CHECK:         [[SUPER_DEALLOC:%.*]] = super_method [[SELF]] : $SubGeneric1<U, V>, #Generic.deinit!deallocator.foreign : <T> Generic<T> -> () -> () , $@convention(objc_method) <τ_0_0> (Generic<τ_0_0>) -> ()
 // CHECK:         [[SUPER:%.*]] = upcast [[SELF:%.*]] : $SubGeneric1<U, V> to $Generic<Int>
 // CHECK:         apply [[SUPER_DEALLOC]]<Int>([[SUPER]])
 class SubGeneric1<U, V>: Generic<Int> {

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -188,7 +188,7 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super39GenericChildToFixedGenericOutsideParent6methodfT_T_
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChildToFixedGenericOutsideParent<A> to $GenericOutsideParent<A>
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToFixedGenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> GenericOutsideParent<A> -> () -> () , $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override func method() {
@@ -198,7 +198,7 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super39GenericChildToFixedGenericOutsideParent11classMethodfT_T_
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type to $@thick GenericOutsideParent<A>.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type, #GenericOutsideParent.classMethod!1 : <A> (GenericOutsideParent<A>.Type) -> () -> () , $@convention(thin) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToFixedGenericOutsideParent<A>.Type, #GenericOutsideParent.classMethod!1 : <A> GenericOutsideParent<A>.Type -> () -> () , $@convention(thin) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@thick GenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {
@@ -210,7 +210,7 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK-LABEL: sil hidden @_TFC19partial_apply_super43GenericChildToResilientGenericOutsideParent6methodfT_T_
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $GenericChildToResilientGenericOutsideParent<A> to $ResilientGenericOutsideParent<A>
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> () , $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $GenericChildToResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> ResilientGenericOutsideParent<A> -> () -> () , $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override func method() {
@@ -220,7 +220,7 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK-LABEL: sil hidden @_TZFC19partial_apply_super43GenericChildToResilientGenericOutsideParent11classMethodfT_T_
   // CHECK: [[DOFOO:%[0-9]+]] = function_ref @_TF19partial_apply_super5doFooFFT_T_T_ : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[CASTED_SELF:%[0-9]+]] = upcast %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type to $@thick ResilientGenericOutsideParent<A>.Type
-  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type, #ResilientGenericOutsideParent.classMethod!1 : <A> (ResilientGenericOutsideParent<A>.Type) -> () -> () , $@convention(thin) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
+  // CHECK: [[SUPER_METHOD:%[0-9]+]] = super_method %0 : $@thick GenericChildToResilientGenericOutsideParent<A>.Type, #ResilientGenericOutsideParent.classMethod!1 : <A> ResilientGenericOutsideParent<A>.Type -> () -> () , $@convention(thin) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: [[PARTIAL_APPLY:%[0-9]+]] = partial_apply [[SUPER_METHOD]]<A>([[CASTED_SELF]]) : $@convention(thin) <τ_0_0> (@thick ResilientGenericOutsideParent<τ_0_0>.Type) -> ()
   // CHECK: apply [[DOFOO]]([[PARTIAL_APPLY]]) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   override class func classMethod() {


### PR DESCRIPTION
As far as I know, the SIL parser was the last major piece that relied on PolymorphicFunctionType in a non-trivial way. This series of patches brings us closer to removing PolymorphicFunctionType, SILFunction::ContextGenericParams, and ConstantInfo::{Context,Inner}GenericParams.
