### PR TITLE
Add support for __gnuc_va_list to ClangImporter

### DIFF
--- a/lib/ClangImporter/MappedTypes.def
+++ b/lib/ClangImporter/MappedTypes.def
@@ -126,6 +126,7 @@ MAP_STDLIB_TYPE("u_int64_t", UnsignedInt, 64, "UInt64", false, DoNothing)
 // stdarg.h types.
 // FIXME: why does this not catch va_list on x86_64?
 MAP_STDLIB_TYPE("va_list", VaList, 0, "CVaListPointer", false, DoNothing)
+MAP_STDLIB_TYPE("__gnuc_va_list", VaList, 0, "CVaListPointer", false, DoNothing)
 
 // libkern/OSTypes.h types.
 MAP_STDLIB_TYPE("UInt", UnsignedInt, 32, "CUnsignedInt", false, DoNothing)

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -286,11 +286,11 @@ final public class VaListBuilder {
 
   func append(arg: CVarArgType) {
     // Write alignment padding if necessary.
-    // This is needed on architectures where the ABI alignment of some 
-    // supported vararg type is greater than the alignment of Int.
-    // FIXME: this implementation is not portable because
-    // alignof differs from the ABI alignment on some architectures
-#if os(watchOS) && arch(arm)   // FIXME: rdar://21203036 should be arch(armv7k)
+    // This is needed on architectures where the ABI alignment of some
+    // supported vararg type is greater than the alignment of Int, such
+    // as non-iOS ARM. Note that we can't use alignof because it
+    // differs from ABI alignment on some architectures.
+#if arch(arm) && !os(iOS)
     if let arg = arg as? _CVarArgAlignedType {
       let alignmentInWords = arg._cVarArgAlignment / sizeof(Int)
       let misalignmentInWords = count % alignmentInWords

--- a/test/1_stdlib/VarArgs.swift
+++ b/test/1_stdlib/VarArgs.swift
@@ -12,8 +12,8 @@ typealias CGFloat = Double
 #endif
 
 func my_printf(format: String, _ arguments: CVarArgType...) {
-  withVaList(arguments) {
-    vprintf(format, $0)
+  withVaList(arguments) { (vaList: CVaListPointer) in
+    vprintf(format, vaList)
   }
 }
 


### PR DESCRIPTION
The implementation of va_list is pretty inconsistent across platforms.  On linux-arm __gnuc_va_list is the type used.  This change adds that to ClangImporter.

The change to the test is optional, but it dramatically improves the error message printed to the console when the test fails.  

Finally, the change to the append method of VaListBuilder ensures proper alignment to AAPCS, which is expected by linux-arm as well as watchos-arm.

Related issue: https://github.com/SwiftAndroid/swift/issues/15#issuecomment-182967084 @jrose-apple 
