### PR TITLE
[Sema] Extend callee diagnoses to non-conforming complex args including generics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -287,6 +287,9 @@ ERROR(cannot_convert_argument_value,none,
       (Type,Type))
 ERROR(cannot_convert_argument_value_protocol,none,
       "argument type %0 does not conform to expected type %1", (Type, Type))
+ERROR(cannot_convert_partial_argument_value_protocol,none,
+      "in argument type %0, %1 does not conform to expected type %2", (Type, Type, Type))
+
 ERROR(cannot_convert_argument_value_nil,none,
       "nil is not compatible with expected argument type %0", (Type))
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -87,10 +87,17 @@ for j in i.wibble(a, a) { // expected-error {{type 'A' does not conform to proto
 func f6<T:P2>(g: Void -> T) -> (c: Int, i: T) {
   return (c: 0, i: g())
 }
+
 func f7() -> (c: Int, v: A) {
   let g: Void -> A = { return A() }
   return f6(g) // expected-error {{cannot convert return expression of type '(c: Int, i: A)' to return type '(c: Int, v: A)'}}
 }
+
+func f8<T:P2>(n: T, _ f: (T) -> T) {}
+f8(3, f4) // expected-error {{in argument type '(Int) -> Int', 'Int' does not conform to expected type 'P2'}}
+typealias Tup = (Int, Double)
+func f9(x: Tup) -> Tup { return x }
+f8((1,2.0), f9) // expected-error {{in argument type '(Tup) -> Tup', 'Tup' (aka '(Int, Double)') does not conform to expected type 'P2'}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}
@@ -643,7 +650,7 @@ let a = safeAssign // expected-error {{generic parameter 'T' could not be inferr
 
 // <rdar://problem/21692808> QoI: Incorrect 'add ()' fixit with trailing closure
 func foo() -> [Int] {
-  return Array <Int> (count: 1) { // expected-error {{cannot invoke initializer for type 'Array<Int>' with an argument list of type '(count: Int, () -> _)'}}
+  return Array <Int> (count: 1) { // expected-error {{cannot invoke initializer for type 'Array<Int>' with an argument list of type '(count: Int, () -> Int)'}}
     // expected-note @-1 {{expected an argument list of type '(count: Int, repeatedValue: Element)'}}
     return 1
   }

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -56,7 +56,7 @@ func useSwap(xi: Int, yi: Float) {
   mySwap(x, x) // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{10-10=&}}
     // expected-error @-1 {{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{13-13=&}}
   
-  mySwap(&x, &y) // expected-error{{cannot convert value of type 'inout Int' to expected argument type 'inout _'}}
+  mySwap(&x, &y) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
 }
 
 func takeTuples<T, U>(_: (T, U), _: (U, T)) {
@@ -208,14 +208,14 @@ func callMin(x: Int, y: Int, a: Float, b: Float) {
   min2(a, b) // expected-error{{argument type 'Float' does not conform to expected type 'IsBefore'}}
 }
 
-func rangeOfIsBefore<  // expected-note {{in call to function 'rangeOfIsBefore'}}
+func rangeOfIsBefore<
   R : GeneratorType where R.Element : IsBefore
 >(range : R) { }
 
 
 func callRangeOfIsBefore(ia: [Int], da: [Double]) {
   rangeOfIsBefore(ia.generate())
-  rangeOfIsBefore(da.generate()) // expected-error{{generic parameter 'R' could not be inferred}}
+  rangeOfIsBefore(da.generate()) // expected-error{{ambiguous reference to member 'generate()'}}
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/StdlibUnittestStaticAssertions.swift
+++ b/validation-test/stdlib/StdlibUnittestStaticAssertions.swift
@@ -16,11 +16,11 @@ struct S2 {}
 func test_expectType() {
   var s1 = S1()
   expectType(S1.self, &s1)
-  expectType(S2.self, &s1) // expected-error {{cannot convert value of type 'inout S1' to expected argument type 'inout _'}}
+  expectType(S2.self, &s1) // expected-error {{cannot convert value of type 'S1' to expected argument type 'S2'}}
 }
 
 func test_expectEqualType() {
   expectEqualType(S1.self, S1.self)
-  expectEqualType(S1.self, S2.self) // expected-error {{cannot convert value of type 'S2.Type' to expected argument type 'S1'}}
+  expectEqualType(S1.self, S2.self) // expected-error {{cannot convert value of type 'S2.Type' to expected argument type 'S1.Type'}}
 }
 


### PR DESCRIPTION
Previously, type checking arguments worked fine if the entire arg was UnresolvedType, but if the type just contained UnresolvedType, the constraint system always failed via explicitly constraining to unresolved.

Now in TypeCheckConstraints, if the solution allows for free variables that are UnresolvedType, then also convert any incoming UnresolvedTypes into variables. At worst, in the solution these just get converted back into the same Unresolved that they started with.

This change allows for incorrect tuple/function type possibilities to make it back out to CSDiag, where they can be more precisely diagnosed with callee info. The rest of the changes are to correctly figure out the failure info when evaluating more types of Types.

New diagnosis for a partial part of an arg type not conforming. Tests added for that. Expected errors changed in several places where we now get real types in the diagnosis instead of '(_)' unresolved.

This is a followup to https://github.com/apple/swift/pull/1160 and https://github.com/apple/swift/pull/1200.
