### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::validateGenericFuncSignature(…)

### DIFF
--- a/validation-test/compiler_crashers/28249-swift-typechecker-validategenericfuncsignature.swift
+++ b/validation-test/compiler_crashers/28249-swift-typechecker-validategenericfuncsignature.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class S<T:S{func g:T.g
+func g


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:4461: void swift::AbstractFunctionDecl::setGenericSignature(swift::GenericSignature *): Assertion `!this->GenericSig && "already have signature?"' failed.
8  swift           0x0000000000e3f6ca swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 3658
13 swift           0x0000000000e1ffc6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
14 swift           0x0000000000debd82 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
15 swift           0x0000000000c93bcf swift::CompilerInstance::performSema() + 2975
17 swift           0x0000000000777121 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
18 swift           0x0000000000771d05 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28249-swift-typechecker-validategenericfuncsignature.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28249-swift-typechecker-validategenericfuncsignature-baa5eb.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28249-swift-typechecker-validategenericfuncsignature.swift:8:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
