### PR TITLE
[Python] Enable PEP 8 rules we already comply with

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [flake8]
 filename = *.py,build-script,gyb,line-directive,ns-html2rst,pre-commit-benchmark,recursive-lipo,submit-benchmark-results,update-checkout,viewcfg
-ignore = E101,E111,E121,E125,E128,E129,E261,E265,E302,E303,E501,W191
+ignore = E101,E111,E128,E265,E302,E501,W191


### PR DESCRIPTION
The entire Python code base already complies with:
- E121: continuation line under-indented for hanging indent
- E125: continuation line with same indent as next logical line
- E129: visually indented line with same indent as next logical line
- E261: at least two spaces before inline comment
- E303: too many blank lines (3)

Adding those to `.pep8` since we don't want any regressions in terms of PEP 8 compliance when new code is added.
