### PR TITLE
Cite bug reports in xfail annotations

### DIFF
--- a/test/1_stdlib/StringOrderRelation.swift
+++ b/test/1_stdlib/StringOrderRelation.swift
@@ -14,8 +14,8 @@ import ObjectiveC
 var StringOrderRelationTestSuite = TestSuite("StringOrderRelation")
 
 StringOrderRelationTestSuite.test("StringOrderRelation/ASCII/NullByte")
-  .xfail(.LinuxAny(reason: "String comparison: ICU vs. Foundation"))
-  .xfail(.FreeBSDAny(reason: "String comparison: ICU vs. Foundation"))
+  .xfail(.NativeRuntime("String comparison: ICU vs. Foundation " +
+    "https://bugs.swift.org/browse/SR-630"))
   .code {
   let baseString = "a"
   let nullbyteString = "a\0"

--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -81,8 +81,8 @@ Algorithm.test("min,max") {
 }
 
 Algorithm.test("sorted/strings")
-  .xfail(.LinuxAny(reason: "String comparison: ICU vs. Foundation"))
-  .xfail(.FreeBSDAny(reason: "String comparison: ICU vs. Foundation"))
+  .xfail(.NativeRuntime("String comparison: ICU vs. Foundation " +
+    "https://bugs.swift.org/browse/SR-530"))
   .code {
   expectEqual(
     [ "Banana", "apple", "cherry" ],


### PR DESCRIPTION
Also replaces two xfails with one that covers both cases.
