### PR TITLE
use proper compilation marker in typelowering

### DIFF
--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1572,7 +1572,7 @@ getTypeLoweringForUncachedLoweredFunctionType(TypeKey key) {
   assert(isa<AnyFunctionType>(key.SubstType));
   assert(key.UncurryLevel == 0);
 
-#ifdef DEBUG
+#ifndef NDEBUG
   // Catch recursions.
   insert(key, nullptr);
 #endif
@@ -1600,7 +1600,7 @@ TypeConverter::getTypeLoweringForUncachedLoweredType(TypeKey key) {
   assert(!find(key) && "re-entrant or already cached");
   assert(isLoweredType(key.SubstType) && "didn't lower out l-value type?");
 
-#ifdef DEBUG
+#ifndef NDEBUG
   // Catch reentrancy bugs.
   insert(key, nullptr);
 #endif


### PR DESCRIPTION
As pointed out by @slavapestov, this is better.
