### PR TITLE
Allow generic signature superclass constraints to contain type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Swift 3
 * Curried function syntax has been removed, and now produces a compile-time
   error.
 
+* Generic signatures can now contain superclass requirements with generic
+  parameter types, for example:
+
+  ```
+  func f<Food : Chunks<Meat>, Meat : Molerat>(f: Food, m: Meat) {}
+  ```
 
 Swift 2.2
 ---------

--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -431,6 +431,10 @@ class ArchetypeBuilder::PotentialArchetype {
   /// the concrete type.
   unsigned RecursiveConcreteType : 1;
 
+  /// Whether we have detected recursion during the substitution of
+  /// the superclass type.
+  unsigned RecursiveSuperclassType : 1;
+
   /// Whether we have renamed this (nested) type due to typo correction.
   unsigned Renamed : 1;
 
@@ -442,7 +446,8 @@ class ArchetypeBuilder::PotentialArchetype {
   PotentialArchetype(PotentialArchetype *Parent, Identifier Name)
     : ParentOrParam(Parent), NameOrAssociatedType(Name), Representative(this),
       IsRecursive(false), Invalid(false), SubstitutingConcreteType(false),
-      RecursiveConcreteType(false), Renamed(false)
+      RecursiveConcreteType(false), RecursiveSuperclassType(false),
+      Renamed(false)
   { 
     assert(Parent != nullptr && "Not an associated type?");
     EquivalenceClass.push_back(this);
@@ -453,7 +458,7 @@ class ArchetypeBuilder::PotentialArchetype {
     : ParentOrParam(Parent), NameOrAssociatedType(AssocType), 
       Representative(this), IsRecursive(false), Invalid(false),
       SubstitutingConcreteType(false), RecursiveConcreteType(false),
-      Renamed(false)
+      RecursiveSuperclassType(false), Renamed(false)
   { 
     assert(Parent != nullptr && "Not an associated type?");
     EquivalenceClass.push_back(this);
@@ -466,7 +471,8 @@ class ArchetypeBuilder::PotentialArchetype {
     : ParentOrParam(GenericParam), RootProtocol(RootProtocol), 
       NameOrAssociatedType(Name), Representative(this), IsRecursive(false),
       Invalid(false), SubstitutingConcreteType(false),
-      RecursiveConcreteType(false), Renamed(false)
+      RecursiveConcreteType(false), RecursiveSuperclassType(false),
+      Renamed(false)
   {
     EquivalenceClass.push_back(this);
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1280,15 +1280,14 @@ ERROR(recursive_requirement_reference,none,
       "type may not reference itself as a requirement",())
 ERROR(recursive_same_type_constraint,none,
       "same-type constraint %0 == %1 is recursive", (Type, Type))
+ERROR(recursive_superclass_constraint,none,
+      "superclass constraint %0 is recursive", (Type))
 ERROR(requires_same_type_conflict,none,
       "generic parameter %0 cannot be equal to both %1 and %2",
       (Identifier, Type, Type))
 ERROR(requires_generic_param_same_type_does_not_conform,none,
       "same-type constraint type %0 does not conform to required protocol %1",
       (Type, Identifier))
-ERROR(dependent_superclass_constraint,none,
-      "superclass constraint %0 cannot depend on a type parameter",
-      (Type))
 
 ERROR(generic_param_access,none,
       "%0 %select{must be declared %select{private|internal|PUBLIC}3"

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -247,11 +247,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
       ClassDecl *superClass = super->getClassOrBoundGenericClass();
       refcount = getReferenceCountingForClass(IGM, superClass);
 
-      // FIXME: Bypass type lowering here, since lowering a generic superclass
-      // requirement triggers a crash when it's dependent on generic params
-      // (rdar://problem/24590570). Nominal class types are currently
-      // unaffected by type lowering (and are likely to remain so).
-      auto &superTI = IGM.getTypeInfoForLowered(super->getCanonicalType());
+      auto &superTI = IGM.getTypeInfoForUnlowered(super);
       reprTy = cast<llvm::PointerType>(superTI.StorageType);
     }
 

--- a/test/Generics/inheritance.swift
+++ b/test/Generics/inheritance.swift
@@ -42,10 +42,6 @@ func call_f0(a: A, b: B, other: Other) {
   f0(other, a, b) // expected-error{{cannot convert value of type 'Other' to expected argument type 'A'}}
 }
 
-// Declaration errors
-func f1<T : A where T : Other>(_: T) { } // expected-error{{generic parameter 'T' cannot be a subclass of both 'A' and 'Other'}}
-func f2<T : A where T : B>(_: T) { }
-
 class X<T> {
   func f() -> T {}
 }

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -1,0 +1,34 @@
+// RUN: %target-parse-verify-swift
+
+class A {
+  func foo() { }
+}
+
+class B : A {
+  func bar() { }
+}
+
+class Other { }
+
+func f1<T : A where T : Other>(_: T) { } // expected-error{{generic parameter 'T' cannot be a subclass of both 'A' and 'Other'}}
+func f2<T : A where T : B>(_: T) { }
+
+class GA<T> {}
+class GB<T> : GA<T> {}
+
+protocol P {}
+
+func f3<T, U where U : GA<T>>(_: T, _: U) {}
+func f4<T, U where U : GA<T>>(_: T, _: U) {}
+func f5<T, U : GA<T>>(_: T, _: U) {}
+func f6<U : GA<T>, T : P>(_: T, _: U) {}
+func f7<U, T where U : GA<T>, T : P>(_: T, _: U) {}
+
+func f8<T : GA<A> where T : GA<B>>(_: T) { } // expected-error{{generic parameter 'T' cannot be a subclass of both 'GA<A>' and 'GA<B>'}}
+
+func f9<T : GA<A> where T : GB<A>>(_: T) { }
+func f10<T : GB<A> where T : GA<A>>(_: T) { }
+
+func f11<T : GA<T>>(_: T) { } // expected-error{{superclass constraint 'GA<T>' is recursive}}
+func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'GA<U>' is recursive}}
+func f13<T : U, U : GA<T>>(_: T, _: U) { } // expected-error{{inheritance from non-protocol, non-class type 'U'}}

--- a/test/decl/protocol/req/class.swift
+++ b/test/decl/protocol/req/class.swift
@@ -7,8 +7,3 @@ protocol P2 : class, class { } // expected-error{{redundant 'class' requirement}
 protocol P3 : P2, class { } // expected-error{{'class' must come first in the requirement list}}{{15-15=class, }}{{17-24=}}
 
 struct X : class { } // expected-error{{'class' requirement only applies to protocols}} {{12-18=}}
-
-
-// rdar://problem/21268222
-class Foo<T>{}
-class Bar<T, U where U : Foo<T>>{} // expected-error{{superclass constraint 'Foo<T>' cannot depend on a type parameter}}

--- a/validation-test/compiler_crashers_fixed/00022-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00022-no-stacktrace.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -parse
+// RUN: %target-swift-frontend %s -parse
 
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)


### PR DESCRIPTION
@DougGregor, @jckarter Can you take a quick look?

This is NOT for Swift 2.2.
