### PR TITLE
[Swift 2.2] Perform a dynamic method call if a class has objc ancestry in specula…

### DIFF
--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -216,6 +216,13 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
   if (CD->isFinal())
     return true;
 
+  // If the class has an @objc ancestry it can be dynamically subclassed and we
+  // can't therefore statically know the default case.
+  auto Ancestry = CD->checkObjCAncestry();
+  if (Ancestry != ObjCClassKind::NonObjC &&
+      Ancestry != ObjCClassKind::ObjCMembers)
+    return false;
+
   // Without an associated context we cannot perform any
   // access-based optimizations.
   if (!DC)

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -219,8 +219,7 @@ static bool isDefaultCaseKnown(ClassHierarchyAnalysis *CHA,
   // If the class has an @objc ancestry it can be dynamically subclassed and we
   // can't therefore statically know the default case.
   auto Ancestry = CD->checkObjCAncestry();
-  if (Ancestry != ObjCClassKind::NonObjC &&
-      Ancestry != ObjCClassKind::ObjCMembers)
+  if (Ancestry != ObjCClassKind::NonObjC)
     return false;
 
   // Without an associated context we cannot perform any

--- a/test/SILOptimizer/devirt_speculative.sil
+++ b/test/SILOptimizer/devirt_speculative.sil
@@ -1,0 +1,53 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt  | FileCheck %s
+
+sil_stage canonical
+
+@objc class MyNSObject {}
+private class Base : MyNSObject {
+   override init()
+  @inline(never) func foo()
+}
+
+private class Sub : Base {
+  override init()
+  @inline(never) override func foo()
+}
+
+sil private [noinline] @_TBaseFooFun : $@convention(method) (@guaranteed Base) -> () {
+bb0(%0 : $Base):
+  %1 = tuple()
+  return %1 : $()
+}
+
+sil private [noinline] @_TSubFooFun : $@convention(method) (@guaranteed Sub) -> () {
+bb0(%0 : $Sub):
+  %1 = tuple()
+  return %1 : $()
+}
+
+sil_vtable Base {
+  #Base.foo!1: _TBaseFooFun
+}
+
+sil_vtable Sub {
+  #Base.foo!1: _TSubFooFun
+}
+
+sil @test_objc_ancestry : $@convention(thin) (@guaranteed Base) -> () {
+bb0(%0: $Base):
+  %1 = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+  %2 = apply %1(%0) : $@convention(method) (@guaranteed Base) -> ()
+  %3 = tuple()
+  return %3 : $()
+}
+
+// Make sure we leave the generic method call because an objc derived class can be extended at runtime.
+
+// CHECK-LABEL: sil @test_objc_ancestry
+// CHECK: bb0
+// CHECK:  [[METH:%.*]] = class_method %0 : $Base, #Base.foo!1 : (Base) -> () -> () , $@convention(method) (@guaranteed Base) -> ()
+// CHECK:  checked_cast_br [exact] %0 : $Base to $Base, bb{{.*}}, bb[[CHECK2:[0-9]+]]
+// CHECK: bb[[CHECK2]]{{.*}}:
+// CHECK:  checked_cast_br [exact] %0 : $Base to $Sub, bb{{.*}}, bb[[GENCALL:[0-9]+]]
+// CHECK: bb[[GENCALL]]{{.*}}:
+// CHECK:  apply [[METH]]

--- a/test/SILOptimizer/devirt_speculative.sil
+++ b/test/SILOptimizer/devirt_speculative.sil
@@ -51,3 +51,56 @@ bb0(%0: $Base):
 // CHECK:  checked_cast_br [exact] %0 : $Base to $Sub, bb{{.*}}, bb[[GENCALL:[0-9]+]]
 // CHECK: bb[[GENCALL]]{{.*}}:
 // CHECK:  apply [[METH]]
+
+struct MyValue {}
+
+private class Generic<T> : MyNSObject {
+  override init()
+}
+
+private class Base2 : Generic<MyValue> {
+   override init()
+  @inline(never) func foo()
+}
+
+private class Sub2 : Base2 {
+  override init()
+  @inline(never) override func foo()
+}
+
+sil private [noinline] @_TBase2FooFun : $@convention(method) (@guaranteed Base2) -> () {
+bb0(%0 : $Base2):
+  %1 = tuple()
+  return %1 : $()
+}
+
+sil private [noinline] @_TSub2FooFun : $@convention(method) (@guaranteed Sub2) -> () {
+bb0(%0 : $Sub2):
+  %1 = tuple()
+  return %1 : $()
+}
+
+sil_vtable Base2 {
+  #Base2.foo!1: _TBase2FooFun
+}
+
+sil_vtable Sub2 {
+  #Base2.foo!1: _TSub2FooFun
+}
+
+sil @test_objc_ancestry2 : $@convention(thin) (@guaranteed Base2) -> () {
+bb0(%0: $Base2):
+  %1 = class_method %0 : $Base2, #Base2.foo!1 : (Base2) -> () -> () , $@convention(method) (@guaranteed Base2) -> ()
+  %2 = apply %1(%0) : $@convention(method) (@guaranteed Base2) -> ()
+  %3 = tuple()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil @test_objc_ancestry2
+// CHECK: bb0
+// CHECK:  [[METH:%.*]] = class_method %0 : $Base2, #Base2.foo!1 : (Base2) -> () -> () , $@convention(method) (@guaranteed Base2) -> ()
+// CHECK:  checked_cast_br [exact] %0 : $Base2 to $Base2, bb{{.*}}, bb[[CHECK2:[0-9]+]]
+// CHECK: bb[[CHECK2]]{{.*}}:
+// CHECK:  checked_cast_br [exact] %0 : $Base2 to $Sub2, bb{{.*}}, bb[[GENCALL:[0-9]+]]
+// CHECK: bb[[GENCALL]]{{.*}}:
+// CHECK:  apply [[METH]]


### PR DESCRIPTION
…tive devirt as fallback.

If a class has an @objc ancestry this class can be dynamically overridden and
therefore we don't know the default case even if we see the full class
hierarchy.

rdar://23228386
## Explanation:

Before this change we would devirtualize a method call to static calls of the potential call targets without a fallback to a class method lookup if we believed to have the full class hierarchy e.g in WMO mode. But during runtime this assumption can be violated because an objective-c class can be dynamically extended and so we would end up calling through the wrong method.

private class A : NSObject {
 func foo() {...}
}
private class B : A { 
  override foo() {...}
}

Before:

callAnA(a : A) {
   if (a isa A) {
    A.foo(a)
   } else {
    B.foo(a)
   }
}

After:

callAnA(a : A) {
   if (a isa A) {
    A.foo(a)
   } else if (a isa B) {
    B.foo(a)
   } else a.foo(a) // call through class method table.
}
## Scope:

The change only effects whether we emit a default case that calls through the class method table. Emitting the call through the class method table is always safe. This risk is low.
## Testing:

There is a unit test testing the change, furthermore the change was tested in the project reported in rdar://23228386 and only with this change the test scenario in the project works.
