### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::assignFixedType(…)

### DIFF
--- a/validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+{println(""""?struct{


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/ConstraintGraph.cpp:207: void swift::constraints::ConstraintGraphNode::addFixedBinding(swift::TypeVariableType *): Assertion `!adjacency.FixedBinding && "Already marked as a fixed binding?"' failed.
9  swift           0x0000000000e5e66e swift::constraints::ConstraintSystem::assignFixedType(swift::TypeVariableType*, swift::Type, bool) + 382
10 swift           0x0000000000eb9c3e swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 4318
11 swift           0x0000000000ebc2cc swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 14188
12 swift           0x0000000000ebf8f2 swift::constraints::ConstraintSystem::simplifyFixConstraint(swift::constraints::Fix, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 482
13 swift           0x0000000000ec4eeb swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 331
14 swift           0x0000000000ecdeaa swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3242
15 swift           0x0000000000ecb8e5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
16 swift           0x0000000000ecf533 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9011
17 swift           0x0000000000ecb8e5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
18 swift           0x0000000000ecdf70 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3440
19 swift           0x0000000000ecb8e5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
20 swift           0x0000000000ecf533 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 9011
21 swift           0x0000000000ecb8e5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
22 swift           0x0000000000ecdf70 swift::constraints::ConstraintSystem::solveSimplified(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 3440
23 swift           0x0000000000ecb8e5 swift::constraints::ConstraintSystem::solveRec(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 325
24 swift           0x0000000000e89968 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 120
25 swift           0x0000000000dd7cc5 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 661
26 swift           0x0000000000dde0e9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
29 swift           0x0000000000e4199a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
30 swift           0x0000000000e6b20c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
31 swift           0x0000000000dde15b swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 683
33 swift           0x0000000000e41ae6 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
34 swift           0x0000000000dc611d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1149
35 swift           0x0000000000c7970f swift::CompilerInstance::performSema() + 2975
37 swift           0x0000000000774901 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
38 swift           0x000000000076f445 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28252-swift-constraints-constraintsystem-assignfixedtype-98f056.o
1.  While type-checking expression at [validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift:8:1 - line:8:21] RangeText="{println(""""?struct{"
2.  While type-checking expression at [validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift:8:2 - line:8:14] RangeText="println(""""?"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
