### PR TITLE
Use operator== to compare YAML iterators

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -224,8 +224,7 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
       return true;
 
     auto seqI = seq->begin(), seqE = seq->end();
-    // FIXME: operator== is not implemented.
-    if (!(seqI != seqE))
+    if (seqI == seqE)
       return true;
 
     auto *secondsRaw = dyn_cast<yaml::ScalarNode>(&*seqI);
@@ -236,8 +235,7 @@ static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
       return true;
 
     ++seqI;
-    // FIXME: operator== is not implemented.
-    if (!(seqI != seqE))
+    if (seqI == seqE)
       return true;
 
     auto *nanosecondsRaw = dyn_cast<yaml::ScalarNode>(&*seqI);


### PR DESCRIPTION
`operator==` was implemented here: https://github.com/apple/swift-llvm/commit/71a6baa31c4a08a3c123953a0239bff001b2e437
/cc @jrose-apple 
