### PR TITLE
[swiftc] Mark twelve crashes as duplicates of other crashes in the repo.

### DIFF
--- a/validation-test/compiler_crashers/26083-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers/26083-std-function-func-swift-type-subst.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 01766-swift-typechecker-validatedecl.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)

--- a/validation-test/compiler_crashers/26864-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers/26864-std-function-func-swift-type-subst.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/27247-swift-constraints-constraintsystem-simplifyconstraint.swift
+++ b/validation-test/compiler_crashers/27247-swift-constraints-constraintsystem-simplifyconstraint.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/27475-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers/27475-swift-typebase-getcanonicaltype.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/27984-llvm-densemapbase-llvm-densemap-swift-declname.swift
+++ b/validation-test/compiler_crashers/27984-llvm-densemapbase-llvm-densemap-swift-declname.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/28041-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/compiler_crashers/28041-swift-typechecker-lookupunqualified.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 26813-generic-enum-tuple-optional-payload.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/28120-swift-unqualifiedlookup-unqualifiedlookup.swift
+++ b/validation-test/compiler_crashers/28120-swift-unqualifiedlookup-unqualifiedlookup.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift
+++ b/validation-test/compiler_crashers/28190-swift-conformancelookuptable-expandimpliedconformances.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 10659-swift-printingdiagnosticconsumer-handlediagnostic.timeout.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
 

--- a/validation-test/compiler_crashers/28205-swift-typechecker-checkgenericarguments.swift
+++ b/validation-test/compiler_crashers/28205-swift-typechecker-checkgenericarguments.swift
@@ -1,5 +1,7 @@
+// DUPLICATE-OF: 26832-swift-typechecker-conformstoprotocol.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
+
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing

--- a/validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 24394-swift-typevariabletype-implementation-getrepresentative.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
 

--- a/validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 01766-swift-typechecker-validatedecl.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license

--- a/validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers/28234-swift-archetypebuilder-getgenericsignature.swift
@@ -1,3 +1,4 @@
+// DUPLICATE-OF: 28212-swift-typechecker-resolvetypeincontext.swift
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
 


### PR DESCRIPTION
Two crashes are defined as duplicates if they give the same output for:

```
$ swiftc FILENAME 2>&1 | \
    grep -E "0x[0-9a-f]" | \
    grep -E '(swift|llvm)::' | \
    grep -vE '(llvm::sys::|frontend_main)' | \
    awk '{ $1=$2=$3=""; print $0 }' | \
    sed 's/^ *//g' | \
    grep -E '(swift|llvm)::' | \
    head -1
```
