### PR TITLE
[swiftc] Add test case for crash triggered in swift::EnumElementDecl::getArgumentInterfaceType()

### DIFF
--- a/validation-test/compiler_crashers/28254-swift-enumelementdecl-getargumentinterfacetype.swift
+++ b/validation-test/compiler_crashers/28254-swift-enumelementdecl-getargumentinterfacetype.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+enum B<s{case c(c(func c


### PR DESCRIPTION
Stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::AnyFunctionType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
8  swift           0x0000000000fcfc9d swift::EnumElementDecl::getArgumentInterfaceType() const + 157
10 swift           0x0000000000dfa99c swift::TypeChecker::checkDeclCircularity(swift::NominalTypeDecl*) + 268
12 swift           0x0000000000df9296 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
13 swift           0x0000000000dc613a swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1178
14 swift           0x0000000000c7970f swift::CompilerInstance::performSema() + 2975
16 swift           0x0000000000774901 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
17 swift           0x000000000076f445 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28254-swift-enumelementdecl-getargumentinterfacetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28254-swift-enumelementdecl-getargumentinterfacetype-6528cf.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28254-swift-enumelementdecl-getargumentinterfacetype.swift:8:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
