### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::matchDeepEqualityTypes(…)

### DIFF
--- a/validation-test/compiler_crashers/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -1,0 +1,14 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class A{let h=B<
+protocol A{
+extension{
+struct A{
+var b={}
+class A:b{
+protocol C{func<


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/swift/lib/Sema/CSSimplify.cpp:976: ConstraintSystem::SolutionKind swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder): Assertion `(bool)nominal1->getParent() == (bool)nominal2->getParent() && "Mismatched parents of nominal types"' failed.
8  swift           0x0000000000ebd1e8 swift::constraints::ConstraintSystem::matchDeepEqualityTypes(swift::Type, swift::Type, swift::constraints::ConstraintLocatorBuilder) + 1000
9  swift           0x0000000000ebda5b swift::constraints::ConstraintSystem::simplifyRestrictedConstraint(swift::constraints::ConversionRestrictionKind, swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 1019
10 swift           0x0000000000ebb264 swift::constraints::ConstraintSystem::matchTypes(swift::Type, swift::Type, swift::constraints::TypeMatchKind, unsigned int, swift::constraints::ConstraintLocatorBuilder) + 9988
11 swift           0x0000000000ec502c swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 652
12 swift           0x0000000000e5f857 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
13 swift           0x0000000000e62464 swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, bool, bool, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >*) + 3252
14 swift           0x0000000000e62de7 swift::constraints::ConstraintSystem::resolveOverload(swift::constraints::ConstraintLocator*, swift::Type, swift::constraints::OverloadChoice) + 519
15 swift           0x0000000000ec5143 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 931
16 swift           0x0000000000e5f857 swift::constraints::ConstraintSystem::addConstraint(swift::constraints::Constraint*, bool, bool) + 23
19 swift           0x0000000000f665d5 swift::Expr::walk(swift::ASTWalker&) + 69
20 swift           0x0000000000ea3e48 swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*) + 200
21 swift           0x0000000000dd7b30 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 256
22 swift           0x0000000000dde0e9 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 569
26 swift           0x0000000000e4064a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 362
27 swift           0x0000000000e4049e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
28 swift           0x0000000000e41068 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
30 swift           0x0000000000dc61b4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
31 swift           0x0000000000c7970f swift::CompilerInstance::performSema() + 2975
33 swift           0x0000000000774901 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
34 swift           0x000000000076f445 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28253-swift-constraints-constraintsystem-matchdeepequalitytypes-09a3bc.o
1.  While type-checking getter for b at validation-test/compiler_crashers/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift:12:5
2.  While type-checking expression at [<invalid loc> - <invalid loc>]
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
