### PR TITLE
[cmake] Enable swift to be built as an llvm tool in-tree.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,21 +690,3 @@ if(XCODE)
   add_custom_target(Miscellaneous
       SOURCES ${SWIFT_TOPLEVEL_HEADERS})
 endif()
-
-# Configure CPack.
-set(CPACK_GENERATOR "TGZ")
-set(CPACK_PACKAGE_RELOCATABLE "false")
-set(CPACK_PACKAGE_VENDOR "LLVM Project")
-set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY "OFF")
-set(CPACK_SET_DESTDIR "ON")
-
-set(CPACK_PACKAGE_NAME "swift")
-set(CPACK_SYSTEM_NAME "macosx")
-
-# FIXME: Real version number.
-execute_process(COMMAND date "+%Y%m%d"
-  OUTPUT_VARIABLE CPACK_PACKAGE_VERSION
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-# CPack must be included *after* its configuration variables are set.
-include(CPack)

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -73,7 +73,8 @@ add_swift_library(swiftAST
   )
 
 if(NOT SWIFT_BUILT_STANDALONE)
-  add_dependencies(swiftAST intrinsics_gen)
+  get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
+  add_dependencies(swiftAST intrinsics_gen ${CLANG_TABLEGEN_TARGETS})
 endif()
 
 set(swift_ast_verifier_flag)


### PR DESCRIPTION
This patch makes the following changes:

(1) Don't include CPack unless you're building standalone, because LLVM includes it already
(2) When building swiftAST standalone add dependencies on Clang's tablegen targets
