### PR TITLE
Adopt llvm::TrailingObjects where relevant/useful

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -28,6 +28,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/TrailingObjects.h"
 #include "clang/Basic/VersionTuple.h"
 
 namespace swift {
@@ -760,7 +761,10 @@ public:
 };
 
 /// Indicates that the given declaration is visible to Objective-C.
-class ObjCAttr : public DeclAttribute {
+class ObjCAttr final : public DeclAttribute,
+    private llvm::TrailingObjects<ObjCAttr, SourceLoc> {
+  friend TrailingObjects;
+
   /// The Objective-C name associated with this entity, stored in its opaque
   /// representation so that we can use null as an indicator for "no name".
   void *NameData;
@@ -793,7 +797,7 @@ class ObjCAttr : public DeclAttribute {
     unsigned length = 2;
     if (auto name = getName())
       length += name->getNumSelectorPieces();
-    return { reinterpret_cast<SourceLoc *>(this + 1), length };
+    return {getTrailingObjects<SourceLoc>(), length};
   }
 
   /// Retrieve the trailing location information.
@@ -802,7 +806,7 @@ class ObjCAttr : public DeclAttribute {
     unsigned length = 2;
     if (auto name = getName())
       length += name->getNumSelectorPieces();
-    return { reinterpret_cast<const SourceLoc *>(this + 1), length };
+    return {getTrailingObjects<SourceLoc>(), length};
   }
 
 public:

--- a/include/swift/AST/ConcreteDeclRef.h
+++ b/include/swift/AST/ConcreteDeclRef.h
@@ -23,6 +23,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/TrailingObjects.h"
 #include <cstring>
 
 namespace swift {
@@ -37,7 +38,10 @@ class ValueDecl;
 class ConcreteDeclRef {
   /// A specialized declaration reference, which provides substitutions
   /// that fully specialize a generic declaration.
-  class SpecializedDeclRef {
+  class SpecializedDeclRef final :
+      private llvm::TrailingObjects<SpecializedDeclRef, Substitution> {
+    friend TrailingObjects;
+
     /// The declaration.
     ValueDecl *TheDecl;
 
@@ -47,9 +51,8 @@ class ConcreteDeclRef {
     SpecializedDeclRef(ValueDecl *decl, ArrayRef<Substitution> substitutions)
       : TheDecl(decl), NumSubstitutions(substitutions.size())
     {
-      std::memcpy(reinterpret_cast<Substitution *>(this + 1),
-                  substitutions.data(),
-                  sizeof(Substitution) * substitutions.size());
+      std::uninitialized_copy(substitutions.begin(), substitutions.end(),
+                              getTrailingObjects<Substitution>());
     }
 
   public:
@@ -58,8 +61,7 @@ class ConcreteDeclRef {
 
     /// Retrieve the substitutions.
     ArrayRef<Substitution> getSubstitutions() const {
-      return llvm::makeArrayRef(reinterpret_cast<const Substitution *>(this+1),
-                                NumSubstitutions);
+      return {getTrailingObjects<Substitution>(), NumSubstitutions};
     }
     
     /// Allocate a new specialized declaration reference.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3653,9 +3653,6 @@ private:
   void configureObservingRecord(ObservingRecord *record,
                                 FuncDecl *willSet, FuncDecl *didSet);
 
-  struct GetSetRecordWithAddressors : AddressorRecord, GetSetRecord {};
-  struct ObservingRecordWithAddressors : AddressorRecord, ObservingRecord {};
-
   llvm::PointerIntPair<GetSetRecord*, 2, OptionalEnum<Accessibility>> GetSetInfo;
 
   ObservingRecord &getDidSetInfo() const {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -24,6 +24,7 @@
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/Availability.h"
+#include "llvm/Support/TrailingObjects.h"
 
 namespace llvm {
   struct fltSemantics;
@@ -1590,6 +1591,8 @@ public:
 /// used to represent the operands to a binary operator.  Note that
 /// expressions like '(4)' are represented with a ParenExpr.
 class TupleExpr : public Expr {
+  // FIXME: We can't use llvm::TrailingObjects yet because there are *three*
+  // trailing buffers here.
   SourceLoc LParenLoc;
   SourceLoc RParenLoc;
   unsigned NumElements;
@@ -2601,19 +2604,18 @@ public:
 /// folded into a tree.  The operands all have even indices, while the
 /// subexpressions with odd indices are all (potentially overloaded)
 /// references to binary operators.
-class SequenceExpr : public Expr {
-  unsigned NumElements;
+class SequenceExpr final : public Expr,
+    private llvm::TrailingObjects<SequenceExpr, Expr *> {
+  friend TrailingObjects;
 
-  Expr **getSubExprs() { return reinterpret_cast<Expr **>(this + 1); }
-  Expr * const *getSubExprs() const {
-    return const_cast<SequenceExpr*>(this)->getSubExprs();
-  }
+  unsigned NumElements;
 
   SequenceExpr(ArrayRef<Expr*> elements)
     : Expr(ExprKind::Sequence, /*Implicit=*/false),
       NumElements(elements.size()) {
     assert(NumElements > 0 && "zero-length sequence!");
-    memcpy(getSubExprs(), elements.data(), elements.size() * sizeof(Expr*));
+    std::uninitialized_copy(elements.begin(), elements.end(),
+                            getTrailingObjects<Expr*>());
   }
 
 public:
@@ -2629,20 +2631,18 @@ public:
   unsigned getNumElements() const { return NumElements; }
 
   MutableArrayRef<Expr*> getElements() {
-    return MutableArrayRef<Expr*>(getSubExprs(), NumElements);
+    return {getTrailingObjects<Expr*>(), NumElements};
   }
 
   ArrayRef<Expr*> getElements() const {
-    return ArrayRef<Expr*>(getSubExprs(), NumElements);
+    return {getTrailingObjects<Expr*>(), NumElements};
   }
 
   Expr *getElement(unsigned i) const {
-    assert(i < NumElements);
-    return getSubExprs()[i];
+    return getElements()[i];
   }
   void setElement(unsigned i, Expr *e) {
-    assert(i < NumElements);
-    getSubExprs()[i] = e;
+    getElements()[i] = e;
   }
 
   // Implement isa/cast/dyncast/etc.

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -19,12 +19,16 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/Basic/OptionSet.h"
+#include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
 
 /// This describes a list of parameters.  Each parameter descriptor is tail
 /// allocated onto this list.
-class alignas(alignof(ParamDecl*)) ParameterList {
+class alignas(ParamDecl *) ParameterList final :
+    private llvm::TrailingObjects<ParameterList, ParamDecl *> {
+  friend TrailingObjects;
+
   void *operator new(size_t Bytes) throw() = delete;
   void operator delete(void *Data) throw() = delete;
   void *operator new(size_t Bytes, void *Mem) throw() = delete;
@@ -84,12 +88,10 @@ public:
   const_iterator end() const { return getArray().end(); }
   
   MutableArrayRef<ParamDecl*> getArray() {
-    auto Ptr = reinterpret_cast<ParamDecl**>(this + 1);
-    return { Ptr, numParameters };
+    return {getTrailingObjects<ParamDecl*>(), numParameters};
   }
   ArrayRef<ParamDecl*> getArray() const {
-    auto Ptr = reinterpret_cast<ParamDecl*const*>(this + 1);
-    return { Ptr, numParameters };
+    return {getTrailingObjects<ParamDecl*>(), numParameters};
   }
 
   size_t size() const {

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -22,6 +22,7 @@
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/NullablePtr.h"
+#include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
   class ASTContext;
@@ -105,8 +106,10 @@ public:
 
 /// BraceStmt - A brace enclosed sequence of expressions, stmts, or decls, like
 /// { var x = 10; print(10) }.
-class BraceStmt : public Stmt {
-private:
+class BraceStmt final : public Stmt,
+    private llvm::TrailingObjects<BraceStmt, ASTNode> {
+  friend TrailingObjects;
+
   unsigned NumElements;
   
   SourceLoc LBLoc;
@@ -114,9 +117,6 @@ private:
 
   BraceStmt(SourceLoc lbloc, ArrayRef<ASTNode> elements,SourceLoc rbloc,
             Optional<bool> implicit);
-  ASTNode *getElementsStorage() {
-    return reinterpret_cast<ASTNode*>(this + 1);
-  }
 
 public:
   static BraceStmt *create(ASTContext &ctx, SourceLoc lbloc,
@@ -136,12 +136,12 @@ public:
 
   /// The elements contained within the BraceStmt.
   MutableArrayRef<ASTNode> getElements() {
-    return MutableArrayRef<ASTNode>(getElementsStorage(), NumElements);
+    return {getTrailingObjects<ASTNode>(), NumElements};
   }
 
   /// The elements contained within the BraceStmt (const version).
   ArrayRef<ASTNode> getElements() const {
-    return const_cast<BraceStmt*>(this)->getElements();
+    return {getTrailingObjects<ASTNode>(), NumElements};
   }
   
   static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Brace; }
@@ -228,7 +228,10 @@ public:
 /// \brief An expression that guards execution based on whether the run-time
 /// configuration supports a given API, e.g.,
 /// #available(OSX >= 10.9, iOS >= 7.0).
-class alignas(8) PoundAvailableInfo {
+class alignas(8) PoundAvailableInfo final :
+    private llvm::TrailingObjects<PoundAvailableInfo, AvailabilitySpec *> {
+  friend TrailingObjects;
+
   SourceLoc PoundLoc;
   SourceLoc RParenLoc;
 
@@ -243,8 +246,8 @@ class alignas(8) PoundAvailableInfo {
                      SourceLoc RParenLoc)
    : PoundLoc(PoundLoc), RParenLoc(RParenLoc), NumQueries(queries.size()),
      AvailableRange(VersionRange::empty()) {
-    memcpy((void*)getQueries().data(), queries.data(),
-           queries.size() * sizeof(AvailabilitySpec *));
+    std::uninitialized_copy(queries.begin(), queries.end(),
+                            getTrailingObjects<AvailabilitySpec *>());
   }
   
 public:
@@ -253,8 +256,8 @@ public:
                                     SourceLoc RParenLoc);
   
   ArrayRef<AvailabilitySpec *> getQueries() const {
-    auto buf = reinterpret_cast<AvailabilitySpec *const*>(this + 1);
-    return ArrayRef<AvailabilitySpec *>(buf, NumQueries);
+    return llvm::makeArrayRef(getTrailingObjects<AvailabilitySpec *>(),
+                              NumQueries);
   }
   
   SourceLoc getStartLoc() const { return PoundLoc; }
@@ -500,26 +503,22 @@ public:
 };
 
 /// DoCatchStmt - do statement with trailing 'catch' clauses.
-class DoCatchStmt : public LabeledStmt {
+class DoCatchStmt final : public LabeledStmt,
+    private llvm::TrailingObjects<DoCatchStmt, CatchStmt *> {
+  friend TrailingObjects;
+
   SourceLoc DoLoc;
   Stmt *Body;
   unsigned NumCatches;
 
-  CatchStmt **getCatchesBuffer() {
-    return reinterpret_cast<CatchStmt **>(this+1);
-  }
-  CatchStmt * const *getCatchesBuffer() const {
-    return reinterpret_cast<CatchStmt * const *>(this+1);
-  }
-  
   DoCatchStmt(LabeledStmtInfo labelInfo, SourceLoc doLoc,
               Stmt *body, ArrayRef<CatchStmt*> catches,
               Optional<bool> implicit)
     : LabeledStmt(StmtKind::DoCatch, getDefaultImplicitFlag(implicit, doLoc),
                   labelInfo),
       DoLoc(doLoc), Body(body), NumCatches(catches.size()) {
-    memcpy(getCatchesBuffer(), catches.data(),
-           catches.size() * sizeof(catches[0]));
+    std::uninitialized_copy(catches.begin(), catches.end(),
+                            getTrailingObjects<CatchStmt *>());
   }
 
 public:
@@ -537,10 +536,10 @@ public:
   void setBody(Stmt *s) { Body = s; }
 
   ArrayRef<CatchStmt*> getCatches() const {
-    return ArrayRef<CatchStmt*>(getCatchesBuffer(), NumCatches);
+    return {getTrailingObjects<CatchStmt*>(), NumCatches};
   }
   MutableArrayRef<CatchStmt*> getMutableCatches() {
-    return MutableArrayRef<CatchStmt*>(getCatchesBuffer(), NumCatches);
+    return {getTrailingObjects<CatchStmt*>(), NumCatches};
   }
 
   /// Does this statement contain a syntactically exhaustive catch
@@ -948,19 +947,15 @@ public:
 ///   default:
 /// \endcode
 ///
-class CaseStmt : public Stmt {
+class CaseStmt final : public Stmt,
+    private llvm::TrailingObjects<CaseStmt, CaseLabelItem> {
+  friend TrailingObjects;
+
   SourceLoc CaseLoc;
   SourceLoc ColonLoc;
 
   llvm::PointerIntPair<Stmt *, 1, bool> BodyAndHasBoundDecls;
   unsigned NumPatterns;
-
-  const CaseLabelItem *getCaseLabelItemsBuffer() const {
-    return reinterpret_cast<const CaseLabelItem *>(this + 1);
-  }
-  CaseLabelItem *getCaseLabelItemsBuffer() {
-    return reinterpret_cast<CaseLabelItem *>(this + 1);
-  }
 
   CaseStmt(SourceLoc CaseLoc, ArrayRef<CaseLabelItem> CaseLabelItems,
            bool HasBoundDecls, SourceLoc ColonLoc, Stmt *Body,
@@ -973,10 +968,10 @@ public:
                           Optional<bool> Implicit = None);
 
   ArrayRef<CaseLabelItem> getCaseLabelItems() const {
-    return { getCaseLabelItemsBuffer(), NumPatterns };
+    return {getTrailingObjects<CaseLabelItem>(), NumPatterns};
   }
   MutableArrayRef<CaseLabelItem> getMutableCaseLabelItems() {
-    return { getCaseLabelItemsBuffer(), NumPatterns };
+    return {getTrailingObjects<CaseLabelItem>(), NumPatterns};
   }
 
   Stmt *getBody() const { return BodyAndHasBoundDecls.getPointer(); }
@@ -997,19 +992,14 @@ public:
 };
 
 /// Switch statement.
-class SwitchStmt : public LabeledStmt {
+class SwitchStmt final : public LabeledStmt,
+    private llvm::TrailingObjects<SwitchStmt, CaseStmt *> {
+  friend TrailingObjects;
+
   SourceLoc SwitchLoc, LBraceLoc, RBraceLoc;
   Expr *SubjectExpr;
   unsigned CaseCount;
-  
-  CaseStmt * const *getCaseBuffer() const {
-    return reinterpret_cast<CaseStmt * const *>(this + 1);
-  }
 
-  CaseStmt **getCaseBuffer() {
-    return reinterpret_cast<CaseStmt **>(this + 1);
-  }
-  
   SwitchStmt(LabeledStmtInfo LabelInfo, SourceLoc SwitchLoc, Expr *SubjectExpr,
              SourceLoc LBraceLoc, unsigned CaseCount, SourceLoc RBraceLoc,
              Optional<bool> implicit = None)
@@ -1046,7 +1036,7 @@ public:
   
   /// Get the list of case clauses.
   ArrayRef<CaseStmt*> getCases() const {
-    return {getCaseBuffer(), CaseCount};
+    return {getTrailingObjects<CaseStmt*>(), CaseCount};
   }
   
   static bool classof(const Stmt *S) {

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/TimeValue.h"
+#include "llvm/Support/TrailingObjects.h"
 #include <functional>
 #include <memory>
 #include <string>
@@ -56,225 +57,237 @@ std::string removeCodeCompletionTokens(StringRef Input,
                                        StringRef TokenName,
                                        unsigned *CompletionOffset);
 
-/// \brief A structured representation of a code completion string.
-class CodeCompletionString {
-  friend class CodeCompletionResultBuilder;
+namespace detail {
+class CodeCompletionStringChunk {
+  friend class swift::ide::CodeCompletionResultBuilder;
 
 public:
-  class Chunk {
-    friend class CodeCompletionResultBuilder;
+  enum class ChunkKind {
+    /// "internal", "private" or "public".
+    AccessControlKeyword,
 
-  public:
-    enum class ChunkKind {
-      /// "internal", "private" or "public".
-      AccessControlKeyword,
+    /// such as @"availability"
+    DeclAttrKeyword,
 
-      /// such as @"availability"
-      DeclAttrKeyword,
+    /// such as "unavailable" etc. for @available
+    DeclAttrParamKeyword,
 
-      /// such as "unavailable" etc. for @available
-      DeclAttrParamKeyword,
+    /// The "override" keyword.
+    OverrideKeyword,
 
-      /// The "override" keyword.
-      OverrideKeyword,
+    /// The "throws" keyword.
+    ThrowsKeyword,
 
-      /// The "throws" keyword.
-      ThrowsKeyword,
+    /// The "rethrows" keyword.
+    RethrowsKeyword,
 
-      /// The "rethrows" keyword.
-      RethrowsKeyword,
+    /// The keyword part of a declaration before the name, like "func".
+    DeclIntroducer,
 
-      /// The keyword part of a declaration before the name, like "func".
-      DeclIntroducer,
+    /// Normal text chunk.
+    Text,
 
-      /// Normal text chunk.
-      Text,
+    /// The first chunk of an optional substring that continues until
+    /// \c NestingLevel decreases.
+    OptionalBegin,
 
-      /// The first chunk of an optional substring that continues until
-      /// \c NestingLevel decreases.
-      OptionalBegin,
+    // Punctuation.
+    LeftParen,
+    RightParen,
+    LeftBracket,
+    RightBracket,
+    LeftAngle,
+    RightAngle,
+    Dot,
+    Ellipsis,
+    Comma,
+    ExclamationMark,
+    QuestionMark,
+    Ampersand,
+    Whitespace,
 
-      // Punctuation.
-      LeftParen,
-      RightParen,
-      LeftBracket,
-      RightBracket,
-      LeftAngle,
-      RightAngle,
-      Dot,
-      Ellipsis,
-      Comma,
-      ExclamationMark,
-      QuestionMark,
-      Ampersand,
-      Whitespace,
+    /// The first chunk of a substring that describes the parameter for a
+    /// generic type.
+    GenericParameterBegin,
+    /// Generic type parameter name.
+    GenericParameterName,
 
-      /// The first chunk of a substring that describes the parameter for a
-      /// generic type.
-      GenericParameterBegin,
-      /// Generic type parameter name.
-      GenericParameterName,
+    /// The first chunk of a substring that describes the parameter for a
+    /// function call.
+    CallParameterBegin,
+    /// Function call parameter name.
+    CallParameterName,
+    /// Function call parameter internal / local name. If the parameter has no
+    /// formal API name, it can still have a local name which can be useful
+    /// for display purposes.
+    ///
+    /// This chunk should not be inserted into the editor buffer.
+    CallParameterInternalName,
+    /// A colon between parameter name and value.  Should be inserted in the
+    /// editor buffer if the preceding CallParameterName was inserted.
+    CallParameterColon,
 
-      /// The first chunk of a substring that describes the parameter for a
-      /// function call.
-      CallParameterBegin,
-      /// Function call parameter name.
-      CallParameterName,
-      /// Function call parameter internal / local name. If the parameter has no
-      /// formal API name, it can still have a local name which can be useful
-      /// for display purposes.
-      ///
-      /// This chunk should not be inserted into the editor buffer.
-      CallParameterInternalName,
-      /// A colon between parameter name and value.  Should be inserted in the
-      /// editor buffer if the preceding CallParameterName was inserted.
-      CallParameterColon,
+    /// A equal sign between parameter name and value. Used in decl attribute.
+    DeclAttrParamEqual,
 
-      /// A equal sign between parameter name and value. Used in decl attribute.
-      DeclAttrParamEqual,
+    /// Required parameter type.
+    CallParameterType,
+    /// Desugared closure parameter type. This can be used to get the
+    /// closure type if CallParameterType is a NameAliasType.
+    CallParameterClosureType,
 
-      /// Required parameter type.
-      CallParameterType,
-      /// Desugared closure parameter type. This can be used to get the
-      /// closure type if CallParameterType is a NameAliasType.
-      CallParameterClosureType,
+    /// A placeholder for \c ! or \c ? in a call to a method found by dynamic
+    /// lookup.
+    ///
+    /// The default spelling is \c !, but clients may render it as \c ? if
+    /// desired.
+    DynamicLookupMethodCallTail,
 
-      /// A placeholder for \c ! or \c ? in a call to a method found by dynamic
-      /// lookup.
-      ///
-      /// The default spelling is \c !, but clients may render it as \c ? if
-      /// desired.
-      DynamicLookupMethodCallTail,
+    /// A placeholder for \c ! or \c ? in a call to an optional method.
+    ///
+    /// The default spelling is \c !, but clients may render it as \c ? if
+    /// desired.
+    OptionalMethodCallTail,
 
-      /// A placeholder for \c ! or \c ? in a call to an optional method.
-      ///
-      /// The default spelling is \c !, but clients may render it as \c ? if
-      /// desired.
-      OptionalMethodCallTail,
+    /// Specifies the type of the whole entity that is returned in this code
+    /// completion result.  For example, for variable references it is the
+    /// variable type, for function calls it is the return type.
+    ///
+    /// This chunk should not be inserted into the editor buffer.
+    TypeAnnotation,
 
-      /// Specifies the type of the whole entity that is returned in this code
-      /// completion result.  For example, for variable references it is the
-      /// variable type, for function calls it is the return type.
-      ///
-      /// This chunk should not be inserted into the editor buffer.
-      TypeAnnotation,
+    /// A brace statement -- left brace and right brace.  The preferred
+    /// position to put the cursor after the completion result is inserted
+    /// into the editor buffer is between the braces.
+    ///
+    /// The spelling as always "{}", but clients may choose to insert newline
+    /// and indentation in between.
+    BraceStmtWithCursor,
 
-      /// A brace statement -- left brace and right brace.  The preferred
-      /// position to put the cursor after the completion result is inserted
-      /// into the editor buffer is between the braces.
-      ///
-      /// The spelling as always "{}", but clients may choose to insert newline
-      /// and indentation in between.
-      BraceStmtWithCursor,
-
-      ///
-    };
-
-    static bool chunkStartsNestedGroup(ChunkKind Kind) {
-      return Kind == ChunkKind::CallParameterBegin ||
-             Kind == ChunkKind::GenericParameterBegin ||
-             Kind == ChunkKind::OptionalBegin;
-    }
-
-    static bool chunkHasText(ChunkKind Kind) {
-      return Kind == ChunkKind::AccessControlKeyword ||
-             Kind == ChunkKind::OverrideKeyword ||
-             Kind == ChunkKind::ThrowsKeyword ||
-             Kind == ChunkKind::RethrowsKeyword ||
-             Kind == ChunkKind::DeclAttrKeyword ||
-             Kind == ChunkKind::DeclIntroducer ||
-             Kind == ChunkKind::Text ||
-             Kind == ChunkKind::LeftParen ||
-             Kind == ChunkKind::RightParen ||
-             Kind == ChunkKind::LeftBracket ||
-             Kind == ChunkKind::RightBracket ||
-             Kind == ChunkKind::LeftAngle ||
-             Kind == ChunkKind::RightAngle ||
-             Kind == ChunkKind::Dot ||
-             Kind == ChunkKind::Ellipsis ||
-             Kind == ChunkKind::Comma ||
-             Kind == ChunkKind::ExclamationMark ||
-             Kind == ChunkKind::QuestionMark ||
-             Kind == ChunkKind::Ampersand ||
-             Kind == ChunkKind::Whitespace ||
-             Kind == ChunkKind::CallParameterName ||
-             Kind == ChunkKind::CallParameterInternalName ||
-             Kind == ChunkKind::CallParameterColon ||
-             Kind == ChunkKind::DeclAttrParamEqual ||
-             Kind == ChunkKind::DeclAttrParamKeyword ||
-             Kind == ChunkKind::CallParameterType ||
-             Kind == ChunkKind::CallParameterClosureType ||
-             Kind == ChunkKind::GenericParameterName ||
-             Kind == ChunkKind::DynamicLookupMethodCallTail ||
-             Kind == ChunkKind::OptionalMethodCallTail ||
-             Kind == ChunkKind::TypeAnnotation ||
-             Kind == ChunkKind::BraceStmtWithCursor;
-    }
-
-  private:
-    unsigned Kind : 8;
-    unsigned NestingLevel : 8;
-
-    /// \brief If true, then this chunk is an annotation that is included only
-    /// for exposition and may not be inserted in the editor buffer.
-    unsigned IsAnnotation : 1;
-
-    StringRef Text;
-
-    Chunk(ChunkKind Kind, unsigned NestingLevel, StringRef Text,
-          bool isAnnotation)
-        : Kind(unsigned(Kind)), NestingLevel(NestingLevel),
-          IsAnnotation(isAnnotation), Text(Text) {
-      assert(chunkHasText(Kind));
-    }
-
-    Chunk(ChunkKind Kind, unsigned NestingLevel, bool isAnnotation)
-        : Kind(unsigned(Kind)), NestingLevel(NestingLevel),
-          IsAnnotation(isAnnotation) {
-      assert(!chunkHasText(Kind));
-    }
-
-    void setIsAnnotation() {
-      IsAnnotation = 1;
-    }
-
-  public:
-    ChunkKind getKind() const {
-      return ChunkKind(Kind);
-    }
-
-    bool is(ChunkKind K) const { return getKind() == K; }
-
-    unsigned getNestingLevel() const {
-      return NestingLevel;
-    }
-
-    bool isAnnotation() const {
-      return IsAnnotation;
-    }
-
-    bool hasText() const { return chunkHasText(getKind()); }
-
-    StringRef getText() const {
-      assert(hasText());
-      return Text;
-    }
-
-    bool endsPreviousNestedGroup(unsigned GroupNestingLevel) const {
-      return NestingLevel < GroupNestingLevel ||
-       (NestingLevel == GroupNestingLevel && chunkStartsNestedGroup(getKind()));
-    }
-
-    static Chunk createWithText(ChunkKind Kind, unsigned NestingLevel,
-                                StringRef Text, bool isAnnotation = false) {
-      return Chunk(Kind, NestingLevel, Text, isAnnotation);
-    }
-
-    static Chunk createSimple(ChunkKind Kind, unsigned NestingLevel,
-                              bool isAnnotation = false) {
-      return Chunk(Kind, NestingLevel, isAnnotation);
-    }
+    ///
   };
+
+  static bool chunkStartsNestedGroup(ChunkKind Kind) {
+    return Kind == ChunkKind::CallParameterBegin ||
+           Kind == ChunkKind::GenericParameterBegin ||
+           Kind == ChunkKind::OptionalBegin;
+  }
+
+  static bool chunkHasText(ChunkKind Kind) {
+    return Kind == ChunkKind::AccessControlKeyword ||
+           Kind == ChunkKind::OverrideKeyword ||
+           Kind == ChunkKind::ThrowsKeyword ||
+           Kind == ChunkKind::RethrowsKeyword ||
+           Kind == ChunkKind::DeclAttrKeyword ||
+           Kind == ChunkKind::DeclIntroducer ||
+           Kind == ChunkKind::Text ||
+           Kind == ChunkKind::LeftParen ||
+           Kind == ChunkKind::RightParen ||
+           Kind == ChunkKind::LeftBracket ||
+           Kind == ChunkKind::RightBracket ||
+           Kind == ChunkKind::LeftAngle ||
+           Kind == ChunkKind::RightAngle ||
+           Kind == ChunkKind::Dot ||
+           Kind == ChunkKind::Ellipsis ||
+           Kind == ChunkKind::Comma ||
+           Kind == ChunkKind::ExclamationMark ||
+           Kind == ChunkKind::QuestionMark ||
+           Kind == ChunkKind::Ampersand ||
+           Kind == ChunkKind::Whitespace ||
+           Kind == ChunkKind::CallParameterName ||
+           Kind == ChunkKind::CallParameterInternalName ||
+           Kind == ChunkKind::CallParameterColon ||
+           Kind == ChunkKind::DeclAttrParamEqual ||
+           Kind == ChunkKind::DeclAttrParamKeyword ||
+           Kind == ChunkKind::CallParameterType ||
+           Kind == ChunkKind::CallParameterClosureType ||
+           Kind == ChunkKind::GenericParameterName ||
+           Kind == ChunkKind::DynamicLookupMethodCallTail ||
+           Kind == ChunkKind::OptionalMethodCallTail ||
+           Kind == ChunkKind::TypeAnnotation ||
+           Kind == ChunkKind::BraceStmtWithCursor;
+  }
+
+private:
+  unsigned Kind : 8;
+  unsigned NestingLevel : 8;
+
+  /// \brief If true, then this chunk is an annotation that is included only
+  /// for exposition and may not be inserted in the editor buffer.
+  unsigned IsAnnotation : 1;
+
+  StringRef Text;
+
+  CodeCompletionStringChunk(ChunkKind Kind, unsigned NestingLevel, StringRef Text,
+                            bool isAnnotation)
+      : Kind(unsigned(Kind)), NestingLevel(NestingLevel),
+        IsAnnotation(isAnnotation), Text(Text) {
+    assert(chunkHasText(Kind));
+  }
+
+  CodeCompletionStringChunk(ChunkKind Kind, unsigned NestingLevel,
+                            bool isAnnotation)
+      : Kind(unsigned(Kind)), NestingLevel(NestingLevel),
+        IsAnnotation(isAnnotation) {
+    assert(!chunkHasText(Kind));
+  }
+
+  void setIsAnnotation() {
+    IsAnnotation = 1;
+  }
+
+public:
+  ChunkKind getKind() const {
+    return ChunkKind(Kind);
+  }
+
+  bool is(ChunkKind K) const { return getKind() == K; }
+
+  unsigned getNestingLevel() const {
+    return NestingLevel;
+  }
+
+  bool isAnnotation() const {
+    return IsAnnotation;
+  }
+
+  bool hasText() const { return chunkHasText(getKind()); }
+
+  StringRef getText() const {
+    assert(hasText());
+    return Text;
+  }
+
+  bool endsPreviousNestedGroup(unsigned GroupNestingLevel) const {
+    return NestingLevel < GroupNestingLevel ||
+     (NestingLevel == GroupNestingLevel && chunkStartsNestedGroup(getKind()));
+  }
+
+  static CodeCompletionStringChunk createWithText(ChunkKind Kind,
+                                                  unsigned NestingLevel,
+                                                  StringRef Text,
+                                                  bool isAnnotation = false) {
+    return CodeCompletionStringChunk(Kind, NestingLevel, Text, isAnnotation);
+  }
+
+  static CodeCompletionStringChunk createSimple(ChunkKind Kind,
+                                                unsigned NestingLevel,
+                                                bool isAnnotation = false) {
+    return CodeCompletionStringChunk(Kind, NestingLevel, isAnnotation);
+  }
+};
+
+} // end namespace detail
+
+/// \brief A structured representation of a code completion string.
+class alignas(detail::CodeCompletionStringChunk) CodeCompletionString final :
+    private llvm::TrailingObjects<CodeCompletionString,
+                                  detail::CodeCompletionStringChunk> {
+  friend class CodeCompletionResultBuilder;
+  friend TrailingObjects;
+
+public:
+  using Chunk = detail::CodeCompletionStringChunk;
 
 private:
   unsigned NumChunks : 16;
@@ -290,8 +303,7 @@ public:
                                       ArrayRef<Chunk> Chunks);
 
   ArrayRef<Chunk> getChunks() const {
-    return llvm::makeArrayRef(reinterpret_cast<const Chunk *>(this + 1),
-                              NumChunks);
+    return {getTrailingObjects<Chunk>(), NumChunks};
   }
 
   StringRef getFirstTextChunk() const;

--- a/include/swift/SIL/Mangle.h
+++ b/include/swift/SIL/Mangle.h
@@ -13,7 +13,6 @@
 #ifndef SWIFT_SIL_MANGLE_H
 #define SWIFT_SIL_MANGLE_H
 
-#include "llvm/ADT/DenseMap.h"
 #include "swift/Basic/Demangle.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/AST/Decl.h"
@@ -21,6 +20,8 @@
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/SILFunction.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/TrailingObjects.h"
 
 namespace swift {
 
@@ -90,7 +91,7 @@ protected:
 /// specific specialization kind.
 template <typename SubType>
 class SpecializationMangler : public SpecializationManglerBase {
-  SubType *asImpl() { return reinterpret_cast<SubType *>(this); }
+  SubType *asImpl() { return static_cast<SubType *>(this); }
 public:
 
   ~SpecializationMangler() = default;

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -136,6 +136,8 @@ namespace swift {
 /// data is tail allocated so that the basic block case is not penalized by
 /// storing this unnecessary information.
 class LoopRegion {
+  // FIXME: This should use llvm::TrailingObjects for its tail allocations, but
+  // that requires restructuring the file a bit.
 
   /// This is a data structure that is an unsigned integer with a top bit flag
   /// that says whether it is an RPO ID for a BB Region or is an RPO ID of the

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -555,8 +555,7 @@ ObjCAttr *ObjCAttr::createNullary(ASTContext &Ctx, SourceLoc AtLoc,
                                   SourceLoc ObjCLoc, SourceLoc LParenLoc, 
                                   SourceLoc NameLoc, Identifier Name,
                                   SourceLoc RParenLoc) {
-  unsigned size = sizeof(ObjCAttr) + 3 * sizeof(SourceLoc);
-  void *mem = Ctx.Allocate(size, alignof(ObjCAttr));
+  void *mem = Ctx.Allocate(totalSizeToAlloc<SourceLoc>(3), alignof(ObjCAttr));
   return new (mem) ObjCAttr(AtLoc, SourceRange(ObjCLoc),
                             ObjCSelector(Ctx, 0, Name),
                             SourceRange(LParenLoc, RParenLoc),
@@ -574,8 +573,8 @@ ObjCAttr *ObjCAttr::createSelector(ASTContext &Ctx, SourceLoc AtLoc,
                                    ArrayRef<Identifier> Names,
                                    SourceLoc RParenLoc) {
   assert(NameLocs.size() == Names.size());
-  unsigned size = sizeof(ObjCAttr) + (NameLocs.size() + 2) * sizeof(SourceLoc);
-  void *mem = Ctx.Allocate(size, alignof(ObjCAttr));
+  void *mem = Ctx.Allocate(totalSizeToAlloc<SourceLoc>(NameLocs.size() + 2),
+                           alignof(ObjCAttr));
   return new (mem) ObjCAttr(AtLoc, SourceRange(ObjCLoc),
                             ObjCSelector(Ctx, Names.size(), Names),
                             SourceRange(LParenLoc, RParenLoc),

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -25,8 +25,7 @@ ConcreteDeclRef::SpecializedDeclRef *
 ConcreteDeclRef::SpecializedDeclRef::create(
                                        ASTContext &ctx, ValueDecl *decl,
                                        ArrayRef<Substitution> substitutions) {
-  unsigned size = sizeof(SpecializedDeclRef)
-  + sizeof(Substitution) * substitutions.size();
+  size_t size = totalSizeToAlloc<Substitution>(substitutions.size());
   void *memory = ctx.Allocate(size, alignof(SpecializedDeclRef));
   return new (memory) SpecializedDeclRef(decl, substitutions);
 }

--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -30,15 +30,14 @@ ParameterList::create(const ASTContext &C, SourceLoc LParenLoc,
   assert(LParenLoc.isValid() == RParenLoc.isValid() &&
          "Either both paren locs are valid or neither are");
   
-  auto byteSize = sizeof(ParameterList)+params.size()*sizeof(ParamDecl*);
+  auto byteSize = totalSizeToAlloc<ParamDecl *>(params.size());
   auto rawMem = C.Allocate(byteSize, alignof(ParameterList));
   
   //  Placement initialize the ParameterList and the Parameter's.
   auto PL = ::new (rawMem) ParameterList(LParenLoc, params.size(), RParenLoc);
 
-  for (size_t i = 0, e = params.size(); i != e; ++i)
-    ::new (&PL->get(i)) ParamDecl*(params[i]);
-  
+  std::uninitialized_copy(params.begin(), params.end(), PL->getArray().begin());
+
   return PL;
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -334,16 +334,15 @@ static Stmt *findNearestStmt(const AbstractFunctionDecl *AFD, SourceLoc Loc,
 }
 
 CodeCompletionString::CodeCompletionString(ArrayRef<Chunk> Chunks) {
-  Chunk *TailChunks = reinterpret_cast<Chunk *>(this + 1);
-  std::copy(Chunks.begin(), Chunks.end(), TailChunks);
+  std::uninitialized_copy(Chunks.begin(), Chunks.end(),
+                          getTrailingObjects<Chunk>());
   NumChunks = Chunks.size();
 }
 
 CodeCompletionString *CodeCompletionString::create(llvm::BumpPtrAllocator &Allocator,
                                                    ArrayRef<Chunk> Chunks) {
-  void *CCSMem = Allocator.Allocate(sizeof(CodeCompletionString) +
-                                    Chunks.size() * sizeof(CodeCompletionString::Chunk),
-                                    llvm::alignOf<CodeCompletionString>());
+  void *CCSMem = Allocator.Allocate(totalSizeToAlloc<Chunk>(Chunks.size()),
+                                    alignof(CodeCompletionString));
   return new (CCSMem) CodeCompletionString(Chunks);
 }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2542,9 +2542,7 @@ const ProtocolInfo &TypeConverter::getProtocolInfo(ProtocolDecl *protocol) {
 /// Allocate a new ProtocolInfo.
 ProtocolInfo *ProtocolInfo::create(unsigned numWitnesses,
                                    ArrayRef<WitnessTableEntry> table) {
-  unsigned numEntries = table.size();
-  size_t bufferSize =
-    sizeof(ProtocolInfo) + numEntries * sizeof(WitnessTableEntry);
+  size_t bufferSize = totalSizeToAlloc<WitnessTableEntry>(table.size());
   void *buffer = ::operator new(bufferSize);
   return new(buffer) ProtocolInfo(numWitnesses, table);
 }

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -232,7 +232,7 @@ namespace {
   };
 
   /// A type implementation for loadable record types imported from Clang.
-  class ClangRecordTypeInfo :
+  class ClangRecordTypeInfo final :
     public StructTypeInfoBase<ClangRecordTypeInfo, LoadableTypeInfo,
                               ClangFieldInfo> {
   public:
@@ -260,7 +260,7 @@ namespace {
   };
 
   /// A type implementation for loadable struct types.
-  class LoadableStructTypeInfo
+  class LoadableStructTypeInfo final
       : public StructTypeInfoBase<LoadableStructTypeInfo, LoadableTypeInfo> {
   public:
     // FIXME: Spare bits between struct members.
@@ -289,7 +289,7 @@ namespace {
   };
 
   /// A type implementation for non-loadable but fixed-size struct types.
-  class FixedStructTypeInfo
+  class FixedStructTypeInfo final
       : public StructTypeInfoBase<FixedStructTypeInfo,
                                   IndirectTypeInfo<FixedStructTypeInfo,
                                                    FixedTypeInfo>> {
@@ -372,7 +372,7 @@ namespace {
   };
 
   /// A type implementation for non-fixed struct types.
-  class NonFixedStructTypeInfo
+  class NonFixedStructTypeInfo final
       : public StructTypeInfoBase<NonFixedStructTypeInfo,
                                   WitnessSizedTypeInfo<NonFixedStructTypeInfo>>
   {

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -179,7 +179,7 @@ namespace {
   };
 
   /// Type implementation for loadable tuples.
-  class LoadableTupleTypeInfo :
+  class LoadableTupleTypeInfo final :
       public TupleTypeInfoBase<LoadableTupleTypeInfo, LoadableTypeInfo> {
   public:
     // FIXME: Spare bits between tuple elements.
@@ -203,7 +203,7 @@ namespace {
   };
 
   /// Type implementation for fixed-size but non-loadable tuples.
-  class FixedTupleTypeInfo :
+  class FixedTupleTypeInfo final :
       public TupleTypeInfoBase<FixedTupleTypeInfo,
                                IndirectTypeInfo<FixedTupleTypeInfo,
                                                 FixedTypeInfo>>
@@ -257,7 +257,7 @@ namespace {
   };
 
   /// Type implementation for non-fixed-size tuples.
-  class NonFixedTupleTypeInfo :
+  class NonFixedTupleTypeInfo final :
       public TupleTypeInfoBase<NonFixedTupleTypeInfo,
                                WitnessSizedTypeInfo<NonFixedTupleTypeInfo>>
   {

--- a/lib/Markup/AST.cpp
+++ b/lib/Markup/AST.cpp
@@ -23,27 +23,27 @@ using namespace llvm;
 using namespace markup;
 
 Document::Document(ArrayRef<MarkupASTNode*> Children)
-    : MarkupASTNode(ASTNodeKind::Document),
-      NumChildren(Children.size()) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+    : MarkupASTNode(ASTNodeKind::Document), NumChildren(Children.size()) {
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Document *Document::create(MarkupContext &MC,
                            ArrayRef<llvm::markup::MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Document) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Document));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Document));
   return new (Mem) Document(Children);
 }
 
 BlockQuote::BlockQuote(ArrayRef<MarkupASTNode*> Children)
-    : MarkupASTNode(ASTNodeKind::BlockQuote),
-      NumChildren(Children.size()) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+    : MarkupASTNode(ASTNodeKind::BlockQuote), NumChildren(Children.size()) {
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 BlockQuote *BlockQuote::create(MarkupContext &MC, ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(BlockQuote) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(BlockQuote));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(BlockQuote));
   return new (Mem) BlockQuote(Children);
 }
 
@@ -69,60 +69,59 @@ CodeBlock *CodeBlock::create(MarkupContext &MC, StringRef LiteralContent,
 }
 
 List::List(ArrayRef<MarkupASTNode *> Children, bool IsOrdered)
-    : MarkupASTNode(ASTNodeKind::List),
-      NumChildren(Children.size()),
+    : MarkupASTNode(ASTNodeKind::List), NumChildren(Children.size()),
       Ordered(IsOrdered) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 List *List::create(MarkupContext &MC, ArrayRef<MarkupASTNode *> Children,
                    bool IsOrdered) {
-  void *Mem = MC.allocate(sizeof(List) + sizeof(MarkupASTNode)
-      * Children.size(), alignof(List));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(List));
   return new (Mem) List(Children, IsOrdered);
 }
 
 Item::Item(ArrayRef<MarkupASTNode*> Children)
-    : MarkupASTNode(ASTNodeKind::Item),
-      NumChildren(Children.size()) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+    : MarkupASTNode(ASTNodeKind::Item), NumChildren(Children.size()) {
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Item *Item::create(MarkupContext &MC, ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Item) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Item));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Item));
   return new (Mem) Item(Children);
 }
 
 Link::Link(StringRef Destination, ArrayRef<MarkupASTNode *> Children)
-    : InlineContent(ASTNodeKind::Link),
-      NumChildren(Children.size()),
+    : InlineContent(ASTNodeKind::Link), NumChildren(Children.size()),
       Destination(Destination) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Link *Link::create(MarkupContext &MC, StringRef Destination,
                    ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Link) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Link));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Link));
   StringRef DestinationCopy = MC.allocateCopy(Destination);
   return new (Mem) Link(DestinationCopy, Children);
 }
 
 Image::Image(StringRef Destination, Optional<StringRef> Title,
              ArrayRef<MarkupASTNode *> Children)
-    : InlineContent(ASTNodeKind::Image),
-      NumChildren(Children.size()),
-      Destination(Destination),
-      Title(Title) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+    : InlineContent(ASTNodeKind::Image), NumChildren(Children.size()),
+      Destination(Destination), Title(Title) {
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Image *Image::create(MarkupContext &MC, StringRef Destination,
                      Optional<StringRef> Title,
                      ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Image) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Image));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Image));
   StringRef DestinationCopy = MC.allocateCopy(Destination);
   Optional<StringRef> TitleCopy;
   if (Title)
@@ -131,30 +130,30 @@ Image *Image::create(MarkupContext &MC, StringRef Destination,
 }
 
 Header::Header(unsigned Level, ArrayRef<MarkupASTNode *> Children)
-    : MarkupASTNode(ASTNodeKind::Header),
-      NumChildren(Children.size()),
+    : MarkupASTNode(ASTNodeKind::Header), NumChildren(Children.size()),
       Level(Level) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Header *Header::create(MarkupContext &MC, unsigned Level,
                        ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Header) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Header));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Header));
   return new (Mem) Header(Level, Children);
 }
 
 Paragraph::Paragraph(ArrayRef<MarkupASTNode *> Children)
     : MarkupASTNode(ASTNodeKind::Paragraph),
       NumChildren(Children.size()) {
-      std::uninitialized_copy(Children.begin(), Children.end(),
-                              getChildrenBuffer());
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Paragraph *Paragraph::create(MarkupContext &MC,
                              ArrayRef<llvm::markup::MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Paragraph) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Paragraph));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Paragraph));
   return new (Mem) Paragraph(Children);
 }
 
@@ -180,52 +179,55 @@ LineBreak *LineBreak::create(MarkupContext &MC) {
 
 Emphasis::Emphasis(ArrayRef<MarkupASTNode *> Children)
     : InlineContent(ASTNodeKind::Emphasis), NumChildren(Children.size()) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Emphasis *Emphasis::create(MarkupContext &MC,
                            ArrayRef<llvm::markup::MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Emphasis) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Emphasis));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Emphasis));
   return new (Mem) Emphasis(Children);
 }
 
 Strong::Strong(ArrayRef<MarkupASTNode *> Children)
     : InlineContent(ASTNodeKind::Strong), NumChildren(Children.size()) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 Strong *Strong::create(MarkupContext &MC,
                        ArrayRef<llvm::markup::MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(Strong) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(Strong));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(Strong));
   return new (Mem) Strong(Children);
 }
 
 ParamField::ParamField(StringRef Name, ArrayRef<MarkupASTNode *> Children)
-    : PrivateExtension(ASTNodeKind::ParamField),
-      Name(Name), NumChildren(Children.size()) {
-  std::uninitialized_copy(Children.begin(), Children.end(), getChildrenBuffer());
+    : PrivateExtension(ASTNodeKind::ParamField), NumChildren(Children.size()),
+      Name(Name) {
+  std::uninitialized_copy(Children.begin(), Children.end(),
+                          getTrailingObjects<MarkupASTNode *>());
 }
 
 ParamField *ParamField::create(MarkupContext &MC, StringRef Name,
                                ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(sizeof(ParamField) + Children.size()
-      * sizeof(MarkupASTNode *), alignof(ParamField));
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
+                          alignof(ParamField));
   return new (Mem) ParamField(Name, Children);
 }
 
 #define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind) \
 Id *Id::create(MarkupContext &MC, ArrayRef<MarkupASTNode *> Children) { \
-  void *Mem = MC.allocate(sizeof(Id) + Children.size() \
-      * sizeof(MarkupASTNode *), alignof(Id)); \
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()), \
+                          alignof(Id)); \
   return new (Mem) Id(Children); \
 } \
 \
 Id::Id(ArrayRef<MarkupASTNode *> Children) \
     : PrivateExtension(ASTNodeKind::Id), NumChildren(Children.size()) { \
-      std::uninitialized_copy(Children.begin(), Children.end(), \
-                          getChildrenBuffer()); \
+  std::uninitialized_copy(Children.begin(), Children.end(), \
+                          getTrailingObjects<MarkupASTNode *>()); \
 }
 #include "swift/Markup/SimpleFields.def"
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -34,7 +34,8 @@ Constraint::Constraint(ConstraintKind kind, ArrayRef<Constraint *> constraints,
     Nested(constraints), Locator(locator)
 {
   assert(kind == ConstraintKind::Disjunction);
-  std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
+  std::uninitialized_copy(typeVars.begin(), typeVars.end(),
+                          getTypeVariablesBuffer().begin());
 }
 
 Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, 
@@ -564,8 +565,7 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
   uniqueTypeVariables(typeVars);
 
   // Create the constraint.
-  unsigned size = sizeof(Constraint) 
-                + typeVars.size() * sizeof(TypeVariableType*);
+  unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, first, second, member, locator, typeVars);
 }
@@ -582,8 +582,7 @@ Constraint *Constraint::createBindOverload(ConstraintSystem &cs, Type type,
   }
 
   // Create the constraint.
-  unsigned size = sizeof(Constraint) 
-                + typeVars.size() * sizeof(TypeVariableType*);
+  unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(type, choice, locator, typeVars);
 }
@@ -602,8 +601,7 @@ Constraint *Constraint::createRestricted(ConstraintSystem &cs,
   uniqueTypeVariables(typeVars);
 
   // Create the constraint.
-  unsigned size = sizeof(Constraint) 
-                + typeVars.size() * sizeof(TypeVariableType*);
+  unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, restriction, first, second, locator,
                               typeVars);
@@ -622,8 +620,7 @@ Constraint *Constraint::createFixed(ConstraintSystem &cs, ConstraintKind kind,
   uniqueTypeVariables(typeVars);
 
   // Create the constraint.
-  unsigned size = sizeof(Constraint)
-  + typeVars.size() * sizeof(TypeVariableType*);
+  unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, fix, first, second, locator, typeVars);
 }
@@ -675,8 +672,7 @@ Constraint *Constraint::createDisjunction(ConstraintSystem &cs,
 
   // Create the disjunction constraint.
   uniqueTypeVariables(typeVars);
-  unsigned size = sizeof(Constraint) 
-                + typeVars.size() * sizeof(TypeVariableType*);
+  unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   auto disjunction =  new (mem) Constraint(ConstraintKind::Disjunction,
                               cs.allocateCopy(constraints), locator, typeVars);

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/ilist_node.h"
+#include "llvm/Support/TrailingObjects.h"
 
 namespace llvm {
 
@@ -325,7 +326,10 @@ public:
 
 
 /// \brief A constraint between two type variables.
-class Constraint : public llvm::ilist_node<Constraint> {
+class Constraint final : public llvm::ilist_node<Constraint>,
+    private llvm::TrailingObjects<Constraint, TypeVariableType *> {
+  friend TrailingObjects;
+
   /// \brief The kind of constraint.
   ConstraintKind Kind : 8;
 
@@ -417,7 +421,7 @@ class Constraint : public llvm::ilist_node<Constraint> {
 
   /// Retrieve the type variables buffer, for internal mutation.
   MutableArrayRef<TypeVariableType *> getTypeVariablesBuffer() {
-    return { reinterpret_cast<TypeVariableType **>(this + 1), NumTypeVariables };
+    return { getTrailingObjects<TypeVariableType *>(), NumTypeVariables };
   }
 
 public:
@@ -485,8 +489,7 @@ public:
 
   /// Retrieve the set of type variables referenced by this constraint.
   ArrayRef<TypeVariableType *> getTypeVariables() const {
-    return { reinterpret_cast<TypeVariableType * const *>(this + 1), 
-             NumTypeVariables };
+    return {getTrailingObjects<TypeVariableType*>(), NumTypeVariables};
   }
 
   /// \brief Determine the classification of this constraint, providing


### PR DESCRIPTION
LLVM now has a helper class that formalizes the notion of tail-allocated objects. Adopt it in Swift where it makes sense, so that we don't shoot ourselves in the foot later.

In this process I found one or two instances of underaligned types, so maybe this was already worth it. :-)
