### PR TITLE
[update-checkout] Always update llvm/clang/llbuild

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -77,9 +77,6 @@ def main():
 repositories.
 
 By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
-    parser.add_argument("-a", "--all",
-        help="also update checkouts of llbuild, LLVM, and Clang",
-        action="store_true")
     parser.add_argument("--clone",
         help="Obtain Sources for Swift and Related Projects",
         action="store_true")
@@ -98,10 +95,9 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         obtain_additional_swift_sources(clone_with_ssh, branch)
         return 0
 
-    if args.all:
-        update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "llbuild"), branch)
-        update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "llvm"), branch)
-        update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "clang"), branch)
+    update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "llbuild"), branch)
+    update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "llvm"), branch)
+    update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "clang"), branch)
 
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "swift"), branch)
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "SourceKit"), branch)


### PR DESCRIPTION
Get rid of the `--all` flag, since having an out-of-date llvm or clang
can cause build failures, and it's not immediately obvious that
`swift/utils/update-checkout` isn't updating those repos.
