### PR TITLE
[swiftc] Add test case for crash triggered in swift::DynamicSelfType::get(…)

### DIFF
--- a/validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift
+++ b/validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+if{func b:a protocol a{{}typealias d:d
+func b->Self


### PR DESCRIPTION
Stack trace:

```
4  swift           0x0000000000f39519 swift::DynamicSelfType::get(swift::Type, swift::ASTContext const&) + 25
6  swift           0x0000000000e1a530 swift::configureImplicitSelf(swift::TypeChecker&, swift::AbstractFunctionDecl*) + 160
11 swift           0x0000000000e1bd70 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 5920
12 swift           0x0000000001021a2c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2892
13 swift           0x00000000010203e0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
14 swift           0x0000000000e4211b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
17 swift           0x0000000000e6ba9e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
19 swift           0x0000000000e6ca14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
20 swift           0x0000000000e6b9aa swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
21 swift           0x0000000000f006e2 swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 146
22 swift           0x0000000000eff96d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
23 swift           0x0000000000e173d9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
24 swift           0x0000000000e1aa95 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1093
28 swift           0x0000000000e6ba9e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
30 swift           0x0000000000e6ca14 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
31 swift           0x0000000000e6b9aa swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
34 swift           0x0000000000e1ffc6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
38 swift           0x0000000000e67246 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
39 swift           0x0000000000debded swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1597
40 swift           0x0000000000c93bcf swift::CompilerInstance::performSema() + 2975
42 swift           0x0000000000777121 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
43 swift           0x0000000000771d05 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28248-swift-dynamicselftype-get-e744d3.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift:7:4
2.  While resolving type a at [validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift:7:11 - line:7:11] RangeText="a"
3.  While resolving type d at [validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift:7:38 - line:7:38] RangeText="d"
4.  While type-checking 'a' at validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift:7:13
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
