### PR TITLE
Replace uses of llvm::Fixnum with llvm::PointerEmbeddedInt.

### DIFF
--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -18,7 +18,7 @@
 #define SWIFT_AST_LAZYRESOLVER_H
 
 #include "swift/AST/TypeLoc.h"
-#include "llvm/ADT/Fixnum.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
 
 namespace swift {
 
@@ -160,7 +160,7 @@ public:
 /// A placeholder for either an array or a member loader.
 template <typename T>
 class LazyLoaderArray {
-  using LengthTy = llvm::Fixnum<31>;
+  using LengthTy = llvm::PointerEmbeddedInt<size_t, 31>;
   PointerUnion<LengthTy, LazyMemberLoader *> lengthOrLoader;
   uint64_t data = 0;
 public:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -28,8 +28,8 @@
 #include "swift/Basic/UUID.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
-#include "llvm/ADT/Fixnum.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -3757,9 +3757,10 @@ DEFINE_EMPTY_CAN_TYPE_WRAPPER(AbstractTypeParamType, SubstitutableType)
 ///
 /// \sa GenericTypeParamDecl
 class GenericTypeParamType : public AbstractTypeParamType {
+  using DepthIndexTy = llvm::PointerEmbeddedInt<unsigned, 31>;
+
   /// The generic type parameter or depth/index.
-  llvm::PointerUnion<GenericTypeParamDecl *, llvm::Fixnum<31>>
-    ParamOrDepthIndex;
+  llvm::PointerUnion<GenericTypeParamDecl *, DepthIndexTy> ParamOrDepthIndex;
 
 public:
   /// Retrieve a generic type parameter at the given depth and index.

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -25,7 +25,6 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Fixnum.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Bitcode/BitstreamReader.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -199,7 +198,9 @@ public:
       : Value(), Offset(offset), IsFullyDeserialized(0) {}
 
     /*implicit*/ PartiallySerialized(RawBitOffset offset)
-      : Value(), Offset(offset), IsFullyDeserialized(0) {}
+      : Value(), Offset(static_cast<unsigned>(offset)), IsFullyDeserialized(0) {
+      assert(Offset == offset && "offset is too large");
+    }
 
     bool isDeserialized() const {
       return Value != T();
@@ -257,7 +258,9 @@ private:
 
     template <typename IntTy>
     /*implicit*/ SerializedIdentifier(IntTy rawOffset)
-      : Offset(rawOffset) {}
+      : Offset(static_cast<unsigned>(rawOffset)) {
+      assert(Offset == rawOffset && "not enough bits");
+    }
   };
 
   /// Identifiers referenced by this module.

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -22,11 +22,12 @@
 #include "swift/AST/Decl.h"
 #include "llvm/Bitcode/RecordLayout.h"
 #include "llvm/Bitcode/BitCodes.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
 
 namespace swift {
 namespace serialization {
 
-using llvm::Fixnum;
+using llvm::PointerEmbeddedInt;
 using llvm::BCArray;
 using llvm::BCBlob;
 using llvm::BCFixed;
@@ -54,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// it just ensures a conflict if two people change the module format.
 const uint16_t VERSION_MINOR = 238; // SILValue changes
 
-using DeclID = Fixnum<31>;
+using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
 
 // TypeID must be the same as DeclID because it is stored in the same way.
@@ -78,7 +79,7 @@ using NormalConformanceIDField = DeclIDField;
 using ModuleID = IdentifierID;
 using ModuleIDField = IdentifierIDField;
 
-using BitOffset = Fixnum<31>;
+using BitOffset = PointerEmbeddedInt<unsigned, 31>;
 using BitOffsetField = BCFixed<31>;
 
 // CharOffset must be the same as BitOffset because it is stored in the

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -32,7 +32,6 @@
 #include <functional>
 #include <iterator>
 using namespace swift;
-using llvm::Fixnum;
 
 bool TypeLoc::isError() const {
   assert(wasValidated() && "Type not yet validated");
@@ -1350,7 +1349,7 @@ unsigned GenericTypeParamType::getDepth() const {
     return param->getDepth();
   }
 
-  auto fixedNum = ParamOrDepthIndex.get<Fixnum<31>>();
+  auto fixedNum = ParamOrDepthIndex.get<DepthIndexTy>();
   return fixedNum >> 16;
 }
 
@@ -1359,7 +1358,7 @@ unsigned GenericTypeParamType::getIndex() const {
     return param->getIndex();
   }
 
-  auto fixedNum = ParamOrDepthIndex.get<Fixnum<31>>();
+  auto fixedNum = ParamOrDepthIndex.get<DepthIndexTy>();
   return fixedNum & 0xFFFF;
 }
 
@@ -1373,7 +1372,7 @@ Identifier GenericTypeParamType::getName() const {
   // getASTContext() doesn't actually mutate an already-canonical type.
   auto &C = const_cast<GenericTypeParamType*>(this)->getASTContext();
   auto &names = C.CanonicalGenericTypeParamTypeNames;
-  unsigned depthIndex = ParamOrDepthIndex.get<Fixnum<31>>();
+  unsigned depthIndex = ParamOrDepthIndex.get<DepthIndexTy>();
   auto cached = names.find(depthIndex);
   if (cached != names.end())
     return cached->second;

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -386,7 +386,6 @@ void SwiftLookupTable::dump() const {
 // ---------------------------------------------------------------------------
 // Serialization
 // ---------------------------------------------------------------------------
-using llvm::Fixnum;
 using llvm::BCArray;
 using llvm::BCBlob;
 using llvm::BCFixed;

--- a/lib/IRGen/EnumPayload.h
+++ b/lib/IRGen/EnumPayload.h
@@ -18,7 +18,7 @@
 #include "TypeInfo.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/DerivedTypes.h"
-#include "llvm/ADT/Fixnum.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
 #include "llvm/ADT/PointerUnion.h"
 #include <utility>
 
@@ -29,7 +29,9 @@ namespace irgen {
 /// A payload can either use a generic word-chunked representation, or attempt
 /// to follow the explosion schema of one of its payload types.
 class EnumPayloadSchema {
-  const llvm::PointerUnion<ExplosionSchema *, llvm::Fixnum<31>> Value;
+  using BitSizeTy = llvm::PointerEmbeddedInt<unsigned, 31>;
+
+  const llvm::PointerUnion<ExplosionSchema *, BitSizeTy> Value;
 
 public:
   EnumPayloadSchema() : Value((ExplosionSchema *)nullptr) {}
@@ -39,7 +41,7 @@ public:
   }
 
   explicit EnumPayloadSchema(unsigned bits)
-    : Value(llvm::Fixnum<31>(bits)) {}
+    : Value(BitSizeTy(bits)) {}
 
   EnumPayloadSchema(ExplosionSchema &s)
     : Value(&s) {}
@@ -69,7 +71,7 @@ public:
     }
     
     // Otherwise, chunk into pointer-sized integer values by default.
-    unsigned bitSize = Value.get<llvm::Fixnum<31>>();
+    unsigned bitSize = Value.get<BitSizeTy>();
     unsigned pointerSize = IGM.getPointerSize().getValueInBits();
     
     while (bitSize >= pointerSize) {

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -22,7 +22,6 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/Fixnum.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -231,9 +230,6 @@ public:
       StoredKindAndValue
     };
 
-    /// \brief The type of storage used for a kind and numeric value.
-    typedef llvm::Fixnum<62> KindAndValueStorage;
-
     /// \brief The actual storage for the path element, which involves both a
     /// kind and (potentially) a value.
     ///
@@ -251,15 +247,13 @@ public:
     uint64_t storedKind : 2;
 
     /// \brief Encode a path element kind and a value into the storage format.
-    static KindAndValueStorage encodeStorage(PathElementKind kind,
-                                             unsigned value) {
-      unsigned result = (value << 8) | (unsigned)kind;
-      return result;
+    static uint64_t encodeStorage(PathElementKind kind, unsigned value) {
+      return ((uint64_t)value << 8) | kind;
     }
 
     /// \brief Decode a storage value into path element kind and value.
     static std::pair<PathElementKind, unsigned>
-    decodeStorage(KindAndValueStorage storage) {
+    decodeStorage(uint64_t storage) {
       return { (PathElementKind)((unsigned)storage & 0xFF), storage >> 8 };
     }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -30,7 +30,6 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeCheckerDebugConsumer.h"
-#include "llvm/ADT/Fixnum.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallPtrSet.h"

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -574,7 +574,8 @@ SILBasicBlock *SILDeserializer::readSILBasicBlock(SILFunction *Fn,
     auto Arg = new (SILMod) SILArgument(CurrentBB,
                                         getSILType(ArgTy,
                                                    (SILValueCategory)Args[I+1]));
-    setLocalValue(Arg, ++LastValueID);
+    LastValueID = LastValueID + 1;
+    setLocalValue(Arg, LastValueID);
   }
   return CurrentBB;
 }
@@ -1728,8 +1729,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     break;
   }
   }
-  if (ResultVal->hasValue())
-    setLocalValue(ResultVal, ++LastValueID);
+  if (ResultVal->hasValue()) {
+    LastValueID = LastValueID + 1;
+    setLocalValue(ResultVal, LastValueID);
+  }
 
   return false;
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -355,7 +355,7 @@ public:
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
     unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, sizeof(DeclID) + sizeof(unsigned) };
+    return { keyLength, sizeof(uint32_t) + sizeof(unsigned) };
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
@@ -364,7 +364,7 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    auto declID = endian::readNext<DeclID, little, unaligned>(data);
+    auto declID = endian::readNext<uint32_t, little, unaligned>(data);
     auto discriminator = endian::readNext<unsigned, little, unaligned>(data);
     return { declID, discriminator };
   }
@@ -432,7 +432,7 @@ public:
       bool isInstanceMethod = *data++ != 0;
       DeclID methodID = endian::readNext<uint32_t, little, unaligned>(data);
       result.push_back(std::make_tuple(typeID, isInstanceMethod, methodID));
-      length -= sizeof(TypeID) + 1 + sizeof(DeclID);
+      length -= sizeof(uint32_t) + 1 + sizeof(uint32_t);
     }
 
     return result;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -55,6 +55,14 @@ using namespace swift::serialization;
 using namespace llvm::support;
 using llvm::BCBlockRAII;
 
+/// Used for static_assert.
+static constexpr bool declIDFitsIn32Bits() {
+  using Int32Info = std::numeric_limits<uint32_t>;
+  using PtrIntInfo = std::numeric_limits<uintptr_t>;
+  using DeclIDTraits = llvm::PointerLikeTypeTraits<DeclID>;
+  return PtrIntInfo::digits - DeclIDTraits::NumLowBitsAvailable <= Int32Info::digits;
+}
+
 namespace {
   /// Used to serialize the on-disk decl hash table.
   class DeclTableInfo {
@@ -75,7 +83,7 @@ namespace {
                                                     key_type_ref key,
                                                     data_type_ref data) {
       uint32_t keyLength = key.str().size();
-      uint32_t dataLength = (sizeof(DeclID) + 1) * data.size();
+      uint32_t dataLength = (sizeof(uint32_t) + 1) * data.size();
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
       writer.write<uint16_t>(dataLength);
@@ -88,7 +96,7 @@ namespace {
 
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
-      static_assert(sizeof(DeclID) <= 4, "DeclID too large");
+      static_assert(declIDFitsIn32Bits(), "DeclID too large");
       endian::Writer<little> writer(out);
       for (auto entry : data) {
         writer.write<uint8_t>(entry.first);
@@ -115,7 +123,7 @@ namespace {
                                                     key_type_ref key,
                                                     data_type_ref data) {
       uint32_t keyLength = key.size();
-      uint32_t dataLength = sizeof(DeclID) + sizeof(unsigned);
+      uint32_t dataLength = sizeof(uint32_t) + sizeof(unsigned);
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
       return { keyLength, dataLength };
@@ -127,9 +135,9 @@ namespace {
 
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
-      static_assert(sizeof(DeclID) <= 4, "DeclID too large");
+      static_assert(declIDFitsIn32Bits(), "DeclID too large");
       endian::Writer<little> writer(out);
-      writer.write<DeclID>(data.first);
+      writer.write<uint32_t>(data.first);
       writer.write<unsigned>(data.second);
     }
   };
@@ -260,7 +268,8 @@ DeclID Serializer::addLocalDeclContextRef(const DeclContext *DC) {
   if (id != 0)
     return id;
 
-  id = { ++LastLocalDeclContextID };
+  LastLocalDeclContextID = LastLocalDeclContextID + 1;
+  id = LastLocalDeclContextID;
   LocalDeclContextsToWrite.push(DC);
   return id;
 }
@@ -285,7 +294,8 @@ DeclContextID Serializer::addDeclContextRef(const DeclContext *DC) {
   if (id)
     return id;
 
-  id = { ++LastDeclContextID };
+  LastDeclContextID = LastDeclContextID + 1;
+  id = LastDeclContextID;
   DeclContextsToWrite.push(DC);
 
   return id;
@@ -317,7 +327,8 @@ DeclID Serializer::addDeclRef(const Decl *D, bool forceSerialization) {
   if (paramList)
     GenericContexts[paramList] = D;
 
-  id = { ++LastDeclID, forceSerialization };
+  LastDeclID = LastDeclID + 1;
+  id = { LastDeclID, forceSerialization };
   DeclsAndTypesToWrite.push(D);
   return id.first;
 }
@@ -330,7 +341,8 @@ TypeID Serializer::addTypeRef(Type ty) {
   if (id.first != 0)
     return id.first;
 
-  id = { ++LastTypeID, true };
+  LastTypeID = LastTypeID + 1;
+  id = { LastTypeID, true };
   DeclsAndTypesToWrite.push(ty);
   return id.first;
 }
@@ -343,7 +355,8 @@ IdentifierID Serializer::addIdentifierRef(Identifier ident) {
   if (id != 0)
     return id;
 
-  id = ++LastIdentifierID;
+  LastIdentifierID = LastIdentifierID + 1;
+  id = LastIdentifierID;
   IdentifiersToWrite.push_back(ident);
   return id;
 }
@@ -372,7 +385,8 @@ NormalConformanceID Serializer::addConformanceRef(
   if (conformanceID)
     return conformanceID;
 
-  conformanceID = ++LastNormalConformanceID;
+  LastNormalConformanceID = LastNormalConformanceID + 1;
+  conformanceID = LastNormalConformanceID;
   NormalConformancesToWrite.push(conformance);
 
   return conformanceID;
@@ -2933,7 +2947,7 @@ void Serializer::writeType(Type ty) {
   case TypeKind::PolymorphicFunction: {
     auto fnTy = cast<PolymorphicFunctionType>(ty.getPointer());
     const Decl *genericContext = getGenericContext(&fnTy->getGenericParams());
-    DeclID dID = genericContext ? addDeclRef(genericContext) : DeclID(0);
+    DeclID dID = genericContext ? addDeclRef(genericContext) : DeclID();
 
     unsigned abbrCode = DeclTypeAbbrCodes[PolymorphicFunctionTypeLayout::Code];
     PolymorphicFunctionTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,
@@ -3619,7 +3633,8 @@ namespace {
                                                     data_type_ref data) {
       llvm::SmallString<32> scratch;
       uint32_t keyLength = key.getString(scratch).size();
-      uint32_t dataLength = (sizeof(TypeID) + 1 + sizeof(DeclID)) * data.size();
+      size_t entrySize = sizeof(uint32_t) + 1 + sizeof(uint32_t);
+      uint32_t dataLength = entrySize * data.size();
 
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
@@ -3633,7 +3648,7 @@ namespace {
 
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
-      static_assert(sizeof(DeclID) <= 4, "DeclID too large");
+      static_assert(declIDFitsIn32Bits(), "DeclID too large");
       endian::Writer<little> writer(out);
       for (auto entry : data) {
         writer.write<uint32_t>(std::get<0>(entry));


### PR DESCRIPTION
The two types are nearly identical, and Fixnum is only in the Swift branches of LLVM,
not in mainline LLVM.

I do want to add ++ to PointerEmbeddedInt and fix some of this ugliness, but that'll
have to go through LLVM review, so it might take a bit.
