### PR TITLE
Runtime attributes

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -44,7 +44,7 @@ int _swift_stdlib_putchar(int c);
 // String handling <string.h>
 __attribute__((pure))
 __swift_size_t _swift_stdlib_strlen(const char *s);
- __attribute__((pure))
+__attribute__((pure))
 int _swift_stdlib_memcmp(const void *s1, const void *s2, __swift_size_t n);
 
 // <unistd.h>

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -54,6 +54,7 @@ __swift_ssize_t _swift_stdlib_write(int fd, const void *buf,
 int _swift_stdlib_close(int fd);
 
 // Non-standard extensions
+__attribute__((pure))
 __swift_size_t _swift_stdlib_malloc_size(const void *ptr);
 __swift_uint32_t _swift_stdlib_arc4random(void);
 __swift_uint32_t _swift_stdlib_arc4random_uniform(__swift_uint32_t upper_bound);

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -35,7 +35,7 @@ typedef struct {
 #include <stdint.h>
 #include <assert.h>
 
- #include "swift/Basic/type_traits.h"
+#include "swift/Basic/type_traits.h"
 
 // Strong reference count.
 

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -47,21 +47,26 @@ _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadata;
 extern const __swift_uint16_t *
 _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix;
 
+__attribute__((pure))
 __swift_int32_t _swift_stdlib_unicode_compare_utf16_utf16(
   const __swift_uint16_t *Left, __swift_int32_t LeftLength,
   const __swift_uint16_t *Right, __swift_int32_t RightLength);
 
+__attribute__((pure))
 __swift_int32_t _swift_stdlib_unicode_compare_utf8_utf16(
   const char *Left, __swift_int32_t LeftLength,
   const __swift_uint16_t *Right, __swift_int32_t RightLength);
 
+__attribute__((pure))
 __swift_int32_t _swift_stdlib_unicode_compare_utf8_utf8(
   const char *Left, __swift_int32_t LeftLength,
   const char *Right, __swift_int32_t RightLength);
 
+__attribute__((pure))
 __swift_intptr_t _swift_stdlib_unicode_hash(
   const __swift_uint16_t *Str, __swift_int32_t Length);
 
+__attribute__((pure))
 __swift_intptr_t _swift_stdlib_unicode_hash_ascii(
   const char *Str, __swift_int32_t Length);
 


### PR DESCRIPTION
This pull request adds readnone to 1 runtime function and readonly to a bunch of unicode functions that compare/hash arrays.
