### PR TITLE
[stdlib] Fix a spate of typos.

### DIFF
--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -178,8 +178,9 @@ T : UnsignedIntegerType, U : _SignedIntegerType
 %   Self = self_ty.stdlib_name
 %   BuiltinName = self_ty.builtin_name
 %   OtherSelf = self_ty.get_opposite_signedness().stdlib_name
+%   Article = 'An' if bits == 8 else 'A'
 
-/// A ${bits}-bit ${'un' if sign == 'u' else ''}signed integer value
+/// ${Article} ${bits}-bit ${'un' if sign == 'u' else ''}signed integer value
 /// type.
 public struct ${Self}
    : ${'SignedIntegerType' if sign == 's' else 'UnsignedIntegerType'},

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1068,7 +1068,7 @@ public struct Dictionary<Key : Hashable, Value> :
     }
   }
 
-  /// Update the value stored in the dictionary for the given key, or, if they
+  /// Update the value stored in the dictionary for the given key, or, if the
   /// key does not exist, add a new key-value pair to the dictionary.
   ///
   /// Returns the value that was replaced, or `nil` if a new key-value pair

--- a/stdlib/public/core/IntegerArithmetic.swift.gyb
+++ b/stdlib/public/core/IntegerArithmetic.swift.gyb
@@ -16,9 +16,12 @@
 
 %{
 integerBinaryOps = [
-   (x[:-1], x[-1], x[:-1].capitalize(), 'a result') 
-    for x in 'add+ subtract- multiply* divide/'.split()
-] + [ ('remainder', '%', 'Divide', 'the remainder') ]
+  ('add', '+', 'Adds', 'the result'),
+  ('subtract', '-', 'Subtracts', 'the result'),
+  ('multiply', '*', 'Multiplies', 'the result'),
+  ('divide', '/', 'Divides', 'the result'),
+  ('remainder', '%', 'Divides', 'the remainder')
+]
 }%
 
 /// This protocol is an implementation detail of `IntegerArithmeticType`; do
@@ -61,7 +64,7 @@ public func ${op} <T : _IntegerArithmeticType>(lhs: T, rhs: T) -> T {
 }
 
 % if (op != '/') and (op != '%'):
-/// ${name} `lhs` and `rhs`, silently discarding any overflow.
+/// ${Action} `lhs` and `rhs`, silently discarding any overflow.
 @_transparent
 @warn_unused_result
 public func &${op} <T : _IntegerArithmeticType>(lhs: T, rhs: T) -> T {
@@ -69,7 +72,7 @@ public func &${op} <T : _IntegerArithmeticType>(lhs: T, rhs: T) -> T {
 }
 % end
 
-/// ${name} `lhs` and `rhs` and store the result in `lhs`, trapping in
+/// ${Action} `lhs` and `rhs` and stores ${result} in `lhs`, trapping in
 /// case of arithmetic overflow (except in -Ounchecked builds).
 @_transparent
 public func ${op}= <T : _IntegerArithmeticType>(inout lhs: T, rhs: T) {

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -51,13 +51,7 @@ public struct Mirror {
   /// `AncestorRepresentation`.  This setting has no effect on mirrors
   /// reflecting value type instances.
   public enum AncestorRepresentation {
-  /// Generate a default mirror for all ancestor classes.  This is the
-  /// default behavior.
-  ///
-  /// - Note: This option bypasses any implementation of `customMirror`
-  ///   that may be supplied by a `CustomReflectable` ancestor, so this
-  ///   is typically not the right option for a `customMirror`implementation 
-    
+
   /// Generate a default mirror for all ancestor classes.
   ///
   /// This case is the default.
@@ -698,10 +692,10 @@ extension PlaygroundQuickLook {
 /// `CustomPlaygroundQuickLookable` and return a custom
 /// `PlaygroundQuickLook`.
 public protocol CustomPlaygroundQuickLookable {
-  /// Return the `Mirror` for `self`.
+  /// Return the `PlaygroundQuickLook` for `self`.
   ///
-  /// - Note: If `Self` has value semantics, the `Mirror` should be
-  ///   unaffected by subsequent mutations of `self`.
+  /// - Note: If `Self` has value semantics, the `PlaygroundQuickLook` should
+  ///   be unaffected by subsequent mutations of `self`.
   @warn_unused_result
   func customPlaygroundQuickLook() -> PlaygroundQuickLook
 }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -66,10 +66,11 @@ public struct RangeGenerator<
 ///
 /// However, subscripting that range still works in a generic context:
 ///
-///     func brackets<Element : ForwardIndexType>(x: Range<Element>, i: Element) -> Element {
-///       return x[i] // Just forward to subscript
+///     func brackets<Element: ForwardIndexType>(x: Range<Element>, _ i: Element) -> Element {
+///         return x[i] // Just forward to subscript
 ///     }
-///     print(brackets(Range<Int>(start:-99, end:100), 0)) // prints 0
+///     print(brackets(Range<Int>(start: -99, end: 100), 0))
+///     // Prints "0"
 public struct Range<
   Element : ForwardIndexType
 > : Equatable, CollectionType,

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -24,12 +24,12 @@
 ///
 /// The pointer can be in one of the following states:
 ///
-/// - memory is not allocated (for example, pointer is null, or memory has
-///   been deallocated previously);
+/// - Memory is not allocated (for example, pointer is null, or memory has
+///   been deallocated previously).
 ///
-/// - memory is allocated, but value has not been initialized;
+/// - Memory is allocated, but value has not been initialized.
 ///
-/// - memory is allocated and value is initialized.
+/// - Memory is allocated and value is initialized.
 public struct ${Self}<Memory>
   : RandomAccessIndexType, Hashable,
     NilLiteralConvertible, _PointerType {


### PR DESCRIPTION
Fix bulleted list formatting in Unsafe(Mutable)Pointer.
Fix incorrect type mentions on CustomPlaygroundQuickLookable.
Use 'An' instead of 'A' before '8-bit (un)signed integer.
Fix error in Range sample code.
Fix typo in Dictionary.updateValue(_:forKey:) doc comment.
Remove extra documentation in Mirror.AncestorRepresentation.
Fix improper case for operators and methods in IntegerArithmeticType.
