### PR TITLE
[WIP][Parser][SR-711] Couple "expected declaration" Diagnose With A Note

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -240,27 +240,27 @@ public:
 
   /// If this DeclContext is a nominal type declaration or an
   /// extension thereof, return the nominal type declaration.
-  NominalTypeDecl *isNominalTypeOrNominalTypeExtensionContext() const;
+  NominalTypeDecl *getAsNominalTypeOrNominalTypeExtensionContext() const;
 
   /// If this DeclContext is a class, or an extension on a class, return the
   /// ClassDecl, otherwise return null.
-  ClassDecl *isClassOrClassExtensionContext() const;
+  ClassDecl *getAsClassOrClassExtensionContext() const;
 
   /// If this DeclContext is an enum, or an extension on an enum, return the
   /// EnumDecl, otherwise return null.
-  EnumDecl *isEnumOrEnumExtensionContext() const;
+  EnumDecl *getAsEnumOrEnumExtensionContext() const;
 
   /// If this DeclContext is a protocol, or an extension on a
   /// protocol, return the ProtocolDecl, otherwise return null.
-  ProtocolDecl *isProtocolOrProtocolExtensionContext() const;
+  ProtocolDecl *getAsProtocolOrProtocolExtensionContext() const;
 
   /// If this DeclContext is a protocol extension, return the extended protocol.
-  ProtocolDecl *isProtocolExtensionContext() const;
+  ProtocolDecl *getAsProtocolExtensionContext() const;
 
   /// \brief Retrieve the generic parameter 'Self' from a protocol or
   /// protocol extension.
   ///
-  /// Only valid if \c isProtocolOrProtocolExtensionContext().
+  /// Only valid if \c getAsProtocolOrProtocolExtensionContext().
   GenericTypeParamDecl *getProtocolSelf() const;
 
   /// getDeclaredTypeOfContext - For a type context, retrieves the declared

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -143,6 +143,11 @@ WARNING(lex_editor_placeholder_in_playground,none,
 // Declaration parsing diagnostics
 //------------------------------------------------------------------------------
 
+NOTE(note_in_decl_extension,none,
+     "in %select{declaration|extension}0 of '%1':", (bool, StringRef))
+
+NOTE(note_in_extension,none, "in extension:", ())
+
 ERROR(declaration_same_line_without_semi,none,
       "consecutive declarations on a line must be separated by ';'", ())
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2949,7 +2949,7 @@ public:
   CanType getLookupType() const { return LookupType; }
   ProtocolDecl *getLookupProtocol() const {
     return getMember().getDecl()->getDeclContext()
-             ->isProtocolOrProtocolExtensionContext();
+             ->getAsProtocolOrProtocolExtensionContext();
   }
   ProtocolConformanceRef getConformance() const { return Conformance; }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1952,7 +1952,8 @@ bool ASTContext::diagnoseUnintendedObjCMethodOverrides(SourceFile &sf) {
         continue;
     }
 
-    auto classDecl = method->getDeclContext()->isClassOrClassExtensionContext();
+    auto classDecl =
+      method->getDeclContext()->getAsClassOrClassExtensionContext();
     if (!classDecl)
       continue; // error-recovery path, only
 
@@ -2238,7 +2239,8 @@ bool ASTContext::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
   bool anyDiagnosed = false;
   for (const auto &unsatisfied : localReqs) {
     // Check whether there is a conflict here.
-    ClassDecl *classDecl = unsatisfied.first->isClassOrClassExtensionContext();
+    ClassDecl *classDecl =
+      unsatisfied.first->getAsClassOrClassExtensionContext();
     auto req = unsatisfied.second;
     auto selector = req->getObjCSelector();
     bool isInstanceMethod = req->isInstanceMember();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1219,7 +1219,7 @@ void PrintAST::printNominalDeclName(NominalTypeDecl *decl) {
       // For a protocol extension, print only the where clause; the
       // generic parameter list is implicit. For other nominal types,
       // print the generic parameters.
-      if (decl->isProtocolOrProtocolExtensionContext())
+      if (decl->getAsProtocolOrProtocolExtensionContext())
         printWhereClause(gp->getRequirements());
       else
         printGenericParams(gp);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1742,7 +1742,7 @@ struct ASTNodeBase {};
       } else {
         auto ext = cast<ExtensionDecl>(decl);
         conformingDC = ext;
-        nominal = ext->isNominalTypeOrNominalTypeExtensionContext();
+        nominal = ext->getAsNominalTypeOrNominalTypeExtensionContext();
       }
 
       auto proto = conformance->getProtocol();

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -1068,7 +1068,8 @@ bool ArchetypeBuilder::addAbstractTypeParamRequirements(
       // Mark all associatedtypes in this protocol as recursive (and error-type)
       // to avoid later crashes dealing with this invalid protocol in other
       // contexts.
-      auto containingProto = assocType->getDeclContext()->isProtocolOrProtocolExtensionContext();
+      auto containingProto =
+        assocType->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
       for (auto member : containingProto->getMembers())
         if (auto assocType = dyn_cast<AssociatedTypeDecl>(member))
           assocType->setIsRecursive();

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -789,7 +789,7 @@ ProtocolConformance *ConformanceLookupTable::getConformance(
     return nullptr;
 
   NominalTypeDecl *conformingNominal
-    = conformingDC->isNominalTypeOrNominalTypeExtensionContext();
+    = conformingDC->getAsNominalTypeOrNominalTypeExtensionContext();
 
   // Form the conformance.
   Type type = entry->getDeclContext()->getDeclaredTypeInContext();
@@ -843,7 +843,7 @@ void ConformanceLookupTable::registerProtocolConformance(
        ProtocolConformance *conformance) {
   auto protocol = conformance->getProtocol();
   auto dc = conformance->getDeclContext();
-  auto nominal = dc->isNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
 
   // If there is an entry to update, do so.
   auto &dcConformances = AllConformances[dc];

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1220,7 +1220,8 @@ bool AbstractStorageDecl::hasFixedLayout() const {
     return true;
 
   // If we're in a nominal type, just query the type.
-  auto nominal = getDeclContext()->isNominalTypeOrNominalTypeExtensionContext();
+  auto nominal =
+    getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
   if (nominal)
     return nominal->hasFixedLayout();
 
@@ -1521,7 +1522,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
 
   signature.Name = getFullName();
   signature.InProtocolExtension
-    = getDeclContext()->isProtocolExtensionContext();
+    = getDeclContext()->getAsProtocolExtensionContext();
 
   // Functions, initializers, and de-initializers include their
   // interface types in their signatures as well as whether they are
@@ -1633,7 +1634,7 @@ ArrayRef<ValueDecl *>
 ValueDecl::getSatisfiedProtocolRequirements(bool Sorted) const {
   // Dig out the nominal type.
   NominalTypeDecl *NTD =
-    getDeclContext()->isNominalTypeOrNominalTypeExtensionContext();
+    getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
   if (!NTD || isa<ProtocolDecl>(NTD))
     return {};
 
@@ -1893,7 +1894,8 @@ Type NominalTypeDecl::computeInterfaceType() const {
 
   // Figure out the interface type of the parent.
   Type parentType;
-  if (auto parent = getDeclContext()->isNominalTypeOrNominalTypeExtensionContext())
+  if (auto parent =
+    getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext())
     parentType = parent->getDeclaredInterfaceType();
 
   Type type;
@@ -2024,7 +2026,7 @@ SourceRange GenericTypeParamDecl::getSourceRange() const {
 bool GenericTypeParamDecl::isProtocolSelf() const {
   if (!isImplicit()) return false;
   auto dc = getDeclContext();
-  if (!dc->isProtocolOrProtocolExtensionContext()) return false;
+  if (!dc->getAsProtocolOrProtocolExtensionContext()) return false;
   return dc->getProtocolSelf() == this;
 }
 
@@ -3302,7 +3304,7 @@ static Type getSelfTypeForContext(DeclContext *dc) {
   // For a protocol or extension thereof, the type is 'Self'.
   // FIXME: Weird that we're producing an archetype for protocol Self,
   // but the declared type of the context in non-protocol cases.
-  if (dc->isProtocolOrProtocolExtensionContext()) {
+  if (dc->getAsProtocolOrProtocolExtensionContext()) {
     // In the parser, generic parameters won't be wired up yet, just give up on
     // producing a type.
     if (dc->getGenericParamsOfContext() == nullptr)
@@ -3971,7 +3973,7 @@ bool FuncDecl::isUnaryOperator() const {
     return false;
   
   unsigned opArgIndex
-    = getDeclContext()->isProtocolOrProtocolExtensionContext() ? 1 : 0;
+    = getDeclContext()->getAsProtocolOrProtocolExtensionContext() ? 1 : 0;
   
   auto *params = getParameterList(opArgIndex);
   return params->size() == 1 && !params->get(0)->isVariadic();
@@ -3982,7 +3984,7 @@ bool FuncDecl::isBinaryOperator() const {
     return false;
   
   unsigned opArgIndex
-    = getDeclContext()->isProtocolOrProtocolExtensionContext() ? 1 : 0;
+    = getDeclContext()->getAsProtocolOrProtocolExtensionContext() ? 1 : 0;
   
   auto *params = getParameterList(opArgIndex);
   return params->size() == 2 && !params->get(1)->isVariadic();
@@ -4084,7 +4086,7 @@ DynamicSelfType *FuncDecl::getDynamicSelfInterface() const {
 }
 
 bool FuncDecl::hasArchetypeSelf() const {
-  if (!getDeclContext()->isProtocolExtensionContext())
+  if (!getDeclContext()->getAsProtocolExtensionContext())
     return false;
 
   auto selfTy = getDeclContext()->getProtocolSelf()->getArchetype();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -39,7 +39,7 @@ ASTContext &DeclContext::getASTContext() const {
 }
 
 NominalTypeDecl *
-DeclContext::isNominalTypeOrNominalTypeExtensionContext() const {
+DeclContext::getAsNominalTypeOrNominalTypeExtensionContext() const {
   switch (getContextKind()) {
   case DeclContextKind::Module:
   case DeclContextKind::FileUnit:
@@ -73,31 +73,31 @@ DeclContext::isNominalTypeOrNominalTypeExtensionContext() const {
   }
 }
 
-ClassDecl *DeclContext::isClassOrClassExtensionContext() const {
+ClassDecl *DeclContext::getAsClassOrClassExtensionContext() const {
   return dyn_cast_or_null<ClassDecl>(
-           isNominalTypeOrNominalTypeExtensionContext());
+           getAsNominalTypeOrNominalTypeExtensionContext());
 }
 
-EnumDecl *DeclContext::isEnumOrEnumExtensionContext() const {
+EnumDecl *DeclContext::getAsEnumOrEnumExtensionContext() const {
   return dyn_cast_or_null<EnumDecl>(
-           isNominalTypeOrNominalTypeExtensionContext());
+           getAsNominalTypeOrNominalTypeExtensionContext());
 }
 
-ProtocolDecl *DeclContext::isProtocolOrProtocolExtensionContext() const {
+ProtocolDecl *DeclContext::getAsProtocolOrProtocolExtensionContext() const {
   return dyn_cast_or_null<ProtocolDecl>(
-           isNominalTypeOrNominalTypeExtensionContext());
+           getAsNominalTypeOrNominalTypeExtensionContext());
 }
 
-ProtocolDecl *DeclContext::isProtocolExtensionContext() const {
+ProtocolDecl *DeclContext::getAsProtocolExtensionContext() const {
   if (getContextKind() != DeclContextKind::ExtensionDecl)
     return nullptr;
 
   return dyn_cast_or_null<ProtocolDecl>(
-           isNominalTypeOrNominalTypeExtensionContext());
+           getAsNominalTypeOrNominalTypeExtensionContext());
 }
 
 GenericTypeParamDecl *DeclContext::getProtocolSelf() const {
-  assert(isProtocolOrProtocolExtensionContext() && "not a protocol");
+  assert(getAsProtocolOrProtocolExtensionContext() && "not a protocol");
   return getGenericParamsOfContext()->getParams().front();
 }
 
@@ -176,7 +176,7 @@ Type DeclContext::getDeclaredTypeInContext() const {
 
 Type DeclContext::getDeclaredInterfaceType() const {
   // FIXME: Need a sugar-preserving getExtendedInterfaceType for extensions
-  if (auto nominal = isNominalTypeOrNominalTypeExtensionContext())
+  if (auto nominal = getAsNominalTypeOrNominalTypeExtensionContext())
     return nominal->getDeclaredInterfaceType();
   return Type();
 }

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -175,7 +175,7 @@ static void doGlobalExtensionLookup(Type BaseType,
   // Look in each extension of this type.
   for (auto extension : nominal->getExtensions()) {
     bool validatedExtension = false;
-    if (TypeResolver && extension->isProtocolExtensionContext()) {
+    if (TypeResolver && extension->getAsProtocolExtensionContext()) {
       if (!TypeResolver->isProtocolExtensionUsable(
               const_cast<DeclContext *>(CurrDC), BaseType, extension)) {
         continue;
@@ -754,7 +754,7 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
         BaseDecl = AFD->getImplicitSelfDecl();
         DC = DC->getParent();
 
-        if (DC->isProtocolExtensionContext())
+        if (DC->getAsProtocolExtensionContext())
           ExtendedType = DC->getProtocolSelf()->getArchetype();
 
         if (auto *FD = dyn_cast<FuncDecl>(AFD))

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -666,7 +666,7 @@ DeclContext *BoundGenericType::getGenericParamContext(
   if (!gpContext)
     return getDecl();
 
-  assert(gpContext->isNominalTypeOrNominalTypeExtensionContext() == getDecl() &&
+  assert(gpContext->getAsNominalTypeOrNominalTypeExtensionContext() == getDecl() &&
          "not a valid context");
   return gpContext;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -225,11 +225,11 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
         // If one declaration is in a protocol or extension thereof and the
         // other is not, prefer the one that is not.
         if ((bool)firstDecl->getDeclContext()
-              ->isProtocolOrProtocolExtensionContext()
+              ->getAsProtocolOrProtocolExtensionContext()
               != (bool)secondDecl->getDeclContext()
-                   ->isProtocolOrProtocolExtensionContext()) {
+                   ->getAsProtocolOrProtocolExtensionContext()) {
           if (firstDecl->getDeclContext()
-                ->isProtocolOrProtocolExtensionContext()) {
+                ->getAsProtocolOrProtocolExtensionContext()) {
             shadowed.insert(firstDecl);
             break;
           } else {
@@ -433,7 +433,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           isCascadingUse = AFD->isCascadingContextForLookup(false);
 
         if (AFD->getExtensionType()) {
-          if (AFD->getDeclContext()->isProtocolOrProtocolExtensionContext()) {
+          if (AFD->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
             ExtendedType = AFD->getDeclContext()->getProtocolSelf()
                              ->getArchetype();
 
@@ -479,13 +479,13 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
         if (!isCascadingUse.hasValue())
           isCascadingUse = ACE->isCascadingContextForLookup(false);
       } else if (ExtensionDecl *ED = dyn_cast<ExtensionDecl>(DC)) {
-        if (ED->isProtocolOrProtocolExtensionContext()) {
+        if (ED->getAsProtocolOrProtocolExtensionContext()) {
           ExtendedType = ED->getProtocolSelf()->getArchetype();
         } else {
           ExtendedType = ED->getExtendedType();
         }
 
-        BaseDecl = ED->isNominalTypeOrNominalTypeExtensionContext();
+        BaseDecl = ED->getAsNominalTypeOrNominalTypeExtensionContext();
         MetaBaseDecl = BaseDecl;
         if (!isCascadingUse.hasValue())
           isCascadingUse = ED->isCascadingContextForLookup(false);

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -635,7 +635,7 @@ ArrayRef<ValueDecl *>
 NominalTypeDecl::getSatisfiedProtocolRequirementsForMember(
                                              const ValueDecl *member,
                                              bool sorted) const {
-  assert(member->getDeclContext()->isNominalTypeOrNominalTypeExtensionContext()
+  assert(member->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext()
            == this);
   assert(!isa<ProtocolDecl>(this));
   prepareConformanceTable();
@@ -654,7 +654,7 @@ DeclContext::getLocalProtocols(
   SmallVector<ProtocolDecl *, 2> result;
 
   // Dig out the nominal type.
-  NominalTypeDecl *nominal = isNominalTypeOrNominalTypeExtensionContext();
+  NominalTypeDecl *nominal = getAsNominalTypeOrNominalTypeExtensionContext();
   if (!nominal)
     return result;
 
@@ -687,7 +687,7 @@ DeclContext::getLocalConformances(
   SmallVector<ProtocolConformance *, 2> result;
 
   // Dig out the nominal type.
-  NominalTypeDecl *nominal = isNominalTypeOrNominalTypeExtensionContext();
+  NominalTypeDecl *nominal = getAsNominalTypeOrNominalTypeExtensionContext();
   if (!nominal)
     return result;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2411,7 +2411,7 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
 
   // If the member is part of a protocol or extension thereof, we need
   // to substitute in the type of Self.
-  if (dc->isProtocolOrProtocolExtensionContext()) {
+  if (dc->getAsProtocolOrProtocolExtensionContext()) {
     // We only substitute into archetypes for now for protocols.
     // FIXME: This seems like an odd restriction. Whatever is depending on
     // this, shouldn't.
@@ -2431,7 +2431,7 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
   LazyResolver *resolver = dc->getASTContext().getLazyResolver();
 
   // Find the superclass type with the context matching that of the member.
-  auto ownerNominal = dc->isNominalTypeOrNominalTypeExtensionContext();
+  auto ownerNominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
   while (!baseTy->is<ErrorType>() &&
          baseTy->getAnyNominal() &&
          baseTy->getAnyNominal() != ownerNominal) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2875,7 +2875,7 @@ namespace {
 
       // Must be a method within a class or extension thereof.
       auto classDecl =
-        method->getDeclContext()->isClassOrClassExtensionContext();
+        method->getDeclContext()->getAsClassOrClassExtensionContext();
       if (!classDecl) return false;
 
       // The class must not have a superclass.
@@ -3633,7 +3633,7 @@ namespace {
 
       // If we're in a protocol, the getter thunk will be polymorphic.
       Type interfaceType;
-      if (dc->isProtocolOrProtocolExtensionContext()) {
+      if (dc->getAsProtocolOrProtocolExtensionContext()) {
         std::tie(getterType, interfaceType)
           = getProtocolMethodType(dc, getterType->castTo<AnyFunctionType>());
       }
@@ -3698,7 +3698,7 @@ namespace {
       // If we're in a protocol or extension thereof, the setter thunk
       // will be polymorphic.
       Type interfaceType;
-      if (dc->isProtocolOrProtocolExtensionContext()) {
+      if (dc->getAsProtocolOrProtocolExtensionContext()) {
         std::tie(setterType, interfaceType)
           = getProtocolMethodType(dc, setterType->castTo<AnyFunctionType>());
       }
@@ -3772,7 +3772,7 @@ namespace {
     void recordObjCOverride(SubscriptDecl *subscript) {
       // Figure out the class in which this subscript occurs.
       auto classTy =
-        subscript->getDeclContext()->isClassOrClassExtensionContext();
+        subscript->getDeclContext()->getAsClassOrClassExtensionContext();
       if (!classTy)
         return;
 
@@ -3849,7 +3849,7 @@ namespace {
         // If the declaration we're starting from is in a class, first
         // look for a class member with the appropriate selector.
         if (auto classDecl
-              = decl->getDeclContext()->isClassOrClassExtensionContext()) {
+              = decl->getDeclContext()->getAsClassOrClassExtensionContext()) {
           auto swiftSel = Impl.importSelector(sel);
           for (auto found : classDecl->lookupDirect(swiftSel, true)) {
             if (auto foundFunc = dyn_cast<FuncDecl>(found))
@@ -3954,9 +3954,9 @@ namespace {
         // Are the getter and the setter in the same type.
         getterAndSetterInSameType =
           (getter->getDeclContext()
-             ->isNominalTypeOrNominalTypeExtensionContext()
+             ->getAsNominalTypeOrNominalTypeExtensionContext()
            == setter->getDeclContext()
-               ->isNominalTypeOrNominalTypeExtensionContext());
+               ->getAsNominalTypeOrNominalTypeExtensionContext());
 
         // Whether we can update the types involved in the subscript
         // operation.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -784,7 +784,7 @@ ParserResult<Pattern> Parser::parsePattern() {
   }
     
   case tok::code_complete:
-    if (!CurDeclContext->isNominalTypeOrNominalTypeExtensionContext()) {
+    if (!CurDeclContext->getAsNominalTypeOrNominalTypeExtensionContext()) {
       // This cannot be an overridden property, so just eat the token. We cannot
       // code complete anything here -- we expect an identifier.
       consumeToken(tok::code_complete);

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -43,7 +43,7 @@ swift::getMethodDispatch(AbstractFunctionDecl *method) {
 
   // Class extension methods are only dynamically dispatched if they're
   // dispatched by objc_msgSend, which happens if they're foreign or dynamic.
-  if (dc->isClassOrClassExtensionContext()) {
+  if (dc->getAsClassOrClassExtensionContext()) {
     if (method->hasClangNode())
       return MethodDispatch::Class;
     if (auto fd = dyn_cast<FuncDecl>(method)) {

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -281,7 +281,7 @@ static SILFunction::ClassVisibility_t getClassVisibility(SILDeclRef constant) {
   if (context->isExtensionContext())
     return SILFunction::NotRelevant;
 
-  auto *classType = context->isClassOrClassExtensionContext();
+  auto *classType = context->getAsClassOrClassExtensionContext();
   if (!classType || classType->isFinal())
     return SILFunction::NotRelevant;
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -524,7 +524,7 @@ public:
 
       // Look up the witness for the archetype.
       auto proto = Constant.getDecl()->getDeclContext()
-                                     ->isProtocolOrProtocolExtensionContext();
+                                     ->getAsProtocolOrProtocolExtensionContext();
       auto archetype = getWitnessMethodSelfType();
       // Get the openend existential value if the archetype is an opened
       // existential type.
@@ -1358,7 +1358,7 @@ public:
     // Determine whether we'll need to use an allocating constructor (vs. the
     // initializing constructor).
     auto nominal = ctorRef->getDecl()->getDeclContext()
-                     ->isNominalTypeOrNominalTypeExtensionContext();
+                     ->getAsNominalTypeOrNominalTypeExtensionContext();
     bool useAllocatingCtor;
     
     // Value types only have allocating initializers.
@@ -3910,7 +3910,7 @@ ArgumentSource SILGenFunction::prepareAccessorBaseArg(SILLocation loc,
       // a non-class protocol, this is innocuous.
 #ifndef NDEBUG
       auto isNonClassProtocolMember = [](Decl *d) {
-        auto p = d->getDeclContext()->isProtocolOrProtocolExtensionContext();
+        auto p = d->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
         return (p && !p->requiresClass());
       };
 #endif
@@ -4050,7 +4050,7 @@ emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
   WritebackScope writebackScope(*this);
 
   assert(!materializeForSet.getDecl()
-           ->getDeclContext()->isProtocolExtensionContext() &&
+           ->getDeclContext()->getAsProtocolExtensionContext() &&
          "direct use of materializeForSet from a protocol extension is"
          " probably a miscompile");
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -624,7 +624,7 @@ ManagedValue SILGenFunction::emitRValueForPropertyLoad(
     (void)baseMeta;
     assert(!baseMeta->is<BoundGenericType>() &&
            "generic static stored properties not implemented");
-    if (field->getDeclContext()->isClassOrClassExtensionContext() &&
+    if (field->getDeclContext()->getAsClassOrClassExtensionContext() &&
         field->hasStorage())
       // FIXME: don't need to check hasStorage, already done above
       assert(field->isFinal() && "non-final class stored properties not implemented");

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -665,7 +665,7 @@ static SILValue getNextUncurryLevelRef(SILGenFunction &gen,
     if (!cast<ArchetypeType>(thisType)->getOpenedExistentialType().isNull())
       OpenedExistential = thisArg;
     auto protocol =
-      next.getDecl()->getDeclContext()->isProtocolOrProtocolExtensionContext();
+      next.getDecl()->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
     auto conformance = ProtocolConformanceRef(protocol);
     return gen.B.createWitnessMethod(loc, thisType, conformance, next,
                                      constantInfo.getSILType(),

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -805,7 +805,7 @@ namespace {
           decl->getAttrs().hasAttribute<DynamicAttr>() ||
           !decl->getMaterializeForSetFunc() ||
           isa<StructDecl>(decl->getDeclContext()) ||
-          decl->getDeclContext()->isProtocolExtensionContext()) {
+          decl->getDeclContext()->getAsProtocolExtensionContext()) {
         return std::move(*this).LogicalPathComponent::getMaterialized(gen,
                                                         loc, base, accessKind);
       }

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -172,7 +172,7 @@ struct MaterializeForSetEmitter {
     // protocol context because IRGen won't know how to reconstruct
     // the type parameters.  (In principle, this can be done in the
     // callback storage if we need to.)
-    if (Witness->getDeclContext()->isProtocolOrProtocolExtensionContext())
+    if (Witness->getDeclContext()->getAsProtocolOrProtocolExtensionContext())
       return true;
 
     return false;

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -267,7 +267,7 @@ public:
   }
 
   void visitDestructorDecl(DestructorDecl *dd) {
-    if (dd->getParent()->isClassOrClassExtensionContext() == theClass) {
+    if (dd->getParent()->getAsClassOrClassExtensionContext() == theClass) {
       // Add the deallocating destructor to the vtable just for the purpose
       // that it is referenced and cannot be eliminated by dead function removal.
       // In reality, the deallocating destructor is referenced directly from
@@ -290,7 +290,7 @@ static void emitTypeMemberGlobalVariable(SILGenModule &SGM,
                                          NominalTypeDecl *theType,
                                          VarDecl *var) {
   assert(!generics && "generic static properties not implemented");
-  if (var->getDeclContext()->isClassOrClassExtensionContext()) {
+  if (var->getDeclContext()->getAsClassOrClassExtensionContext()) {
     assert(var->isFinal() && "only 'static' ('class final') stored properties are implemented in classes");
   }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -931,7 +931,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI) {
   auto *AFD = dyn_cast<AbstractFunctionDecl>(Callee->getDeclContext());
   if (!AFD)
     return nullptr;
-  auto *PD = AFD->getDeclContext()->isProtocolOrProtocolExtensionContext();
+  auto *PD = AFD->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
 
 
   // No need to propagate anything into the callee operand.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5450,7 +5450,7 @@ TypeChecker::diagnoseInvalidDynamicConstructorReferences(Expr *base,
       !base->isStaticallyDerivedMetatype() &&
       !ctorDecl->hasClangNode() &&
       !(ctorDecl->isRequired() ||
-        ctorDecl->getDeclContext()->isProtocolOrProtocolExtensionContext())) {
+        ctorDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext())) {
     if (SuppressDiagnostics)
       return false;
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -317,7 +317,7 @@ static Type addCurriedSelfType(ASTContext &ctx, Type type, DeclContext *dc) {
   if (!dc->isTypeContext())
     return type;
 
-  auto nominal = dc->isNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
   auto selfTy = nominal->getInterfaceType()->castTo<MetatypeType>()
                   ->getInstanceType();
   if (auto sig = nominal->getGenericSignatureOfContext())
@@ -424,13 +424,13 @@ static bool hasEmptyExistentialParameterMismatch(ValueDecl *decl1,
 static bool isProtocolExtensionAsSpecializedAs(TypeChecker &tc,
                                                DeclContext *dc1,
                                                DeclContext *dc2) {
-  assert(dc1->isProtocolExtensionContext());
-  assert(dc2->isProtocolExtensionContext());
+  assert(dc1->getAsProtocolExtensionContext());
+  assert(dc2->getAsProtocolExtensionContext());
 
   // If one of the protocols being extended inherits the other, prefer the
   // more specialized protocol.
-  auto proto1 = dc1->isProtocolExtensionContext();
-  auto proto2 = dc2->isProtocolExtensionContext();
+  auto proto1 = dc1->getAsProtocolExtensionContext();
+  auto proto2 = dc2->getAsProtocolExtensionContext();
   if (proto1 != proto2) {
     if (proto1->inheritsFrom(proto2))
       return true;
@@ -516,9 +516,9 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
 
       // Members of protocol extensions have special overloading rules.
       ProtocolDecl *inProtocolExtension1 = decl1->getDeclContext()
-                                             ->isProtocolExtensionContext();
+                                             ->getAsProtocolExtensionContext();
       ProtocolDecl *inProtocolExtension2 = decl2->getDeclContext()
-                                             ->isProtocolExtensionContext();
+                                             ->getAsProtocolExtensionContext();
       if (inProtocolExtension1 && inProtocolExtension2) {
         // Both members are in protocol extensions.
         // Determine whether the 'Self' type from the first protocol extension

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -333,7 +333,7 @@ static FuncDecl *createMaterializeForSetPrototype(AbstractStorageDecl *storage,
   // setter mutating if we're inside a protocol, because it seems some
   // things break otherwise -- the root cause should be fixed eventually.
   materializeForSet->setMutating(
-      setter->getDeclContext()->isProtocolOrProtocolExtensionContext() ||
+      setter->getDeclContext()->getAsProtocolOrProtocolExtensionContext() ||
       (!setter->getAttrs().hasAttribute<NonMutatingAttr>() &&
        !storage->isSetterNonMutating()));
 
@@ -702,7 +702,7 @@ static void maybeMarkTransparent(FuncDecl *accessor,
                                  AbstractStorageDecl *storage,
                                  TypeChecker &TC) {
   auto *nominal = storage->getDeclContext()
-      ->isNominalTypeOrNominalTypeExtensionContext();
+      ->getAsNominalTypeOrNominalTypeExtensionContext();
   if (nominal && nominal->hasFixedLayout())
     accessor->getAttrs().add(new (TC.Context) TransparentAttr(IsImplicit));
 }
@@ -846,7 +846,7 @@ void swift::addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
   // cases, we need to expose a materializeForSet.
   //
   // Global stored properties don't get a materializeForSet.
-  if (setter && DC->isNominalTypeOrNominalTypeExtensionContext()) {
+  if (setter && DC->getAsNominalTypeOrNominalTypeExtensionContext()) {
     FuncDecl *materializeForSet = addMaterializeForSet(storage, TC);
     synthesizeMaterializeForSet(materializeForSet, storage, TC);
     TC.typeCheckDecl(materializeForSet, false);
@@ -980,7 +980,7 @@ void swift::synthesizeObservingAccessors(VarDecl *VD, TypeChecker &TC) {
 
     // Make sure the didSet/willSet accessors are marked final if in a class.
     if (!willSet->isFinal() &&
-        VD->getDeclContext()->isClassOrClassExtensionContext())
+        VD->getDeclContext()->getAsClassOrClassExtensionContext())
       makeFinal(Ctx, willSet);
   }
   
@@ -1007,7 +1007,7 @@ void swift::synthesizeObservingAccessors(VarDecl *VD, TypeChecker &TC) {
 
     // Make sure the didSet/willSet accessors are marked final if in a class.
     if (!didSet->isFinal() &&
-        VD->getDeclContext()->isClassOrClassExtensionContext())
+        VD->getDeclContext()->getAsClassOrClassExtensionContext())
       makeFinal(Ctx, didSet);
   }
 
@@ -1232,7 +1232,7 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   // prevents it from being dynamically dispatched.  Note that we do this after
   // the accessors are set up, because we don't want the setter for the lazy
   // property to inherit these properties from the storage.
-  if (VD->getDeclContext()->isClassOrClassExtensionContext())
+  if (VD->getDeclContext()->getAsClassOrClassExtensionContext())
     makeFinal(Context, Storage);
   Storage->setImplicit();
   Storage->setAccessibility(Accessibility::Private);
@@ -1264,13 +1264,13 @@ void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
 
   // We only need materializeForSet in polymorphic contexts:
   NominalTypeDecl *container = storage->getDeclContext()
-      ->isNominalTypeOrNominalTypeExtensionContext();
+      ->getAsNominalTypeOrNominalTypeExtensionContext();
   if (!container) return;
 
   //   - in non-ObjC protocols, but not protocol extensions.
   if (auto protocol = dyn_cast<ProtocolDecl>(container)) {
     if (protocol->isObjC()) return;
-    if (storage->getDeclContext()->isProtocolExtensionContext()) return;
+    if (storage->getDeclContext()->getAsProtocolExtensionContext()) return;
 
   //   - in classes when the storage decl is not final and does
   //     not override a decl that requires a materializeForSet
@@ -1314,7 +1314,7 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
 
     auto *getter = createGetterPrototype(var, TC);
     // lazy getters are mutating on an enclosing value type.
-    if (!var->getDeclContext()->isClassOrClassExtensionContext())
+    if (!var->getDeclContext()->getAsClassOrClassExtensionContext())
       getter->setMutating();
     getter->setAccessibility(var->getFormalAccess());
 
@@ -1336,7 +1336,7 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
   if (var->isImplicit())
     return;
 
-  auto nominal = var->getDeclContext()->isNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = var->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
   if (!nominal) {
     // Fixed-layout global variables don't get accessors.
     if (var->hasFixedLayout())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -925,9 +925,9 @@ void ConstraintSystem::openGeneric(
       // Determine whether this is the protocol 'Self' constraint we should
       // skip.
       if (skipProtocolSelfConstraint &&
-          (proto->getDecl() == dc->isProtocolOrProtocolExtensionContext() ||
+          (proto->getDecl() == dc->getAsProtocolOrProtocolExtensionContext() ||
            proto->getDecl()
-             == dc->getParent()->isProtocolOrProtocolExtensionContext())&&
+             == dc->getParent()->getAsProtocolOrProtocolExtensionContext())&&
           isProtocolSelfType(req.getFirstType())) {
         break;
       }
@@ -1109,7 +1109,7 @@ ConstraintSystem::getTypeOfMemberReference(
 
       // Determine the object type of 'self'.
       auto nominal = value->getDeclContext()
-          ->isNominalTypeOrNominalTypeExtensionContext();
+          ->getAsNominalTypeOrNominalTypeExtensionContext();
       
       // We want to track if the generic context is represented by a
       // class-bound existential so we won't inappropriately wrap the
@@ -1119,7 +1119,7 @@ ConstraintSystem::getTypeOfMemberReference(
                                             isClassExistentialType();
       }
       
-      if (dc->isProtocolOrProtocolExtensionContext()) {
+      if (dc->getAsProtocolOrProtocolExtensionContext()) {
         // Retrieve the type variable for 'Self'.
         selfTy = replacements[dc->getProtocolSelf()->getDeclaredType()
                                 ->getCanonicalType()];
@@ -1187,7 +1187,7 @@ ConstraintSystem::getTypeOfMemberReference(
   // Constrain the 'self' object type.
   auto openedFnType = openedType->castTo<FunctionType>();
   Type selfObjTy = openedFnType->getInput()->getRValueInstanceType();
-  if (value->getDeclContext()->isProtocolOrProtocolExtensionContext()) {
+  if (value->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
     // For a protocol, substitute the base object directly. We don't need a
     // conformance constraint because we wouldn't have found the declaration
     // if it didn't conform.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -302,7 +302,7 @@ deriveBodyHashable_enum_hashValue(AbstractFunctionDecl *hashValueDecl) {
   auto parentDC = hashValueDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto enumDecl = parentDC->isEnumOrEnumExtensionContext();
+  auto enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
   SmallVector<ASTNode, 3> statements;
   auto selfDecl = hashValueDecl->getImplicitSelfDecl();
 

--- a/lib/Sema/DerivedConformanceErrorType.cpp
+++ b/lib/Sema/DerivedConformanceErrorType.cpp
@@ -46,7 +46,7 @@ static void deriveBodyErrorType_enum_code(AbstractFunctionDecl *codeDecl) {
   auto parentDC = codeDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto enumDecl = parentDC->isEnumOrEnumExtensionContext();
+  auto enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
   Type enumType = parentDC->getDeclaredTypeInContext();
 
   SmallVector<CaseStmt*, 4> cases;

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -78,7 +78,7 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
   auto parentDC = toRawDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto enumDecl = parentDC->isEnumOrEnumExtensionContext();
+  auto enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
 
   Type rawTy = enumDecl->getRawType();
   assert(rawTy);
@@ -173,7 +173,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
   auto parentDC = initDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto nominalTypeDecl = parentDC->isNominalTypeOrNominalTypeExtensionContext();
+  auto nominalTypeDecl = parentDC->getAsNominalTypeOrNominalTypeExtensionContext();
   auto enumDecl = cast<EnumDecl>(nominalTypeDecl);
 
   Type rawTy = enumDecl->getRawType();

--- a/lib/Sema/ITCNameLookup.cpp
+++ b/lib/Sema/ITCNameLookup.cpp
@@ -51,7 +51,7 @@ bool IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(
   case DeclContextKind::ExtensionDecl: {
     auto ext = cast<ExtensionDecl>(dc);
     // FIXME: bind the extension. We currently assume this is done.
-    nominal = ext->isNominalTypeOrNominalTypeExtensionContext();
+    nominal = ext->getAsNominalTypeOrNominalTypeExtensionContext();
     if (!nominal) return true;
     break;
   }
@@ -88,7 +88,7 @@ bool IterativeTypeChecker::isQualifiedLookupInDeclContextSatisfied(
 void IterativeTypeChecker::processQualifiedLookupInDeclContext(
        TypeCheckRequest::DeclContextLookupPayloadType payload,
        UnsatisfiedDependency unsatisfiedDependency) {
-  auto nominal = payload.DC->isNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = payload.DC->getAsNominalTypeOrNominalTypeExtensionContext();
   assert(nominal && "Only nominal types are handled here");
 
   // For classes, we need the superclass (if any) to support qualified lookup.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -517,7 +517,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       const auto *VD = cast<ValueDecl>(D);
       const TypeDecl *declParent =
-          VD->getDeclContext()->isNominalTypeOrNominalTypeExtensionContext();
+          VD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
       if (!declParent) {
         assert(VD->getDeclContext()->isModuleScopeContext());
         declParent = VD->getDeclContext()->getParentModule();
@@ -1918,7 +1918,7 @@ class ObjCSelectorWalker : public ASTWalker {
 
     // Look for members with the given name.
     auto nominal =
-      method->getDeclContext()->isNominalTypeOrNominalTypeExtensionContext();
+      method->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
     auto result = TC.lookupMember(const_cast<DeclContext *>(DC),
                                   nominal->getInterfaceType(), lookupName,
                                   (defaultMemberLookupOptions |
@@ -2107,11 +2107,11 @@ public:
 
       // If this method is within a protocol...
       if (auto proto =
-            method->getDeclContext()->isProtocolOrProtocolExtensionContext()) {
+            method->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
         // If the best so far is not from a protocol, or is from a
         // protocol that inherits this protocol, we have a new best.
         auto bestProto = bestMethod->getDeclContext()
-          ->isProtocolOrProtocolExtensionContext();
+          ->getAsProtocolOrProtocolExtensionContext();
         if (!bestProto || bestProto->inheritsFrom(proto))
           bestMethod = method;
         continue;
@@ -2119,11 +2119,11 @@ public:
 
       // This method is from a class.
       auto classDecl =
-        method->getDeclContext()->isClassOrClassExtensionContext();
+        method->getDeclContext()->getAsClassOrClassExtensionContext();
 
       // If the best method was from a protocol, keep it.
       auto bestClassDecl =
-        bestMethod->getDeclContext()->isClassOrClassExtensionContext();
+        bestMethod->getDeclContext()->getAsClassOrClassExtensionContext();
       if (!bestClassDecl) continue;
 
       // If the best method was from a subclass of the place where
@@ -2148,7 +2148,7 @@ public:
       {
         llvm::raw_svector_ostream out(replacement);
         auto nominal = bestMethod->getDeclContext()
-                         ->isNominalTypeOrNominalTypeExtensionContext();
+                         ->getAsNominalTypeOrNominalTypeExtensionContext();
         auto name = bestMethod->getFullName();
         out << "#selector(" << nominal->getName().str() << "."
             << name.getBaseName().str();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -532,7 +532,7 @@ bool TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   } else if (auto ctor = dyn_cast<ConstructorDecl>(func)) {
     // FIXME: shouldn't this just be
     // ctor->getDeclContext()->getDeclaredInterfaceType()?
-    if (ctor->getDeclContext()->isProtocolOrProtocolExtensionContext()) {
+    if (ctor->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
       funcTy = ctor->getDeclContext()->getProtocolSelf()->getDeclaredType();
     } else {
       funcTy = ctor->getExtensionType()->getAnyNominal()

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -112,7 +112,7 @@ namespace {
         conformanceOptions |= ConformanceCheckFlags::InExpression;
 
       DeclContext *foundDC = found->getDeclContext();
-      auto foundProto = foundDC->isProtocolOrProtocolExtensionContext();
+      auto foundProto = foundDC->getAsProtocolOrProtocolExtensionContext();
 
       // Determine the nominal type through which we found the
       // declaration.
@@ -124,7 +124,7 @@ namespace {
         if (isa<AbstractFunctionDecl>(baseDC))
           baseDC = baseDC->getParent();
 
-        baseNominal = baseDC->isNominalTypeOrNominalTypeExtensionContext();
+        baseNominal = baseDC->getAsNominalTypeOrNominalTypeExtensionContext();
         assert(baseNominal && "Did not find nominal type");
       } else {
         baseNominal = cast<NominalTypeDecl>(base);
@@ -217,7 +217,7 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclName name,
     } else {
       auto baseNominal = cast<NominalTypeDecl>(found.getBaseDecl());
       for (auto currentDC = dc; currentDC; currentDC = currentDC->getParent()) {
-        if (currentDC->isNominalTypeOrNominalTypeExtensionContext()
+        if (currentDC->getAsNominalTypeOrNominalTypeExtensionContext()
               == baseNominal) {
           foundInType = currentDC->getDeclaredTypeInContext();
         }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1744,7 +1744,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     }
     
     // Inject the typealias into the nominal decl that conforms to the protocol.
-    if (auto nominal = DC->isNominalTypeOrNominalTypeExtensionContext()) {
+    if (auto nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext()) {
       TC.computeAccessibility(nominal);
       aliasDecl->setAccessibility(nominal->getFormalAccess());
       if (nominal == DC) {
@@ -2041,7 +2041,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     }
 
     if (auto *ext = dyn_cast<ExtensionDecl>(match.Witness->getDeclContext()))
-      if (!ext->isConstrainedExtension() && ext->isProtocolExtensionContext())
+      if (!ext->isConstrainedExtension() && ext->getAsProtocolExtensionContext())
         anyFromUnconstrainedExtension = true;
 
     matches.push_back(std::move(match));
@@ -3189,10 +3189,10 @@ void ConformanceChecker::resolveTypeWitnesses() {
 
       // Record this value witness, popping it when we exit the current scope.
       valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
-      if (witnessReq.Witness->getDeclContext()->isProtocolExtensionContext())
+      if (witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
         ++numValueWitnessesInProtocolExtensions;
       defer {
-        if (witnessReq.Witness->getDeclContext()->isProtocolExtensionContext())
+        if (witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
           --numValueWitnessesInProtocolExtensions;
         valueWitnesses.pop_back();
       };
@@ -4130,7 +4130,7 @@ bool TypeChecker::isProtocolExtensionUsable(DeclContext *dc, Type type,
                                             ExtensionDecl *protocolExtension) {
   using namespace constraints;
 
-  assert(protocolExtension->isProtocolExtensionContext() &&
+  assert(protocolExtension->getAsProtocolExtensionContext() &&
          "Only intended for protocol extensions");
 
   resolveExtension(protocolExtension);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -247,7 +247,7 @@ Type TypeChecker::resolveTypeInContext(
   // type.
   auto ownerDC = typeDecl->getDeclContext();
   bool nonTypeOwner = !ownerDC->isTypeContext();
-  auto ownerNominal = ownerDC->isNominalTypeOrNominalTypeExtensionContext();
+  auto ownerNominal = ownerDC->getAsNominalTypeOrNominalTypeExtensionContext();
   auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl);
   DeclContext *typeParent = nullptr;
   assert((ownerNominal || nonTypeOwner) &&
@@ -260,7 +260,7 @@ Type TypeChecker::resolveTypeInContext(
     // a generic type with no generic arguments or a non-generic type, use the
     // type within the context.
     if (nominalType) {
-      if (parentDC->isNominalTypeOrNominalTypeExtensionContext() == nominalType)
+      if (parentDC->getAsNominalTypeOrNominalTypeExtensionContext() == nominalType)
         return resolver->resolveTypeOfContext(parentDC);
       if (!parentDC->isModuleScopeContext() && !isa<TopLevelCodeDecl>(parentDC))
         continue;
@@ -286,7 +286,7 @@ Type TypeChecker::resolveTypeInContext(
     // reference to this associated type is our own `Self`. If we can't resolve
     // the associated type during this iteration, try again on the next.
     if (assocType) {
-      if (auto proto = parentDC->isProtocolOrProtocolExtensionContext()) {
+      if (auto proto = parentDC->getAsProtocolOrProtocolExtensionContext()) {
         auto assocProto = assocType->getProtocol();
         if (proto == assocProto || proto->inheritsFrom(assocProto)) {
           // If the associated type is from our own protocol or we inherit from
@@ -342,7 +342,7 @@ Type TypeChecker::resolveTypeInContext(
       if (fromType->getAnyNominal() == ownerNominal) {
         // If we are referring into a protocol or extension thereof,
         // the base type is the 'Self'.
-        if (ownerDC->isProtocolOrProtocolExtensionContext()) {
+        if (ownerDC->getAsProtocolOrProtocolExtensionContext()) {
           auto selfTy = ownerDC->getProtocolSelf()->getDeclaredType()
                           ->castTo<GenericTypeParamType>();
           fromType = resolver->resolveGenericTypeParamType(selfTy);
@@ -374,7 +374,7 @@ Type TypeChecker::resolveTypeInContext(
   // Substitute in the appropriate type for 'Self'.
   // FIXME: We shouldn't have to guess here; the caller should tell us.
   Type fromType;
-  if (typeParent->isProtocolOrProtocolExtensionContext())
+  if (typeParent->getAsProtocolOrProtocolExtensionContext())
     fromType = typeParent->getProtocolSelf()->getArchetype();
   else
     fromType = resolver->resolveTypeOfContext(typeParent);
@@ -568,7 +568,7 @@ static NominalTypeDecl *getEnclosingNominalContext(DeclContext *dc) {
   while (dc->isLocalContext())
     dc = dc->getParent();
 
-  if (auto nominal = dc->isNominalTypeOrNominalTypeExtensionContext())
+  if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
     return nominal;
 
   return nullptr;
@@ -756,7 +756,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
                                                   comp->getIdLoc() })))
         return nullptr;
 
-      auto nominal = DC->isNominalTypeOrNominalTypeExtensionContext();
+      auto nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
       SmallVector<ValueDecl *, 4> decls;
       if (DC->lookupQualified(nominal->getDeclaredInterfaceType(),
                               comp->getIdentifier(),

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -572,7 +572,7 @@ NormalProtocolConformance *ModuleFile::readNormalConformance(
   uint64_t offset = conformanceEntry;
   conformanceEntry = conformance;
 
-  dc->isNominalTypeOrNominalTypeExtensionContext()
+  dc->getAsNominalTypeOrNominalTypeExtensionContext()
     ->registerProtocolConformance(conformance);
 
 
@@ -989,8 +989,8 @@ static void filterValues(Type expectedTy, Module *expectedModule,
     // filter by whether we expect to find something in a protocol extension or
     // not. This lets us distinguish between a protocol member and a protocol
     // extension member that have the same type.
-    if (value->getDeclContext()->isProtocolOrProtocolExtensionContext() &&
-        (bool)value->getDeclContext()->isProtocolExtensionContext()
+    if (value->getDeclContext()->getAsProtocolOrProtocolExtensionContext() &&
+        (bool)value->getDeclContext()->getAsProtocolExtensionContext()
           != inProtocolExt)
       return true;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1383,7 +1383,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     Type ty = SD->getInterfaceType()->getCanonicalType();
 
     abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
-    bool isProtocolExt = SD->getDeclContext()->isProtocolExtensionContext();
+    bool isProtocolExt = SD->getDeclContext()->getAsProtocolExtensionContext();
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addIdentifierRef(SD->getName()),
@@ -1398,7 +1398,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
 
         Type ty = storage->getInterfaceType()->getCanonicalType();
         auto nameID = addIdentifierRef(storage->getName());
-        bool isProtocolExt = fn->getDeclContext()->isProtocolExtensionContext();
+        bool isProtocolExt = fn->getDeclContext()->getAsProtocolExtensionContext();
         abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
         XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                              addTypeRef(ty), nameID,
@@ -1426,13 +1426,13 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
       abbrCode = DeclTypeAbbrCodes[XRefInitializerPathPieceLayout::Code];
       XRefInitializerPathPieceLayout::emitRecord(
         Out, ScratchRecord, abbrCode, addTypeRef(ty),
-        (bool)ctor->getDeclContext()->isProtocolExtensionContext(),
+        (bool)ctor->getDeclContext()->getAsProtocolExtensionContext(),
         getStableCtorInitializerKind(ctor->getInitKind()));
       break;
     }
 
     abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
-    bool isProtocolExt = fn->getDeclContext()->isProtocolExtensionContext();
+    bool isProtocolExt = fn->getDeclContext()->getAsProtocolExtensionContext();
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addIdentifierRef(fn->getName()),
@@ -1500,7 +1500,7 @@ void Serializer::writeCrossReference(const Decl *D) {
 
   auto val = cast<ValueDecl>(D);
   auto ty = val->getInterfaceType()->getCanonicalType();
-  bool isProtocolExt = D->getDeclContext()->isProtocolExtensionContext();
+  bool isProtocolExt = D->getDeclContext()->getAsProtocolExtensionContext();
   abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
   XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                        addTypeRef(ty),

--- a/test/BuildConfigurations/decl_parse_errors.swift
+++ b/test/BuildConfigurations/decl_parse_errors.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift
 
-class C {
+class C { // expected-note 3 {{in declaration of 'C':}}
 
 #if os(iOS)
 	func foo() {}

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -112,7 +112,7 @@ enum Recovery2 {
 enum Recovery3 {
   case UE2(): // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
-enum Recovery4 {
+enum Recovery4 { // expected-note {{in declaration of 'Recovery4':}}
   case Self Self // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{12-12=;}} expected-error {{expected declaration}}
 }
 enum Recovery5 {

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -21,7 +21,7 @@ x
 x x // expected-error{{consecutive statements}} {{2-2=;}}
 
 // rdar://19582475
-public struct S {
+public struct S { // expected-note{{in declaration of 'S':}}
 // expected-error@+1{{expected declaration}}
 / ###line 25 "line-directive.swift"
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -354,7 +354,7 @@ struct ErrorTypeInVarDeclFunctionType1 {
   var v2 : Int
 }
 
-struct ErrorTypeInVarDeclArrayType1 {
+struct ErrorTypeInVarDeclArrayType1 { // expected-note{{in declaration of 'ErrorTypeInVarDeclArrayType1':}}
   var v1 : Int[+] // expected-error {{expected declaration}} expected-error {{consecutive declarations on a line must be separated by ';'}}
   // expected-error @-1 {{expected expression after unary operator}}
   // expected-error @-2 {{expected expression}}
@@ -409,7 +409,7 @@ struct ErrorInFunctionSignatureResultArrayType5 {
 }
 
 
-struct ErrorInFunctionSignatureResultArrayType11 {
+struct ErrorInFunctionSignatureResultArrayType11 { // expected-note{{in declaration of 'ErrorInFunctionSignatureResultArrayType11':}}
   func foo() -> Int[(a){a++}] { // expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error {{expected ']' in array type}} expected-note {{to match this opening '['}} expected-error {{use of unresolved identifier 'a'}} expected-error {{expected declaration}}
   }
 }
@@ -448,7 +448,7 @@ class ExprSuper2 {
 
 //===--- Recovery for braces inside a nominal decl.
 
-struct BracesInsideNominalDecl1 {
+struct BracesInsideNominalDecl1 { // expected-note{{in declaration of 'BracesInsideNominalDecl1':}}
   { // expected-error {{expected declaration}}
     aaa
   }
@@ -461,7 +461,7 @@ func use_BracesInsideNominalDecl1() {
 
 //===--- Recovery for wrong decl introducer keyword.
 
-class WrongDeclIntroducerKeyword1 {
+class WrongDeclIntroducerKeyword1 { // expected-note{{in declaration of 'WrongDeclIntroducerKeyword1':}}
   notAKeyword() {} // expected-error {{expected declaration}}
   func foo() {}
   class func bar() {}

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -71,10 +71,10 @@ struct Y1 {
 
 // Parsing errors
 // FIXME: Recovery here is horrible
-struct A0 {
+struct A0 { // expected-note{{in declaration of 'A0'}}
   subscript // expected-error{{expected '(' for subscript parameters}}
     i : Int // expected-error{{expected declaration}}
-     -> Int { 
+     -> Int {
     get {
       return stored
     }
@@ -84,7 +84,7 @@ struct A0 {
   }
 }
 
-struct A1 {
+struct A1 { // expected-note{{in declaration of 'A1'}}
   subscript (i : Int) // expected-error{{expected '->' for subscript element type}}
      Int {  // expected-error{{expected declaration}}
     get {
@@ -96,7 +96,7 @@ struct A1 {
   }
 }
 
-struct A2 {
+struct A2 { // expected-note{{in declaration of 'A2'}}
   subscript (i : Int) -> // expected-error{{expected subscripting element type}}
      {  // expected-error{{expected declaration}}
     get {
@@ -108,7 +108,7 @@ struct A2 {
   }
 }
 
-struct A3 {
+struct A3 { // expected-note{{in declaration of 'A3'}}
   subscript(i : Int) // expected-error {{expected '->' for subscript element type}}
   { // expected-error {{expected declaration}}
     get {
@@ -117,7 +117,7 @@ struct A3 {
   }
 }
 
-struct A4 {
+struct A4 { // expected-note{{in declaration of 'A4'}}
   subscript(i : Int) { // expected-error {{expected '->' for subscript element type}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{21-21=;}} expected-error {{expected declaration}}
     get {
       return i
@@ -129,7 +129,7 @@ struct A5 {
   subscript(i : Int) -> Int // expected-error {{expected '{' in subscript to specify getter and setter implementation}}
 }
 
-struct A6 {
+struct A6 { // expected-note{{in declaration of 'A6'}}
   subscript(i: Int)(j: Int) -> Int { // expected-error {{expected '->' for subscript element type}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{20-20=;}} expected-error {{expected declaration}}
     get {
       return i + j
@@ -153,7 +153,7 @@ struct A7b {
   }
 }
 
-struct A8 {
+struct A8 { // expected-note{{in declaration of 'A8'}}
   subscript(i : Int) -> Int // expected-error{{expected '{' in subscript to specify getter and setter implementation}}
     get { // expected-error{{expected declaration}}
       return stored

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -435,7 +435,7 @@ struct StructWithDelegatingInit {
 func test_recovery_missing_name_2(let: Int) {} // expected-error 2{{expected ',' separator}} {{38-38=,}} expected-error 2 {{expected parameter name followed by ':'}}
 
 // <rdar://problem/16792027> compiler infinite loops on a really really mutating function
-struct F {
+struct F { // expected-note 2 {{in declaration of 'F':}}
   mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error 2 {{expected declaration}}
   }
   

--- a/test/SourceKit/SourceDocInfo/rdar_18677108-2.swift.response
+++ b/test/SourceKit/SourceDocInfo/rdar_18677108-2.swift.response
@@ -51,6 +51,13 @@
         key.filepath: rdar_18677108-2-a.swift,
         key.severity: source.diagnostic.severity.note,
         key.description: "to match this opening '{'"
+      },
+      {
+        key.line: 1,
+        key.column: 7,
+        key.filepath: rdar_18677108-2-a.swift,
+        key.severity: source.diagnostic.severity.note,
+        key.description: "in declaration of 'CameraController':"
       }
     ]
   },

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift.response
@@ -65,7 +65,16 @@
       key.filepath: syntaxmap-edit-del.swift,
       key.severity: source.diagnostic.severity.error,
       key.description: "unexpected end of block comment",
-      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+      key.diagnostics: [
+        {
+          key.line: 2,
+          key.column: 8,
+          key.filepath: syntaxmap-edit-del.swift,
+          key.severity: source.diagnostic.severity.note,
+          key.description: "in declaration of 'Foo':"
+        }
+      ]
     },
     {
       key.line: 4,

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -2,7 +2,7 @@
 //
 // REQUIRES: objc_interop
 
-class MixedKeywordsAndAttributes {
+class MixedKeywordsAndAttributes { // expected-note{{in declaration of 'MixedKeywordsAndAttributes':}}
   // expected-error@+1 {{expected declaration}} expected-error@+1 {{consecutive declarations on a line must be separated by ';'}} {{11-11=;}}
   override @objc func f1() {}
 }

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -3,7 +3,7 @@
 @override // expected-error {{'override' can only be specified on class members}} {{1-11=}} expected-error {{'override' is a declaration modifier, not an attribute}} {{1-2=}}
 func virtualAttributeCanNotBeUsedInSource() {}
 
-class MixedKeywordsAndAttributes {
+class MixedKeywordsAndAttributes { // expected-note {{in declaration of 'MixedKeywordsAndAttributes':}}
   // expected-error@+1 {{expected declaration}} expected-error@+1 {{consecutive declarations on a line must be separated by ';'}} {{11-11=;}}
   override @inline(never) func f1() {}
 }

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -246,7 +246,7 @@ protocol ProtosEvilTwin {
 extension ProtoAdopter : ProtosEvilTwin {}
 
 // rdar://18990358
-public struct Foo {
+public struct Foo { // expected-note {{in declaration of 'Foo':}}
   public static let S { a // expected-error{{computed property must have an explicit type}}
     // expected-error@-1{{type annotation missing in pattern}}
     // expected-error@-2{{'let' declarations cannot be computed properties}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -61,7 +61,7 @@ static Type findBaseTypeForReplacingArchetype(const ValueDecl *VD, const Type Ty
 
   // Find the nominal type decl related to VD.
   NominalTypeDecl *NTD = VD->getDeclContext()->
-    isNominalTypeOrNominalTypeExtensionContext();
+    getAsNominalTypeOrNominalTypeExtensionContext();
   if (!NTD)
     return Type();
   Type Result;

--- a/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
+++ b/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
@@ -4,6 +4,6 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol c : b { // expected-error {{use of undeclared type 'b'}}
+protocol c : b { // expected-error {{use of undeclared type 'b'}} expected-note {{in declaration of 'c':}}
 	func b // expected-error {{expected '(' in argument list of function declaration}}
 // expected-error@+1 {{expected declaration}}


### PR DESCRIPTION
As reported in [SR-711](https://bugs.swift.org/browse/SR-711), when an (unexpected) statement appears in a type declaration, we note the beginning of the declaration in addiction to the existing diagnostic.
