### PR TITLE
[Parser][SR-698][Qol] add diagnostic for trailing ',' in lists

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -659,11 +659,17 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
       RightLoc = Tok.getLoc();
       return Status;
     }
+    SourceLoc SepLoc = Tok.getLoc();
     if (consumeIf(SeparatorK)) {
-      if (AllowSepAfterLast && Tok.is(RightK))
+      if (Tok.is(RightK)) {
+        if (!AllowSepAfterLast) {
+          diagnose(Tok, diag::unexpected_separator,
+                   SeparatorK == tok::comma ? "," : ";")
+            .fixItRemove(SourceRange(SepLoc));
+        }
         break;
-      else
-        continue;
+      }
+      continue;
     }
     if (!OptionalSep) {
       // If we're in a comma-separated list and the next token starts a new

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -64,3 +64,5 @@ func f573(s Starfish,  // expected-error {{parameter requires an explicit type}}
           _ ss: Salmon) -> [Int] {}
 func g573() { f573(Starfish(), Salmon()) }
 
+func SR698(a: Int, b: Int) {}
+SR698(1, b: 2,) // expected-error {{unexpected ',' separator}}


### PR DESCRIPTION
```
f(a: Int, b: Int) {}
f(1, b: 2,) // this trailing comma now gets a proper diagnostic.
```

see https://bugs.swift.org/browse/SR-698
