### PR TITLE
[Python] Fix "too many leading '#' for block comment"

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [flake8]
 filename = *.py,build-script,gyb,line-directive,ns-html2rst,pre-commit-benchmark,recursive-lipo,submit-benchmark-results,update-checkout,viewcfg
-ignore = E101,E111,E114,E128,E266,E265,E302,E402,E501,W191
+ignore = E101,E111,E128,E265,E302,E402,E501,W191

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -33,7 +33,7 @@ c_object_p = POINTER(c_void_p)
 
 callbacks = {}
 
-### Structures and Utility Classes ###
+# Structures and Utility Classes
 
 class CachedProperty(object):
     """Decorator that lazy-loads the value of a property.

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -1,14 +1,12 @@
 ##===--------------------------------------------------*- coding: utf-8 -*-===##
-##
-## This source file is part of the Swift.org open source project
-##
-## Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-## Licensed under Apache License v2.0 with Runtime Library Exception
-##
-## See http://swift.org/LICENSE.txt for license information
-## See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-##
-##===----------------------------------------------------------------------===##
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import re
 import codecs

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -1,14 +1,12 @@
 ##===--- SwiftIntTypes.py -----------------------------*- coding: utf-8 -*-===##
-##
-## This source file is part of the Swift.org open source project
-##
-## Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-## Licensed under Apache License v2.0 with Runtime Library Exception
-##
-## See http://swift.org/LICENSE.txt for license information
-## See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-##
-##===----------------------------------------------------------------------===##
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 # Bit counts for all int types
 _all_integer_type_bitwidths = [8, 16, 32, 64]

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -47,13 +47,13 @@ literalText = r'(?: [^$\n%] | \$(?![${]) | %(?!%) )*'
 # The part of an '%end' line that follows the '%' sign
 linesClose = r'[\ \t]* end [\ \t]* (?: \# .* )? $'
 
-## Note: Where "# Absorb" appears below, the regexp attempts to eat up
-## through the end of ${...} and %{...}% constructs.  In reality we
-## handle this with the Python tokenizer, which avoids mis-detections
-## due to nesting, comments and strings.  This extra absorption in the
-## regexp facilitates testing the regexp on its own, by preventing the
-## interior of some of these constructs from being treated as literal
-## text.
+# Note: Where "# Absorb" appears below, the regexp attempts to eat up
+# through the end of ${...} and %{...}% constructs.  In reality we
+# handle this with the Python tokenizer, which avoids mis-detections
+# due to nesting, comments and strings.  This extra absorption in the
+# regexp facilitates testing the regexp on its own, by preventing the
+# interior of some of these constructs from being treated as literal
+# text.
 tokenizeRE = re.compile(
     r'''
 # %-lines and %{...}-blocks

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 ##===--- swift-bench.py -------------------------------*- coding: utf-8 -*-===##
-##
-## This source file is part of the Swift.org open source project
-##
-## Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-## Licensed under Apache License v2.0 with Runtime Library Exception
-##
-## See http://swift.org/LICENSE.txt for license information
-## See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-##
-##===----------------------------------------------------------------------===##
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 # This file implements a test harness for running Swift performance benchmarks.
 #


### PR DESCRIPTION
As discussed with @gribozavr in https://github.com/apple/swift/pull/1287#issuecomment-183413319
