### PR TITLE
[Python] Ignore some newly introduced flake8 rules that we do not comply with

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [flake8]
 filename = *.py,build-script,gyb,line-directive,ns-html2rst,pre-commit-benchmark,recursive-lipo,submit-benchmark-results,update-checkout,viewcfg
-ignore = E101,E111,E128,E265,E302,E501,W191
+ignore = E101,E111,E114,E128,E266,E265,E302,E402,E501,W191


### PR DESCRIPTION
Disable rules:
- `E114 indentation is not a multiple of four (comment)`
- `E266 too many leading '#' for block comment`
- `E402 module level import not at top of file`

After this commit:

```
$ flake8
$
```

Notes:
- Fixing "indentation is not a multiple of four (comment)" is doable but would mess up `git blame` for a handful of Python files. Perhaps worth it?
- Fixing "too many leading '#' for block comment" would require changing the file header format used for Python files in the Swift repo.
- Fixing "module level import not at top of file" would require taking care of some `sys.path.append(…)` magic.
