### PR TITLE
[stdlib] Fix documentation for Int and UInt sizes

### DIFF
--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -179,8 +179,20 @@ T : UnsignedIntegerType, U : _SignedIntegerType
 %   BuiltinName = self_ty.builtin_name
 %   OtherSelf = self_ty.get_opposite_signedness().stdlib_name
 
+% if self_ty.is_word:
+/// ${'An un' if sign == 'u' else 'A '}signed integer value type that has
+/// the same size as the current platform's native word size.
+///
+%   non_word_types = self_ty.get_corresponding_non_word_types()
+%   for bitwidth in sorted(non_word_types):
+%     non_word_type = non_word_types[bitwidth]
+/// On a ${bitwidth}-bit platform, `${Self}` is the same size
+/// as `${non_word_type.stdlib_name}`.
+%   end
+% else:
 /// A ${bits}-bit ${'un' if sign == 'u' else ''}signed integer value
 /// type.
+% end
 public struct ${Self}
    : ${'SignedIntegerType' if sign == 's' else 'UnsignedIntegerType'},
      Comparable, Equatable {

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -38,6 +38,18 @@ class SwiftIntegerType(object):
     def get_opposite_signedness(self):
         return SwiftIntegerType(self.is_word, self.bits, not self.is_signed)
 
+    # If self is a word type (Int or UInt), returns a dictionary
+    # whose keys are the type's possible bit widths on different
+    # platforms and whose values are the corresponding non-word types.
+    # Returns an empty dictionary if self is a non-word type.
+    def get_corresponding_non_word_types(self):
+        non_word_types = {}
+        for bitwidth in self.possible_bitwidths:
+            non_word_types[bitwidth] = \
+                SwiftIntegerType(is_word=False, bits=bitwidth,
+                    is_signed=self.is_signed)
+        return non_word_types
+
     def __eq__(self, other):
         return self.is_word == other.is_word and \
             self.bits == other.bits and \


### PR DESCRIPTION
Discussion on swift-dev: https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20160208/001049.html

Add a note in the doc comments for Int and UInt that these types have
platform-dependent sizes.

Before this change, the documentation for Int is:

```
/// A 64-bit signed integer value type.
public struct Int
```

With this change, the documentation says:

```
/// A signed integer value type that has
/// the same size as the current platform's native word size.
///
/// On a 32-bit platform, `Int` is the same size
/// as `Int32`.
/// On a 64-bit platform, `Int` is the same size
/// as `Int64`.
public struct Int
```

(And analogously for UInt.)

The documentation for Int8, UInt8, Int16, etc. is unchanged.
