### PR TITLE
Runtime: Build with -fvisibility=hidden.

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -59,5 +59,7 @@
 # define SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 #endif
 
-#endif // SWIFT_RUNTIME_CONFIG_H
+// Bring in visibility attribute macros
+#include "../../../stdlib/public/SwiftShims/Visibility.h"
 
+#endif // SWIFT_RUNTIME_CONFIG_H

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -19,6 +19,7 @@
 
 #include <llvm/Support/Compiler.h>
 #include <stdint.h>
+#include "swift/Runtime/Config.h"
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
 
@@ -101,6 +102,7 @@ swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                          const void *targetType, const char *targetName, 
                          const char *message = nullptr);
 
+SWIFT_RUNTIME_EXPORT
 extern "C"
 void swift_reportError(uint32_t flags, const char *message);
 

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_RUNTIME_ENUM_H
 #define SWIFT_RUNTIME_ENUM_H
 
+#include "swift/Runtime/Config.h"
+
 namespace swift {
   
 struct OpaqueValue;
@@ -32,6 +34,7 @@ struct TypeLayout;
 ///                  witness table for the enum.
 /// \param payload - type metadata for the payload case of the enum.
 /// \param emptyCases - the number of empty cases in the enum.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_initEnumValueWitnessTableSinglePayload(
                                                     ValueWitnessTable *vwtable,
                                                     const TypeLayout *payload,
@@ -47,6 +50,7 @@ extern "C" void swift_initEnumValueWitnessTableSinglePayload(
 /// \returns -1 if the payload case is inhabited. If an empty case is inhabited,
 ///          returns a value greater than or equal to zero and less than
 ///          emptyCases.
+SWIFT_RUNTIME_EXPORT
 extern "C" int swift_getEnumCaseSinglePayload(const OpaqueValue *value,
                                               const Metadata *payload,
                                               unsigned emptyCases);
@@ -62,6 +66,7 @@ extern "C" int swift_getEnumCaseSinglePayload(const OpaqueValue *value,
 ///                    case, or a value greater than or equal to zero and less
 ///                    than emptyCases for an empty case.
 /// \param emptyCases - the number of empty cases in the enum.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_storeEnumTagSinglePayload(OpaqueValue *value,
                                                  const Metadata *payload,
                                                  int whichCase,
@@ -69,6 +74,7 @@ extern "C" void swift_storeEnumTagSinglePayload(OpaqueValue *value,
 
 /// \brief Initialize the value witness table for a generic, multi-payload
 ///        enum instance.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_initEnumMetadataMultiPayload(ValueWitnessTable *vwtable,
                                        EnumMetadata *enumType,
                                        unsigned numPayloads,
@@ -81,11 +87,13 @@ extern "C" void swift_initEnumMetadataMultiPayload(ValueWitnessTable *vwtable,
 /// \param enumType - type metadata for the enum.
 ///
 /// \returns The index of the enum case.
+SWIFT_RUNTIME_EXPORT
 extern "C" unsigned swift_getEnumCaseMultiPayload(const OpaqueValue *value,
                                                   const EnumMetadata *enumType);
   
 /// \brief Store the tag value for the given case into a multi-payload enum,
 ///        whose associated payload (if any) has already been initialized.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_storeEnumTagMultiPayload(OpaqueValue *value,
                                                const EnumMetadata *enumType,
                                                unsigned whichCase);

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -49,6 +49,7 @@ struct OpaqueValue;
 ///
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *swift_allocObject(HeapMetadata const *metadata,
                                          size_t requiredSize,
                                          size_t requiredAlignmentMask);
@@ -58,12 +59,14 @@ extern "C" HeapObject *swift_allocObject(HeapMetadata const *metadata,
 /// \param metadata - the object's metadata which is stored in the header
 /// \param object - the pointer to the object's memory on the stack
 /// \returns the passed object pointer.
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *swift_initStackObject(HeapMetadata const *metadata,
                                              HeapObject *object);
 
 /// Performs verification that the lifetime of a stack allocated object has
 /// ended. It aborts if the reference counts of the object indicate that the
 /// object did escape to some other location.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_verifyEndOfLifetime(HeapObject *object);
 
 /// A structure that's two pointers in size.
@@ -130,16 +133,19 @@ using BoxPair = TwoWordPair<HeapObject *, OpaqueValue *>;
 /// appropriate to store a value of the given type.
 /// The heap object has an initial retain count of 1, and its metadata is set
 /// such that destroying the heap object destroys the contained value.
+SWIFT_RUNTIME_EXPORT
 extern "C" BoxPair::Return swift_allocBox(Metadata const *type);
 
 // Allocate plain old memory. This is the generalized entry point
 // Never returns nil. The returned memory is uninitialized. 
 //
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_slowAlloc(size_t bytes, size_t alignMask);
 
 // If the caller cannot promise to zero the object during destruction,
 // then call these corresponding APIs:
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
 
 /// Atomically increments the retain count of an object.
@@ -154,7 +160,9 @@ extern "C" void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
 ///      - maybe a variant that can assume a non-null object
 /// It may also prove worthwhile to have this use a custom CC
 /// which preserves a larger set of registers.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_retain(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_retain_n(HeapObject *object, uint32_t n);
 
 static inline void _swift_retain_inlined(HeapObject *object) {
@@ -165,9 +173,11 @@ static inline void _swift_retain_inlined(HeapObject *object) {
 
 /// Atomically increments the reference count of an object, unless it has
 /// already been destroyed. Returns nil if the object is dead.
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *swift_tryRetain(HeapObject *object);
 
 /// Returns true if an object is in the process of being deallocated.
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isDeallocating(HeapObject *object);
 
 /// Attempts to atomically pin an object and increment its reference
@@ -177,12 +187,14 @@ extern "C" bool swift_isDeallocating(HeapObject *object);
 /// calling swift_unpin on the return value.
 ///
 /// The object reference may not be nil.
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *swift_tryPin(HeapObject *object);
 
 /// Given that an object is pinned, atomically unpin it and decrement
 /// the reference count.
 ///
 /// The object reference may be nil (to simplify the protocol).
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unpin(HeapObject *object);
   
 /// Atomically decrements the retain count of an object.  If the
@@ -200,50 +212,61 @@ extern "C" void swift_unpin(HeapObject *object);
 ///      - a variant that can safely use non-atomic operations
 ///      - maybe a variant that can assume a non-null object
 /// It's unlikely that a custom CC would be beneficial here.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_release(HeapObject *object);
 
 /// Atomically decrements the retain count of an object n times. If the retain
 /// count reaches zero, the object is destroyed
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_release_n(HeapObject *object, uint32_t n);
 
 /// Is this pointer a non-null unique reference to an object
 /// that uses Swift reference counting?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedNonObjC(const void *);
 
 /// Is this non-null pointer a unique reference to an object
 /// that uses Swift reference counting?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedNonObjC_nonNull(const void *);
 
 /// Is this non-null pointer a reference to an object that uses Swift
 /// reference counting and is either uniquely referenced or pinned?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedOrPinnedNonObjC_nonNull(const void *);
 
 /// Is this non-null BridgeObject a unique reference to an object
 /// that uses Swift reference counting?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedNonObjC_nonNull_bridgeObject(
   uintptr_t bits);
 
 /// Is this non-null BridgeObject a unique or pinned reference to an
 /// object that uses Swift reference counting?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedOrPinnedNonObjC_nonNull_bridgeObject(
   uintptr_t bits);
 
 /// Is this native Swift pointer a non-null unique reference to
 /// an object?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferenced_native(const struct HeapObject *);
 
 /// Is this native Swift pointer a non-null unique or pinned reference
 /// to an object?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedOrPinned_native(
   const struct HeapObject *);
 
 /// Is this non-null native Swift pointer a unique reference to
 /// an object?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferenced_nonNull_native(
   const struct HeapObject *);
 
 /// Does this non-null native Swift pointer refer to an object that
 /// is either uniquely referenced or pinned?
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isUniquelyReferencedOrPinned_nonNull_native(
   const struct HeapObject *);
 
@@ -262,6 +285,7 @@ extern "C" bool swift_isUniquelyReferencedOrPinned_nonNull_native(
 /// POSSIBILITIES: It may be useful to have a variant which
 /// requires the object to have been fully zeroed from offsets
 /// sizeof(SwiftHeapObject) to allocatedSize.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_deallocObject(HeapObject *object, size_t allocatedSize,
                                     size_t allocatedAlignMask);
 
@@ -281,6 +305,7 @@ extern "C" void swift_deallocObject(HeapObject *object, size_t allocatedSize,
 /// POSSIBILITIES: It may be useful to have a variant which
 /// requires the object to have been fully zeroed from offsets
 /// sizeof(SwiftHeapObject) to allocatedSize.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_deallocClassInstance(HeapObject *object,
                                            size_t allocatedSize,
                                            size_t allocatedAlignMask);
@@ -299,6 +324,7 @@ extern "C" void swift_deallocClassInstance(HeapObject *object,
 ///   program's perspective, i.e. the value
 /// \param allocatedAlignMask - the alignment requirement that was passed
 ///   to allocObject
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
                                                   const HeapMetadata *type,
                                                   size_t allocatedSize,
@@ -308,11 +334,13 @@ extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
 /// by swift_allocBox but is otherwise in an unknown state. The given Metadata
 /// pointer must be the same metadata pointer that was passed to swift_allocBox
 /// when the memory was allocated.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_deallocBox(HeapObject *object);
 
 /// Project the value out of a box. `object` must have been allocated
 /// using `swift_allocBox`, or by the compiler using a statically-emitted
 /// box metadata object.
+SWIFT_RUNTIME_EXPORT
 extern "C" OpaqueValue *swift_projectBox(HeapObject *object);
 
 /// RAII object that wraps a Swift heap object and releases it upon
@@ -367,27 +395,34 @@ struct UnownedReference {
 };
 
 /// Increment the weak/unowned retain count.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedRetain(HeapObject *value);
 
 /// Decrement the weak/unowned retain count.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedRelease(HeapObject *value);
 
 /// Increment the weak/unowned retain count by n.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedRetain_n(HeapObject *value, int n);
 
 /// Decrement the weak/unowned retain count by n.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedRelease_n(HeapObject *value, int n);
 
 /// Increment the strong retain count of an object, aborting if it has
 /// been deallocated.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedRetainStrong(HeapObject *value);
 
 /// Increment the strong retain count of an object which may have been
 /// deallocated, aborting if it has been deallocated, and decrement its
 /// weak/unowned reference count.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedRetainStrongAndRelease(HeapObject *value);
 
 /// Aborts if the object has been deallocated.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unownedCheck(HeapObject *value);
 
 static inline void swift_unownedInit(UnownedReference *ref, HeapObject *value) {
@@ -464,12 +499,14 @@ struct WeakReference {
 ///
 /// \param ref - never null
 /// \param value - can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakInit(WeakReference *ref, HeapObject *value);
 
 /// Assign a new value to a weak reference.
 ///
 /// \param ref - never null
 /// \param value - can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakAssign(WeakReference *ref, HeapObject *value);
 
 /// Load a value from a weak reference.  If the current value is a
@@ -478,6 +515,7 @@ extern "C" void swift_weakAssign(WeakReference *ref, HeapObject *value);
 ///
 /// \param ref - never null
 /// \return can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *swift_weakLoadStrong(WeakReference *ref);
 
 /// Load a value from a weak reference as if by swift_weakLoadStrong,
@@ -485,43 +523,51 @@ extern "C" HeapObject *swift_weakLoadStrong(WeakReference *ref);
 ///
 /// \param ref - never null
 /// \return can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *swift_weakTakeStrong(WeakReference *ref);
 
 /// Destroy a weak reference.
 ///
 /// \param ref - never null, but can refer to a null object
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakDestroy(WeakReference *ref);
 
 /// Copy initialize a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakCopyInit(WeakReference *dest, WeakReference *src);
 
 /// Take initialize a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakTakeInit(WeakReference *dest, WeakReference *src);
 
 /// Copy assign a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakCopyAssign(WeakReference *dest, WeakReference *src);
 
 /// Take assign a weak reference.
 ///
 /// \param dest - never null, but can refer to a null object
 /// \param src - never null, but can refer to a null object
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_weakTakeAssign(WeakReference *dest, WeakReference *src);
 
 /*****************************************************************************/
 /************************* OTHER REFERENCE-COUNTING **************************/
 /*****************************************************************************/
 
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_bridgeObjectRetain(void *value);
 /// Increment the strong retain count of a bridged object by n.
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_bridgeObjectRetain_n(void *value, int n);
 
 /*****************************************************************************/
@@ -532,9 +578,11 @@ extern "C" void *swift_bridgeObjectRetain_n(void *value, int n);
 
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownRetain(void *value);
 /// Increment the strong retain count of an object which might not be a native
 /// Swift object by n.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownRetain_n(void *value, int n);
 
 #else
@@ -549,17 +597,21 @@ static inline void swift_unknownRetain_n(void *value, int n) {
 
 #endif /* SWIFT_OBJC_INTEROP */
 
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_bridgeObjectRelease(void *value);
 /// Decrement the strong retain count of a bridged object by n.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_bridgeObjectRelease_n(void *value, int n);
 
 #if SWIFT_OBJC_INTEROP
 
 /// Decrement the strong retain count of an object which might not be a native
 /// Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownRelease(void *value);
 /// Decrement the strong retain count of an object which might not be a native
 /// Swift object by n.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownRelease_n(void *value, int n);
 
 #else
@@ -584,6 +636,7 @@ static inline void swift_unknownRelease_n(void *value, int n) {
 ///
 /// \param ref - never null
 /// \param value - not necessarily a native Swift object; can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownWeakInit(WeakReference *ref, void *value);
 
 #else
@@ -600,6 +653,7 @@ static inline void swift_unknownWeakInit(WeakReference *ref, void *value) {
 ///
 /// \param ref - never null
 /// \param value - not necessarily a native Swift object; can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownWeakAssign(WeakReference *ref, void *value);
 
 #else
@@ -617,6 +671,7 @@ static inline void swift_unknownWeakAssign(WeakReference *ref, void *value) {
 ///
 /// \param ref - never null
 /// \return can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_unknownWeakLoadStrong(WeakReference *ref);
 
 #else
@@ -635,6 +690,7 @@ static inline void swift_unknownWeakLoadStrong(WeakReference *ref) {
 ///
 /// \param ref - never null
 /// \return can be null
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_unknownWeakTakeStrong(WeakReference *ref);
 
 #else
@@ -649,6 +705,7 @@ static inline void swift_unknownWeakTakeStrong(WeakReference *ref) {
 
 /// Destroy a weak reference variable that might not refer to a native
 /// Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownWeakDestroy(WeakReference *object);
 
 #else
@@ -663,11 +720,14 @@ static inline void swift_unknownWeakDestroy(WeakReference *object) {
 
 /// Copy-initialize a weak reference variable from one that might not
 /// refer to a native Swift object.
-extern "C" void swift_unknownWeakCopyInit(WeakReference *dest, WeakReference *src);
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_unknownWeakCopyInit(WeakReference *dest,
+                                          WeakReference *src);
 
 #else
 
-static inline void swift_unknownWeakCopyInit(WeakReference *dest, WeakReference *src) {
+static inline void swift_unknownWeakCopyInit(WeakReference *dest,
+                                             WeakReference *src) {
   swift_weakCopyInit(dest, src);
 }
 
@@ -677,11 +737,14 @@ static inline void swift_unknownWeakCopyInit(WeakReference *dest, WeakReference 
 
 /// Take-initialize a weak reference variable from one that might not
 /// refer to a native Swift object.
-extern "C" void swift_unknownWeakTakeInit(WeakReference *dest, WeakReference *src);
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_unknownWeakTakeInit(WeakReference *dest,
+                                          WeakReference *src);
 
 #else
 
-static inline void swift_unknownWeakTakeInit(WeakReference *dest, WeakReference *src) {
+static inline void swift_unknownWeakTakeInit(WeakReference *dest,
+                                             WeakReference *src) {
   swift_weakTakeInit(dest, src);
 }
 
@@ -691,11 +754,14 @@ static inline void swift_unknownWeakTakeInit(WeakReference *dest, WeakReference 
 
 /// Copy-assign a weak reference variable from another when either
 /// or both variables might not refer to a native Swift object.
-extern "C" void swift_unknownWeakCopyAssign(WeakReference *dest, WeakReference *src);
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_unknownWeakCopyAssign(WeakReference *dest,
+                                            WeakReference *src);
 
 #else
 
-static inline void swift_unknownWeakCopyAssign(WeakReference *dest, WeakReference *src) {
+static inline void swift_unknownWeakCopyAssign(WeakReference *dest,
+                                               WeakReference *src) {
   swift_weakCopyAssign(dest, src);
 }
 
@@ -705,11 +771,14 @@ static inline void swift_unknownWeakCopyAssign(WeakReference *dest, WeakReferenc
 
 /// Take-assign a weak reference variable from another when either
 /// or both variables might not refer to a native Swift object.
-extern "C" void swift_unknownWeakTakeAssign(WeakReference *dest, WeakReference *src);
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_unknownWeakTakeAssign(WeakReference *dest,
+                                            WeakReference *src);
 
 #else
 
-static inline void swift_unknownWeakTakeAssign(WeakReference *dest, WeakReference *src) {
+static inline void swift_unknownWeakTakeAssign(WeakReference *dest,
+                                               WeakReference *src) {
   swift_weakTakeAssign(dest, src);
 }
 
@@ -723,6 +792,7 @@ static inline void swift_unknownWeakTakeAssign(WeakReference *dest, WeakReferenc
 
 /// Initialize an unowned reference to an object with unknown reference
 /// counting.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedInit(UnownedReference *ref, void *value);
 
 #else
@@ -738,6 +808,7 @@ static inline void swift_unknownUnownedInit(UnownedReference *ref,
 
 /// Assign to an unowned reference holding an object with unknown reference
 /// counting.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedAssign(UnownedReference *ref, void *value);
 
 #else
@@ -753,6 +824,7 @@ static inline void swift_unknownUnownedAssign(UnownedReference *ref,
 
 /// Load from an unowned reference to an object with unknown reference
 /// counting.
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_unknownUnownedLoadStrong(UnownedReference *ref);
 
 #else
@@ -767,6 +839,7 @@ static inline void *swift_unknownUnownedLoadStrong(UnownedReference *ref) {
 
 /// Take from an unowned reference to an object with unknown reference
 /// counting.
+SWIFT_RUNTIME_EXPORT
 extern "C" void *swift_unknownUnownedTakeStrong(UnownedReference *ref);
 
 #else
@@ -780,6 +853,7 @@ static inline void *swift_unknownUnownedTakeStrong(UnownedReference *ref) {
 #if SWIFT_OBJC_INTEROP
   
 /// Destroy an unowned reference to an object with unknown reference counting.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedDestroy(UnownedReference *ref);
 
 #else
@@ -794,6 +868,7 @@ static inline void swift_unknownUnownedDestroy(UnownedReference *ref) {
 
 /// Copy-initialize an unowned reference variable from one that might not
 /// refer to a native Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedCopyInit(UnownedReference *dest,
                                              UnownedReference *src);
 
@@ -810,6 +885,7 @@ static inline void swift_unknownUnownedCopyInit(UnownedReference *dest,
 
 /// Take-initialize an unowned reference variable from one that might not
 /// refer to a native Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedTakeInit(UnownedReference *dest,
                                              UnownedReference *src);
 
@@ -826,6 +902,7 @@ static inline void swift_unknownUnownedTakeInit(UnownedReference *dest,
 
 /// Copy-assign an unowned reference variable from another when either
 /// or both variables might not refer to a native Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedCopyAssign(UnownedReference *dest,
                                                UnownedReference *src);
 
@@ -842,6 +919,7 @@ static inline void swift_unknownUnownedCopyAssign(UnownedReference *dest,
 
 /// Take-assign an unowned reference variable from another when either
 /// or both variables might not refer to a native Swift object.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownUnownedTakeAssign(UnownedReference *dest,
                                                UnownedReference *src);
 

--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -20,30 +20,46 @@
 
 namespace swift {
 
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *(*_swift_allocObject)(HeapMetadata const *metadata,
                                              size_t requiredSize,
                                              size_t requiredAlignmentMask);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" BoxPair::Return (*_swift_allocBox)(Metadata const *type);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_retain)(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_retain_n)(HeapObject *object, uint32_t n);
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *(*_swift_tryRetain)(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" bool (*_swift_isDeallocating)(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_release)(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_release_n)(HeapObject *object, uint32_t n);
 
 // liboainject on iOS 8 patches the function pointers below if present. 
 // Do not reuse these names unless you do what oainject expects you to do.
 typedef size_t AllocIndex;
+SWIFT_RUNTIME_EXPORT
 extern "C" void *(*_swift_alloc)(AllocIndex idx);
+SWIFT_RUNTIME_EXPORT
 extern "C" void *(*_swift_tryAlloc)(AllocIndex idx);
+SWIFT_RUNTIME_EXPORT
 extern "C" void *(*_swift_slowAlloc)(size_t bytes, size_t alignMask,
                                      uintptr_t flags);
+SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_dealloc)(void *ptr, AllocIndex idx);
+SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_slowDealloc)(void *ptr, size_t bytes, size_t alignMask);
+SWIFT_RUNTIME_EXPORT
 extern "C" size_t _swift_indexToSize(AllocIndex idx);
+SWIFT_RUNTIME_EXPORT
 extern "C" int _swift_sizeToIndex(size_t size);
+SWIFT_RUNTIME_EXPORT
 extern "C" void _swift_zone_init(void);
 
 };

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -561,6 +561,7 @@ typedef void destructiveInjectEnumTag(OpaqueValue *src,
 
 /// A standard routine, suitable for placement in the value witness
 /// table, for copying an opaque POD object.
+SWIFT_RUNTIME_EXPORT
 extern "C" OpaqueValue *swift_copyPOD(OpaqueValue *dest,
                                       OpaqueValue *src,
                                       const Metadata *self);
@@ -807,38 +808,55 @@ inline unsigned TypeLayout::getNumExtraInhabitants() const {
 
 // The "Int" tables are used for arbitrary POD data with the matching
 // size/alignment characteristics.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVBi8_;      // Builtin.Int8
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVBi16_;     // Builtin.Int16
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVBi32_;     // Builtin.Int32
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVBi64_;     // Builtin.Int64
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVBi128_;    // Builtin.Int128
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVBi256_;    // Builtin.Int256
 
 // The object-pointer table can be used for arbitrary Swift refcounted
 // pointer types.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVBo; // Builtin.NativeObject
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVXoBo; // unowned Builtin.NativeObject
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVXwGSqBo_; // weak Builtin.NativeObject?
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVBb; // Builtin.BridgeObject
 
 #if SWIFT_OBJC_INTEROP
 // The ObjC-pointer table can be used for arbitrary ObjC pointer types.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVBO; // Builtin.UnknownObject
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVXoBO; // unowned Builtin.UnknownObject
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVXwGSqBO_; // weak Builtin.UnknownObject?
 #endif
 
 // The () -> () table can be used for arbitrary function types.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVFT_T_;     // () -> ()
 
 // The @convention(thin) () -> () table can be used for arbitrary thin function types.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVXfT_T_;     // @convention(thin) () -> ()
 
 // The () table can be used for arbitrary empty types.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ValueWitnessTable _TWVT_;        // ()
 
 // The table for aligned-pointer-to-pointer types.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVMBo; // Builtin.NativeObject.Type
 
 /// Return the value witnesses for unmanaged pointers.
@@ -1136,16 +1154,26 @@ struct OpaqueMetadata {
 // The "Int" metadata are used for arbitrary POD data with the
 // matching characteristics.
 typedef FullMetadata<OpaqueMetadata> FullOpaqueMetadata;
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBi8_;      // Builtin.Int8
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBi16_;     // Builtin.Int16
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBi32_;     // Builtin.Int32
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBi64_;     // Builtin.Int64
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBi128_;    // Builtin.Int128
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBi256_;    // Builtin.Int256
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBo;        // Builtin.NativeObject
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBb;        // Builtin.BridgeObject
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBB;        // Builtin.UnsafeValueBuffer
 #if SWIFT_OBJC_INTEROP
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBO;        // Builtin.UnknownObject
 #endif
 
@@ -1856,6 +1884,7 @@ struct TupleTypeMetadata : public Metadata {
 };
   
 /// The standard metadata for the empty tuple type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const FullMetadata<TupleTypeMetadata> _TMT_;
 
 struct ProtocolDescriptor;
@@ -2438,6 +2467,7 @@ public:
 
 /// \brief Fetch a uniqued metadata object for a nominal type with
 /// resilient layout.
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
 swift_getResilientMetadata(GenericMetadata *pattern);
 
@@ -2458,17 +2488,20 @@ swift_getResilientMetadata(GenericMetadata *pattern);
 ///                         metadata)
 ///     return metadata
 ///   }
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
 swift_getGenericMetadata(GenericMetadata *pattern,
                          const void *arguments);
 
 // Callback to allocate a generic class metadata object.
+SWIFT_RUNTIME_EXPORT
 extern "C" ClassMetadata *
 swift_allocateGenericClassMetadata(GenericMetadata *pattern,
                                    const void *arguments,
                                    ClassMetadata *superclass);
 
 // Callback to allocate a generic struct/enum metadata object.
+SWIFT_RUNTIME_EXPORT
 extern "C" Metadata *
 swift_allocateGenericValueMetadata(GenericMetadata *pattern,
                                    const void *arguments);
@@ -2492,27 +2525,31 @@ swift_allocateGenericValueMetadata(GenericMetadata *pattern,
 ///   never form part of the uniquing key for the conformance, which
 ///   is ultimately a statement about the user model of overlapping
 ///   conformances.
-///
+SWIFT_RUNTIME_EXPORT
 extern "C" const WitnessTable *
 swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
                              const Metadata *type,
                              void * const *instantiationArgs);
 
 /// \brief Fetch a uniqued metadata for a function type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata(const void *flagsArgsAndResult[]);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
                                const void *arg0,
                                const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata2(FunctionTypeFlags flags,
                                const void *arg0,
                                const void *arg1,
                                const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
                                const void *arg0,
@@ -2521,22 +2558,27 @@ swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
                                const Metadata *resultMetadata);
 
 /// \brief Fetch a uniqued metadata for a thin function type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata(size_t numArguments,
                                   const void * argsAndResult []);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata0(const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata1(const void *arg0,
                                    const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata2(const void *arg0,
                                    const void *arg1,
                                    const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getThinFunctionTypeMetadata3(const void *arg0,
                                    const void *arg1,
@@ -2544,22 +2586,27 @@ swift_getThinFunctionTypeMetadata3(const void *arg0,
                                    const Metadata *resultMetadata);
 
 /// \brief Fetch a uniqued metadata for a C function type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata(size_t numArguments,
                                const void * argsAndResult []);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata0(const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata1(const void *arg0,
                                 const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata2(const void *arg0,
                                 const void *arg1,
                                 const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getCFunctionTypeMetadata3(const void *arg0,
                                 const void *arg1,
@@ -2568,37 +2615,45 @@ swift_getCFunctionTypeMetadata3(const void *arg0,
 
 #if SWIFT_OBJC_INTEROP
 /// \brief Fetch a uniqued metadata for a block type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getBlockTypeMetadata(size_t numArguments,
                            const void *argsAndResult []);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getBlockTypeMetadata0(const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getBlockTypeMetadata1(const void *arg0,
                             const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getBlockTypeMetadata2(const void *arg0,
                             const void *arg1,
                             const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const FunctionTypeMetadata *
 swift_getBlockTypeMetadata3(const void *arg0,
                             const void *arg1,
                             const void *arg2,
                             const Metadata *resultMetadata);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" void
 swift_instantiateObjCClass(const ClassMetadata *theClass);
 #endif
 
 /// \brief Fetch a uniqued type metadata for an ObjC class.
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
 swift_getObjCClassMetadata(const ClassMetadata *theClass);
 
 /// \brief Fetch a unique type metadata object for a foreign type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ForeignTypeMetadata *
 swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
 
@@ -2625,16 +2680,19 @@ swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
 /// \param proposedWitnesses - an optional proposed set of value witnesses.
 ///   This is useful when working with a non-dependent tuple type
 ///   where the entrypoint is just being used to unique the metadata.
+SWIFT_RUNTIME_EXPORT
 extern "C" const TupleTypeMetadata *
 swift_getTupleTypeMetadata(size_t numElements,
                            const Metadata * const *elements,
                            const char *labels,
                            const ValueWitnessTable *proposedWitnesses);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const TupleTypeMetadata *
 swift_getTupleTypeMetadata2(const Metadata *elt0, const Metadata *elt1,
                             const char *labels,
                             const ValueWitnessTable *proposedWitnesses);
+SWIFT_RUNTIME_EXPORT
 extern "C" const TupleTypeMetadata *
 swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
                             const Metadata *elt2, const char *labels,
@@ -2642,6 +2700,7 @@ swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
 
 /// Initialize the value witness table and struct field offset vector for a
 /// struct, using the "Universal" layout strategy.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_initStructMetadata_UniversalStrategy(size_t numFields,
                                          const TypeLayout * const *fieldTypes,
                                          size_t *fieldOffsets,
@@ -2654,21 +2713,25 @@ struct ClassFieldLayout {
 
 /// Initialize the field offset vector for a dependent-layout class, using the
 /// "Universal" layout strategy.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_initClassMetadata_UniversalStrategy(ClassMetadata *self,
                                       size_t numFields,
                                       const ClassFieldLayout *fieldLayouts,
                                       size_t *fieldOffsets);
 
 /// \brief Fetch a uniqued metadata for a metatype type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const MetatypeMetadata *
 swift_getMetatypeMetadata(const Metadata *instanceType);
 
 /// \brief Fetch a uniqued metadata for an existential metatype type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExistentialMetatypeMetadata *
 swift_getExistentialMetatypeMetadata(const Metadata *instanceType);
 
 /// \brief Fetch a uniqued metadata for an existential type. The array
 /// referenced by \c protocols will be sorted in-place.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExistentialTypeMetadata *
 swift_getExistentialTypeMetadata(size_t numProtocols,
                                  const ProtocolDescriptor **protocols);
@@ -2689,6 +2752,7 @@ swift_getExistentialTypeMetadata(size_t numProtocols,
 ///
 /// \return true if the cast succeeded. Depending on the flags,
 ///   swift_dynamicCast may fail rather than return false.
+SWIFT_RUNTIME_EXPORT
 extern "C" bool
 swift_dynamicCast(OpaqueValue *dest, OpaqueValue *src,
                   const Metadata *srcType,
@@ -2702,6 +2766,7 @@ swift_dynamicCast(OpaqueValue *dest, OpaqueValue *src,
 /// a Swift class type.
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastClass(const void *object, const ClassMetadata *targetType);
 
@@ -2714,6 +2779,7 @@ swift_dynamicCastClass(const void *object, const ClassMetadata *targetType);
 /// a Swift class type.
 ///
 /// \returns the object.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastClassUnconditional(const void *object,
                                     const ClassMetadata *targetType);
@@ -2726,6 +2792,7 @@ swift_dynamicCastClassUnconditional(const void *object,
 /// a class type, but not necessarily valid type metadata.
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastObjCClass(const void *object, const ClassMetadata *targetType);
 
@@ -2736,6 +2803,7 @@ swift_dynamicCastObjCClass(const void *object, const ClassMetadata *targetType);
 /// a foreign class type.
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastForeignClass(const void *object,
                               const ForeignClassMetadata *targetType);
@@ -2752,6 +2820,7 @@ swift_dynamicCastForeignClass(const void *object,
 /// a class type, but not necessarily valid type metadata.
 ///
 /// \returns the object.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastObjCClassUnconditional(const void *object,
                                         const ClassMetadata *targetType);
@@ -2763,6 +2832,7 @@ swift_dynamicCastObjCClassUnconditional(const void *object,
 /// a foreign class type.
 ///
 /// \returns the object if the cast succeeds, or null otherwise.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastForeignClassUnconditional(
   const void *object,
@@ -2777,6 +2847,7 @@ swift_dynamicCastForeignClassUnconditional(
 /// class type or a wrapped Objective-C class type.
 ///
 /// \returns the object, or null if it doesn't have the given target type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastUnknownClass(const void *object, const Metadata *targetType);
 
@@ -2791,28 +2862,35 @@ swift_dynamicCastUnknownClass(const void *object, const Metadata *targetType);
 /// class type or a wrapped Objective-C class type.
 ///
 /// \returns the object.
+SWIFT_RUNTIME_EXPORT
 extern "C" const void *
 swift_dynamicCastUnknownClassUnconditional(const void *object,
                                            const Metadata *targetType);
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
 swift_dynamicCastMetatype(const Metadata *sourceType,
                           const Metadata *targetType);
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
 swift_dynamicCastMetatypeUnconditional(const Metadata *sourceType,
                                        const Metadata *targetType);
 #if SWIFT_OBJC_INTEROP
+SWIFT_RUNTIME_EXPORT
 extern "C" const ClassMetadata *
 swift_dynamicCastObjCClassMetatype(const ClassMetadata *sourceType,
                                    const ClassMetadata *targetType);
+SWIFT_RUNTIME_EXPORT
 extern "C" const ClassMetadata *
 swift_dynamicCastObjCClassMetatypeUnconditional(const ClassMetadata *sourceType,
                                                 const ClassMetadata *targetType);
 #endif
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const ClassMetadata *
 swift_dynamicCastForeignClassMetatype(const ClassMetadata *sourceType,
                                    const ClassMetadata *targetType);
+SWIFT_RUNTIME_EXPORT
 extern "C" const ClassMetadata *
 swift_dynamicCastForeignClassMetatypeUnconditional(
   const ClassMetadata *sourceType,
@@ -2822,6 +2900,7 @@ swift_dynamicCastForeignClassMetatypeUnconditional(
 ///
 /// \param value An opaque value.
 /// \param self  The static type metadata for the opaque value.
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *
 swift_getDynamicType(OpaqueValue *value, const Metadata *self);
 
@@ -2831,11 +2910,13 @@ swift_getDynamicType(OpaqueValue *value, const Metadata *self);
 /// by KVO.
 ///
 /// The object pointer may be a tagged pointer, but cannot be null.
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *swift_getObjectType(HeapObject *object);
 
 /// \brief Perform a copy-assignment from one existential container to another.
 /// Both containers must be of the same existential type representable with the
 /// same number of witness tables.
+SWIFT_RUNTIME_EXPORT
 extern "C" OpaqueValue *swift_assignExistentialWithCopy(OpaqueValue *dest,
                                              const OpaqueValue *src,
                                              const Metadata *type);
@@ -2940,16 +3021,19 @@ inline constexpr unsigned swift_getFunctionPointerExtraInhabitantCount() {
 ///             check.
 /// \param protocol The protocol descriptor for the protocol to check
 ///                 conformance for.
+SWIFT_RUNTIME_EXPORT
 extern "C"
 const WitnessTable *swift_conformsToProtocol(const Metadata *type,
                                             const ProtocolDescriptor *protocol);
 
 /// Register a block of protocol conformance records for dynamic lookup.
+SWIFT_RUNTIME_EXPORT
 extern "C"
 void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
                                         const ProtocolConformanceRecord *end);
 
 /// Register a block of type metadata records dynamic lookup.
+SWIFT_RUNTIME_EXPORT
 extern "C"
 void swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
                                        const TypeMetadataRecord *end);

--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -73,6 +73,7 @@ namespace swift {
 // Swift reference counting. [super dealloc] MUST NOT be called after this,
 // for the object will have already been deallocated by the time
 // this function returns.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_rootObjCDealloc(HeapObject *self);
 
 }

--- a/include/swift/Runtime/Once.h
+++ b/include/swift/Runtime/Once.h
@@ -37,6 +37,7 @@ typedef std::once_flag swift_once_t;
 /// Runs the given function with the given context argument exactly once.
 /// The predicate argument must point to a global or static variable of static
 /// extent of type swift_once_t.
+SWIFT_RUNTIME_EXPORT
 extern "C"
 void swift_once(swift_once_t *predicate, void (*fn)(void *));
 

--- a/include/swift/Runtime/Reflection.h
+++ b/include/swift/Runtime/Reflection.h
@@ -47,6 +47,7 @@ struct MirrorReturn {
 /// Produce a mirror for any value. If the value's type conforms to _Reflectable,
 /// invoke its _getMirror() method; otherwise, fall back to an implementation
 /// in the runtime that structurally reflects values of any type.
+SWIFT_RUNTIME_EXPORT
 extern "C" MirrorReturn
 swift_reflectAny(OpaqueValue *value, const Metadata *T);
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -12,6 +12,13 @@ if(CXX_SUPPORTS_EXIT_TIME_DESTRUCTORS_WARNING)
   list(APPEND SWIFT_CORE_CXX_FLAGS "-Wexit-time-destructors")
 endif()
 
+# We don't want runtime C++ code to export symbols we didn't explicitly
+# choose to.
+check_cxx_compiler_flag("-fvisibility=hidden" CXX_SUPPORTS_DEFAULT_HIDDEN_VISIBILITY)
+if(CXX_SUPPORTS_DEFAULT_HIDDEN_VISIBILITY)
+  list(APPEND SWIFT_CORE_CXX_FLAGS "-fvisibility=hidden")
+endif()
+
 if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
   SwiftStddef.h
   SwiftStdint.h
   UnicodeShims.h
+  Visibility.h
   module.map
   )
 set(output_dir "${SWIFTLIB_DIR}/shims")

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -21,6 +21,7 @@
 
 #include "SwiftStdint.h"
 #include "SwiftStddef.h"
+#include "Visibility.h"
 
 #ifdef __cplusplus
 namespace swift { extern "C" {
@@ -36,27 +37,38 @@ typedef long int __swift_ssize_t;
 
 // General utilities <stdlib.h>
 // Memory management functions
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_free(void *ptr);
 
 // Input/output <stdio.h>
+SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_putchar_unlocked(int c);
 
 // String handling <string.h>
 __attribute__((pure))
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_size_t _swift_stdlib_strlen(const char *s);
+
 __attribute__((pure))
+SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_memcmp(const void *s1, const void *s2, __swift_size_t n);
 
 // <unistd.h>
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_ssize_t _swift_stdlib_read(int fd, void *buf, __swift_size_t nbyte);
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_ssize_t _swift_stdlib_write(int fd, const void *buf,
                                     __swift_size_t nbyte);
+SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_close(int fd);
 
 // Non-standard extensions
 __attribute__((const))
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_size_t _swift_stdlib_malloc_size(const void *ptr);
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint32_t _swift_stdlib_arc4random(void);
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_uint32_t _swift_stdlib_arc4random_uniform(__swift_uint32_t upper_bound);
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -20,6 +20,7 @@
 
 #include "SwiftStddef.h"
 #include "SwiftStdint.h"
+#include "Visibility.h"
 
 #ifdef __cplusplus
 namespace swift { extern "C" {
@@ -27,35 +28,45 @@ namespace swift { extern "C" {
 #define bool _Bool
 #endif
 
+SWIFT_RUNTIME_EXPORT
 bool swift_objc_class_usesNativeSwiftReferenceCounting(const void *);
 
 /// Return an NSString to be used as the Mirror summary of the object
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void *_swift_objCMirrorSummary(const void * nsObject);
 
 /// Call strtold_l with the C locale, swapping argument and return
 /// types so we can operate on Float80.  Return NULL on overflow.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const char *_swift_stdlib_strtold_clocale(const char *nptr, void *outResult);
 /// Call strtod_l with the C locale, swapping argument and return
 /// types so we can operate consistently on Float80.  Return NULL on
 /// overflow.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const char *_swift_stdlib_strtod_clocale(const char *nptr, double *outResult);
 /// Call strtof_l with the C locale, swapping argument and return
 /// types so we can operate consistently on Float80.  Return NULL on
 /// overflow.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const char *_swift_stdlib_strtof_clocale(const char *nptr, float *outResult);
 
 struct Metadata;
   
 /// Return the superclass, if any.  The result is nullptr for root
 /// classes and class protocol types.
+SWIFT_RUNTIME_EXPORT
 const struct Metadata *swift_class_getSuperclass(
   const struct Metadata *);
   
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_flockfile_stdout(void);
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_funlockfile_stdout(void);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_putc_stderr(int C);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_size_t _swift_stdlib_getHardwareConcurrency();
 
 #ifdef __cplusplus

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -17,6 +17,9 @@
 #ifndef SWIFT_STDLIB_SHIMS_UNICODESHIMS_H_
 #define SWIFT_STDLIB_SHIMS_UNICODESHIMS_H_
 
+#include "Visibility.h"
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern const __swift_uint8_t *_swift_stdlib_GraphemeClusterBreakPropertyTrie;
 
 struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy {
@@ -41,39 +44,48 @@ struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy {
   unsigned SuppDataBytesOffset;
 };
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern const struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy
 _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadata;
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern const __swift_uint16_t *
 _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix;
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __attribute__((pure))
 __swift_int32_t _swift_stdlib_unicode_compare_utf16_utf16(
   const __swift_uint16_t *Left, __swift_int32_t LeftLength,
   const __swift_uint16_t *Right, __swift_int32_t RightLength);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __attribute__((pure))
 __swift_int32_t _swift_stdlib_unicode_compare_utf8_utf16(
   const char *Left, __swift_int32_t LeftLength,
   const __swift_uint16_t *Right, __swift_int32_t RightLength);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __attribute__((pure))
 __swift_int32_t _swift_stdlib_unicode_compare_utf8_utf8(
   const char *Left, __swift_int32_t LeftLength,
   const char *Right, __swift_int32_t RightLength);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __attribute__((pure))
 __swift_intptr_t _swift_stdlib_unicode_hash(
   const __swift_uint16_t *Str, __swift_int32_t Length);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __attribute__((pure))
 __swift_intptr_t _swift_stdlib_unicode_hash_ascii(
   const char *Str, __swift_int32_t Length);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_int32_t _swift_stdlib_unicode_strToUpper(
   __swift_uint16_t *Destination, __swift_int32_t DestinationCapacity,
   const __swift_uint16_t *Source, __swift_int32_t SourceLength);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_int32_t _swift_stdlib_unicode_strToLower(
   __swift_uint16_t *Destination, __swift_int32_t DestinationCapacity,
   const __swift_uint16_t *Source, __swift_int32_t SourceLength);

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -1,0 +1,42 @@
+//===--- Visibility.h - Visibility macros for runtime exports -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  These macros are used to declare symbols that should be exported from the
+//  Swift runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_VISIBILITY_H
+#define SWIFT_STDLIB_SHIMS_VISIBILITY_H
+
+/// Attribute used to export symbols from the runtime.
+#if __MACH__
+# define SWIFT_RUNTIME_EXPORT __attribute__((visibility("default")))
+#elif __ELF__
+// Use protected visibility for ELF, since we don't want Swift symbols to be
+// interposable. The relative relocations we form to metadata aren't
+// valid in ELF shared objects, and leaving them relocatable at load time
+// defeats the purpose of the relative references.
+# define SWIFT_RUNTIME_EXPORT __attribute__((visibility("protected")))
+#else
+// __dllexport/__dllimport for Windows?
+# error "Unimplemented object format"
+#endif
+
+/// Attribute for runtime-stdlib SPI interfaces.
+///
+/// Since the stdlib is currently fully fragile, runtime-stdlib SPI currently
+/// needs to be exported from the core dylib. When the stdlib admits more
+//resilience we may be able to make this hidden.
+#define SWIFT_RUNTIME_STDLIB_INTERFACE SWIFT_RUNTIME_EXPORT
+
+#endif

--- a/stdlib/public/SwiftShims/module.map
+++ b/stdlib/public/SwiftShims/module.map
@@ -10,5 +10,6 @@ module SwiftShims {
   header "SwiftStddef.h"
   header "SwiftStdint.h"
   header "UnicodeShims.h"
+  header "Visibility.h"
   export *
 }

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -340,6 +340,7 @@ std::string swift::nameForMetadata(const Metadata *type,
   return result;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C"
 TwoWordPair<const char *, uintptr_t>::Return
 swift_getTypeName(const Metadata *type, bool qualified) {
@@ -805,6 +806,7 @@ static void deallocateDynamicValue(OpaqueValue *value, const Metadata *type) {
 }
 
 #if SWIFT_OBJC_INTEROP
+SWIFT_RUNTIME_EXPORT
 extern "C" id
 swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
   switch (metatype->getKind()) {
@@ -836,6 +838,7 @@ swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
   }
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" id
 swift_dynamicCastMetatypeToObjectUnconditional(const Metadata *metatype) {
   switch (metatype->getKind()) {
@@ -2512,6 +2515,7 @@ findBridgeWitness(const Metadata *T) {
 }
 
 /// \param value passed at +1, consumed.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" HeapObject *swift_bridgeNonVerbatimToObjectiveC(
   OpaqueValue *value, const Metadata *T
 ) {
@@ -2534,6 +2538,7 @@ extern "C" HeapObject *swift_bridgeNonVerbatimToObjectiveC(
   return nullptr;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" const Metadata *swift_getBridgedNonVerbatimObjectiveCType(
   const Metadata *value, const Metadata *T
 ) {
@@ -2555,6 +2560,7 @@ extern "C" const Metadata *swift_getBridgedNonVerbatimObjectiveCType(
 //     nativeType: NativeType.Type
 //     inout result: T?
 // )
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void
 swift_bridgeNonVerbatimFromObjectiveC(
   HeapObject *sourceValue,
@@ -2597,6 +2603,7 @@ swift_bridgeNonVerbatimFromObjectiveC(
 //   nativeType: T.Type,
 //   inout result: T?
 // ) -> Bool
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" bool
 swift_bridgeNonVerbatimFromObjectiveCConditional(
   HeapObject *sourceValue,
@@ -2636,6 +2643,7 @@ swift_bridgeNonVerbatimFromObjectiveCConditional(
 }
 
 // func isBridgedNonVerbatimToObjectiveC<T>(x: T.Type) -> Bool
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" bool swift_isBridgedNonVerbatimToObjectiveC(
   const Metadata *value, const Metadata *T
 ) {
@@ -2647,12 +2655,14 @@ extern "C" bool swift_isBridgedNonVerbatimToObjectiveC(
 #endif
 
 // func isClassOrObjCExistential<T>(x: T.Type) -> Bool
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isClassOrObjCExistentialType(const Metadata *value,
                                                const Metadata *T) {
   return swift_isClassOrObjCExistentialTypeImpl(T);
 }
 
 // func swift_class_getSuperclass(_: AnyClass) -> AnyClass?
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *swift_class_getSuperclass(
   const Metadata *theClass
 ) {
@@ -2662,10 +2672,12 @@ extern "C" const Metadata *swift_class_getSuperclass(
   return nullptr;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isClassType(const Metadata *type) {
   return Metadata::isAnyKindOfClass(type->getKind());
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" bool swift_isOptionalType(const Metadata *type) {
   return type->getKind() == MetadataKind::Optional;
 }

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -142,12 +142,14 @@ struct SwiftError : SwiftErrorHeader {
 /// copied (or taken if \c isTake is true) into the newly-allocated error box.
 /// If value is null, the box's contents will be left uninitialized, and
 /// \c isTake should be false.
+SWIFT_RUNTIME_EXPORT
 extern "C" BoxPair::Return swift_allocError(const Metadata *type,
                                           const WitnessTable *errorConformance,
                                           OpaqueValue *value, bool isTake);
   
 /// Deallocate an error object whose contained object has already been
 /// destroyed.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_deallocError(SwiftError *error, const Metadata *type);
 
 struct ErrorValueResult {
@@ -163,21 +165,28 @@ struct ErrorValueResult {
 /// temporary buffer. The implementation may write a reference to itself to
 /// that buffer if the error object is a toll-free-bridged NSError instead of
 /// a native Swift error, in which case the object itself is the "boxed" value.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_getErrorValue(const SwiftError *errorObject,
                                     void **scratch,
                                     ErrorValueResult *out);
 
 /// Retain and release SwiftError boxes.
+SWIFT_RUNTIME_EXPORT
 extern "C" SwiftError *swift_errorRetain(SwiftError *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_errorRelease(SwiftError *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_errorInMain(SwiftError *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_willThrow(SwiftError *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unexpectedError(SwiftError *object)
   __attribute__((noreturn));
 
 #if SWIFT_OBJC_INTEROP
 
 /// Initialize an ErrorType box to make it usable as an NSError instance.
+SWIFT_RUNTIME_EXPORT
 extern "C" id swift_bridgeErrorTypeToNSError(SwiftError *errorObject);
 
 /// Attempt to dynamically cast an NSError instance to a Swift ErrorType

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -150,6 +150,7 @@ _swift_allocError_(const Metadata *type,
   return BoxPair{reinterpret_cast<HeapObject*>(instance), valuePtr};
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_allocError = _swift_allocError_;
 
 BoxPair::Return
@@ -167,6 +168,7 @@ _swift_deallocError_(SwiftError *error,
   object_dispose((id)error);
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_deallocError = _swift_deallocError_;
 
 void
@@ -246,6 +248,7 @@ _swift_getErrorValue_(const SwiftError *errorObject,
   return;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_getErrorValue = _swift_getErrorValue_;
 
 void
@@ -306,6 +309,7 @@ static id _swift_bridgeErrorTypeToNSError_(SwiftError *errorObject) {
   return ns;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_bridgeErrorTypeToNSError = _swift_bridgeErrorTypeToNSError_;
 
 id
@@ -400,6 +404,7 @@ static SwiftError *_swift_errorRetain_(SwiftError *error) {
   return (SwiftError*)objc_retain((id)error);
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_errorRetain = _swift_errorRetain_;
 
 SwiftError *swift::swift_errorRetain(SwiftError *error) {
@@ -411,6 +416,7 @@ static void _swift_errorRelease_(SwiftError *error) {
   return objc_release((id)error);
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_errorRelease = _swift_errorRelease_;
 
 void swift::swift_errorRelease(SwiftError *error) {
@@ -419,6 +425,7 @@ void swift::swift_errorRelease(SwiftError *error) {
 
 static void _swift_willThrow_(SwiftError *error) { }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" auto *_swift_willThrow = _swift_willThrow_;
 
 void swift::swift_willThrow(SwiftError *error) {

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -234,6 +234,7 @@ swift::fatalError(uint32_t flags, const char *format, ...)
 }
 
 // Crash when a deleted method is called by accident.
+SWIFT_RUNTIME_EXPORT
 LLVM_ATTRIBUTE_NORETURN
 extern "C" void
 swift_deletedMethodError() {

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -91,6 +91,7 @@ swift::swift_verifyEndOfLifetime(HeapObject *object) {
 /// \brief Allocate a reference-counted object on the heap that
 /// occupies <size> bytes of maximally-aligned storage.  The object is
 /// uninitialized except for its header.
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject* swift_bufferAllocate(
   HeapMetadata const* bufferType, size_t size, size_t alignMask)
 {
@@ -102,6 +103,7 @@ extern "C" HeapObject* swift_bufferAllocate(
 /// optimized module is imported into a non-optimized main module.
 /// TODO: This is only a workaround. Remove this function as soon as we can
 /// get rid of the llvm SwiftStackPromotion pass.
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject* swift_bufferAllocateOnStack(
   HeapMetadata const* bufferType, size_t size, size_t alignMask) {
   return swift::swift_allocObject(bufferType, size, alignMask);
@@ -113,9 +115,11 @@ extern "C" HeapObject* swift_bufferAllocateOnStack(
 /// optimized module is imported into a non-optimized main module.
 /// TODO: This is only a workaround. Remove this function as soon as we can
 /// get rid of the llvm SwiftStackPromotion pass.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_bufferDeallocateFromStack(HeapObject *) {
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" intptr_t swift_bufferHeaderSize() { return sizeof(HeapObject); }
 
 namespace {
@@ -439,6 +443,7 @@ void swift::swift_deallocClassInstance(HeapObject *object,
 }
 
 /// Variant of the above used in constructor failure paths.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
                                                   HeapMetadata const *metadata,
                                                   size_t allocatedSize,

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -25,12 +25,16 @@ namespace swift {
 struct HeapObject;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_leaks_startTrackingObjects(const char *)
     __attribute__((noinline, used));
+SWIFT_RUNTIME_EXPORT
 extern "C" int swift_leaks_stopTrackingObjects(const char *)
     __attribute__((noinline, used));
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_leaks_startTrackingObject(swift::HeapObject *)
     __attribute__((noinline, used));
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_leaks_stopTrackingObject(swift::HeapObject *)
     __attribute__((noinline, used));
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1726,6 +1726,7 @@ getMetatypeValueWitnesses(const Metadata *instanceType) {
 }
 
 /// \brief Fetch a uniqued metadata for a metatype type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const MetatypeMetadata *
 swift::swift_getMetatypeMetadata(const Metadata *instanceMetadata) {
   // Search the cache.
@@ -1837,6 +1838,7 @@ getExistentialMetatypeValueWitnesses(ExistentialMetatypeState &EM,
 }
 
 /// \brief Fetch a uniqued metadata for a metatype type.
+SWIFT_RUNTIME_EXPORT
 extern "C" const ExistentialMetatypeMetadata *
 swift::swift_getExistentialMetatypeMetadata(const Metadata *instanceMetadata) {
   // Search the cache.
@@ -2425,6 +2427,7 @@ Metadata::getClassObject() const {
 }
 
 #ifndef NDEBUG
+SWIFT_RUNTIME_EXPORT
 extern "C"
 void _swift_debug_verifyTypeLayoutAttribute(Metadata *type,
                                             const void *runtimeValue,
@@ -2457,6 +2460,7 @@ void _swift_debug_verifyTypeLayoutAttribute(Metadata *type,
 }
 #endif
 
+SWIFT_RUNTIME_EXPORT
 extern "C"
 void swift_initializeSuperclass(ClassMetadata *theClass,
                                 bool copyFieldOffsetVectors) {
@@ -2468,12 +2472,6 @@ void swift_initializeSuperclass(ClassMetadata *theClass,
   swift_instantiateObjCClass(theClass);
 #endif
 }
-
-namespace llvm { namespace hashing { namespace detail {
-  // An extern variable expected by LLVM's hashing templates. We don't link any
-  // LLVM libs into the runtime, so define this here.
-  size_t fixed_seed_override = 0;
-} } }
 
 /*** Protocol witness tables *************************************************/
 
@@ -2597,6 +2595,7 @@ allocateWitnessTable(GenericWitnessTable *genericTable,
   return entry;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const WitnessTable *
 swift::swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
                                     const Metadata *type,

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -312,6 +312,7 @@ _typeByMangledName(const llvm::StringRef typeName) {
 /// implementation of _typeByName(). The human readable name returned
 /// by swift_getTypeName() is non-unique, so we used mangled names
 /// internally.
+SWIFT_RUNTIME_EXPORT
 extern "C"
 const Metadata *
 swift_getTypeByMangledName(const char *typeName, size_t typeNameLength) {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -26,6 +26,7 @@ namespace swift {
   struct ProtocolDescriptor;
 
 #if SWIFT_HAS_ISA_MASKING
+  SWIFT_RUNTIME_EXPORT
   extern "C" uintptr_t swift_isaMask;
 #endif
 

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -261,6 +261,7 @@ static_assert(offsetof(MagicMirror, MirrorWitness) ==
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
   
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 AnyReturn swift_MagicMirrorData_value(HeapObject *owner,
                                       const OpaqueValue *value,
@@ -273,6 +274,7 @@ AnyReturn swift_MagicMirrorData_value(HeapObject *owner,
 
   return AnyReturn(result);
 }
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const Metadata *swift_MagicMirrorData_valueType(HeapObject *owner,
                                                 const OpaqueValue *value,
@@ -281,6 +283,7 @@ const Metadata *swift_MagicMirrorData_valueType(HeapObject *owner,
 }
 
 #if SWIFT_OBJC_INTEROP
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 AnyReturn swift_MagicMirrorData_objcValue(HeapObject *owner,
                                           const OpaqueValue *value,
@@ -298,6 +301,7 @@ AnyReturn swift_MagicMirrorData_objcValue(HeapObject *owner,
 
 #pragma clang diagnostic pop
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const char *swift_OpaqueSummary(const Metadata *T) {
   switch (T->getKind()) {
@@ -330,6 +334,7 @@ const char *swift_OpaqueSummary(const Metadata *T) {
   }
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 void swift_MagicMirrorData_summary(const Metadata *T, String *result) {
   switch (T->getKind()) {
@@ -379,7 +384,7 @@ void swift_MagicMirrorData_summary(const Metadata *T, String *result) {
   }
 }
 
-  
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const Metadata *swift_MagicMirrorData_objcValueType(HeapObject *owner,
                                                     const OpaqueValue *value,
@@ -391,6 +396,7 @@ const Metadata *swift_MagicMirrorData_objcValueType(HeapObject *owner,
   
 // -- Tuple destructuring.
   
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 intptr_t swift_TupleMirror_count(HeapObject *owner,
                                  const OpaqueValue *value,
@@ -497,6 +503,7 @@ static Mirror reflect(HeapObject *owner,
   
 /// \param owner passed at +1, consumed.
 /// \param value passed unowned.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 StringMirrorTuple swift_TupleMirror_subscript(intptr_t i,
                                               HeapObject *owner,
@@ -543,6 +550,7 @@ static const char *getFieldName(const char *fieldNames, size_t i) {
 
 // -- Struct destructuring.
   
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 intptr_t swift_StructMirror_count(HeapObject *owner,
                                   const OpaqueValue *value,
@@ -551,6 +559,7 @@ intptr_t swift_StructMirror_count(HeapObject *owner,
   return Struct->Description->Struct.NumFields;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 StringMirrorTuple swift_StructMirror_subscript(intptr_t i,
                                                HeapObject *owner,
@@ -629,6 +638,7 @@ static void getEnumMirrorInfo(const OpaqueValue *value,
     *indirectPtr = indirect;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const char *swift_EnumMirror_caseName(HeapObject *owner,
                                       const OpaqueValue *value,
@@ -644,6 +654,7 @@ const char *swift_EnumMirror_caseName(HeapObject *owner,
   return getFieldName(Description.CaseNames, tag);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
   // Build a magic mirror. Unconditionally destroy the value at the end.
@@ -669,6 +680,7 @@ const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *type) {
   return result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 intptr_t swift_EnumMirror_count(HeapObject *owner,
                                 const OpaqueValue *value,
@@ -681,6 +693,7 @@ intptr_t swift_EnumMirror_count(HeapObject *owner,
   return (payloadType != nullptr) ? 1 : 0;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 StringMirrorTuple swift_EnumMirror_subscript(intptr_t i,
                                              HeapObject *owner,
@@ -726,6 +739,7 @@ static Mirror getMirrorForSuperclass(const ClassMetadata *sup,
                                      const OpaqueValue *value,
                                      const Metadata *type);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 intptr_t swift_ClassMirror_count(HeapObject *owner,
                                  const OpaqueValue *value,
@@ -744,6 +758,7 @@ intptr_t swift_ClassMirror_count(HeapObject *owner,
 
 /// \param owner passed at +1, consumed.
 /// \param value passed unowned.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 StringMirrorTuple swift_ClassMirror_subscript(intptr_t i,
                                               HeapObject *owner,
@@ -865,6 +880,7 @@ static const Metadata *getMetadataForEncoding(const char *encoding) {
 
 /// \param owner passed at +1, consumed.
 /// \param value passed unowned.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 intptr_t swift_ObjCMirror_count(HeapObject *owner,
                                 const OpaqueValue *value,
@@ -900,6 +916,7 @@ static Mirror ObjC_getMirrorForSuperclass(Class sup,
                                           const OpaqueValue *value,
                                           const Metadata *type);
   
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 StringMirrorTuple swift_ObjCMirror_subscript(intptr_t i,
                                              HeapObject *owner,
@@ -963,6 +980,7 @@ StringMirrorTuple swift_ObjCMirror_subscript(intptr_t i,
 #endif
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" OptionalPlaygroundQuickLook
 swift_ClassMirror_quickLookObject(HeapObject *owner, const OpaqueValue *value,
                                   const Metadata *type) {
@@ -1319,6 +1337,7 @@ MirrorReturn swift::swift_reflectAny(OpaqueValue *value, const Metadata *T) {
 
 // NB: This function is not used directly in the Swift codebase, but is
 // exported for Xcode support. Please coordinate before changing.
+SWIFT_RUNTIME_EXPORT
 extern "C" void swift_stdlib_demangleName(const char *mangledName,
                                           size_t mangledNameLength,
                                           String *demangledName) {

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -88,6 +88,7 @@ static_assert(std::is_trivially_destructible<SwiftObject_s>::value,
 #if __has_attribute(objc_root_class)
 __attribute__((objc_root_class))
 #endif
+SWIFT_RUNTIME_EXPORT
 @interface SwiftObject<NSObject> {
   // FIXME: rdar://problem/18950072 Clang emits ObjC++ classes as having
   // non-trivial structors if they contain any struct fields at all, regardless of
@@ -1031,6 +1032,7 @@ bool swift::classConformsToObjCProtocol(const void *theClass,
   return [((Class) theClass) conformsToProtocol: (Protocol*) protocol];
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolUnconditional(
                                                  const Metadata *type,
                                                  size_t numProtocols,
@@ -1079,6 +1081,7 @@ extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolUnconditional(
   return type;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolConditional(
                                                 const Metadata *type,
                                                 size_t numProtocols,
@@ -1125,6 +1128,7 @@ extern "C" const Metadata *swift_dynamicCastTypeToObjCProtocolConditional(
   return type;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" id swift_dynamicCastObjCProtocolUnconditional(id object,
                                                  size_t numProtocols,
                                                  Protocol * const *protocols) {
@@ -1139,6 +1143,7 @@ extern "C" id swift_dynamicCastObjCProtocolUnconditional(id object,
   return object;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" id swift_dynamicCastObjCProtocolConditional(id object,
                                                  size_t numProtocols,
                                                  Protocol * const *protocols) {
@@ -1151,7 +1156,7 @@ extern "C" id swift_dynamicCastObjCProtocolConditional(id object,
   return object;
 }
 
-extern "C" void swift::swift_instantiateObjCClass(const ClassMetadata *_c) {
+void swift::swift_instantiateObjCClass(const ClassMetadata *_c) {
   static const objc_image_info ImageInfo = {0, 0};
 
   // Ensure the superclass is realized.
@@ -1165,6 +1170,7 @@ extern "C" void swift::swift_instantiateObjCClass(const ClassMetadata *_c) {
   (void)registered;
 }
 
+SWIFT_RUNTIME_EXPORT
 extern "C" Class swift_getInitializedObjCClass(Class c) {
   // Used when we have class metadata and we want to ensure a class has been
   // initialized by the Objective C runtime. We need to do this because the
@@ -1336,6 +1342,7 @@ bool swift::swift_isUniquelyReferencedOrPinned_nonNull_native(
 
 using ClassExtents = TwoWordPair<size_t, size_t>;
 
+SWIFT_RUNTIME_EXPORT
 extern "C"
 ClassExtents::Return
 swift_class_getInstanceExtents(const Metadata *c) {
@@ -1348,6 +1355,8 @@ swift_class_getInstanceExtents(const Metadata *c) {
 }
 
 #if SWIFT_OBJC_INTEROP
+
+SWIFT_RUNTIME_EXPORT
 extern "C"
 ClassExtents::Return
 swift_objc_class_unknownGetInstanceExtents(const ClassMetadata* c) {
@@ -1357,6 +1366,7 @@ swift_objc_class_unknownGetInstanceExtents(const ClassMetadata* c) {
   
   return swift_class_getInstanceExtents(c);
 }
+
 #endif
 
 const ClassMetadata *swift::getRootSuperclass() {

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 #include <cstdint>
 #include <stdio.h>
@@ -24,6 +25,7 @@ using namespace swift;
 // Report a fatal error to system console, stderr, and crash logs.
 // <prefix>: <message>: file <file>, line <line>\n
 // The message may be omitted by passing messageLength=0.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void
 _swift_stdlib_reportFatalErrorInFile(const char *prefix, intptr_t prefixLength,
                                    const char *message, intptr_t messageLength,
@@ -42,6 +44,7 @@ _swift_stdlib_reportFatalErrorInFile(const char *prefix, intptr_t prefixLength,
 // Report a fatal error to system console, stderr, and crash logs.
 // <prefix>: <message>: file <file>, line <line>\n
 // The message may be omitted by passing messageLength=0.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void
 _swift_stdlib_reportFatalError(const char *prefix,
                                intptr_t prefixLength,
@@ -59,6 +62,7 @@ _swift_stdlib_reportFatalError(const char *prefix,
 // Report a call to an unimplemented initializer.
 // <file>: <line>: <column>: fatal error: use of unimplemented
 // initializer '<initName>' for class 'className'
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void
 _swift_stdlib_reportUnimplementedInitializerInFile(
          const char *className, intptr_t classNameLength, const char *initName,
@@ -77,6 +81,7 @@ _swift_stdlib_reportUnimplementedInitializerInFile(
 // Report a call to an unimplemented initializer.
 // fatal error: use of unimplemented initializer '<initName>' for class
 // 'className'
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void
 _swift_stdlib_reportUnimplementedInitializer(const char *className,
                                              intptr_t classNameLength,

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -74,6 +74,7 @@ static NSOperatingSystemVersion operatingSystemVersionFromPlist() {
 
 /// Return the version of the operating system currently running for use in
 /// API availability queries.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" NSOperatingSystemVersion _swift_stdlib_operatingSystemVersion() {
   static NSOperatingSystemVersion version = ([]{
     // Use -[NSProcessInfo.operatingSystemVersion] when present

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -17,7 +17,9 @@
 //===----------------------------------------------------------------------===//
 
 #import <CoreFoundation/CoreFoundation.h>
+#include "swift/Runtime/Config.h"
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 void _swift_stdlib_CFStringGetCharacters(CFStringRef theString,
                                          CFRange range,
@@ -25,16 +27,19 @@ void _swift_stdlib_CFStringGetCharacters(CFStringRef theString,
   return CFStringGetCharacters(theString, range, buffer);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const UniChar * _swift_stdlib_CFStringGetCharactersPtr(CFStringRef theString) {
   return CFStringGetCharactersPtr(theString);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 CFIndex _swift_stdlib_CFStringGetLength(CFStringRef theString) {
   return CFStringGetLength(theString);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 CFStringRef _swift_stdlib_CFStringCreateWithSubstring(CFAllocatorRef alloc,
                                                       CFStringRef str,
@@ -42,12 +47,14 @@ CFStringRef _swift_stdlib_CFStringCreateWithSubstring(CFAllocatorRef alloc,
   return CFStringCreateWithSubstring(alloc, str, range);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 UniChar _swift_stdlib_CFStringGetCharacterAtIndex(CFStringRef theString,
                                                   CFIndex idx) {
   return CFStringGetCharacterAtIndex(theString, idx);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 CFStringRef
 _swift_stdlib_CFStringCreateCopy(CFAllocatorRef alloc,
@@ -55,12 +62,14 @@ _swift_stdlib_CFStringCreateCopy(CFAllocatorRef alloc,
   return CFStringCreateCopy(alloc, theString);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const char *_swift_stdlib_CFStringGetCStringPtr(CFStringRef theString,
                                                 CFStringEncoding encoding) {
   return CFStringGetCStringPtr(theString, encoding);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" CFComparisonResult
 _swift_stdlib_CFStringCompare(CFStringRef theString1,
                               CFStringRef theString2,
@@ -68,6 +77,7 @@ _swift_stdlib_CFStringCompare(CFStringRef theString1,
   return CFStringCompare(theString1, theString2, compareOptions);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" Boolean
 _swift_stdlib_CFStringFindWithOptions(CFStringRef theString,
                                       CFStringRef stringToFind,
@@ -78,6 +88,7 @@ _swift_stdlib_CFStringFindWithOptions(CFStringRef theString,
                                  searchOptions, result);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" CFStringRef
 _swift_stdlib_objcDebugDescription(id __nonnull nsObject) {
   return (__bridge CFStringRef)[nsObject debugDescription];

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -21,8 +21,10 @@
 namespace swift {
 
 // _direct type metadata for Swift._EmptyArrayStorage
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" ClassMetadata _TMCs18_EmptyArrayStorage;
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" _SwiftEmptyArrayStorage _swiftEmptyArrayStorage = {
   // HeapObject header;
   {
@@ -36,7 +38,15 @@ extern "C" _SwiftEmptyArrayStorage _swiftEmptyArrayStorage = {
   }
 };
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride = 0;
 
 }
+
+namespace llvm { namespace hashing { namespace detail {
+  // An extern variable expected by LLVM's hashing templates. We don't link any
+  // LLVM libs into the runtime, so define this here.
+  size_t fixed_seed_override = 0;
+} } }
+

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -62,6 +62,7 @@ static uint64_t uint64ToStringImpl(char *Buffer, uint64_t Value,
   return size_t(P - Buffer);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
                                         int64_t Value, int64_t Radix,
                                         bool Uppercase) {
@@ -85,6 +86,7 @@ extern "C" uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
                             Negative);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" uint64_t swift_uint64ToString(char *Buffer, intptr_t BufferLength,
                                          uint64_t Value, int64_t Radix,
                                          bool Uppercase) {
@@ -173,18 +175,21 @@ static uint64_t swift_floatingPointToString(char *Buffer, size_t BufferLength,
   return i;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" uint64_t swift_float32ToString(char *Buffer, size_t BufferLength,
                                           float Value, bool Debug) {
   return swift_floatingPointToString<float>(Buffer, BufferLength, Value,
                                             "%0.*g", Debug);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" uint64_t swift_float64ToString(char *Buffer, size_t BufferLength,
                                           double Value, bool Debug) {
   return swift_floatingPointToString<double>(Buffer, BufferLength, Value,
                                              "%0.*g", Debug);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
                                           long double Value, bool Debug) {
   return swift_floatingPointToString<long double>(Buffer, BufferLength, Value,
@@ -196,19 +201,23 @@ extern "C" uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
 ///
 /// \returns Size of character data returned in \c LinePtr, or -1
 /// if an error occurred, or EOF was reached.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" ssize_t swift_stdlib_readLine_stdin(char **LinePtr) {
   size_t Capacity = 0;
   return getline(LinePtr, &Capacity, stdin);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" float _swift_fmodf(float lhs, float rhs) {
     return fmodf(lhs, rhs);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" double _swift_fmod(double lhs, double rhs) {
     return fmod(lhs, rhs);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
     return fmodl(lhs, rhs);
 }
@@ -226,6 +235,7 @@ extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
     (defined(__linux__) && defined(__powerpc64__))
 
 typedef int      ti_int __attribute__ ((mode (TI)));
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 ti_int
 __muloti4(ti_int a, ti_int b, int* overflow)
@@ -275,6 +285,7 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // missing.  Perhaps relevant bug report:
 // FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
 typedef int      di_int __attribute__ ((mode (DI)));
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 di_int
 __mulodi4(di_int a, di_int b, int* overflow)
@@ -334,36 +345,43 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   return EndPtr;
 }
     
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" const char *_swift_stdlib_strtold_clocale(
   const char * nptr, void *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(
     nptr, static_cast<long double*>(outResult), HUGE_VALL, strtold_l);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" const char *_swift_stdlib_strtod_clocale(
     const char * nptr, double *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(
     nptr, outResult, HUGE_VAL, strtod_l);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" const char *_swift_stdlib_strtof_clocale(
     const char * nptr, float *outResult) {
   return _swift_stdlib_strtoX_clocale_impl(
     nptr, outResult, HUGE_VALF, strtof_l);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void _swift_stdlib_flockfile_stdout() {
   flockfile(stdout);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void _swift_stdlib_funlockfile_stdout() {
   funlockfile(stdout);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" int _swift_stdlib_putc_stderr(int C) {
   return putc(C, stderr);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" size_t _swift_stdlib_getHardwareConcurrency() {
   return sysconf(_SC_NPROCESSORS_ONLN);
 }

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -45,6 +45,7 @@
 using namespace swift;
 
 % for Class in ('Array', 'Dictionary', 'Set', 'String', 'Enumerator'):
+SWIFT_RUNTIME_STDLIB_INTERFACE
 @interface _SwiftNativeNS${Class}Base : NS${Class}
 {
   // TODO: Workaround for rdar://problem/18950072
@@ -94,6 +95,7 @@ using namespace swift;
 @end
 % end
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" bool
 swift_stdlib_NSObject_isEqual(NSObject *NS_RELEASES_ARGUMENT lhs,
                               NSObject *NS_RELEASES_ARGUMENT rhs) {
@@ -103,6 +105,7 @@ swift_stdlib_NSObject_isEqual(NSObject *NS_RELEASES_ARGUMENT lhs,
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
     NSString *NS_RELEASES_ARGUMENT lhs, NSString *NS_RELEASES_ARGUMENT rhs) {
   // 'kCFCompareNonliteral' actually means "normalize to NFD".
@@ -113,6 +116,7 @@ extern "C" int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" size_t
 swift_stdlib_NSStringNFDHashValue(NSString *NS_RELEASES_ARGUMENT str) {
   int Result = str.decomposedStringWithCanonicalMapping.hash;
@@ -121,6 +125,7 @@ swift_stdlib_NSStringNFDHashValue(NSString *NS_RELEASES_ARGUMENT str) {
 }
 
 // For strings we know only have ASCII
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" size_t
 swift_stdlib_NSStringASCIIHashValue(NSString *NS_RELEASES_ARGUMENT str) {
   int Result = str.hash;
@@ -128,6 +133,7 @@ swift_stdlib_NSStringASCIIHashValue(NSString *NS_RELEASES_ARGUMENT str) {
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
                                                   NSString *prefix) {
   auto Length = CFStringGetLength((__bridge CFStringRef)theString);
@@ -140,6 +146,7 @@ extern "C" bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" bool
 swift_stdlib_NSStringHasSuffixNFD(NSString *NS_RELEASES_ARGUMENT theString,
                                   NSString *NS_RELEASES_ARGUMENT suffix) {
@@ -153,6 +160,7 @@ swift_stdlib_NSStringHasSuffixNFD(NSString *NS_RELEASES_ARGUMENT theString,
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" NS_RETURNS_RETAINED NSString *
 swift_stdlib_NSStringLowercaseString(NSString *NS_RELEASES_ARGUMENT str) {
   NSString *Result = objc_retain(str.lowercaseString);
@@ -160,6 +168,7 @@ swift_stdlib_NSStringLowercaseString(NSString *NS_RELEASES_ARGUMENT str) {
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" NS_RETURNS_RETAINED NSString *
 swift_stdlib_NSStringUppercaseString(NSString *NS_RELEASES_ARGUMENT str) {
   NSString *Result = objc_retain(str.uppercaseString);
@@ -167,6 +176,7 @@ swift_stdlib_NSStringUppercaseString(NSString *NS_RELEASES_ARGUMENT str) {
   return Result;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" void swift_stdlib_CFSetGetValues(NSSet *NS_RELEASES_ARGUMENT set,
                                             const void **values) {
   CFSetGetValues((__bridge CFSetRef)set, values);

--- a/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
+++ b/stdlib/public/stubs/UnicodeExtendedGraphemeClusters.cpp.gyb
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Runtime/Config.h"
+
 %{
 
 # FIXME: this table should be moved to a Swift file in stdlib.  Unfortunately,
@@ -56,12 +58,14 @@ trie_generator.serialize(grapheme_cluster_break_property_table)
 
 #include <stdint.h>
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const uint8_t _swift_stdlib_GraphemeClusterBreakPropertyTrieImpl[] = {
 % for byte in trie_generator.trie_bytes:
   ${byte},
 % end
 };
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 const uint8_t *_swift_stdlib_GraphemeClusterBreakPropertyTrie =
     _swift_stdlib_GraphemeClusterBreakPropertyTrieImpl;
@@ -88,6 +92,7 @@ struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy {
   unsigned SuppDataBytesOffset;
 };
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" const struct _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadataTy
 _swift_stdlib_GraphemeClusterBreakPropertyTrieMetadata = {
   ${trie_generator.BMP_first_level_index_bits},
@@ -118,12 +123,15 @@ extended_grapheme_cluster_rules_matrix = \
 
 }%
 
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const uint16_t _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrixImpl[] = {
 % for row in get_extended_grapheme_cluster_rules_matrix(grapheme_cluster_break_property_table):
   ${row},
 % end
 };
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const uint16_t *_swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix =
     _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrixImpl;
 

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -123,6 +123,7 @@ private:
 ///  <0 the left string is less than the right string.
 /// ==0 the strings are equal according to their collation.
 ///  >0 the left string is greater than the right string.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 int32_t _swift_stdlib_unicode_compare_utf16_utf16(const uint16_t *LeftString,
                                                   int32_t LeftLength,
@@ -138,6 +139,7 @@ int32_t _swift_stdlib_unicode_compare_utf16_utf16(const uint16_t *LeftString,
 ///  <0 the left string is less than the right string.
 /// ==0 the strings are equal according to their collation.
 ///  >0 the left string is greater than the right string.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 int32_t _swift_stdlib_unicode_compare_utf8_utf16(const char *LeftString,
                                                  int32_t LeftLength,
@@ -163,6 +165,7 @@ int32_t _swift_stdlib_unicode_compare_utf8_utf16(const char *LeftString,
 ///  <0 the left string is less than the right string.
 /// ==0 the strings are equal according to their collation.
 ///  >0 the left string is greater than the right string.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 int32_t _swift_stdlib_unicode_compare_utf8_utf8(const char *LeftString,
                                                 int32_t LeftLength,
@@ -230,6 +233,7 @@ static intptr_t hashFinish(intptr_t HashState) {
   return HashState;
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 intptr_t _swift_stdlib_unicode_hash(const uint16_t *Str, int32_t Length) {
   UErrorCode ErrorCode = U_ZERO_ERROR;
@@ -242,6 +246,7 @@ intptr_t _swift_stdlib_unicode_hash(const uint16_t *Str, int32_t Length) {
   return hashFinish(HashState);
 }
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" intptr_t _swift_stdlib_unicode_hash_ascii(const char *Str,
                                                      int32_t Length) {
   const ASCIICollation *Table = ASCIICollation::getTable();
@@ -269,6 +274,7 @@ extern "C" intptr_t _swift_stdlib_unicode_hash_ascii(const char *Str,
 /// required buffer length as a result. If this length does not match the
 /// 'DestinationCapacity' this function must be called again with a buffer of
 /// the required length to get an uppercase version of the string.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 int32_t _swift_stdlib_unicode_strToUpper(uint16_t *Destination,
                                          int32_t DestinationCapacity,
@@ -288,6 +294,7 @@ int32_t _swift_stdlib_unicode_strToUpper(uint16_t *Destination,
 /// required buffer length as a result. If this length does not match the
 /// 'DestinationCapacity' this function must be called again with a buffer of
 /// the required length to get a lowercase version of the string.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 int32_t _swift_stdlib_unicode_strToLower(uint16_t *Destination,
                                          int32_t DestinationCapacity,

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -9,8 +9,11 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
       weak.mm
       Refcounting.mm
       )
+    # We need to link swiftCore on Darwin because the runtime still relies on
+    # some stdlib hooks to implement SwiftObject.
     list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
       ${FOUNDATION_LIBRARY}
+      swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
       swiftStdlibUnittest${SWIFT_PRIMARY_VARIANT_SUFFIX}
       )
   endif()
@@ -22,9 +25,12 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     ${PLATFORM_SOURCES}
     )
 
+  # The runtime tests link to internal runtime symbols, which aren't exported
+  # from the swiftCore dylib, so we need to link to both the runtime archive
+  # and the stdlib.
   # FIXME: cross-compile for all variants.
   target_link_libraries(SwiftRuntimeTests
-    swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
+    swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
     )
 endif()


### PR DESCRIPTION
...and explicitly mark symbols we export, either for use by executables or for runtime-stdlib interaction. Until the stdlib supports resilience we have to allow programs to link to these SPI symbols.
