### PR TITLE
[WIP] Runtime: Support for resiliently adding protocol requirements with de…

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -153,6 +153,9 @@ public:
   /// array of the generic parameters for the innermost generic type.
   ArrayRef<GenericTypeParamType *> getInnermostGenericParams() const;
 
+  GenericSignature *partialSubstGenericArgs(ModuleDecl *M, ArrayRef<Type> args,
+                                            TypeSubstitutionMap &subs) const;
+
   /// Retrieve the requirements.
   ArrayRef<Requirement> getRequirements() const {
     return const_cast<GenericSignature *>(this)->getRequirementsBuffer();

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -94,7 +94,7 @@ namespace irgen {
   /// witness method.
   inline unsigned getTrailingWitnessSignatureLength(IRGenModule &IGM,
                                                     CanSILFunctionType type) {
-    return 1;
+    return 2;
   }
 
   /// Add the trailing arguments necessary for calling a witness method.
@@ -104,6 +104,7 @@ namespace irgen {
 
   struct WitnessMetadata {
     llvm::Value *SelfMetadata = nullptr;
+    llvm::Value *SelfWitnessTable = nullptr;
   };
 
   /// Collect any required metadata for a witness method from the end

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2003,6 +2003,20 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     }
   }
 
+  if (origCalleeType->getRepresentation() ==
+      SILFunctionTypeRepresentation::WitnessMethod) {
+    auto genericSig = origCalleeType->getGenericSignature();
+    assert(genericSig &&
+           "witness_method calls must retain their generic signature");
+    auto selfType = genericSig->getGenericParams()[0];
+    assert(selfType->getDepth() == 0 && selfType->getIndex() == 0 &&
+           "first generic parameter must be protocol Self type");
+    auto conformsTo = genericSig->getConformsTo(
+        selfType, *IGM.SILMod->getSwiftModule());
+    assert(conformsTo.size() == 1 &&
+           "Self type must conform to exactly one protocol");
+  }
+
   Explosion llArgs;    
   CallEmission emission =
     getCallEmissionForLoweredValue(*this, origCalleeType, substCalleeType,

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -727,8 +727,11 @@ static ApplySite devirtualizeWitnessMethod(ApplySite AI, SILFunction *F,
   // Figure out the exact bound type of the function to be called by
   // applying all substitutions.
   auto CalleeCanType = F->getLoweredFunctionType();
-  auto SubstCalleeCanType = CalleeCanType->substGenericArgs(
-    Module, Module.getSwiftModule(), NewSubstList);
+  auto SubstCalleeCanType = CalleeCanType;
+  if (!NewSubstList.empty()) {
+    SubstCalleeCanType = SubstCalleeCanType->partialSubstGenericArgs(
+      Module, Module.getSwiftModule(), NewSubstList);
+  }
 
   // Collect arguments from the apply instruction.
   auto Arguments = SmallVector<SILValue, 4>();

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -89,8 +89,8 @@ entry(%b : $ErrorType):
   // CHECK: [[CODE_ADDR:%.*]] = getelementptr {{.*}} [[WITNESS]], i32 1
   // CHECK: [[CODE:%.*]] = load {{.*}} [[CODE_ADDR]]
   %m = witness_method $@opened("01234567-89AB-CDEF-0123-000000000000") ErrorType, #ErrorType._code!getter.1, %o : $*@opened("01234567-89AB-CDEF-0123-000000000000") ErrorType : $@convention(witness_method) <Self: ErrorType> (@in_guaranteed Self) -> Int
-  // CHECK: [[CODE_FN:%.*]] = bitcast i8* [[CODE]] to [[INT:i[0-9]+]] (%swift.opaque*, %swift.type*)*
-  // CHECK: [[RESULT:%.*]] = call [[INT]] [[CODE_FN]](%swift.opaque* noalias nocapture [[ADDR]], %swift.type* [[TYPE]])
+  // CHECK: [[CODE_FN:%.*]] = bitcast i8* [[CODE]] to [[INT:i[0-9]+]] (%swift.opaque*, %swift.type*, i8**)*
+  // CHECK: [[RESULT:%.*]] = call [[INT]] [[CODE_FN]](%swift.opaque* noalias nocapture [[ADDR]], %swift.type* [[TYPE]], i8** [[WITNESS]])
   %c = apply %m<@opened("01234567-89AB-CDEF-0123-000000000000") ErrorType>(%o) : $@convention(witness_method) <Self: ErrorType> (@in_guaranteed Self) -> Int
   // CHECK: ret [[INT]] [[RESULT]]
   return %c : $Int

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -88,14 +88,14 @@ func class_bounded_archetype_method<T : ClassBoundBinary>(x: T, y: T) {
   // CHECK: [[INHERITED:%.*]] = load i8*, i8** %T.ClassBoundBinary, align 8
   // CHECK: [[INHERITED_WTBL:%.*]] = bitcast i8* [[INHERITED]] to i8**
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** [[INHERITED_WTBL]], align 8
-  // CHECK: [[WITNESS_FUNC:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %swift.type*)
-  // CHECK: call void [[WITNESS_FUNC]](%objc_object* %0, %swift.type* {{.*}})
+  // CHECK: [[WITNESS_FUNC:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %swift.type*, i8**)
+  // CHECK: call void [[WITNESS_FUNC]](%objc_object* %0, %swift.type* {{.*}}, i8** [[INHERITED_WTBL]])
   x.classBoundBinaryMethod(y)
   // CHECK: [[WITNESS_ENTRY:%.*]] = getelementptr inbounds i8*, i8** %T.ClassBoundBinary, i32 1
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ENTRY]], align 8
   // CHECK: call void @swift_unknownRetain(%objc_object* [[Y:%.*]])
-  // CHECK: [[WITNESS_FUNC:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %objc_object*, %swift.type*)
-  // CHECK: call void [[WITNESS_FUNC]](%objc_object* [[Y]], %objc_object* %0, %swift.type* {{.*}})
+  // CHECK: [[WITNESS_FUNC:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %objc_object*, %swift.type*, i8**)
+  // CHECK: call void [[WITNESS_FUNC]](%objc_object* [[Y]], %objc_object* %0, %swift.type* %T, i8** %T.ClassBoundBinary)
 }
 
 // CHECK-LABEL: define hidden { %objc_object*, %objc_object* } @_TF22class_bounded_generics29class_bounded_archetype_tuple{{.*}}(%objc_object*, %swift.type* %T, i8** %T.ClassBound)
@@ -153,9 +153,10 @@ func class_bounded_erasure(x: ConcreteClass) -> ClassBound {
 // CHECK-LABEL: define hidden void @_TF22class_bounded_generics29class_bounded_protocol_method{{.*}}(%objc_object*, i8**) {{.*}} {
 func class_bounded_protocol_method(x: ClassBound) {
   x.classBoundMethod()
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getObjectType(%objc_object* %0)
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_TABLE:%.*]], align 8
-  // CHECK: [[WITNESS_FN:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %swift.type*)
-  // CHECK: call void [[WITNESS_FN]](%objc_object* %0, %swift.type* {{.*}})
+  // CHECK: [[WITNESS_FN:%.*]] = bitcast i8* [[WITNESS]] to void (%objc_object*, %swift.type*, i8**)
+  // CHECK: call void [[WITNESS_FN]](%objc_object* %0, %swift.type* [[METADATA]], i8** [[WITNESS_TABLE]])
 }
 
 // CHECK-LABEL: define hidden %C22class_bounded_generics13ConcreteClass* @_TF22class_bounded_generics28class_bounded_archetype_cast{{.*}}(%objc_object*, %swift.type* %T, i8** %T.ClassBound)

--- a/test/IRGen/dependent_reabstraction.swift
+++ b/test/IRGen/dependent_reabstraction.swift
@@ -8,7 +8,7 @@ protocol A {
 }
 
 struct X<Y> : A {
-  // CHECK-LABEL: define hidden void @_TTWurGV23dependent_reabstraction1Xx_S_1AS_FS1_1bfwx1BT_(%swift.type** noalias nocapture dereferenceable({{.*}}), %V23dependent_reabstraction1X* noalias nocapture, %swift.type* %Self)
+  // CHECK-LABEL: define hidden void @_TTWurGV23dependent_reabstraction1Xx_S_1AS_FS1_1bfwx1BT_(%swift.type** noalias nocapture dereferenceable({{.*}}), %V23dependent_reabstraction1X* noalias nocapture, %swift.type* %Self, i8** %SelfWitnessTable)
   func b(b: X.Type) {
     let x: Any = b
     markUsed(b as X.Type)

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -12,7 +12,7 @@ import objc_protocols_Bas
 // -- Protocol "Frungible" inherits only objc protocols and should have no
 //    out-of-line inherited witnesses in its witness table.
 // CHECK: [[ZIM_FRUNGIBLE_WITNESS:@_TWPC14objc_protocols3ZimS_9FrungibleS_]] = hidden constant [1 x i8*] [
-// CHECK:    i8* bitcast (void (%C14objc_protocols3Zim*, %swift.type*)* @_TTWC14objc_protocols3ZimS_9FrungibleS_FS1_6frungefT_T_ to i8*)
+// CHECK:    i8* bitcast (void (%C14objc_protocols3Zim*, %swift.type*, i8**)* @_TTWC14objc_protocols3ZimS_9FrungibleS_FS1_6frungefT_T_ to i8*)
 // CHECK: ]
 
 protocol Ansible {

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -59,8 +59,8 @@ protocol InternalProtocol {
 // CHECK-SAME:   i32 1031,
 // CHECK-SAME:   i16 4,
 // CHECK-SAME:   i16 2,
-// CHECK-SAME:   void (%swift.opaque*, %swift.type*)* @defaultC,
-// CHECK-SAME:   void (%swift.opaque*, %swift.type*)* @defaultD  
+// CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultC,
+// CHECK-SAME:   void (%swift.opaque*, %swift.type*, i8**)* @defaultD
 // CHECK-SAME: }>
 
 // CHECK: @_TMp19protocol_resilience16InternalProtocol = {{(protected )?}}constant %swift.protocol {

--- a/test/IRGen/sil_generic_witness_methods.swift
+++ b/test/IRGen/sil_generic_witness_methods.swift
@@ -17,23 +17,23 @@ struct S {}
 func call_methods<T: P, U>(x: T, y: S, z: U) {
   // CHECK: [[STATIC_METHOD_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.P, i32 1
   // CHECK: [[STATIC_METHOD_PTR:%.*]] = load i8*, i8** [[STATIC_METHOD_ADDR]], align 8
-  // CHECK: [[STATIC_METHOD:%.*]] = bitcast i8* [[STATIC_METHOD_PTR]] to void (%swift.type*, %swift.type*)*
-  // CHECK: call void [[STATIC_METHOD]](%swift.type* %T, %swift.type* %T)
+  // CHECK: [[STATIC_METHOD:%.*]] = bitcast i8* [[STATIC_METHOD_PTR]] to void (%swift.type*, %swift.type*, i8**)*
+  // CHECK: call void [[STATIC_METHOD]](%swift.type* %T, %swift.type* %T, i8** %T.P)
   T.concrete_static_method()
 
   // CHECK: [[CONCRETE_METHOD_PTR:%.*]] = load i8*, i8** %T.P, align 8
-  // CHECK: [[CONCRETE_METHOD:%.*]] = bitcast i8* [[CONCRETE_METHOD_PTR]] to void (%swift.opaque*, %swift.type*)*
-  // CHECK: call void [[CONCRETE_METHOD]](%swift.opaque* noalias nocapture {{%.*}}, %swift.type* %T)
+  // CHECK: [[CONCRETE_METHOD:%.*]] = bitcast i8* [[CONCRETE_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, i8**)*
+  // CHECK: call void [[CONCRETE_METHOD]](%swift.opaque* noalias nocapture {{%.*}}, %swift.type* %T, i8** %T.P)
   x.concrete_method()
   // CHECK: [[GENERIC_METHOD_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.P, i32 2
   // CHECK: [[GENERIC_METHOD_PTR:%.*]] = load i8*, i8** [[GENERIC_METHOD_ADDR]], align 8
-  // CHECK: [[GENERIC_METHOD:%.*]] = bitcast i8* [[GENERIC_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*)*
-  // CHECK: call void [[GENERIC_METHOD]](%swift.opaque* noalias nocapture {{.*}}, %swift.type* {{.*}} @_TMfV27sil_generic_witness_methods1S, {{.*}} %swift.opaque* {{.*}}, %swift.type* %T)
+  // CHECK: [[GENERIC_METHOD:%.*]] = bitcast i8* [[GENERIC_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*, i8**)*
+  // CHECK: call void [[GENERIC_METHOD]](%swift.opaque* noalias nocapture {{.*}}, %swift.type* {{.*}} @_TMfV27sil_generic_witness_methods1S, {{.*}} %swift.opaque* {{.*}}, %swift.type* %T, i8** %T.P)
   x.generic_method(y)
   // CHECK: [[GENERIC_METHOD_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.P, i32 2
   // CHECK: [[GENERIC_METHOD_PTR:%.*]] = load i8*, i8** [[GENERIC_METHOD_ADDR]], align 8
-  // CHECK: [[GENERIC_METHOD:%.*]] = bitcast i8* [[GENERIC_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*)*
-  // CHECK: call void [[GENERIC_METHOD]](%swift.opaque* noalias nocapture {{.*}}, %swift.type* %U, %swift.opaque* {{.*}}, %swift.type* %T)
+  // CHECK: [[GENERIC_METHOD:%.*]] = bitcast i8* [[GENERIC_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*, i8**)*
+  // CHECK: call void [[GENERIC_METHOD]](%swift.opaque* noalias nocapture {{.*}}, %swift.type* %U, %swift.opaque* {{.*}}, %swift.type* %T, i8** %T.P)
   x.generic_method(z)
 }
 
@@ -44,8 +44,8 @@ func call_existential_methods(x: P, y: S) {
   // CHECK: [[WTABLE_ADDR:%.*]] = getelementptr inbounds %P27sil_generic_witness_methods1P_, %P27sil_generic_witness_methods1P_* [[X]], i32 0, i32 2
   // CHECK: [[WTABLE:%.*]] = load i8**, i8*** [[WTABLE_ADDR]], align 8
   // CHECK: [[CONCRETE_METHOD_PTR:%.*]] = load i8*, i8** [[WTABLE]], align 8
-  // CHECK: [[CONCRETE_METHOD:%.*]] = bitcast i8* [[CONCRETE_METHOD_PTR]] to void (%swift.opaque*, %swift.type*)*
-  // CHECK: call void [[CONCRETE_METHOD]](%swift.opaque* noalias nocapture {{%.*}}, %swift.type* [[METADATA]])
+  // CHECK: [[CONCRETE_METHOD:%.*]] = bitcast i8* [[CONCRETE_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, i8**)*
+  // CHECK: call void [[CONCRETE_METHOD]](%swift.opaque* noalias nocapture {{%.*}}, %swift.type* [[METADATA]], i8** [[WTABLE]])
   x.concrete_method()
 
   // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %P27sil_generic_witness_methods1P_, %P27sil_generic_witness_methods1P_* [[X]], i32 0, i32 1
@@ -54,7 +54,7 @@ func call_existential_methods(x: P, y: S) {
   // CHECK: [[WTABLE:%.*]] = load i8**, i8*** [[WTABLE_ADDR]], align 8
   // CHECK: [[GENERIC_METHOD_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[WTABLE]], i32 2
   // CHECK: [[GENERIC_METHOD_PTR:%.*]] = load i8*, i8** [[GENERIC_METHOD_ADDR]], align 8
-  // CHECK: [[GENERIC_METHOD:%.*]] = bitcast i8* [[GENERIC_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*)*
-  // CHECK: call void [[GENERIC_METHOD]](%swift.opaque* noalias nocapture {{.*}}, %swift.type* {{.*}} @_TMfV27sil_generic_witness_methods1S, {{.*}} %swift.opaque* noalias nocapture {{%.*}}, %swift.type* [[METADATA]])
+  // CHECK: [[GENERIC_METHOD:%.*]] = bitcast i8* [[GENERIC_METHOD_PTR]] to void (%swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*, i8**)*
+  // CHECK: call void [[GENERIC_METHOD]](%swift.opaque* noalias nocapture {{.*}}, %swift.type* {{.*}} @_TMfV27sil_generic_witness_methods1S, {{.*}} %swift.opaque* noalias nocapture {{%.*}}, %swift.type* [[METADATA]], i8** [[WTABLE]])
   x.generic_method(y)
 }

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -39,13 +39,13 @@ struct Conformer: Q, QQ {
 // CHECK: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@_TWPV39sil_witness_tables_external_conformance17ExternalConformerS_9ExternalPS_]] = external global i8*
 // CHECK: [[CONFORMER_Q_WITNESS_TABLE:@_TWPV18sil_witness_tables9ConformerS_1QS_]] = hidden constant [2 x i8*] [
 // CHECK:   i8* bitcast ([4 x i8*]* [[CONFORMER_P_WITNESS_TABLE:@_TWPV18sil_witness_tables9ConformerS_1PS_]] to i8*),
-// CHECK:   i8* bitcast (void (%V18sil_witness_tables9Conformer*, %swift.type*)* @_TTWV18sil_witness_tables9ConformerS_1QS_FS1_7qMethod{{.*}} to i8*)
+// CHECK:   i8* bitcast (void (%V18sil_witness_tables9Conformer*, %swift.type*, i8**)* @_TTWV18sil_witness_tables9ConformerS_1QS_FS1_7qMethod{{.*}} to i8*)
 // CHECK: ]
 // CHECK: [[CONFORMER_P_WITNESS_TABLE]] = hidden constant [4 x i8*] [
 // CHECK:   i8* bitcast (%swift.type* ()* @_TMaV18sil_witness_tables14AssocConformer to i8*),
 // CHECK:   i8* bitcast (i8** ()* @_TWaV18sil_witness_tables14AssocConformerS_1AS_ to i8*)
-// CHECK:   i8* bitcast (void (%swift.type*, %swift.type*)* @_TTWV18sil_witness_tables9ConformerS_1PS_ZFS1_12staticMethod{{.*}} to i8*),
-// CHECK:   i8* bitcast (void (%V18sil_witness_tables9Conformer*, %swift.type*)* @_TTWV18sil_witness_tables9ConformerS_1PS_FS1_14instanceMethod{{.*}} to i8*)
+// CHECK:   i8* bitcast (void (%swift.type*, %swift.type*, i8**)* @_TTWV18sil_witness_tables9ConformerS_1PS_ZFS1_12staticMethod{{.*}} to i8*),
+// CHECK:   i8* bitcast (void (%V18sil_witness_tables9Conformer*, %swift.type*, i8**)* @_TTWV18sil_witness_tables9ConformerS_1PS_FS1_14instanceMethod{{.*}} to i8*)
 // CHECK: ]
 // CHECK: [[CONFORMER2_P_WITNESS_TABLE:@_TWPV18sil_witness_tables10Conformer2S_1PS_]] = hidden constant [4 x i8*]
 

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -15,7 +15,7 @@ entry(%0: $*T, %1: $@thick T.Type):
 
   // CHECK-i386:   [[WITNESS:%.*]] = load i8*, i8** %T.DefCon, align 4
   // CHECK-x86_64: [[WITNESS:%.*]] = load i8*, i8** %T.DefCon, align 8
-  // CHECK: [[METHOD:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.type*, %swift.type*)*
+  // CHECK: [[METHOD:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.type*, %swift.type*, i8**)*
   // CHECK: call void [[METHOD]]
   %m = witness_method $T, #DefCon.init!allocator.1 : $@convention(witness_method) <U: DefCon> (@out U, @thick U.Type) -> ()
   %z = apply %m<T>(%0, %1) : $@convention(witness_method) <V: DefCon> (@out V, @thick V.Type) -> ()
@@ -35,7 +35,7 @@ struct ImplementsDerived : Derived {
 sil @testInheritedConformance : $@convention(thin) (@in ImplementsDerived) -> () {
 entry(%0: $*ImplementsDerived):
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** @_TWPV14witness_method17ImplementsDerivedS_4BaseS_
-  // CHECK: [[METHOD:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.type*)*
+  // CHECK: [[METHOD:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.type*, i8**)*
   // CHECK: call void [[METHOD]]
   %m = witness_method $ImplementsDerived, #Base.foo!1 : $@convention(witness_method) <U: Base> (@in_guaranteed U) -> ()
   %z = apply %m<ImplementsDerived>(%0) : $@convention(witness_method) <V: Base> (@in_guaranteed V) -> ()


### PR DESCRIPTION
…fault implementations

This is the first patch in a series that will allow new protocol
requirements to be added resiliently, with the runtime filling in
default implementations in witness tables.

Introduce a new swift_getResilientWitnessTable() entry point for
singleton runtime-instantiated conformances, and factor out common
code between swift_get{Generic,Resilient}WitnessTable() into a new
function.

The swift_get{Generic,Resilient}WitnessTable() entry points now
fill in the default witnesses from the protocol if the witness table
template is smaller than the expected witness table size.

While we're at it, change the layout of instantiated witness tables
to move the address point to the end of private data. Previously
the private data came after the requirements, but this meant that
adding new requirements would require sliding the private data down,
and accessing it indirectly. It is much simpler to access it from
negative offsets instead.

IRGen has been updated for the address point change, and also to
pass in nullptr as the value of the new defaultWitnesses parameter
of swift_getGenericWitnessTable(). The swift_getResilientWitnessTable()
is not used yet.
