### PR TITLE
[Swift 2.2] Extract Version value out of optional when parsing _compiler_version

### DIFF
--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -241,7 +241,7 @@ Version Version::getCurrentCompilerVersion() {
          "Embedded Swift language version couldn't be parsed: '"
          SWIFT_COMPILER_VERSION
          "'");
-  return currentVersion;
+  return currentVersion.getValue();
 #else
   return Version();
 #endif


### PR DESCRIPTION
Without this patch, the build is broken when SWIFT_COMPILER_VERSION is set.

rdar://problem/24476174
