### PR TITLE
Minor clean-up of -assert-config option handling.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4392,7 +4392,7 @@ The compiler flag that influences the value of the ``assert_configuration``
 function application is the optimization flag: at ``-Onone` the application will
 be replaced by ``Debug`` at higher optimization levels the instruction will be
 replaced by ``Release``. Optionally, the value to use for replacement can be
-specified with the ``-AssertConf`` flag which overwrites the value selected by
+specified with the ``-assert-config`` flag which overwrites the value selected by
 the optimization flag (possible values are ``Debug``, ``Release``,
 ``DisableReplacement``).
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -75,9 +75,9 @@ public:
   enum AssertConfiguration: unsigned {
     // Used by standard library code to distinguish between a debug and release
     // build.
-    Debug = 0,   // Enables all asserts.
-    Release = 1, // Disables asserts.
-    Fast = 2,    // Disables asserts, library precondition, and runtime checks.
+    Debug = 0,     // Enables all asserts.
+    Release = 1,   // Disables asserts.
+    Unchecked = 2, // Disables asserts, preconditions, and runtime checks.
 
     // Leave the assert_configuration instruction around.
     DisableReplacement = UINT_MAX

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -290,7 +290,7 @@ def gline_tables_only : Flag<["-"], "gline-tables-only">,
 def AssertConfig : Separate<["-"], "assert-config">,
   Flags<[FrontendOption]>,
   HelpText<"Specify the assert_configuration replacement. "
-           "Possible values are Debug, Release, Replacement.">;
+           "Possible values are Debug, Release, Unchecked, DisableReplacement.">;
 
 // File types
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -988,7 +988,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Opts.Optimization = SILOptions::SILOptMode::OptimizeUnchecked;
       // Removal of cond_fail (overflow on binary operations).
       Opts.RemoveRuntimeAsserts = true;
-      Opts.AssertConfig = SILOptions::Fast;
+      Opts.AssertConfig = SILOptions::Unchecked;
     } else if (A->getOption().matches(OPT_Oplayground)) {
       // For now -Oplayground is equivalent to -Onone.
       IRGenOpts.Optimize = false;
@@ -1009,8 +1009,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Opts.AssertConfig = SILOptions::Debug;
     } else if (Configuration == "Release") {
       Opts.AssertConfig = SILOptions::Release;
-    } else if (Configuration == "Fast") {
-      Opts.AssertConfig = SILOptions::Fast;
+    } else if (Configuration == "Unchecked") {
+      Opts.AssertConfig = SILOptions::Unchecked;
     } else {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -39,20 +39,17 @@
 // RUN: %swift_driver -assert-config Debug -### | FileCheck -check-prefix=ASSERTCONFIG %s
 // ASSERTCONFIG: -assert-config Debug
 
-// RUN: %swiftc_driver -assert-config Debug -### %s | FileCheck -check-prefix=ASSERTCONFIG2 %s
-// ASSERTCONFIG2: -assert-config Debug
+// RUN: %swiftc_driver -assert-config Release -### %s | FileCheck -check-prefix=ASSERTCONFIG_RELEASE %s
+// RUN: %swift_driver -assert-config Release -### %s | FileCheck -check-prefix=ASSERTCONFIG_RELEASE %s
+// ASSERTCONFIG_RELEASE: -assert-config Release
 
-// RUN: %swiftc_driver -assert-config Release -### %s | FileCheck -check-prefix=ASSERTCONFIG3 %s
-// ASSERTCONFIG3: -assert-config Release
+// RUN: %swiftc_driver -assert-config Unchecked -### %s | FileCheck -check-prefix=ASSERTCONFIG_UNCHECKED %s
+// RUN: %swift_driver -assert-config Unchecked -### %s | FileCheck -check-prefix=ASSERTCONFIG_UNCHECKED %s
+// ASSERTCONFIG_UNCHECKED: -assert-config Unchecked
 
-// RUN: %swiftc_driver -assert-config Release -### %s | FileCheck -check-prefix=ASSERTCONFIG4 %s
-// ASSERTCONFIG4: -assert-config Release
-
-// RUN: %swiftc_driver -assert-config DisableReplacement -### %s | FileCheck -check-prefix=ASSERTCONFIG5 %s
-// ASSERTCONFIG5: -assert-config DisableReplacement
-
-// RUN: %swiftc_driver -assert-config DisableReplacement -### %s | FileCheck -check-prefix=ASSERTCONFIG6 %s
-// ASSERTCONFIG6: -assert-config DisableReplacement
+// RUN: %swiftc_driver -assert-config DisableReplacement -### %s | FileCheck -check-prefix=ASSERTCONFIG_DISABLEREPLACEMENT %s
+// RUN: %swift_driver -assert-config DisableReplacement -### %s | FileCheck -check-prefix=ASSERTCONFIG_DISABLEREPLACEMENT %s
+// ASSERTCONFIG_DISABLEREPLACEMENT: -assert-config DisableReplacement
 
 // RUN: not %swiftc_driver -import-objc-header fake.h -import-underlying-module -c %s 2>&1 | FileCheck -check-prefix=FRAMEWORK_BRIDGING_HEADER %s
 // FRAMEWORK_BRIDGING_HEADER: error: using bridging headers with framework targets is unsupported

--- a/test/IRGen/assert_conf_default.sil
+++ b/test/IRGen/assert_conf_default.sil
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -assert-config DisableReplacement -emit-ir %s   | FileCheck %s --check-prefix=DISABLED
 // RUN: %target-swift-frontend -assert-config Release -emit-ir %s   | FileCheck %s --check-prefix=RELEASE
 // RUN: %target-swift-frontend -assert-config Debug -emit-ir %s   | FileCheck %s --check-prefix=DEBUG
+// RUN: %target-swift-frontend -assert-config Unchecked -emit-ir %s   | FileCheck %s --check-prefix=UNCHECKED
 
 import Builtin
 
@@ -17,3 +18,6 @@ sil @remove_assert_configuration : $@convention(thin) () -> Builtin.Int32 {
 
 // RELEASE-LABEL: @remove_assert_configuration
 // RELEASE: ret i32 1
+
+// UNCHECKED-LABEL: @remove_assert_configuration
+// UNCHECKED: ret i32 2


### PR DESCRIPTION
- Replace 'Fast' with 'Unchecked' everywhere.
- Update the help text to specify DisableReplacement rather than
  Replacement and to document Unchecked.
- Simplify tests slightly and add a tests for Unchecked.
