### PR TITLE
[Parser][SR-711] Couple "expected declaration" Diagnose With A Note

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -143,6 +143,9 @@ WARNING(lex_editor_placeholder_in_playground,none,
 // Declaration parsing diagnostics
 //------------------------------------------------------------------------------
 
+NOTE(note_in_decl_extension,none,
+     "in %select{declaration|extension}0 of %1", (bool, Identifier))
+
 ERROR(declaration_same_line_without_semi,none,
       "consecutive declarations on a line must be separated by ';'", ())
 

--- a/test/Parse/ConditionalCompilation/decl_parse_errors.swift
+++ b/test/Parse/ConditionalCompilation/decl_parse_errors.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift
 
-class C {
+class C { // expected-note 3 {{in declaration of 'C'}}
 
 #if os(iOS)
 	func foo() {}

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -112,7 +112,7 @@ enum Recovery2 {
 enum Recovery3 {
   case UE2(): // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
-enum Recovery4 {
+enum Recovery4 { // expected-note {{in declaration of 'Recovery4'}}
   case Self Self // expected-error {{expected identifier in enum 'case' declaration}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{12-12=;}} expected-error {{expected declaration}}
 }
 enum Recovery5 {

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -21,7 +21,7 @@ x
 x x // expected-error{{consecutive statements}} {{2-2=;}}
 
 // rdar://19582475
-public struct S {
+public struct S { // expected-note{{in declaration of 'S'}}
 // expected-error@+1{{expected declaration}}
 / ###line 25 "line-directive.swift"
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -354,7 +354,7 @@ struct ErrorTypeInVarDeclFunctionType1 {
   var v2 : Int
 }
 
-struct ErrorTypeInVarDeclArrayType1 {
+struct ErrorTypeInVarDeclArrayType1 { // expected-note{{in declaration of 'ErrorTypeInVarDeclArrayType1'}}
   var v1 : Int[+] // expected-error {{expected declaration}} expected-error {{consecutive declarations on a line must be separated by ';'}}
   // expected-error @-1 {{expected expression after unary operator}}
   // expected-error @-2 {{expected expression}}
@@ -409,7 +409,7 @@ struct ErrorInFunctionSignatureResultArrayType5 {
 }
 
 
-struct ErrorInFunctionSignatureResultArrayType11 {
+struct ErrorInFunctionSignatureResultArrayType11 { // expected-note{{in declaration of 'ErrorInFunctionSignatureResultArrayType11'}}
   func foo() -> Int[(a){a++}] { // expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error {{expected ']' in array type}} expected-note {{to match this opening '['}} expected-error {{use of unresolved identifier 'a'}} expected-error {{expected declaration}}
   }
 }
@@ -448,7 +448,7 @@ class ExprSuper2 {
 
 //===--- Recovery for braces inside a nominal decl.
 
-struct BracesInsideNominalDecl1 {
+struct BracesInsideNominalDecl1 { // expected-note{{in declaration of 'BracesInsideNominalDecl1'}}
   { // expected-error {{expected declaration}}
     aaa
   }
@@ -459,9 +459,18 @@ func use_BracesInsideNominalDecl1() {
   var _ : BracesInsideNominalDecl1.A // no-error
 }
 
+class SR771 { // expected-note {{in declaration of 'SR771'}}
+    print("No one else was in the room where it happened") // expected-error {{expected declaration}}
+}
+
+extension SR771 { // expected-note {{in extension of 'SR771'}}
+    print("The room where it happened, the room where it happened") // expected-error {{expected declaration}}
+}
+
+
 //===--- Recovery for wrong decl introducer keyword.
 
-class WrongDeclIntroducerKeyword1 {
+class WrongDeclIntroducerKeyword1 { // expected-note{{in declaration of 'WrongDeclIntroducerKeyword1'}}
   notAKeyword() {} // expected-error {{expected declaration}}
   func foo() {}
   class func bar() {}

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -71,10 +71,10 @@ struct Y1 {
 
 // Parsing errors
 // FIXME: Recovery here is horrible
-struct A0 {
+struct A0 { // expected-note{{in declaration of 'A0'}}
   subscript // expected-error{{expected '(' for subscript parameters}}
     i : Int // expected-error{{expected declaration}}
-     -> Int { 
+     -> Int {
     get {
       return stored
     }
@@ -84,7 +84,7 @@ struct A0 {
   }
 }
 
-struct A1 {
+struct A1 { // expected-note{{in declaration of 'A1'}}
   subscript (i : Int) // expected-error{{expected '->' for subscript element type}}
      Int {  // expected-error{{expected declaration}}
     get {
@@ -96,7 +96,7 @@ struct A1 {
   }
 }
 
-struct A2 {
+struct A2 { // expected-note{{in declaration of 'A2'}}
   subscript (i : Int) -> // expected-error{{expected subscripting element type}}
      {  // expected-error{{expected declaration}}
     get {
@@ -108,7 +108,7 @@ struct A2 {
   }
 }
 
-struct A3 {
+struct A3 { // expected-note{{in declaration of 'A3'}}
   subscript(i : Int) // expected-error {{expected '->' for subscript element type}}
   { // expected-error {{expected declaration}}
     get {
@@ -117,7 +117,7 @@ struct A3 {
   }
 }
 
-struct A4 {
+struct A4 { // expected-note{{in declaration of 'A4'}}
   subscript(i : Int) { // expected-error {{expected '->' for subscript element type}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{21-21=;}} expected-error {{expected declaration}}
     get {
       return i
@@ -129,7 +129,7 @@ struct A5 {
   subscript(i : Int) -> Int // expected-error {{expected '{' in subscript to specify getter and setter implementation}}
 }
 
-struct A6 {
+struct A6 { // expected-note{{in declaration of 'A6'}}
   subscript(i: Int)(j: Int) -> Int { // expected-error {{expected '->' for subscript element type}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{20-20=;}} expected-error {{expected declaration}}
     get {
       return i + j
@@ -153,7 +153,7 @@ struct A7b {
   }
 }
 
-struct A8 {
+struct A8 { // expected-note{{in declaration of 'A8'}}
   subscript(i : Int) -> Int // expected-error{{expected '{' in subscript to specify getter and setter implementation}}
     get { // expected-error{{expected declaration}}
       return stored

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -435,7 +435,7 @@ struct StructWithDelegatingInit {
 func test_recovery_missing_name_2(let: Int) {} // expected-error 2{{expected ',' separator}} {{38-38=,}} expected-error 2 {{expected parameter name followed by ':'}}
 
 // <rdar://problem/16792027> compiler infinite loops on a really really mutating function
-struct F {
+struct F { // expected-note 2 {{in declaration of 'F'}}
   mutating mutating mutating f() { // expected-error 2 {{duplicate modifier}} expected-note 2 {{modifier already specified here}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error 2 {{expected declaration}}
   }
   

--- a/test/SourceKit/SourceDocInfo/rdar_18677108-2.swift.response
+++ b/test/SourceKit/SourceDocInfo/rdar_18677108-2.swift.response
@@ -60,6 +60,15 @@
     key.filepath: rdar_18677108-2-a.swift,
     key.severity: source.diagnostic.severity.error,
     key.description: "expected declaration",
-    key.diagnostic_stage: source.diagnostic.stage.swift.parse
+    key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+    key.diagnostics: [
+      {
+        key.line: 1,
+        key.column: 7,
+        key.filepath: rdar_18677108-2-a.swift,
+        key.severity: source.diagnostic.severity.note,
+        key.description: "in declaration of 'CameraController'"
+      }
+    ]
   }
 ]

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift.response
@@ -73,7 +73,16 @@
       key.filepath: syntaxmap-edit-del.swift,
       key.severity: source.diagnostic.severity.error,
       key.description: "expected declaration",
-      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+      key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+      key.diagnostics: [
+        {
+          key.line: 2,
+          key.column: 8,
+          key.filepath: syntaxmap-edit-del.swift,
+          key.severity: source.diagnostic.severity.note,
+          key.description: "in declaration of 'Foo'"
+        }
+      ]
     }
   ]
 }

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -2,7 +2,7 @@
 //
 // REQUIRES: objc_interop
 
-class MixedKeywordsAndAttributes {
+class MixedKeywordsAndAttributes { // expected-note{{in declaration of 'MixedKeywordsAndAttributes'}}
   // expected-error@+1 {{expected declaration}} expected-error@+1 {{consecutive declarations on a line must be separated by ';'}} {{11-11=;}}
   override @objc func f1() {}
 }

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -3,7 +3,7 @@
 @override // expected-error {{'override' can only be specified on class members}} {{1-11=}} expected-error {{'override' is a declaration modifier, not an attribute}} {{1-2=}}
 func virtualAttributeCanNotBeUsedInSource() {}
 
-class MixedKeywordsAndAttributes {
+class MixedKeywordsAndAttributes { // expected-note {{in declaration of 'MixedKeywordsAndAttributes'}}
   // expected-error@+1 {{expected declaration}} expected-error@+1 {{consecutive declarations on a line must be separated by ';'}} {{11-11=;}}
   override @inline(never) func f1() {}
 }

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -246,7 +246,7 @@ protocol ProtosEvilTwin {
 extension ProtoAdopter : ProtosEvilTwin {}
 
 // rdar://18990358
-public struct Foo {
+public struct Foo { // expected-note {{in declaration of 'Foo'}}
   public static let S { a // expected-error{{computed property must have an explicit type}}
     // expected-error@-1{{type annotation missing in pattern}}
     // expected-error@-2{{'let' declarations cannot be computed properties}}

--- a/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
+++ b/validation-test/compiler_crashers_fixed/00058-get-self-type-for-container.swift
@@ -4,6 +4,6 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol c : b { // expected-error {{use of undeclared type 'b'}}
+protocol c : b { // expected-error {{use of undeclared type 'b'}} expected-note {{in declaration of 'c'}}
 	func b // expected-error {{expected '(' in argument list of function declaration}}
 // expected-error@+1 {{expected declaration}}


### PR DESCRIPTION
As reported in [SR-711](https://bugs.swift.org/browse/SR-711), when an (unexpected) statement appears in a type declaration, we note the beginning of the declaration in addiction to the existing diagnostic.
