### PR TITLE
[Swift-2.2] [SourceKit] Omit internal parameters from filter name

### DIFF
--- a/test/SourceKit/CodeComplete/complete_filter.swift
+++ b/test/SourceKit/CodeComplete/complete_filter.swift
@@ -106,3 +106,20 @@ func test() {
 // GROUP-NEXT: ]
 // GROUP-LABEL: Results for filterText: overloadp [
 // GROUP-NEXT: ]
+
+struct UnnamedArgs {
+  func dontMatchAgainst(unnamed: Int, arguments: Int, _ unnamed2:Int) {}
+  func test() {
+    self.#^UNNAMED_ARGS_0,dont,arguments,unnamed^#
+  }
+}
+
+// RUN: %complete-test -tok=UNNAMED_ARGS_0 %s | FileCheck %s -check-prefix=UNNAMED_ARGS_0
+// UNNAMED_ARGS_0: Results for filterText: dont [
+// UNNAMED_ARGS_0-NEXT:   dontMatchAgainst(unnamed: Int, arguments: Int, unnamed2: Int)
+// UNNAMED_ARGS_0-NEXT: ]
+// UNNAMED_ARGS_0-NEXT: Results for filterText: arguments [
+// UNNAMED_ARGS_0-NEXT:   dontMatchAgainst(unnamed: Int, arguments: Int, unnamed2: Int)
+// UNNAMED_ARGS_0-NEXT: ]
+// UNNAMED_ARGS_0-NEXT: Results for filterText: unnamed [
+// UNNAMED_ARGS_0-NEXT: ]

--- a/test/SourceKit/CodeComplete/complete_member.swift.response
+++ b/test/SourceKit/CodeComplete/complete_member.swift.response
@@ -13,7 +13,7 @@
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
-      key.name: "fooInstanceFunc1(a:)",
+      key.name: "fooInstanceFunc1(:)",
       key.sourcetext: "fooInstanceFunc1(<#T##a: Int##Int#>)",
       key.description: "fooInstanceFunc1(a: Int)",
       key.typename: "Double",

--- a/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
+++ b/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
@@ -9,7 +9,7 @@ func test() {
 // RUN: FileCheck %s < %t
 
 // Swift == 1
-// CHECK-LABEL:  key.name: "abs(x:)",
+// CHECK-LABEL:  key.name: "abs(:)",
 // CHECK-NEXT:   key.sourcetext: "abs(<#T##x: T##T#>)",
 // CHECK-NEXT:   key.description: "abs(x: T)",
 // CHECK-NEXT:   key.typename: "T",
@@ -22,7 +22,7 @@ func test() {
 // CHECK-NEXT: },
 
 // FooHelper.FooHelperExplicit == 1
-// CHECK-LABEL:  key.name: "fooHelperExplicitFrameworkFunc1(a:)",
+// CHECK-LABEL:  key.name: "fooHelperExplicitFrameworkFunc1(:)",
 // CHECK-NEXT:   key.sourcetext: "fooHelperExplicitFrameworkFunc1(<#T##a: Int32##Int32#>)",
 // CHECK-NEXT:   key.description: "fooHelperExplicitFrameworkFunc1(a: Int32)",
 // CHECK-NEXT:   key.typename: "Int32",

--- a/test/SourceKit/CodeComplete/complete_name.swift
+++ b/test/SourceKit/CodeComplete/complete_name.swift
@@ -2,16 +2,19 @@
 // RUN: %complete-test -raw -tok=METHOD_NAME %s | FileCheck %s -check-prefix=METHOD_NAME
 
 struct S {
-  init(a: Int, b: Int) {}
-  func foo(a: Int, b: Int) {}
+  init(a: Int, b: Int, _ c: Int) {}
+  init(_ a: Int, _ b: Int) {}
+  func foo1(a: Int, _ b: Int, _ c: Int) {}
+  func foo2(a a: Int, b: Int, c: Int) {}
 }
 
 func test01() {
   S(#^INIT_NAME^#)
 }
-// INIT_NAME: key.name: "a:b:)"
+// INIT_NAME: key.name: "a:b::)"
 
 func test02(x: S) {
   x.#^METHOD_NAME^#
 }
-// METHOD_NAME: key.name: "foo(a:b:)"
+// METHOD_NAME: key.name: "foo1(:::)"
+// METHOD_NAME: key.name: "foo2(a:b:c:)"

--- a/test/SourceKit/CodeComplete/complete_with_closure_param.swift
+++ b/test/SourceKit/CodeComplete/complete_with_closure_param.swift
@@ -9,12 +9,12 @@ C().
 // RUN: %sourcekitd-test -req=complete -pos=7:5 %s -- %s | FileCheck %s
 
 // CHECK:      key.kind: source.lang.swift.decl.function.method.instance,
-// CHECK-NEXT: key.name: "foo(x:)",
+// CHECK-NEXT: key.name: "foo(:)",
 // CHECK-NEXT: key.sourcetext: "foo(<#T##x: Int -> Int##Int -> Int#>)",
 // CHECK-NEXT: key.description: "foo(x: Int -> Int)",
 // CHECK-NEXT: key.typename: "Void",
 
 // CHECK:      key.kind: source.lang.swift.decl.function.method.instance,
-// CHECK-NEXT: key.name: "foo2(x:)",
+// CHECK-NEXT: key.name: "foo2(:)",
 // CHECK-NEXT: key.sourcetext: "foo2(<#T##x: MyFnTy##MyFnTy##Int -> Int#>)",
 // CHECK-NEXT: key.description: "foo2(x: MyFnTy)",

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -873,6 +873,7 @@ void CompletionBuilder::getFilterName(CodeCompletionString *str,
       bool shouldPrint = !C.isAnnotation();
       switch (C.getKind()) {
       case ChunkKind::TypeAnnotation:
+      case ChunkKind::CallParameterInternalName:
       case ChunkKind::CallParameterClosureType:
       case ChunkKind::CallParameterType:
       case ChunkKind::DeclAttrParamEqual:


### PR DESCRIPTION
Pull into swift-2.2-branch:

The internal parameter names are just there to give an extra hint in the
source text for what the argument is. Consequently, we don't want to
allow filtering to match against them.
