### PR TITLE
Add --fast flag to utils/update-checkout

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -44,7 +44,7 @@ def update_working_copy(repo_path, branch):
         check_call(["git", "fetch"])
         check_call(["git", "rebase", "FETCH_HEAD"])
 
-def obtain_additional_swift_sources(with_ssh, branch, fast):
+def obtain_additional_swift_sources(with_ssh, branch, skip_history):
     additional_repos = {
         'llvm': 'apple/swift-llvm',
         'clang': 'apple/swift-clang',
@@ -65,7 +65,7 @@ def obtain_additional_swift_sources(with_ssh, branch, fast):
                     remote = "git@github.com:" + repo + '.git'
                 else:
                     remote = "https://github.com/" + repo + '.git'
-                if fast:
+                if skip_history:
                     check_call(['git', 'clone', '--depth', '1', remote, dir_name])
                 else:
                     check_call(['git', 'clone', remote, dir_name])
@@ -86,8 +86,8 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     parser.add_argument("--clone-with-ssh",
         help="Obtain Sources for Swift and Related Projects via SSH",
         action="store_true")
-    parser.add_argument("--fast",
-        help="Obtain Sources Fast",
+    parser.add_argument("--skip-history",
+        help="Skip histories when obtain sources",
         action="store_true")
     parser.add_argument("--branch",
         help="Obtain Sources for specific branch")
@@ -95,11 +95,11 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
 
     clone = args.clone
     clone_with_ssh = args.clone_with_ssh
-    clone_fast = args.fast
+    skip_history = args.skip_history
     branch = args.branch
 
     if clone or clone_with_ssh:
-        obtain_additional_swift_sources(clone_with_ssh, branch, clone_fast)
+        obtain_additional_swift_sources(clone_with_ssh, branch, skip_history)
         return 0
 
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "llbuild"), branch)

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -44,7 +44,7 @@ def update_working_copy(repo_path, branch):
         check_call(["git", "fetch"])
         check_call(["git", "rebase", "FETCH_HEAD"])
 
-def obtain_additional_swift_sources(with_ssh, branch):
+def obtain_additional_swift_sources(with_ssh, branch, fast):
     additional_repos = {
         'llvm': 'apple/swift-llvm',
         'clang': 'apple/swift-clang',
@@ -65,7 +65,10 @@ def obtain_additional_swift_sources(with_ssh, branch):
                     remote = "git@github.com:" + repo + '.git'
                 else:
                     remote = "https://github.com/" + repo + '.git'
-                check_call(['git', 'clone', remote, dir_name])
+                if fast:
+                    check_call(['git', 'clone', '--depth', '1', remote, dir_name])
+                else:
+                    check_call(['git', 'clone', remote, dir_name])
                 if branch:
                     src_path = SWIFT_SOURCE_ROOT + "/" + dir_name + "/" + ".git"
                     check_call(['git', '--git-dir', src_path, '--work-tree', os.path.join(SWIFT_SOURCE_ROOT, dir_name), 'checkout', branch])
@@ -83,16 +86,20 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
     parser.add_argument("--clone-with-ssh",
         help="Obtain Sources for Swift and Related Projects via SSH",
         action="store_true")
+    parser.add_argument("--fast",
+        help="Obtain Sources Fast",
+        action="store_true")
     parser.add_argument("--branch",
         help="Obtain Sources for specific branch")
     args = parser.parse_args()
 
     clone = args.clone
     clone_with_ssh = args.clone_with_ssh
+    clone_fast = args.fast
     branch = args.branch
 
     if clone or clone_with_ssh:
-        obtain_additional_swift_sources(clone_with_ssh, branch)
+        obtain_additional_swift_sources(clone_with_ssh, branch, clone_fast)
         return 0
 
     update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, "llbuild"), branch)


### PR DESCRIPTION
To build snapshots, it is not necessary to fetch all history.
`--clone --fast` flags make `utils/update-checkout` fetch latest revisions only.
