### PR TITLE
Add sequential variant of Integrate benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SWIFT_BENCH_MODULES
     single-source/Hanoi
     single-source/Hash
     single-source/Histogram
+    single-source/Integrate
     single-source/Join
     single-source/LinkedList
     single-source/MapReduce

--- a/benchmark/single-source/Integrate.swift
+++ b/benchmark/single-source/Integrate.swift
@@ -1,0 +1,68 @@
+//===--- Integrate.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+// A micro-benchmark for recursive divide and conquer problems.
+// The program performs integration via Gaussian Quadrature
+
+class Integrate {
+  static let epsilon = 1.0e-9;
+
+  let fun:(Double)->Double;
+
+  init (f:(Double)->Double) {
+    fun = f;
+  }
+    
+  private func recEval(l:Double, fl:Double, r:Double, fr:Double, a:Double)->Double {
+    let h = (r - l) / 2
+    let hh = h / 2
+    let c = l + h
+    let fc = fun(c)
+    let al = (fl + fc) * hh
+    let ar = (fr + fc) * hh
+    let alr = al + ar
+    let error = abs(alr-a)
+    if (error < Integrate.epsilon) {
+      return alr
+    } else {
+      let a1 = recEval(c, fl:fc, r:r, fr:fr, a:ar)
+      let a2 = recEval(l, fl:fl, r:c, fr:fc, a:al)
+      return a1 + a2
+    }
+  }
+
+  @inline(never)
+  func computeArea(left:Double, right:Double)->Double {
+    return recEval(left, fl:fun(left), r:right, fr:fun(right), a:0)
+  }
+}
+
+@inline(never)
+public func run_Integrate(N: Int) {
+  let obj = Integrate(f: { x in (x*x + 1.0) * x});
+  let left = 0.0
+  let right = 10.0
+  let ref_result = 2550.0
+  let bound = 0.0001
+  var result = 0.0
+  for _ in 1...N {
+    result = obj.computeArea(left, right:right)
+    if abs(result - ref_result) > bound {
+      break
+    }
+  }
+
+  CheckResults(abs(result - ref_result) < bound,
+               "Incorrect results in Integrate: abs(\(result) - \(ref_result)) > \(bound)")
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -51,6 +51,7 @@ import GlobalClass
 import Hanoi
 import Hash
 import Histogram
+import Integrate
 import Join
 import LinkedList
 import MapReduce
@@ -73,12 +74,12 @@ import RC4
 import RGBHistogram
 import RangeAssignment
 import RecursiveOwnedParameter
-import StaticArray
 import SetTests
 import SevenBoom
 import Sim2DArray
 import SortLettersInPlace
 import SortStrings
+import StaticArray
 import StrComplexWalk
 import StrToInt
 import StringBuilder
@@ -126,6 +127,7 @@ precommitTests = [
   "Hanoi": run_Hanoi,
   "HashTest": run_HashTest,
   "Histogram": run_Histogram,
+  "Integrate": run_Integrate,
   "Join": run_Join,
   "LinkedList": run_LinkedList,
   "MapReduce": run_MapReduce,
@@ -149,7 +151,6 @@ precommitTests = [
   "RGBHistogram": run_RGBHistogram,
   "RangeAssignment": run_RangeAssignment,
   "RecursiveOwnedParameter": run_RecursiveOwnedParameter,
-  "StaticArray": run_StaticArray,
   "SetExclusiveOr": run_SetExclusiveOr,
   "SetIntersect": run_SetIntersect,
   "SetIsSubsetOf": run_SetIsSubsetOf,
@@ -158,6 +159,7 @@ precommitTests = [
   "Sim2DArray": run_Sim2DArray,
   "SortLettersInPlace": run_SortLettersInPlace,
   "SortStrings": run_SortStrings,
+  "StaticArray": run_StaticArray,
   "StrComplexWalk": run_StrComplexWalk,
   "StrToInt": run_StrToInt,
   "StringBuilder": run_StringBuilder,


### PR DESCRIPTION
A simple recursive divide and conquer algorithm
whose parallel variant is often used to assess
scheduling overheads in dynamic task-based runtimes.
