### PR TITLE
[_BridgedNSError] Emit dynamic cast witness tables

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -161,14 +161,6 @@ public:
 typedef llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *>
   TypeOrExtensionDecl;
 
-/// An entry in the protocol conformance map.
-///
-/// The pointer is the actual conformance providing the witnesses used to
-/// provide conformance. The Boolean indicates whether the type explicitly
-/// conforms to the protocol. A non-null conformance with a false Bool occurs
-/// when error recovery has suggested implicit conformance.
-typedef llvm::PointerIntPair<ProtocolConformance *, 1, bool> ConformanceEntry;
-
 /// ASTContext - This object creates and owns the AST objects.
 class ASTContext {
   ASTContext(const ASTContext&) = delete;
@@ -222,11 +214,6 @@ public:
 #define IDENTIFIER_WITH_NAME(Name, IdStr) Identifier Id_##Name;
 #include "swift/AST/KnownIdentifiers.def"
 
-  // FIXME: Once DenseMap learns about move semantics, use std::unique_ptr
-  // and remove the explicit delete loop in the destructor.
-  typedef llvm::DenseMap<std::pair<CanType, ProtocolDecl *>, 
-                         ConformanceEntry> ConformsToMap;
-  
   /// \brief The list of external definitions imported by this context.
   llvm::SetVector<Decl *> ExternalDefinitions;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -832,8 +832,8 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
 
   // _BridgedNSError is in the Foundation module.
   if (kind == KnownProtocolKind::BridgedNSError) {
-    Module *foundation = const_cast<ASTContext *>(this)->getModule(
-                           {{Id_Foundation, SourceLoc()}});
+    Module *foundation =
+        const_cast<ASTContext *>(this)->getLoadedModule(Id_Foundation);
     if (!foundation)
       return nullptr;
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1410,6 +1410,7 @@ ManagedValue SILGenFunction::getManagedValue(SILLocation loc,
 
 RValue RValueEmitter::visitForcedCheckedCastExpr(ForcedCheckedCastExpr *E,
                                                  SGFContext C) {
+  SGF.checkForImportedUsedConformances(E);
   return emitUnconditionalCheckedCast(SGF, E, E->getSubExpr(), E->getType(),
                                       E->getCastKind(), C);
 }
@@ -1418,12 +1419,14 @@ RValue RValueEmitter::visitForcedCheckedCastExpr(ForcedCheckedCastExpr *E,
 RValue RValueEmitter::
 visitConditionalCheckedCastExpr(ConditionalCheckedCastExpr *E,
                                 SGFContext C) {
+  SGF.checkForImportedUsedConformances(E);
   ManagedValue operand = SGF.emitRValueAsSingleValue(E->getSubExpr());
   return emitConditionalCheckedCast(SGF, E, operand, E->getSubExpr()->getType(),
                                     E->getType(), E->getCastKind(), C);
 }
 
 RValue RValueEmitter::visitIsExpr(IsExpr *E, SGFContext C) {
+  SGF.checkForImportedUsedConformances(E);
   SILValue isa = emitIsa(SGF, E, E->getSubExpr(),
                          E->getCastTypeLoc().getType(), E->getCastKind());
 
@@ -1437,6 +1440,7 @@ RValue RValueEmitter::visitIsExpr(IsExpr *E, SGFContext C) {
 }
 
 RValue RValueEmitter::visitCoerceExpr(CoerceExpr *E, SGFContext C) {
+  SGF.checkForImportedUsedConformances(E);
   return visit(E->getSubExpr(), C);
 }
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -895,3 +895,19 @@ SILGenBuilder::createAllocExistentialBox(SILLocation Loc,
                                                ConcreteType,
                                                Conformances);
 }
+
+void SILGenFunction::checkForImportedUsedConformances(Type type) {
+  // Recognize _BridgedNSError, which must pull in its witness table for
+  // dynamic casts to work
+  if (auto bridgedNSErrorProtocol =
+          getASTContext().getProtocol(KnownProtocolKind::BridgedNSError)) {
+    if (auto nominalDecl = type->getAnyNominal()) {
+      auto conformances = nominalDecl->getAllConformances();
+      for (auto conformance : conformances) {
+        if (conformance->getProtocol() == bridgedNSErrorProtocol) {
+          SGM.useConformance(ProtocolConformanceRef(conformance));
+        }
+      }
+    }
+  }
+}

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1546,6 +1546,16 @@ public:
   /// Produce a substitution for invoking a pointer argument conversion
   /// intrinsic.
   Substitution getPointerSubstitution(Type pointerType);
+
+  /// Recognize used conformances from an imported type when we must emit the
+  /// witness table.
+  ///
+  /// This arises in _BridgedNSError, where we wouldn't otherwise pull in the
+  /// witness table, causing dynamic casts to perform incorrectly.
+  void checkForImportedUsedConformances(Type type);
+  void checkForImportedUsedConformances(ExplicitCastExpr *expr) {
+    checkForImportedUsedConformances(expr->getCastTypeLoc().getType());
+  }
 };
 
 

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1567,7 +1567,9 @@ void PatternMatchEmission::emitIsDispatch(ArrayRef<RowToSpecialize> rows,
                                       const FailureHandler &failure) {
   CanType sourceType = rows[0].Pattern->getType()->getCanonicalType();
   CanType targetType = getTargetType(rows[0]);
-  
+
+  SGF.checkForImportedUsedConformances(targetType);
+
   // Make any abstraction modifications necessary for casting.
   SmallVector<ConsumableManagedValue, 4> borrowedValues;
   ConsumableManagedValue operand =

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1214,6 +1214,12 @@ bool TypeChecker::coercePatternToType(Pattern *&P, DeclContext *dc, Type type,
 
     auto castType = IP->getCastTypeLoc().getType();
 
+    if (auto bridgedNSErrorProtocol =
+            Context.getProtocol(KnownProtocolKind::BridgedNSError)) {
+      conformsToProtocol(castType, bridgedNSErrorProtocol, dc,
+                         ConformanceCheckFlags::Used);
+    }
+
     // Determine whether we have an imbalance in the number of optionals.
     SmallVector<Type, 2> inputTypeOptionals;
     type->lookThroughAllAnyOptionalTypes(inputTypeOptionals);

--- a/test/ClangModules/enum-error-execute.swift
+++ b/test/ClangModules/enum-error-execute.swift
@@ -24,12 +24,6 @@ func printError(err: TestError) {
   }
 }
 
-// FIXME: If I remove the constraint on _BridgedNSError, then the test will
-// fail, as NSError will no longer bridge to TestError
-func forceConformance<T : _BridgedNSError>(a: T) -> T {
-  return a
-}
-
 func testError() {
   let terr = getErr()
   switch (terr) { case .TENone, .TEOne, .TETwo: break } // ok
@@ -37,7 +31,7 @@ func testError() {
     // CHECK: TestError: TEOne
 
   do {
-    throw forceConformance(TestError.TETwo)
+    throw TestError.TETwo
   } catch let error as TestError {
     printError(error)
     // CHECK-NEXT: TestError: TETwo

--- a/test/ClangModules/enum-error.swift
+++ b/test/ClangModules/enum-error.swift
@@ -1,9 +1,77 @@
-// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/enum-error.h -verify
 // REQUIRES: OS=macosx
+
+// RUN: %target-swift-frontend -DNONE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=NONE
+// RUN: %target-swift-frontend -DEMPTYCATCH -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=EMPTYCATCH
+// RUN: %target-swift-frontend -DASQEXPR -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=ASQEXPR
+// RUN: %target-swift-frontend -DASBANGEXPR -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=ASBANGEXPR
+// RUN: %target-swift-frontend -DCATCHIS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=CATCHIS
+// RUN: %target-swift-frontend -DCATCHAS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=CATCHAS
+// RUN: %target-swift-frontend -DGENERICONLY -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | FileCheck %s -check-prefix=GENERICONLY
+
+// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/enum-error.h -verify
 
 import Foundation
 
+
 func testError() {
+  let testErrorNSError = NSError(domain: TestErrorDomain,
+                                 code: Int(TestError.TENone.rawValue),
+                                 userInfo: nil)
+
+// Below are a number of test cases to make sure that various pattern and cast
+// expression forms are sufficient in pulling in th _NSBridgedError
+// conformance.
+#if NONE
+// NONE-NOT: TestError: _BridgedNSError
+  let terr = getErr(); terr
+
+#elseif EMPTYCATCH
+// EMPTYCATCH-NOT: TestError: _BridgedNSError
+  do {
+    throw TestError.TENone
+  } catch {}
+
+#elseif ASQEXPR
+// ASQEXPR: sil_witness_table shared TestError: _BridgedNSError module __ObjC
+  let wasTestError = testErrorNSError as? TestError; wasTestError
+
+#elseif ASBANGEXPR
+// ASBANGEXPR: sil_witness_table shared TestError: _BridgedNSError module __ObjC
+  let terr2 = testErrorNSError as! TestError; terr2
+
+#elseif ISEXPR
+// ISEXPR: sil_witness_table shared TestError: _BridgedNSError module __ObjC
+  if (testErrorNSError is TestError) {
+    print("true")
+  } else {
+    print("false")
+  }
+
+#elseif CATCHIS
+// CATCHIS: sil_witness_table shared TestError: _BridgedNSError module __ObjC
+  do {
+    throw TestError.TETwo
+  } catch is TestError {
+  } catch {}
+
+#elseif CATCHAS
+// CATCHAS: sil_witness_table shared TestError: _BridgedNSError module __ObjC
+  do {
+    throw TestError.TETwo
+  } catch let err as TestError {
+    err
+  } catch {}
+
+#elseif GENERICONLY
+// FIXME: THE BELOW IS WRONG! This alone doesn't pull in the conformance, but it should.
+// GENERICONLY-NOT: TestError: _BridgedNSError
+  func dyncast<T, U>(x: T) -> U {
+    return x as! U
+  }
+  let _ : TestError = dyncast(testErrorNSError)
+
+#else
+// CHECK: sil_witness_table shared TestError: _BridgedNSError module __ObjC
   let terr = getErr()
   switch (terr) { case .TENone, .TEOne, .TETwo: break } // ok
 
@@ -15,15 +83,8 @@ func testError() {
   do {
     throw TestError.TEOne
   } catch is TestError {
-  } catch {
-  }
+  } catch {}
 
-  func errorIdentity<T>(err: T) -> T { return err }
-  func errorIdentityBridged<T : _BridgedNSError>(err: T) -> T { return err }
-  do {
-    throw errorIdentityBridged(errorIdentity(TestError.TETwo))
-  } catch is TestError {
-  } catch {
-  }
+#endif
 
 }


### PR DESCRIPTION
This is a series of 3 commits: one cleanup, one safety change, and the main one that finishes support for _BridgedNSError imported from NS_ERROR_ENUMs.

I had to modify both the type checker, in order to make sure the _BridgedNSError conformance was known to be Complete, and SILGen, to make sure that the witness table is emitted for the conformance.
