### PR TITLE
Add 'ExtraStringAPIs.swift' to make list.

### DIFF
--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_library(swiftFoundation IS_SDK_OVERLAY
   NSError.swift
   NSStringAPI.swift
   NSValue.swift
+  ExtraStringAPIs.swift
   Thunks.mm
 
   SWIFT_MODULE_DEPENDS ObjectiveC CoreGraphics Dispatch

--- a/test/1_stdlib/StringDiagnostics.swift
+++ b/test/1_stdlib/StringDiagnostics.swift
@@ -58,3 +58,21 @@ func testStringDeprecation(hello: String) {
 
 
 }
+
+// Positive and negative tests for String index types
+func acceptsForwardIndex<I: ForwardIndexType>(index: I) {}
+func acceptsBidirectionalIndex<I: BidirectionalIndexType>(index: I) {}
+func acceptsRandomAccessIndex<I: RandomAccessIndexType>(index: I) {}
+
+func testStringIndexTypes(s: String) {
+  acceptsForwardIndex(s.utf8.startIndex)
+  acceptsBidirectionalIndex(s.utf8.startIndex) // expected-error{{argument type 'String.UTF8View.Index' does not conform to expected type 'BidirectionalIndexType'}}
+  acceptsBidirectionalIndex(s.unicodeScalars.startIndex)
+  acceptsRandomAccessIndex(s.unicodeScalars.startIndex) // expected-error{{argument type 'String.UnicodeScalarView.Index' does not conform to expected type 'RandomAccessIndexType'}}
+  acceptsBidirectionalIndex(s.characters.startIndex)
+  acceptsRandomAccessIndex(s.characters.startIndex) // expected-error{{argument type 'String.CharacterView.Index' does not conform to expected type 'RandomAccessIndexType'}}
+  
+  // UTF16View.Index is random-access with Foundation, bidirectional without
+  acceptsRandomAccessIndex(s.utf16.startIndex)
+}
+

--- a/test/1_stdlib/StringDiagnostics_without_Foundation.swift
+++ b/test/1_stdlib/StringDiagnostics_without_Foundation.swift
@@ -1,0 +1,20 @@
+// RUN: %target-parse-verify-swift
+
+// Positive and negative tests for String index types
+func acceptsForwardIndex<I: ForwardIndexType>(index: I) {}
+func acceptsBidirectionalIndex<I: BidirectionalIndexType>(index: I) {}
+func acceptsRandomAccessIndex<I: RandomAccessIndexType>(index: I) {}
+
+func testStringIndexTypes(s: String) {
+  acceptsForwardIndex(s.utf8.startIndex)
+  acceptsBidirectionalIndex(s.utf8.startIndex) // expected-error{{argument type 'String.UTF8View.Index' does not conform to expected type 'BidirectionalIndexType'}}
+  acceptsBidirectionalIndex(s.unicodeScalars.startIndex)
+  acceptsRandomAccessIndex(s.unicodeScalars.startIndex) // expected-error{{argument type 'String.UnicodeScalarView.Index' does not conform to expected type 'RandomAccessIndexType'}}
+  acceptsBidirectionalIndex(s.characters.startIndex)
+  acceptsRandomAccessIndex(s.characters.startIndex) // expected-error{{argument type 'String.CharacterView.Index' does not conform to expected type 'RandomAccessIndexType'}}
+  
+  // UTF16View.Index is random-access with Foundation, bidirectional without
+  acceptsBidirectionalIndex(s.utf16.startIndex)
+  acceptsRandomAccessIndex(s.utf16.startIndex) // expected-error{{argument type 'String.UTF16View.Index' does not conform to expected type 'RandomAccessIndexType'}}
+}
+


### PR DESCRIPTION
This one file was missing from the make list, resulting in `String.UTF16View.Index` not getting random-access index capabilities.
