### PR TITLE
Reduce memory threshold for expression_too_complex

### DIFF
--- a/test/Misc/expression_too_complex.swift
+++ b/test/Misc/expression_too_complex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-parse-verify-swift -solver-memory-threshold 5000
+// RUN: %target-parse-verify-swift -solver-memory-threshold 4000
 
 var x = [1, 2, 3, 4.5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ,19] // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
 


### PR DESCRIPTION
The 5000 byte treshold is too generous on 32-bit systems to trigger the expression too complex test.  Reducing it to 4000 causes the compiler to bail (as expected) on these platforms while retaining the expected behavior on 64-bit systems.
