### PR TITLE
Fixes missing Xcode "Quick Help" for enum values as switch case patterns

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -306,8 +306,8 @@ bool SemaAnnotator::walkToTypeReprPost(TypeRepr *T) {
 }
 
 std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
-  if (auto *EEP = dyn_cast<EnumElementPattern>(P)) {
-    return { passReference(EEP->getElementDecl(), EEP->getType(), EEP->getLoc()), P };
+  if (auto *EP = dyn_cast<EnumElementPattern>(P)) {
+    return { passReference(EP->getElementDecl(), EP->getType(), EP->getLoc()), P };
   }
 
   auto *TP = dyn_cast<TypedPattern>(P);

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -306,6 +306,10 @@ bool SemaAnnotator::walkToTypeReprPost(TypeRepr *T) {
 }
 
 std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
+  if (auto *EEP = dyn_cast<EnumElementPattern>(P)) {
+    return { passReference(EEP->getElementDecl(), EEP->getType(), EEP->getLoc()), P };
+  }
+
   auto *TP = dyn_cast<TypedPattern>(P);
   if (!TP || !TP->isPropagatedType())
     return { true, P };

--- a/test/SourceKit/Indexing/index_enum_case.swift
+++ b/test/SourceKit/Indexing/index_enum_case.swift
@@ -1,0 +1,21 @@
+// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+public enum E {
+
+    case one, two(a: String), three
+
+    var text: String {
+        switch self {
+        case .one:
+            return "one"
+        case .two(let a):
+            return a
+        case .three:
+            return "three"
+        }
+    }
+
+}
+
+let e: E = .two(a:"String")

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -1,0 +1,133 @@
+{
+  key.hash: <hash>,
+  key.dependencies: [
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "Swift",
+      key.filepath: Swift.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1
+    }
+  ],
+  key.entities: [
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.name: "E",
+      key.usr: "s:O15index_enum_case1E",
+      key.line: 4,
+      key.column: 13,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "one",
+          key.usr: "s:FO15index_enum_case1E3oneFMS0_S0_",
+          key.line: 6,
+          key.column: 10
+        },
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "two",
+          key.usr: "s:FO15index_enum_case1E3twoFMS0_FT1aSS_S0_",
+          key.line: 6,
+          key.column: 15,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "String",
+              key.usr: "s:SS",
+              key.line: 6,
+              key.column: 22
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.enumelement,
+          key.name: "three",
+          key.usr: "s:FO15index_enum_case1E5threeFMS0_S0_",
+          key.line: 6,
+          key.column: 31
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "text",
+          key.usr: "s:vO15index_enum_case1E4textSS",
+          key.line: 8,
+          key.column: 9,
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:FO15index_enum_case1Eg4textSS",
+              key.line: 8,
+              key.column: 22,
+              key.entities: [
+                {
+                  key.kind: source.lang.swift.ref.enumelement,
+                  key.name: "one",
+                  key.usr: "s:FO15index_enum_case1E3oneFMS0_S0_",
+                  key.line: 10,
+                  key.column: 15
+                },
+                {
+                  key.kind: source.lang.swift.ref.enumelement,
+                  key.name: "two",
+                  key.usr: "s:FO15index_enum_case1E3twoFMS0_FT1aSS_S0_",
+                  key.line: 12,
+                  key.column: 15
+                },
+                {
+                  key.kind: source.lang.swift.ref.enumelement,
+                  key.name: "three",
+                  key.usr: "s:FO15index_enum_case1E5threeFMS0_S0_",
+                  key.line: 14,
+                  key.column: 15
+                }
+              ]
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.ref.struct,
+          key.name: "String",
+          key.usr: "s:SS",
+          key.line: 8,
+          key.column: 15
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.var.global,
+      key.name: "e",
+      key.usr: "s:v15index_enum_case1eOS_1E",
+      key.line: 21,
+      key.column: 5,
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.function.accessor.getter,
+          key.usr: "s:F15index_enum_caseg1eOS_1E",
+          key.line: 21,
+          key.column: 5
+        },
+        {
+          key.kind: source.lang.swift.decl.function.accessor.setter,
+          key.usr: "s:F15index_enum_cases1eOS_1E",
+          key.line: 21,
+          key.column: 5
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.ref.enum,
+      key.name: "E",
+      key.usr: "s:O15index_enum_case1E",
+      key.line: 21,
+      key.column: 8
+    },
+    {
+      key.kind: source.lang.swift.ref.enumelement,
+      key.name: "two",
+      key.usr: "s:FO15index_enum_case1E3twoFMS0_FT1aSS_S0_",
+      key.line: 21,
+      key.column: 13
+    }
+  ]
+}


### PR DESCRIPTION
Fix for bugreporter problem: #24431424 "Swift enum values used in case statements not indexed"

In Xcode, if you select an enum value as the pattern for a switch statement “Quick Help” is not available as the USR for the enum is not currently recorded in SourceKit’s tree traversal. This change picks up the missing one case where an enum value is being used as the pattern and makes sure it is returned in the "cursor info" and "index source” data.

e.g.

public enum E {

```
case one, two, three

var text: String {
    switch self {
    case .one:
        return "one"
    case .two:
        return "two"
    case .three:
        return "three"
    }
}
```

}

Without this fix, If you select the .one in the switch it will not show Quick Help as it is not seen in SourceKit’s AST traversal.

Tested by building the 2.2 branch, preparing a toolchain and launching Xcode with it loaded, building “eidolon” OSS application and running it.

With the fix it is possible to get “Quick Help” to see where enums in switch cases are defined and also use right-click “Find Selected Symbol in Workspace” to get a complete list of the places the enum value is used as the index db is fully populated. The intended use for this fix is to make sure the index db is complete to aid in Refactoring.
