### PR TITLE
[stdlib] Documentation consistency fix for String.UnicodeScalarView

### DIFF
--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -28,7 +28,7 @@ public func <(
 
 extension String {
   /// A collection of [Unicode scalar values](http://www.unicode.org/glossary/#unicode_scalar_value) that
-  /// encode a `String` .
+  /// encodes a `String` value.
   public struct UnicodeScalarView : CollectionType, CustomStringConvertible, CustomDebugStringConvertible {
     init(_ _core: _StringCore) {
       self._core = _core


### PR DESCRIPTION
Brings the abstract for `UnicodeScalarView` in line with `UTF8View` and `UTF16View`.
