### PR TITLE
IRGen: Work around crash lowering generic base class-constrained type parameter.

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -248,7 +248,11 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
       ClassDecl *superClass = super->getClassOrBoundGenericClass();
       refcount = getReferenceCountingForClass(IGM, superClass);
 
-      auto &superTI = IGM.getTypeInfoForUnlowered(super);
+      // FIXME: Bypass type lowering here, since lowering a generic superclass
+      // requirement triggers a crash when it's dependent on generic params
+      // (rdar://problem/24590570). Nominal class types are currently
+      // unaffected by type lowering (and are likely to remain so).
+      auto &superTI = IGM.getTypeInfoForLowered(super->getCanonicalType());
       reprTy = cast<llvm::PointerType>(superTI.StorageType);
     }
 

--- a/test/IRGen/dependent_generic_base_class_constraint.swift
+++ b/test/IRGen/dependent_generic_base_class_constraint.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir -verify %s
+class GenericClass<T> { }
+
+protocol MyProtocol { }
+
+class MyClass {
+  func myFunction<T, O: GenericClass<T> where T: MyProtocol>(myArg: O) -> T {
+    fatalError()
+  }
+}
+
+


### PR DESCRIPTION
Type lowering a type with abstract type parameters requires a generic signature, but type lowering does not ever affect class types, so we can be unprincipled and bypass the problem. Work around for rdar://problem/24590570.
