### PR TITLE
[Swift 2.2][Parser] Disambiguate between object literals and collection literals.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1165,13 +1165,14 @@ public:
 
   Expr *parseExprAnonClosureArg();
   ParserResult<Expr> parseExprList(tok LeftTok, tok RightTok);
+  bool isCollectionLiteralStartingWithLSquareLit();
   ParserResult<Expr> parseExprObjectLiteral();
   ParserResult<Expr> parseExprCallSuffix(ParserResult<Expr> fn,
                                          Identifier firstSelectorPiece
                                            = Identifier(),
                                          SourceLoc firstSelectorPieceLoc
                                            = SourceLoc());
-  ParserResult<Expr> parseExprCollection();
+  ParserResult<Expr> parseExprCollection(SourceLoc LSquareLoc = SourceLoc());
   ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc, Expr *FirstExpr);
   ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc, Expr *FirstKey);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1023,6 +1023,17 @@ ParserResult<Expr> Parser::parseExprPostfix(Diag<> ID, bool isExprBasic) {
     break;
 
   case tok::l_square_lit: // [#Color(...)#], [#Image(...)#]
+    // If this is actually a collection literal starting with '[#', handle it
+    // as such.
+    if (isCollectionLiteralStartingWithLSquareLit()) {
+      // Split the token into two.
+      SourceLoc LSquareLoc = consumeStartingCharacterOfCurrentToken();
+
+      // Consume the '[' token.
+      Result = parseExprCollection(LSquareLoc);
+      break;
+    }
+
     Result = parseExprObjectLiteral();
     break;
 
@@ -2197,6 +2208,17 @@ ParserResult<Expr> Parser::parseExprList(tok LeftTok, tok RightTok) {
                         /*Implicit=*/false));
 }
 
+bool Parser::isCollectionLiteralStartingWithLSquareLit() {
+  BacktrackingScope backtracking(*this);
+  (void)consumeToken(tok::l_square_lit);
+  if (!consumeIf(tok::identifier)) return false;
+
+  // Skip over a parenthesized argument, if present.
+  if (Tok.is(tok::l_paren)) skipSingle();
+
+  return Tok.isNot(tok::r_square_lit);
+}
+
 /// \brief Parse an object literal expression.
 ///
 /// expr-literal:
@@ -2289,9 +2311,14 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn,
 ///     expr-array
 ///     expr-dictionary
 //      lsquare-starting ']'
-ParserResult<Expr> Parser::parseExprCollection() {
-  Parser::StructureMarkerRAII ParsingCollection(*this, Tok);
-  SourceLoc LSquareLoc = consumeToken(tok::l_square);
+ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
+  // If the caller didn't already consume the '[', do so now.
+  if (LSquareLoc.isInvalid())
+    LSquareLoc = consumeToken(tok::l_square);
+
+  Parser::StructureMarkerRAII ParsingCollection(
+                                *this, LSquareLoc,
+                                StructureMarkerKind::OpenSquare);
 
   // [] is always an array.
   if (Tok.is(tok::r_square)) {

--- a/test/Parse/object_literals.swift
+++ b/test/Parse/object_literals.swift
@@ -3,4 +3,4 @@
 let _ = [##] // expected-error{{expected identifier after '[#' in object literal expression}} expected-error{{consecutive statements on a line must be separated by ';'}} {{11-11=;}} expected-error{{expected expression}}
 let _ = [#what#] // expected-error{{expected argument list in object literal}} expected-error{{consecutive statements on a line must be separated by ';'}} {{15-15=;}} expected-error{{expected expression}}
 let _ = [#what()#] // expected-error{{use of unknown object literal name 'what'}}
-let _ = [#Color( // expected-error{{expected ',' separator}} {{17-17=,}} expected-error@+1{{expected expression in list of expressions}}
+let _ = [#Color( // expected-error{{expected expression in container literal}}

--- a/test/expr/primary/literal/context.swift
+++ b/test/expr/primary/literal/context.swift
@@ -1,0 +1,24 @@
+// RUN: %target-parse-verify-swift
+
+// Test "context" literals, #file, #line, #column, etc.
+
+func requireInt(x: Int) { }
+func requireString(s: String) { }
+
+func testContextLiterals() {
+  let file = #file
+  requireString(file)
+  let line = #line
+  requireInt(line)
+  let column = #column
+  requireInt(column)
+  let function = #function
+  requireString(function)
+}
+
+// Disambiguate between collection literals and object literals.
+func collectionLiteralDisambiguation() {
+  _ = [#line]
+  _ = [#line, #column]
+  _ = [#line : #column]
+}


### PR DESCRIPTION
Now that we have expressions that start with #, the [# introducer for
object literals is no longer guaranteed to indicate an object
literal. For example:

```
[#line, #column]
```

is an array literal and

```
[#line : #column]
```

is a dictionary literal. Use additional lookahead in the parser to
disambiguate these cases from object literals. Fixes
rdar://problem/24533081.
