### PR TITLE
[Swift 2.2] Remove hackery introduced for Swift 3 migration 

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5018,6 +5018,8 @@ canSkipOverTypedef(ClangImporter::Implementation &Impl,
 
 bool ClangImporter::Implementation::shouldTrySwift3Migration(
        Decl *swiftDecl, const clang::NamedDecl *clangDecl) {
+  if (!SwiftContext.LangOpts.Swift3Migration) return false;
+
   // Never map subscript declarations.
   if (isa<SubscriptDecl>(swiftDecl)) return false;
 


### PR DESCRIPTION
These hacks should only be there for Swift 3 migration; they pessimize normal compilation for 2.2
