### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::SolverScope::~SolverScope()

### DIFF
--- a/validation-test/compiler_crashers/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift
+++ b/validation-test/compiler_crashers/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift
@@ -1,0 +1,7 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{func a(a)class a{var _=a(a{{a{


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000ee0c96 swift::constraints::ConstraintSystem::SolverScope::~SolverScope() + 582
5  swift           0x0000000000ee5e6b swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3915
6  swift           0x0000000000ee3605 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
7  swift           0x0000000000ee33b9 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 73
8  swift           0x0000000000df4b56 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 614
9  swift           0x0000000000dfafa9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
10 swift           0x0000000000dfc152 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 162
11 swift           0x0000000000dfc32b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
16 swift           0x0000000000e16116 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 swift           0x0000000000e5d23a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
20 swift           0x0000000000e869dc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
21 swift           0x0000000000dfb01b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
23 swift           0x0000000000e5d386 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
24 swift           0x0000000000de1f5d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1597
25 swift           0x0000000000c8b4df swift::CompilerInstance::performSema() + 2975
27 swift           0x00000000007769f1 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
28 swift           0x00000000007715d5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28247-swift-constraints-constraintsystem-solverscope-solverscope-c50a21.o
1.  While type-checking expression at [validation-test/compiler_crashers/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift:7:1 - line:7:31] RangeText="{func a(a)class a{var _=a(a{{a{"
2.  While type-checking 'a' at validation-test/compiler_crashers/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift:7:11
3.  While type-checking expression at [validation-test/compiler_crashers/28247-swift-constraints-constraintsystem-solverscope-solverscope.swift:7:25 - line:7:31] RangeText="a(a{{a{"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
