### PR TITLE
IRGen: Don't try to bind witness tables for archetype protocol requirements that don't need them.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2158,6 +2158,9 @@ void WitnessTableBuilder::bindArchetypes(IRGenFunction &IGF,
     //     be stored in the private section of the witness table.
     SmallVector<llvm::Value*, 4> archetypeWitnessTables;
     for (auto protocol : archetype->getConformsTo()) {
+      if (!Lowering::TypeConverter::protocolRequiresWitnessTable(protocol))
+        continue;
+
       llvm::Value *wtable;
       if (auto fulfillment =
             fulfillments.getWitnessTable(CanType(archetype), protocol)) {

--- a/test/IRGen/extension_conformance_anyobject_conformance.swift
+++ b/test/IRGen/extension_conformance_anyobject_conformance.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-ir -verify %s
+
+public struct TestGeneratorCrashy <Key: AnyObject, Value: AnyObject> {
+    public mutating func next() -> (Key, Value)? {
+        return nil
+    }
+}
+
+extension TestGeneratorCrashy: GeneratorType {
+}


### PR DESCRIPTION
Fixes rdar://problem/24568361.
