### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::addImplicitConstructors(…)

### DIFF
--- a/validation-test/compiler_crashers/28251-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers/28251-swift-typechecker-addimplicitconstructors.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+enum w{class d:a
+var d=[[]a
+class a:d


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:6690: void swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl *): Assertion `!classDecl->hasSuperclass() || classDecl->getSuperclass()->getAnyNominal()->isInvalid() || classDecl->getSuperclass()->getAnyNominal() ->addedImplicitInitializers()' failed.
8  swift           0x0000000000e10c96 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 4390
9  swift           0x0000000000e03522 swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5986
10 swift           0x0000000000e0575f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1903
11 swift           0x000000000100c57c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2892
12 swift           0x000000000100af30 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
13 swift           0x0000000000e2cabb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
16 swift           0x0000000000e5643e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
18 swift           0x0000000000e573b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
19 swift           0x0000000000e5634a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
20 swift           0x0000000000e030ea swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 4906
21 swift           0x0000000000e0575f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1903
26 swift           0x0000000000e0a966 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000dd6722 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1490
28 swift           0x0000000000c7c65f swift::CompilerInstance::performSema() + 2975
30 swift           0x0000000000777ce1 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
31 swift           0x00000000007728c5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28251-swift-typechecker-addimplicitconstructors.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28251-swift-typechecker-addimplicitconstructors-e1f071.o
1.  While type-checking 'w' at validation-test/compiler_crashers/28251-swift-typechecker-addimplicitconstructors.swift:8:1
2.  While resolving type a at [validation-test/compiler_crashers/28251-swift-typechecker-addimplicitconstructors.swift:8:16 - line:8:16] RangeText="a"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
