### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::typeCheckDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift
+++ b/validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift
@@ -1,0 +1,9 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class B<h{var d={struct d{typealias e:B
+let t:e,A


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:3991: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
10 swift           0x0000000000e06976 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
11 swift           0x0000000000e5e7c5 swift::addTrivialAccessorsToStorage(swift::AbstractStorageDecl*, swift::TypeChecker&) + 469
12 swift           0x0000000000e626c4 swift::maybeAddAccessorsToVariable(swift::VarDecl*, swift::TypeChecker&) + 852
13 swift           0x0000000000e018f9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 2297
14 swift           0x0000000000df81bf swift::TypeChecker::getTypeOfRValue(swift::ValueDecl*, bool) + 15
15 swift           0x0000000000e629ab swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 539
16 swift           0x0000000000e0c109 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1417
19 swift           0x0000000000e06976 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift           0x0000000000e4daaa swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
23 swift           0x0000000000e7724c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
24 swift           0x0000000000deb87b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
25 swift           0x0000000000dec9b2 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 162
26 swift           0x0000000000decb8b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
31 swift           0x0000000000e06976 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
32 swift           0x0000000000dd2732 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
33 swift           0x0000000000c7936f swift::CompilerInstance::performSema() + 2975
35 swift           0x0000000000777461 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
36 swift           0x0000000000772045 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28250-swift-typechecker-typecheckdecl-302629.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift:8:1
2.  While type-checking expression at [validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift:8:17 - line:9:9] RangeText="{struct d{typealias e:B
3.  While type-checking 'd' at validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift:8:18
4.  While type-checking getter for t at validation-test/compiler_crashers/28250-swift-typechecker-typecheckdecl.swift:9:5
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
