### PR TITLE
[SR-610][stdlib] Use SequenceType._initializeTo where possible

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -556,11 +556,15 @@ public struct Logging${Kind}<Base: ${Kind}Type> : ${Kind}Type, LoggingType {
     return base._copyToNativeArrayBuffer()
   }
 
-  /// Copy a Sequence into an array.
-  public func _initializeTo(ptr: UnsafeMutablePointer<Base.Generator.Element>)
-    -> UnsafeMutablePointer<Base.Generator.Element> {
+  /// Copy `self` into uninitialized contiguous memory of size `capacity`,
+  /// returning one past the last element initialized, or a `nil` pointer
+  /// if the copy cannot be safely made given `capacity`.
+  public func _initializeTo(
+    ptr: UnsafeMutablePointer<Base.Generator.Element>,
+    capacity: Int
+  ) -> UnsafeMutablePointer<Base.Generator.Element> {
     Log._initializeTo[selfType] += 1
-    return base._initializeTo(ptr)
+    return base._initializeTo(ptr, capacity: capacity)
   }
   
   public var base: Base

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -1341,7 +1341,11 @@ public struct Defaulted${traversal}RangeReplaceableSlice<Element>
   }
 
   public func generate() -> MinimalGenerator<Element> {
-    return MinimalGenerator(Array(self))
+    var array: [Element] = []
+    for index in startIndex..<endIndex {
+      array.append(self[index])
+    }
+    return MinimalGenerator(array)
   }
 
   public subscript(index: Index) -> Element {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2013,14 +2013,16 @@ public func checkSequence<
     var count = 0
     for _ in sequence { count += 1 }
     let buf = UnsafeMutablePointer<S.Generator.Element>.alloc(count)
-    let end = sequence._initializeTo(buf)
-    expectTrue(end == buf + count, "_initializeTo returned the wrong value")
-    var j = expected.startIndex
-    for i in 0..<(end - buf) {
-      expectTrue(sameValue(expected[j], buf[i]))
-      j = j.successor()
+    let end = sequence._initializeTo(buf, capacity: count)
+    if end != nil {
+      expectTrue(end == buf + count, "_initializeTo returned the wrong value")
+      var j = expected.startIndex
+      for i in 0..<(end - buf) {
+        expectTrue(sameValue(expected[j], buf[i]))
+        j = j.successor()
+      }
+      buf.destroy(end - buf)
     }
-    buf.destroy(end - buf)
     buf.dealloc(count)
   }
 }

--- a/stdlib/public/core/ArrayBufferType.swift
+++ b/stdlib/public/core/ArrayBufferType.swift
@@ -157,28 +157,31 @@ extension _ArrayBufferType {
       newTailStart.moveInitializeBackwardFrom(oldTailStart, count: tailCount)
 
       // Assign over the original subRange
-      var i = newValues.startIndex
-      for j in subRange {
-        elements[j] = newValues[i]
-        i._successorInPlace()
+      var generator = newValues.generate()
+      for i in subRange { 
+        let element = generator.next()
+        _collectionAssert(element != nil)
+        elements[i] = element!
       }
       // Initialize the hole left by sliding the tail forward
-      for j in oldTailIndex..<newTailIndex {
-        (elements + j).initialize(newValues[i])
-        i._successorInPlace()
+      for i in oldTailIndex..<newTailIndex {
+        let element = generator.next()
+        _collectionAssert(element != nil)
+        (elements + i).initialize(element!)
       }
-      _expectEnd(i, newValues)
+      _collectionAssert(generator.next() == nil)
     }
     else { // We're not growing the buffer
       // Assign all the new elements into the start of the subRange
       var i = subRange.startIndex
-      var j = newValues.startIndex
+      var generator = newValues.generate()
       for _ in 0..<newCount {
-        elements[i] = newValues[j]
+        let element = generator.next()
+        _collectionAssert(element != nil)
+        elements[i] = element!
         i._successorInPlace()
-        j._successorInPlace()
       }
-      _expectEnd(j, newValues)
+      _collectionAssert(generator.next() == nil)
 
       // If the size didn't change, we're done.
       if growth == 0 {

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -76,6 +76,5 @@ protocol _ArrayType
   associatedtype _Buffer : _ArrayBufferType
   init(_ buffer: _Buffer)
 
-  // For testing.
   var _buffer: _Buffer { get }
 }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -934,6 +934,9 @@ internal func _arrayOutOfPlaceReplace<
   )
 }
 
+/// Copy elements from `source` into uninitialized memory starting at `ptr`.
+/// `ptr` must have enough space to take `count` elements, which must be
+/// equal to `source.count`.
 internal func _initializeMemoryFromCollection<
   C : CollectionType
 >(ptr: UnsafeMutablePointer<C.Generator.Element>, from source: C, count: Int) {
@@ -942,28 +945,35 @@ internal func _initializeMemoryFromCollection<
   }
   let end = source._initializeTo(ptr, capacity: count)
   if end != nil {
-    _debugPrecondition(end == ptr + count)
+    _collectionAssert(end == ptr + count)
   }
   else {
     var p = ptr
-    var i = source.startIndex
+    var generator = source.generate()
     for _ in 0..<count {
-      p.initialize(source[i])
+      guard let element = generator.next() else { break }
+      p.initialize(element)
       p += 1
-      i._successorInPlace()
     }
-    _expectEnd(i, source)
+    _collectionAssert(p - ptr == count && generator.next() == nil)
   }
 }
 
-/// A _debugPrecondition check that `i` has exactly reached the end of
-/// `s`.  This test is never used to ensure memory safety; that is
-/// always guaranteed by measuring `s` once and re-using that value.
-internal func _expectEnd<C : CollectionType>(i: C.Index, _ s: C) {
+/// This wrapper around a _debugPrecondition is used to produce a
+/// consistent error message when a collection's `count` is not in
+/// agreement with its actual contents. This is important because it
+/// isn't always clear that the problem is with the collection, not
+/// with the code that's using it.
+///
+/// This is never used to ensure memory safety; that is always
+/// guaranteed by never copying more items than the count that we
+/// actually allocated space for.
+@_transparent
+internal func _collectionAssert(@autoclosure condition: ()->Bool) {
   _debugPrecondition(
-    i == s.endIndex,
-      "invalid CollectionType: count differed in successive traversals"
-    )
+    condition(),
+    "invalid CollectionType: inconsistent element count"
+  )
 }
 
 @warn_unused_result

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -903,14 +903,7 @@ internal struct _InitializeMemoryFromCollection<
   C: CollectionType
 > : _PointerFunctionType {
   func call(rawMemory: UnsafeMutablePointer<C.Generator.Element>, count: Int) {
-    var p = rawMemory
-    var q = newValues.startIndex
-    for _ in 0..<count {
-      p.initialize(newValues[q])
-      q = q.successor()
-      p += 1
-    }
-    _expectEnd(q, newValues)
+    _initializeMemoryFromCollection(rawMemory, from: newValues, count: count)
   }
 
   init(_ newValues: C) {
@@ -939,6 +932,28 @@ internal func _arrayOutOfPlaceReplace<
     subRange.startIndex - source.startIndex, insertCount,
     _InitializeMemoryFromCollection(newValues)
   )
+}
+
+internal func _initializeMemoryFromCollection<
+  C : CollectionType
+>(ptr: UnsafeMutablePointer<C.Generator.Element>, from source: C, count: Int) {
+  if count == 0 {
+    return
+  }
+  let end = source._initializeTo(ptr, capacity: count)
+  if end != nil {
+    _debugPrecondition(end == ptr + count)
+  }
+  else {
+    var p = ptr
+    var i = source.startIndex
+    for _ in 0..<count {
+      p.initialize(source[i])
+      p += 1
+      i._successorInPlace()
+    }
+    _expectEnd(i, source)
+  }
 }
 
 /// A _debugPrecondition check that `i` has exactly reached the end of
@@ -992,14 +1007,6 @@ public func += <
   Element, S : SequenceType
   where S.Generator.Element == Element
 >(lhs: inout ${Self}<Element>, rhs: S) {
-  let oldCount = lhs.count
-  let capacity = lhs.capacity
-  let newCount = oldCount + rhs.underestimateCount()
-
-  if newCount > capacity {
-    lhs.reserveCapacity(
-      max(newCount, _growArrayCapacity(capacity)))
-  }
   _arrayAppendSequence(&lhs._buffer, rhs)
 }
 
@@ -1021,7 +1028,10 @@ public func += <
     max(newCount, _growArrayCapacity(capacity))
     : newCount)
 
-  (lhs._buffer.firstElementAddress + oldCount).initializeFrom(rhs)
+  _initializeMemoryFromCollection(
+    lhs._buffer.firstElementAddress + oldCount,
+    from: rhs,
+    count: rhsCount)
   lhs._buffer.count = newCount
 }
 % end
@@ -1223,31 +1233,40 @@ internal func _arrayAppendSequence<
 >(
   buffer: inout Buffer, _ newItems: S
 ) {
-  var stream = newItems.generate()
-  var nextItem = stream.next()
+  let minimumCapacity = buffer.count + newItems.underestimateCount()
+  let newCapacity = (
+    minimumCapacity > buffer.capacity
+    ? max(minimumCapacity, _growArrayCapacity(buffer.capacity))
+    : minimumCapacity)
 
-  if nextItem == nil {
+  // This will force uniqueness
+  _arrayReserve(&buffer, newCapacity)
+
+  var count = buffer.count
+  let remainingCapacity = buffer.capacity - count
+  let start = buffer.firstElementAddress + count
+  let end = newItems._initializeTo(start, capacity: remainingCapacity)
+  if end != nil {
+    let growth = end - start
+    _precondition(growth >= 0 && growth <= remainingCapacity, 
+      "invalid SequenceType: _initializeTo returned an out of bounds pointer")
+    buffer.count += growth
     return
   }
 
-  // This will force uniqueness
-  var count = buffer.count
-  _arrayReserve(&buffer, count + 1)
-  while true {
-    let capacity = buffer.capacity
-    let base = buffer.firstElementAddress
-
-    while (nextItem != nil) && count < capacity {
-      (base + count).initialize(nextItem!)
-      count += 1
-      nextItem = stream.next()
+  var capacity = buffer.capacity
+  var base = buffer.firstElementAddress
+  for item in newItems {
+    if _slowPath(count == capacity) {
+      buffer.count = count
+      _arrayReserve(&buffer, max(1, _growArrayCapacity(buffer.capacity)))
+      capacity = buffer.capacity
+      base = buffer.firstElementAddress
     }
-    buffer.count = count
-    if nextItem == nil {
-      return
-    }
-    _arrayReserve(&buffer, _growArrayCapacity(capacity))
+    (base + count).initialize(item)
+    count += 1
   }
+  buffer.count = count
 }
 
 % for (Self, a_Self) in arrayTypes:

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -592,22 +592,22 @@ extension CollectionType
 extension SequenceType
   where Self : _ArrayType, Self.Element == Self.Generator.Element {
   // A fast implementation for when you are backed by a contiguous array.
-  public func _initializeTo(ptr: UnsafeMutablePointer<Generator.Element>)
-    -> UnsafeMutablePointer<Generator.Element> {
-    let s = self._baseAddressIfContiguous
-    if s != nil {
-      let count = self.count
-      ptr.initializeFrom(s, count: count)
-      _fixLifetime(self._owner)
-      return ptr + count
-    } else {
-      var p = ptr
-      for x in self {
-        p.initialize(x)
-        p += 1
-      }
-      return p
+  @warn_unused_result
+  public func _initializeTo(
+    start: UnsafeMutablePointer<Generator.Element>,
+    capacity: Int
+  ) -> UnsafeMutablePointer<Generator.Element> {
+    let count = self.count
+    if capacity < count {
+      return nil
     }
+    let s = self._baseAddressIfContiguous
+    if s == nil {
+      return nil
+    }
+    start.initializeFrom(s, count: count)
+    _fixLifetime(self._owner)
+    return start + count
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -100,6 +100,7 @@ public struct IndexingGenerator<Elements : Indexable>
   /// element exists.
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
+  @inline(__always)
   public mutating func next() -> Elements._Element? {
     if _position == _elements.endIndex { return nil }
     let element = _elements[_position]

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -326,14 +326,14 @@ extension CollectionType {
     var result = ContiguousArray<T>()
     result.reserveCapacity(count)
 
-    var i = self.startIndex
-
+    var generator = self.generate()
     for _ in 0..<count {
-      result.append(try transform(self[i]))
-      i = i.successor()
+      let element = generator.next()
+      _collectionAssert(element != nil)
+      result.append(try transform(element!))
     }
-
-    _expectEnd(i, self)
+    _collectionAssert(generator.next() == nil)
+    
     return Array(result)
   }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -590,24 +590,21 @@ extension CollectionType
 }
 
 extension SequenceType
-  where Self : _ArrayType, Self.Element == Self.Generator.Element {
+  where
+  Self : _ArrayType,
+  Self.Element == Self.Generator.Element,
+  Self._Buffer.Index == Int,
+  Self._Buffer.Element == Self.Element {
+  
   // A fast implementation for when you are backed by a contiguous array.
   @warn_unused_result
   public func _initializeTo(
-    start: UnsafeMutablePointer<Generator.Element>,
-    capacity: Int
-  ) -> UnsafeMutablePointer<Generator.Element> {
-    let count = self.count
+    start: UnsafeMutablePointer<Element>, capacity: Int
+  ) -> UnsafeMutablePointer<Element>? {
     if capacity < count {
       return nil
     }
-    let s = self._baseAddressIfContiguous
-    if s == nil {
-      return nil
-    }
-    start.initializeFrom(s, count: count)
-    _fixLifetime(self._owner)
-    return start + count
+    return _buffer._uninitializedCopy(_buffer.indices, target: start)
   }
 }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -132,7 +132,9 @@ internal class _AnySequenceBox<Element> {
 
   internal func _underestimateCount() -> Int { _abstract() }
 
-  internal func _initializeTo(ptr: UnsafeMutablePointer<Element>)
+  @warn_unused_result
+  internal func _initializeTo(
+    start: UnsafeMutablePointer<Element>, capacity: Int)
     -> UnsafeMutablePointer<Element> {
     _abstract()
   }
@@ -176,9 +178,11 @@ internal final class _${Kind}Box<
   override func _underestimateCount() -> Int {
     return _base.underestimateCount()
   }
-  override func _initializeTo(ptr: UnsafeMutablePointer<Element>)
-    -> UnsafeMutablePointer<Element> {
-    return _base._initializeTo(ptr)
+  @warn_unused_result
+  override func _initializeTo(
+    start: UnsafeMutablePointer<Element>, capacity: Int
+  ) -> UnsafeMutablePointer<Element> {
+    return _base._initializeTo(start, capacity: capacity)
   }
   override func _copyToNativeArrayBuffer() -> _ContiguousArrayStorageBase {
     return _base._copyToNativeArrayBuffer()._storage
@@ -296,9 +300,11 @@ extension Any${Kind} {
     return _box._underestimateCount()
   }
 
-  public func _initializeTo(ptr: UnsafeMutablePointer<Element>)
-    -> UnsafeMutablePointer<Element> {
-    return _box._initializeTo(ptr)
+  @warn_unused_result
+  public func _initializeTo(
+    start: UnsafeMutablePointer<Element>, capacity: Int
+  ) -> UnsafeMutablePointer<Element> {
+    return _box._initializeTo(start, capacity: capacity)
   }
 
   public func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Element> {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3965,6 +3965,7 @@ public struct ${Self}Generator<${TypeParametersDecl}> : GeneratorType {
   /// element exists.
   ///
   /// - Requires: No preceding call to `self.next()` has returned `nil`.
+  @inline(__always)
   public mutating func next() -> ${SequenceType}? {
     if _fastPath(_guaranteedNative) {
       return _nativeNext()

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -87,10 +87,11 @@ extension LazyCollection : SequenceType {
     return _base._copyToNativeArrayBuffer()
   }
   
+  @warn_unused_result
   public func _initializeTo(
-    ptr: UnsafeMutablePointer<Base.Generator.Element>
+    start: UnsafeMutablePointer<Base.Generator.Element>, capacity: Int
   ) -> UnsafeMutablePointer<Base.Generator.Element> {
-    return _base._initializeTo(ptr)
+    return _base._initializeTo(start, capacity: capacity)
   }
 
   public func _customContainsEquatableElement(

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -194,10 +194,14 @@ public protocol SequenceType {
   /// in the same order.
   func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Generator.Element>
 
-  /// Copy a Sequence into an array, returning one past the last
-  /// element initialized.
-  func _initializeTo(ptr: UnsafeMutablePointer<Generator.Element>)
-    -> UnsafeMutablePointer<Generator.Element>
+  /// Copy the contents of `self` into uninitialized contiguous memory
+  /// of size `capacity`, returning one past the last element
+  /// initialized, or a `nil` pointer if the copy cannot be safely
+  /// made given `capacity`.
+  @warn_unused_result
+  func _initializeTo(
+    start: UnsafeMutablePointer<Generator.Element>, capacity: Int
+  ) -> UnsafeMutablePointer<Generator.Element>
 }
 
 /// A default generate() function for `GeneratorType` instances that
@@ -604,14 +608,11 @@ public func underestimateCount<T : SequenceType>(x: T) -> Int {
 }
 
 extension SequenceType {
-  public func _initializeTo(ptr: UnsafeMutablePointer<Generator.Element>)
-    -> UnsafeMutablePointer<Generator.Element> {
-    var p = UnsafeMutablePointer<Generator.Element>(ptr)
-    for x in GeneratorSequence(self.generate()) {
-      p.initialize(x)
-      p += 1
-    }
-    return p
+  @warn_unused_result
+  public func _initializeTo(
+    start: UnsafeMutablePointer<Generator.Element>, capacity: Int
+  ) -> UnsafeMutablePointer<Generator.Element> {
+    return nil
   }
 }
 

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -71,10 +71,14 @@ extension SequenceType
     return _base._copyToNativeArrayBuffer()
   }
 
-  /// Copy a Sequence into an array, returning one past the last
-  /// element initialized.
-  public func _initializeTo(ptr: UnsafeMutablePointer<Base.Generator.Element>)
-    -> UnsafeMutablePointer<Base.Generator.Element> {
-    return _base._initializeTo(ptr)
+  /// Copy the contents of `self` into uninitialized contiguous memory
+  /// of size `capacity`, returning one past the last element
+  /// initialized, or a `nil` pointer if the copy cannot be safely
+  /// made given `capacity`.
+  @warn_unused_result
+  public func _initializeTo(
+    start: UnsafeMutablePointer<Base.Generator.Element>, capacity: Int
+  ) -> UnsafeMutablePointer<Base.Generator.Element> {
+    return _base._initializeTo(start, capacity: capacity)
   }
 }

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -125,6 +125,7 @@ extension String {
       ///
       /// - Requires: The next value is representable.
       @warn_unused_result
+      @inline(__always)
       public func successor() -> Index {
         let currentUnit = UTF8.CodeUnit(truncatingBitPattern: _buffer)
         let hiNibble = currentUnit >> 4

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -275,20 +275,7 @@ ${comment}
     C : CollectionType where C.Generator.Element == Memory
   >(source: C) {
     let count: Int = numericCast(source.count)
-    let end = source._initializeTo(self, capacity: count)
-    if end != nil {
-      _debugPrecondition(end == self + count)
-    }
-    else {
-      var p = self
-      var i = source.startIndex
-      for _ in 0..<count {
-        p.initialize(source[i])
-        i = i.successor()
-        p += 1
-      }
-      _expectEnd(i, source)
-    }
+    _initializeMemoryFromCollection(self, from: source, count: count)
   }
 
   /// Assign from `count` values beginning at `source` into initialized

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -274,7 +274,21 @@ ${comment}
   public func initializeFrom<
     C : CollectionType where C.Generator.Element == Memory
   >(source: C) {
-    source._initializeTo(self)
+    let count: Int = numericCast(source.count)
+    let end = source._initializeTo(self, capacity: count)
+    if end != nil {
+      _debugPrecondition(end == self + count)
+    }
+    else {
+      var p = self
+      var i = source.startIndex
+      for _ in 0..<count {
+        p.initialize(source[i])
+        i = i.successor()
+        p += 1
+      }
+      _expectEnd(i, source)
+    }
   }
 
   /// Assign from `count` values beginning at `source` into initialized

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -160,11 +160,16 @@ extension LoggingSequenceType
     return base._copyToNativeArrayBuffer()
   }
 
-  /// Copy a Sequence into an array.
-  public func _initializeTo(ptr: UnsafeMutablePointer<Base.Generator.Element>)
-    -> UnsafeMutablePointer<Base.Generator.Element> {
+  /// Copy the contents of `self` into uninitialized contiguous memory
+  /// of size `capacity`, returning one past the last element
+  /// initialized, or a `nil` pointer if the copy cannot be safely
+  /// made given `capacity`.
+  public func _initializeTo(
+    ptr: UnsafeMutablePointer<Base.Generator.Element>,
+    capacity: Int
+  ) -> UnsafeMutablePointer<Base.Generator.Element>? {
     ++Log._initializeTo[selfType]
-    return base._initializeTo(ptr)
+    return base._initializeTo(ptr, capacity: capacity)
   }
 }
 

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -1610,14 +1610,7 @@ final class EvilCollection : CollectionType {
 
 for (step, evilBoundsCheck) in [ (1, true), (-1, false), (-1, true) ] {
 
-  let message = step < 0 && evilBoundsCheck
-    ? evilBoundsError
-    : "invalid CollectionType: count differed in successive traversals"
-
-  let constructionMessage =
-    /*_isStdlibInternalChecksEnabled() && !evilBoundsCheck && step <= 0
-      ? "_UnsafePartiallyInitializedContiguousArrayBuffer has no more capacity"
-      :*/ message
+  let message = "invalid CollectionType: inconsistent element count"
 
   // The invalid CollectionType error is a _debugPreconditon that will only fire
   // in a Debug assert configuration.
@@ -1651,7 +1644,7 @@ for (step, evilBoundsCheck) in [ (1, true), (-1, false), (-1, true) ] {
 
   let t2 = ArrayTestSuite.test("\(testPrefix)/Construction")
   (_isDebugAssertConfiguration() && expectedToFail
-    ? t2.crashOutputMatches(constructionMessage) : t2)
+    ? t2.crashOutputMatches(message) : t2)
   .code {
     let evil = EvilCollection(step, boundsChecked: evilBoundsCheck)
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -411,7 +411,8 @@ func expectSequencePassthrough<
   SequenceLog._initializeTo.expectIncrement(baseType) { () -> Void in
     let buf = UnsafeMutablePointer<S.Generator.Element>.alloc(count)
 
-    if let end = s._initializeTo(buf, capacity: count) {
+    let end = s._initializeTo(buf, capacity: count)
+    if end != nil {
       expectTrue(end >= buf && end <= buf + count)
       buf.destroy(end - buf)
     }

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -411,9 +411,10 @@ func expectSequencePassthrough<
   SequenceLog._initializeTo.expectIncrement(baseType) { () -> Void in
     let buf = UnsafeMutablePointer<S.Generator.Element>.alloc(count)
 
-    let end = s._initializeTo(buf)
-    expectTrue(end <= buf + count)
-    buf.destroy(end - buf)
+    if let end = s._initializeTo(buf, capacity: count) {
+      expectTrue(end >= buf && end <= buf + count)
+      buf.destroy(end - buf)
+    }
     buf.dealloc(count)
   }
 }


### PR DESCRIPTION
(This is an updated version of PR #1084.)

Change the `SequenceType._initializeTo` entry point to support memory safety better,
and use it in more places where `Array` elements are initialized in bulk:
- Conversion of sequences and collections to `Array`
- `<ArrayType> += <SequenceType>`
- `ArrayType.replaceRange` (when used for insertion)

The speedup achieved is highly sensitive to the mood of the optimizer. The most remarkable result is that insertion of an `Array` into another `Array` can be 4-35x faster depending on the element type. Besides `Array`, `ArraySlice` and `ContiguousArray` also have custom `_initializeTo` implementations, but interestingly, only `Array` seems to be meaningfully impacted by these changes. (The behavior of the
optimizer can be highly unintuitive, making attempts at micro-optimization less useful; see SR-653.)

When `_initializeTo` isn't available, prefer `Generator` to looping over index ranges when iterating over elements of a collection. This speeds up the above operations for collections with complex indexes. 
For example, operations on standard hashed collections typically improve by about 10-40%.
