### PR TITLE
[Sema] improved binary op diagnostic notes for structs and payloaded enums

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -243,6 +243,11 @@ NOTE(suggest_partial_overloads,none,
       "partially matching parameter lists|result types}0: %2",
       (bool, StringRef, StringRef))
 
+NOTE(no_binary_op_overload_for_enum_with_payload,none,
+      "binary operator '%0' cannot be synthesized for enums "
+      "with associated values",
+      (StringRef))
+
 ERROR(cannot_convert_initializer_value,none,
       "cannot convert value of type %0 to specified type %1", (Type,Type))
 ERROR(cannot_convert_initializer_value_protocol,none,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3975,8 +3975,19 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
       .highlight(lhsExpr->getSourceRange())
       .highlight(rhsExpr->getSourceRange());
     }
-    
-    calleeInfo.suggestPotentialOverloads(callExpr->getLoc());
+
+    if (lhsType->isEqual(rhsType) &&
+        isNameOfStandardComparisonOperator(overloadName) &&
+        lhsType->is<EnumType>() &&
+        !lhsType->getAs<EnumType>()->getDecl()
+          ->hasOnlyCasesWithoutAssociatedValues()) {
+      diagnose(callExpr->getLoc(),
+               diag::no_binary_op_overload_for_enum_with_payload,
+               overloadName);
+    } else {
+      calleeInfo.suggestPotentialOverloads(callExpr->getLoc());
+    }
+
     return true;
   }
   

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -718,4 +718,10 @@ func test17875634() {
   match.append(row, col)  // expected-error {{extra argument in call}}
 }
 
+// <https://github.com/apple/swift/pull/1205> Improved diagnostics for enums with associated values
+enum AssocTest {
+  case one(Int)
+}
 
+if AssocTest.one(1) == AssocTest.one(1) {} // expected-error{{binary operator '==' cannot be applied to two 'AssocTest' operands}}
+// expected-note @-1 {{binary operator '==' cannot be synthesized for enums with associated values}}


### PR DESCRIPTION
In master, given this code

```
enum AssocTest {
    case one(Int)
}

if AssocTest.one(1) == AssocTest.one(1) {}
```

the compiler now emits the following error and note

```
test.swift:5:21: error: binary operator '==' cannot be applied to two 'AssocTest' operands
if AssocTest.one(1) == AssocTest.one(1) {}
   ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~
test.swift:5:21: note: overloads for '==' exist with these partially matching parameter lists: (FloatingPointClassification, FloatingPointClassification), (Mirror.DisplayStyle, Mirror.DisplayStyle), (_MirrorDisposition, _MirrorDisposition), (Bool, Bool), (Any.Type?, Any.Type?), (COpaquePointer, COpaquePointer), (Character, Character), (UInt8, UInt8), (Int8, Int8), (UInt16, UInt16), (Int16, Int16), (UInt32, UInt32), (Int32, Int32), (UInt64, UInt64), (Int64, Int64), (UInt, UInt), (Int, Int), (Float, Float), (Double, Double), (Float80, Float80), (ObjectIdentifier, ObjectIdentifier), (String, String), (Index, Index), (String.UnicodeScalarView.Index, String.UnicodeScalarView.Index), (String.UTF16View.Index, String.UTF16View.Index), (String.UTF8View.Index, String.UTF8View.Index), (UnicodeScalar, UnicodeScalar), (_SwiftNSOperatingSystemVersion, _SwiftNSOperatingSystemVersion), (Bit, Bit), (AnyForwardIndex, AnyForwardIndex), (AnyBidirectionalIndex, AnyBidirectionalIndex), (AnyRandomAccessIndex, AnyRandomAccessIndex), (ContiguousArray<Element>, ContiguousArray<Element>), (ArraySlice<Element>, ArraySlice<Element>), (Array<Element>, Array<Element>), (AutoreleasingUnsafeMutablePointer<Memory>, AutoreleasingUnsafeMutablePointer<Memory>), (LazyFilterIndex<Base>, LazyFilterIndex<Base>), (FlattenCollectionIndex<BaseElements>, FlattenCollectionIndex<BaseElements>), (FlattenBidirectionalCollectionIndex<BaseElements>, FlattenBidirectionalCollectionIndex<BaseElements>), (Set<Element>, Set<Element>), ([Key : Value], [Key : Value]), (SetIndex<Element>, SetIndex<Element>), (DictionaryIndex<Key, Value>, DictionaryIndex<Key, Value>), (_HeapBuffer<Value, Element>, _HeapBuffer<Value, Element>), (HalfOpenInterval<Bound>, HalfOpenInterval<Bound>), (ClosedInterval<Bound>, ClosedInterval<Bound>), (ManagedBufferPointer<Value, Element>, ManagedBufferPointer<Value, Element>), (T?, T?), (T?, _OptionalNilComparisonType), (_OptionalNilComparisonType, T?), (Range<Element>, Range<Element>), (ReverseIndex<Base>, ReverseIndex<Base>), (UnsafeMutablePointer<Memory>, UnsafeMutablePointer<Memory>), (UnsafePointer<Memory>, UnsafePointer<Memory>), ((A, B), (A, B)), ((A, B, C), (A, B, C)), ((A, B, C, D), (A, B, C, D)), ((A, B, C, D, E), (A, B, C, D, E)), ((A, B, C, D, E, F), (A, B, C, D, E, F))
```

The same thing happens when comparing two structs of the same type. This is likely a regression, since there's no partial match and the list given seems to be the list off all `==` overloads.

Before fixing the candidate list generator, I'd like to improve the notes given in the special cases of comparing two enums with associated values of the same type or two structs of the same type if the relevant binary operators has not been overloaded. Since there's no suggestion for partial match possible (the compiler will generate a type conversion error instead if a partial match to an overloaded binary op exists), I'd like to emit a note that's more indicative of what the user needs to do to fix the error.

Example:
`binary operator '==' cannot be synthesized for enums with associated values`
