### PR TITLE
Prettifying the changelog a bit more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Swift 2.2
 * Associated types in protocols can now be specified with a new 'associatedtype'
   declaration, to replace the use of 'typealias':
 
-    ```
+    ```swift
     protocol P {
       associatedtype Ty
     }
@@ -25,29 +25,29 @@ Swift 2.2
   Swift 3.
 
 * The ++ and -- operators have been deprecated, and are slated to be removed in
-  Swift 3.0.  As a replacement, please use "`x += 1`" on integer or floating point
-  types, and "`x = x.successor()`" on Index types.
+  Swift 3.0.  As a replacement, please use `x += 1` on integer or floating point
+  types, and `x = x.successor()` on Index types.
 
 * The implicit tuple splat behavior in function application has been deprecated
   and will be removed in Swift 3.0.  For example, this code:
 
-    ```
+    ```swift
     func foo(a : Int, b : Int) { ... }
     let x = (1, b: 2)
     foo(x)   // Warning, deprecated.
     ```
 
   should move to being written as:
-    ```
+    ```swift
     foo(x.0, x.b)
     ```
 
   For more information and rationale, see 
   [SE-0029](https://github.com/apple/swift-evolution/blob/master/proposals/0029-remove-implicit-tuple-splat.md).
 
-* New #file, #line, #column, and #function expressions have been introduced to
-  replace the existing __FILE__, __LINE__, __COLUMN__, and __FUNCTION__ symbols.
-  The __FILE__-style symbols have been deprecated, and will be removed in
+* New `#file`, `#line`, `#column`, and `#function` expressions have been introduced to
+  replace the existing `__FILE__`, `__LINE__`, `__COLUMN__`, and `__FUNCTION__` symbols.
+  The `__FILE__`-style symbols have been deprecated, and will be removed in
   Swift 3.
 
 * The operator identifier lexer grammar has been revised to simplify the rules
@@ -55,12 +55,12 @@ Swift 2.2
   that starts with a dot may contain other dots in it, but operators that start
   with some other character may not contain dots.  For example:
 
-    ```
+    ```swift
     x....foo   --> "x" "...." "foo"
     x&%^.foo   --> "x" "&%^"  ".foo"
     ```
 
-  This eliminates a special case for the ..< operator, folding it into a simple
+  This eliminates a special case for the `..<` operator, folding it into a simple
   and consistent rule.
 
 * The "C-style for loop", which is spelled `for init; comparison; increment {}`
@@ -78,7 +78,7 @@ Swift 2.2
   are specified.
 
 * Designated class initializers declared as failable or throwing may now
-  return nil or throw an error, respectively, before the object has been
+  return `nil` or throw an error, respectively, before the object has been
   fully initialized. For example:
 
     ```swift
@@ -130,7 +130,9 @@ Swift 2.2
 * Argument labels and parameter names can now be any keyword except
   `var`, `let`, or `inout`. For example:
 
+   ```swift
     NSURLProtectionSpace(host: "somedomain.com", port: 443, protocol: "https", realm: "Some Domain", authenticationMethod: "Basic")
+   ```
 
   would previously have required `protocol` to be surrounded in
   back-ticks. For more information, see
@@ -152,11 +154,13 @@ Swift 2.2
 * When referencing a function or initializer, one can provide the
   complete name, including argument labels. For example:
 
+   ```swift
       let fn1 = someView.insertSubview(_:at:)
       let fn2 = someView.insertSubview(_:aboveSubview:)
 
       let buttonFactory = UIButton.init(type:)
-
+   ```
+   
   For more information, see [SE-0021](https://github.com/apple/swift-evolution/blob/master/proposals/0021-generalized-naming.md).
 
 * There is a new build configuration function, `#if swift(>=x.y)`, which
@@ -180,24 +184,30 @@ Swift 2.2
 * The Objective-C selector of a Swift method can now be determined
   directly with the #selector expression, e.g.,:
 
+   ```swift
       let sel = #selector(insertSubview(_:aboveSubview:)) // sel has type Selector
-
+   ```
+   
   Along with this change, the use of string literals as selectors has
   been deprecated, e.g.,
 
+  ```swift
       let sel: Selector = "insertSubview:aboveSubview:"
-
+  ```
+   
   Generally, such string literals should be replaced with uses of
   `#selector`, and the compiler will provide Fix-Its that use
   `#selector`. In cases where they is not possible (e.g., when referring
   to the getter of a property), one can still directly construct
   selectors, e.g.,:
 
+  ```swift
       let sel = Selector("propertyName")
-
+  ```
+   
   Note that the compiler is now checking the string literals used to
   construct Selectors to ensure that they are well-formed Objective-C
-  selectors and that there is an '@objc' method with that selector.
+  selectors and that there is an `@objc` method with that selector.
 
 
 2015-09-17 [Xcode 7.1, Swift 2.1]
@@ -1857,9 +1867,9 @@ Swift 2.2
     }
     ```
 
-  In the current implementation, struct and enum initializers can return nil
+  In the current implementation, struct and enum initializers can return `nil`
   at any point inside the initializer, but class initializers can only return
-  nil after all of the stored properties of the object have been initialized
+  `nil` after all of the stored properties of the object have been initialized
   and `self.init` or `super.init` has been called. If `self.init` or
   `super.init` is used to delegate to a failable initializer, then the `nil`
   return is implicitly propagated through the current initializer if the
@@ -5288,7 +5298,7 @@ Swift 2.2
     ```
 
   Swift also supports a special form of weak reference, called `[unowned]`, for
-  references that should never be nil but are required to be weak to break
+  references that should never be `nil` but are required to be weak to break
   cycles, such as parent or sibling references. Accessing an `[unowned]`
   reference asserts that the reference is still valid and implicitly promotes
   the loaded reference to a strong reference, so it does not need to be loaded


### PR DESCRIPTION
Marked swift keywords like `nil` and `@objc` with code formatting and moved all swift examples into their own

``` swift
// swift code blocks
```
