### PR TITLE
IRGen: Emit public definitions with protected visibility on ELF.

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -937,7 +937,6 @@ static llvm::Constant *findSwiftAsObjCThunk(IRGenModule &IGM, SILDeclRef ref) {
   SILFunction *SILFn = IGM.SILMod->lookUpFunction(ref);
   assert(SILFn && "no IR function for swift-as-objc thunk");
   auto fn = IGM.getAddrOfSILFunction(SILFn, NotForDefinition);
-  // FIXME: Should set the linkage of the SILFunction to 'internal'.
   fn->setVisibility(llvm::GlobalValue::DefaultVisibility);
   fn->setLinkage(llvm::GlobalValue::InternalLinkage);
   fn->setUnnamedAddr(true);

--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -616,7 +616,12 @@ public:
                                   Optional<SILLocation> DebugLoc = None,
                                   StringRef DebugName = StringRef());
 
-  bool isUsed() const;
+  bool isUsed() const {
+    return ForDefinition && isUsed(Linkage, Visibility);
+  }
+  
+  static bool isUsed(llvm::GlobalValue::LinkageTypes Linkage,
+                     llvm::GlobalValue::VisibilityTypes Visibility);
 };
 
 } // end namespace irgen

--- a/test/ClangModules/attr-swift_private.swift
+++ b/test/ClangModules/attr-swift_private.swift
@@ -16,7 +16,7 @@ import SwiftPrivateAttr
 // half of a module, or from an overlay. At that point we should test that these
 // are available in that case and /not/ in the normal import case.
 
-// CHECK-LABEL: define void @{{.+}}12testProperty
+// CHECK-LABEL: define{{( protected)?}} void @{{.+}}12testProperty
 public func testProperty(foo: Foo) {
   // CHECK: @"\01L_selector(setPrivValue:)"
   _ = foo.__privValue
@@ -27,7 +27,7 @@ public func testProperty(foo: Foo) {
 #endif
 }
 
-// CHECK-LABEL: define void @{{.+}}11testMethods
+// CHECK-LABEL: define{{( protected)?}} void @{{.+}}11testMethods
 public func testMethods(foo: Foo) {
   // CHECK: @"\01L_selector(noArgs)"
   foo.__noArgs()
@@ -37,7 +37,7 @@ public func testMethods(foo: Foo) {
   foo.__twoArgs(1, other: 2)
 }
 
-// CHECK-LABEL: define void @{{.+}}16testInitializers
+// CHECK-LABEL: define{{( protected)?}} void @{{.+}}16testInitializers
 public func testInitializers() {
   // Checked below; look for "CSo3Bar".
   _ = Bar(__noArgs: ())
@@ -46,7 +46,7 @@ public func testInitializers() {
   _ = Bar(__: 1)
 }
 
-// CHECK-LABEL: define void @{{.+}}18testFactoryMethods
+// CHECK-LABEL: define{{( protected)?}} void @{{.+}}18testFactoryMethods
 public func testFactoryMethods() {
   // CHECK: @"\01L_selector(fooWithOneArg:)"
   _ = Foo(__oneArg: 1)
@@ -63,7 +63,7 @@ public func testSubscript(foo: Foo) {
 }
 #endif
 
-// CHECK-LABEL: define void @{{.+}}12testTopLevel
+// CHECK-LABEL: define{{( protected)?}} void @{{.+}}12testTopLevel
 public func testTopLevel() {
   // Checked below; look for "PrivFooSub".
   let foo = __PrivFooSub()

--- a/test/DebugInfo/inlinescopes.swift
+++ b/test/DebugInfo/inlinescopes.swift
@@ -5,7 +5,7 @@
 // RUN: FileCheck %s < %t.ll
 // RUN: FileCheck %s -check-prefix=TRANSPARENT-CHECK < %t.ll
 
-// CHECK: define{{( signext)?}} i32 @main
+// CHECK: define{{( protected)?( signext)?}} i32 @main
 // CHECK: tail call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %[[C:.*]], i64 %[[C]]), !dbg ![[MULSCOPE:.*]]
 // CHECK-DAG: ![[TOPLEVEL:.*]] = !DIFile(filename: "inlinescopes.swift"
 

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -9,7 +9,7 @@ import Foundation
 // cleanups/no cleanups, single / multiple return locations.
 
 // RUN: FileCheck %s --check-prefix=CHECK_NONE < %t.ll
-// CHECK_NONE: define void {{.*}}none
+// CHECK_NONE: define{{( protected)?}} void {{.*}}none
 public func none(inout a: Int64) {
   // CHECK_NONE: call void @llvm.dbg{{.*}}, !dbg
   // CHECK_NONE: !dbg ![[NONE_INIT:.*]]

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -439,7 +439,7 @@ class Foo {
 // armv7k-watchos: define internal %struct.One @makeOne(float %f, float %s)
 
 // rdar://17631440 - Expand direct arguments that are coerced to aggregates.
-// x86_64-macosx: define float @_TF8abitypes13testInlineAggFVSC6MyRectSf(%VSC6MyRect* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// x86_64-macosx: define{{( protected)?}} float @_TF8abitypes13testInlineAggFVSC6MyRectSf(%VSC6MyRect* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // x86_64-macosx: [[COERCED:%.*]] = alloca %VSC6MyRect, align 4
 // x86_64-macosx: store float %
 // x86_64-macosx: store float %

--- a/test/IRGen/access_control.sil
+++ b/test/IRGen/access_control.sil
@@ -4,13 +4,13 @@ import Builtin
 import Swift
 
 public struct PublicStruct { var x: Int }
-// CHECK: @_TWVV14access_control12PublicStruct = constant
-// CHECK: @_TMnV14access_control12PublicStruct = constant
+// CHECK: @_TWVV14access_control12PublicStruct = {{(protected )?}}constant
+// CHECK: @_TMnV14access_control12PublicStruct = {{(protected )?}}constant
 // CHECK: @_TMfV14access_control12PublicStruct = internal constant
 
 internal struct InternalStruct { var x: Int }
-// CHECK: @_TWVV14access_control14InternalStruct = constant
-// CHECK: @_TMnV14access_control14InternalStruct = constant
+// CHECK: @_TWVV14access_control14InternalStruct = {{(protected )?}}constant
+// CHECK: @_TMnV14access_control14InternalStruct = {{(protected )?}}constant
 // CHECK: @_TMfV14access_control14InternalStruct = internal constant
 
 private struct PrivateStruct { var x: Int }
@@ -25,7 +25,7 @@ func local() {
   // CHECK: @_TMfVF14access_control5localFT_T_L_11LocalStruct = internal constant
 }
 
-// CHECK: @_TMV14access_control12PublicStruct = alias
-// CHECK: @_TMV14access_control14InternalStruct = alias
+// CHECK: @_TMV14access_control12PublicStruct = {{(protected )?}}alias
+// CHECK: @_TMV14access_control14InternalStruct = {{(protected )?}}alias
 // CHECK: @_TMV14access_controlP33_8F630B0A1EEF3ED34B761E3ED76C95A813PrivateStruct = hidden alias
 // CHECK: @_TMVF14access_control5localFT_T_L_11LocalStruct = hidden alias

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -4,7 +4,7 @@ import Builtin
 
 struct Huge { var x,y,z,w,a,b,c,d: Builtin.Int32 }
 
-// CHECK-LABEL: define void @arguments_in_def(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( protected)?}} void @arguments_in_def(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> () {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   // CHECK: call void @arguments_in_decl(i32* nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, %V14argument_attrs4Huge* noalias nocapture dereferenceable(32) {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.type* %T)
@@ -19,7 +19,7 @@ entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Hu
 // CHECK-LABEL: declare void @arguments_in_decl(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
 sil @arguments_in_decl : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
 
-// CHECK-LABEL: define void @arguments_in_def_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( protected)?}} void @arguments_in_def_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def_out : $@convention(thin) <T> (@out Builtin.Int32, @inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> () {
 entry(%0 : $*Builtin.Int32, %1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   // CHECK: call void @arguments_in_decl_out(i32* noalias nocapture sret {{%.*}}, i32* nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, %V14argument_attrs4Huge* noalias nocapture dereferenceable(32) {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}})
@@ -34,7 +34,7 @@ entry(%0 : $*Builtin.Int32, %1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*B
 // CHECK-LABEL: declare void @arguments_in_decl_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
 sil @arguments_in_decl_out : $@convention(thin) <T> (@out Builtin.Int32, @inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
 
-// CHECK-LABEL: define void @arguments_in_def_huge_ret(%V14argument_attrs4Huge* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( protected)?}} void @arguments_in_def_huge_ret(%V14argument_attrs4Huge* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   %f = function_ref @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge

--- a/test/IRGen/autorelease.sil
+++ b/test/IRGen/autorelease.sil
@@ -24,23 +24,23 @@ sil @foo : $@convention(thin) (@owned C?) -> @autoreleased C? {
 bb0(%0 : $C?):
   return %0 : $C?
 }
-// x86_64:    define i64 @foo(i64) {{.*}} {
+// x86_64:    define{{( protected)?}} i64 @foo(i64) {{.*}} {
 // x86_64:      [[T0:%.*]] = tail call i64 bitcast ([[OBJC]]* ([[OBJC]]*)* @objc_autoreleaseReturnValue to i64 (i64)*)(i64 %0)
 // x86_64-NEXT: ret i64 [[T0]]
 
-// i386:     define i32 @foo(i32) {{.*}} {
+// i386:     define{{( protected)?}} i32 @foo(i32) {{.*}} {
 // i386:       [[T0:%.*]] = tail call i32 bitcast ([[OBJC]]* ([[OBJC]]*)* @objc_autoreleaseReturnValue to i32 (i32)*)(i32 %0)
 // i386-NEXT:  ret i32 [[T0]]
 
-// arm64:    define i64 @foo(i64) {{.*}} {
+// arm64:    define{{( protected)?}} i64 @foo(i64) {{.*}} {
 // arm64:      [[T0:%.*]] = tail call i64 bitcast ([[OBJC]]* ([[OBJC]]*)* @objc_autoreleaseReturnValue to i64 (i64)*)(i64 %0)
 // arm64-NEXT: ret i64 [[T0]]
 
-// armv7:    define i32 @foo(i32) {{.*}} {
+// armv7:    define{{( protected)?}} i32 @foo(i32) {{.*}} {
 // armv7:      [[T0:%.*]] = tail call i32 bitcast ([[OBJC]]* ([[OBJC]]*)* @objc_autoreleaseReturnValue to i32 (i32)*)(i32 %0)
 // armv7-NEXT: ret i32 [[T0]]
 
-// armv7k:    define i32 @foo(i32) {{.*}} {
+// armv7k:    define{{( protected)?}} i32 @foo(i32) {{.*}} {
 // armv7k:      [[T0:%.*]] = tail call i32 bitcast ([[OBJC]]* ([[OBJC]]*)* @objc_autoreleaseReturnValue to i32 (i32)*)(i32 %0)
 // armv7k-NEXT: ret i32 [[T0]]
 
@@ -50,21 +50,21 @@ bb0(%0 : $C?):
   %2 = apply %1(%0) : $@convention(thin) (@owned C?) -> @autoreleased C?
   return %2 : $C?
 }
-// x86_64:    define i64 @bar(i64)
+// x86_64:    define{{( protected)?}} i64 @bar(i64)
 // x86_64:      [[T0:%.*]] = call i64 @foo(i64 %0)
 // x86_64-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to i8*
 // x86_64-NEXT: [[T2:%.*]] = call i8* @objc_retainAutoreleasedReturnValue(i8* [[T1]])
 // x86_64-NEXT: [[T3:%.*]] = ptrtoint i8* [[T2]] to i64
 // x86_64-NEXT: ret i64 [[T3]]
 
-// i386:    define i32 @bar(i32)
+// i386:    define{{( protected)?}} i32 @bar(i32)
 // i386:      [[T0:%.*]] = call i32 @foo(i32 %0)
 // i386-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to i8*
 // i386-NEXT: [[T2:%.*]] = call i8* @objc_retainAutoreleasedReturnValue(i8* [[T1]])
 // i386-NEXT: [[T3:%.*]] = ptrtoint i8* [[T2]] to i32
 // i386-NEXT: ret i32 [[T3]]
 
-// arm64:    define i64 @bar(i64)
+// arm64:    define{{( protected)?}} i64 @bar(i64)
 // arm64:      [[T0:%.*]] = call i64 @foo(i64 %0)
 // arm64-NEXT: call void asm sideeffect "mov
 // arm64-NEXT: [[T1:%.*]] = inttoptr i64 [[T0]] to i8*
@@ -72,7 +72,7 @@ bb0(%0 : $C?):
 // arm64-NEXT: [[T3:%.*]] = ptrtoint i8* [[T2]] to i64
 // arm64-NEXT: ret i64 [[T3]]
 
-// armv7:    define i32 @bar(i32)
+// armv7:    define{{( protected)?}} i32 @bar(i32)
 // armv7:      [[T0:%.*]] = call i32 @foo(i32 %0)
 // armv7-NEXT: call void asm sideeffect "mov
 // armv7-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to i8*
@@ -80,7 +80,7 @@ bb0(%0 : $C?):
 // armv7-NEXT: [[T3:%.*]] = ptrtoint i8* [[T2]] to i32
 // armv7-NEXT: ret i32 [[T3]]
 
-// armv7k:    define i32 @bar(i32)
+// armv7k:    define{{( protected)?}} i32 @bar(i32)
 // armv7k:      [[T0:%.*]] = call i32 @foo(i32 %0)
 // armv7k-NEXT: call void asm sideeffect "mov
 // armv7k-NEXT: [[T1:%.*]] = inttoptr i32 [[T0]] to i8*

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -16,7 +16,7 @@ sil_vtable C {}
 
 protocol CP: class {}
 
-// CHECK-i386-LABEL: define i32 @bitcast_trivial(%C7bitcast1C*) {{.*}} {
+// CHECK-i386-LABEL: define{{( protected)?}} i32 @bitcast_trivial(%C7bitcast1C*) {{.*}} {
 // CHECK-i386:         [[BUF:%.*]] = alloca %C7bitcast1C*, align 4
 // CHECK-i386:         store %C7bitcast1C* %0, %C7bitcast1C** [[BUF]]
 // CHECK-i386:         [[OUT_BUF:%.*]] = bitcast %C7bitcast1C** [[BUF]] to %Si*
@@ -25,7 +25,7 @@ protocol CP: class {}
 // CHECK-i386:         ret i32 [[VALUE]]
 // CHECK-i386:       }
 
-// CHECK-x86_64-LABEL: define i64 @bitcast_trivial(%C7bitcast1C*) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( protected)?}} i64 @bitcast_trivial(%C7bitcast1C*) {{.*}} {
 // CHECK-x86_64:         [[BUF:%.*]] = alloca %C7bitcast1C*, align 8
 // CHECK-x86_64:         store %C7bitcast1C* %0, %C7bitcast1C** [[BUF]]
 // CHECK-x86_64:         [[OUT_BUF:%.*]] = bitcast %C7bitcast1C** [[BUF]] to %Si*
@@ -40,7 +40,7 @@ entry(%c : $C):
 }
 
 
-// CHECK-x86_64-LABEL: define { i64, i1 } @bitcast_trivial_optional(i64, i1) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( protected)?}} { i64, i1 } @bitcast_trivial_optional(i64, i1) {{.*}} {
 // CHECK-x86_64-NEXT:  entry:
 // CHECK-x86_64-NEXT:   %2 = insertvalue { i64, i1 } undef, i64 %0, 0
 // CHECK-x86_64-NEXT:   %3 = insertvalue { i64, i1 } %2, i1 %1, 1
@@ -52,13 +52,13 @@ entry(%c : $Optional<Int>):
   return %i : $ImplicitlyUnwrappedOptional<Int>
 }
 
-// CHECK-i386-LABEL: define i32 @bitcast_ref(%C7bitcast1C*) {{.*}} {
+// CHECK-i386-LABEL: define{{( protected)?}} i32 @bitcast_ref(%C7bitcast1C*) {{.*}} {
 // CHECK-i386-NEXT:  entry:
 // CHECK-i386-NEXT:    [[VALUE:%.*]] = ptrtoint %C7bitcast1C* %0 to i32
 // CHECK-i386-NEXT:    ret i32 [[VALUE]]
 // CHECK-i386-NEXT:  }
 
-// CHECK-x86_64-LABEL: define i64 @bitcast_ref(%C7bitcast1C*) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( protected)?}} i64 @bitcast_ref(%C7bitcast1C*) {{.*}} {
 // CHECK-x86_64-NEXT:  entry:
 // CHECK-x86_64-NEXT:    [[VALUE:%.*]] = ptrtoint %C7bitcast1C* %0 to i64
 // CHECK-x86_64-NEXT:    ret i64 [[VALUE]]
@@ -114,7 +114,7 @@ bb0(%0 : $Int, %1 : $Int):
   return %i3 : $Int
 }
 
-// CHECK-LABEL: define void @unchecked_ref_cast_addr
+// CHECK-LABEL: define{{( protected)?}} void @unchecked_ref_cast_addr
 // CHECK-i386: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i32 7)
 // CHECK-x86_64: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i64 7)
 sil @unchecked_ref_cast_addr : $@convention(thin) <T, U> (@out U, @in T) -> () {
@@ -128,11 +128,11 @@ bb0(%0 : $*U, %1 : $*T):
   return %r : $()
 }
 
-// CHECK-i386-LABEL: define i32 @unchecked_ref_cast_class_optional
+// CHECK-i386-LABEL: define{{( protected)?}} i32 @unchecked_ref_cast_class_optional
 // CHECK-i386: ptrtoint %C7bitcast1A* %0 to i32
 // CHECK-i386-NEXT: ret i32
 
-// CHECK-x86_64-LABEL: define i64 @unchecked_ref_cast_class_optional
+// CHECK-x86_64-LABEL: define{{( protected)?}} i64 @unchecked_ref_cast_class_optional
 // CHECK-x86_64: ptrtoint %C7bitcast1A* %0 to i64
 // CHECK-x86_64-NEXT: ret i64
 sil @unchecked_ref_cast_class_optional : $@convention(thin) (@owned A) -> @owned Optional<AnyObject> {
@@ -141,10 +141,10 @@ bb0(%0 : $A):
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define i32 @unchecked_ref_cast_optional_optional
+// CHECK-i386-LABEL: define{{( protected)?}} i32 @unchecked_ref_cast_optional_optional
 // CHECK-i386: ret i32 %0
 
-// CHECK-x86_64-LABEL: define i64 @unchecked_ref_cast_optional_optional
+// CHECK-x86_64-LABEL: define{{( protected)?}} i64 @unchecked_ref_cast_optional_optional
 // CHECK-x86_64: ret i64 %0
 sil @unchecked_ref_cast_optional_optional : $@convention(thin) (@owned Optional<A>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<A>):
@@ -152,11 +152,11 @@ bb0(%0 : $Optional<A>):
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define i32 @unchecked_ref_cast_proto_optional
+// CHECK-i386-LABEL: define{{( protected)?}} i32 @unchecked_ref_cast_proto_optional
 // CHECK-i386: ptrtoint {{%objc_object|%swift.refcounted}}* %0 to i32
 // CHECK-i386-NEXT: ret i32
 
-// CHECK-x86_64-LABEL: define i64 @unchecked_ref_cast_proto_optional
+// CHECK-x86_64-LABEL: define{{( protected)?}} i64 @unchecked_ref_cast_proto_optional
 // CHECK-x86_64: ptrtoint {{%objc_object|%swift.refcounted}}* %0 to i64
 // CHECK-x86_64-NEXT: ret i64
 sil @unchecked_ref_cast_proto_optional : $@convention(thin) (@owned CP) -> @owned Optional<AnyObject> {
@@ -165,10 +165,10 @@ bb0(%0 : $CP):
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define i32 @unchecked_ref_cast_optionalproto_optional
+// CHECK-i386-LABEL: define{{( protected)?}} i32 @unchecked_ref_cast_optionalproto_optional
 // CHECK-i386: ret i32 %0
 
-// CHECK-x86_64-LABEL: define i64 @unchecked_ref_cast_optionalproto_optional
+// CHECK-x86_64-LABEL: define{{( protected)?}} i64 @unchecked_ref_cast_optionalproto_optional
 // CHECK-x86_64: ret i64 %0
 sil @unchecked_ref_cast_optionalproto_optional : $@convention(thin) (@owned Optional<CP>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<CP>):

--- a/test/IRGen/bitcast_different_size.sil
+++ b/test/IRGen/bitcast_different_size.sil
@@ -6,7 +6,7 @@ sil_stage canonical
 
 import Swift
 
-// CHECK-LABEL: define i64 @bitcast_different_size1
+// CHECK-LABEL: define{{( protected)?}} i64 @bitcast_different_size1
 
 sil @bitcast_different_size1 : $@convention(thin) (Int32) -> Int64 {
 entry(%i : $Int32):

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -2,7 +2,7 @@
 
 import Swift
 
-// CHECK-LABEL: define void @retain_release_boxed_existential(%swift.error*)
+// CHECK-LABEL: define{{( protected)?}} void @retain_release_boxed_existential(%swift.error*)
 sil @retain_release_boxed_existential : $@convention(thin) (ErrorType) -> () {
 entry(%e : $ErrorType):
   // CHECK-objc: @swift_errorRetain
@@ -14,7 +14,7 @@ entry(%e : $ErrorType):
   return undef : $()
 }
 
-// CHECK-LABEL: define %swift.error* @alloc_boxed_existential(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.ErrorType)
+// CHECK-LABEL: define{{( protected)?}} %swift.error* @alloc_boxed_existential(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.ErrorType)
 sil @alloc_boxed_existential : $@convention(thin) <T: ErrorType> (@in T) -> @owned ErrorType {
 entry(%x : $*T):
   // CHECK: [[BOX_PAIR:%.*]] = call { %swift.error*, %swift.opaque* } @swift_allocError(%swift.type* %T, i8** %T.ErrorType, %swift.opaque* null, i1 false)
@@ -33,7 +33,7 @@ struct SomeError: ErrorType {
   let _code: Int
 }
 
-// CHECK-LABEL: define %swift.error* @alloc_boxed_existential_concrete
+// CHECK-LABEL: define{{( protected)?}} %swift.error* @alloc_boxed_existential_concrete
 sil @alloc_boxed_existential_concrete : $@convention(thin) (@owned SomeError) -> @owned ErrorType {
 entry(%x : $SomeError):
   // CHECK: [[BOX_PAIR:%.*]] = call { %swift.error*, %swift.opaque* } @swift_allocError(%swift.type* {{.*}} @_TMfV17boxed_existential9SomeError, {{.*}}, i8** @_TWPV17boxed_existential9SomeErrors9ErrorTypeS_, %swift.opaque* null, i1 false)
@@ -47,7 +47,7 @@ entry(%x : $SomeError):
   return %b : $ErrorType
 }
 
-// CHECK-LABEL: define void @dealloc_boxed_existential(%swift.error*, %swift.type* %T, i8** %T.ErrorType)
+// CHECK-LABEL: define{{( protected)?}} void @dealloc_boxed_existential(%swift.error*, %swift.type* %T, i8** %T.ErrorType)
 sil @dealloc_boxed_existential : $@convention(thin) <T: ErrorType> (@owned ErrorType) -> () {
 entry(%b : $ErrorType):
   // CHECK: call void @swift_deallocError(%swift.error* %0, %swift.type* %T)
@@ -55,7 +55,7 @@ entry(%b : $ErrorType):
   return undef : $()
 }
 
-// CHECK-LABEL: define {{i[0-9]+}} @project_boxed_existential(%swift.error*)
+// CHECK-LABEL: define{{( protected)?}} {{i[0-9]+}} @project_boxed_existential(%swift.error*)
 sil @project_boxed_existential : $@convention(thin) (@owned ErrorType) -> Int {
 entry(%b : $ErrorType):
   // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])
@@ -75,7 +75,7 @@ entry(%b : $ErrorType):
   return %l : $Int
 }
 
-// CHECK-LABEL: define {{i[0-9]+}} @open_boxed_existential(%swift.error*)
+// CHECK-LABEL: define{{( protected)?}} {{i[0-9]+}} @open_boxed_existential(%swift.error*)
 sil @open_boxed_existential : $@convention(thin) (@owned ErrorType) -> Int {
 entry(%b : $ErrorType):
   // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])

--- a/test/IRGen/bridge_object.sil
+++ b/test/IRGen/bridge_object.sil
@@ -11,7 +11,7 @@ sil_vtable C {}
 
 @objc protocol ObjC {}
 
-// X86_64-LABEL: define void @retain_release_bridge_object
+// X86_64-LABEL: define{{( protected)?}} void @retain_release_bridge_object
 // X86_64:         call [[BRIDGE:%swift.bridge\*]] @swift_bridgeObjectRetain
 // X86_64:         call void @swift_bridgeObjectRelease
 sil @retain_release_bridge_object : $(Builtin.BridgeObject) -> () {
@@ -21,7 +21,7 @@ entry(%b : $Builtin.BridgeObject):
   return undef : $()
 }
 
-// X86_64-LABEL: define %swift.bridge* @convert_to_bridge_object
+// X86_64-LABEL: define{{( protected)?}} %swift.bridge* @convert_to_bridge_object
 // X86_64:         [[REFBITS:%.*]] = ptrtoint [[C:%C13bridge_object1C\*]] %0 to i64
 // X86_64:         [[OR:%.*]] = or i64 [[REFBITS]], %1
 // X86_64:         inttoptr i64 [[OR]] to [[BRIDGE]]
@@ -31,7 +31,7 @@ entry(%c : $C, %w : $Builtin.Word):
   return %b : $Builtin.BridgeObject
 }
 
-// X86_64-LABEL: define { %objc_object*, i64 } @convert_from_bridge_object
+// X86_64-LABEL: define{{( protected)?}} { %objc_object*, i64 } @convert_from_bridge_object
 // X86_64:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE]] %0 to i64
 // --                                                     0x8000_0000_0000_0001
 // X86_64:         [[TAGBITS:%.*]] = and i64 [[BOBITS]], -9223372036854775807
@@ -48,7 +48,7 @@ entry(%c : $C, %w : $Builtin.Word):
 // X86_64:      tagged-cont:
 // X86_64:         phi [[C]] [ [[TAGGED_RESULT]], %tagged-pointer ], [ [[MASKED_RESULT]], %not-tagged-pointer ]
 
-// ARM64-LABEL: define { %objc_object*, i64 } @convert_from_bridge_object
+// ARM64-LABEL: define{{( protected)?}} { %objc_object*, i64 } @convert_from_bridge_object
 // ARM64:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE:%swift.bridge\*]] %0 to i64
 // --                                                     0x8000_0000_0000_0000
 // ARM64:         [[TAGBITS:%.*]] = and i64 [[BOBITS]], -9223372036854775808
@@ -65,7 +65,7 @@ entry(%c : $C, %w : $Builtin.Word):
 // ARM64:      tagged-cont:
 // ARM64:         phi [[C]] [ [[TAGGED_RESULT]], %tagged-pointer ], [ [[MASKED_RESULT]], %not-tagged-pointer ]
 
-// ARMV7-LABEL: define { %objc_object*, i32 } @convert_from_bridge_object
+// ARMV7-LABEL: define{{( protected)?}} { %objc_object*, i32 } @convert_from_bridge_object
 // ARMV7:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE:%swift.bridge\*]] %0 to i32
 // ARMV7:         [[MASKED_BITS:%.*]] = and i32 [[BOBITS]], -4
 // ARMV7:         inttoptr i32 [[MASKED_BITS]] to [[C:%objc_object\*]]
@@ -77,7 +77,7 @@ entry(%b : $Builtin.BridgeObject):
   return %t : $(ObjC, Builtin.Word)
 }
 
-// X86_64-LABEL: define %C13bridge_object1C* @convert_from_native_bridge_object
+// X86_64-LABEL: define{{( protected)?}} %C13bridge_object1C* @convert_from_native_bridge_object
 // X86_64:         [[BOBITS:%.*]] = ptrtoint %swift.bridge* %0 to i64
 // X86_64:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 72057594037927928
 // X86_64:         [[RESULT:%.*]] = inttoptr i64 [[MASKED_BITS]] to [[C:%C13bridge_object1C\*]]

--- a/test/IRGen/builtin_word.sil
+++ b/test/IRGen/builtin_word.sil
@@ -6,11 +6,11 @@
 sil_stage canonical
 import Builtin
 
-// INTEL: define i64 @word_literal() {{.*}} {
+// INTEL: define{{( protected)?}} i64 @word_literal() {{.*}} {
 // INTEL: entry:
 // INTEL:   ret i64 12345
 // INTEL: }
-// ARM32: define i32 @word_literal() {{.*}} {
+// ARM32: define{{( protected)?}} i32 @word_literal() {{.*}} {
 // ARM32: entry:
 // ARM32:   ret i32 12345
 // ARM32: }
@@ -20,14 +20,14 @@ entry:
   return %w : $Builtin.Word
 }
 
-// INTEL: define { i64, i64 } @word_zextOrBitCast(i32, i64) {{.*}} {
+// INTEL: define{{( protected)?}} { i64, i64 } @word_zextOrBitCast(i32, i64) {{.*}} {
 // INTEL: entry:
 // INTEL:   %2 = zext i32 %0 to i64
 // INTEL:   %3 = insertvalue { i64, i64 } undef, i64 %2, 0
 // INTEL:   %4 = insertvalue { i64, i64 } %3, i64 %1, 1
 // INTEL:   ret { i64, i64 } %4
 // INTEL: }
-// ARM32: define { i32, i64 } @word_zextOrBitCast(i32, i32) {{.*}} {
+// ARM32: define{{( protected)?}} { i32, i64 } @word_zextOrBitCast(i32, i32) {{.*}} {
 // ARM32: entry:
 // ARM32:   %2 = zext i32 %1 to i64
 // ARM32:   %3 = insertvalue { i32, i64 } undef, i32 %0, 0
@@ -42,14 +42,14 @@ entry(%i : $Builtin.Int32, %w : $Builtin.Word):
   return %t : $(Builtin.Word, Builtin.Int64)
 }
 
-// INTEL: define { i32, i64 } @word_truncOrBitCast(i64, i64) {{.*}} {
+// INTEL: define{{( protected)?}} { i32, i64 } @word_truncOrBitCast(i64, i64) {{.*}} {
 // INTEL: entry:
 // INTEL:   %2 = trunc i64 %0 to i32
 // INTEL:   %3 = insertvalue { i32, i64 } undef, i32 %2, 0
 // INTEL:   %4 = insertvalue { i32, i64 } %3, i64 %1, 1
 // INTEL:   ret { i32, i64 } %4
 // INTEL: }
-// ARM32: define { i32, i32 } @word_truncOrBitCast(i32, i64) {{.*}} {
+// ARM32: define{{( protected)?}} { i32, i32 } @word_truncOrBitCast(i32, i64) {{.*}} {
 // ARM32: entry:
 // ARM32:   %2 = trunc i64 %1 to i32
 // ARM32:   %3 = insertvalue { i32, i32 } undef, i32 %0, 0

--- a/test/IRGen/c_function_pointer.sil
+++ b/test/IRGen/c_function_pointer.sil
@@ -2,13 +2,13 @@
 
 import Swift
 
-// CHECK-LABEL: define void @c_native_function_pointer(void ()*)
+// CHECK-LABEL: define{{( protected)?}} void @c_native_function_pointer(void ()*)
 sil @c_native_function_pointer : $@convention(c) (@convention(c) () -> ()) -> () {
 entry(%f : $@convention(c) () -> ()):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @call_with_native_c_function_pointer(i8*)
+// CHECK-LABEL: define{{( protected)?}} void @call_with_native_c_function_pointer(i8*)
 sil @call_with_native_c_function_pointer : $@convention(thin) (@convention(c) () -> ()) -> () {
 entry(%f : $@convention(c) () -> ()):
   %c = function_ref @c_native_function_pointer : $@convention(c) (@convention(c) () -> ()) -> ()
@@ -16,7 +16,7 @@ entry(%f : $@convention(c) () -> ()):
   return %z : $()
 }
 
-// CHECK-LABEL: define %swift.type* @c_function_pointer_metadata()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @c_function_pointer_metadata()
 sil @c_function_pointer_metadata : $@convention(thin) () -> @thick Any.Type {
 entry:
   // CHECK: call %swift.type* @_TMacT_T_()

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -27,7 +27,7 @@ bb0:
   %r = tuple ()
   return %r : $()
 }
-// CHECK-x86_64: define void @test0()
+// CHECK-x86_64: define{{( protected)?}} void @test0()
 // CHECK-x86_64:   [[RESULT:%.*]] = alloca %VSC11BitfieldOne, align 8
 // CHECK-x86_64:   [[ARG:%.*]] = alloca %VSC11BitfieldOne, align 8
 //   Make the first call and pull all the values out of the indirect result.
@@ -106,7 +106,7 @@ bb0:
 sil public_external @createSIMDStruct : $@convention(c) () -> SIMDStruct
 sil public_external @consumeSIMDStruct : $@convention(c) SIMDStruct -> ()
 
-// CHECK-x86_64-LABEL: define void @testSIMDStruct()
+// CHECK-x86_64-LABEL: define{{( protected)?}} void @testSIMDStruct()
 // CHECK-x86_64:         call <3 x float> @createSIMDStruct
 // CHECK-x86_64:         call void @consumeSIMDStruct(<3 x float>
 sil @testSIMDStruct : $() -> () {
@@ -125,7 +125,7 @@ bb0:
   return %s : $Builtin.Word
 }
 
-// CHECK-x86_64-LABEL: define void @testIntegerExtension
+// CHECK-x86_64-LABEL: define{{( protected)?}} void @testIntegerExtension
 // CHECK-x86_64:         call signext i8 @chareth(i8 signext %0)
 // CHECK-x86_64:         call signext i8 @signedChareth(i8 signext %1)
 // CHECK-x86_64:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
@@ -141,7 +141,7 @@ bb0:
 // CHECK-x86_64-LABEL: declare i32 @ints(i32)
 // CHECK-x86_64-LABEL: declare i32 @unsigneds(i32)
 
-// CHECK-i386-LABEL: define void @testIntegerExtension
+// CHECK-i386-LABEL: define{{( protected)?}} void @testIntegerExtension
 // CHECK-i386:         call signext i8 @chareth(i8 signext %0)
 // CHECK-i386:         call signext i8 @signedChareth(i8 signext %1)
 // CHECK-i386:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
@@ -157,7 +157,7 @@ bb0:
 // CHECK-i386-LABEL: declare i32 @ints(i32)
 // CHECK-i386-LABEL: declare i32 @unsigneds(i32)
 
-// CHECK-armv7-LABEL: define void @testIntegerExtension
+// CHECK-armv7-LABEL: define{{( protected)?}} void @testIntegerExtension
 // CHECK-armv7:         call signext i8 @chareth(i8 signext %0)
 // CHECK-armv7:         call signext i8 @signedChareth(i8 signext %1)
 // CHECK-armv7:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
@@ -173,7 +173,7 @@ bb0:
 // CHECK-armv7-LABEL: declare i32 @ints(i32)
 // CHECK-armv7-LABEL: declare i32 @unsigneds(i32)
 
-// CHECK-armv7k-LABEL: define void @testIntegerExtension
+// CHECK-armv7k-LABEL: define{{( protected)?}} void @testIntegerExtension
 // CHECK-armv7k:         call signext i8 @chareth(i8 signext %0)
 // CHECK-armv7k:         call signext i8 @signedChareth(i8 signext %1)
 // CHECK-armv7k:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
@@ -189,7 +189,7 @@ bb0:
 // CHECK-armv7k-LABEL: declare i32 @ints(i32)
 // CHECK-armv7k-LABEL: declare i32 @unsigneds(i32)
 
-// CHECK-arm64-LABEL: define void @testIntegerExtension
+// CHECK-arm64-LABEL: define{{( protected)?}} void @testIntegerExtension
 // CHECK-arm64:         call signext i8 @chareth(i8 signext %0)
 // CHECK-arm64:         call signext i8 @signedChareth(i8 signext %1)
 // CHECK-arm64:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
@@ -231,7 +231,7 @@ entry(%a : $CChar, %b : $CSignedChar, %c : $CUnsignedChar, %d : $CShort, %e : $C
   return undef : $()
 }
 
-// CHECK-x86_64-LABEL: define i8 @testIntegerExtensionInBlock(%objc_block*, i8)
+// CHECK-x86_64-LABEL: define{{( protected)?}} i8 @testIntegerExtensionInBlock(%objc_block*, i8)
 sil @testIntegerExtensionInBlock : $@convention(thin) (@owned @convention(block) (CChar) -> CChar, CChar) -> CChar {
 entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
 // CHECK-x86_64: call signext i8 {{%.*}}(%objc_block* {{%.*}}, i8 signext {{%.*}})
@@ -239,7 +239,7 @@ entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
   return %r : $CChar
 }
 
-// CHECK-x86_64-LABEL: define void @testBitfieldInBlock
+// CHECK-x86_64-LABEL: define{{( protected)?}} void @testBitfieldInBlock
 // CHECK-x86_64:         call void {{%.*}}(%VSC11BitfieldOne* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %VSC11BitfieldOne* byval align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -16,7 +16,7 @@ class B: A {}
 sil_vtable A {}
 sil_vtable B {}
 
-// CHECK-LABEL: define %C5casts1B* @unchecked_addr_cast(%C5casts1A** noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %C5casts1B* @unchecked_addr_cast(%C5casts1A** noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         bitcast %C5casts1A** %0 to %C5casts1B**
 sil @unchecked_addr_cast : $(@in A) -> B {
 entry(%a : $*A):
@@ -29,7 +29,7 @@ protocol CP: class {}
 protocol CP2: class {}
 @objc protocol OP: class {}
 
-// CHECK-LABEL: define i8* @ref_to_raw_pointer_existential(%objc_object*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i8* @ref_to_raw_pointer_existential(%objc_object*, i8**) {{.*}} {
 // CHECK:         [[CAST:%.*]] = bitcast %objc_object* %0 to i8*
 // CHECK:         ret i8* [[CAST]]
 sil @ref_to_raw_pointer_existential : $@convention(thin) (@owned CP) -> Builtin.RawPointer {
@@ -38,7 +38,7 @@ entry(%p : $CP):
   return %r : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define %objc_object* @raw_pointer_to_ref_existential(i8*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_object* @raw_pointer_to_ref_existential(i8*) {{.*}} {
 // CHECK:         [[CAST:%.*]] = bitcast i8* %0 to %objc_object*
 // CHECK:         ret %objc_object* [[CAST]]
 sil @raw_pointer_to_ref_existential : $@convention(thin) (@owned Builtin.RawPointer) -> AnyObject {
@@ -53,9 +53,9 @@ entry(%n : $Builtin.NativeObject):
   return %r : $AnyObject
 }
 
-// CHECK-LABEL: define { %objc_object*, i8** } @u_cast_to_class_existential(%objc_object*)
+// CHECK-LABEL: define{{( protected)?}} { %objc_object*, i8** } @u_cast_to_class_existential(%objc_object*)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @_TMp5casts2CP)
-// CHECK-LABEL: define private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8*, %swift.type*, %swift.protocol*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8*, %swift.type*, %swift.protocol*) {{.*}} {
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -71,7 +71,7 @@ entry(%a : $AnyObject):
   return %p : $CP
 }
 
-// CHECK-LABEL: define { %swift.type*, i8** } @u_cast_to_existential_metatype(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} { %swift.type*, i8** } @u_cast_to_existential_metatype(%swift.type*)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* %1, %swift.type* %0, %swift.protocol* @_TMp5casts2CP)
 sil @u_cast_to_existential_metatype : $@convention(thin) (@owned @thick Any.Type) -> @owned @thick CP.Type {
 entry(%a : $@thick Any.Type):
@@ -79,9 +79,9 @@ entry(%a : $@thick Any.Type):
   return %p : $@thick CP.Type
 }
 
-// CHECK-LABEL: define { %objc_object*, i8**, i8** } @u_cast_to_class_existential_2(%objc_object*)
+// CHECK-LABEL: define{{( protected)?}} { %objc_object*, i8**, i8** } @u_cast_to_class_existential_2(%objc_object*)
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @_TMp5casts2CP, %swift.protocol* @_TMp5casts3CP2)
-// CHECK-LABEL: define private { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
+// CHECK-LABEL: define{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -99,7 +99,7 @@ entry(%a : $AnyObject):
   return %p : $protocol<CP, CP2>
 }
 
-// CHECK-LABEL: define { %objc_object*, i8**, i8** } @u_cast_to_class_existential_mixed(%objc_object*)
+// CHECK-LABEL: define{{( protected)?}} { %objc_object*, i8**, i8** } @u_cast_to_class_existential_mixed(%objc_object*)
 // CHECK:         call %objc_object* @swift_dynamicCastObjCProtocolUnconditional
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @_TMp5casts2CP, %swift.protocol* @_TMp5casts3CP2)
 sil @u_cast_to_class_existential_mixed : $@convention(thin) (@owned AnyObject) -> @owned protocol<CP, OP, CP2> {
@@ -108,7 +108,7 @@ entry(%a : $AnyObject):
   return %p : $protocol<CP, OP, CP2>
 }
 
-// CHECK-LABEL: define { %swift.type*, i8**, i8** } @u_cast_to_existential_metatype_mixed(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} { %swift.type*, i8**, i8** } @u_cast_to_existential_metatype_mixed(%swift.type*)
 // CHECK:         call %swift.type* @swift_dynamicCastTypeToObjCProtocolUnconditional(%swift.type* %0, {{(i32|i64)}} 1, i8** {{%.*}})
 // CHECK:         [[CAST:%.*]] = call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{.*}}, %swift.type* %0, %swift.protocol* @_TMp5casts2CP, %swift.protocol* @_TMp5casts3CP2)
 // CHECK:         [[OBJPTR:%.*]] = extractvalue { i8*, i8**, i8** } [[CAST]], 0
@@ -121,9 +121,9 @@ entry(%a : $@thick Any.Type):
 }
 
 
-// CHECK-LABEL: define { %objc_object*, i8** } @c_cast_to_class_existential(%objc_object*)
+// CHECK-LABEL: define{{( protected)?}} { %objc_object*, i8** } @c_cast_to_class_existential(%objc_object*)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* {{.*}}, %swift.type* %.Type, %swift.protocol* @_TMp5casts2CP)
-// CHECK-LABEL: define private { i8*, i8** } @dynamic_cast_existential_1_conditional(i8*, %swift.type*, %swift.protocol*)
+// CHECK-LABEL: define{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_conditional(i8*, %swift.type*, %swift.protocol*)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -140,7 +140,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define { %swift.type*, i8** } @c_cast_to_existential_metatype(%swift.type*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { %swift.type*, i8** } @c_cast_to_existential_metatype(%swift.type*) {{.*}} {
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* %1, %swift.type* %0, %swift.protocol* @_TMp5casts2CP)
 sil @c_cast_to_existential_metatype : $@convention(thin) (@owned @thick Any.Type) -> @owned @thick CP.Type {
 entry(%a : $@thick Any.Type):
@@ -151,9 +151,9 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define { %objc_object*, i8**, i8** } @c_cast_to_class_existential_2(%objc_object*)
+// CHECK-LABEL: define{{( protected)?}} { %objc_object*, i8**, i8** } @c_cast_to_class_existential_2(%objc_object*)
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @_TMp5casts2CP, %swift.protocol* @_TMp5casts3CP2)
-// CHECK-LABEL: define private { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
+// CHECK-LABEL: define{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -174,7 +174,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define { %objc_object*, i8**, i8** } @c_cast_to_class_existential_mixed(%objc_object*)
+// CHECK-LABEL: define{{( protected)?}} { %objc_object*, i8**, i8** } @c_cast_to_class_existential_mixed(%objc_object*)
 // CHECK:         [[CAST:%.*]] = call %objc_object* @swift_dynamicCastObjCProtocolConditional
 // CHECK:         [[IS_NULL:%.*]] = icmp eq %objc_object* [[CAST]], null
 // CHECK:         br i1 [[IS_NULL]], label %cont, label %success
@@ -192,7 +192,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define { %swift.type*, i8**, i8** } @c_cast_to_existential_metatype_mixed(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} { %swift.type*, i8**, i8** } @c_cast_to_existential_metatype_mixed(%swift.type*)
 // CHECK:         [[OBJC_CAST:%.*]] = call %swift.type* @swift_dynamicCastTypeToObjCProtocolConditional(%swift.type* %0, {{(i32|i64)}} 1, i8** {{%.*}})
 // CHECK:         [[IS_NULL:%.*]] = icmp eq %swift.type* [[OBJC_CAST]], null
 // CHECK:         br i1 [[IS_NULL]], label %cont, label %success
@@ -207,7 +207,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define %objc_object* @checked_upcast(%C5casts1A*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_object* @checked_upcast(%C5casts1A*) {{.*}} {
 // -- Don't need to check conformance of an object to AnyObject.
 // CHECK-NOT:     call %objc_object* @swift_dynamicCastObjCProtocolConditional
 // CHECK:         phi %objc_object*
@@ -220,7 +220,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define %C5casts1A* @checked_downcast_optional({{(i32|i64)}}) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %C5casts1A* @checked_downcast_optional({{(i32|i64)}}) {{.*}} {
 // CHECK:         [[OBJ_PTR:%.*]] = inttoptr {{(i32|i64)}} %0 to i8*
 // CHECK:         [[METADATA:%.*]] = call %swift.type* @_TMaC5casts1A()
 // CHECK:         [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
@@ -237,7 +237,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define void @checked_metatype_to_object_casts
+// CHECK-LABEL: define{{( protected)?}} void @checked_metatype_to_object_casts
 sil @checked_metatype_to_object_casts : $@convention(thin) <T> (@thick Any.Type) -> () {
 entry(%e : $@thick Any.Type):
   %a = metatype $@thin NotClass.Type
@@ -286,7 +286,7 @@ entry(%x : $OB):
   return %x : $OB
 }
 
-// CHECK-LABEL: define %C5casts1B* @checked_object_to_object_casts(%C5casts1A*)
+// CHECK-LABEL: define{{( protected)?}} %C5casts1B* @checked_object_to_object_casts(%C5casts1A*)
 // CHECK:         @swift_dynamicCastClassUnconditional
 sil @checked_object_to_object_casts : $@convention(thin) (A) -> B {
 entry(%a : $A):
@@ -294,7 +294,7 @@ entry(%a : $A):
   return %b : $B
 }
 
-// CHECK-LABEL: define %C5casts2OB* @checked_objc_object_to_object_casts(%C5casts2OA*)
+// CHECK-LABEL: define{{( protected)?}} %C5casts2OB* @checked_objc_object_to_object_casts(%C5casts2OA*)
 // CHECK:         @swift_dynamicCastClassUnconditional
 sil @checked_objc_object_to_object_casts : $@convention(thin) (OA) -> OB {
 entry(%a : $OA):

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -28,7 +28,7 @@ bb0(%0 : $CCRefrigerator):
   return %3 : $()
 }
 
-// CHECK:    define void @call_generic([[REFRIGERATOR]]*) {{.*}} {
+// CHECK:    define{{( protected)?}} void @call_generic([[REFRIGERATOR]]*) {{.*}} {
 // CHECK:      [[T0:%.*]] = bitcast [[REFRIGERATOR]]* %0 to [[OBJC]]*
 // CHECK-NEXT: [[T1:%.*]] = call [[TYPE]]* @_TMaCSo14CCRefrigerator()
 // CHECK-NEXT: call void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T1]])

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -44,7 +44,7 @@ sil_vtable C {}
 // \ CHECK: }>
 
 // Destroying destructor
-// CHECK: define [[REF]]* @_TFC5class1Cd([[C_CLASS]]*) {{.*}} {
+// CHECK: define{{( protected)?}} [[REF]]* @_TFC5class1Cd([[C_CLASS]]*) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[OBJ_PTR:%[a-zA-Z0-9]+]] = bitcast [[C_CLASS]]* %0 to [[REF]]*
 // CHECK-NEXT: ret [[REF]]* [[OBJ_PTR]]
@@ -55,7 +55,7 @@ bb0(%0 : $C):
 }
 
 // Deallocating destructor
-// CHECK: define void @_TFC5class1CD([[C_CLASS]]*)
+// CHECK: define{{( protected)?}} void @_TFC5class1CD([[C_CLASS]]*)
 sil @_TFC5class1CD : $@convention(method) (@owned C) -> () {
 bb0(%0 : $C):
   // CHECK-NEXT: entry
@@ -72,7 +72,7 @@ bb0(%0 : $C):
   return %5 : $()                                 // id: %6
 }
 
-// CHECK: define [[REF]]* @unchecked_ref_cast_cast([[C_CLASS]]*)
+// CHECK: define{{( protected)?}} [[REF]]* @unchecked_ref_cast_cast([[C_CLASS]]*)
 // CHECK:   bitcast [[C_CLASS]]* {{%.*}} to [[REF]]*
 sil @unchecked_ref_cast_cast : $@convention(thin) C -> Builtin.NativeObject {
 entry(%c : $C):
@@ -80,7 +80,7 @@ entry(%c : $C):
   return %r : $Builtin.NativeObject
 }
 
-// CHECK: define [[OBJCOBJ]]* @ref_to_objc_pointer_cast([[C_CLASS]]*)
+// CHECK: define{{( protected)?}} [[OBJCOBJ]]* @ref_to_objc_pointer_cast([[C_CLASS]]*)
 // CHECK:   bitcast [[C_CLASS]]* %0 to [[OBJCOBJ]]*
 sil @ref_to_objc_pointer_cast : $@convention(thin) C -> Builtin.UnknownObject {
 entry(%c : $C):
@@ -88,7 +88,7 @@ entry(%c : $C):
   return %r : $Builtin.UnknownObject
 }
 
-// CHECK-LABEL: define %C5class1C* @alloc_ref_dynamic(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %C5class1C* @alloc_ref_dynamic(%swift.type*)
 sil @alloc_ref_dynamic : $@convention(thin) (@thick C.Type) -> @owned C {
 bb0(%0 : $@thick C.Type):
   // CHECK:   [[META_PTR:%[0-9]+]] = bitcast %swift.type* %0 to i8*
@@ -105,7 +105,7 @@ bb0(%0 : $@thick C.Type):
   return %1 : $C
 }
 
-// CHECK-LABEL: define %C5class1C* @autorelease(%C5class1C*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %C5class1C* @autorelease(%C5class1C*) {{.*}} {
 // CHECK:         %1 = bitcast %C5class1C* %0 to %objc_object*
 // CHECK:         call %objc_object* @objc_autorelease(%objc_object* %1)
 // CHECK:         ret %C5class1C* %0
@@ -115,7 +115,7 @@ entry(%c : $C):
   return %c : $C
 }
 
-// CHECK-LABEL: define i64 @autorelease_optional(i64) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i64 @autorelease_optional(i64) {{.*}} {
 // CHECK:         %1 = inttoptr i64 %0 to %objc_object*
 // CHECK:         call %objc_object* @objc_autorelease(%objc_object* %1)
 // CHECK:         ret i64 %0
@@ -163,7 +163,7 @@ entry(%x : $ClassConstrainedGenericField<ClassConstraintConformance>):
   %b = load %a : $*ClassConstraintConformance
   return %b : $ClassConstraintConformance
 }
-// CHECK-LABEL: define %C5class26ClassConstraintConformance* @fixed_class_generic_field(%C5class28ClassConstrainedGenericField*)
+// CHECK-LABEL: define{{( protected)?}} %C5class26ClassConstraintConformance* @fixed_class_generic_field(%C5class28ClassConstrainedGenericField*)
 // CHECK:         [[FIELD_ADDR_GENERIC:%.*]] = getelementptr inbounds %C5class28ClassConstrainedGenericField, %C5class28ClassConstrainedGenericField* %0, i32 0, i32 1
 // CHECK:         [[FIELD_ADDR_CONCRETE:%.*]] = bitcast %objc_object** [[FIELD_ADDR_GENERIC]] to %C5class26ClassConstraintConformance**
 // CHECK:         load %C5class26ClassConstraintConformance*, %C5class26ClassConstraintConformance** [[FIELD_ADDR_CONCRETE]]

--- a/test/IRGen/class_isa_pointers.sil
+++ b/test/IRGen/class_isa_pointers.sil
@@ -17,7 +17,7 @@ class Purebred {
 }
 sil_vtable Purebred {}
 
-// CHECK-LABEL: define void @purebred_method(%C18class_isa_pointers8Purebred*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @purebred_method(%C18class_isa_pointers8Purebred*) {{.*}} {
 // CHECK:         [[ISA_PTR:%.*]] = bitcast %C18class_isa_pointers8Purebred* %0 to %swift.type**
 // CHECK:         [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_PTR]]
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
@@ -38,7 +38,7 @@ class Mongrel: Gizmo {
 }
 sil_vtable Mongrel {}
 
-// CHECK-LABEL: define void @mongrel_method(%C18class_isa_pointers7Mongrel*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @mongrel_method(%C18class_isa_pointers7Mongrel*) {{.*}} {
 // CHECK:         [[T0:%.*]] = bitcast {{.*}} %0 to i64*
 // CHECK-NEXT:    [[T1:%.*]] = load i64, i64* [[T0]], align 8
 // CHECK-NEXT:    [[T2:%.*]] = load i64, i64* @swift_isaMask, align 8

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -3,20 +3,20 @@
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 
-// CHECK: @_TWvdvC16class_resilience26ClassWithResilientProperty1sV16resilient_struct4Size = global [[INT]] 0
-// CHECK: @_TWvdvC16class_resilience26ClassWithResilientProperty5colorVs5Int32 = global [[INT]] 0
+// CHECK: @_TWvdvC16class_resilience26ClassWithResilientProperty1sV16resilient_struct4Size = {{(protected )?}}global [[INT]] 0
+// CHECK: @_TWvdvC16class_resilience26ClassWithResilientProperty5colorVs5Int32 = {{(protected )?}}global [[INT]] 0
 
-// CHECK: @_TWvdvC16class_resilience33ClassWithResilientlySizedProperty1rV16resilient_struct9Rectangle = global [[INT]] 0
-// CHECK: @_TWvdvC16class_resilience33ClassWithResilientlySizedProperty5colorVs5Int32 = global [[INT]] 0
+// CHECK: @_TWvdvC16class_resilience33ClassWithResilientlySizedProperty1rV16resilient_struct9Rectangle = {{(protected )?}}global [[INT]] 0
+// CHECK: @_TWvdvC16class_resilience33ClassWithResilientlySizedProperty5colorVs5Int32 = {{(protected )?}}global [[INT]] 0
 
-// CHECK: @_TWvdvC16class_resilience14ResilientChild5fieldVs5Int32 = global [[INT]] {{12|16}}
-// CHECK: @_TWvivC16class_resilience21ResilientGenericChild5fieldVs5Int32 = global [[INT]] {{56|88}}
+// CHECK: @_TWvdvC16class_resilience14ResilientChild5fieldVs5Int32 = {{(protected )?}}global [[INT]] {{12|16}}
+// CHECK: @_TWvivC16class_resilience21ResilientGenericChild5fieldVs5Int32 = {{(protected )?}}global [[INT]] {{56|88}}
 
-// CHECK: @_TWvdvC16class_resilience28ClassWithMyResilientProperty1rVS_17MyResilientStruct = constant [[INT]] {{12|16}}
-// CHECK: @_TWvdvC16class_resilience28ClassWithMyResilientProperty5colorVs5Int32 = constant [[INT]] {{16|20}}
+// CHECK: @_TWvdvC16class_resilience28ClassWithMyResilientProperty1rVS_17MyResilientStruct = {{(protected )?}}constant [[INT]] {{12|16}}
+// CHECK: @_TWvdvC16class_resilience28ClassWithMyResilientProperty5colorVs5Int32 = {{(protected )?}}constant [[INT]] {{16|20}}
 
-// CHECK: @_TWvdvC16class_resilience30ClassWithIndirectResilientEnum1sO14resilient_enum10FunnyShape = constant [[INT]] {{12|16}}
-// CHECK: @_TWvdvC16class_resilience30ClassWithIndirectResilientEnum5colorVs5Int32 = constant [[INT]] {{16|24}}
+// CHECK: @_TWvdvC16class_resilience30ClassWithIndirectResilientEnum1sO14resilient_enum10FunnyShape = {{(protected )?}}constant [[INT]] {{12|16}}
+// CHECK: @_TWvdvC16class_resilience30ClassWithIndirectResilientEnum5colorVs5Int32 = {{(protected )?}}constant [[INT]] {{16|24}}
 
 import resilient_class
 import resilient_struct
@@ -113,7 +113,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ClassWithResilientProperty metadata accessor
 
-// CHECK-LABEL: define %swift.type* @_TMaC16class_resilience26ClassWithResilientProperty()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaC16class_resilience26ClassWithResilientProperty()
 // CHECK:      [[CACHE:%.*]] = load %swift.type*, %swift.type** @_TMLC16class_resilience26ClassWithResilientProperty
 // CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
 // CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
@@ -130,7 +130,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ClassWithResilientProperty.color getter
 
-// CHECK-LABEL: define i32 @_TFC16class_resilience26ClassWithResilientPropertyg5colorVs5Int32(%C16class_resilience26ClassWithResilientProperty*)
+// CHECK-LABEL: define{{( protected)?}} i32 @_TFC16class_resilience26ClassWithResilientPropertyg5colorVs5Int32(%C16class_resilience26ClassWithResilientProperty*)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_TWvdvC16class_resilience26ClassWithResilientProperty5colorVs5Int32
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %C16class_resilience26ClassWithResilientProperty* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -142,7 +142,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ClassWithResilientlySizedProperty metadata accessor
 
-// CHECK-LABEL: define %swift.type* @_TMaC16class_resilience33ClassWithResilientlySizedProperty()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaC16class_resilience33ClassWithResilientlySizedProperty()
 // CHECK:      [[CACHE:%.*]] = load %swift.type*, %swift.type** @_TMLC16class_resilience33ClassWithResilientlySizedProperty
 // CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
 // CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
@@ -159,7 +159,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ClassWithResilientlySizedProperty.color getter
 
-// CHECK-LABEL: define i32 @_TFC16class_resilience33ClassWithResilientlySizedPropertyg5colorVs5Int32(%C16class_resilience33ClassWithResilientlySizedProperty*)
+// CHECK-LABEL: define{{( protected)?}} i32 @_TFC16class_resilience33ClassWithResilientlySizedPropertyg5colorVs5Int32(%C16class_resilience33ClassWithResilientlySizedProperty*)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_TWvdvC16class_resilience33ClassWithResilientlySizedProperty5colorVs5Int32
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %C16class_resilience33ClassWithResilientlySizedProperty* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -171,7 +171,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ClassWithIndirectResilientEnum.color getter
 
-// CHECK-LABEL: define i32 @_TFC16class_resilience30ClassWithIndirectResilientEnumg5colorVs5Int32(%C16class_resilience30ClassWithIndirectResilientEnum*)
+// CHECK-LABEL: define{{( protected)?}} i32 @_TFC16class_resilience30ClassWithIndirectResilientEnumg5colorVs5Int32(%C16class_resilience30ClassWithIndirectResilientEnum*)
 // CHECK:      [[FIELD_PTR:%.*]] = getelementptr inbounds %C16class_resilience30ClassWithIndirectResilientEnum, %C16class_resilience30ClassWithIndirectResilientEnum* %0, i32 0, i32 2
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Vs5Int32, %Vs5Int32* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, i32* [[FIELD_PAYLOAD]]
@@ -180,7 +180,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ResilientChild.field getter
 
-// CHECK-LABEL: define i32 @_TFC16class_resilience14ResilientChildg5fieldVs5Int32(%C16class_resilience14ResilientChild*)
+// CHECK-LABEL: define{{( protected)?}} i32 @_TFC16class_resilience14ResilientChildg5fieldVs5Int32(%C16class_resilience14ResilientChild*)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @_TWvdvC16class_resilience14ResilientChild5fieldVs5Int32
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %C16class_resilience14ResilientChild* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -193,7 +193,7 @@ public class MyResilientChild : MyResilientParent {
 // ResilientGenericChild.field getter
 
 
-// CHECK-LABEL: define i32 @_TFC16class_resilience21ResilientGenericChildg5fieldVs5Int32(%C16class_resilience21ResilientGenericChild*)
+// CHECK-LABEL: define{{( protected)?}} i32 @_TFC16class_resilience21ResilientGenericChildg5fieldVs5Int32(%C16class_resilience21ResilientGenericChild*)
 
 // FIXME: we could eliminate the unnecessary isa load by lazily emitting
 // metadata sources in EmitPolymorphicParameters
@@ -217,7 +217,7 @@ public class MyResilientChild : MyResilientParent {
 
 // MyResilientChild.field getter
 
-// CHECK-LABEL: define i32 @_TFC16class_resilience16MyResilientChildg5fieldVs5Int32(%C16class_resilience16MyResilientChild*)
+// CHECK-LABEL: define{{( protected)?}} i32 @_TFC16class_resilience16MyResilientChildg5fieldVs5Int32(%C16class_resilience16MyResilientChild*)
 // CHECK:      [[FIELD_ADDR:%.*]] = getelementptr inbounds %C16class_resilience16MyResilientChild, %C16class_resilience16MyResilientChild* %0, i32 0, i32 2
 // CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = getelementptr inbounds %Vs5Int32, %Vs5Int32* [[FIELD_ADDR]], i32 0, i32 0
 // CHECK-NEXT: [[RESULT:%.*]] = load i32, i32* [[PAYLOAD_ADDR]]
@@ -227,7 +227,7 @@ public class MyResilientChild : MyResilientParent {
 // ClassWithResilientProperty metadata instantiation function
 
 
-// CHECK-LABEL: define private %swift.type* @create_generic_metadata_ClassWithResilientProperty(%swift.type_pattern*, i8**)
+// CHECK-LABEL: define{{( protected)?}} private %swift.type* @create_generic_metadata_ClassWithResilientProperty(%swift.type_pattern*, i8**)
 // CHECK:             [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(
 // CHECK:             [[SIZE_METADATA:%.*]] = call %swift.type* @_TMaV16resilient_struct4Size()
 // CHECK:             call void @swift_initClassMetadata_UniversalStrategy(
@@ -244,7 +244,7 @@ public class MyResilientChild : MyResilientParent {
 
 // ClassWithResilientlySizedProperty metadata instantiation function
 
-// CHECK-LABEL: define private %swift.type* @create_generic_metadata_ClassWithResilientlySizedProperty(%swift.type_pattern*, i8**)
+// CHECK-LABEL: define{{( protected)?}} private %swift.type* @create_generic_metadata_ClassWithResilientlySizedProperty(%swift.type_pattern*, i8**)
 // CHECK:             [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(
 // CHECK:             [[RECTANGLE_METADATA:%.*]] = call %swift.type* @_TMaV16resilient_struct9Rectangle()
 // CHECK:             call void @swift_initClassMetadata_UniversalStrategy(

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -16,7 +16,7 @@ struct TestStruct {
 
 sil_vtable TestClass {}
 
-// CHECK-LABEL: define void @simple_promote
+// CHECK-LABEL: define{{( protected)?}} void @simple_promote
 // CHECK: %reference.raw = alloca %[[C:[a-zA-Z0-9_]+]], align 8
 // CHECK: [[M:%[0-9]+]] = call %swift.type* @_TMa[[C]]()
 // CHECK: [[O:%[0-9]+]] = bitcast %[[C]]* %reference.raw to %swift.refcounted*
@@ -39,7 +39,7 @@ bb0:
 // A stack promotion limit of 48 bytes allows that one of the two alloc_refs
 // can be allocated on the stack.
 
-// CHECK-LABEL: define void @exceed_limit
+// CHECK-LABEL: define{{( protected)?}} void @exceed_limit
 // CHECK: alloca {{.*}}TestClass
 // CHECK: alloca {{.*}}TestStruct
 // CHECK-NOT: alloca

--- a/test/IRGen/concrete_inherits_generic_base.swift
+++ b/test/IRGen/concrete_inherits_generic_base.swift
@@ -17,7 +17,7 @@ class Base<T> {
   }
 }
 
-// CHECK-LABEL: define %swift.type* @_TMaC3foo12SuperDerived()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaC3foo12SuperDerived()
 // CHECK:          [[CACHE:%.*]] = load %swift.type*, %swift.type** @_TMLC3foo12SuperDerived
 // CHECK-NEXT:     [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
 // CHECK-NEXT:     br i1 [[COND]], label %cacheIsNull, label %cont
@@ -33,7 +33,7 @@ class Base<T> {
 class SuperDerived: Derived {
 }
 
-// CHECK-LABEL: define %swift.type* @_TMaC3foo7Derived()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaC3foo7Derived()
 // CHECK:          [[CACHE:%.*]] = load %swift.type*, %swift.type** @_TMLC3foo7Derived
 // CHECK-NEXT:     [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
 // CHECK-NEXT:     br i1 [[COND]], label %cacheIsNull, label %cont
@@ -69,7 +69,7 @@ presentBase(Derived(x: "two"))
 presentBase(Base(x: "two"))
 presentBase(Base(x: 2))
 
-// CHECK-LABEL: define private %swift.type* @create_generic_metadata_SuperDerived(%swift.type_pattern*, i8**)
+// CHECK-LABEL: define{{( protected)?}} private %swift.type* @create_generic_metadata_SuperDerived(%swift.type_pattern*, i8**)
 // CHECK:         [[TMP:%.*]] = call %swift.type* @_TMaC3foo7Derived()
 // CHECK-NEXT:    [[SUPER:%.*]] = bitcast %swift.type* [[TMP:%.*]] to %objc_class*
 // CHECK-NEXT:    [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_pattern* %0, i8** %1, %objc_class* [[SUPER]])

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -19,7 +19,7 @@ struct S {
 
 // CHECK: [[INT:%Si]] = type <{ [[LLVM_PTRSIZE_INT:i(32|64)]] }>
 
-// CHECK-LABEL: define void @testUnconditional0(
+// CHECK-LABEL: define{{( protected)?}} void @testUnconditional0(
 sil @testUnconditional0 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -38,7 +38,7 @@ bb0(%0 : $*P):
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_TMaP12dynamic_cast1P_()
 // CHECK:       call %swift.type* @swift_getExistentialTypeMetadata(
 
-// CHECK-LABEL: define void @testUnconditional1(
+// CHECK-LABEL: define{{( protected)?}} void @testUnconditional1(
 sil @testUnconditional1 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -54,7 +54,7 @@ bb0(%0 : $*P):
   return %2 : $()
 }
 
-// CHECK-LABEL: define void @testUnconditional2(
+// CHECK-LABEL: define{{( protected)?}} void @testUnconditional2(
 sil @testUnconditional2 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -70,7 +70,7 @@ bb0(%0 : $*P):
   return %2 : $()
 }
 
-// CHECK-LABEL: define void @testConditional0(
+// CHECK-LABEL: define{{( protected)?}} void @testConditional0(
 sil @testConditional0 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -90,7 +90,7 @@ bb2:
   return %2 : $()
 }
 
-// CHECK-LABEL: define void @testConditional1(
+// CHECK-LABEL: define{{( protected)?}} void @testConditional1(
 sil @testConditional1 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -110,7 +110,7 @@ bb2:
   return %2 : $()
 }
 
-// CHECK-LABEL: define void @testConditional2(
+// CHECK-LABEL: define{{( protected)?}} void @testConditional2(
 sil @testConditional2 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -16,7 +16,7 @@ sil @_TFC12dynamic_init1CcfMS0_FT_S0_ : $@convention(method) (@owned C) -> @owne
 sil @_TFC12dynamic_init1Cd : $@convention(method) (@owned C) -> @owned Builtin.NativeObject
 sil @_TFC12dynamic_init1CD : $@convention(method) (@owned C) -> ()
 
-// CHECK-LABEL: define void @_TF12dynamic_init15testDynamicInitFT2cmMCS_1C_T_
+// CHECK-LABEL: define{{( protected)?}} void @_TF12dynamic_init15testDynamicInitFT2cmMCS_1C_T_
 sil @_TF12dynamic_init15testDynamicInitFT2cmMCS_1C_T_ : $@convention(thin) (@thick C.Type) -> () {
 bb0(%0 : $@thick C.Type):
   // CHECK:   [[META:%[0-9]+]] = bitcast %swift.type* %0 to %C12dynamic_init1C* (%swift.type*)**

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -51,7 +51,7 @@ bb0(%0 : $X):
   return %7 : $Int
 }
 
-// CHECK: define void @dynamic_lookup_br(%objc_object*)
+// CHECK: define{{( protected)?}} void @dynamic_lookup_br(%objc_object*)
 sil @dynamic_lookup_br : $@convention(thin) (AnyObject) -> () {
 bb0(%0 : $AnyObject):
   %1 = alloc_box $AnyObject
@@ -80,7 +80,7 @@ bb3:
   return %43 : $()
 }
 
-// CHECK: define void @dynamic_lookup_static_br(%swift.type*)
+// CHECK: define{{( protected)?}} void @dynamic_lookup_static_br(%swift.type*)
 sil @dynamic_lookup_static_br : $@convention(thin) (@thick AnyObject.Type) -> () {
 bb0(%0 : $@thick AnyObject.Type):
   // CHECK: [[SEL:%[0-9]+]] = load i8*, i8** @"\01L_selector(g)", align {{(4|8)}}
@@ -123,7 +123,7 @@ bb3:
   return %43 : $()  
 }
 
-// CHECK-LABEL: define void @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_(%objc_object*, {{(i32|i64)}})
+// CHECK-LABEL: define{{( protected)?}} void @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_(%objc_object*, {{(i32|i64)}})
 sil @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_ : $@convention(thin) (AnyObject, Int) -> () {
 bb0(%0 : $AnyObject, %1 : $Int):
   %2 = alloc_box $AnyObject

--- a/test/IRGen/dynamic_self.sil
+++ b/test/IRGen/dynamic_self.sil
@@ -11,7 +11,7 @@ protocol P {
   func f() -> Self
 }
 
-// CHECK-LABEL: define void @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_
+// CHECK-LABEL: define{{( protected)?}} void @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_
 sil @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_ : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   debug_value_addr %0 : $*P, let, name "p" // id: %1

--- a/test/IRGen/empty_array.sil
+++ b/test/IRGen/empty_array.sil
@@ -12,11 +12,11 @@ sil_stage canonical
 
 import Builtin
 
-// CHECK-32-LABEL: define void @empty_array(%swift.opaque* noalias nocapture) {{.*}} {
+// CHECK-32-LABEL: define{{( protected)?}} void @empty_array(%swift.opaque* noalias nocapture) {{.*}} {
 // CHECK-32:         %1 = bitcast %swift.opaque* %0 to i8*
 // CHECK-32:         %2 = getelementptr inbounds i8, i8* %1, i32 0
 
-// CHECK-64-LABEL: define void @empty_array(%swift.opaque* noalias nocapture) {{.*}} {
+// CHECK-64-LABEL: define{{( protected)?}} void @empty_array(%swift.opaque* noalias nocapture) {{.*}} {
 // CHECK-64:         %1 = bitcast %swift.opaque* %0 to i8*
 // CHECK-64:         %2 = getelementptr inbounds i8, i8* %1, i64 0
 

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -104,7 +104,7 @@ import Swift
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[DYNAMICSINGLETON_FIELD_NAMES:@.*]] = private constant [7 x i8] c"value\00\00"
 // CHECK: [[DYNAMICSINGLETON_NAME:@.*]] = private constant [25 x i8] c"O4enum16DynamicSingleton\00"
-// CHECK: @_TMnO4enum16DynamicSingleton = constant <{ {{.*}} i32 }> <{
+// CHECK: @_TMnO4enum16DynamicSingleton = {{(protected )?}}constant <{ {{.*}} i32 }> <{
 // CHECK:   [25 x i8]* [[DYNAMICSINGLETON_NAME]]
 // --       One payload
 // CHECK:   i32 1,
@@ -120,7 +120,7 @@ import Swift
 // CHECK:   i32 1, i32 0
 // CHECK: }>
 
-// CHECK: @_TMPO4enum16DynamicSingleton = global <{ {{.*}}* }> <{
+// CHECK: @_TMPO4enum16DynamicSingleton = {{(protected )?}}global <{ {{.*}}* }> <{
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_DynamicSingleton
 // CHECK:   @_TMnO4enum16DynamicSingleton
 // CHECK:   i8* null
@@ -129,7 +129,7 @@ import Swift
 
 // -- No-payload enums have extra inhabitants in
 //    their value witness table.
-// CHECK: @_TWVO4enum10NoPayloads = constant [26 x i8*] [
+// CHECK: @_TWVO4enum10NoPayloads = {{(protected )?}}constant [26 x i8*] [
 // -- ...
 // -- size
 // CHECK:   i8* inttoptr ([[WORD:i32|i64]] 1 to i8*),
@@ -147,7 +147,7 @@ import Swift
 
 // -- Single-payload enums take unused extra inhabitants from their payload
 //    as their own.
-// CHECK: @_TWVO4enum19SinglePayloadNested = constant [26 x i8*] [
+// CHECK: @_TWVO4enum19SinglePayloadNested = {{(protected )?}}constant [26 x i8*] [
 // -- ...
 // -- size
 // CHECK:   i8* inttoptr ([[WORD]] 1 to i8*),
@@ -164,13 +164,13 @@ import Swift
 // CHECK: ] 
 
 
-// CHECK: @_TMPO4enum20DynamicSinglePayload = global <{ {{.*}}* }> <{
+// CHECK: @_TMPO4enum20DynamicSinglePayload = {{(protected )?}}global <{ {{.*}}* }> <{
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_DynamicSinglePayload
 // CHECK:   i8* null
 // CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @_TwxsO4enum20DynamicSinglePayload to i8*)
 // CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @_TwxgO4enum20DynamicSinglePayload to i8*)
 
-// CHECK: @_TWVO4enum18MultiPayloadNested = constant [26 x i8*] [
+// CHECK: @_TWVO4enum18MultiPayloadNested = {{(protected )?}}constant [26 x i8*] [
 // CHECK:   i8* inttoptr ([[WORD]] 9 to i8*),
 // CHECK:   i8* inttoptr ([[WORD]] 16 to i8*)
 // CHECK: ]
@@ -193,7 +193,7 @@ enum DynamicSingleton<T> {
   case value(T)
 }
 
-// CHECK: define void @singleton_switch(i64, i64) {{.*}} {
+// CHECK: define{{( protected)?}} void @singleton_switch(i64, i64) {{.*}} {
 sil @singleton_switch : $(Singleton) -> () {
 // CHECK: entry:
 entry(%u : $Singleton):
@@ -207,7 +207,7 @@ dest:
   return %x : $()
 }
 
-// CHECK: define void @singleton_switch_arg(i64, i64) {{.*}} {
+// CHECK: define{{( protected)?}} void @singleton_switch_arg(i64, i64) {{.*}} {
 sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK: entry:
 entry(%u : $Singleton):
@@ -225,7 +225,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define void @singleton_switch_indirect(%O4enum9Singleton* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @singleton_switch_indirect(%O4enum9Singleton* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: ; <label>:[[DEST]]
@@ -241,7 +241,7 @@ dest:
   return %x : $()
 }
 
-// CHECK: define { i64, i64 } @singleton_inject(i64, i64) {{.*}} {
+// CHECK: define{{( protected)?}} { i64, i64 } @singleton_inject(i64, i64) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[A:%.*]] = insertvalue { i64, i64 } undef, i64 %0, 0
 // CHECK:   [[B:%.*]] = insertvalue { i64, i64 } [[A]], i64 %1, 1
@@ -254,7 +254,7 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define void @singleton_inject_indirect(i64, i64, %O4enum9Singleton* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @singleton_inject_indirect(i64, i64, %O4enum9Singleton* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %O4enum9Singleton* %2 to <{ i64, i64 }>*
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[DATA_ADDR]], i32 0, i32 0
@@ -288,7 +288,7 @@ sil @e : $@convention(thin) () -> ()
 sil @f : $@convention(thin) () -> ()
 
 
-// CHECK: define void @no_payload_switch(i2) {{.*}} {
+// CHECK: define{{( protected)?}} void @no_payload_switch(i2) {{.*}} {
 sil @no_payload_switch : $@convention(thin) (NoPayloads) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads):
@@ -330,7 +330,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define void @no_payload_switch_indirect(%O4enum10NoPayloads* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @no_payload_switch_indirect(%O4enum10NoPayloads* nocapture dereferenceable({{.*}})) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %O4enum10NoPayloads, %O4enum10NoPayloads* %0, i32 0, i32 0
@@ -349,7 +349,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define i2 @no_payload_inject_x() {{.*}} {
+// CHECK: define{{( protected)?}} i2 @no_payload_inject_x() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i2 0
 // CHECK: }
@@ -359,7 +359,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define i2 @no_payload_inject_y() {{.*}} {
+// CHECK: define{{( protected)?}} i2 @no_payload_inject_y() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i2 1
 // CHECK: }
@@ -369,7 +369,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define i2 @no_payload_inject_z() {{.*}} {
+// CHECK: define{{( protected)?}} i2 @no_payload_inject_z() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i2 -2
 // CHECK: }
@@ -379,7 +379,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define void @no_payload_inject_z_indirect(%O4enum10NoPayloads* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @no_payload_inject_z_indirect(%O4enum10NoPayloads* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %O4enum10NoPayloads, %O4enum10NoPayloads* %0, i32 0, i32 0
 // CHECK:   store i2 -2, i2* [[TAG_ADDR]]
@@ -402,7 +402,7 @@ enum NoPayloads2 {
   case y
 }
 
-// CHECK: define void @no_payload_switch_2(i3) {{.*}} {
+// CHECK: define{{( protected)?}} void @no_payload_switch_2(i3) {{.*}} {
 sil @no_payload_switch_2 : $@convention(thin) (NoPayloads2) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads2):
@@ -449,8 +449,8 @@ enum SinglePayloadNoXI2 {
   case u
 }
 
-// CHECK-64: define void @single_payload_no_xi_switch([[WORD:i64]], i1) {{.*}} {
-// CHECK-32: define void @single_payload_no_xi_switch([[WORD:i32]], i1) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_no_xi_switch([[WORD:i64]], i1) {{.*}} {
+// CHECK-32: define{{( protected)?}} void @single_payload_no_xi_switch([[WORD:i32]], i1) {{.*}} {
 sil @single_payload_no_xi_switch : $@convention(thin) (SinglePayloadNoXI2) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadNoXI2):
@@ -523,7 +523,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define void @single_payload_no_xi_switch_arg([[WORD]], i1) {{.*}} {
+// CHECK: define{{( protected)?}} void @single_payload_no_xi_switch_arg([[WORD]], i1) {{.*}} {
 sil @single_payload_no_xi_switch_arg : $@convention(thin) (SinglePayloadNoXI2) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadNoXI2):
@@ -576,7 +576,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define { [[WORD]], i1 } @single_payload_no_xi_inject_x([[WORD]]) {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], i1 } @single_payload_no_xi_inject_x([[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[A:%.*]] = insertvalue { [[WORD]], i1 } undef, [[WORD]] %0, 0
 // CHECK:   [[B:%.*]] = insertvalue { [[WORD]], i1 } [[A]], i1 false, 1
@@ -588,7 +588,7 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define void @single_payload_no_xi_inject_x_indirect([[WORD]], %O4enum18SinglePayloadNoXI2* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @single_payload_no_xi_inject_x_indirect([[WORD]], %O4enum18SinglePayloadNoXI2* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %O4enum18SinglePayloadNoXI2* %1 to [[WORD]]*
 // CHECK:   store [[WORD]] %0, [[WORD]]* [[DATA_ADDR]]
@@ -606,7 +606,7 @@ entry(%0 : $Builtin.Word, %1 : $*SinglePayloadNoXI2):
   return %v : $()
 }
 
-// CHECK: define { [[WORD]], i1 } @single_payload_no_xi_inject_y() {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], i1 } @single_payload_no_xi_inject_y() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret { [[WORD]], i1 } { [[WORD]] 0, i1 true }
 // CHECK: }
@@ -616,7 +616,7 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define void @single_payload_no_xi_inject_y_indirect(%O4enum18SinglePayloadNoXI2* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @single_payload_no_xi_inject_y_indirect(%O4enum18SinglePayloadNoXI2* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum18SinglePayloadNoXI2* %0 to [[WORD]]*
 // CHECK:   store [[WORD]] 0, [[WORD]]* [[PAYLOAD_ADDR]]
@@ -632,7 +632,7 @@ entry(%0 : $*SinglePayloadNoXI2):
   return %v : $()
 }
 
-// CHECK: define { [[WORD]], i1 } @single_payload_no_xi_inject_z() {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], i1 } @single_payload_no_xi_inject_z() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret { [[WORD]], i1 } { [[WORD]] 1, i1 true }
 // CHECK: }
@@ -654,7 +654,7 @@ enum AggregateSinglePayload {
 sil @int21_sink : $@convention(thin) (Builtin.Int21) -> ()
 sil @int64_sink : $@convention(thin) (Builtin.Word) -> ()
 
-// CHECK-LABEL: define void @aggregate_single_payload_unpack
+// CHECK-LABEL: define{{( protected)?}} void @aggregate_single_payload_unpack
 // CHECK:         ([[WORD]], [[WORD]], i1) {{.*}} {
 sil @aggregate_single_payload_unpack : $@convention(thin) (AggregateSinglePayload) -> () {
 entry(%u : $AggregateSinglePayload):
@@ -677,7 +677,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define { [[WORD]], [[WORD]] } @aggregate_single_payload_unsafe_unpack([[WORD]], [[WORD]], i1) {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], [[WORD]] } @aggregate_single_payload_unsafe_unpack([[WORD]], [[WORD]], i1) {{.*}} {
 // CHECK:  [[A:%.*]] = insertvalue { [[WORD]], [[WORD]] } undef, [[WORD]] %0, 0
 // CHECK:  [[B:%.*]] = insertvalue { [[WORD]], [[WORD]] } [[A]], [[WORD]] %1, 1
 // CHECK:  ret { [[WORD]], [[WORD]] } [[B]]
@@ -687,7 +687,7 @@ entry(%u : $AggregateSinglePayload):
   return %x : $(Builtin.Word, Builtin.Word)
 }
 
-// CHECK: define { [[WORD]], [[WORD]], i1 } @aggregate_single_payload_inject([[WORD]], [[WORD]]) {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], [[WORD]], i1 } @aggregate_single_payload_inject([[WORD]], [[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[RES_0:%.*]] = insertvalue { [[WORD]], [[WORD]], i1 } undef, [[WORD]] %0, 0
 // CHECK:   [[RES_1:%.*]] = insertvalue { [[WORD]], [[WORD]], i1 } [[RES_0]], [[WORD]] %1, 1
@@ -711,7 +711,7 @@ enum AggregateSinglePayload2 {
   case z
 }
 
-// CHECK: define void @aggregate_single_payload_unpack_2(%O4enum23AggregateSinglePayload2* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} void @aggregate_single_payload_unpack_2(%O4enum23AggregateSinglePayload2* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
 // CHECK: [[CHUNK0:%.*]] = load [[WORD]]
@@ -733,7 +733,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define void @aggregate_single_payload_2_inject(%O4enum23AggregateSinglePayload2* noalias nocapture sret, i21, [[WORD]], [[WORD]], [[WORD]]) {{.*}} {
+// CHECK: define{{( protected)?}} void @aggregate_single_payload_2_inject(%O4enum23AggregateSinglePayload2* noalias nocapture sret, i21, [[WORD]], [[WORD]], [[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[ZEXT_0:%.*]] = zext i21 %1 to [[WORD]]
 // CHECK:   store [[WORD]] [[ZEXT_0]]
@@ -754,7 +754,7 @@ enum AggregateSinglePayload3 {
   case z
 }
 
-// CHECK: define void @aggregate_single_payload_unpack_3([[WORD]], [[WORD]]) {{.*}} {
+// CHECK: define{{( protected)?}} void @aggregate_single_payload_unpack_3([[WORD]], [[WORD]]) {{.*}} {
 sil @aggregate_single_payload_unpack_3 : $@convention(thin) (AggregateSinglePayload3) -> () {
 entry(%u : $AggregateSinglePayload3):
   switch_enum %u : $AggregateSinglePayload3, case #AggregateSinglePayload3.x!enumelt.1: x_dest, default end
@@ -778,7 +778,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_x3(i21, [[WORD]]) {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_x3(i21, [[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[ZEXT_0:%.*]] = zext i21 %0 to [[WORD]]
 // CHECK:   [[A:%.*]] = insertvalue { [[WORD]], [[WORD]] } undef, [[WORD]] [[ZEXT_0]], 0
@@ -792,7 +792,7 @@ entry(%0 : $Builtin.Int21, %1 : $Builtin.Word):
   return %u : $AggregateSinglePayload3
 }
 
-// CHECK: define { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_y3() {{.*}} {
+// CHECK: define{{( protected)?}} { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_y3() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret { [[WORD]], [[WORD]] } { [[WORD]] 2097152, [[WORD]] 0 }
 // CHECK: }
@@ -809,8 +809,8 @@ enum SinglePayloadSpareBit {
   case z
 }
 
-// CHECK-64: define void @single_payload_spare_bit_switch(i64) {{.*}} {
-// CHECK-32: define void @single_payload_spare_bit_switch(i32, i32) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_spare_bit_switch(i64) {{.*}} {
+// CHECK-32: define{{( protected)?}} void @single_payload_spare_bit_switch(i32, i32) {{.*}} {
 sil @single_payload_spare_bit_switch : $@convention(thin) (SinglePayloadSpareBit) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadSpareBit):
@@ -864,7 +864,7 @@ end:
   return %x : $()
 }
 
-// CHECK-64: define void @single_payload_spare_bit_switch_arg(i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_spare_bit_switch_arg(i64) {{.*}} {
 sil @single_payload_spare_bit_switch_arg : $@convention(thin) (SinglePayloadSpareBit) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadSpareBit):
@@ -937,7 +937,7 @@ end:
   return %x : $()
 }
 
-// CHECK-64: define i64 @single_payload_spare_bit_inject_x(i63) {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @single_payload_spare_bit_inject_x(i63) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[A:%.*]] = zext i63 %0 to i64
 // CHECK-64:   ret i64 [[A]]
@@ -948,7 +948,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define void @single_payload_spare_bit_inject_x_indirect(i63, %O4enum21SinglePayloadSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_spare_bit_inject_x_indirect(i63, %O4enum21SinglePayloadSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum21SinglePayloadSpareBit* %1 to i63*
 // CHECK-64:   store i63 %0, i63* [[DATA_ADDR]]
@@ -963,7 +963,7 @@ entry(%0 : $Builtin.Int63, %1 : $*SinglePayloadSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define i64 @single_payload_spare_bit_inject_y() {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @single_payload_spare_bit_inject_y() {{.*}} {
 // CHECK-64: entry:
 // --              0x8000_0000_0000_0000
 // CHECK-64:   ret i64 -9223372036854775808
@@ -974,7 +974,7 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define void @single_payload_spare_bit_inject_y_indirect(%O4enum21SinglePayloadSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_spare_bit_inject_y_indirect(%O4enum21SinglePayloadSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum21SinglePayloadSpareBit* %0 to i64*
 // --                0x8000_0000_0000_0000
@@ -988,7 +988,7 @@ entry(%0 : $*SinglePayloadSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define i64 @single_payload_spare_bit_inject_z() {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @single_payload_spare_bit_inject_z() {{.*}} {
 // CHECK-64: entry:
 //                 0x8000_0000_0000_0001
 // CHECK-64:   ret i64 -9223372036854775807
@@ -1013,7 +1013,7 @@ enum SinglePayloadNestedNested {
   case h
 }
 
-// CHECK: define void @single_payload_nested_switch(i8) {{.*}} {
+// CHECK: define{{( protected)?}} void @single_payload_nested_switch(i8) {{.*}} {
 sil @single_payload_nested_switch : $(SinglePayloadNestedNested) -> () {
 entry(%u : $SinglePayloadNestedNested):
 // CHECK:   switch i8 {{%.*}}, label {{%.*}} [
@@ -1082,7 +1082,7 @@ enum SinglePayloadClass {
   case w
 }
 
-// CHECK-64: define void @single_payload_class_switch(i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_class_switch(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
@@ -1092,7 +1092,7 @@ enum SinglePayloadClass {
 // CHECK-64: ; <label>
 // CHECK-64:   inttoptr [[WORD]] %0 to %C4enum1C*
 
-// CHECK-32: define void @single_payload_class_switch(i32) {{.*}} {
+// CHECK-32: define{{( protected)?}} void @single_payload_class_switch(i32) {{.*}} {
 // CHECK-32: entry:
 // CHECK-32:   switch i32 %0, label {{%.*}} [
 // CHECK-32:     i32 0, label {{%.*}}
@@ -1132,7 +1132,7 @@ enum SinglePayloadObjCProtocol {
   case y, z, w
 }
 
-// CHECK-64: define void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-64:     i64 2, label {{%.*}}
@@ -1143,7 +1143,7 @@ enum SinglePayloadObjCProtocol {
 // CHECK-native-64:   inttoptr i64 %0 to %swift.refcounted*
 // CHECK-64:   inttoptr i64 %1 to i8**
 
-// CHECK-32: define void @single_payload_class_protocol_switch(i32, i32) {{.*}} {
+// CHECK-32: define{{( protected)?}} void @single_payload_class_protocol_switch(i32, i32) {{.*}} {
 // CHECK-32:   switch i32 %0, label {{%.*}} [
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
@@ -1171,7 +1171,7 @@ end:
   return undef : $()
 }
 
-// CHECK-64: define void @single_payload_objc_protocol_switch(i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @single_payload_objc_protocol_switch(i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}}
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-64:     i64 2, label {{%.*}}
@@ -1180,7 +1180,7 @@ end:
 // CHECK-objc-64:     inttoptr i64 %0 to %objc_object*
 // CHECK-native-64:   inttoptr i64 %0 to %swift.refcounted*
 
-// CHECK-32: define void @single_payload_objc_protocol_switch(i32) {{.*}} {
+// CHECK-32: define{{( protected)?}} void @single_payload_objc_protocol_switch(i32) {{.*}} {
 // CHECK-32:   switch i32 %0, label {{%.*}}
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
@@ -1214,7 +1214,7 @@ enum DynamicSinglePayload<T> {
   case w
 }
 
-// CHECK: define void @dynamic_single_payload_switch(%O4enum20DynamicSinglePayload* noalias nocapture, %swift.type* %T) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_switch(%O4enum20DynamicSinglePayload* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %O4enum20DynamicSinglePayload* %0 to %swift.opaque*
 // CHECK:   [[CASE_INDEX:%.*]] = call i32 @swift_getEnumCaseSinglePayload(%swift.opaque* [[OPAQUE_ENUM]], %swift.type* %T, i32 3)
 // CHECK:   switch i32 [[CASE_INDEX]], label {{%.*}} [
@@ -1239,7 +1239,7 @@ end:
   return %v : $()
 }
 
-// CHECK: define void @dynamic_single_payload_inject_x(%O4enum20DynamicSinglePayload* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_inject_x(%O4enum20DynamicSinglePayload* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   [[ADDR:%.*]] = bitcast %O4enum20DynamicSinglePayload* %0 to %swift.opaque*
 // CHECK:   call void @swift_storeEnumTagSinglePayload(%swift.opaque* [[ADDR]], %swift.type* %T, i32 -1, i32 3)
 sil @dynamic_single_payload_inject_x : $<T> (@out DynamicSinglePayload<T>, @in T) -> () {
@@ -1249,7 +1249,7 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define void @dynamic_single_payload_inject_y(%O4enum20DynamicSinglePayload* noalias nocapture sret, %swift.type* %T) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_inject_y(%O4enum20DynamicSinglePayload* noalias nocapture sret, %swift.type* %T) {{.*}} {
 // CHECK:   [[ADDR:%.*]] = bitcast %O4enum20DynamicSinglePayload* %0 to %swift.opaque*
 // CHECK:   call void @swift_storeEnumTagSinglePayload(%swift.opaque* [[ADDR]], %swift.type* %T, i32 0, i32 3)
 sil @dynamic_single_payload_inject_y : $<T> (@out DynamicSinglePayload<T>) -> () {
@@ -1262,7 +1262,7 @@ entry(%r : $*DynamicSinglePayload<T>):
 // -- Ensure instantiations of single-payload types with empty payloads work.
 //    Bug discovered by Greg Parker.
 
-// CHECK: define void @dynamic_single_payload_empty_payload_switch(i2) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_empty_payload_switch(i2) {{.*}} {
 // CHECK:   switch i2 {{%.*}}, label {{.*}} [
 // CHECK:     i2 0, label {{.*}}
 // CHECK:     i2 1, label {{.*}}
@@ -1292,7 +1292,7 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define i2 @dynamic_single_payload_empty_payload_load([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( protected)?}} i2 @dynamic_single_payload_empty_payload_load([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i2*
 // CHECK:   %2 = load i2, i2* %1
@@ -1304,7 +1304,7 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define void @dynamic_single_payload_empty_payload_store([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}}), i2) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_empty_payload_store([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}}), i2) {{.*}} {
 // CHECK: entry:
 // CHECK:   %2 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i2*
 // CHECK:   store i2 %1, i2* %2
@@ -1317,7 +1317,7 @@ entry(%p : $*DynamicSinglePayload<()>, %x : $DynamicSinglePayload<()>):
   return %v : $()
 }
 
-// CHECK: define i2 @dynamic_single_payload_empty_payload_inject_payload() {{.*}} {
+// CHECK: define{{( protected)?}} i2 @dynamic_single_payload_empty_payload_inject_payload() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i2 0
 // CHECK: }
@@ -1327,7 +1327,7 @@ sil @dynamic_single_payload_empty_payload_inject_payload : $() -> DynamicSingleP
   return %u : $DynamicSinglePayload<()>
 }
 
-// CHECK: define i2 @dynamic_single_payload_empty_payload_inject_no_payload() {{.*}} {
+// CHECK: define{{( protected)?}} i2 @dynamic_single_payload_empty_payload_inject_no_payload() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i2 1
 // CHECK: }
@@ -1337,7 +1337,7 @@ sil @dynamic_single_payload_empty_payload_inject_no_payload : $() -> DynamicSing
 }
 
 // <rdar://problem/15383966>
-// CHECK: define void @dynamic_single_payload_generic_destroy
+// CHECK: define{{( protected)?}} void @dynamic_single_payload_generic_destroy
 // CHECK:   br i1
 // CHECK: <label>
 // CHECK:   call void %destroy
@@ -1358,7 +1358,7 @@ enum MultiPayloadNoSpareBits {
   case c
 }
 
-// CHECK-64: define void @multi_payload_no_spare_bits_switch(i64, i2) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_no_spare_bits_switch(i64, i2) {{.*}} {
 sil @multi_payload_no_spare_bits_switch : $(MultiPayloadNoSpareBits) -> () {
 entry(%u : $MultiPayloadNoSpareBits):
 // CHECK-64:   switch i2 %1, label %[[UNREACHABLE:[0-9]+]] [
@@ -1430,7 +1430,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define void @multi_payload_no_spare_bits_switch_indirect(%O4enum23MultiPayloadNoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_no_spare_bits_switch_indirect(%O4enum23MultiPayloadNoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum23MultiPayloadNoSpareBits* %0 to i64*
@@ -1477,7 +1477,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define { i64, i2 } @multi_payload_no_spare_bit_inject_x(i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_x(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i2 } undef, i64 %0, 0
 // CHECK-64:   [[RES:%.*]] = insertvalue { i64, i2 } [[RES_0]], i2 0, 1
@@ -1489,7 +1489,7 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define void @multi_payload_no_spare_bit_inject_x_indirect(i64, %O4enum23MultiPayloadNoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_no_spare_bit_inject_x_indirect(i64, %O4enum23MultiPayloadNoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum23MultiPayloadNoSpareBits* %1 to i64*
 // CHECK-64:   store i64 %0, i64* [[DATA_ADDR]]
@@ -1507,7 +1507,7 @@ entry(%0 : $Builtin.Int64, %1 : $*MultiPayloadNoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define { i64, i2 } @multi_payload_no_spare_bit_inject_y(i32) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_y(i32) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i32 %0 to i64
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i2 } undef, i64 [[ZEXT]], 0
@@ -1520,7 +1520,7 @@ entry(%0 : $Builtin.Int32):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define { i64, i2 } @multi_payload_no_spare_bit_inject_z(i63) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_z(i63) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i63 %0 to i64
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i2 } undef, i64 [[ZEXT]], 0
@@ -1533,7 +1533,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define { i64, i2 } @multi_payload_no_spare_bit_inject_a() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_a() {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   ret { i64, i2 } { i64 0, i2 -1 }
 // CHECK-64: }
@@ -1543,7 +1543,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define void @multi_payload_no_spare_bit_inject_a_indirect(%O4enum23MultiPayloadNoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_no_spare_bit_inject_a_indirect(%O4enum23MultiPayloadNoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum23MultiPayloadNoSpareBits* %0 to i64*
 // CHECK-64:   store i64 0, i64* [[PAYLOAD_ADDR]]
@@ -1559,7 +1559,7 @@ entry(%0 : $*MultiPayloadNoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define { i64, i2 } @multi_payload_no_spare_bit_inject_b() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_b() {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   ret { i64, i2 } { i64 1, i2 -1 }
 // CHECK-64: }
@@ -1569,7 +1569,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define { i64, i2 } @multi_payload_no_spare_bit_inject_c() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i2 } @multi_payload_no_spare_bit_inject_c() {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   ret { i64, i2 } { i64 2, i2 -1 }
 // CHECK-64: }
@@ -1588,7 +1588,7 @@ enum MultiPayloadOneSpareBit {
   case c
 }
 
-// CHECK-64: define void @multi_payload_one_spare_bit_switch(i64, i1) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_one_spare_bit_switch(i64, i1) {{.*}} {
 sil @multi_payload_one_spare_bit_switch : $(MultiPayloadOneSpareBit) -> () {
 entry(%u : $MultiPayloadOneSpareBit):
 // CHECK-64:   [[SPARE_TAG_LSHR:%.*]] = lshr i64 %0, 63
@@ -1728,7 +1728,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define { i64, i1 } @multi_payload_one_spare_bit_inject_x(i62) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i1 } @multi_payload_one_spare_bit_inject_x(i62) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i62 %0 to i64
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i1 } undef, i64 [[ZEXT]], 0
@@ -1741,7 +1741,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define void @multi_payload_one_spare_bit_inject_x_indirect(i62, %O4enum23MultiPayloadOneSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_one_spare_bit_inject_x_indirect(i62, %O4enum23MultiPayloadOneSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum23MultiPayloadOneSpareBit* %1 to i62*
 // CHECK-64:   store i62 %0, i62* [[DATA_ADDR]]
@@ -1765,7 +1765,7 @@ entry(%0 : $Builtin.Int62, %1 : $*MultiPayloadOneSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define { i64, i1 } @multi_payload_one_spare_bit_inject_y(i63) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i1 } @multi_payload_one_spare_bit_inject_y(i63) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i63 %0 to i64
 // --                                        0x8000_0000_0000_0000
@@ -1780,7 +1780,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define void @multi_payload_one_spare_bit_inject_y_indirect(i63, %O4enum23MultiPayloadOneSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_one_spare_bit_inject_y_indirect(i63, %O4enum23MultiPayloadOneSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum23MultiPayloadOneSpareBit* %1 to i63*
 // CHECK-64:   store i63 %0, i63* [[DATA_ADDR]]
@@ -1807,7 +1807,7 @@ entry(%0 : $Builtin.Int63, %1 : $*MultiPayloadOneSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define { i64, i1 } @multi_payload_one_spare_bit_inject_z(i61) {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i1 } @multi_payload_one_spare_bit_inject_z(i61) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i61 %0 to i64
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i1 } undef, i64 [[ZEXT]], 0
@@ -1820,7 +1820,7 @@ entry(%0 : $Builtin.Int61):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define { i64, i1 } @multi_payload_one_spare_bit_inject_a() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i1 } @multi_payload_one_spare_bit_inject_a() {{.*}} {
 // CHECK-64: entry:
 // --                            0x8000_0000_0000_0000
 // CHECK-64:   ret { i64, i1 } { i64 -9223372036854775808, i1 true }
@@ -1831,7 +1831,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define void @multi_payload_one_spare_bit_inject_a_indirect(%O4enum23MultiPayloadOneSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_one_spare_bit_inject_a_indirect(%O4enum23MultiPayloadOneSpareBit* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum23MultiPayloadOneSpareBit* %0 to i64*
 // --                0x8000_0000_0000_0000
@@ -1848,7 +1848,7 @@ entry(%0 : $*MultiPayloadOneSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define { i64, i1 } @multi_payload_one_spare_bit_inject_b() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i1 } @multi_payload_one_spare_bit_inject_b() {{.*}} {
 // CHECK-64: entry:
 // --                            0x8000_0000_0000_0001
 // CHECK-64:   ret { i64, i1 } { i64 -9223372036854775807, i1 true }
@@ -1859,7 +1859,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define { i64, i1 } @multi_payload_one_spare_bit_inject_c() {{.*}} {
+// CHECK-64: define{{( protected)?}} { i64, i1 } @multi_payload_one_spare_bit_inject_c() {{.*}} {
 // CHECK-64: entry:
 // --                            0x8000_0000_0000_0002
 // CHECK-64:   ret { i64, i1 } { i64 -9223372036854775806, i1 true }
@@ -1880,7 +1880,7 @@ enum MultiPayloadTwoSpareBits {
   case c
 }
 
-// CHECK-64: define void @multi_payload_two_spare_bits_switch(i64) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_two_spare_bits_switch(i64) {{.*}} {
 sil @multi_payload_two_spare_bits_switch : $(MultiPayloadTwoSpareBits) -> () {
 entry(%u : $MultiPayloadTwoSpareBits):
 // CHECK-64:   [[TAG_LSHR:%.*]] = lshr i64 %0, 62
@@ -1964,7 +1964,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define i64 @multi_payload_two_spare_bits_inject_x(i62) {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @multi_payload_two_spare_bits_inject_x(i62) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i62 %0 to i64
 // CHECK-64:   ret i64 [[ZEXT]]
@@ -1975,7 +1975,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define void @multi_payload_two_spare_bits_inject_x_indirect(i62, %O4enum24MultiPayloadTwoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_two_spare_bits_inject_x_indirect(i62, %O4enum24MultiPayloadTwoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum24MultiPayloadTwoSpareBits* %1 to i62*
 // CHECK-64:   store i62 %0, i62* [[DATA_ADDR]]
@@ -1996,7 +1996,7 @@ entry(%0 : $Builtin.Int62, %1 : $*MultiPayloadTwoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define i64 @multi_payload_two_spare_bits_inject_y(i60) {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @multi_payload_two_spare_bits_inject_y(i60) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i60 %0 to i64
 // --                     0x4000_0000_0000_0000
@@ -2009,7 +2009,7 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define void @multi_payload_two_spare_bits_inject_y_indirect(i60, %O4enum24MultiPayloadTwoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_two_spare_bits_inject_y_indirect(i60, %O4enum24MultiPayloadTwoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %O4enum24MultiPayloadTwoSpareBits* %1 to i60*
 // CHECK-64:   store i60 %0, i60* [[DATA_ADDR]]
@@ -2032,7 +2032,7 @@ entry(%0 : $Builtin.Int60, %1 : $*MultiPayloadTwoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define i64 @multi_payload_two_spare_bits_inject_z(i61) {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @multi_payload_two_spare_bits_inject_z(i61) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i61 %0 to i64
 // --                      0x8000_0000_0000_0000
@@ -2045,7 +2045,7 @@ entry(%0 : $Builtin.Int61):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define i64 @multi_payload_two_spare_bits_inject_a() {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @multi_payload_two_spare_bits_inject_a() {{.*}} {
 // CHECK-64: entry:
 // --              0xC000_0000_0000_0000
 // CHECK-64:   ret i64 -4611686018427387904
@@ -2056,7 +2056,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define void @multi_payload_two_spare_bits_inject_a_indirect(%O4enum24MultiPayloadTwoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( protected)?}} void @multi_payload_two_spare_bits_inject_a_indirect(%O4enum24MultiPayloadTwoSpareBits* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %O4enum24MultiPayloadTwoSpareBits* %0 to i64*
 // --                0xC000_0000_0000_0000
@@ -2070,7 +2070,7 @@ entry(%0 : $*MultiPayloadTwoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define i64 @multi_payload_two_spare_bits_inject_b() {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @multi_payload_two_spare_bits_inject_b() {{.*}} {
 // CHECK-64: entry:
 // --              0xC000_0000_0000_0001
 // CHECK-64:   ret i64 -4611686018427387903
@@ -2081,7 +2081,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define i64 @multi_payload_two_spare_bits_inject_c() {{.*}} {
+// CHECK-64: define{{( protected)?}} i64 @multi_payload_two_spare_bits_inject_c() {{.*}} {
 // CHECK-64: entry:
 // --              0xC000_0000_0000_0002
 // CHECK-64:   ret i64 -4611686018427387902
@@ -2104,7 +2104,7 @@ enum MultiPayloadClasses {
   case w
 }
 
-// CHECK-64-LABEL: define void @multi_payload_classes_switch(i64) {{.*}} {
+// CHECK-64-LABEL: define{{( protected)?}} void @multi_payload_classes_switch(i64) {{.*}} {
 // CHECK-64:   %1 = lshr i64 %0, 62
 // CHECK-64:   %2 = trunc i64 %1 to i2
 // CHECK-64:   switch i2 %2, label {{%.*}} [
@@ -2125,7 +2125,7 @@ enum MultiPayloadClasses {
 // CHECK-64:   [[MASKED:%.*]] = and i64 %0, 4611686018427387903
 // CHECK-64:   inttoptr i64 [[MASKED]] to %C4enum1D*
 
-// CHECK-32-LABEL: define void @multi_payload_classes_switch(i32) {{.*}} {
+// CHECK-32-LABEL: define{{( protected)?}} void @multi_payload_classes_switch(i32) {{.*}} {
 // CHECK-32:   %1 = trunc i32 %0 to i2
 // CHECK-32:   switch i2 %1, label {{%.*}} [
 // CHECK-32:     i2 0, label {{%.*}}
@@ -2176,7 +2176,7 @@ enum MultiPayloadSpareBitAggregates {
   case z(S)
 }
 
-// CHECK-64-LABEL: define void @multi_payload_spare_bit_aggregate_switch(i64, i64) {{.*}} {
+// CHECK-64-LABEL: define{{( protected)?}} void @multi_payload_spare_bit_aggregate_switch(i64, i64) {{.*}} {
 // CHECK-64:   [[T0:%.*]] = lshr i64 %0, 62
 // CHECK-64:   [[TAG:%.*]] = trunc i64 [[T0]] to i2
 // CHECK-64:   switch i2 [[TAG]], label {{%.*}} [
@@ -2224,7 +2224,7 @@ enum MultiPayloadNested {
   case B(MultiPayloadInner)
 }
 
-// CHECK-LABEL: define void @multi_payload_nested_switch
+// CHECK-LABEL: define{{( protected)?}} void @multi_payload_nested_switch
 // CHECK:   %1 = bitcast %O4enum18MultiPayloadNested* %0 to { [[WORD]], i8 }*
 // CHECK:   %2 = getelementptr
 // CHECK:   %3 = load [[WORD]], [[WORD]]* %2
@@ -2262,7 +2262,7 @@ enum MultiPayloadNestedSpareBits {
   case B(MultiPayloadInnerSpareBits)
 }
 
-// CHECK-64-LABEL: define void @multi_payload_nested_spare_bits_switch(%O4enum27MultiPayloadNestedSpareBits* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64-LABEL: define{{( protected)?}} void @multi_payload_nested_spare_bits_switch(%O4enum27MultiPayloadNestedSpareBits* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   %1 = bitcast %O4enum27MultiPayloadNestedSpareBits* %0 to [[WORD]]*
 // CHECK-64:   %2 = load [[WORD]], [[WORD]]* %1
@@ -2317,15 +2317,15 @@ enum MultiPayloadClassGeneric<T: AnyObject> {
   case B(T)
 }
 
-// CHECK-64-LABEL: define { i64, i64, i1 } @multi_payload_class_generic_no_spare_bits(i64, i64, i1, %swift.type* %T)
-// CHECK-32-LABEL: define { i32, i32, i1 } @multi_payload_class_generic_no_spare_bits(i32, i32, i1, %swift.type* %T)
+// CHECK-64-LABEL: define{{( protected)?}} { i64, i64, i1 } @multi_payload_class_generic_no_spare_bits(i64, i64, i1, %swift.type* %T)
+// CHECK-32-LABEL: define{{( protected)?}} { i32, i32, i1 } @multi_payload_class_generic_no_spare_bits(i32, i32, i1, %swift.type* %T)
 sil @multi_payload_class_generic_no_spare_bits : $@convention(thin) <T: AnyObject> (@owned MultiPayloadClassGeneric<T>) -> MultiPayloadClassGeneric<T> {
 entry(%e : $MultiPayloadClassGeneric<T>):
   return %e : $MultiPayloadClassGeneric<T>
 }
 
-// CHECK-64-LABEL: define { i64, i64, i1 } @multi_payload_class_instance_no_spare_bits(i64, i64, i1)
-// CHECK-32-LABEL: define { i32, i32, i1 } @multi_payload_class_instance_no_spare_bits(i32, i32, i1)
+// CHECK-64-LABEL: define{{( protected)?}} { i64, i64, i1 } @multi_payload_class_instance_no_spare_bits(i64, i64, i1)
+// CHECK-32-LABEL: define{{( protected)?}} { i32, i32, i1 } @multi_payload_class_instance_no_spare_bits(i32, i32, i1)
 sil @multi_payload_class_instance_no_spare_bits : $@convention(thin) (@owned MultiPayloadClassGeneric<C>) -> MultiPayloadClassGeneric<C> {
 entry(%e : $MultiPayloadClassGeneric<C>):
   return %e : $MultiPayloadClassGeneric<C>
@@ -2336,7 +2336,7 @@ enum MultiPayloadAddressOnlyFixed {
   case Y(Builtin.Int32)
 }
 
-// CHECK-LABEL: define void @multi_payload_address_only_destroy(%O4enum28MultiPayloadAddressOnlyFixed* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @multi_payload_address_only_destroy(%O4enum28MultiPayloadAddressOnlyFixed* noalias nocapture dereferenceable({{.*}}))
 sil @multi_payload_address_only_destroy : $@convention(thin) (@in MultiPayloadAddressOnlyFixed) -> () {
 entry(%m : $*MultiPayloadAddressOnlyFixed):
   destroy_addr %m : $*MultiPayloadAddressOnlyFixed
@@ -2356,7 +2356,7 @@ enum MultiPayloadAddressOnlySpareBits {
   case Y(AddressOnlySpareBitsPayload)
 }
 
-// CHECK-LABEL: define void @multi_payload_address_only_spare_bits(%O4enum32MultiPayloadAddressOnlySpareBits* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @multi_payload_address_only_spare_bits(%O4enum32MultiPayloadAddressOnlySpareBits* noalias nocapture dereferenceable({{.*}}))
 sil @multi_payload_address_only_spare_bits : $@convention(thin) (@in MultiPayloadAddressOnlySpareBits) -> () {
 entry(%m : $*MultiPayloadAddressOnlySpareBits):
   destroy_addr %m : $*MultiPayloadAddressOnlySpareBits
@@ -2385,7 +2385,7 @@ typealias AllConcreteTestEnums = (
 
 sil_global @x : $AllConcreteTestEnums
 
-// CHECK: define void @dynamic_singleton_switch_indirect([[DYNAMIC_SINGLETON]]* noalias nocapture, %swift.type* %T) {{.*}} {
+// CHECK: define{{( protected)?}} void @dynamic_singleton_switch_indirect([[DYNAMIC_SINGLETON]]* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   bitcast [[DYNAMIC_SINGLETON]]* %0 to %swift.opaque*
 // CHECK:   ret void
 // CHECK: }
@@ -2403,13 +2403,13 @@ dest:
 sil_global @aa : $DynamicSingleton<()>
 sil_global @bb : $DynamicSingleton<NoPayloads>
 
-// CHECK: define void @dynamic_singleton_instance_arg_1()
+// CHECK: define{{( protected)?}} void @dynamic_singleton_instance_arg_1()
 sil @dynamic_singleton_instance_arg_1 : $(DynamicSingleton<()>) -> () {
 entry(%0 : $DynamicSingleton<()>):
   %v = tuple ()
   return %v : $()
 }
-// CHECK: define void @dynamic_singleton_instance_arg_2(i2)
+// CHECK: define{{( protected)?}} void @dynamic_singleton_instance_arg_2(i2)
 sil @dynamic_singleton_instance_arg_2 : $(DynamicSingleton<NoPayloads>) -> () {
 entry(%0 : $DynamicSingleton<NoPayloads>):
   %v = tuple ()
@@ -2418,9 +2418,9 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 
 // Check that payloads get properly masked in nested single-payload enums.
 // rdar://problem/18841262
-// CHECK-64-LABEL: define i1 @optional_optional_class_protocol(i64, i64)
+// CHECK-64-LABEL: define{{( protected)?}} i1 @optional_optional_class_protocol(i64, i64)
 // CHECK-64:         icmp eq i64 %0, 2
-// CHECK-32-LABEL: define i1 @optional_optional_class_protocol(i32, i32)
+// CHECK-32-LABEL: define{{( protected)?}} i1 @optional_optional_class_protocol(i32, i32)
 // CHECK-32:         icmp eq i32 %0, 1
 enum Optionable<T> {
   case Some(T), None
@@ -2464,7 +2464,7 @@ entry:
   return %t : $(Optionable<ContainsUnownedObjC>, Optionable<Optionable<ContainsUnownedObjC>>)
 }
 
-// CHECK-64-LABEL: define { i64, i1 } @empty_payload_enum_in_enum(i32)
+// CHECK-64-LABEL: define{{( protected)?}} { i64, i1 } @empty_payload_enum_in_enum(i32)
 sil @empty_payload_enum_in_enum : $@convention(thin) (Int32) -> Optional<(Optional<()>, Int32)> {
 entry(%x : $Int32):
   %a = tuple ()
@@ -2495,7 +2495,7 @@ struct StructWithWeakVar {
 weak var delegate: delegateProtocol?
 }
 
-// CHECK-64-LABEL: define void @weak_optional(%Sq{{.*}}* noalias nocapture dereferenceable({{.*}}))
+// CHECK-64-LABEL: define{{( protected)?}} void @weak_optional(%Sq{{.*}}* noalias nocapture dereferenceable({{.*}}))
 sil @weak_optional : $@convention(thin) (@in StructWithWeakVar?) -> () {
 entry(%x : $*StructWithWeakVar?):
   // CHECK-64:      icmp eq [[WORD]] {{%.*}}, 0
@@ -2515,7 +2515,7 @@ x:
   return undef : $()
 }
 
-// CHECK-LABEL: define void @force_global_variables_to_materialize
+// CHECK-LABEL: define{{( protected)?}} void @force_global_variables_to_materialize
 sil @force_global_variables_to_materialize : $() -> () {
 entry:
   // Force the global variables to materialize.
@@ -2539,7 +2539,7 @@ enum Target {
 // Ensure that we generate IR that does not run into verification
 // issues for the case where there is a single tag bit and extra
 // inhabitants.
-// CHECK-LABEL: define void @generate_conditional_branch
+// CHECK-LABEL: define{{( protected)?}} void @generate_conditional_branch
 sil @generate_conditional_branch : $@convention(thin) (@owned Target) -> () {
 bb0(%0 : $Target):
   debug_value %0 : $Target
@@ -2565,7 +2565,7 @@ bb4:
 
 // -- Fill function for dynamic singleton. The value witness table flags just
 //    get copied over from the element.
-// CHECK: define private %swift.type* @create_generic_metadata_DynamicSingleton(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_DynamicSingleton(%swift.type_pattern*, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = load i8*, i8** %1
 // CHECK:   [[T:%.*]] = bitcast i8* [[T0]] to %swift.type*
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_pattern* %0, i8** %1)
@@ -2613,7 +2613,7 @@ bb4:
 
 // -- Fill function for dynamic single-payload. Call into the runtime to
 //    calculate the size.
-// CHECK: define private %swift.type* @create_generic_metadata_DynamicSinglePayload(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_DynamicSinglePayload(%swift.type_pattern*, i8**) {{.*}} {
 // CHECK:   call void @swift_initEnumValueWitnessTableSinglePayload
 
 // CHECK-64-LABEL: define linkonce_odr hidden void @_TwxsV4enum17StructWithWeakVar(%swift.opaque* %dest, i32 %index, %swift.type* %StructWithWeakVar)

--- a/test/IRGen/enum_32_bit.sil
+++ b/test/IRGen/enum_32_bit.sil
@@ -37,19 +37,19 @@ enum Bas {
   case Z
 }
 
-// CHECK-LABEL: define void @foo(i32)
+// CHECK-LABEL: define{{( protected)?}} void @foo(i32)
 sil @foo : $@convention(thin) (@owned Foo) -> () {
 entry(%0 : $Foo):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @bar(i32)
+// CHECK-LABEL: define{{( protected)?}} void @bar(i32)
 sil @bar : $@convention(thin) (@owned Bar) -> () {
 entry(%0 : $Bar):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @bas(i32)
+// CHECK-LABEL: define{{( protected)?}} void @bas(i32)
 sil @bas : $@convention(thin) (@owned Bas) -> () {
 entry(%0 : $Bas):
   return undef : $()

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -24,15 +24,15 @@ sil_vtable C {}
 
 // -- The runtime doesn't track spare bits, so fixed instances of the dynamic
 //    type can't use them.
-// CHECK-64-LABEL: define { i64, i1 } @fixed_instances_dont_use_spare_bits(i64, i1)
-// CHECK-32-LABEL: define { i32, i1 } @fixed_instances_dont_use_spare_bits(i32, i1)
+// CHECK-64-LABEL: define{{( protected)?}} { i64, i1 } @fixed_instances_dont_use_spare_bits(i64, i1)
+// CHECK-32-LABEL: define{{( protected)?}} { i32, i1 } @fixed_instances_dont_use_spare_bits(i32, i1)
 sil @fixed_instances_dont_use_spare_bits : $@convention(thin) (@owned Either<C, C>) -> @owned Either<C, C> {
 entry(%e : $Either<C, C>):
   return %e : $Either<C, C>
 }
 
 // -- Handle case where all of the payloads become empty.
-// CHECK-LABEL: define void @empty_instance(i1) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @empty_instance(i1) {{.*}} {
 sil @empty_instance : $@convention(thin) (Either<(), ()>) -> () {
 // CHECK-NEXT: entry:
 entry(%e : $Either<(), ()>):
@@ -83,7 +83,7 @@ next(%z : $Builtin.Int8):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @empty_instance2(i2) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @empty_instance2(i2) {{.*}} {
 sil @empty_instance2 : $@convention(thin) (EitherOr<(), ()>) -> () {
 // CHECK-NEXT: entry:
 entry(%e : $EitherOr<(), ()>):
@@ -157,7 +157,7 @@ next(%z : $Builtin.Int8):
 
 sil hidden_external @consume_case_test_result : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1, Builtin.Int1) -> ()
 
-// CHECK-LABEL: define void @static_multi_payload_case_test
+// CHECK-LABEL: define{{( protected)?}} void @static_multi_payload_case_test
 // CHECK:         call void @consume_case_test_result(i1 true, i1 true, i1 true, i1 true)
 sil @static_multi_payload_case_test : $@convention(thin) () -> () {
 entry:
@@ -194,7 +194,7 @@ entry:
   return %r : $()
 }
 
-// CHECK-LABEL: define void @static_multi_payload_case_test_empty
+// CHECK-LABEL: define{{( protected)?}} void @static_multi_payload_case_test_empty
 // CHECK:         call void @consume_case_test_result(i1 true, i1 true, i1 true, i1 true)
 sil @static_multi_payload_case_test_empty : $@convention(thin) () -> () {
 entry:
@@ -230,7 +230,7 @@ entry:
   return %r : $()
 }
 
-// CHECK-LABEL: define void @dynamic_multi_payload_case_test
+// CHECK-LABEL: define{{( protected)?}} void @dynamic_multi_payload_case_test
 sil @dynamic_multi_payload_case_test : $@convention(thin) <T, U> () -> () {
 entry:
   %t = integer_literal $Builtin.Int1, 1
@@ -266,7 +266,7 @@ entry:
   return %r : $()
 }
 
-// CHECK-LABEL: define void @dynamic_inject
+// CHECK-LABEL: define{{( protected)?}} void @dynamic_inject
 // CHECK:         ([[EITHER_OR:%O26enum_dynamic_multi_payload8EitherOr.*]]* noalias nocapture sret, %swift.type* %T)
 sil @dynamic_inject : $@convention(thin) <T> (@out EitherOr<T, Builtin.Int64>) -> () {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
@@ -282,7 +282,7 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dynamic_project
+// CHECK-LABEL: define{{( protected)?}} void @dynamic_project
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret, %swift.type* %T)
 sil @dynamic_project : $@convention(thin) <T> (@out EitherOr<T, Builtin.Int64>) -> () {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
@@ -294,7 +294,7 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dynamic_switch
+// CHECK-LABEL: define{{( protected)?}} void @dynamic_switch
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret, %swift.type* %T)
 sil @dynamic_switch : $@convention(thin) <T> (@out EitherOr<T, Builtin.Int64>) -> () {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
@@ -335,7 +335,7 @@ next(%x : $Builtin.Int8):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dynamic_value_semantics
+// CHECK-LABEL: define{{( protected)?}} void @dynamic_value_semantics
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret, [[EITHER_OR]]* noalias nocapture, %swift.type* %T)
 sil @dynamic_value_semantics : $@convention(thin) <T> (@out EitherOr<T, Builtin.Int64>, @in EitherOr<T, Builtin.Int64>) -> () {
 entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
@@ -371,7 +371,7 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dynamic_value_semantics2
+// CHECK-LABEL: define{{( protected)?}} void @dynamic_value_semantics2
 // CHECK:         ([[EITHER_OR:%O26enum_dynamic_multi_payload8EitherOr.*]]* noalias nocapture sret, [[EITHER_OR]]* noalias nocapture, %swift.type* %T)
 sil @dynamic_value_semantics2 : $@convention(thin) <T> (@out EitherOr<T, C>, @in EitherOr<T, C>) -> () {
 entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
@@ -423,7 +423,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   return undef : $()
 }
 
-// CHECK: define private %swift.type* [[CREATE_GENERIC_METADATA]](%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* [[CREATE_GENERIC_METADATA]](%swift.type_pattern*, i8**) {{.*}} {
 // CHECK:   [[BUF:%.*]] = alloca [2 x i8**]
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -57,7 +57,7 @@ enum InternalEither {
   case Right(ReferenceFast)
 }
 
-// CHECK-LABEL: define void @_TF15enum_resilience25functionWithResilientEnumFO14resilient_enum6MediumS1_(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( protected)?}} void @_TF15enum_resilience25functionWithResilientEnumFO14resilient_enum6MediumS1_(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
 public func functionWithResilientEnum(m: Medium) -> Medium {
 
 // CHECK:      [[METADATA:%.*]] = call %swift.type* @_TMaO14resilient_enum6Medium()
@@ -73,7 +73,7 @@ public func functionWithResilientEnum(m: Medium) -> Medium {
   return m
 }
 
-// CHECK-LABEL: define void @_TF15enum_resilience33functionWithIndirectResilientEnumFO14resilient_enum16IndirectApproachS1_(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( protected)?}} void @_TF15enum_resilience33functionWithIndirectResilientEnumFO14resilient_enum16IndirectApproachS1_(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
 public func functionWithIndirectResilientEnum(ia: IndirectApproach) -> IndirectApproach {
 
 // CHECK:      [[METADATA:%.*]] = call %swift.type* @_TMaO14resilient_enum16IndirectApproach()
@@ -89,7 +89,7 @@ public func functionWithIndirectResilientEnum(ia: IndirectApproach) -> IndirectA
   return ia
 }
 
-// CHECK-LABEL: define void @_TF15enum_resilience31constructResilientEnumNoPayloadFT_O14resilient_enum6Medium
+// CHECK-LABEL: define{{( protected)?}} void @_TF15enum_resilience31constructResilientEnumNoPayloadFT_O14resilient_enum6Medium
 public func constructResilientEnumNoPayload() -> Medium {
 // CHECK:      [[METADATA:%.*]] = call %swift.type* @_TMaO14resilient_enum6Medium()
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
@@ -105,7 +105,7 @@ public func constructResilientEnumNoPayload() -> Medium {
   return Medium.Paper
 }
 
-// CHECK-LABEL: define void @_TF15enum_resilience29constructResilientEnumPayloadFV16resilient_struct4SizeO14resilient_enum6Medium
+// CHECK-LABEL: define{{( protected)?}} void @_TF15enum_resilience29constructResilientEnumPayloadFV16resilient_struct4SizeO14resilient_enum6Medium
 public func constructResilientEnumPayload(s: Size) -> Medium {
 // CHECK:      [[METADATA:%.*]] = call %swift.type* @_TMaV16resilient_struct4Size()
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
@@ -136,7 +136,7 @@ public func constructResilientEnumPayload(s: Size) -> Medium {
   return Medium.Postcard(s)
 }
 
-// CHECK-LABEL: define {{i32|i64}} @_TF15enum_resilience19resilientSwitchTestFO14resilient_enum6MediumSi(%swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( protected)?}} {{i32|i64}} @_TF15enum_resilience19resilientSwitchTestFO14resilient_enum6MediumSi(%swift.opaque* noalias nocapture)
 // CHECK: [[BUFFER:%.*]] = alloca [[BUFFER_TYPE:\[(12|24) x i8\]]]
 
 // CHECK: [[METADATA:%.*]] = call %swift.type* @_TMaO14resilient_enum6Medium()
@@ -190,7 +190,7 @@ public func resilientSwitchTest(m: Medium) -> Int {
 
 public func reabstraction<T>(f: Medium -> T) {}
 
-// CHECK-LABEL: define void @_TF15enum_resilience25resilientEnumPartialApplyFFO14resilient_enum6MediumSiT_(i8*, %swift.refcounted*)
+// CHECK-LABEL: define{{( protected)?}} void @_TF15enum_resilience25resilientEnumPartialApplyFFO14resilient_enum6MediumSiT_(i8*, %swift.refcounted*)
 public func resilientEnumPartialApply(f: Medium -> Int) {
 
 // CHECK:     [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_allocObject
@@ -214,7 +214,7 @@ public enum EnumWithResilientPayload {
 // Make sure we call a function to access metadata of enums with
 // resilient layout.
 
-// CHECK-LABEL: define %swift.type* @_TF15enum_resilience20getResilientEnumTypeFT_PMP_()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TF15enum_resilience20getResilientEnumTypeFT_PMP_()
 // CHECK:      [[METADATA:%.*]] = call %swift.type* @_TMaO15enum_resilience24EnumWithResilientPayload()
 // CHECK-NEXT: ret %swift.type* [[METADATA]]
 
@@ -223,7 +223,7 @@ public func getResilientEnumType() -> Any.Type {
 }
 
 // Public metadata accessor for our resilient enum
-// CHECK-LABEL: define %swift.type* @_TMaO15enum_resilience24EnumWithResilientPayload()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaO15enum_resilience24EnumWithResilientPayload()
 // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** @_TMLO15enum_resilience24EnumWithResilientPayload
 // CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[METADATA]], null
 // CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
@@ -240,4 +240,4 @@ public func getResilientEnumType() -> Any.Type {
 
 // FIXME: this is bogus
 
-// CHECK-LABEL: define private %swift.type* @create_generic_metadata_EnumWithResilientPayload(%swift.type_pattern*, i8**)
+// CHECK-LABEL: define{{( protected)?}} private %swift.type* @create_generic_metadata_EnumWithResilientPayload(%swift.type_pattern*, i8**)

--- a/test/IRGen/enum_spare_bits.sil
+++ b/test/IRGen/enum_spare_bits.sil
@@ -58,8 +58,8 @@ sil_global @existentialntp: $ExistentialNoTaggedPointers
 sil_global @archetypeBoundToSwift: $Archetype<C>
 sil_global @archetypeBoundToObjC: $Archetype<NSObject>
 
-// CHECK: @archetypeBoundToSwift = global [[ARCHETYPE]]
-// CHECK: @archetypeBoundToObjC = global [[ARCHETYPE]]
+// CHECK: @archetypeBoundToSwift = {{(protected )?}}global [[ARCHETYPE]]
+// CHECK: @archetypeBoundToObjC = {{(protected )?}}global [[ARCHETYPE]]
 
 sil @instantiate_globals : $() -> () {
 entry:

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -92,7 +92,7 @@ enum GenericFixedLayout<T> {
 }
 
 
-// CHECK-LABEL: @_TWVO20enum_value_semantics20SinglePayloadTrivial = constant [26 x i8*] [
+// CHECK-LABEL: @_TWVO20enum_value_semantics20SinglePayloadTrivial = {{(protected )?}}constant [26 x i8*] [
 // CHECK:   i8* bitcast (void (i8*, %swift.type*)* @__swift_noop_void_return to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, i8*, %swift.type*)* @__swift_memcpy9_8 to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, %swift.type*)* @__swift_noop_self_return to i8*),
@@ -130,7 +130,7 @@ enum GenericFixedLayout<T> {
 // CHECK: }>
 
 
-// CHECK-LABEL: @_TWVO20enum_value_semantics23SinglePayloadNontrivial = constant [26 x i8*] [
+// CHECK-LABEL: @_TWVO20enum_value_semantics23SinglePayloadNontrivial = {{(protected )?}}constant [26 x i8*] [
 // CHECK:   i8* bitcast (void ([24 x i8]*, %swift.type*)* @_TwXXO20enum_value_semantics23SinglePayloadNontrivial to i8*),
 // CHECK:   i8* bitcast (%swift.opaque* ([24 x i8]*, [24 x i8]*, %swift.type*)* @_TwCPO20enum_value_semantics23SinglePayloadNontrivial to i8*),
 // CHECK:   i8* bitcast (i8* (i8*, %swift.type*)* @__swift_noop_self_return to i8*),
@@ -171,7 +171,7 @@ enum GenericFixedLayout<T> {
 // CHECK: }>
 
 
-// CHECK-LABEL: @_TMPO20enum_value_semantics18GenericFixedLayout = global <{{[{].*\* [}]}}> <{
+// CHECK-LABEL: @_TMPO20enum_value_semantics18GenericFixedLayout = {{(protected )?}}global <{{[{].*\* [}]}}> <{
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_GenericFixedLayout
 // CHECK:   i32 48, i16 1, i16 8,
 // CHECK:   [16 x i8*] zeroinitializer,
@@ -191,7 +191,7 @@ bb0(%0 : $SinglePayloadNontrivial):
   return %v : $()
 }
 
-// CHECK-LABEL: define void @single_payload_nontrivial_copy_destroy(i64)
+// CHECK-LABEL: define{{( protected)?}} void @single_payload_nontrivial_copy_destroy(i64)
 // CHECK:      switch i64 %0, label [[PRESENT:%.*]] [
 // CHECK-NEXT:   i64 0, label [[NOT_PRESENT:%.*]]
 // CHECK-NEXT:   i64 2, label [[NOT_PRESENT]]

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -14,7 +14,7 @@ entry:
   unreachable
 }
 
-// CHECK: define void @throws(%swift.refcounted*, %swift.error**) {{.*}} {
+// CHECK: define{{( protected)?}} void @throws(%swift.refcounted*, %swift.error**) {{.*}} {
 sil @throws : $@convention(thin) () -> @error ErrorType {
   // CHECK: [[T0:%.*]] = call %swift.error* @create_error()
   %0 = function_ref @create_error : $@convention(thin) () -> @owned ErrorType
@@ -27,7 +27,7 @@ sil @throws : $@convention(thin) () -> @error ErrorType {
   throw %1 : $ErrorType
 }
 
-// CHECK: define void @doesnt_throw(%swift.refcounted*, %swift.error**) {{.*}} {
+// CHECK: define{{( protected)?}} void @doesnt_throw(%swift.refcounted*, %swift.error**) {{.*}} {
 sil @doesnt_throw : $@convention(thin) () -> @error ErrorType {
   //   We don't have to do anything here because the caller always
   //   zeroes the error slot before a call.
@@ -39,8 +39,8 @@ sil @doesnt_throw : $@convention(thin) () -> @error ErrorType {
 
 sil @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error ErrorType)
 
-// CHECK-objc: define void @try_apply(%objc_object*)
-// CHECK-native: define void @try_apply(%swift.refcounted*)
+// CHECK-objc: define{{( protected)?}} void @try_apply(%objc_object*)
+// CHECK-native: define{{( protected)?}} void @try_apply(%swift.refcounted*)
 sil @try_apply : $@convention(thin) (@owned AnyObject) -> () {
 entry(%0 : $AnyObject):
   // CHECK:      [[ERRORSLOT:%.*]] = alloca %swift.error*, align
@@ -93,7 +93,7 @@ bb0(%0 : $ErrorType):
 
 // rdar://21084084 - Partial application of throwing functions.
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_single(%C6errors1A*)
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_single(%C6errors1A*)
 // CHECK:       insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%swift.refcounted*, %swift.error**)* @_TPA_partial_apply_single_helper to i8*), %swift.refcounted* undef },
 // CHECK-LABEL: define internal void @_TPA_partial_apply_single_helper(%swift.refcounted*, %swift.error**)
 // CHECK:       [[T0:%.*]] = bitcast %swift.refcounted* {{%.*}} to %C6errors1A*

--- a/test/IRGen/existential_metatypes.sil
+++ b/test/IRGen/existential_metatypes.sil
@@ -49,7 +49,7 @@ bb0(%0 : $*Float):
   return %3 : $Int
 }
 
-// CHECK: define void @test0()
+// CHECK: define{{( protected)?}} void @test0()
 sil @test0 : $@convention(thin) () -> () {
 bb0:
   // CHECK:      [[V:%.*]] = alloca { %swift.type*, i8** }, align 8
@@ -86,7 +86,7 @@ bb0(%0 : $@thick Kindable.Type):
   return %2 : $()
 }
 
-// CHECK: define void @test1(i64, i64)
+// CHECK: define{{( protected)?}} void @test1(i64, i64)
 sil @test1 : $@convention(thin) (Optional<Kindable.Type>) -> () {
 bb0(%0 : $Optional<Kindable.Type>):
   // CHECK:     [[TYPE:%.*]] = inttoptr i64 %0 to %swift.type*

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -8,7 +8,7 @@ import Swift
 
 protocol CP: class {}
 
-// CHECK-DAG: define { %swift.refcounted*, i8** } @class_existential_unowned(%swift.refcounted*, i8**) {{.*}} {
+// CHECK-DAG: define{{( protected)?}} { %swift.refcounted*, i8** } @class_existential_unowned(%swift.refcounted*, i8**) {{.*}} {
 sil @class_existential_unowned : $@convention(thin) (@owned CP) -> @owned CP {
 entry(%s : $CP):
   %u = ref_to_unowned %s : $CP to $@sil_unowned CP
@@ -33,7 +33,7 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define void @class_existential_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64)
+// CHECK-DAG: define{{( protected)?}} void @class_existential_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64)
 sil @class_existential_weak : $@convention(thin) (@out @sil_weak CP?, @owned CP?) -> () {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, i8** }

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -18,7 +18,7 @@ bb0(%0 : $*protocol<>, %1 : $T):
   %3 = tuple ()
   return %3 : $()
 }
-// CHECK-DAG:   define void @init_opaque_existential([[ANY:%"protocol<>"]]* noalias nocapture sret, [[GIZMO:%.*]]*, [[TYPE:%.*]]* %T)
+// CHECK-DAG:   define{{( protected)?}} void @init_opaque_existential([[ANY:%"protocol<>"]]* noalias nocapture sret, [[GIZMO:%.*]]*, [[TYPE:%.*]]* %T)
 // CHECK:         [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* %0, i32 0, i32 1
 // CHECK-NEXT:    store [[TYPE]]* %T, [[TYPE]]** [[T0]], align 8
 // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* %0, i32 0, i32 0
@@ -33,7 +33,7 @@ bb0(%0 : $*protocol<>, %1 : $*protocol<>):
   return %3 : $()
 }
 
-// CHECK-DAG:   define void @take_opaque_existential([[ANY:%"protocol<>"]]* noalias nocapture sret, %"protocol<>"* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-DAG:   define{{( protected)?}} void @take_opaque_existential([[ANY:%"protocol<>"]]* noalias nocapture sret, %"protocol<>"* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[SRC:%1]], i32 0, i32 1
 // CHECK-NEXT:    [[TYPE:%.*]] = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK-NEXT:    [[T0:%.*]] = getelementptr inbounds [[ANY]], [[ANY]]* [[DEST:%0]], i32 0, i32 1
@@ -53,7 +53,7 @@ bb0(%0 : $*protocol<>, %1 : $*protocol<>):
 @objc protocol OP {}
 @objc protocol OP2: OP {}
 
-// CHECK-DAG: define %objc_object* @init_existential_objc_to_objc(%objc_object*) {{.*}} {
+// CHECK-DAG: define{{( protected)?}} %objc_object* @init_existential_objc_to_objc(%objc_object*) {{.*}} {
 // CHECK:       ret %objc_object* %0
 sil @init_existential_objc_to_objc : $@convention(thin) (@owned OP2) -> @owned OP {
 entry(%o : $OP2):
@@ -63,7 +63,7 @@ entry(%o : $OP2):
 
 protocol CP: class {}
 
-// CHECK-DAG: define { %objc_object*, i8** } @class_existential_unowned(%objc_object*, i8**) {{.*}} {
+// CHECK-DAG: define{{( protected)?}} { %objc_object*, i8** } @class_existential_unowned(%objc_object*, i8**) {{.*}} {
 sil @class_existential_unowned : $@convention(thin) (@owned CP) -> @owned CP {
 entry(%s : $CP):
   %u1 = alloc_stack $@sil_unowned CP
@@ -96,7 +96,7 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define void @class_existential_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64)
+// CHECK-DAG: define{{( protected)?}} void @class_existential_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64)
 sil @class_existential_weak : $@convention(thin) (@out @sil_weak CP?, @owned CP?) -> () {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, i8** }

--- a/test/IRGen/field_type_vectors.sil
+++ b/test/IRGen/field_type_vectors.sil
@@ -4,15 +4,15 @@
 
 import Swift
 
-// CHECK-LABEL: @_TMnV18field_type_vectors3Foo = constant 
+// CHECK-LABEL: @_TMnV18field_type_vectors3Foo = {{(protected )?}}constant 
 // CHECK:         %swift.type** (%swift.type*)* [[FOO_TYPES_ACCESSOR:@[A-Za-z0-9_]*]]
 struct Foo {
   var x: Int
 }
 
-// CHECK-LABEL: @_TMnV18field_type_vectors3Bar = constant
+// CHECK-LABEL: @_TMnV18field_type_vectors3Bar = {{(protected )?}}constant
 // CHECK:         %swift.type** (%swift.type*)* [[BAR_TYPES_ACCESSOR:@[A-Za-z0-9_]*]]
-// CHECK-LABEL: @_TMPV18field_type_vectors3Bar = global
+// CHECK-LABEL: @_TMPV18field_type_vectors3Bar = {{(protected )?}}global
 // -- There should be 5 words between the address point and the field type
 //    vector slot, with type %swift.type**
 // CHECK:         i64, <{ {{[^}]*}} }>*, %swift.type*, i64, %swift.type*, %swift.type**
@@ -20,9 +20,9 @@ struct Bar<T> {
   var y: Int
 }
 
-// CHECK-LABEL: @_TMnV18field_type_vectors3Bas = constant
+// CHECK-LABEL: @_TMnV18field_type_vectors3Bas = {{(protected )?}}constant
 // CHECK:         %swift.type** (%swift.type*)* [[BAS_TYPES_ACCESSOR:@[A-Za-z0-9_]*]]
-// CHECK-LABEL: @_TMPV18field_type_vectors3Bas = global
+// CHECK-LABEL: @_TMPV18field_type_vectors3Bas = {{(protected )?}}global
 // -- There should be 7 words between the address point and the field type
 //    vector slot, with type %swift.type**
 // CHECK:         i64, <{ {{[^}]*}} }>*, %swift.type*, i64, i64, %swift.type*, %swift.type*, %swift.type**
@@ -31,9 +31,9 @@ struct Bas<T, U> {
   var bar: Bar<T>
 }
 
-// CHECK-LABEL: @_TMnC18field_type_vectors3Zim = constant
+// CHECK-LABEL: @_TMnC18field_type_vectors3Zim = {{(protected )?}}constant
 // CHECK:         %swift.type** (%swift.type*)* [[ZIM_TYPES_ACCESSOR:@[A-Za-z0-9_]*]]
-// CHECK-LABEL: @_TMPC18field_type_vectors3Zim = global
+// CHECK-LABEL: @_TMPC18field_type_vectors3Zim = {{(protected )?}}global
 // -- There should be 14 words between the address point and the field type
 //    vector slot, with type %swift.type**
 // CHECK:         i64, %swift.type*, %swift.opaque*, %swift.opaque*, i64, i32, i32, i32, i16, i16, i32, i32, <{ {{[^}]*}} }>*, i8*, %swift.type*, %swift.type*, i8*, i64, i64, i64, %swift.type**
@@ -46,9 +46,9 @@ sil_vtable Zim {}
 
 sil @_TFC18field_type_vectors3ZimcU___fMGS0_Q_Q0__FT_GS0_Q_Q0__ : $@convention(method) <T, U> (@owned Zim<T, U>) -> @owned Zim<T, U>
 
-// CHECK-LABEL: @_TMnC18field_type_vectors4Zang = constant
+// CHECK-LABEL: @_TMnC18field_type_vectors4Zang = {{(protected )?}}constant
 // CHECK:         %swift.type** (%swift.type*)* [[ZANG_TYPES_ACCESSOR:@[A-Za-z0-9_]*]]
-// CHECK-LABEL: @_TMPC18field_type_vectors4Zang = global
+// CHECK-LABEL: @_TMPC18field_type_vectors4Zang = {{(protected )?}}global
 // -- There should be 16 words between the address point and the field type
 //    vector slot, with type %swift.type**
 // CHECK:         i64, %swift.type*, %swift.opaque*, %swift.opaque*, i64, i32, i32, i32, i16, i16, i32, i32, <{ {{[^}]*}} }>*, i8*, %swift.type*, %swift.type*, i8*, i64, i64, i64, %swift.type*, i64, %swift.type**
@@ -73,7 +73,7 @@ sil_vtable StorageQualified {}
 
 // CHECK:       [[FOO_TYPE_VECTOR_SLOT:@.*Foo.*]] = private global %swift.type** null
 
-// CHECK: define private %swift.type** [[FOO_TYPES_ACCESSOR]](%swift.type* %Foo)
+// CHECK: define{{( protected)?}} private %swift.type** [[FOO_TYPES_ACCESSOR]](%swift.type* %Foo)
 // CHECK:   [[EXISTING:%.*]] = load %swift.type**, %swift.type*** [[FOO_TYPE_VECTOR_SLOT]]
 // CHECK:   [[IS_NULL:%.*]] = icmp eq %swift.type** [[EXISTING]], null
 // CHECK:   br i1 [[IS_NULL]], label %[[BUILD_FIELD_TYPES:.*]], label %[[DONE:.*]]
@@ -81,7 +81,7 @@ sil_vtable StorageQualified {}
 // CHECK:   store {{.*}} @_TMSi
 // CHECK:   cmpxchg {{.*}} [[FOO_TYPE_VECTOR_SLOT]]
 
-// CHECK: define private %swift.type** [[BAR_TYPES_ACCESSOR]](%swift.type* %"Bar<T>")
+// CHECK: define{{( protected)?}} private %swift.type** [[BAR_TYPES_ACCESSOR]](%swift.type* %"Bar<T>")
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %"Bar<T>" to %swift.type***
 // -- 5 words between the address point and the slot
 // CHECK:   [[SLOT:%.*]] = getelementptr inbounds %swift.type**, %swift.type*** [[T0]], i32 5
@@ -91,7 +91,7 @@ sil_vtable StorageQualified {}
 // CHECK:   store {{.*}} @_TMSi
 
 
-// CHECK: define private %swift.type** [[BAS_TYPES_ACCESSOR]](%swift.type* %"Bas<T, U>")
+// CHECK: define{{( protected)?}} private %swift.type** [[BAS_TYPES_ACCESSOR]](%swift.type* %"Bas<T, U>")
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %"Bas<T, U>" to %swift.type***
 // -- 7 words between the address point and the slot
 // CHECK:   [[SLOT:%.*]] = getelementptr inbounds %swift.type**, %swift.type*** [[T0]], i32 7
@@ -100,13 +100,13 @@ sil_vtable StorageQualified {}
 // CHECK:   store {{.*}} @_TMfV18field_type_vectors3Foo
 // CHECK:   call %swift.type* @_TMaV18field_type_vectors3Bar(%swift.type* %T)
 
-// CHECK: define private %swift.type** [[ZIM_TYPES_ACCESSOR]](%swift.type* %"Zim<T, U>")
+// CHECK: define{{( protected)?}} private %swift.type** [[ZIM_TYPES_ACCESSOR]](%swift.type* %"Zim<T, U>")
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %"Zim<T, U>" to %swift.type***
 // -- 14 words between the address point and the slot
 // CHECK:   [[SLOT:%.*]] = getelementptr inbounds %swift.type**, %swift.type*** [[T0]], i32 16
 // CHECK:   load %swift.type**, %swift.type*** [[SLOT]], align 8
 
-// CHECK: define private %swift.type** [[ZANG_TYPES_ACCESSOR]](%swift.type* %"Zang<V>")
+// CHECK: define{{( protected)?}} private %swift.type** [[ZANG_TYPES_ACCESSOR]](%swift.type* %"Zang<V>")
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %"Zang<V>" to %swift.type***
 // -- 16 words between the address point and the slot
 // CHECK:   [[SLOT:%.*]] = getelementptr inbounds %swift.type**, %swift.type*** [[T0]], i32 18

--- a/test/IRGen/fixed_size_buffer_peepholes.sil
+++ b/test/IRGen/fixed_size_buffer_peepholes.sil
@@ -5,7 +5,7 @@ import Builtin
 sil @consume : $@convention(thin) <T> (@in T) -> ()
 sil @produce : $@convention(thin) <T> (@out T) -> ()
 
-// CHECK-LABEL: define void @join_alloc_stack_copy_addr
+// CHECK-LABEL: define{{( protected)?}} void @join_alloc_stack_copy_addr
 sil @join_alloc_stack_copy_addr : $@convention(thin) <T> (@in T) -> () {
 entry(%x : $*T):
   // CHECK: [[BUFFER:%.*]] = alloca [[BUFFER_TYPE:\[.* x i8\]]]
@@ -25,7 +25,7 @@ entry(%x : $*T):
 
 protocol P {}
 
-// CHECK-LABEL: define void @join_init_existential_copy_addr(%P27fixed_size_buffer_peepholes1P_* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.P)
+// CHECK-LABEL: define{{( protected)?}} void @join_init_existential_copy_addr(%P27fixed_size_buffer_peepholes1P_* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.P)
 // CHECK:         [[BUFFER:%.*]] = getelementptr inbounds %P27fixed_size_buffer_peepholes1P_, %P27fixed_size_buffer_peepholes1P_* %0, i32 0, i32 0
 // CHECK:         call %swift.opaque* %initializeBufferWithTake([[BUFFER_TYPE]]* [[BUFFER]], %swift.opaque* %1
 sil @join_init_existential_copy_addr : $@convention(thin) <T: P> (@out P, @in T) -> () {
@@ -35,7 +35,7 @@ entry(%p : $*P, %x: $*T):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dont_join_alloc_stack_copy_addr_if_intervening_use
+// CHECK-LABEL: define{{( protected)?}} void @dont_join_alloc_stack_copy_addr_if_intervening_use
 sil @dont_join_alloc_stack_copy_addr_if_intervening_use : $@convention(thin) <T> (@in T) -> () {
 entry(%x : $*T):
   // CHECK: [[BUFFER:%.*]] = alloca [[BUFFER_TYPE:\[.* x i8\]]]
@@ -53,7 +53,7 @@ entry(%x : $*T):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dont_join_alloc_stack_copy_addr_if_no_copy_addr
+// CHECK-LABEL: define{{( protected)?}} void @dont_join_alloc_stack_copy_addr_if_no_copy_addr
 sil @dont_join_alloc_stack_copy_addr_if_no_copy_addr : $@convention(thin) <T> (@in T) -> () {
 entry(%x : $*T):
   // CHECK: [[BUFFER:%.*]] = alloca [[BUFFER_TYPE:\[.* x i8\]]]
@@ -66,7 +66,7 @@ entry(%x : $*T):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dont_join_alloc_stack_if_copy_addr_in_different_bb
+// CHECK-LABEL: define{{( protected)?}} void @dont_join_alloc_stack_if_copy_addr_in_different_bb
 sil @dont_join_alloc_stack_if_copy_addr_in_different_bb : $@convention(thin) <T> (@in T) -> () {
 entry(%x : $*T):
   // CHECK: [[BUFFER:%.*]] = alloca [[BUFFER_TYPE:\[.* x i8\]]]

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -8,7 +8,7 @@
 // unnecessary.
 // ONONE-NOT: @__swift_fixLifetime
 
-// CHECK-objc-LABEL: define void @test(%C11fixlifetime1C*, %objc_object*, i8**, i8*, %swift.refcounted*, %V11fixlifetime3Agg* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-objc-LABEL: define{{( protected)?}} void @test(%C11fixlifetime1C*, %objc_object*, i8**, i8*, %swift.refcounted*, %V11fixlifetime3Agg* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-objc: entry:
 // CHECK-objc:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%C11fixlifetime1C*)*)(%C11fixlifetime1C*
 // CHECK-objc:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%objc_object*)*)(%objc_object*
@@ -18,7 +18,7 @@
 // CHECK-objc:  call void @__swift_fixLifetime(%swift.refcounted*
 // CHECK-objc:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%C11fixlifetime1C**)*)(%C11fixlifetime1C**
 
-// CHECK-native-LABEL: define void @test(%C11fixlifetime1C*, %swift.refcounted*, i8**, i8*, %swift.refcounted*, %V11fixlifetime3Agg* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-native-LABEL: define{{( protected)?}} void @test(%C11fixlifetime1C*, %swift.refcounted*, i8**, i8*, %swift.refcounted*, %V11fixlifetime3Agg* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-native: entry:
 // CHECK-native:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%C11fixlifetime1C*)*)(%C11fixlifetime1C*
 // CHECK-native:  call void @__swift_fixLifetime(%swift.refcounted*

--- a/test/IRGen/function_param_convention.sil
+++ b/test/IRGen/function_param_convention.sil
@@ -10,7 +10,7 @@ struct X {
 // Make sure we can irgen a SIL function with various parameter attributes
 // without choking. This is just a basic reality check.
 
-// CHECK: define void @foo(%V4Test1X* noalias nocapture sret, %V4Test1X* noalias nocapture dereferenceable({{.*}}), %V4Test1X* nocapture dereferenceable({{.*}}), %V4Test1X* noalias nocapture dereferenceable({{.*}}), i32, i32, i32, i32) {{.*}} {
+// CHECK: define{{( protected)?}} void @foo(%V4Test1X* noalias nocapture sret, %V4Test1X* noalias nocapture dereferenceable({{.*}}), %V4Test1X* nocapture dereferenceable({{.*}}), %V4Test1X* noalias nocapture dereferenceable({{.*}}), i32, i32, i32, i32) {{.*}} {
 
 sil @foo : $@convention(thin) (@out X, @in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X, @deallocating X) -> () {
 bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : $X, %5 : $X, %6 : $X, %7 : $X):

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -12,7 +12,7 @@ import Builtin
 
 sil_stage canonical
 
-// CHECK-LABEL: define i8* @thin_func_value(i8*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i8* @thin_func_value(i8*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 // CHECK-NEXT:  }
@@ -21,7 +21,7 @@ entry(%x : $@convention(thin) () -> ()):
   return %x : $@convention(thin) () -> ()
 }
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @thick_func_value(i8*, %swift.refcounted*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @thick_func_value(i8*, %swift.refcounted*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    call void @swift_retain(%swift.refcounted* %1) {{#[0-9]+}}
 // CHECK-NEXT:    call void @swift_release(%swift.refcounted* %1) {{#[0-9]+}}
@@ -36,7 +36,7 @@ entry(%x : $() -> ()):
   return %x : $() -> ()
 }
 
-// CHECK-LABEL: define i8* @thin_witness_value(i8*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i8* @thin_witness_value(i8*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 // CHECK-NEXT:  }
@@ -49,7 +49,7 @@ struct X {}
 
 sil @out_void_return : $@convention(thin) (@out X) -> ()
 
-// CHECK-LABEL: define void @use_void_return_value(%V14function_types1X* noalias nocapture sret) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @use_void_return_value(%V14function_types1X* noalias nocapture sret) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    call void @out_void_return(%V14function_types1X* noalias nocapture sret %0)
 // CHECK-NEXT:    ret void
@@ -61,7 +61,7 @@ entry(%x : $*X):
   return %z : $()
 }
 
-// CHECK-LABEL: define i1 @test_is_nonnull_function(i8*, %swift.refcounted*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i1 @test_is_nonnull_function(i8*, %swift.refcounted*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:  %2 = icmp ne i8* %0, null
 // CHECK-NEXT:  ret i1 %2
@@ -73,7 +73,7 @@ bb0(%0 : $() -> ()):
   return %3 : $Builtin.Int1                                 // id: %5
 }
 
-// CHECK-LABEL: define i8* @test_function_to_pointer(i8*)
+// CHECK-LABEL: define{{( protected)?}} i8* @test_function_to_pointer(i8*)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 sil @test_function_to_pointer : $@convention(thin) (@convention(thin) () -> ()) -> Builtin.RawPointer {
@@ -82,7 +82,7 @@ bb0(%0 : $@convention(thin) () -> ()):
   return %1 : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define i8* @test_pointer_to_function(i8*)
+// CHECK-LABEL: define{{( protected)?}} i8* @test_pointer_to_function(i8*)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 sil @test_pointer_to_function : $@convention(thin) (Builtin.RawPointer) -> @convention(thin) () -> () {

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -11,7 +11,7 @@ import Swift
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[ROOTGENERIC_NAME:@.*]] = private constant [32 x i8] c"C15generic_classes11RootGeneric\00"
 // CHECK: [[ROOTGENERIC_FIELDS:@.*]] = private constant [7 x i8] c"x\00y\00z\00\00"
-// CHECK: @_TMnC15generic_classes11RootGeneric = constant <{ {{.*}} i32 }> <{
+// CHECK: @_TMnC15generic_classes11RootGeneric = {{(protected )?}}constant <{ {{.*}} i32 }> <{
 // --       name
 // CHECK:   [32 x i8]* [[ROOTGENERIC_NAME]]
 // --       num fields
@@ -27,7 +27,7 @@ import Swift
 // --       generic parameter count, primary count, witness table counts
 // CHECK:   i32 1, i32 1, i32 0
 // CHECK: }
-// CHECK: @_TMPC15generic_classes11RootGeneric = global
+// CHECK: @_TMPC15generic_classes11RootGeneric = {{(protected )?}}global
 // --       template fill function
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_RootGeneric
 // --       nominal type descriptor
@@ -42,14 +42,14 @@ import Swift
 
 // -- Check that offset vars are emitted for fixed-layout generics
 //    <rdar://problem/15081049>
-// CHECK: @_TWvdvC15generic_classes22RootGenericFixedLayout1xVs5UInt8 = constant i64 16, align 8
-// CHECK: @_TWvdvC15generic_classes22RootGenericFixedLayout1yGSax_ = constant i64 24, align 8
-// CHECK: @_TWvdvC15generic_classes22RootGenericFixedLayout1zVs5UInt8 = constant i64 32, align 8
+// CHECK: @_TWvdvC15generic_classes22RootGenericFixedLayout1xVs5UInt8 = {{(protected )?}}constant i64 16, align 8
+// CHECK: @_TWvdvC15generic_classes22RootGenericFixedLayout1yGSax_ = {{(protected )?}}constant i64 24, align 8
+// CHECK: @_TWvdvC15generic_classes22RootGenericFixedLayout1zVs5UInt8 = {{(protected )?}}constant i64 32, align 8
 
 // -- fixed-layout nongeneric descriptor
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[ROOTNONGENERIC_NAME:@.*]] = private constant [35 x i8] c"C15generic_classes14RootNonGeneric\00"
-// CHECK: @_TMnC15generic_classes14RootNonGeneric = constant <{ {{.*}} i32 }> <{
+// CHECK: @_TMnC15generic_classes14RootNonGeneric = {{(protected )?}}constant <{ {{.*}} i32 }> <{
 // --       name
 // CHECK:   [35 x i8]* [[ROOTNONGENERIC_NAME]]
 // --       num fields
@@ -84,7 +84,7 @@ import Swift
 // CHECK:   {{.*}}* @_TMnC15generic_classes14RootNonGeneric,
 // CHECK: }>
 
-// CHECK: @_TMPC15generic_classes22GenericInheritsGeneric = global
+// CHECK: @_TMPC15generic_classes22GenericInheritsGeneric = {{(protected )?}}global
 // --       template fill function
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_GenericInheritsGeneric
 // --       RootGeneric vtable
@@ -203,7 +203,7 @@ sil_vtable RecursiveGenericInheritsGeneric {}
 sil @_TFC15generic_classes31RecursiveGenericInheritsGenericD : $@convention(method) <T,U> (RecursiveGenericInheritsGeneric<T,U>) -> ()
 
 
-// CHECK: define [[ROOTGENERIC]]* @RootGeneric_fragile_dependent_alloc
+// CHECK: define{{( protected)?}} [[ROOTGENERIC]]* @RootGeneric_fragile_dependent_alloc
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @_TMaC15generic_classes11RootGeneric
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
 // CHECK:   [[T0:%.*]] = getelementptr inbounds i8, i8* [[METADATA_ARRAY]], i32 48
@@ -222,7 +222,7 @@ entry:
 }
 
 // RootGeneric.x has fixed layout
-// CHECK: define i8 @RootGeneric_concrete_fragile_dependent_member_access_x
+// CHECK: define{{( protected)?}} i8 @RootGeneric_concrete_fragile_dependent_member_access_x
 // CHECK:   getelementptr inbounds [[ROOTGENERIC]], [[ROOTGENERIC]]* %0, i32 0, i32 1
 sil @RootGeneric_concrete_fragile_dependent_member_access_x : $<F> RootGeneric<F> -> UInt8 {
 entry(%c : $RootGeneric<F>):
@@ -232,7 +232,7 @@ entry(%c : $RootGeneric<F>):
 }
 
 // RootGeneric.y has dependent layout; load the offset from the metadata
-// CHECK-LABEL: define void @RootGeneric_concrete_fragile_dependent_member_access_y
+// CHECK-LABEL: define{{( protected)?}} void @RootGeneric_concrete_fragile_dependent_member_access_y
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
 // CHECK:   [[Y_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 16
 // CHECK:   [[Y_OFFSET:%.*]] = load i64, i64* [[Y_OFFSET_ADDR]], align 8
@@ -247,7 +247,7 @@ entry(%z : $*F, %c : $RootGeneric<F>):
   return %t : $()
 }
 
-// CHECK-LABEL: define void @RootGeneric_subst_concrete_fragile_dependent_member_access_y
+// CHECK-LABEL: define{{( protected)?}} void @RootGeneric_subst_concrete_fragile_dependent_member_access_y
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
 // CHECK:   [[Y_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 16
 // CHECK:   [[Y_OFFSET:%.*]] = load i64, i64* [[Y_OFFSET_ADDR]], align 8
@@ -263,7 +263,7 @@ entry(%z : $*Int, %c : $RootGeneric<Int>):
 }
 
 // RootGeneric.z has dependent layout; load the offset from the metadata
-// CHECK-LABEL: define i8 @RootGeneric_concrete_fragile_dependent_member_access_z
+// CHECK-LABEL: define{{( protected)?}} i8 @RootGeneric_concrete_fragile_dependent_member_access_z
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
 // CHECK:   [[Z_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 17
 // CHECK:   [[Z_OFFSET:%.*]] = load i64, i64* [[Z_OFFSET_ADDR]], align 8
@@ -277,7 +277,7 @@ entry(%c : $RootGeneric<F>):
   return %z : $UInt8
 }
 
-// CHECK-LABEL: define i8 @RootGeneric_subst_concrete_fragile_dependent_member_access_z
+// CHECK-LABEL: define{{( protected)?}} i8 @RootGeneric_subst_concrete_fragile_dependent_member_access_z
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
 // CHECK:   [[Z_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 17
 // CHECK:   [[Z_OFFSET:%.*]] = load i64, i64* [[Z_OFFSET_ADDR]], align 8
@@ -306,16 +306,16 @@ entry(%c : $RootGeneric<Int32>):
 }
  */
 
-// CHECK: define private %swift.type* @create_generic_metadata_RootGeneric(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_RootGeneric(%swift.type_pattern*, i8**) {{.*}} {
 // -- initialize the dependent field offsets
 // CHECK:   call void @swift_initClassMetadata_UniversalStrategy(%swift.type* {{%.*}}, i64 3, i64* {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
-// CHECK: define private %swift.type* @create_generic_metadata_RootGenericFixedLayout(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_RootGenericFixedLayout(%swift.type_pattern*, i8**) {{.*}} {
 // CHECK:   call void @swift_initializeSuperclass(%swift.type* {{%.*}}, i1 false)
 // CHECK: }
 
-// CHECK: define private %swift.type* @create_generic_metadata_GenericInheritsGeneric(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_GenericInheritsGeneric(%swift.type_pattern*, i8**) {{.*}} {
 //   Bind the generic parameters.
 // CHECK:   [[T0:%.*]] = load i8*, i8** %1
 // CHECK:   %A = bitcast i8* [[T0]] to %swift.type*

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -118,7 +118,7 @@ func makeGenericMetatypes() {
 // CHECK: define linkonce_odr hidden %swift.type* @_TMaGV17generic_metatypes6OneArgVS_3Foo_() [[NOUNWIND_READNONE_OPT:#[0-9]+]]
 // CHECK:   call %swift.type* @_TMaV17generic_metatypes6OneArg(%swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
-// CHECK-LABEL: define %swift.type* @_TMaV17generic_metatypes6OneArg(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV17generic_metatypes6OneArg(%swift.type*)
 // CHECK:   [[BUFFER:%.*]] = alloca { %swift.type* }
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.start
@@ -134,7 +134,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[T0:%.*]] = call %swift.type* @_TMaC17generic_metatypes3Bar()
 // CHECK:   call %swift.type* @_TMaV17generic_metatypes7TwoArgs(%swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}, %swift.type* [[T0]])
 
-// CHECK-LABEL: define %swift.type* @_TMaV17generic_metatypes7TwoArgs(%swift.type*, %swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV17generic_metatypes7TwoArgs(%swift.type*, %swift.type*)
 // CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type* }
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.start
@@ -152,7 +152,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[T0:%.*]] = call %swift.type* @_TMaC17generic_metatypes3Bar()
 // CHECK:   call %swift.type* @_TMaV17generic_metatypes9ThreeArgs(%swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}) [[NOUNWIND_READNONE]]
 
-// CHECK-LABEL: define %swift.type* @_TMaV17generic_metatypes9ThreeArgs(%swift.type*, %swift.type*, %swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV17generic_metatypes9ThreeArgs(%swift.type*, %swift.type*, %swift.type*)
 // CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type* }
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.start
@@ -172,7 +172,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[T0:%.*]] = call %swift.type* @_TMaC17generic_metatypes3Bar()
 // CHECK:   call %swift.type* @_TMaV17generic_metatypes8FourArgs(%swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}, %swift.type* [[T0]]) [[NOUNWIND_READNONE]]
 
-// CHECK-LABEL: define %swift.type* @_TMaV17generic_metatypes8FourArgs(%swift.type*, %swift.type*, %swift.type*, %swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV17generic_metatypes8FourArgs(%swift.type*, %swift.type*, %swift.type*, %swift.type*)
 // CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type*, %swift.type* }
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.start
@@ -194,7 +194,7 @@ func makeGenericMetatypes() {
 // CHECK:   [[T0:%.*]] = call %swift.type* @_TMaC17generic_metatypes3Bar()
 // CHECK:   call %swift.type* @_TMaV17generic_metatypes8FiveArgs(%swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}, %swift.type* [[T0]], %swift.type* {{.*}} @_TMfV17generic_metatypes3Foo, {{.*}}) [[NOUNWIND_READNONE]]
 
-// CHECK-LABEL: define %swift.type* @_TMaV17generic_metatypes8FiveArgs(%swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV17generic_metatypes8FiveArgs(%swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type*)
 // CHECK:   [[BUFFER:%.*]] = alloca { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }
 // CHECK:   [[BUFFER_PTR:%.*]] = bitcast { %swift.type*, %swift.type*, %swift.type*, %swift.type*, %swift.type* }* [[BUFFER]] to i8*
 // CHECK:   call void @llvm.lifetime.start

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -10,7 +10,7 @@ import Builtin
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[SINGLEDYNAMIC_NAME:@.*]] = private constant [34 x i8] c"V15generic_structs13SingleDynamic\00"
 // CHECK: [[SINGLEDYNAMIC_FIELDS:@.*]] = private constant [3 x i8] c"x\00\00"
-// CHECK: @_TMnV15generic_structs13SingleDynamic = constant <{ {{.*}} i32 }> <{
+// CHECK: @_TMnV15generic_structs13SingleDynamic = {{(protected )?}}constant <{ {{.*}} i32 }> <{
 // --       name
 // CHECK:   [34 x i8]* [[SINGLEDYNAMIC_NAME]]
 // --       field count
@@ -26,7 +26,7 @@ import Builtin
 // --       generic parameter count, primary counts; generic parameter witness counts
 // CHECK:   i32 1, i32 1, i32 0
 // CHECK: }>
-// CHECK: @_TMPV15generic_structs13SingleDynamic = global <{{[{].*\* [}]}}> <{
+// CHECK: @_TMPV15generic_structs13SingleDynamic = {{(protected )?}}global <{{[{].*\* [}]}}> <{
 // -- template header
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_SingleDynamic,
 // CHECK:   i32 240, i16 1, i16 8, [{{[0-9]+}} x i8*] zeroinitializer,
@@ -51,7 +51,7 @@ import Builtin
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
 // CHECK: [[DYNAMICWITHREQUIREMENTS_NAME:@.*]] = private constant [44 x i8] c"V15generic_structs23DynamicWithRequirements\00"
 // CHECK: [[DYNAMICWITHREQUIREMENTS_FIELDS:@.*]] = private constant [5 x i8] c"x\00y\00\00"
-// CHECK: @_TMnV15generic_structs23DynamicWithRequirements = constant <{ {{.*}} i32 }> <{
+// CHECK: @_TMnV15generic_structs23DynamicWithRequirements = {{(protected )?}}constant <{ {{.*}} i32 }> <{
 // --       name
 // CHECK:   [44 x i8]* [[DYNAMICWITHREQUIREMENTS_NAME]]
 // --       field count
@@ -68,7 +68,7 @@ import Builtin
 // CHECK:   i32 3, i32 2, i32 1, i32 1, i32 0
 // CHECK: }>
 
-// CHECK: @_TMPV15generic_structs23DynamicWithRequirements = global <{ {{.*}}* }> <{
+// CHECK: @_TMPV15generic_structs23DynamicWithRequirements = {{(protected )?}}global <{ {{.*}}* }> <{
 // -- field offset vector; generic parameter vector
 // CHECK:   i64 0, i64 0, %swift.type* null, %swift.type* null, %swift.type* null, i8** null, i8** null,
 // CHECK: }>
@@ -105,7 +105,7 @@ struct Stringly {
   var size : Builtin.Int64
 }
 
-// CHECK-LABEL: define { i64, i21 } @concrete_instances(i64, i21) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i64, i21 } @concrete_instances(i64, i21) {{.*}} {
 // CHECK: entry:
 // CHECK:   %2 = insertvalue { i64, i21 } undef, i64 %0, 0
 // CHECK:   %3 = insertvalue { i64, i21 } %2, i21 %1, 1
@@ -126,7 +126,7 @@ struct ComplexDynamic<U, V> {
   var d : Chareth
 }
 
-// CHECK-LABEL: define void @explode_complex_dynamic
+// CHECK-LABEL: define{{( protected)?}} void @explode_complex_dynamic
 sil @explode_complex_dynamic : $<A, B> (@in ComplexDynamic<A, B>, @inout Byteful, @inout A, @inout B, @inout Chareth) -> () {
 entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Chareth):
   %a = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.a2
@@ -278,7 +278,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // CHECK-NEXT: [[T2:%.*]] = bitcast {{.*}} [[T1]] to %swift.opaque*
 // CHECK-NEXT: ret %swift.opaque* [[T2]]
 
-// CHECK-LABEL: define private %swift.type* @create_generic_metadata_SingleDynamic(%swift.type_pattern*, i8**)
+// CHECK-LABEL: define{{( protected)?}} private %swift.type* @create_generic_metadata_SingleDynamic(%swift.type_pattern*, i8**)
 // CHECK:   [[T0:%.*]] = load i8*, i8** %1, align 8
 // CHECK:   %T = bitcast i8* [[T0]] to %swift.type*
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_pattern* %0, i8** %1)

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -10,7 +10,7 @@ import Swift
 // CHECK: [[C:%C13generic_types1C]] = type
 // CHECK: [[D:%C13generic_types1D]] = type
 
-// CHECK: @_TMPC13generic_types1A = global
+// CHECK: @_TMPC13generic_types1A = {{(protected )?}}global
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_A,
 // CHECK-native: i32 160,
 // CHECK-objc:   i32 344,
@@ -36,7 +36,7 @@ import Swift
 // CHECK:   void (%swift.opaque*, [[A]]*)* @_TFC13generic_types1A3run
 // CHECK:   %C13generic_types1A* (i64, %C13generic_types1A*)* @_TFC13generic_types1AcfT1ySi_GS0_x_
 // CHECK: }
-// CHECK: @_TMPC13generic_types1B = global
+// CHECK: @_TMPC13generic_types1B = {{(protected )?}}global
 // CHECK:   %swift.type* (%swift.type_pattern*, i8**)* @create_generic_metadata_B,
 // CHECK-native: i32 152,
 // CHECK-objc:   i32 336,
@@ -60,7 +60,7 @@ import Swift
 // CHECK:   i32 16,
 // CHECK:   %swift.type* null
 // CHECK: }
-// CHECK: @_TMPC13generic_types1C = global
+// CHECK: @_TMPC13generic_types1C = {{(protected )?}}global
 // CHECK:   void ([[C]]*)* @_TFC13generic_types1CD,
 // CHECK:   i8** @_TWVBo,
 // CHECK:   i64 0,
@@ -71,7 +71,7 @@ import Swift
 // CHECK:   i64 1,
 // CHECK:   void (%swift.opaque*, [[A]]*)* @_TFC13generic_types1A3run
 // CHECK: }
-// CHECK: @_TMPC13generic_types1D = global
+// CHECK: @_TMPC13generic_types1D = {{(protected )?}}global
 // CHECK:   void ([[D]]*)* @_TFC13generic_types1DD,
 // CHECK:   i8** @_TWVBo,
 // CHECK:   i64 0,
@@ -83,7 +83,7 @@ import Swift
 // CHECK:   void (%Si*, [[D]]*)* @_TTVFC13generic_types1D3runfSiT_
 // CHECK: }
 
-// CHECK: define private %swift.type* @create_generic_metadata_A(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_A(%swift.type_pattern*, i8**) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[T0:%.*]] = load i8*, i8** %1
 // CHECK:   %T = bitcast i8* [[T0]] to %swift.type*
@@ -97,7 +97,7 @@ import Swift
 // CHECK:   ret %swift.type* [[METADATA]]
 // CHECK: }
 
-// CHECK: define private %swift.type* @create_generic_metadata_B(%swift.type_pattern*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_B(%swift.type_pattern*, i8**) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[T0:%.*]] = load i8*, i8** %1
 // CHECK:   %T = bitcast i8* [[T0]] to %swift.type*

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -19,7 +19,7 @@ public struct SmallResilientStruct {
   let x: Int32 = 0
 }
 
-// CHECK: @smallGlobal = global [[BUFFER:\[(12|24) x i8\]]] zeroinitializer
+// CHECK: @smallGlobal = {{(protected )?}}global [[BUFFER:\[(12|24) x i8\]]] zeroinitializer
 sil_global [let] @smallGlobal : $SmallResilientStruct
 
 //
@@ -33,7 +33,7 @@ public struct LargeResilientStruct {
   let z: Int64 = 0
 }
 
-// CHECK: @largeGlobal = global [[BUFFER]] zeroinitializer
+// CHECK: @largeGlobal = {{(protected )?}}global [[BUFFER]] zeroinitializer
 sil_global [let] @largeGlobal : $LargeResilientStruct
 
 //
@@ -49,10 +49,10 @@ sil_global hidden @fixedGlobal : $LargeResilientStruct
 // management.
 //
 
-// CHECK: @otherGlobal = global [[BUFFER]] zeroinitializer
+// CHECK: @otherGlobal = {{(protected )?}}global [[BUFFER]] zeroinitializer
 sil_global [let] @otherGlobal : $Size
 
-// CHECK-LABEL: define void @testSmallGlobal()
+// CHECK-LABEL: define{{( protected)?}} void @testSmallGlobal()
 sil @testSmallGlobal : $@convention(thin) () -> () {
 bb0:
   // This is just a no-op
@@ -69,7 +69,7 @@ bb0:
   return %tuple : $()
 }
 
-// CHECK-LABEL: define void @testLargeGlobal()
+// CHECK-LABEL: define{{( protected)?}} void @testLargeGlobal()
 sil @testLargeGlobal : $@convention(thin) () -> () {
 bb0:
   // CHECK: [[ALLOC:%.*]] = call noalias i8* @swift_slowAlloc([[INT]] 32, [[INT]] 7)
@@ -85,7 +85,7 @@ bb0:
   return %tuple : $()
 }
 
-// CHECK-LABEL: define void @testFixedGlobal()
+// CHECK-LABEL: define{{( protected)?}} void @testFixedGlobal()
 sil @testFixedGlobal : $@convention(thin) () -> () {
 bb0:
   alloc_global @fixedGlobal

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -40,18 +40,18 @@ extension A {
 // CHECK-NOT: TY8
 // CHECK-NOT: TY9
 
-// CHECK: @_Tv7globals2g0Si = global [[INT]] zeroinitializer, align 8
-// CHECK: @_Tv7globals2g1TT_SiT__ = global <{ [[INT]] }> zeroinitializer, align 8
-// CHECK: @_Tv7globals2g2TT_SiSi_ = global <{ [[INT]], [[INT]] }> zeroinitializer, align 8
-// CHECK: @_Tv7globals2g3Sb = global [[BOOL]] zeroinitializer, align 1
-// CHECK: @_Tv7globals2g6Sd = global [[DOUBLE]] zeroinitializer, align 8
-// CHECK: @_Tv7globals2g7Sf = global [[FLOAT]] zeroinitializer, align 4
-// CHECK: @_TZvV7globals1A3fooSi = global [[INT]] zeroinitializer, align 8
+// CHECK: @_Tv7globals2g0Si = {{(protected )?}}global [[INT]] zeroinitializer, align 8
+// CHECK: @_Tv7globals2g1TT_SiT__ = {{(protected )?}}global <{ [[INT]] }> zeroinitializer, align 8
+// CHECK: @_Tv7globals2g2TT_SiSi_ = {{(protected )?}}global <{ [[INT]], [[INT]] }> zeroinitializer, align 8
+// CHECK: @_Tv7globals2g3Sb = {{(protected )?}}global [[BOOL]] zeroinitializer, align 1
+// CHECK: @_Tv7globals2g6Sd = {{(protected )?}}global [[DOUBLE]] zeroinitializer, align 8
+// CHECK: @_Tv7globals2g7Sf = {{(protected )?}}global [[FLOAT]] zeroinitializer, align 4
+// CHECK: @_TZvV7globals1A3fooSi = {{(protected )?}}global [[INT]] zeroinitializer, align 8
 
 // CHECK-NOT: g8
 // CHECK-NOT: g9
 
-// CHECK: define i32 @main(i32, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} i32 @main(i32, i8**) {{.*}} {
 // CHECK:      store  i64 {{.*}}, i64* getelementptr inbounds ([[INT]], [[INT]]* @_Tv7globals2g0Si, i32 0, i32 0), align 8
 
 // FIXME: give these initializers a real mangled name

--- a/test/IRGen/indexing.sil
+++ b/test/IRGen/indexing.sil
@@ -12,7 +12,7 @@ struct SameSizeStride { var x, y: Builtin.Int32 }
 // This type has unequal stride and size.
 struct DifferentSizeStride { var x: Builtin.Int32, y: Builtin.Int16 }
 
-// CHECK: define void @same_size_stride(%V8indexing14SameSizeStride* noalias nocapture dereferenceable({{.*}}), i64) {{.*}} {
+// CHECK: define{{( protected)?}} void @same_size_stride(%V8indexing14SameSizeStride* noalias nocapture dereferenceable({{.*}}), i64) {{.*}} {
 // CHECK:   getelementptr inbounds %V8indexing14SameSizeStride, %V8indexing14SameSizeStride* %0, i64 %1
 sil @same_size_stride : $@convention(thin) (@in SameSizeStride, Builtin.Word) -> () {
 entry(%p : $*SameSizeStride, %i: $Builtin.Word):
@@ -20,7 +20,7 @@ entry(%p : $*SameSizeStride, %i: $Builtin.Word):
   return undef : $()
 }
 
-// CHECK:      define void @different_size_stride(%V8indexing19DifferentSizeStride* noalias nocapture dereferenceable({{.*}}), i64) {{.*}} {
+// CHECK:      define{{( protected)?}} void @different_size_stride(%V8indexing19DifferentSizeStride* noalias nocapture dereferenceable({{.*}}), i64) {{.*}} {
 // CHECK:        %2 = bitcast %V8indexing19DifferentSizeStride* %0 to i8*
 // CHECK-NEXT:   %3 = mul nsw i64 %1, 8
 // CHECK-NEXT:   %4 = getelementptr inbounds i8, i8* %2, i64 %3
@@ -31,7 +31,7 @@ entry(%p : $*DifferentSizeStride, %i: $Builtin.Word):
   return undef : $()
 }
 
-// CHECK:      define void @dynamic_size(%swift.opaque* noalias nocapture, i64, %swift.type* %T) {{.*}} {
+// CHECK:      define{{( protected)?}} void @dynamic_size(%swift.opaque* noalias nocapture, i64, %swift.type* %T) {{.*}} {
 // CHECK:        %3 = bitcast %swift.type* %T to i8***
 // CHECK-NEXT:   %4 = getelementptr inbounds i8**, i8*** %3, i64 -1
 // CHECK-NEXT:   %T.valueWitnesses = load i8**, i8*** %4, align 8

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -12,7 +12,7 @@ struct HugeAlignment {
 }
 
 // TODO: could be the context param
-// CHECK-LABEL: define void @huge_method(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_method(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP:%.*]] = alloca
 // CHECK:         call void @huge_method(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}) [[TMP]])
 sil @huge_method : $@convention(method) Huge -> () {
@@ -22,7 +22,7 @@ entry(%x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define void @huge_param(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_param(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP:%.*]] = alloca
 // CHECK:         call void @huge_param(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}) [[TMP]])
 sil @huge_param : $@convention(thin) Huge -> () {
@@ -32,7 +32,7 @@ entry(%x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define void @huge_alignment_param(%V17indirect_argument13HugeAlignment* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_alignment_param(%V17indirect_argument13HugeAlignment* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP:%.*]] = alloca
 // CHECK:         call void @huge_alignment_param(%V17indirect_argument13HugeAlignment* noalias nocapture dereferenceable({{.*}}) [[TMP]])
 sil @huge_alignment_param : $@convention(thin) HugeAlignment -> () {
@@ -42,7 +42,7 @@ entry(%x : $HugeAlignment):
   return %z : $()
 }
 
-// CHECK-LABEL: define void @huge_param_and_return(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_param_and_return(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         call void @huge_param_and_return(%V17indirect_argument4Huge* noalias nocapture sret [[TMP_RET]], %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]])
@@ -53,7 +53,7 @@ entry(%x : $Huge):
   return %z : $Huge
 }
 
-// CHECK-LABEL: define void @huge_param_and_indirect_return(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_param_and_indirect_return(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         call void @huge_param_and_indirect_return(%V17indirect_argument4Huge* noalias nocapture sret %0, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}) [[TMP_ARG]])
 sil @huge_param_and_indirect_return : $@convention(thin) (@out Huge, Huge) -> () {
@@ -63,7 +63,7 @@ entry(%o : $*Huge, %x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define void @huge_partial_application(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_partial_application(%V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %V17indirect_argument4Huge }>*
@@ -80,7 +80,7 @@ entry(%x : $Huge, %y : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define void @huge_partial_application_stret(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @huge_partial_application_stret(%V17indirect_argument4Huge* noalias nocapture sret, %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}), %V17indirect_argument4Huge* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_ARG:%.*]] = alloca
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_allocObject

--- a/test/IRGen/indirect_enum.sil
+++ b/test/IRGen/indirect_enum.sil
@@ -2,10 +2,10 @@
 
 import Swift
 
-// CHECK-64: @_TWVO13indirect_enum5TreeA = constant {{.*}} i8* inttoptr ([[WORD:i64]] 8 to i8*), i8* inttoptr (i64 2162695 to i8*), i8* inttoptr (i64 8 to i8*)
-// CHECK-32: @_TWVO13indirect_enum5TreeA = constant {{.*}} i8* inttoptr ([[WORD:i32]] 4 to i8*), i8* inttoptr (i32 2162691 to i8*), i8* inttoptr (i32 4 to i8*)
+// CHECK-64: @_TWVO13indirect_enum5TreeA = {{(protected )?}}constant {{.*}} i8* inttoptr ([[WORD:i64]] 8 to i8*), i8* inttoptr (i64 2162695 to i8*), i8* inttoptr (i64 8 to i8*)
+// CHECK-32: @_TWVO13indirect_enum5TreeA = {{(protected )?}}constant {{.*}} i8* inttoptr ([[WORD:i32]] 4 to i8*), i8* inttoptr (i32 2162691 to i8*), i8* inttoptr (i32 4 to i8*)
 
-// CHECK-LABEL: define private %swift.type** @get_field_types_TreeA
+// CHECK-LABEL: define{{( protected)?}} private %swift.type** @get_field_types_TreeA
 // -- Leaf(T)
 // CHECK:         [[BITS:%.*]] = ptrtoint %swift.type* %T to [[WORD]]
 // CHECK:         [[INDIRECT_FLAG:%.*]] = or [[WORD]] [[BITS]], 1
@@ -19,7 +19,7 @@ indirect enum TreeA<T> {
   case Branch(left: TreeA<T>, right: TreeA<T>)
 }
 
-// CHECK-LABEL: define private %swift.type** @get_field_types_TreeB
+// CHECK-LABEL: define{{( protected)?}} private %swift.type** @get_field_types_TreeB
 // -- Leaf(T)
 // CHECK-NOT:     ptrtoint %swift.type* %T
 // -- Branch(TreeA, TreeA)
@@ -32,7 +32,7 @@ enum TreeB<T> {
   indirect case Branch(left: TreeB<T>, right: TreeB<T>)
 }
 
-// CHECK-LABEL: define private %swift.type** @get_field_types_Foo
+// CHECK-LABEL: define{{( protected)?}} private %swift.type** @get_field_types_Foo
 // -- Foo(Int)
 // CHECK-64:         (i64 or (i64 ptrtoint (%swift.type* @_TMSi {{.*}}), [[WORD]] 1)
 // CHECK-32:         (i32 or (i32 ptrtoint (%swift.type* @_TMSi {{.*}}), [[WORD]] 1)

--- a/test/IRGen/int_to_fp.sil
+++ b/test/IRGen/int_to_fp.sil
@@ -7,7 +7,7 @@ sil_stage canonical
 
 import Builtin
 
-// CHECK-LABEL: define float @test_large
+// CHECK-LABEL: define{{( protected)?}} float @test_large
 // CHECK: %1 = trunc i2048 %0 to i64
 // CHECK: %2 = sitofp i64 %1 to float
 // CHECK: ret float %2
@@ -17,7 +17,7 @@ bb0(%0 : $Builtin.Int2048):
   return %2 : $Builtin.FPIEEE32
 }
 
-// CHECK-LABEL: define float @test_small
+// CHECK-LABEL: define{{( protected)?}} float @test_small
 // CHECK: %1 = sext i32 %0 to i64
 // CHECK: %2 = sitofp i64 %1 to float
 // CHECK: ret float %2

--- a/test/IRGen/lazy_globals.swift
+++ b/test/IRGen/lazy_globals.swift
@@ -3,9 +3,9 @@
 // REQUIRES: CPU=x86_64
 
 // CHECK: @globalinit_[[T:.*]]_token0 = internal global i64 0, align 8
-// CHECK: @_Tv12lazy_globals1xSi = global %Si zeroinitializer, align 8
-// CHECK: @_Tv12lazy_globals1ySi = global %Si zeroinitializer, align 8
-// CHECK: @_Tv12lazy_globals1zSi = global %Si zeroinitializer, align 8
+// CHECK: @_Tv12lazy_globals1xSi = {{(protected )?}}global %Si zeroinitializer, align 8
+// CHECK: @_Tv12lazy_globals1ySi = {{(protected )?}}global %Si zeroinitializer, align 8
+// CHECK: @_Tv12lazy_globals1zSi = {{(protected )?}}global %Si zeroinitializer, align 8
 
 // CHECK: define internal void @globalinit_[[T]]_func0() {{.*}} {
 // CHECK: entry:

--- a/test/IRGen/lifetime.sil
+++ b/test/IRGen/lifetime.sil
@@ -17,7 +17,7 @@ bb0(%x : $*T):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK:    define void @generic([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
+// CHECK:    define{{( protected)?}} void @generic([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
 //   The fixed-size buffer.
 // CHECK:      [[YBUF:%.*]] = alloca [[BUFFER:.*]], align
 // CHECK-NEXT: [[YBUFLIFE:%.*]] = bitcast [[BUFFER]]* [[YBUF]] to i8*
@@ -56,7 +56,7 @@ bb0(%x : $*T):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK:    define void @generic_with_reuse([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
+// CHECK:    define{{( protected)?}} void @generic_with_reuse([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
 //   The fixed-size buffer.
 // CHECK:      [[YBUF:%.*]] = alloca [[BUFFER:.*]], align
 // CHECK-NEXT: [[YBUFLIFE:%.*]] = bitcast [[BUFFER]]* [[YBUF]] to i8*
@@ -99,7 +99,7 @@ bb0(%x : $*Builtin.Int64):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK-LABEL: define void @fixed_size(i64* noalias nocapture dereferenceable(8))
+// CHECK-LABEL: define{{( protected)?}} void @fixed_size(i64* noalias nocapture dereferenceable(8))
 // CHECK:         [[XBUF:%.*]] = alloca i64
 // CHECK-NEXT:    [[XBUFLIFE:%.*]] = bitcast i64* [[XBUF]] to i8*
 // CHECK-NEXT:    call void @llvm.lifetime.start(i64 8, i8* [[XBUFLIFE]])

--- a/test/IRGen/literals.sil
+++ b/test/IRGen/literals.sil
@@ -16,7 +16,7 @@ bb0:
   %0 = string_literal utf8 "help\tme"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define i8* @utf8_literal() {{.*}} {
+// CHECK: define{{( protected)?}} i8* @utf8_literal() {{.*}} {
 // CHECK:   ret i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[U8_0]], i64 0, i64 0)
 
 sil @utf8_literal_with_nul : $@convention(thin) () -> Builtin.RawPointer {
@@ -24,7 +24,7 @@ bb0:
   %0 = string_literal utf8 "\u{00}x\u{01ab}"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define i8* @utf8_literal_with_nul() {{.*}} {
+// CHECK: define{{( protected)?}} i8* @utf8_literal_with_nul() {{.*}} {
 // CHECK:   ret i8* getelementptr inbounds ([5 x i8], [5 x i8]* [[U8_1]], i64 0, i64 0)
 
 sil @utf16_literal : $@convention(thin) () -> Builtin.RawPointer {
@@ -32,7 +32,7 @@ bb0:
   %0 = string_literal utf16 "help\tme"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define i8* @utf16_literal() {{.*}} {
+// CHECK: define{{( protected)?}} i8* @utf16_literal() {{.*}} {
 // CHECK:   ret i8* bitcast ([8 x i16]* [[U16_0]] to i8*)
 
 sil @utf16_literal_with_nul : $@convention(thin) () -> Builtin.RawPointer {
@@ -40,6 +40,6 @@ bb0:
   %0 = string_literal utf16 "\u{00}x\u{01ab}"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define i8* @utf16_literal_with_nul() {{.*}} {
+// CHECK: define{{( protected)?}} i8* @utf16_literal_with_nul() {{.*}} {
 // CHECK:   ret i8* bitcast ([4 x i16]* [[U16_1]] to i8*)
 

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -87,7 +87,7 @@ public func innerIfConfig() {
 }
 
 
-// CHECK-LABEL: define void @_TF11local_types8callTestFT_T_() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @_TF11local_types8callTestFT_T_() {{.*}} {
 public func callTest() {
   // CHECK: call %swift.type* @_TMaMVF18local_types_helper4testFT_T_L_1S()
   test()

--- a/test/IRGen/metatype.sil
+++ b/test/IRGen/metatype.sil
@@ -19,7 +19,7 @@ sil @_TFC8metatype1Xd : $@convention(method) (@owned X) -> @owned Builtin.Native
 
 sil @_TFC8metatype1XD : $@convention(method) (@owned X) -> ()
 
-// CHECK-LABEL: define %objc_class* @_TF8metatype22thick_to_objc_metatypeFT2xmMCS_1X_T_(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %objc_class* @_TF8metatype22thick_to_objc_metatypeFT2xmMCS_1X_T_(%swift.type*)
 sil @_TF8metatype22thick_to_objc_metatypeFT2xmMCS_1X_T_ : $@convention(thin) (@thick X.Type) -> @objc_metatype X.Type {
 bb0(%0 : $@thick X.Type):
   // CHECK: [[RESULT:%[0-9a-zA-Z_-]+]] = bitcast %swift.type* %0 to %objc_class*
@@ -28,7 +28,7 @@ bb0(%0 : $@thick X.Type):
   return %1 : $@objc_metatype X.Type
 }
 
-// CHECK-LABEL: define %objc_class* @foreign_thick_to_objc(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} %objc_class* @foreign_thick_to_objc(%swift.type*)
 sil @foreign_thick_to_objc : $@convention(thin) (@thick Gizmo.Type) -> @objc_metatype Gizmo.Type {
 bb0(%0 : $@thick Gizmo.Type):
   // CHECK: [[KIND_GEP:%[0-9A-Za-z_.]+]] = getelementptr inbounds %swift.type, %swift.type* %0, i32 0, i32 0
@@ -40,7 +40,7 @@ bb0(%0 : $@thick Gizmo.Type):
   return %1 : $@objc_metatype Gizmo.Type
 }
 
-// CHECK-LABEL: define %swift.type* @_TF8metatype22objc_to_thick_metatypeFT2xmMCS_1X_T_(%objc_class*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TF8metatype22objc_to_thick_metatypeFT2xmMCS_1X_T_(%objc_class*)
 sil @_TF8metatype22objc_to_thick_metatypeFT2xmMCS_1X_T_ : $@convention(thin) (@objc_metatype X.Type) -> @thick X.Type {
 bb0(%0 : $@objc_metatype X.Type):
   // CHECK: [[RESULT:%[0-9a-zA-Z_-]+]] = call %swift.type* @swift_getObjCClassMetadata(%objc_class* %0)
@@ -49,7 +49,7 @@ bb0(%0 : $@objc_metatype X.Type):
   return %1 : $@thick X.Type
 }
 
-// CHECK-LABEL: define %swift.type* @foreign_objc_to_thick(%objc_class*)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @foreign_objc_to_thick(%objc_class*)
 sil @foreign_objc_to_thick : $@convention(thin) (@objc_metatype Gizmo.Type) -> @thick Gizmo.Type {
 bb0(%0 : $@objc_metatype Gizmo.Type):
   // CHECK: [[RESULT:%[0-9a-zA-Z_-]+]] = call %swift.type* @swift_getObjCClassMetadata(%objc_class* %0)
@@ -60,7 +60,7 @@ bb0(%0 : $@objc_metatype Gizmo.Type):
 
 protocol CP: class {}
 
-// CHECK-LABEL: define %objc_class* @archetype_objc_metatype(%swift.type* %T, i8** %T.CP)
+// CHECK-LABEL: define{{( protected)?}} %objc_class* @archetype_objc_metatype(%swift.type* %T, i8** %T.CP)
 // CHECK:         [[IS_OBJC_WRAPPER:%.*]] = icmp eq i64 {{%.*}}, 14
 // CHECK:         br i1 [[IS_OBJC_WRAPPER]], label %isWrapper, label %metadataForClass.cont
 // CHECK:       isWrapper:
@@ -73,7 +73,7 @@ entry:
   return %m : $@objc_metatype T.Type
 }
 
-// CHECK-LABEL: define %objc_class* @existential_objc_metatype(%objc_object*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_class* @existential_objc_metatype(%objc_object*) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: [[METATYPE:%.*]] = call %objc_class* @object_getClass(%objc_object* %0) {{#[0-9]+}}
 // CHECK-NEXT: ret %objc_class* [[METATYPE]]

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -5,7 +5,7 @@
 
 import Swift
 
-// CHECK-LABEL: define void @archetype_metatype_cast
+// CHECK-LABEL: define{{( protected)?}} void @archetype_metatype_cast
 // CHECK:         %0 = call %swift.type* @swift_dynamicCastMetatype(%swift.type* %T, %swift.type* %U)
 // CHECK:         %1 = icmp ne %swift.type* %0, null
 sil @archetype_metatype_cast : $@convention(thin) <T, U> () -> () {
@@ -24,7 +24,7 @@ end:
 
 protocol P {}
 
-// CHECK-LABEL: define void @existential_archetype_metatype_cast(%swift.type*, i8**, %swift.type* %T)
+// CHECK-LABEL: define{{( protected)?}} void @existential_archetype_metatype_cast(%swift.type*, i8**, %swift.type* %T)
 // CHECK:         [[T0:%.*]] = call %swift.type* @swift_dynamicCastMetatype(%swift.type* %0, %swift.type* %T)
 // CHECK:         [[T1:%.*]] = icmp ne %swift.type* [[T0]], null
 sil @existential_archetype_metatype_cast : $@convention(thin) <T> (@thick P.Type) -> () {
@@ -43,7 +43,7 @@ end:
 class SomeClass {}
 sil_vtable SomeClass {}
 
-// CHECK-LABEL: define %objc_object* @metatype_object_conversion(%objc_class*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_object* @metatype_object_conversion(%objc_class*) {{.*}} {
 // CHECK:         %1 = bitcast %objc_class* %0 to %objc_object*
 // CHECK:         ret %objc_object* %1
 // CHECK:       }
@@ -55,7 +55,7 @@ entry(%m : $@objc_metatype SomeClass.Type):
 
 protocol SomeClassProtocol : class {}
 
-// CHECK-LABEL: define %objc_object* @existential_metatype_object_conversion(%objc_class*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_object* @existential_metatype_object_conversion(%objc_class*, i8**) {{.*}} {
 // CHECK:         [[T0:%.*]] = bitcast %objc_class* %0 to %objc_object*
 // CHECK:         ret %objc_object* [[T0]]
 // CHECK:       }
@@ -68,7 +68,7 @@ entry(%m : $@objc_metatype SomeClassProtocol.Type):
 class OtherClass : SomeClass {}
 sil_vtable OtherClass {}
 
-// CHECK-LABEL: define void @value_metatype_cast(%C14metatype_casts9SomeClass*)
+// CHECK-LABEL: define{{( protected)?}} void @value_metatype_cast(%C14metatype_casts9SomeClass*)
 // CHECK:         [[T0:%.*]] = bitcast %C14metatype_casts9SomeClass* %0 to %swift.type**
 // CHECK:         [[T1:%.*]] = load %swift.type*, %swift.type** [[T0]]
 // CHECK:         [[T2:%.*]] = icmp eq %swift.type* [[T1]], {{.*}} @_TMfC14metatype_casts10OtherClass
@@ -87,7 +87,7 @@ end:
   return undef : $()
 }
 
-// CHECK-LABEL: define %swift.type* @checked_cast_to_anyobject_type
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @checked_cast_to_anyobject_type
 // CHECK:         [[METATYPE:%.*]] = call %swift.type* @_TMaC14metatype_casts9SomeClass()
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* [[METATYPE]] to i8*
 // CHECK:         [[CAST:%.*]] = call { i8* } @dynamic_cast_existential_0_class_unconditional(i8* [[T0]], %swift.type* [[METATYPE]])

--- a/test/IRGen/method_linkage.swift
+++ b/test/IRGen/method_linkage.swift
@@ -35,12 +35,12 @@ extension Base {
 }
 
 public class PublicClass {
-  // CHECK: define void @_TFC14method_linkage11PublicClass{{.*}}4pfoofT_T_
+  // CHECK: define{{( protected)?}} void @_TFC14method_linkage11PublicClass{{.*}}4pfoofT_T_
   @inline(never)
   private func pfoo() {
   }
 
-  // CHECK: define void @_TFC14method_linkage11PublicClass4pbarfT_T_
+  // CHECK: define{{( protected)?}} void @_TFC14method_linkage11PublicClass4pbarfT_T_
   @inline(never)
   internal func pbar() {
   }

--- a/test/IRGen/nondominant.sil
+++ b/test/IRGen/nondominant.sil
@@ -15,7 +15,7 @@ bb1:
   %0 = integer_literal $Builtin.Int8, 7
   br bb2
 }
-// CHECK:   define i8 @test0()
+// CHECK:   define{{( protected)?}} i8 @test0()
 // CHECK:     br
 // CHECK-NOT: }
 // CHECK:     ret i8 7

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -16,7 +16,7 @@ entry(%b : $@convention(block) Foo -> Foo, %x : $Foo):
   %y = apply %b(%x) : $@convention(block) Foo -> Foo
   return %y : $Foo
 }
-// CHECK-LABEL: define %C10objc_block3Foo* @call_block(%objc_block*, %C10objc_block3Foo*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %C10objc_block3Foo* @call_block(%objc_block*, %C10objc_block3Foo*) {{.*}} {
 // CHECK:       entry:
 // CHECK:         %2 = getelementptr inbounds %objc_block, %objc_block* %0, i32 0, i32 3
 // CHECK:         %3 = load i8*, i8** %2
@@ -36,7 +36,7 @@ entry(%b : $*@convention(block) () -> ()):
   return %z : $()
 }
 
-// CHECK-LABEL: define void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
 // --                                                                               0x100_0001 = block convention, 1 arg
 // CHECK:         call %swift.type* @swift_getFunctionTypeMetadata1([[WORD:i(64|32)]] 16777217
 

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -36,7 +36,7 @@ import gizmo
 // CHECK:   i8* {{.*}} [[NSRECT_BLOCK_SIGNATURE]]
 // CHECK: }
 
-// CHECK-LABEL: define i8* @project_block_storage({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i8* @project_block_storage({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds { %objc_block, i8* }, { %objc_block, i8* }* %0, i32 0, i32 1
 // CHECK-NEXT:    %2 = load i8*, i8** %1, align 8
@@ -49,7 +49,7 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
   return %p : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define fp128 @overaligned_project_block_storage({ %objc_block, fp128 }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} fp128 @overaligned_project_block_storage({ %objc_block, fp128 }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds { %objc_block, fp128 }, { %objc_block, fp128 }* %0, i32 0, i32 1
 // CHECK-NEXT:    %2 = load fp128, fp128* %1, align 16
@@ -62,7 +62,7 @@ entry(%0 : $*@block_storage Builtin.FPIEEE128):
   return %p : $Builtin.FPIEEE128
 }
 
-// CHECK-LABEL: define %objc_block* @init_block_header_trivial({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_block* @init_block_header_trivial({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         %1 = getelementptr inbounds { %objc_block, i8* }, { %objc_block, i8* }* %0, i32 0, i32 0
 // CHECK:         store %objc_block {
 // CHECK:           %objc_class* [[BLOCK_ISA]]
@@ -81,7 +81,7 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
   return %b : $@convention(block) () -> ()
 }
 
-// CHECK-LABEL: define void @invoke_trivial(void (...)*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @invoke_trivial(void (...)*) {{.*}} {
 // CHECK:         %1 = bitcast void (...)* %0 to { %objc_block, i8* }*
 // CHECK:         %2 = getelementptr inbounds { %objc_block, i8* }, { %objc_block, i8* }* %1, i32 0, i32 1
 sil @invoke_trivial : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> () {
@@ -99,14 +99,14 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
 
 sil @invoke_trivial_block_param : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer, @convention(block) (Int) -> Int) -> ()
 
-// CHECK-LABEL: define i64 @invoke_trivial_with_arg(void (...)*, i64) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i64 @invoke_trivial_with_arg(void (...)*, i64) {{.*}} {
 // CHECK:         ret i64 %1
 sil @invoke_trivial_with_arg : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer, Int) -> Int {
 entry(%0 : $*@block_storage Builtin.RawPointer, %1 : $Int):
   return %1 : $Int
 }
 
-// CHECK-LABEL: define %objc_block* @init_block_header_nontrivial({ %objc_block, %swift.refcounted* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_block* @init_block_header_nontrivial({ %objc_block, %swift.refcounted* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         store %objc_block {
 // CHECK:           %objc_class* [[BLOCK_ISA]]
 // --                  0x4200_0000 -- HAS_SIGNATURE, HAS_COPY_DISPOSE
@@ -140,7 +140,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 
 sil public_external @invoke_nontrivial : $@convention(c) (@inout_aliasable @block_storage Builtin.NativeObject) -> ()
 
-// CHECK-LABEL: define %objc_block* @init_block_header_stret({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %objc_block* @init_block_header_stret({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         store %objc_block {
 // CHECK:           %objc_class* [[BLOCK_ISA]]
 // --                  0x6000_0000 -- HAS_STRET, HAS_SIGNATURE

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -15,7 +15,7 @@
 // CHECK: [[NSSIZE:%VSC6NSSize]] = type <{ %Sd, %Sd }>
 // CHECK: [[OBJC:%objc_object]] = type opaque
 
-// CHECK: @"OBJC_METACLASS_$__TtC17objc_class_export3Foo" = global %objc_class {
+// CHECK: @"OBJC_METACLASS_$__TtC17objc_class_export3Foo" = {{(protected )?}}global %objc_class {
 // CHECK:   %objc_class* @"OBJC_METACLASS_$_SwiftObject",
 // CHECK:   %objc_class* @"OBJC_METACLASS_$_SwiftObject",
 // CHECK:   %swift.opaque* @_objc_empty_cache,

--- a/test/IRGen/objc_errors.sil
+++ b/test/IRGen/objc_errors.sil
@@ -7,7 +7,7 @@
 import Swift
 import Foundation
 
-// CHECK-LABEL: define %swift.error* @errortype_from_nserror(%CSo7NSError*)
+// CHECK-LABEL: define{{( protected)?}} %swift.error* @errortype_from_nserror(%CSo7NSError*)
 // CHECK:         %1 = bitcast %CSo7NSError* %0 to %swift.error*
 sil @errortype_from_nserror : $@convention(thin) (@owned NSError) -> @owned ErrorType {
 entry(%0 : $NSError):

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -13,7 +13,7 @@ import gizmo
 // CHECK: @_TMOSC16NSRuncingOptions = linkonce_odr hidden global
 // CHECK: @_TWPOSC28NeverActuallyMentionedByNames9Equatable5gizmo = linkonce_odr hidden constant
 
-// CHECK-LABEL: define i32 @main
+// CHECK-LABEL: define{{( protected)?}} i32 @main
 // CHECK:         call %swift.type* @_TMaOSC16NSRuncingOptions()
 
 // CHECK: define hidden i16 @_TF12objc_ns_enum22imported_enum_inject_aFT_OSC16NSRuncingOptions()

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -15,7 +15,7 @@ extension NSString {
   }
 }
 
-// CHECK-LABEL: define private void @runtime_registration
+// CHECK-LABEL: define{{( protected)?}} private void @runtime_registration
 // CHECK:         [[GET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(classProp)
 // CHECK:         call i8* @class_replaceMethod(%objc_class* @"OBJC_METACLASS_$_NSString", i8* [[GET_CLASS_PROP]]
 // CHECK:         [[SET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(setClassProp:)

--- a/test/IRGen/objc_protocol_conversion.sil
+++ b/test/IRGen/objc_protocol_conversion.sil
@@ -12,7 +12,7 @@ import ObjectiveC
 
 @objc protocol OP {}
 
-// CHECK-LABEL: define %CSo8Protocol* @protocol_conversion() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} %CSo8Protocol* @protocol_conversion() {{.*}} {
 // CHECK:         %0 = load i8*, i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP24objc_protocol_conversion2OP_", align 8
 // CHECK:         %1 = bitcast i8* %0 to %CSo8Protocol*
 // CHECK:         ret %CSo8Protocol* %1
@@ -26,7 +26,7 @@ entry:
 
 // The Protocol class has been hidden in newer ObjC APIs, so when we need its
 // metadata, we treat it like a foreign class.
-// CHECK-LABEL: define %swift.type* @protocol_metatype()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @protocol_metatype()
 sil @protocol_metatype : $@convention(thin) () -> @thick Protocol.Type {
 entry:
   // CHECK: call %swift.type* @swift_getForeignTypeMetadata

--- a/test/IRGen/objc_protocol_multi_file.swift
+++ b/test/IRGen/objc_protocol_multi_file.swift
@@ -5,7 +5,7 @@
 // This used to crash <rdar://problem/17929944>.
 // To tickle the crash, SubProto must not be used elsewhere in this file.
 protocol SubProto : BaseProto {}
-// CHECK: @_TMp24objc_protocol_multi_file8SubProto = constant %swift.protocol
+// CHECK: @_TMp24objc_protocol_multi_file8SubProto = {{(protected )?}}constant %swift.protocol
 
 protocol DoubleSubProto : IntermediateProto {}
-// CHECK: @_TMp24objc_protocol_multi_file14DoubleSubProto = constant %swift.protocol
+// CHECK: @_TMp24objc_protocol_multi_file14DoubleSubProto = {{(protected )?}}constant %swift.protocol

--- a/test/IRGen/objc_selector.sil
+++ b/test/IRGen/objc_selector.sil
@@ -9,7 +9,7 @@ import Builtin
 // CHECK: @"\01L_selector_data(help:me:)" = private global [9 x i8] c"help:me:\00", section "__TEXT,__objc_methname,cstring_literals"
 // CHECK: @"\01L_selector(help:me:)" = private externally_initialized global i8* getelementptr inbounds ([9 x i8], [9 x i8]* @"\01L_selector_data(help:me:)", {{i(32|64)}} 0, {{i(32|64)}} 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip"
 
-// CHECK-LABEL: define i8* @objc_selector_literal() #0 {
+// CHECK-LABEL: define{{( protected)?}} i8* @objc_selector_literal() #0 {
 sil @objc_selector_literal : $@convention(thin) () -> Builtin.RawPointer {
 bb0:
   // CHECK: [[SEL:%[0-9]+]] = load i8*, i8** @"\01L_selector(help:me:)"

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -13,29 +13,29 @@ func forceStuff(x: float4, y: float3) -> (Float,Float,Float,Float) {
   }
 }
 
-// x86_64-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// i386-LABEL: define <2 x i64> @simd_c_args(<4 x float>)
-// arm64-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// armv6-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// armv7-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// armv7s-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// armv7k-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// powerpc64-LABEL: define <4 x float> @simd_c_args(<4 x float>)
-// powerpc64le-LABEL: define <4 x float> @simd_c_args(<4 x float>)
+// x86_64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// i386-LABEL: define{{( protected)?}} <2 x i64> @simd_c_args(<4 x float>)
+// arm64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv6-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv7-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv7s-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv7k-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// powerpc64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// powerpc64le-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 sil @simd_c_args : $@convention(c) (float4) -> float4 {
 entry(%x : $float4):
   return %x : $float4
 }
 
-// x86_64-LABEL: define <3 x float> @simd_c_args_float3(<3 x float>)
-// i386-LABEL: define <2 x i64> @simd_c_args_float3(<3 x float>)
-// arm64-LABEL: define <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv6-LABEL: define <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7-LABEL: define <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7s-LABEL: define <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7k-LABEL: define <3 x float> @simd_c_args_float3(<4 x i32>)
-// powerpc64-LABEL: define <3 x float> @simd_c_args_float3(<3 x float>)
-// powerpc64le-LABEL: define <3 x float> @simd_c_args_float3(<3 x float>)
+// x86_64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// i386-LABEL: define{{( protected)?}} <2 x i64> @simd_c_args_float3(<3 x float>)
+// arm64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv6-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7s-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7k-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// powerpc64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// powerpc64le-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
 sil @simd_c_args_float3 : $@convention(c) (float3) -> float3 {
 entry(%x : $float3):
 // x86_64: [[COERCE:%.*]] = alloca <3 x float>, align 16
@@ -44,15 +44,15 @@ entry(%x : $float3):
   return %x : $float3
 }
 
-// x86_64-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// i386-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// arm64-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// armv6-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// armv7-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// armv7s-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// armv7k-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// powerpc64-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
-// powerpc64le-LABEL: define void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// x86_64-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// i386-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// arm64-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// armv6-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// armv7-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// armv7s-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// armv7k-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// powerpc64-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
+// powerpc64le-LABEL: define{{( protected)?}} void @simd_native_args(%V4simd6float4* noalias nocapture sret, %V4simd6float4* noalias nocapture dereferenceable({{.*}}))
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
 entry(%x : $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4
@@ -60,15 +60,15 @@ entry(%x : $float4):
   return %y : $float4
 }
 
-// x86_64-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// i386-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// arm64-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// armv6-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// armv7-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// armv7s-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// armv7k-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// powerpc64-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
-// powerpc64le-LABEL: define { float, float, float } @simd_native_args_float3(float, float, float)
+// x86_64-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// i386-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// arm64-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// armv6-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// armv7-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// armv7s-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// armv7k-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// powerpc64-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
+// powerpc64le-LABEL: define{{( protected)?}} { float, float, float } @simd_native_args_float3(float, float, float)
 sil @simd_native_args_float3 : $@convention(thin) (float3) -> float3 {
 entry(%x : $float3):
   %f = function_ref @simd_c_args_float3 : $@convention(c) (float3) -> float3

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -12,9 +12,9 @@
 // CHECK: [[GIZMO:%CSo5Gizmo]] = type opaque
 // CHECK: [[OBJC:%objc_object]] = type opaque
 
-// CHECK-32: @_TWvdvC13objc_subclass10SwiftGizmo1xSi = global i32 12, align [[WORD_SIZE_IN_BYTES:4]]
-// CHECK-64: @_TWvdvC13objc_subclass10SwiftGizmo1xSi = global i64 16, align [[WORD_SIZE_IN_BYTES:8]]
-// CHECK: @"OBJC_METACLASS_$__TtC13objc_subclass10SwiftGizmo" = global [[OBJC_CLASS]] { [[OBJC_CLASS]]* @"OBJC_METACLASS_$_NSObject", [[OBJC_CLASS]]* @"OBJC_METACLASS_$_Gizmo", [[OPAQUE]]* @_objc_empty_cache, [[OPAQUE]]* null, [[LLVM_PTRSIZE_INT]] ptrtoint ({{.*}} @_METACLASS_DATA__TtC13objc_subclass10SwiftGizmo to [[LLVM_PTRSIZE_INT]]) }
+// CHECK-32: @_TWvdvC13objc_subclass10SwiftGizmo1xSi = {{(protected )?}}global i32 12, align [[WORD_SIZE_IN_BYTES:4]]
+// CHECK-64: @_TWvdvC13objc_subclass10SwiftGizmo1xSi = {{(protected )?}}global i64 16, align [[WORD_SIZE_IN_BYTES:8]]
+// CHECK: @"OBJC_METACLASS_$__TtC13objc_subclass10SwiftGizmo" = {{(protected )?}}global [[OBJC_CLASS]] { [[OBJC_CLASS]]* @"OBJC_METACLASS_$_NSObject", [[OBJC_CLASS]]* @"OBJC_METACLASS_$_Gizmo", [[OPAQUE]]* @_objc_empty_cache, [[OPAQUE]]* null, [[LLVM_PTRSIZE_INT]] ptrtoint ({{.*}} @_METACLASS_DATA__TtC13objc_subclass10SwiftGizmo to [[LLVM_PTRSIZE_INT]]) }
 // CHECK: [[STRING_X:@.*]] = private unnamed_addr constant [2 x i8] c"x\00"
 // CHECK: [[STRING_EMPTY:@.*]] = private unnamed_addr constant [1 x i8] zeroinitializer
 // CHECK-32: [[METHOD_TYPE_ENCODING1:@.*]] = private unnamed_addr constant [7 x i8] c"l8@0:4\00"

--- a/test/IRGen/optional_metatype.sil
+++ b/test/IRGen/optional_metatype.sil
@@ -8,15 +8,15 @@ import Builtin
 import Swift
 import gizmo
 
-// x86_64-LABEL: define void @optional_objc_metatype(i64)
+// x86_64-LABEL: define{{( protected)?}} void @optional_objc_metatype(i64)
 // x86_64:         icmp eq i64 %0, 0
-// i386-LABEL:   define void @optional_objc_metatype(i32)
+// i386-LABEL:   define{{( protected)?}} void @optional_objc_metatype(i32)
 // i386:           icmp eq i32 %0, 0
-// arm64-LABEL:  define void @optional_objc_metatype(i64)
+// arm64-LABEL:  define{{( protected)?}} void @optional_objc_metatype(i64)
 // arm64:          icmp eq i64 %0, 0
-// armv7-LABEL:  define void @optional_objc_metatype(i32)
+// armv7-LABEL:  define{{( protected)?}} void @optional_objc_metatype(i32)
 // armv7:           icmp eq i32 %0, 0
-// armv7k-LABEL: define void @optional_objc_metatype(i32)
+// armv7k-LABEL: define{{( protected)?}} void @optional_objc_metatype(i32)
 // armv7k:          icmp eq i32 %0, 0
 
 sil @optional_objc_metatype : $@convention(thin) (Optional<@objc_metatype Gizmo.Type>) -> () {
@@ -30,15 +30,15 @@ cont:
   return undef : $()
 }
 
-// x86_64-LABEL: define void @optional_swift_metatype(i64)
+// x86_64-LABEL: define{{( protected)?}} void @optional_swift_metatype(i64)
 // x86_64:           icmp eq i64 %0, 0
-// i386-LABEL:   define void @optional_swift_metatype(i32)
+// i386-LABEL:   define{{( protected)?}} void @optional_swift_metatype(i32)
 // i386:             icmp eq i32 %0, 0
-// arm64-LABEL:  define void @optional_swift_metatype(i64)
+// arm64-LABEL:  define{{( protected)?}} void @optional_swift_metatype(i64)
 // arm64:            icmp eq i64 %0, 0
-// armv7-LABEL:  define void @optional_swift_metatype(i32)
+// armv7-LABEL:  define{{( protected)?}} void @optional_swift_metatype(i32)
 // armv7:            icmp eq i32 %0, 0
-// armv7k-LABEL: define void @optional_swift_metatype(i32)
+// armv7k-LABEL: define{{( protected)?}} void @optional_swift_metatype(i32)
 // armv7k:           icmp eq i32 %0, 0
 
 sil @optional_swift_metatype : $@convention(thin) (Optional<@thick Gizmo.Type>) -> () {

--- a/test/IRGen/ordering.sil
+++ b/test/IRGen/ordering.sil
@@ -31,6 +31,6 @@ bb0:
 }
 
 // Make sure that these functions are emitted in the order they 
-// CHECK: define void @foo
-// CHECK: define void @bar
-// CHECK: define void @baz
+// CHECK: define{{( protected)?}} void @foo
+// CHECK: define{{( protected)?}} void @bar
+// CHECK: define{{( protected)?}} void @baz

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -42,7 +42,7 @@ bb0(%0 : $ObjCClass):
   return %0 : $ObjCClass
 }
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @indirect_partial_apply(i8*, %swift.refcounted*, i64) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @indirect_partial_apply(i8*, %swift.refcounted*, i64) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata, i32 0, i32 2), i64 40, i64 7)
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %swift.refcounted* [[OBJ]] to [[DATA_TYPE:<{ %swift.refcounted, i64, %swift.refcounted\*, i8\* }>]]*
@@ -75,7 +75,7 @@ entry(%f : $@callee_owned (Builtin.Word) -> (), %x : $Builtin.Word):
   return %p : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @objc_partial_apply(%C13partial_apply9ObjCClass*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @objc_partial_apply(%C13partial_apply9ObjCClass*) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata.2, i32 0, i32 2), i64 24, i64 7)
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %swift.refcounted* [[OBJ]] to [[DATA_TYPE:<{ %swift.refcounted, %C13partial_apply9ObjCClass\* }>]]*
@@ -107,7 +107,7 @@ entry(%c : $ObjCClass):
   return %p : $@callee_owned Int -> ()
 }
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @objc_partial_apply_consumes_self(%C13partial_apply9ObjCClass*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @objc_partial_apply_consumes_self(%C13partial_apply9ObjCClass*) {{.*}} {
 // CHECK:         bitcast %swift.refcounted* {{%.*}} to [[DATA_TYPE:<{ %swift.refcounted, %C13partial_apply9ObjCClass\* }>]]*
 // CHECK:         insertvalue {{.*}} [[OBJC_CONSUMES_SELF_PARTIAL_APPLY_STUB:@_TPA[A-Za-z0-9_.]*]]
 // CHECK: define internal %C13partial_apply9ObjCClass* [[OBJC_CONSUMES_SELF_PARTIAL_APPLY_STUB]](%swift.refcounted*) {{.*}} {
@@ -134,7 +134,7 @@ entry(%x : $Int):
   return %v : $()
 }
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @dynamic_lookup_br_partial_apply(%objc_object*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @dynamic_lookup_br_partial_apply(%objc_object*) {{.*}} {
 // CHECK:   phi i8* [ bitcast (void (i64)* @dummy to i8*), {{%.*}} ], [ bitcast (void (i64, %swift.refcounted*)* [[DYNAMIC_LOOKUP_BR_PARTIAL_APPLY_STUB:@_TPA[A-Za-z0-9_.]*]] to i8*), {{%.*}} ]
 // CHECK: define internal void [[DYNAMIC_LOOKUP_BR_PARTIAL_APPLY_STUB]](i64, %swift.refcounted*) {{.*}} {
 // CHECK:   load i8*, i8** @"\01L_selector(methodWithX:)", align 8
@@ -162,7 +162,7 @@ sil @_TFC13partial_apply10SwiftClassD : $@convention(method) (SwiftClass) -> ()
 
 sil @partially_applyable_to_class : $@convention(thin) (@owned SwiftClass) -> ()
 
-// CHECK: define { i8*, %swift.refcounted* } @partial_apply_class(%C13partial_apply10SwiftClass*) {{.*}} {
+// CHECK: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_class(%C13partial_apply10SwiftClass*) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = bitcast %C13partial_apply10SwiftClass* %0 to %swift.refcounted*
 // CHECK:   %2 = insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%C13partial_apply10SwiftClass*)* @partially_applyable_to_class to i8*), %swift.refcounted* undef }, %swift.refcounted* %1, 1
@@ -177,7 +177,7 @@ entry(%c : $SwiftClass):
 
 sil @partially_applyable_to_pure_objc : $@convention(thin) Gizmo -> ()
 
-// CHECK: define { i8*, %swift.refcounted* } @partial_apply_pure_objc
+// CHECK: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_pure_objc
 // CHECK:   @swift_allocObject
 sil @partial_apply_pure_objc : $@convention(thin) Gizmo -> @callee_owned () -> () {
 entry(%c : $Gizmo):
@@ -228,7 +228,7 @@ entry(%a : $*T):
 
 sil public_external @guaranteed_captured_class_param : $@convention(thin) (Int, @guaranteed SwiftClass) -> Int
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_param(%C13partial_apply10SwiftClass*)
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_param(%C13partial_apply10SwiftClass*)
 // CHECK:         [[CONTEXT_OBJ:%.*]] = bitcast %C13partial_apply10SwiftClass* {{%.*}} to %swift.refcounted*
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@_TPA_[A-Za-z0-9_]+]] {{.*}} [[CONTEXT_OBJ]]
 // CHECK:         ret {{.*}} [[T0]]
@@ -249,7 +249,7 @@ bb0(%x : $SwiftClass):
 
 sil public_external @indirect_guaranteed_captured_class_param : $@convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_param(%C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_param(%C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[X:%.*]] = load %C13partial_apply10SwiftClass*, %C13partial_apply10SwiftClass** %0
 // CHECK-NEXT:    [[CONTEXT_OBJ:%.*]] = bitcast %C13partial_apply10SwiftClass* [[X]] to %swift.refcounted*
@@ -278,7 +278,7 @@ bb0(%x : $*SwiftClass):
 
 sil public_external @indirect_consumed_captured_class_param : $@convention(thin) (Int, @in SwiftClass) -> Int
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_param(%C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_param(%C13partial_apply10SwiftClass** noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[X:%.*]] = load %C13partial_apply10SwiftClass*, %C13partial_apply10SwiftClass** %0
 // CHECK-NEXT:    [[CONTEXT_OBJ:%.*]] = bitcast %C13partial_apply10SwiftClass* [[X]] to %swift.refcounted*
@@ -314,7 +314,7 @@ struct SwiftClassPair { var x: SwiftClass, y: SwiftClass }
 
 sil public_external @guaranteed_captured_class_pair_param : $@convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_pair_param(%C13partial_apply10SwiftClass*, %C13partial_apply10SwiftClass*)
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_pair_param(%C13partial_apply10SwiftClass*, %C13partial_apply10SwiftClass*)
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK:         [[PAIR_ADDR:%.*]] = getelementptr
 // CHECK-NEXT:    [[X_ADDR:%.*]] = getelementptr inbounds %V13partial_apply14SwiftClassPair, %V13partial_apply14SwiftClassPair* [[PAIR_ADDR]], i32 0, i32 0
@@ -345,7 +345,7 @@ bb0(%x : $SwiftClassPair):
 
 sil public_external @indirect_guaranteed_captured_class_pair_param : $@convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_pair_param(%V13partial_apply14SwiftClassPair* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_pair_param(%V13partial_apply14SwiftClassPair* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@_TPA_[A-Za-z0-9_]+]] {{.*}} [[CONTEXT_OBJ]]
@@ -368,7 +368,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @indirect_consumed_captured_class_pair_param : $@convention(thin) (Int, @in SwiftClassPair) -> Int
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_pair_param(%V13partial_apply14SwiftClassPair* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_pair_param(%V13partial_apply14SwiftClassPair* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@_TPA_[A-Za-z0-9_]+]] {{.*}} [[CONTEXT_OBJ]]
@@ -392,7 +392,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @captured_fixed_and_dependent_params : $@convention(thin) <A> (@owned SwiftClass, @in A, Int) -> ()
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_indirect_non_fixed_layout(%C13partial_apply10SwiftClass*, %swift.opaque* noalias nocapture, i64, %swift.type* %T)
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_indirect_non_fixed_layout(%C13partial_apply10SwiftClass*, %swift.opaque* noalias nocapture, i64, %swift.type* %T)
 // -- Round the base offset for the T field up to T's alignment.
 // CHECK:         [[T_METADATA_BASE:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:         [[T_VWTABLE_ADDR:%.*]] = getelementptr {{.*}} [[T_METADATA_BASE]], [[WORD:i[0-9]+]] -1
@@ -471,7 +471,7 @@ bb0(%x : $Int32, %f : $@callee_owned (@out T, Int32) -> ()):
   return %p : $@callee_owned (@out T) -> ()
 }
 
-// CHECK-LABEL: define { i8*, %swift.refcounted* } @partial_apply_dynamic_with_out_param
+// CHECK-LABEL: define{{( protected)?}} { i8*, %swift.refcounted* } @partial_apply_dynamic_with_out_param
 // CHECK:         insertvalue {{.*}} [[FORWARDER:@_TPA[A-Za-z0-9_]*]]
 // CHECK:       define internal void [[FORWARDER]]
 // CHECK:         call void {{%.*}}(%swift.opaque* noalias nocapture sret
@@ -493,7 +493,7 @@ bb0(%0 : $Base):
 
 sil public_external @receive_closure : $@convention(thin) <C where C : Base> (@owned @callee_owned () -> (@owned C)) -> ()
 
-// CHECK-LABEL: define void @test_partial_apply(%C13partial_apply4Base*)
+// CHECK-LABEL: define{{( protected)?}} void @test_partial_apply(%C13partial_apply4Base*)
 // CHECK:  [[CTX:%.*]] = bitcast %C13partial_apply4Base* %0 to %swift.refcounted*
 // CHECK:  [[TYPE:%.*]] = call %swift.type* @_TMaC13partial_apply3Sub()
 // CHECK:  call void @receive_closure(i8* bitcast (%C13partial_apply3Sub* (%swift.refcounted*)* @_TPA_parametric_casting_closure.28 to i8*), %swift.refcounted* [[CTX]], %swift.type* [[TYPE]])
@@ -524,7 +524,7 @@ bb0(%0 : $Base):
 
 sil public_external @partial_empty_box : $@convention(thin) (@owned @box (), @inout ()) -> ()
 
-// CHECK-LABEL: define void @empty_box()
+// CHECK-LABEL: define{{( protected)?}} void @empty_box()
 sil @empty_box : $@convention(thin) () -> () {
 entry:
   // CHECK: store %swift.refcounted* null

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -13,12 +13,12 @@ public func anchor() {}
 
 anchor()
 
-// CHECK-LABEL: define i32 @main
+// CHECK-LABEL: define{{( protected)?}} i32 @main
 // CHECK:         call void @runtime_registration
 // CHECK:         call void @_TF10playground6anchorFT_T_
 // CHECK:         ret void
 // CHECK:       }
 
-// CHECK-LABEL: define private void @runtime_registration
+// CHECK-LABEL: define{{( protected)?}} private void @runtime_registration
 // CHECK:         call void @swift_instantiateObjCClass({{.*}} @_TMC10playground1C
 

--- a/test/IRGen/protocol_extensions.sil
+++ b/test/IRGen/protocol_extensions.sil
@@ -24,7 +24,7 @@ bb0(%0 : $*Self):
   return %5 : $()                                 // id: %6
 }
 
-// CHECK-LABEL: define void @_TFP19protocol_extensions2P16extP1bUS0___fQPS0_FT_T_
+// CHECK-LABEL: define{{( protected)?}} void @_TFP19protocol_extensions2P16extP1bUS0___fQPS0_FT_T_
 sil @_TFP19protocol_extensions2P16extP1bUS0___fQPS0_FT_T_ : $@convention(method) <Self where Self : P1> (@in Self) -> () {
 bb0(%0 : $*Self):
   debug_value_addr %0 : $*Self, let, name "self" // id: %1

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -18,19 +18,19 @@ protocol C : class { func c() }
 protocol AB : A, B { func ab() }
 protocol ABO : A, B, O { func abo() }
 
-// CHECK: @_TMp17protocol_metadata1A = constant %swift.protocol {
+// CHECK: @_TMp17protocol_metadata1A = {{(protected )?}}constant %swift.protocol {
 // -- size 72
 // -- flags: 1 = Swift | 2 = Not Class-Constrained | 4 = Needs Witness Table
 // CHECK:   i32 72, i32 7,
 // CHECK:   i16 0, i16 0
 // CHECK: }
 
-// CHECK: @_TMp17protocol_metadata1B = constant %swift.protocol {
+// CHECK: @_TMp17protocol_metadata1B = {{(protected )?}}constant %swift.protocol {
 // CHECK:   i32 72, i32 7,
 // CHECK:   i16 0, i16 0
 // CHECK: }
 
-// CHECK: @_TMp17protocol_metadata1C = constant %swift.protocol {
+// CHECK: @_TMp17protocol_metadata1C = {{(protected )?}}constant %swift.protocol {
 // -- flags: 1 = Swift | 4 = Needs Witness Table
 // CHECK:   i32 72, i32 5,
 // CHECK:   i16 0, i16 0
@@ -62,7 +62,7 @@ protocol ABO : A, B, O { func abo() }
 // CHECK:   %swift.protocol* @_TMp17protocol_metadata1A,
 // CHECK:   %swift.protocol* @_TMp17protocol_metadata1B
 // CHECK: }
-// CHECK: @_TMp17protocol_metadata2AB = constant %swift.protocol { 
+// CHECK: @_TMp17protocol_metadata2AB = {{(protected )?}}constant %swift.protocol { 
 // CHECK:   [[AB_INHERITED]]
 // CHECK:   i32 72, i32 7,
 // CHECK:   i16 0, i16 0

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -49,13 +49,13 @@ protocol InternalProtocol {
   func f()
 }
 
-// CHECK: @_TMp19protocol_resilience5Proto = constant %swift.protocol {
+// CHECK: @_TMp19protocol_resilience5Proto = {{(protected )?}}constant %swift.protocol {
 // CHECK-SAME:   i32 1031,
 // CHECK-SAME:   i16 0,
 // CHECK-SAME:   i16 0
 // CHECK-SAME: }
 
-// CHECK: @_TMp19protocol_resilience17ResilientProtocol = constant <{{.*}}> <{
+// CHECK: @_TMp19protocol_resilience17ResilientProtocol = {{(protected )?}}constant <{{.*}}> <{
 // CHECK-SAME:   i32 1031,
 // CHECK-SAME:   i16 4,
 // CHECK-SAME:   i16 2,
@@ -63,7 +63,7 @@ protocol InternalProtocol {
 // CHECK-SAME:   void (%swift.opaque*, %swift.type*)* @defaultD  
 // CHECK-SAME: }>
 
-// CHECK: @_TMp19protocol_resilience16InternalProtocol = constant %swift.protocol {
+// CHECK: @_TMp19protocol_resilience16InternalProtocol = {{(protected )?}}constant %swift.protocol {
 // CHECK-SAME:   i32 7,
 // CHECK-SAME:   i16 0,
 // CHECK-SAME:   i16 0

--- a/test/IRGen/readonly.sil
+++ b/test/IRGen/readonly.sil
@@ -19,7 +19,7 @@ sil @_TFC8readonly3XXXCfMS0_FT_S0_ : $@convention(thin) (@thick XXX.Type) -> @ow
 //CHECK: target datalayout
 
 //CHECK: ; Function Attrs: readonly
-//CHECK-NEXT: define void @function_foo(
+//CHECK-NEXT: define{{( protected)?}} void @function_foo(
 sil [readonly] @function_foo : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = tuple ()                                   // user: %2
@@ -27,7 +27,7 @@ bb0(%0 : $Int):
 }
 
 //CHECK-NOT: ; Function Attrs: readonly
-//CHECK: define void @function_bar(
+//CHECK: define{{( protected)?}} void @function_bar(
 sil [readonly] @function_bar : $@convention(thin) (@owned XXX) -> () {
 bb0(%0 : $XXX):
   strong_release %0 : $XXX                        // id: %2

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -15,4 +15,4 @@ public extension P where Foo == DefaultFoo<Self> {
   }
 }
 
-// CHECK: define void @_TFe21same_type_constraintsRxS_1Pwx3FoozGVS_10DefaultFoox_rS0_3foofT_GS2_x_
+// CHECK: define{{( protected)?}} void @_TFe21same_type_constraintsRxS_1Pwx3FoozGVS_10DefaultFoox_rS0_3foofT_GS2_x_

--- a/test/IRGen/select_enum.sil
+++ b/test/IRGen/select_enum.sil
@@ -7,7 +7,7 @@ enum SinglePayloadSingleEmpty {
   case DataCase(Builtin.Word)
 }
 
-// CHECK-LABEL: define void @select_enum_SinglePayloadSingleEmpty(%O11select_enum24SinglePayloadSingleEmpty* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @select_enum_SinglePayloadSingleEmpty(%O11select_enum24SinglePayloadSingleEmpty* noalias nocapture dereferenceable({{.*}}))
 sil @select_enum_SinglePayloadSingleEmpty : $@convention(thin) (@in SinglePayloadSingleEmpty) -> () {
 bb0(%0 : $*SinglePayloadSingleEmpty):
   %1 = load %0 : $*SinglePayloadSingleEmpty
@@ -79,7 +79,7 @@ enum NoPayloadSingleton {
   case One
 }
 
-// CHECK-LABEL: define i1 @testOptionalOfNoPayloadSingleton(i1)
+// CHECK-LABEL: define{{( protected)?}} i1 @testOptionalOfNoPayloadSingleton(i1)
 sil @testOptionalOfNoPayloadSingleton : $@convention(thin) (MyOptional<NoPayloadSingleton>) -> Builtin.Int1 {
 bb0(%0 : $MyOptional<NoPayloadSingleton>):
 // CHECK:  [[NOT:%.*]] = xor i1 %0, true

--- a/test/IRGen/select_enum_single_payload.sil
+++ b/test/IRGen/select_enum_single_payload.sil
@@ -9,7 +9,7 @@ enum ManyEmptyCases {
     case C(Builtin.Int32)
 }
 
-// CHECK-LABEL: define i1 @select_enum_A(i32, i1)
+// CHECK-LABEL: define{{( protected)?}} i1 @select_enum_A(i32, i1)
 // CHECK:         [[PAYLOAD:%.*]] = icmp eq i32 %0, 0
 // CHECK:         [[EXTRA:%.*]] = and i1 %1, [[PAYLOAD]]
 // CHECK:         ret i1 [[EXTRA]]
@@ -21,7 +21,7 @@ entry(%0 : $ManyEmptyCases):
   return %6 : $Builtin.Int1
 }
 
-// CHECK-LABEL: define i1 @select_enum_B(i32, i1)
+// CHECK-LABEL: define{{( protected)?}} i1 @select_enum_B(i32, i1)
 // CHECK:         [[PAYLOAD:%.*]] = icmp eq i32 %0, 1
 // CHECK:         [[EXTRA:%.*]] = and i1 %1, [[PAYLOAD]]
 // CHECK:         ret i1 [[EXTRA]]

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -2,20 +2,20 @@
 
 sil_stage canonical
 
-// CHECK: define void @public_fragile_function_test() {{.*}} {
-// CHECK: define void @hidden_fragile_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} void @public_fragile_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden void @shared_fragile_function_test() {{.*}} {
-// CHECK: define void @private_fragile_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} void @private_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden void @public_external_fragile_function_def_test() {{.*}} {
-// CHECK: define available_externally void @hidden_external_fragile_function_def_test() {{.*}} {
+// CHECK: define{{( protected)?}} available_externally void @hidden_external_fragile_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden void @shared_external_fragile_function_def_test() {{.*}} {
-// CHECK: define available_externally void @private_external_fragile_function_def_test() {{.*}} {
-// CHECK: define void @public_resilient_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} available_externally void @private_external_fragile_function_def_test() {{.*}} {
+// CHECK: define{{( protected)?}} void @public_resilient_function_test() {{.*}} {
 // CHECK: define hidden void @hidden_resilient_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden void @shared_resilient_function_test() {{.*}} {
 // CHECK: define internal void @private_resilient_function_test() {{.*}}{
 // CHECK: define linkonce_odr hidden void @public_external_resilient_function_def_test() {{.*}} {
-// CHECK: define available_externally hidden void @hidden_external_resilient_function_def_test() {{.*}} {
+// CHECK: define{{( protected)?}} available_externally hidden void @hidden_external_resilient_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden void @shared_external_resilient_function_def_test() {{.*}} {
 
 sil public [fragile] @public_fragile_function_test : $@convention(thin) () -> () {

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -19,14 +19,14 @@ protocol P {
   func generic_method<Z>(x: Z)
 }
 
-// CHECK-LABEL: define %swift.type* @concrete_type_concrete_method_witness(%V19sil_witness_methods3Foo* noalias nocapture, %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @concrete_type_concrete_method_witness(%V19sil_witness_methods3Foo* noalias nocapture, %swift.type* %Self)
 sil @concrete_type_concrete_method_witness : $@convention(witness_method) (@in Foo) -> @thick Foo.Type {
 entry(%x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define %swift.type* @generic_type_concrete_method_witness(%C19sil_witness_methods3Bar** noalias nocapture dereferenceable({{.*}}), %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @generic_type_concrete_method_witness(%C19sil_witness_methods3Bar** noalias nocapture dereferenceable({{.*}}), %swift.type* %Self)
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK:         [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
 // CHECK:         %T = load %swift.type*, %swift.type** [[T1]], align 8
@@ -48,14 +48,14 @@ entry(%x : $*Bar<T, U, V>):
 
 // TODO: %Self Type arg is redundant for static method witness
 
-// CHECK-LABEL: define %swift.type* @concrete_type_concrete_static_method_witness(%swift.type*, %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @concrete_type_concrete_static_method_witness(%swift.type*, %swift.type* %Self)
 sil @concrete_type_concrete_static_method_witness : $@convention(witness_method) (@thick Foo.Type) -> @thick Foo.Type {
 entry(%x : $@thick Foo.Type):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define %swift.type* @generic_type_concrete_static_method_witness(%swift.type*, %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @generic_type_concrete_static_method_witness(%swift.type*, %swift.type* %Self)
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK:         [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
 // CHECK:         %T = load %swift.type*, %swift.type** [[T1]], align 8
@@ -77,14 +77,14 @@ entry(%x : $@thick Bar<T, U, V>.Type):
 
 // TODO: %Self Type arg is redundant for class method witness
 
-// CHECK-LABEL: define %swift.type* @concrete_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %V19sil_witness_methods3Foo* noalias nocapture, %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @concrete_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %V19sil_witness_methods3Foo* noalias nocapture, %swift.type* %Self)
 sil @concrete_type_generic_method_witness : $@convention(witness_method) <Z> (@in Z, @in Foo) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define %swift.type* @generic_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %C19sil_witness_methods3Bar** noalias nocapture dereferenceable({{.*}}), %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @generic_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %C19sil_witness_methods3Bar** noalias nocapture dereferenceable({{.*}}), %swift.type* %Self)
 sil @generic_type_generic_method_witness : $@convention(witness_method) <T, U, V, Z> (@in Z, @in Bar<T, U, V>) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $*Bar<T, U, V>):
   %t = metatype $@thick T.Type
@@ -95,14 +95,14 @@ entry(%z : $*Z, %x : $*Bar<T, U, V>):
   return %m : $@thick Bar<T, U, V>.Type
 }
 
-// CHECK-LABEL: define %swift.type* @concrete_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type*, %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @concrete_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type*, %swift.type* %Self)
 sil @concrete_type_generic_static_method_witness : $@convention(witness_method) <Z> (@in Z, @thick Foo.Type) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $@thick Foo.Type):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define %swift.type* @generic_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type*, %swift.type* %Self)
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @generic_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type*, %swift.type* %Self)
 sil @generic_type_generic_static_method_witness : $@convention(witness_method) <T, U, V, Z> (@in Z, @thick Bar<T, U, V>.Type) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $@thick Bar<T, U, V>.Type):
   %t = metatype $@thick T.Type
@@ -113,7 +113,7 @@ entry(%z : $*Z, %x : $@thick Bar<T, U, V>.Type):
   return %m : $@thick Bar<T, U, V>.Type
 }
 
-// CHECK-LABEL: define void @call_concrete_witness() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @call_concrete_witness() {{.*}} {
 // CHECK:         call %swift.type* @concrete_type_concrete_method_witness(%V19sil_witness_methods3Foo* {{.*}}, %swift.type* {{.*}} @_TMfV19sil_witness_methods3Foo, {{.*}})
 sil @call_concrete_witness : $(Foo) -> () {
 entry(%x : $Foo):
@@ -125,7 +125,7 @@ entry(%x : $Foo):
   return undef : $()
 }
 
-// CHECK-LABEL: define void @call_concrete_static_witness() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @call_concrete_static_witness() {{.*}} {
 // CHECK:         call %swift.type* @concrete_type_concrete_static_method_witness(%swift.type* {{.*}} @_TMfV19sil_witness_methods3Foo, {{.*}} %swift.type* {{.*}} @_TMfV19sil_witness_methods3Foo, {{.*}})
 sil @call_concrete_static_witness : $() -> () {
 entry:

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -73,7 +73,7 @@ func externalErasure(c c: ExternalConformer) -> ExternalP {
 
 // FIXME: why do these have different linkages?
 
-// CHECK-LABEL: define %swift.type* @_TMaV18sil_witness_tables14AssocConformer()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV18sil_witness_tables14AssocConformer()
 // CHECK:         ret %swift.type* bitcast (i64* getelementptr inbounds {{.*}} @_TMfV18sil_witness_tables14AssocConformer, i32 0, i32 1) to %swift.type*)
 
 // CHECK-LABEL: define hidden i8** @_TWaV18sil_witness_tables9ConformerS_1PS_()

--- a/test/IRGen/special_protocols.sil
+++ b/test/IRGen/special_protocols.sil
@@ -1,21 +1,21 @@
 // RUN: %target-swift-frontend %s -emit-ir -parse-stdlib -module-name Swift | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 protocol AnyObject: class {}
-// CHECK-LABEL: @_TMps9AnyObject = constant %swift.protocol {
+// CHECK-LABEL: @_TMps9AnyObject = {{(protected )?}}constant %swift.protocol {
 // --                 0x0000_0049: special protocol 01, class, empty, swift
 // CHECK:         i32 73,
 // CHECK:         i16 0,
 // CHECK:         i16 0 }
 
 protocol ErrorType {}
-// CHECK-LABEL: @_TMps9ErrorType = constant %swift.protocol {
+// CHECK-LABEL: @_TMps9ErrorType = {{(protected )?}}constant %swift.protocol {
 // --                 0x0000_0087: special protocol 02, non-class, witness, swift
 // CHECK:         i32 135,
 // CHECK:         i16 0,
 // CHECK:         i16 0 }
 
 protocol PlainOldProtocol {}
-// CHECK-LABEL: @_TMps16PlainOldProtocol = constant %swift.protocol {
+// CHECK-LABEL: @_TMps16PlainOldProtocol = {{(protected )?}}constant %swift.protocol {
 // --                 0x0000_0007: no special protocol, non-class, witness, swift
 // CHECK:         i32 7,
 // CHECK:         i16 0,

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -24,10 +24,10 @@ public struct S2 {
 // CHECK: %V18static_initializer1S = type <{ %Vs5Int32 }>
 
 sil_global @_Tv2ch1xSi : $Int32, @globalinit_func0 : $@convention(thin) () -> ()
-// CHECK: @_Tv2ch1xSi = global %Vs5Int32 <{ i32 2 }>, align 4
+// CHECK: @_Tv2ch1xSi = {{(protected )?}}global %Vs5Int32 <{ i32 2 }>, align 4
 
 sil_global @_Tv6nested1xVS_2S2 : $S2, @globalinit_func1 : $@convention(thin) () -> ()
-// CHECK: @_Tv6nested1xVS_2S2 = global %V18static_initializer2S2 <{ %Vs5Int32 <{ i32 2 }>, %Vs5Int32 <{ i32 3 }>, %V18static_initializer1S <{ %Vs5Int32 <{ i32 4 }> }> }>, align 4
+// CHECK: @_Tv6nested1xVS_2S2 = {{(protected )?}}global %V18static_initializer2S2 <{ %Vs5Int32 <{ i32 2 }>, %Vs5Int32 <{ i32 3 }>, %V18static_initializer1S <{ %Vs5Int32 <{ i32 4 }> }> }>, align 4
 
 sil private @globalinit_func0 : $@convention(thin) () -> () {
 bb0:
@@ -39,7 +39,7 @@ bb0:
   return %4 : $()
 }
 
-// CHECK-LABEL: define i8* @_TF2cha1xSi() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i8* bitcast (%Vs5Int32* @_Tv2ch1xSi to i8*)
 sil [global_init] @_TF2cha1xSi : $@convention(thin) () -> Builtin.RawPointer {
@@ -49,7 +49,7 @@ bb0:
   return %1 : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define i32 @_TF2ch1fFT_Si() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i32 @_TF2ch1fFT_Si() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: load i32, i32* getelementptr inbounds (%Vs5Int32, %Vs5Int32* @_Tv2ch1xSi, i32 0, i32 0)
 // CHECK-NEXT: ret
@@ -76,7 +76,7 @@ bb0:
   return %10 : $()
 }
 
-// CHECK-LABEL: define i8* @_TF6nesteda1xVS_2S2() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} i8* @_TF6nesteda1xVS_2S2() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i8* bitcast (%V18static_initializer2S2* @_Tv6nested1xVS_2S2 to i8*)
 sil [global_init] @_TF6nesteda1xVS_2S2 : $@convention(thin) () -> Builtin.RawPointer {
@@ -86,7 +86,7 @@ bb0:
   return %1 : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define { i32, i32, i32 } @_TF6nested1fFT_VS_2S2() {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i32, i32, i32 } @_TF6nested1fFT_VS_2S2() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: load i32, i32* getelementptr inbounds (%V18static_initializer2S2, %V18static_initializer2S2* @_Tv6nested1xVS_2S2, i32 0, i32 0, i32 0)
 // CHECK-NEXT: load i32, i32* getelementptr inbounds (%V18static_initializer2S2, %V18static_initializer2S2* @_Tv6nested1xVS_2S2, i32 0, i32 1, i32 0)

--- a/test/IRGen/struct_layout.sil
+++ b/test/IRGen/struct_layout.sil
@@ -9,9 +9,9 @@ import Swift
 // 64: %V4main14Rdar15410780_C = type <{ %Sq[[C:(\.[0-9]+)?]] }>
 // 64: %Sq[[C]] = type <{ [24 x i8], [1 x i8] }>
 
-// 64: @_TWVV4main14Rdar15410780_A = constant {{.*}} (i64 257
-// 64: @_TWVV4main14Rdar15410780_B = constant {{.*}} (i64 258
-// 64: @_TWVV4main14Rdar15410780_C = constant {{.*}} (i64 25
+// 64: @_TWVV4main14Rdar15410780_A = {{(protected )?}}constant {{.*}} (i64 257
+// 64: @_TWVV4main14Rdar15410780_B = {{(protected )?}}constant {{.*}} (i64 258
+// 64: @_TWVV4main14Rdar15410780_C = {{(protected )?}}constant {{.*}} (i64 25
 
 
 // 32: %V4main14Rdar15410780_A = type <{ i2048, %Vs4Int8 }>
@@ -20,9 +20,9 @@ import Swift
 // 32: %V4main14Rdar15410780_C = type <{ %Sq[[C:(\.[0-9]+)?]] }>
 // 32: %Sq[[C]] = type <{ [12 x i8], [1 x i8] }>
 
-// 32: @_TWVV4main14Rdar15410780_A = constant {{.*}} (i32 257
-// 32: @_TWVV4main14Rdar15410780_B = constant {{.*}} (i32 258
-// 32: @_TWVV4main14Rdar15410780_C = constant {{.*}} (i32 13
+// 32: @_TWVV4main14Rdar15410780_A = {{(protected )?}}constant {{.*}} (i32 257
+// 32: @_TWVV4main14Rdar15410780_B = {{(protected )?}}constant {{.*}} (i32 258
+// 32: @_TWVV4main14Rdar15410780_C = {{(protected )?}}constant {{.*}} (i32 13
 
 
 // <rdar://problem/15410780>

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -6,12 +6,12 @@ import resilient_enum
 
 // CHECK: %Si = type <{ [[INT:i32|i64]] }>
 
-// CHECK-LABEL: @_TMPV17struct_resilience26StructWithResilientStorage = global
+// CHECK-LABEL: @_TMPV17struct_resilience26StructWithResilientStorage = {{(protected )?}}global
 
 // Resilient structs from outside our resilience domain are manipulated via
 // value witnesses
 
-// CHECK-LABEL: define void @_TF17struct_resilience26functionWithResilientTypesFTV16resilient_struct4Size1fFS1_S1__S1_(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, i8*, %swift.refcounted*)
+// CHECK-LABEL: define{{( protected)?}} void @_TF17struct_resilience26functionWithResilientTypesFTV16resilient_struct4Size1fFS1_S1__S1_(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, i8*, %swift.refcounted*)
 
 public func functionWithResilientTypes(s: Size, f: Size -> Size) -> Size {
 
@@ -52,7 +52,7 @@ public func functionWithResilientTypes(s: Size, f: Size -> Size) -> Size {
 // Make sure we use a type metadata accessor function, and load indirect
 // field offsets from it.
 
-// CHECK-LABEL: define void @_TF17struct_resilience26functionWithResilientTypesFV16resilient_struct9RectangleT_(%V16resilient_struct9Rectangle* noalias nocapture)
+// CHECK-LABEL: define{{( protected)?}} void @_TF17struct_resilience26functionWithResilientTypesFV16resilient_struct9RectangleT_(%V16resilient_struct9Rectangle* noalias nocapture)
 public func functionWithResilientTypes(r: Rectangle) {
 
 // CHECK: [[METADATA:%.*]] = call %swift.type* @_TMaV16resilient_struct9Rectangle()
@@ -81,7 +81,7 @@ public struct MySize {
   public let h: Int
 }
 
-// CHECK-LABEL: define void @_TF17struct_resilience28functionWithMyResilientTypesFTVS_6MySize1fFS0_S0__S0_(%V17struct_resilience6MySize* {{.*}}, %V17struct_resilience6MySize* {{.*}}, i8*, %swift.refcounted*)
+// CHECK-LABEL: define{{( protected)?}} void @_TF17struct_resilience28functionWithMyResilientTypesFTVS_6MySize1fFS0_S0__S0_(%V17struct_resilience6MySize* {{.*}}, %V17struct_resilience6MySize* {{.*}}, i8*, %swift.refcounted*)
 public func functionWithMyResilientTypes(s: MySize, f: MySize -> MySize) -> MySize {
 
 // CHECK: [[TEMP:%.*]] = alloca %V17struct_resilience6MySize
@@ -111,7 +111,7 @@ public struct StructWithResilientStorage {
 // resilient layout, and go through the field offset vector in the
 // metadata when accessing stored properties.
 
-// CHECK-LABEL: define {{i32|i64}} @_TFV17struct_resilience26StructWithResilientStorageg1nSi(%V17struct_resilience26StructWithResilientStorage* {{.*}})
+// CHECK-LABEL: define{{( protected)?}} {{i32|i64}} @_TFV17struct_resilience26StructWithResilientStorageg1nSi(%V17struct_resilience26StructWithResilientStorage* {{.*}})
 // CHECK: [[METADATA:%.*]] = call %swift.type* @_TMaV17struct_resilience26StructWithResilientStorage()
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
 // CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], i32 3
@@ -133,7 +133,7 @@ public struct StructWithIndirectResilientEnum {
 }
 
 
-// CHECK-LABEL: define {{i32|i64}} @_TFV17struct_resilience31StructWithIndirectResilientEnumg1nSi(%V17struct_resilience31StructWithIndirectResilientEnum* {{.*}})
+// CHECK-LABEL: define{{( protected)?}} {{i32|i64}} @_TFV17struct_resilience31StructWithIndirectResilientEnumg1nSi(%V17struct_resilience31StructWithIndirectResilientEnum* {{.*}})
 // CHECK: [[FIELD_PTR:%.*]] = getelementptr inbounds %V17struct_resilience31StructWithIndirectResilientEnum, %V17struct_resilience31StructWithIndirectResilientEnum* %0, i32 0, i32 1
 // CHECK-NEXT: [[FIELD_PAYLOAD_PTR:%.*]] = getelementptr inbounds %Si, %Si* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = load [[INT]], [[INT]]* [[FIELD_PAYLOAD_PTR]]
@@ -142,13 +142,13 @@ public struct StructWithIndirectResilientEnum {
 
 // Public metadata accessor for our resilient struct
 
-// CHECK-LABEL: define %swift.type* @_TMaV17struct_resilience6MySize()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaV17struct_resilience6MySize()
 // CHECK: ret %swift.type* bitcast ([[INT]]* getelementptr inbounds {{.*}} @_TMfV17struct_resilience6MySize, i32 0, i32 1) to %swift.type*)
 
 
 // FIXME: this should modify the template in-place instead of copying it
 
-// CHECK-LABEL: define private %swift.type* @create_generic_metadata_StructWithResilientStorage(%swift.type_pattern*, i8**)
+// CHECK-LABEL: define{{( protected)?}} private %swift.type* @create_generic_metadata_StructWithResilientStorage(%swift.type_pattern*, i8**)
 // CHECK: [[FIELDS:%.*]] = alloca [4 x i8**]
 // CHECK: [[RESULT:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_pattern* %0, i8** %1)
 // CHECK: [[RESULT_ADDR:%.*]] = bitcast %swift.type* [[RESULT]] to i8**

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -51,7 +51,7 @@ bb0(%0 : $ChildToResilientParent):
 }
 
 // ChildToResilientParent is in our resilience domain - can load the superclass's metadata directly.
-// CHECK-LABEL: define void @_TFC5super22ChildToResilientParent6methodfT_T_(%C5super22ChildToResilientParent*)
+// CHECK-LABEL: define{{( protected)?}} void @_TFC5super22ChildToResilientParent6methodfT_T_(%C5super22ChildToResilientParent*)
 // CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_TMaC15resilient_class22ResilientOutsideParent()
 // CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%C15resilient_class22ResilientOutsideParent*)**
 // CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%C15resilient_class22ResilientOutsideParent*)*, void (%C15resilient_class22ResilientOutsideParent*)** [[OPAQUE_SUPER_METADATA]]
@@ -70,7 +70,7 @@ bb0(%0 : $@thick ChildToResilientParent.Type):
 }
 
 // ChildToResilientParent is in our resilience domain - can load the superclass's metadata directly.
-// CHECK-LABEL: define void @_TZFC5super22ChildToResilientParent11classMethodfT_T_(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} void @_TZFC5super22ChildToResilientParent11classMethodfT_T_(%swift.type*)
 // CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_TMaC15resilient_class22ResilientOutsideParent()
 // CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
 // CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[OPAQUE_SUPER_METADATA]]
@@ -97,7 +97,7 @@ bb0(%0 : $ChildToFixedParent):
   return %7 : $()
 }
 
-// CHECK-LABEL: define void @_TFC5super18ChildToFixedParent6methodfT_T_(%C5super18ChildToFixedParent*)
+// CHECK-LABEL: define{{( protected)?}} void @_TFC5super18ChildToFixedParent6methodfT_T_(%C5super18ChildToFixedParent*)
 // CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_TMaC15resilient_class13OutsideParent()
 // CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%C15resilient_class13OutsideParent*)**
 // CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%C15resilient_class13OutsideParent*)*, void (%C15resilient_class13OutsideParent*)** [[OPAQUE_SUPER_METADATA]]
@@ -117,7 +117,7 @@ bb0(%0 : $@thick ChildToFixedParent.Type):
 }
 
 // ChildToFixedParent is in our resilience domain - load super metadata directly.
-// CHECK-LABEL: define void @_TZFC5super18ChildToFixedParent11classMethodfT_T_(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} void @_TZFC5super18ChildToFixedParent11classMethodfT_T_(%swift.type*)
 // CHECK: [[SUPER_METADATA:%[0-9]+]] = call %swift.type* @_TMaC15resilient_class13OutsideParent()
 // CHECK: [[OPAQUE_SUPER_METADATA:%[0-9]+]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
 // CHECK: [[VTABLE_SLOT:%[0-9]+]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[OPAQUE_SUPER_METADATA]]
@@ -139,7 +139,7 @@ bb0(%0 : $ResilientOutsideChild):
 }
 
 // Extending a resilient class - load super metadata indirectly.
-// CHECK-LABEL: define void @_TFE5superC15resilient_class21ResilientOutsideChild15callSuperMethodfT_T_(%C15resilient_class21ResilientOutsideChild*)
+// CHECK-LABEL: define{{( protected)?}} void @_TFE5superC15resilient_class21ResilientOutsideChild15callSuperMethodfT_T_(%C15resilient_class21ResilientOutsideChild*)
 // CHECK: [[METADATA:%[0-9]+]] = call %swift.type* @_TMaC15resilient_class21ResilientOutsideChild()
 // CHECK: [[OPAQUE_METADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to %swift.type**
 // CHECK: [[SUPER_METADATA_PTR:%[0-9]+]] = getelementptr inbounds %swift.type*, %swift.type** [[OPAQUE_METADATA]], i32 1
@@ -162,7 +162,7 @@ bb0(%0 : $@thick ResilientOutsideChild.Type):
 }
 
 // Extending a resilient class - load super metadata indirectly.
-// CHECK-LABEL: define void @_TZFE5superC15resilient_class21ResilientOutsideChild20callSuperClassMethodfT_T_(%swift.type*)
+// CHECK-LABEL: define{{( protected)?}} void @_TZFE5superC15resilient_class21ResilientOutsideChild20callSuperClassMethodfT_T_(%swift.type*)
 // CHECK: [[METADATA:%[0-9]+]] = call %swift.type* @_TMaC15resilient_class21ResilientOutsideChild()
 // CHECK: [[OPAQUE_METADATA:%[0-9]+]] = bitcast %swift.type* [[METADATA]] to %swift.type**
 // CHECK: [[SUPER_METADATA_PTR:%[0-9]+]] = getelementptr inbounds %swift.type*, %swift.type** [[OPAQUE_METADATA]], i32 1

--- a/test/IRGen/swift_native_objc_runtime_base.sil
+++ b/test/IRGen/swift_native_objc_runtime_base.sil
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
 // REQUIRES: objc_interop
 
-// CHECK-LABEL: @_TMmC30swift_native_objc_runtime_base1C = global %objc_class {
+// CHECK-LABEL: @_TMmC30swift_native_objc_runtime_base1C = {{(protected )?}}global %objc_class {
 // -- metaclass "isa" is root metaclass
 // CHECK:         %objc_class* @"OBJC_METACLASS_$_NSObject",
 // -- metaclass "super" is super metaclass

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -16,8 +16,8 @@ enum EMult { case X(Int64), Y(Int64) }
 @_alignment(4)
 struct CommonLayout { var x,y,z,w: Int8 }
 
-// CHECK:       @_TMPV11type_layout14TypeLayoutTest = global {{.*}} @create_generic_metadata_TypeLayoutTest
-// CHECK:       define private %swift.type* @create_generic_metadata_TypeLayoutTest
+// CHECK:       @_TMPV11type_layout14TypeLayoutTest = {{(protected )?}}global {{.*}} @create_generic_metadata_TypeLayoutTest
+// CHECK:       define{{( protected)?}} private %swift.type* @create_generic_metadata_TypeLayoutTest
 struct TypeLayoutTest<T> {
   // -- dynamic layout, projected from metadata
   // CHECK:       [[T0:%.*]] = bitcast %swift.type* %T to i8***

--- a/test/IRGen/type_layout_objc.swift
+++ b/test/IRGen/type_layout_objc.swift
@@ -20,8 +20,8 @@ enum EMult { case X(Int64), Y(Int64) }
 @_alignment(4)
 struct CommonLayout { var x,y,z,w: Int8 }
 
-// CHECK:       @_TMPV16type_layout_objc14TypeLayoutTest = global {{.*}} @create_generic_metadata_TypeLayoutTest
-// CHECK:       define private %swift.type* @create_generic_metadata_TypeLayoutTest
+// CHECK:       @_TMPV16type_layout_objc14TypeLayoutTest = {{(protected )?}}global {{.*}} @create_generic_metadata_TypeLayoutTest
+// CHECK:       define{{( protected)?}} private %swift.type* @create_generic_metadata_TypeLayoutTest
 struct TypeLayoutTest<T> {
   // -- dynamic layout, projected from metadata
   // CHECK:       [[T0:%.*]] = bitcast %swift.type* %T to i8***

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -4,8 +4,8 @@ class C {}
 protocol P: class {}
 protocol Q: class {}
 
-// CHECK: @_TMPV29type_layout_reference_storage26ReferenceStorageTypeLayout = global {{.*}} @create_generic_metadata_ReferenceStorageTypeLayout
-// CHECK: define private %swift.type* @create_generic_metadata_ReferenceStorageTypeLayout
+// CHECK: @_TMPV29type_layout_reference_storage26ReferenceStorageTypeLayout = {{(protected )?}}global {{.*}} @create_generic_metadata_ReferenceStorageTypeLayout
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_ReferenceStorageTypeLayout
 struct ReferenceStorageTypeLayout<T> {
   var z: T
 

--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -8,8 +8,8 @@ class C: NSObject {}
 @objc protocol Q {}
 protocol NonObjC: class {}
 
-// CHECK: @_TMPV34type_layout_reference_storage_objc26ReferenceStorageTypeLayout = global {{.*}} @create_generic_metadata_ReferenceStorageTypeLayout
-// CHECK: define private %swift.type* @create_generic_metadata_ReferenceStorageTypeLayout
+// CHECK: @_TMPV34type_layout_reference_storage_objc26ReferenceStorageTypeLayout = {{(protected )?}}global {{.*}} @create_generic_metadata_ReferenceStorageTypeLayout
+// CHECK: define{{( protected)?}} private %swift.type* @create_generic_metadata_ReferenceStorageTypeLayout
 struct ReferenceStorageTypeLayout<T> {
   var z: T
 

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -4,7 +4,7 @@ sil_stage canonical
 import Builtin
 
 
-// CHECK-LABEL: define void @pod_box_8_8_a
+// CHECK-LABEL: define{{( protected)?}} void @pod_box_8_8_a
 sil @pod_box_8_8_a : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD:i[0-9]+]] 24, [[WORD]] 7)
@@ -20,7 +20,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define void @pod_box_8_8_b
+// CHECK-LABEL: define{{( protected)?}} void @pod_box_8_8_b
 sil @pod_box_8_8_b : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA]], {{.*}} [[WORD]] 24, [[WORD]] 7)
@@ -41,7 +41,7 @@ struct OverAligned {
   var x,y,z,w: Builtin.Int64
 }
 
-// CHECK-LABEL: define void @pod_box_32_32
+// CHECK-LABEL: define{{( protected)?}} void @pod_box_32_32
 sil @pod_box_32_32 : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[POD_32_32_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 64, [[WORD]] 31)
@@ -62,7 +62,7 @@ sil_vtable C {}
 class D {}
 sil_vtable D {}
 
-// CHECK-LABEL: define void @rc_box_a
+// CHECK-LABEL: define{{( protected)?}} void @rc_box_a
 sil @rc_box_a : $@convention(thin) () -> () {
 entry:
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
@@ -74,7 +74,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define void @rc_box_b
+// CHECK-LABEL: define{{( protected)?}} void @rc_box_b
 sil @rc_box_b : $@convention(thin) () -> () {
 entry:
   // TODO: Should reuse metadata
@@ -87,7 +87,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define void @unknown_rc_box
+// CHECK-LABEL: define{{( protected)?}} void @unknown_rc_box
 sil @unknown_rc_box : $@convention(thin) () -> () {
 entry:
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 16, [[WORD]] 3)
@@ -121,7 +121,7 @@ struct Dyn<T> {
 sil @take_dyn : $@convention(thin) <T> (@in Dyn<T>) -> ()
 sil @take_t : $@convention(thin) <T> (@in T) -> ()
 
-// CHECK-LABEL: define void @dyn_box_a
+// CHECK-LABEL: define{{( protected)?}} void @dyn_box_a
 sil @dyn_box_a : $@convention(thin) <T> () -> () {
 entry:
   // CHECK: [[METADATA:%.*]] = call %swift.type* @_TMaV11typed_boxes3Dyn(%swift.type* %T)
@@ -139,7 +139,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define void @dyn_box_b
+// CHECK-LABEL: define{{( protected)?}} void @dyn_box_b
 sil @dyn_box_b : $@convention(thin) <T> () -> () {
 entry:
   // CHECK: [[ALLOC:%.*]] = call { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* %T)
@@ -155,7 +155,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define i64 @proj_box
+// CHECK-LABEL: define{{( protected)?}} i64 @proj_box
 sil @proj_box : $@convention(thin) (@box Builtin.Int64) -> Builtin.Int64 {
 entry(%0 : $@box Builtin.Int64):
   // CHECK-32: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* %0 to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[4 x i8\], \[8 x i8\] \}>]]*
@@ -170,7 +170,7 @@ entry(%0 : $@box Builtin.Int64):
   return %l : $Builtin.Int64
 }
 
-// CHECK-LABEL: define void @dyn_proj_box_a
+// CHECK-LABEL: define{{( protected)?}} void @dyn_proj_box_a
 sil @dyn_proj_box_a : $@convention(thin) <T> (@box Dyn<T>) -> () {
 entry(%0 : $@box Dyn<T>):
   // CHECK: [[PTR:%.*]] = call %swift.opaque* @swift_projectBox(%swift.refcounted* %0)
@@ -183,7 +183,7 @@ entry(%0 : $@box Dyn<T>):
 }
 
 
-// CHECK-LABEL: define void @dyn_proj_box_b
+// CHECK-LABEL: define{{( protected)?}} void @dyn_proj_box_b
 sil @dyn_proj_box_b : $@convention(thin) <T> (@box T) -> () {
 entry(%0 : $@box T):
   // CHECK: [[PTR:%.*]] = call %swift.opaque* @swift_projectBox(%swift.refcounted* %0)

--- a/test/IRGen/typemetadata.sil
+++ b/test/IRGen/typemetadata.sil
@@ -25,7 +25,7 @@ bb0:
   return %100 : $()
 }
 
-// CHECK-LABEL: define %swift.type* @_TMaC12typemetadata1C()
+// CHECK-LABEL: define{{( protected)?}} %swift.type* @_TMaC12typemetadata1C()
 // CHECK:      [[T0:%.*]] = load %swift.type*, %swift.type**  @_TMLC12typemetadata1C, align 8
 // CHECK-NEXT: [[T1:%.*]] = icmp eq %swift.type* [[T0]], null
 // CHECK-NEXT: br i1 [[T1]]

--- a/test/IRGen/unconditional_checked_cast.sil
+++ b/test/IRGen/unconditional_checked_cast.sil
@@ -10,7 +10,7 @@ sil_vtable C {}
 class D : C {}
 sil_vtable D {}
 
-// CHECK-LABEL: define void @downcast_test(%C26unconditional_checked_cast1D** noalias nocapture sret, %C26unconditional_checked_cast1C** nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @downcast_test(%C26unconditional_checked_cast1D** noalias nocapture sret, %C26unconditional_checked_cast1C** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: [[INPUTPTR:%[0-9]+]] = load %C26unconditional_checked_cast1C*, %C26unconditional_checked_cast1C** [[INPUTPTRPTR:%[0-9]+]], align 8
 // CHECK-NEXT: [[I8INPUTPTR:%[0-9]+]] = bitcast %C26unconditional_checked_cast1C* [[INPUTPTR]] to i8*

--- a/test/IRGen/undef.sil
+++ b/test/IRGen/undef.sil
@@ -4,7 +4,7 @@
 
 import Builtin
 
-// CHECK: define void @undefined() {{.*}} {
+// CHECK: define{{( protected)?}} void @undefined() {{.*}} {
 // CHECK: entry:
 // CHECK:   store i64 undef, i64* undef, align 8
 // CHECK:   store i8 undef, i8* undef, align 8

--- a/test/IRGen/unowned.sil
+++ b/test/IRGen/unowned.sil
@@ -26,7 +26,7 @@ bb0(%0 : $@sil_unowned C):
   %3 = tuple ()
   %4 = return %3 : $()
 }
-// CHECK:    define void @test_weak_rr_class([[C]]*) {{.*}} {
+// CHECK:    define{{( protected)?}} void @test_weak_rr_class([[C]]*) {{.*}} {
 // CHECK:      call void bitcast (void ([[REF]]*)* @swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
@@ -38,7 +38,7 @@ bb0(%0 : $@sil_unowned P):
   %3 = tuple ()
   %4 = return %3 : $()
 }
-// CHECK:    define void @test_weak_rr_proto(%swift.refcounted*, i8**) {{.*}} {
+// CHECK:    define{{( protected)?}} void @test_weak_rr_proto(%swift.refcounted*, i8**) {{.*}} {
 // CHECK:      call void @swift_unownedRetain(%swift.refcounted* %0)
 // CHECK:      call void @swift_unownedRelease(%swift.refcounted* %0)
 // CHECK-NEXT: ret void

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -33,12 +33,12 @@ bb0(%0 : $@sil_unowned C):
   %3 = tuple ()
   %4 = return %3 : $()
 }
-// CHECK:    define void @test_weak_rr_class([[C]]*) {{.*}} {
+// CHECK:    define{{( protected)?}} void @test_weak_rr_class([[C]]*) {{.*}} {
 // CHECK:      call void bitcast (void ([[REF]]*)* @swift_unownedRetain to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
 
-// CHECK:    define void @test_unknown_unowned_copies([[UNKNOWN]]*, i8**, [[UNKNOWN]]*, i8**)
+// CHECK:    define{{( protected)?}} void @test_unknown_unowned_copies([[UNKNOWN]]*, i8**, [[UNKNOWN]]*, i8**)
 sil @test_unknown_unowned_copies : $@convention(thin) (@owned P, @owned P) -> () {
 bb0(%p : $P, %q : $P):
 

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -50,7 +50,7 @@ bb0:
 
 // CHECK: define linkonce_odr hidden void @qux()
 // CHECK: define hidden void @fred()
-// CHECK: define void @frieda()
+// CHECK: define{{( protected)?}} void @frieda()
 
 // NEGATIVE-NOT: @foo
 // NEGATIVE-NOT: @bar

--- a/test/IRGen/upcast.sil
+++ b/test/IRGen/upcast.sil
@@ -2,7 +2,7 @@
 
 // Make sure that we are able to lower upcast addresses.
 
-// CHECK-LABEL: define void @upcast_test(%C6upcast1D** nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @upcast_test(%C6upcast1D** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: bitcast %C6upcast1D** {{%[0-0]+}} to %C6upcast1C**
 // CHECK-NEXT: ret void

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -18,7 +18,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $Int):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define void @alloc_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
+// CHECK-LABEL: define{{( protected)?}} void @alloc_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to %Si*
 // CHECK-NEXT: [[T2:%.*]] = getelementptr inbounds %Si, %Si* [[T0]], i32 0, i32 0
@@ -32,7 +32,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $Int):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define void @project_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
+// CHECK-LABEL: define{{( protected)?}} void @project_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to %Si*
 // CHECK-NEXT: [[T2:%.*]] = getelementptr inbounds %Si, %Si* [[T0]], i32 0, i32 0
@@ -45,7 +45,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define void @dealloc_small([24 x i8]* nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @dealloc_small([24 x i8]* nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret void
 
@@ -56,7 +56,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define void @alloc_big([24 x i8]* nocapture dereferenceable({{.*}}), %V13value_buffers9BigStruct* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @alloc_big([24 x i8]* nocapture dereferenceable({{.*}}), %V13value_buffers9BigStruct* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK: [[SLOT0:%.*]] = load i64
 // CHECK: [[SLOT1:%.*]] = load i64
@@ -87,7 +87,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define void @project_big([24 x i8]* nocapture dereferenceable({{.*}}), %V13value_buffers9BigStruct* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @project_big([24 x i8]* nocapture dereferenceable({{.*}}), %V13value_buffers9BigStruct* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK: [[SLOT0:%.*]] = load i64
 // CHECK: [[SLOT1:%.*]] = load i64
@@ -115,7 +115,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define void @dealloc_big([24 x i8]* nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( protected)?}} void @dealloc_big([24 x i8]* nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to i8**
 // CHECK-NEXT: [[ADDR:%.*]] = load i8*, i8** [[T0]], align 8

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -41,7 +41,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define void @test_weak_load_store([[A]]* nocapture dereferenceable({{.*}}), i64) {{.*}} {
+// CHECK:    define{{( protected)?}} void @test_weak_load_store([[A]]* nocapture dereferenceable({{.*}}), i64) {{.*}} {
 // CHECK:      [[X:%.*]] = getelementptr inbounds [[A]], [[A]]* %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = call [[C]]* bitcast ([[REF]]* ([[WEAK]]*)* @swift_weakLoadStrong to [[C]]* ([[WEAK]]*)*)([[WEAK]]* [[X]])
 // CHECK-NEXT: %3 = ptrtoint  %C4weak1C* %2 to i64
@@ -64,7 +64,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define void @test_weak_load_store_proto([[B]]* nocapture dereferenceable({{.*}}), i64, i64)
+// CHECK:    define{{( protected)?}} void @test_weak_load_store_proto([[B]]* nocapture dereferenceable({{.*}}), i64, i64)
 // CHECK:      [[X:%.*]] = getelementptr inbounds [[B]], [[B]]* %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = call [[UNKNOWN]]* @swift_unknownWeakLoadStrong([[WEAK]]* [[T0]])
@@ -88,7 +88,7 @@ bb0(%0 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define void @test_weak_alloc_stack(i64, i64)
+// CHECK:    define{{( protected)?}} void @test_weak_alloc_stack(i64, i64)
 // CHECK:      [[X:%.*]] = alloca { [[WEAK]], i8** }, align 8
 // CHECK: [[TMPOBJ:%.*]] = inttoptr {{.*}} to %objc_object*
 // CHECK: [[TMPTAB:%.*]] = inttoptr {{.*}} to i8**

--- a/test/IRGen/weak_class_protocol.sil
+++ b/test/IRGen/weak_class_protocol.sil
@@ -6,7 +6,7 @@ import Swift
 
 protocol Foo: class { }
 
-// CHECK-LABEL: define void @store_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @store_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64) {{.*}} {
 // CHECK:       entry:
 // CHECK-objc:    [[INSTANCE:%.*]] = inttoptr i64 %1 to %objc_object*
 // CHECK-native:  [[INSTANCE:%.*]] = inttoptr i64 %1 to %swift.refcounted*

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -9,7 +9,7 @@ protocol DefCon {
 }
 
 
-// CHECK-LABEL: define void @defcon(%swift.opaque* noalias nocapture sret, %swift.type*, %swift.type* %T, i8** %T.DefCon) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} void @defcon(%swift.opaque* noalias nocapture sret, %swift.type*, %swift.type* %T, i8** %T.DefCon) {{.*}} {
 sil @defcon : $@convention(thin) <T: DefCon> (@out T, @thick T.Type) -> () {
 entry(%0: $*T, %1: $@thick T.Type):
 
@@ -31,7 +31,7 @@ struct ImplementsDerived : Derived {
   func foo() {}
 }
 
-// CHECK-LABEL: define void @testInheritedConformance
+// CHECK-LABEL: define{{( protected)?}} void @testInheritedConformance
 sil @testInheritedConformance : $@convention(thin) (@in ImplementsDerived) -> () {
 entry(%0: $*ImplementsDerived):
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** @_TWPV14witness_method17ImplementsDerivedS_4BaseS_

--- a/test/LLVMPasses/basic.ll
+++ b/test/LLVMPasses/basic.ll
@@ -139,7 +139,7 @@ define void @objc_retain_release_opt(%objc_object* %P, i32* %IP) {
   ret void
 }
 
-; CHECK-LABEL: define void @swift_fixLifetimeTest
+; CHECK-LABEL: define{{( protected)?}} void @swift_fixLifetimeTest
 ; CHECK: swift_retain
 ; CHECK: swift_fixLifetime
 ; CHECK: swift_release

--- a/test/LLVMPasses/contract.ll
+++ b/test/LLVMPasses/contract.ll
@@ -20,7 +20,7 @@ declare void @user(%swift.refcounted*)
 declare void @noread_user_bridged(%swift.bridge*) readnone
 declare void @user_bridged(%swift.bridge*)
 
-; CHECK-LABEL: define void @fixlifetime_removal(i8*) {
+; CHECK-LABEL: define{{( protected)?}} void @fixlifetime_removal(i8*) {
 ; CHECK-NOT: call void swift_fixLifetime
 define void @fixlifetime_removal(i8*) {
 entry:
@@ -29,7 +29,7 @@ entry:
   ret void
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractRetainN(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainN(%swift.refcounted* %A) {
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
@@ -67,7 +67,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractRetainNWithRCIdentity(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainNWithRCIdentity(%swift.refcounted* %A) {
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
@@ -99,7 +99,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractReleaseN(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractReleaseN(%swift.refcounted* %A) {
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
@@ -137,7 +137,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractReleaseNWithRCIdentity(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractReleaseNWithRCIdentity(%swift.refcounted* %A) {
 ; CHECK: entry:
 ; CHECK-NEXT: br i1 undef
 ; CHECK: bb1:
@@ -173,7 +173,7 @@ bb3:
 ; Make sure that we do not form retainN,releaseN over uses that may
 ; read the reference count of the object.
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractRetainNWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainNWithUnknown(%swift.refcounted* %A) {
 ; CHECK-NOT: call %swift.refcounted* @swift_retain_n
 define %swift.refcounted* @swift_contractRetainNWithUnknown(%swift.refcounted* %A) {
 entry:
@@ -197,7 +197,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractReleaseNWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractReleaseNWithUnknown(%swift.refcounted* %A) {
 ; CHECK-NOT: call void @swift_release_n
 define %swift.refcounted* @swift_contractReleaseNWithUnknown(%swift.refcounted* %A) {
 entry:
@@ -222,7 +222,7 @@ bb3:
 }
 
 ; But do make sure that we can form retainN, releaseN in between such uses
-; CHECK-LABEL: define %swift.refcounted* @swift_contractRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
 ; CHECK: tail call void @swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
@@ -274,7 +274,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
 ; CHECK-NEXT: @swift_release(
 ; CHECK-NEXT: @user
@@ -306,7 +306,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
 ; CHECK-NEXT: tail call void @swift_retain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
@@ -362,7 +362,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractUnknownRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractUnknownRetainNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
 ; CHECK: tail call void @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
@@ -414,7 +414,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractUnknownReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractUnknownReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
 ; CHECK-NEXT: @swift_unknownRelease(
 ; CHECK-NEXT: @user
@@ -446,7 +446,7 @@ bb3:
   ret %swift.refcounted* %A
 }
 
-; CHECK-LABEL: define %swift.refcounted* @swift_contractUnknownRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.refcounted* @swift_contractUnknownRetainReleaseNInterleavedWithUnknown(%swift.refcounted* %A) {
 ; CHECK: bb1:
 ; CHECK-NEXT: tail call void @swift_unknownRetain(%swift.refcounted* %A)
 ; CHECK-NEXT: call void @user(%swift.refcounted* %A)
@@ -502,7 +502,7 @@ bb3:
 }
 
 
-; CHECK-LABEL: define %swift.bridge* @swift_contractBridgeRetainWithBridge(%swift.bridge* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.bridge* @swift_contractBridgeRetainWithBridge(%swift.bridge* %A) {
 ; CHECK: bb1:
 ; CHECK-NEXT: [[RET0:%.+]] = tail call %swift.bridge* @swift_bridgeObjectRetain_n(%swift.bridge* %A, i32 2)
 ; CHECK-NEXT: tail call void @swift_bridgeObjectRelease(%swift.bridge* [[RET0:%.+]])
@@ -517,7 +517,7 @@ bb1:
   ret %swift.bridge* %A
 }
 
-; CHECK-LABEL: define %swift.bridge* @swift_contractBridgeRetainReleaseNInterleavedWithBridge(%swift.bridge* %A) {
+; CHECK-LABEL: define{{( protected)?}} %swift.bridge* @swift_contractBridgeRetainReleaseNInterleavedWithBridge(%swift.bridge* %A) {
 ; CHECK: bb1:
 ; CHECK-NEXT: [[RET0:%.+]] = tail call %swift.bridge* @swift_bridgeObjectRetain(%swift.bridge* %A)
 ; CHECK-NEXT: call void @user_bridged(%swift.bridge* %A)

--- a/test/LLVMPasses/llvm-aa.ll
+++ b/test/LLVMPasses/llvm-aa.ll
@@ -5,7 +5,7 @@ target triple = "x86_64-apple-macosx10.9"
 
 declare void @swift_retain(i8 *) nounwind
 
-; CHECK-LABEL: define i8 @test_eliminate_loads_over_retain(i8*) {
+; CHECK-LABEL: define{{( protected)?}} i8 @test_eliminate_loads_over_retain(i8*) {
 ; CHECK: load
 ; CHECK-NOT: load
 define i8 @test_eliminate_loads_over_retain(i8*) {

--- a/test/LLVMPasses/stack_promotion.ll
+++ b/test/LLVMPasses/stack_promotion.ll
@@ -6,7 +6,7 @@ target triple = "x86_64-apple-macosx10.9"
 %swift.type = type { i64 }
 %objc_object = type opaque
 
-; CHECK-LABEL: define void @promote_buffer()
+; CHECK-LABEL: define{{( protected)?}} void @promote_buffer()
 ; CHECK: [[B:%.+]] = alloca i8, i32 48, align 8
 ; CHECK: [[M:%.+]] = call %swift.type* @get_buffer_metadata()
 ; CHECK: [[BC:%.+]] = bitcast i8* [[B]] to %objc_object*
@@ -22,7 +22,7 @@ entry:
   ret void
 }
 
-; CHECK-LABEL: define void @dont_promote_buffer_exceeding_limit()
+; CHECK-LABEL: define{{( protected)?}} void @dont_promote_buffer_exceeding_limit()
 ; CHECK: [[M:%.+]] = call %swift.type* @get_buffer_metadata()
 ; CHECK: call %objc_object* @swift_bufferAllocate(%swift.type* [[M]], i64 48, i64 7)
 ; CHECK-NEXT: ret void

--- a/test/SIL/Parser/apply_with_conformance.sil
+++ b/test/SIL/Parser/apply_with_conformance.sil
@@ -18,7 +18,7 @@ struct S {
 // test.S.foo (test.S)<A : test.P>(A) -> ()
 sil @_TFV4test1S3foofS0_US_1P__FQ_T_ : $@convention(method) <T where T : P> (@in T, S) -> ()
 
-// CHECK-LABEL: define void @_TF4test3barFTVS_1SVS_1X_T_()
+// CHECK-LABEL: define{{( protected)?}} void @_TF4test3barFTVS_1SVS_1X_T_()
 // CHECK: call
 // test.bar (test.S, test.X) -> ()
 sil @_TF4test3barFTVS_1SVS_1X_T_ : $@convention(thin) (S, X) -> () {

--- a/test/SILGen/NSApplicationMain.swift
+++ b/test/SILGen/NSApplicationMain.swift
@@ -11,7 +11,7 @@ class MyDelegate: NSApplicationDelegate {}
 
 // CHECK-LABEL: sil @main
 // CHECK:         function_ref @NSApplicationMain
-// IR-LABEL: define i32 @main
+// IR-LABEL: define{{( protected)?}} i32 @main
 // IR:            call i32 @NSApplicationMain
 
 // Ensure that we coexist with normal references to the functions we

--- a/test/SILGen/UIApplicationMain.swift
+++ b/test/SILGen/UIApplicationMain.swift
@@ -12,7 +12,7 @@ class MyDelegate : UIApplicationDelegate {}
 
 // CHECK-LABEL: sil @main
 // CHECK:         function_ref @UIApplicationMain
-// IR-LABEL: define i32 @main
+// IR-LABEL: define{{( protected)?}} i32 @main
 // IR:            call i32 @UIApplicationMain
 
 // Ensure that we coexist with normal references to the functions we

--- a/test/SILGen/enum_derived.swift
+++ b/test/SILGen/enum_derived.swift
@@ -19,14 +19,14 @@ enum E {
 // Check if the hashValue getter can be compiled to a simple zext instruction.
 
 // CHECK-NORMAL-LABEL:define hidden i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i2)
-// CHECK-TESTABLE-LABEL:define i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i2)
+// CHECK-TESTABLE-LABEL:define{{( protected)?}} i{{.*}} @_TFO12enum_derived1Eg9hashValueSi(i2)
 // CHECK: %1 = zext i2 %0 to i{{.*}}
 // CHECK: ret i{{.*}} %1
 
 // Check if the == comparison can be compiled to a simple icmp instruction.
 
 // CHECK-NORMAL-LABEL:define hidden i1 @_TZF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
-// CHECK-TESTABLE-LABEL:define i1 @_TZF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
+// CHECK-TESTABLE-LABEL:define{{( protected)?}} i1 @_TZF12enum_derivedoi2eeFTOS_1ES0__Sb(i2, i2)
 // CHECK: %2 = icmp eq i2 %0, %1
 // CHECK: ret i1 %2
 
@@ -35,13 +35,13 @@ enum E {
 
 extension def_enum.TrafficLight : ErrorType {}
 
-// CHECK-LABEL: define i{{32|64}} @_TFE12enum_derivedO8def_enum12TrafficLightg5_codeSi(i2)
+// CHECK-LABEL: define{{( protected)?}} i{{32|64}} @_TFE12enum_derivedO8def_enum12TrafficLightg5_codeSi(i2)
 
 
 extension def_enum.Term : ErrorType {}
 
 // CHECK-NORMAL-LABEL: define hidden i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T) #1
-// CHECK-TESTABLE-LABEL: define i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T) #1
+// CHECK-TESTABLE-LABEL: define{{( protected)?}} i64 @_TFO12enum_derived7Phantomg8rawValueVs5Int64(i1, %swift.type* nocapture readnone %T) #1
 
 enum Phantom<T> : Int64 {
   case Up


### PR DESCRIPTION
This prevents the linker from trying to emit relative relocations to locally-defined public symbols into dynamic libraries, which gives ld.so heartache.
