### PR TITLE
[gardening] Fix recently introduced typos

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -102,7 +102,7 @@ Using the Harness Generator
 contained in the directories `single-source` and `multi-source`. It gathers
 information about the tests and then generates the files from templates using
 jinja2. The motivation for creating this script was to eliminate the need to
-manually add atleast three lines to harness files (one to `CMakeLists.txt` and
+manually add at least three lines to harness files (one to `CMakeLists.txt` and
 two to `utils/main.swift`) for every new benchmark added.
 
 **Warning:**
@@ -162,7 +162,7 @@ To add a new multiple file test:
         │   │   ├── TestFile2.swift
         │   │   ├── TestFile3.swift
 
-    Atleast one run function (specified in the template below) must
+    At least one run function (specified in the template below) must
     exist in the files.
 
 2.  Regenerate harness files by following the directions in

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -45,7 +45,7 @@ func genIOUArray() {
 }
 
 // Check the performance of destroying an array of structs where the
-// struct has a multipe fields of trivial type. Destroying the
+// struct has multiple fields of trivial type. Destroying the
 // elements should be a nop.
 struct S<T> {
   var x : T

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -667,7 +667,7 @@ public func run_HashTest(N: Int) {
       SH.update(S)
     }
 
-    // Check that the order in which we push values does not chage the result.
+    // Check that the order in which we push values does not change the result.
     SH.reset()
     L = ""
     for _ in 1...size {

--- a/benchmark/single-source/PolymorphicCalls.swift
+++ b/benchmark/single-source/PolymorphicCalls.swift
@@ -15,7 +15,7 @@ This benchmark is used to check the performance of polymorphic invocations.
 Essentially, it checks how good a compiler can optimize virtual calls of class
 methods in cases where multiple sub-classes of a given class are available.
 
-In particular, this benchark would benefit from a good devirtualization.
+In particular, this benchmark would benefit from a good devirtualization.
 In case of applying a speculative devirtualization, it would be benefit from
 applying a jump-threading in combination with the speculative devirtualization.
 */

--- a/benchmark/single-source/RecursiveOwnedParameter.swift
+++ b/benchmark/single-source/RecursiveOwnedParameter.swift
@@ -14,7 +14,7 @@ import TestsUtils
 
 // This test recursively visits each element of an array in a class and compares
 // it with every value in a different array stored in a different class. The
-// idea is to make sure that we can get rid of the overhead from gauranteed
+// idea is to make sure that we can get rid of the overhead from guaranteed
 // parameters.
 
 // We use final since we are not interesting in devirtualization for the

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -242,7 +242,7 @@ class SampleRunner {
   }
 }
 
-/// Invoke the benchmark entry point and return the run time in miliseconds.
+/// Invoke the benchmark entry point and return the run time in milliseconds.
 func runBench(name: String, _ fn: (Int) -> Void, _ c: TestConfig) -> BenchResults {
 
   var samples = [UInt64](count: c.numSamples, repeatedValue: 0)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5614,7 +5614,7 @@ static bool checkStructDeclCircularity(StructDecl *S, NominalDeclSet &known,
                                        Type baseType,
                                        bool isGenericArg = false);
 
-// dispatch arbitrary declaration to relavent circularity checks.
+// dispatch arbitrary declaration to relevant circularity checks.
 static bool checkNominalDeclCircularity(Decl *decl, NominalDeclSet &known,
                                         Type baseType,
                                         bool isGenericArg = false) {

--- a/test/Sema/unsupported_recursive_value_type.swift
+++ b/test/Sema/unsupported_recursive_value_type.swift
@@ -49,13 +49,13 @@ enum OptionallySelfRecursiveEnum { // expected-error{{recursive enum 'Optionally
   case A(Optional<OptionallySelfRecursiveEnum>)
 }
 
-// self-recursive struct with self as member's type argement, a proper name would
+// self-recursive struct with self as member's type argument, a proper name would
 // be too long.
 struct X<T> { // expected-error{{value type 'X<T>' cannot have a stored property that references itself}}
   let s: X<X>
 }
 
-// self-recursive enum with self as generic arugment associated type, a proper
+// self-recursive enum with self as generic argument associated type, a proper
 // name would be too long
 enum Y<T> { // expected-error{{recursive enum 'Y<T>' is not marked 'indirect'}}
     case A(Int, Y<Y>)
@@ -102,7 +102,7 @@ struct Outer {
 struct NestedGenericParamStruct {
     let n: [[Int]]
 }
-struct NestedGenercParamEnum {
+struct NestedGenericParamEnum {
     let n: Int??
 }
 


### PR DESCRIPTION
Fixed:
- "argement" → "argument"
- "arugment" → "argument"
- "atleast" → "at least"
- "benchark" → "benchmark"
- "chage" → "change"
- "gauranteed" → "guaranteed"
- "generc" → "generic"
- "miliseconds" → "milliseconds"
- "multipe" → "multiple"
- "relavent" → "relevant"
