### PR TITLE
use keyword "associatedtype" in benchmark code

### DIFF
--- a/benchmark/single-source/ArrayOfGenericRef.swift
+++ b/benchmark/single-source/ArrayOfGenericRef.swift
@@ -16,7 +16,7 @@
 // For comparison, we always create three arrays of 10,000 words.
 
 protocol Constructible {
-  typealias Element
+  associatedtype Element
   init(e:Element)
 }
 class ConstructibleArray<T:Constructible> {

--- a/benchmark/single-source/ArrayOfRef.swift
+++ b/benchmark/single-source/ArrayOfRef.swift
@@ -17,7 +17,7 @@
 // For comparison, we always create four arrays of 10,000 words.
 
 protocol Constructible {
-  typealias Element
+  associatedtype Element
   init(e:Element)
 }
 class ConstructibleArray<T:Constructible> {


### PR DESCRIPTION
…so that we don't get warned during compilation anymore.
