### PR TITLE
[runtime] Fix leak in backtrace demangling

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -105,6 +105,7 @@ demangledLine(std::string line) {
       return false;
     } else {
       out = demangled;
+      free(demangled);
       return true;
     }
   });


### PR DESCRIPTION
`abi::__cxa_demangle` returns a `malloc`'d pointer that we need to `free`.
