### PR TITLE
[PrintAsObjC] Use @objc name for enums in enum references

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1001,7 +1001,7 @@ private:
   void visitEnumType(EnumType *ET, Optional<OptionalTypeKind> optionalKind) {
     const EnumDecl *ED = ET->getDecl();
     maybePrintTagKeyword(ED);
-    os << ED->getName();
+    os << getNameForObjC(ED);
   }
 
   void visitClassType(ClassType *CT, Optional<OptionalTypeKind> optionalKind) {
@@ -1396,7 +1396,7 @@ public:
     assert(ED->isObjC() || ED->hasClangNode());
     
     forwardDeclare(ED, [&]{
-      os << "enum " << ED->getName() << " : ";
+      os << "enum " << getNameForObjC(ED) << " : ";
       printer.print(ED->getRawType(), OTK_None);
       os << ";\n";
     });
@@ -1546,7 +1546,7 @@ public:
         return elem->getName().str() == "Domain";
       });
       if (!hasDomainCase) {
-        os << "static NSString * _Nonnull const " << ED->getName()
+        os << "static NSString * _Nonnull const " << getNameForObjC(ED)
            << "Domain = @\"" << M.getName() << "." << ED->getName() << "\";\n";
       }
     }

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -12,18 +12,24 @@
 import Foundation
 
 // NEGATIVE-NOT: NSMalformedEnumMissingTypedef :
+// NEGATIVE-NOT: enum EnumNamed
 // CHECK-LABEL: enum FooComments : NSInteger;
 // CHECK-LABEL: enum NegativeValues : int16_t;
+// CHECK-LABEL: enum ObjcEnumNamed : NSInteger;
 
 // CHECK-LABEL: @interface AnEnumMethod
 // CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo;
 // CHECK-NEXT: - (void)acceptPlainEnum:(enum NSMalformedEnumMissingTypedef)_;
+// CHECK-NEXT: - (enum ObjcEnumNamed)takeAndReturnRenamedEnum:(enum ObjcEnumNamed)foo;
 // CHECK: @end
 @objc class AnEnumMethod {
   @objc func takeAndReturnEnum(foo: FooComments) -> NegativeValues {
     return .Zung
   }
   @objc func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
+  @objc func takeAndReturnRenamedEnum(foo: EnumNamed) -> EnumNamed {
+    return .A
+  }
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {
@@ -102,6 +108,14 @@ import Foundation
 // NEGATIVE-NOT: NSString * _Nonnull const SomeOtherErrorTypeDomain
 @objc enum SomeOtherErrorType: Int, ErrorType {
   case Domain // collision!
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcErrorType, "SomeRenamedErrorType") {
+// CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
+// CHECK-NEXT: };
+// CHECK-NEXT: static NSString * _Nonnull const ObjcErrorTypeDomain = @"enums.SomeRenamedErrorType";
+@objc(ObjcErrorType) enum SomeRenamedErrorType: Int, ErrorType {
+  case BadStuff
 }
 
 // CHECK-NOT: enum {{[A-Z]+}}


### PR DESCRIPTION
Also make sure the `FooDomain` constant for `ErrorType` enums uses the
correct name.

Fixes SR-693: Custom named @objc enum still exposes original Swift name
in Objective-C
