### PR TITLE
build-script: force LLVM to use libc++ on Darwin

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -394,6 +394,7 @@ function set_deployment_target_based_options() {
                 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="${cmake_osx_deployment_target}"
                 -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                 -DLLVM_HOST_TRIPLE:STRING="${llvm_host_triple}"
+                -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
             )
             swift_cmake_options=(
                 "${swift_cmake_options[@]}"
@@ -401,6 +402,7 @@ function set_deployment_target_based_options() {
                 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_IOS="${DARWIN_DEPLOYMENT_VERSION_IOS}"
                 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS="${DARWIN_DEPLOYMENT_VERSION_TVOS}"
                 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS="${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
+                -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
             )
 
             if [[ "${llvm_target_arch}" ]] ; then


### PR DESCRIPTION
Under certain circumstances, when the OS X machine has the `/usr/include` directory that contains stale headers (not from the current Xcode installation), the build might fail.  This patch works around the issue by ensuring that LLVM CMake scripts don't try to look in `/usr/include`.

rdar://problem/24452118
