### PR TITLE
Only visit "arc interesting instruction"

### DIFF
--- a/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
@@ -20,7 +20,7 @@
 
 #define DEBUG_TYPE "arc-sequence-opts"
 #include "swift/SILOptimizer/PassManager/Passes.h"
-#include "GlobalARCPairingAnalysis.h"
+#include "ARCSequenceOpts.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.h
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.h
@@ -1,0 +1,142 @@
+//===--- GlobalARCPairingAnalysis.h -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_GLOBALARCPAIRINGANALYSIS_H
+#define SWIFT_SILOPTIMIZER_PASSMANAGER_GLOBALARCPAIRINGANALYSIS_H
+
+#include "GlobalARCSequenceDataflow.h"
+#include "GlobalLoopARCSequenceDataflow.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Utils/LoopUtils.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace swift {
+
+class SILInstruction;
+class SILFunction;
+class AliasAnalysis;
+class PostOrderAnalysis;
+class LoopRegionFunctionInfo;
+class SILLoopInfo;
+class RCIdentityFunctionInfo;
+
+/// A set of matching reference count increments, decrements, increment
+/// insertion pts, and decrement insertion pts.
+struct ARCMatchingSet {
+
+  /// The pointer that this ARCMatchingSet is providing matching increment and
+  /// decrement sets for.
+  ///
+  /// TODO: This should really be called RCIdentity.
+  SILValue Ptr;
+
+  /// The set of reference count increments that were paired.
+  llvm::SetVector<SILInstruction *> Increments;
+
+  /// An insertion point for an increment means the earliest point in the
+  /// program after the increment has occurred that the increment can be moved
+  /// to
+  /// without moving the increment over an instruction that may decrement a
+  /// reference count.
+  llvm::SetVector<SILInstruction *> IncrementInsertPts;
+
+  /// The set of reference count decrements that were paired.
+  llvm::SetVector<SILInstruction *> Decrements;
+
+  /// An insertion point for a decrement means the latest point in the program
+  /// before the decrement that the optimizer conservatively assumes that a
+  /// reference counted value could be used.
+  llvm::SetVector<SILInstruction *> DecrementInsertPts;
+
+  // This is a data structure that cannot be moved or copied.
+  ARCMatchingSet() = default;
+  ARCMatchingSet(const ARCMatchingSet &) = delete;
+  ARCMatchingSet(ARCMatchingSet &&) = delete;
+  ARCMatchingSet &operator=(const ARCMatchingSet &) = delete;
+  ARCMatchingSet &operator=(ARCMatchingSet &&) = delete;
+
+  void clear() {
+    Ptr = SILValue();
+    Increments.clear();
+    IncrementInsertPts.clear();
+    Decrements.clear();
+    DecrementInsertPts.clear();
+  }
+};
+
+struct MatchingSetFlags {
+  bool KnownSafe;
+  bool Partial;
+};
+static_assert(std::is_pod<MatchingSetFlags>::value,
+              "MatchingSetFlags should be a pod.");
+
+struct ARCMatchingSetBuilder {
+  using TDMapTy = BlotMapVector<SILInstruction *, TopDownRefCountState>;
+  using BUMapTy = BlotMapVector<SILInstruction *, BottomUpRefCountState>;
+
+  TDMapTy &TDMap;
+  BUMapTy &BUMap;
+
+  llvm::SmallVector<SILInstruction *, 8> NewIncrements;
+  llvm::SmallVector<SILInstruction *, 8> NewDecrements;
+  bool MatchedPair;
+  ARCMatchingSet MatchSet;
+  bool PtrIsGuaranteedArg;
+
+  RCIdentityFunctionInfo *RCIA;
+
+public:
+  ARCMatchingSetBuilder(TDMapTy &TDMap, BUMapTy &BUMap,
+                        RCIdentityFunctionInfo *RCIA)
+      : TDMap(TDMap), BUMap(BUMap), MatchedPair(false),
+        PtrIsGuaranteedArg(false), RCIA(RCIA) {}
+
+  void init(SILInstruction *Inst) {
+    clear();
+    MatchSet.Ptr = RCIA->getRCIdentityRoot(Inst->getOperand(0));
+
+    // If we have a function argument that is guaranteed, set the guaranteed
+    // flag so we know that it is always known safe.
+    if (auto *A = dyn_cast<SILArgument>(MatchSet.Ptr)) {
+      if (A->isFunctionArg()) {
+        auto C = A->getParameterInfo().getConvention();
+        PtrIsGuaranteedArg = C == ParameterConvention::Direct_Guaranteed;
+      }
+    }
+    NewIncrements.push_back(Inst);
+  }
+
+  void clear() {
+    MatchSet.clear();
+    MatchedPair = false;
+    NewIncrements.clear();
+    NewDecrements.clear();
+  }
+
+  bool matchUpIncDecSetsForPtr();
+
+  // We only allow for get result when this object is invalidated via a move.
+  ARCMatchingSet &getResult() { return MatchSet; }
+
+  bool matchedPair() const { return MatchedPair; }
+
+private:
+  /// Returns .Some(MatchingSetFlags) on success and .None on failure.
+  Optional<MatchingSetFlags> matchIncrementsToDecrements();
+  Optional<MatchingSetFlags> matchDecrementsToIncrements();
+};
+
+} // end swift namespace
+
+#endif

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -70,6 +70,13 @@ public:
   /// Is this Region from which we can leak memory safely?
   bool allowsLeaks() const { return AllowsLeaks; }
 
+  /// Return the region associated with this ARCRegionState.
+  ///
+  /// Even though Region is a NullablePtr, it is only null during
+  /// initialization. This method should not be called then.
+  const LoopRegion *getRegion() const { return Region.get(); }
+  LoopRegion *getRegion() { return Region.get(); }
+
   /// Top Down Iterators
   using topdown_iterator = TopDownMapTy::iterator;
   using topdown_const_iterator = TopDownMapTy::const_iterator;
@@ -129,6 +136,17 @@ public:
     clearBottomUpState();
   }
 
+  using const_reverse_summarizedinterestinginsts_iterator =
+      decltype(SummarizedInterestingInsts)::const_reverse_iterator;
+  const_reverse_summarizedinterestinginsts_iterator
+  summarizedinterestinginsts_rbegin() const {
+    return SummarizedInterestingInsts.rbegin();
+  }
+  const_reverse_summarizedinterestinginsts_iterator
+  summarizedinterestinginsts_rend() const {
+    return SummarizedInterestingInsts.rend();
+  }
+
   using const_summarizedinterestinginsts_iterator =
       decltype(SummarizedInterestingInsts)::const_iterator;
   const_summarizedinterestinginsts_iterator
@@ -144,9 +162,6 @@ public:
     return {summarizedinterestinginsts_begin(),
             summarizedinterestinginsts_end()};
   }
-
-  /// Returns a reference to the basic block that we are tracking.
-  const LoopRegion *getRegion() const { return Region.get(); }
 
   /// Merge in the state of the successor basic block. This is currently a stub.
   void mergeSuccBottomUp(ARCRegionState &SuccRegion);
@@ -187,9 +202,19 @@ public:
       BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);
 
+  void summarizeBlock(SILBasicBlock *BB);
+
   void summarize(
       LoopRegionFunctionInfo *LRFI,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);
+
+  /// Add \p I to the interesting instruction list of this region if it is a
+  /// block. We assume that I is an instruction in the block.
+  void addInterestingInst(SILInstruction *I);
+
+  /// Remove \p I from the interesting instruction list of this region if it is
+  /// a block. We assume that I is an instruction in the block.
+  void removeInterestingInst(SILInstruction *I);
 
 private:
   void processBlockBottomUpPredTerminators(const LoopRegion *R,
@@ -210,7 +235,6 @@ private:
   bool processLoopTopDown(const LoopRegion *R, ARCRegionState *State,
                           AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI);
 
-  void summarizeBlock(SILBasicBlock *BB);
   void summarizeLoop(
       const LoopRegion *R, LoopRegionFunctionInfo *LRFI,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -42,98 +42,6 @@ STATISTIC(NumRefCountOpsRemoved, "Total number of increments removed");
 llvm::cl::opt<bool> EnableLoopARC("enable-loop-arc", llvm::cl::init(true));
 
 //===----------------------------------------------------------------------===//
-//                            ARC Pairing Context
-//===----------------------------------------------------------------------===//
-
-bool ARCPairingContext::performMatching(CodeMotionOrDeleteCallback &Callback) {
-  bool MatchedPair = false;
-
-  DEBUG(llvm::dbgs() << "**** Computing ARC Matching Sets for " << F.getName()
-                     << " ****\n");
-
-  /// For each increment that we matched to a decrement, try to match it to a
-  /// decrement -> increment pair.
-  for (auto Pair : IncToDecStateMap) {
-    if (!Pair.hasValue())
-      continue;
-
-    SILInstruction *Increment = Pair->first;
-    if (!Increment)
-      continue; // blotted
-
-    DEBUG(llvm::dbgs() << "Constructing Matching Set For: " << *Increment);
-    ARCMatchingSetBuilder Builder(DecToIncStateMap, IncToDecStateMap, RCIA);
-    Builder.init(Increment);
-    if (Builder.matchUpIncDecSetsForPtr()) {
-      MatchedPair |= Builder.matchedPair();
-      auto &Set = Builder.getResult();
-      for (auto *I : Set.Increments)
-        IncToDecStateMap.blot(I);
-      for (auto *I : Set.Decrements)
-        DecToIncStateMap.blot(I);
-
-      // Add the Set to the callback. *NOTE* No instruction destruction can
-      // happen here since we may remove instructions that are insertion points
-      // for other instructions.
-      Callback.processMatchingSet(Set);
-    }
-  }
-
-  // Then finalize the callback. This is the only place instructions can be
-  // deleted.
-  Callback.finalize();
-  return MatchedPair;
-}
-
-//===----------------------------------------------------------------------===//
-//                                  Loop ARC
-//===----------------------------------------------------------------------===//
-
-void LoopARCPairingContext::runOnLoop(SILLoop *L) {
-  auto *Region = LRFI->getRegion(L);
-  if (processRegion(Region, false, false)) {
-    // We do not recompute for now since we only look at the top function level
-    // for post dominating releases.
-    processRegion(Region, true, false);
-  }
-
-  // Now that we have finished processing the loop, summarize the loop.
-  Evaluator.summarizeLoop(Region);
-}
-
-void LoopARCPairingContext::runOnFunction(SILFunction *F) {
-  if (processRegion(LRFI->getTopLevelRegion(), false, false)) {
-    // We recompute the final post dom release since we may have moved the final
-    // post dominated releases.
-    processRegion(LRFI->getTopLevelRegion(), true, true);
-  }
-}
-
-bool LoopARCPairingContext::processRegion(const LoopRegion *Region,
-                                          bool FreezePostDomReleases,
-                                          bool RecomputePostDomReleases) {
-  bool MadeChange = false;
-  bool NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases,
-                                             RecomputePostDomReleases);
-  bool MatchedPair = Context.performMatching(Callback);
-  MadeChange |= MatchedPair;
-  Evaluator.clearLoopState(Region);
-  Context.DecToIncStateMap.clear();
-  Context.IncToDecStateMap.clear();
-
-  while (NestingDetected && MatchedPair) {
-    NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases, false);
-    MatchedPair = Context.performMatching(Callback);
-    MadeChange |= MatchedPair;
-    Evaluator.clearLoopState(Region);
-    Context.DecToIncStateMap.clear();
-    Context.IncToDecStateMap.clear();
-  }
-
-  return MadeChange;
-}
-
-//===----------------------------------------------------------------------===//
 //                                Code Motion
 //===----------------------------------------------------------------------===//
 
@@ -170,15 +78,13 @@ static SILInstruction *createDecrement(SILValue Ptr, SILInstruction *InsertPt) {
   return B.createReleaseValue(Loc, Ptr);
 }
 
-//===----------------------------------------------------------------------===//
-//                             Mutating Callback
-//===----------------------------------------------------------------------===//
-
 // This routine takes in the ARCMatchingSet \p MatchSet and inserts new
 // increments, decrements at the insertion points and adds the old increment,
 // decrements to the delete list. Sets changed to true if anything was moved or
 // deleted.
-void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
+void ARCPairingContext::optimizeMatchingSet(
+    ARCMatchingSet &MatchSet,
+    llvm::SmallVectorImpl<SILInstruction *> &InstsToDelete) {
   DEBUG(llvm::dbgs() << "**** Optimizing Matching Set ****\n");
 
   // Insert the new increments.
@@ -189,7 +95,7 @@ void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
       continue;
     }
 
-    Changed = true;
+    MadeChange = true;
     SILInstruction *NewIncrement = createIncrement(MatchSet.Ptr, InsertPt);
     (void)NewIncrement;
     DEBUG(llvm::dbgs() << "    Inserting new increment: " << *NewIncrement
@@ -205,7 +111,7 @@ void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
       continue;
     }
 
-    Changed = true;
+    MadeChange = true;
     SILInstruction *NewDecrement = createDecrement(MatchSet.Ptr, InsertPt);
     (void)NewDecrement;
     DEBUG(llvm::dbgs() << "    Inserting new NewDecrement: " << *NewDecrement
@@ -215,19 +121,111 @@ void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
 
   // Add the old increments to the delete list.
   for (SILInstruction *Increment : MatchSet.Increments) {
-    Changed = true;
+    MadeChange = true;
     DEBUG(llvm::dbgs() << "    Deleting increment: " << *Increment);
-    InstructionsToDelete.push_back(Increment);
+    InstsToDelete.push_back(Increment);
     ++NumRefCountOpsRemoved;
   }
 
   // Add the old decrements to the delete list.
   for (SILInstruction *Decrement : MatchSet.Decrements) {
-    Changed = true;
+    MadeChange = true;
     DEBUG(llvm::dbgs() << "    Deleting decrement: " << *Decrement);
-    InstructionsToDelete.push_back(Decrement);
+    InstsToDelete.push_back(Decrement);
     ++NumRefCountOpsRemoved;
   }
+}
+
+bool ARCPairingContext::performMatching() {
+  bool MatchedPair = false;
+
+  DEBUG(llvm::dbgs() << "**** Computing ARC Matching Sets for " << F.getName()
+                     << " ****\n");
+
+  llvm::SmallVector<SILInstruction *, 8> InstructionsToDelete;
+
+  /// For each increment that we matched to a decrement, try to match it to a
+  /// decrement -> increment pair.
+  for (auto Pair : IncToDecStateMap) {
+    if (!Pair.hasValue())
+      continue;
+
+    SILInstruction *Increment = Pair->first;
+    if (!Increment)
+      continue; // blotted
+
+    DEBUG(llvm::dbgs() << "Constructing Matching Set For: " << *Increment);
+    ARCMatchingSetBuilder Builder(DecToIncStateMap, IncToDecStateMap, RCIA);
+    Builder.init(Increment);
+    if (Builder.matchUpIncDecSetsForPtr()) {
+      MatchedPair |= Builder.matchedPair();
+      auto &Set = Builder.getResult();
+      for (auto *I : Set.Increments)
+        IncToDecStateMap.blot(I);
+      for (auto *I : Set.Decrements)
+        DecToIncStateMap.blot(I);
+
+      // Add the Set to the callback. *NOTE* No instruction destruction can
+      // happen here since we may remove instructions that are insertion points
+      // for other instructions.
+      optimizeMatchingSet(Set, InstructionsToDelete);
+    }
+  }
+
+  // Then delete all of the instructions that we still have.
+  while (!InstructionsToDelete.empty()) {
+    InstructionsToDelete.pop_back_val()->eraseFromParent();
+  }
+
+  return MatchedPair;
+}
+
+//===----------------------------------------------------------------------===//
+//                                  Loop ARC
+//===----------------------------------------------------------------------===//
+
+void LoopARCPairingContext::runOnLoop(SILLoop *L) {
+  auto *Region = LRFI->getRegion(L);
+  if (processRegion(Region, false, false)) {
+    // We do not recompute for now since we only look at the top function level
+    // for post dominating releases.
+    processRegion(Region, true, false);
+  }
+
+  // Now that we have finished processing the loop, summarize the loop.
+  Evaluator.summarizeLoop(Region);
+}
+
+void LoopARCPairingContext::runOnFunction(SILFunction *F) {
+  if (processRegion(LRFI->getTopLevelRegion(), false, false)) {
+    // We recompute the final post dom release since we may have moved the final
+    // post dominated releases.
+    processRegion(LRFI->getTopLevelRegion(), true, true);
+  }
+}
+
+bool LoopARCPairingContext::processRegion(const LoopRegion *Region,
+                                          bool FreezePostDomReleases,
+                                          bool RecomputePostDomReleases) {
+  bool MadeChange = false;
+  bool NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases,
+                                             RecomputePostDomReleases);
+  bool MatchedPair = Context.performMatching();
+  MadeChange |= MatchedPair;
+  Evaluator.clearLoopState(Region);
+  Context.DecToIncStateMap.clear();
+  Context.IncToDecStateMap.clear();
+
+  while (NestingDetected && MatchedPair) {
+    NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases, false);
+    MatchedPair = Context.performMatching();
+    MadeChange |= MatchedPair;
+    Evaluator.clearLoopState(Region);
+    Context.DecToIncStateMap.clear();
+    Context.IncToDecStateMap.clear();
+  }
+
+  return MadeChange;
 }
 
 //===----------------------------------------------------------------------===//
@@ -250,7 +248,6 @@ processFunctionWithoutLoopSupport(SILFunction &F, bool FreezePostDomReleases,
 
   bool Changed = false;
   BlockARCPairingContext Context(F, AA, POTA, RCIA, PTFI);
-  CodeMotionOrDeleteCallback Callback;
   // Until we do not remove any instructions or have nested increments,
   // decrements...
   while (true) {
@@ -260,9 +257,9 @@ processFunctionWithoutLoopSupport(SILFunction &F, bool FreezePostDomReleases,
     // We need to blot pointers we remove after processing an individual pointer
     // so we don't process pairs after we have paired them up. Thus we pass in a
     // lambda that performs the work for us.
-    bool ShouldRunAgain = Context.run(FreezePostDomReleases, Callback);
+    bool ShouldRunAgain = Context.run(FreezePostDomReleases);
 
-    Changed |= Callback.madeChange();
+    Changed |= Context.madeChange();
 
     // If we did not remove any instructions or have any nested increments, do
     // not perform another iteration.

--- a/lib/SILOptimizer/ARC/CMakeLists.txt
+++ b/lib/SILOptimizer/ARC/CMakeLists.txt
@@ -3,7 +3,7 @@ set(ARC_SOURCES
   ARC/ARCRegionState.cpp
   ARC/ARCLoopOpts.cpp
   ARC/ARCSequenceOpts.cpp
-  ARC/GlobalARCPairingAnalysis.cpp
+  ARC/ARCMatchingSet.cpp
   ARC/GlobalARCSequenceDataflow.cpp
   ARC/GlobalLoopARCSequenceDataflow.cpp
   ARC/RCStateTransition.cpp

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -285,7 +285,28 @@ void LoopARCSequenceDataflowEvaluator::summarizeLoop(
   RegionStateInfo[R]->summarize(LRFI, RegionStateInfo);
 }
 
+void LoopARCSequenceDataflowEvaluator::summarizeSubregionBlocks(
+    const LoopRegion *R) {
+  for (unsigned SubregionID : R->getSubregions()) {
+    auto *Subregion = LRFI->getRegion(SubregionID);
+    if (!Subregion->isBlock())
+      continue;
+    RegionStateInfo[Subregion]->summarizeBlock(Subregion->getBlock());
+  }
+}
+
 void LoopARCSequenceDataflowEvaluator::clearLoopState(const LoopRegion *R) {
   for (unsigned SubregionID : R->getSubregions())
     getARCState(LRFI->getRegion(SubregionID)).clear();
+}
+
+void LoopARCSequenceDataflowEvaluator::addInterestingInst(SILInstruction *I) {
+  auto *Region = LRFI->getRegion(I->getParent());
+  RegionStateInfo[Region]->addInterestingInst(I);
+}
+
+void LoopARCSequenceDataflowEvaluator::removeInterestingInst(
+    SILInstruction *I) {
+  auto *Region = LRFI->getRegion(I->getParent());
+  RegionStateInfo[Region]->removeInterestingInst(I);
 }

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -90,9 +90,21 @@ public:
   bool runOnLoop(const LoopRegion *R, bool FreezeOwnedArgEpilogueReleases,
                  bool RecomputePostDomReleases);
 
+  /// Summarize the subregions of \p R that are blocks.
+  ///
+  /// We assume that all subregions that are loops have already been summarized
+  /// since we are processing bottom up through the loop nest hierarchy.
+  void summarizeSubregionBlocks(const LoopRegion *R);
+
   /// Summarize the contents of the loop so that loops further up the loop tree
   /// can reason about the loop.
   void summarizeLoop(const LoopRegion *R);
+
+  /// Add \p I to the interesting instruction list of its parent block.
+  void addInterestingInst(SILInstruction *I);
+
+  /// Remove \p I from the interesting instruction list of its parent block.
+  void removeInterestingInst(SILInstruction *I);
 
 private:
   /// Merge in the BottomUp state of any successors of DataHandle.getBB() into


### PR DESCRIPTION
This series of commits changes ARC to only visit "interesting" ARC instructions.

This will help compile time, especially in debug builds.

On some evil examples I have seen a reduction of compile time by 1/3. I am going to after running some perf tests, post more information (before this lands).
