### PR TITLE
[Parser] Fix-it for declaration attributes being applied to parameter types (SR-215)

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -244,6 +244,24 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
       // (':' type)?
       if (consumeIf(tok::colon)) {
+        // Check if token is @ sign ergo an attribute
+        if (Tok.is(tok::at_sign)) {
+          Token nextToken = peekToken();
+          // Check if attribute is invalid type attribute
+          // and actually a declaration attribute
+          TypeAttrKind TK = TypeAttributes::getAttrKindFromString(nextToken.getText()); 
+          DeclAttrKind DK = DeclAttribute::getAttrKindFromString(nextToken.getText());
+          if ((TK == TAK_Count || (TK == TAK_noescape && !isInSILMode()))
+              && DK != DAK_Count
+              && DeclAttribute::getOptions(DK) & AccessibilityAttr::OnParam) { 
+            SourceLoc AtLoc = consumeToken(tok::at_sign);
+            SourceLoc AttrLoc = consumeToken(tok::identifier);
+            diagnose(AtLoc, diag::decl_attribute_applied_to_type)
+              .fixItRemove(SourceRange(AtLoc, AttrLoc))
+              .fixItInsert(StartLoc, "@" + nextToken.getText().str()+" ");
+          }
+        }
+
         auto type = parseType(diag::expected_parameter_type);
         status |= type;
         param.Type = type.getPtrOrNull();

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -2,6 +2,8 @@
 
 @noescape var fn : () -> Int = { 4 }  // expected-error {{@noescape may only be used on 'parameter' declarations}} {{1-11=}}
 
+func appliedToType(g: @noescape ()->Void) { g() }  // expected-error {{attribute can only be applied to declarations, not types}} {{20-20=@noescape }} {{23-33=}}
+
 func doesEscape(fn : () -> Int) {}
 
 func takesGenericClosure<T>(a : Int, @noescape _ fn : () -> T) {}


### PR DESCRIPTION
Original PR #673 but reverted due to test failures and later due to typo. Third time's a charm, eh? CI should spot anything now which is a neat addition. Original description:

As described in SR-215, previously the fix-it was suggesting that declaration attributes applied to parameter types be moved to before the function func declaration itself.

This pull request fixes this so that it is instead moved to before the parameter name.
