### PR TITLE
[Python] Add flake8 config with only the currently passing rules enabled

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[flake8]
+filename = *.py,build-script,gyb,line-directive,ns-html2rst,pre-commit-benchmark,recursive-lipo,submit-benchmark-results,update-checkout,viewcfg
+ignore = E101,E111,E121,E125,E128,E129,E231,E261,E265,E302,E303,E501,W191


### PR DESCRIPTION
Running `flake8` prior to committing new Python code makes sure that no regressions w.r.t. PEP 8 compliance are introduced.

Please note that all potentially controversial PEP 8 rules are disabled in this config file. Only the remaining non-controversial and currently passing rules are kept enabled.

Running flake8:

```
$ flake8
```

Installing flake8:

```
$ pip install flake8
```
