### PR TITLE
[Python] Fix minor PEP 8 regression (E261: at least two spaces before inline comment)

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -515,7 +515,7 @@ also build for Apple watchos, but disallow tests that require an watchOS device"
         help="""enable code coverage analysis in Swift (false, not-merged,
         merged).""",
         choices=["false", "not-merged", "merged"],
-        default="false", # so CMake can see the inert mode as a false value
+        default="false",  # so CMake can see the inert mode as a false value
         dest="swift_analyze_code_coverage")
 
     parser.add_argument("--build-subdir",


### PR DESCRIPTION
Prior to this commit:

```
$ flake8
./utils/build-script:518:25: E261 at least two spaces before inline comment
$
```

After this commit:

```
$ flake8
$
```
