### PR TITLE
ARC compile time and memory consumption improvement.

### DIFF
--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -1,0 +1,393 @@
+//===--- ImmutablePointerSet.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This file contains an implementation of a bump ptr allocated immutable
+/// pointer set.
+///
+/// The target of this data structure are sets of pointers (with N < 100) that
+/// are propagated through many basic blocks. These pointer sets will be merged
+/// and copied far more than being created from an array.
+///
+/// Thus we assume the following constraints:
+///
+/// 1. Our set operations are purely additive. Given a set, one can only add
+/// elements to it. One can not remove elements to it. This means we only
+/// support construction of sets from arrays and concatentation of pointer sets.
+///
+/// 2. Our sets must always be ordered and be able to be iterated over
+/// efficiently in that order.
+///
+/// 3. An O(log(n)) set contains method.
+///
+/// Beyond these constraints, we would like for our data structure to have the
+/// following properties for performance reasons:
+///
+/// 1. Its memory should be bump ptr allocated. We like fast allocation.
+///
+/// 2. No destructors need to be called when the bump ptr allocator is being
+/// destroyed. We like fast destruction and do not want to have to iterate over
+/// potentially many of these sets and invoke destructors.
+///
+/// Thus our design is to represent our sets as bump ptr allocated arrays whose
+/// elements are sorted and uniqued. The actual uniquing of the arrays
+/// themselves is performed via folding set node.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_IMMUTABLEPOINTERSET_H
+#define SWIFT_BASIC_IMMUTABLEPOINTERSET_H
+
+#include "swift/Basic/STLExtras.h"
+#include "swift/Basic/NullablePtr.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/ADT/FoldingSet.h"
+#include <algorithm>
+#include <type_traits>
+
+// Include these here for now to reduce build times while I am testing. Putting
+// things into STLExtras causes pretty much everything to recompile.
+namespace swift {
+
+/// @{
+
+/// The equivalent of std::for_each, but visits the set union of two sorted
+/// lists without allocating additional memory.
+template <typename InputIt1, typename InputIt2, typename BinaryFunction>
+inline void set_union_for_each(InputIt1 I1, InputIt1 E1, InputIt2 I2,
+                               InputIt2 E2, BinaryFunction f) {
+  while (true) {
+    // If we have reached the end of either list, visit the rest of the other
+    // list, We do not need to worry about duplicates since each array we know
+    // is unique.
+    if (I1 == E1) {
+      std::for_each(I2, E2, f);
+      return;
+    }
+
+    if (I2 == E2) {
+      std::for_each(I1, E1, f);
+      return;
+    }
+
+    // If I1 < I2, then visit I1 and continue.
+    if (*I1 < *I2) {
+      f(*I1);
+      ++I1;
+      continue;
+    }
+
+    // If I2 < I1, visit I2 and continue.
+    if (*I2 < *I1) {
+      f(*I2);
+      ++I2;
+      continue;
+    }
+
+    // Otherwise, we know that I1 and I2 equal. We know that we can only have
+    // one of each element in each list, so we can just visit I1 and continue.
+    f(*I1);
+    ++I1;
+    ++I2;
+  }
+}
+
+/// A container adapter for set_union_for_each.
+template <typename Container1, typename Container2, typename BinaryFunction>
+inline void set_union_for_each(Container1 &&C1, Container2 &&C2,
+                               BinaryFunction f) {
+  set_union_for_each(C1.begin(), C1.end(), C2.begin(), C2.end(), f);
+}
+
+/// @}
+
+/// Returns true if [II, IE) is a sorted and uniqued array. Returns false
+/// otherwise.
+template <typename IterTy> bool is_sorted_and_uniqued(IterTy II, IterTy IE) {
+  // The empty list is always sorted and uniqued.
+  if (II == IE)
+    return true;
+
+  // The list of one element is always sorted and uniqued.
+  auto LastI = II;
+  ++II;
+  if (II == IE)
+    return true;
+
+  // Otherwise, until we reach the end of the list...
+  while (II != IE) {
+    // If LastI is greater than II then we know that our array is not sorted. If
+    // LastI equals II, then we know that our array is not unique. If both of
+    // those are conditions are false, then visit the next iterator element.
+    if (*LastI < *II) {
+      LastI = II;
+      ++II;
+      continue;
+    }
+
+    // Return false otherwise.
+    return false;
+  }
+
+  // Success!
+  return true;
+}
+
+template <typename Container> bool is_sorted_and_uniqued(Container &&C) {
+  return is_sorted_and_uniqued(C.begin(), C.end());
+}
+
+} // end swift namespace
+
+namespace swift {
+
+template <typename PtrTy> class ImmutablePointerSetFactory;
+
+/// An immutable set of pointers. It is backed by a tail allocated sorted array
+/// ref.
+template <typename T> class ImmutablePointerSet : public llvm::FoldingSetNode {
+  using PtrTy = typename std::add_pointer<T>::type;
+  friend class ImmutablePointerSetFactory<T>;
+
+  NullablePtr<ImmutablePointerSetFactory<T>> ParentFactory;
+  ArrayRef<PtrTy> Data;
+
+  ImmutablePointerSet(ImmutablePointerSetFactory<T> *ParentFactory,
+                      ArrayRef<PtrTy> NewData)
+      : ParentFactory(ParentFactory), Data(NewData) {}
+
+public:
+  ~ImmutablePointerSet() = default;
+  ImmutablePointerSet(const ImmutablePointerSet &) = default;
+  ImmutablePointerSet(ImmutablePointerSet &&) = default;
+
+  ImmutablePointerSet &operator=(const ImmutablePointerSet &) = default;
+  ImmutablePointerSet &operator=(ImmutablePointerSet &&) = default;
+
+  bool operator==(const ImmutablePointerSet<T> &P) const {
+    // If both are empty, they must be equivalent.
+    if (empty() && P.empty())
+      return true;
+    // Ok, at least one is non-empty. If either are empty at this point, then we
+    // are comparing a non-empty set with an empty set, i.e. they do not equal.
+    if (empty() || P.empty())
+      return false;
+
+    // Ok, both sets are not empty. Compare their profiles.
+    llvm::FoldingSetNodeID ID1, ID2;
+    Profile(ID1);
+    P.Profile(ID2);
+    return ID1 == ID2;
+  }
+
+  bool operator!=(const ImmutablePointerSet<T> &P) const {
+    return !(*this == P);
+  }
+
+  unsigned count(PtrTy Ptr) const {
+    // This returns the first element >= Ptr. Since we know that our array is
+    // sorted and uniqued, Ptr must be that element.
+    auto LowerBound = std::lower_bound(begin(), end(), Ptr);
+
+    // If Ptr is > than everything in the array, then we obviously have 0.
+    if (LowerBound == end())
+      return 0;
+
+    // Then check if Ptr is > or Ptr is ==. We only have Ptr if we have == to.
+    return *LowerBound == Ptr;
+  }
+
+  using iterator = typename decltype(Data)::iterator;
+  iterator begin() const { return Data.begin(); }
+  iterator end() const { return Data.end(); }
+
+  unsigned size() const { return Data.size(); }
+  bool empty() const { return Data.empty(); }
+
+  void Profile(llvm::FoldingSetNodeID &ID) const {
+    assert(!Data.empty() && "Should not profile empty ImmutablePointerSet");
+    for (PtrTy P : Data) {
+      ID.AddPointer(P);
+    }
+  }
+
+  ImmutablePointerSet<T> *concat(ImmutablePointerSet<T> *Other) {
+    if (empty())
+      return Other;
+    if (Other->empty())
+      return this;
+    assert(Other->ParentFactory.get() == ParentFactory.get());
+    return ParentFactory.get()->concat(this, Other);
+  }
+};
+
+template <typename T> class ImmutablePointerSetFactory {
+  using PtrTy = typename std::add_pointer<T>::type;
+
+  using PtrSet = ImmutablePointerSet<T>;
+  static constexpr unsigned AllocAlignment =
+      (alignof(PtrSet) > alignof(PtrTy)) ? alignof(PtrSet) : alignof(PtrTy);
+
+  llvm::BumpPtrAllocator &Allocator;
+  llvm::FoldingSetVector<PtrSet> Set;
+  static PtrSet EmptyPtrSet;
+
+public:
+  ImmutablePointerSetFactory(llvm::BumpPtrAllocator &A) : Allocator(A), Set() {}
+  ImmutablePointerSetFactory(const ImmutablePointerSetFactory &) = delete;
+  ImmutablePointerSetFactory(ImmutablePointerSetFactory &&) = delete;
+  ImmutablePointerSetFactory &
+  operator=(const ImmutablePointerSetFactory &) = delete;
+  ImmutablePointerSetFactory &operator=(ImmutablePointerSetFactory &&) = delete;
+
+  // We use a sentinel value here so that we can create an empty value
+  // statically.
+  static PtrSet *getEmptySet() { return &EmptyPtrSet; }
+
+  /// Given a sorted and uniqued list \p Array, return the ImmutablePointerSet
+  /// containing Array. Asserts if \p Array is not sorted and uniqued.
+  PtrSet *get(ArrayRef<PtrTy> Array) {
+    if (Array.empty())
+      return ImmutablePointerSetFactory::getEmptySet();
+
+    // We expect our users to sort/unique the input array. This is because doing
+    // it here would either require us to allocate more memory than we need or
+    // write into the input Array, which we don't want.
+    assert(is_sorted_and_uniqued(Array));
+
+    llvm::FoldingSetNodeID ID;
+    for (PtrTy Ptr : Array) {
+      ID.AddPointer(Ptr);
+    }
+
+    void *InsertPt;
+    if (auto *PSet = Set.FindNodeOrInsertPos(ID, InsertPt)) {
+      return PSet;
+    }
+
+    size_t NumElts = Array.size();
+    size_t MemSize = sizeof(PtrSet) + sizeof(PtrTy) * NumElts;
+
+    // Allocate the memory.
+    auto *Mem =
+        reinterpret_cast<PtrSet *>(Allocator.Allocate(MemSize, AllocAlignment));
+
+    // Copy in the pointers into the tail allocated memory. We do not need to do
+    // any sorting/uniquing ourselves since we assume that our users perform
+    // this task for us.
+    MutableArrayRef<PtrTy> DataMem(reinterpret_cast<PtrTy *>(&Mem[1]), NumElts);
+    std::copy(Array.begin(), Array.end(), DataMem.begin());
+
+    // Allocate the new node and insert it into the Set.
+    auto *NewNode = new (Mem) PtrSet(this, DataMem);
+    Set.InsertNode(NewNode, InsertPt);
+    return NewNode;
+  }
+
+  PtrSet *concat(PtrSet *S1, ArrayRef<PtrTy> S2) {
+    if (S1->empty())
+      return get(S2);
+
+    if (S2.empty())
+      return S1;
+
+    // We assume that S2 is sorted and uniqued.
+    assert(is_sorted_and_uniqued(S2));
+
+    llvm::FoldingSetNodeID ID;
+
+    // We know that both of our pointer sets are sorted, so we can essentially
+    // perform a sorted set merging algorithm to create the ID. We also count
+    // the number of unique elements for allocation purposes.
+    unsigned NumElts = 0;
+    set_union_for_each(*S1, S2, [&ID, &NumElts](const PtrTy Ptr) -> void {
+      ID.AddPointer(Ptr);
+      NumElts++;
+    });
+
+    // If we find our ID then continue.
+    void *InsertPt;
+    if (auto *PSet = Set.FindNodeOrInsertPos(ID, InsertPt)) {
+      return PSet;
+    }
+
+    unsigned MemSize = sizeof(PtrSet) + sizeof(PtrTy) * NumElts;
+
+    // Allocate the memory.
+    auto *Mem =
+        reinterpret_cast<PtrSet *>(Allocator.Allocate(MemSize, AllocAlignment));
+
+    // Copy in the union of the two pointer sets into the tail allocated
+    // memory. Since we know that our sorted arrays are uniqued, we can use
+    // set_union to get the uniqued sorted array that we want.
+    MutableArrayRef<PtrTy> DataMem(reinterpret_cast<PtrTy *>(&Mem[1]), NumElts);
+    std::set_union(S1->begin(), S1->end(), S2.begin(), S2.end(),
+                   DataMem.begin());
+
+    // Allocate the new node, insert it into the Set, and return it.
+    auto *NewNode = new (Mem) PtrSet(this, DataMem);
+    Set.InsertNode(NewNode, InsertPt);
+    return NewNode;
+  }
+
+  PtrSet *concat(PtrSet *S1, PtrSet *S2) {
+    // If either S1 or S2 are the empty PtrSet, just return S2 or S1.
+    if (S1->empty())
+      return S2;
+    if (S2->empty())
+      return S1;
+
+    llvm::FoldingSetNodeID ID;
+
+    // We know that both of our pointer sets are sorted, so we can essentially
+    // perform a sorted set merging algorithm to create the ID. We also count
+    // the number of unique elements for allocation purposes.
+    unsigned NumElts = 0;
+    set_union_for_each(*S1, *S2, [&ID, &NumElts](const PtrTy Ptr) -> void {
+      ID.AddPointer(Ptr);
+      NumElts++;
+    });
+
+    // If we find our ID then continue.
+    void *InsertPt;
+    if (auto *PSet = Set.FindNodeOrInsertPos(ID, InsertPt)) {
+      return PSet;
+    }
+
+    unsigned MemSize = sizeof(PtrSet) + sizeof(PtrTy) * NumElts;
+
+    // Allocate the memory.
+    auto *Mem =
+        reinterpret_cast<PtrSet *>(Allocator.Allocate(MemSize, AllocAlignment));
+
+    // Copy in the union of the two pointer sets into the tail allocated
+    // memory. Since we know that our sorted arrays are uniqued, we can use
+    // set_union to get the uniqued sorted array that we want.
+    MutableArrayRef<PtrTy> DataMem(reinterpret_cast<PtrTy *>(&Mem[1]), NumElts);
+    std::set_union(S1->begin(), S1->end(), S2->begin(), S2->end(),
+                   DataMem.begin());
+
+    // Allocate the new node, insert it into the Set, and return it.
+    auto *NewNode = new (Mem) PtrSet(this, DataMem);
+    Set.InsertNode(NewNode, InsertPt);
+    return NewNode;
+  }
+};
+
+template <typename T>
+ImmutablePointerSet<T> ImmutablePointerSetFactory<T>::EmptyPtrSet =
+    ImmutablePointerSet<T>(nullptr, {});
+
+} // end swift namespace
+
+#endif

--- a/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCLoopOpts.cpp
@@ -20,7 +20,7 @@
 
 #define DEBUG_TYPE "arc-sequence-opts"
 #include "swift/SILOptimizer/PassManager/Passes.h"
-#include "GlobalARCPairingAnalysis.h"
+#include "ARCSequenceOpts.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.h
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.h
@@ -1,0 +1,142 @@
+//===--- GlobalARCPairingAnalysis.h -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_GLOBALARCPAIRINGANALYSIS_H
+#define SWIFT_SILOPTIMIZER_PASSMANAGER_GLOBALARCPAIRINGANALYSIS_H
+
+#include "GlobalARCSequenceDataflow.h"
+#include "GlobalLoopARCSequenceDataflow.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Utils/LoopUtils.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace swift {
+
+class SILInstruction;
+class SILFunction;
+class AliasAnalysis;
+class PostOrderAnalysis;
+class LoopRegionFunctionInfo;
+class SILLoopInfo;
+class RCIdentityFunctionInfo;
+
+/// A set of matching reference count increments, decrements, increment
+/// insertion pts, and decrement insertion pts.
+struct ARCMatchingSet {
+
+  /// The pointer that this ARCMatchingSet is providing matching increment and
+  /// decrement sets for.
+  ///
+  /// TODO: This should really be called RCIdentity.
+  SILValue Ptr;
+
+  /// The set of reference count increments that were paired.
+  llvm::SetVector<SILInstruction *> Increments;
+
+  /// An insertion point for an increment means the earliest point in the
+  /// program after the increment has occurred that the increment can be moved
+  /// to
+  /// without moving the increment over an instruction that may decrement a
+  /// reference count.
+  llvm::SetVector<SILInstruction *> IncrementInsertPts;
+
+  /// The set of reference count decrements that were paired.
+  llvm::SetVector<SILInstruction *> Decrements;
+
+  /// An insertion point for a decrement means the latest point in the program
+  /// before the decrement that the optimizer conservatively assumes that a
+  /// reference counted value could be used.
+  llvm::SetVector<SILInstruction *> DecrementInsertPts;
+
+  // This is a data structure that cannot be moved or copied.
+  ARCMatchingSet() = default;
+  ARCMatchingSet(const ARCMatchingSet &) = delete;
+  ARCMatchingSet(ARCMatchingSet &&) = delete;
+  ARCMatchingSet &operator=(const ARCMatchingSet &) = delete;
+  ARCMatchingSet &operator=(ARCMatchingSet &&) = delete;
+
+  void clear() {
+    Ptr = SILValue();
+    Increments.clear();
+    IncrementInsertPts.clear();
+    Decrements.clear();
+    DecrementInsertPts.clear();
+  }
+};
+
+struct MatchingSetFlags {
+  bool KnownSafe;
+  bool Partial;
+};
+static_assert(std::is_pod<MatchingSetFlags>::value,
+              "MatchingSetFlags should be a pod.");
+
+struct ARCMatchingSetBuilder {
+  using TDMapTy = BlotMapVector<SILInstruction *, TopDownRefCountState>;
+  using BUMapTy = BlotMapVector<SILInstruction *, BottomUpRefCountState>;
+
+  TDMapTy &TDMap;
+  BUMapTy &BUMap;
+
+  llvm::SmallVector<SILInstruction *, 8> NewIncrements;
+  llvm::SmallVector<SILInstruction *, 8> NewDecrements;
+  bool MatchedPair;
+  ARCMatchingSet MatchSet;
+  bool PtrIsGuaranteedArg;
+
+  RCIdentityFunctionInfo *RCIA;
+
+public:
+  ARCMatchingSetBuilder(TDMapTy &TDMap, BUMapTy &BUMap,
+                        RCIdentityFunctionInfo *RCIA)
+      : TDMap(TDMap), BUMap(BUMap), MatchedPair(false),
+        PtrIsGuaranteedArg(false), RCIA(RCIA) {}
+
+  void init(SILInstruction *Inst) {
+    clear();
+    MatchSet.Ptr = RCIA->getRCIdentityRoot(Inst->getOperand(0));
+
+    // If we have a function argument that is guaranteed, set the guaranteed
+    // flag so we know that it is always known safe.
+    if (auto *A = dyn_cast<SILArgument>(MatchSet.Ptr)) {
+      if (A->isFunctionArg()) {
+        auto C = A->getParameterInfo().getConvention();
+        PtrIsGuaranteedArg = C == ParameterConvention::Direct_Guaranteed;
+      }
+    }
+    NewIncrements.push_back(Inst);
+  }
+
+  void clear() {
+    MatchSet.clear();
+    MatchedPair = false;
+    NewIncrements.clear();
+    NewDecrements.clear();
+  }
+
+  bool matchUpIncDecSetsForPtr();
+
+  // We only allow for get result when this object is invalidated via a move.
+  ARCMatchingSet &getResult() { return MatchSet; }
+
+  bool matchedPair() const { return MatchedPair; }
+
+private:
+  /// Returns .Some(MatchingSetFlags) on success and .None on failure.
+  Optional<MatchingSetFlags> matchIncrementsToDecrements();
+  Optional<MatchingSetFlags> matchDecrementsToIncrements();
+};
+
+} // end swift namespace
+
+#endif

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -70,6 +70,13 @@ public:
   /// Is this Region from which we can leak memory safely?
   bool allowsLeaks() const { return AllowsLeaks; }
 
+  /// Return the region associated with this ARCRegionState.
+  ///
+  /// Even though Region is a NullablePtr, it is only null during
+  /// initialization. This method should not be called then.
+  const LoopRegion *getRegion() const { return Region.get(); }
+  LoopRegion *getRegion() { return Region.get(); }
+
   /// Top Down Iterators
   using topdown_iterator = TopDownMapTy::iterator;
   using topdown_const_iterator = TopDownMapTy::const_iterator;
@@ -129,6 +136,17 @@ public:
     clearBottomUpState();
   }
 
+  using const_reverse_summarizedinterestinginsts_iterator =
+      decltype(SummarizedInterestingInsts)::const_reverse_iterator;
+  const_reverse_summarizedinterestinginsts_iterator
+  summarizedinterestinginsts_rbegin() const {
+    return SummarizedInterestingInsts.rbegin();
+  }
+  const_reverse_summarizedinterestinginsts_iterator
+  summarizedinterestinginsts_rend() const {
+    return SummarizedInterestingInsts.rend();
+  }
+
   using const_summarizedinterestinginsts_iterator =
       decltype(SummarizedInterestingInsts)::const_iterator;
   const_summarizedinterestinginsts_iterator
@@ -144,9 +162,6 @@ public:
     return {summarizedinterestinginsts_begin(),
             summarizedinterestinginsts_end()};
   }
-
-  /// Returns a reference to the basic block that we are tracking.
-  const LoopRegion *getRegion() const { return Region.get(); }
 
   /// Merge in the state of the successor basic block. This is currently a stub.
   void mergeSuccBottomUp(ARCRegionState &SuccRegion);
@@ -187,9 +202,19 @@ public:
       BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);
 
+  void summarizeBlock(SILBasicBlock *BB);
+
   void summarize(
       LoopRegionFunctionInfo *LRFI,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);
+
+  /// Add \p I to the interesting instruction list of this region if it is a
+  /// block. We assume that I is an instruction in the block.
+  void addInterestingInst(SILInstruction *I);
+
+  /// Remove \p I from the interesting instruction list of this region if it is
+  /// a block. We assume that I is an instruction in the block.
+  void removeInterestingInst(SILInstruction *I);
 
 private:
   void processBlockBottomUpPredTerminators(const LoopRegion *R,
@@ -210,7 +235,6 @@ private:
   bool processLoopTopDown(const LoopRegion *R, ARCRegionState *State,
                           AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI);
 
-  void summarizeBlock(SILBasicBlock *BB);
   void summarizeLoop(
       const LoopRegion *R, LoopRegionFunctionInfo *LRFI,
       llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);

--- a/lib/SILOptimizer/ARC/ARCRegionState.h
+++ b/lib/SILOptimizer/ARC/ARCRegionState.h
@@ -189,7 +189,8 @@ public:
       AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       LoopRegionFunctionInfo *LRFI,
       BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
-      llvm::DenseMap<const LoopRegion *, ARCRegionState *> &LoopRegionState);
+      llvm::DenseMap<const LoopRegion *, ARCRegionState *> &LoopRegionState,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
 
   /// If this region is a block, process all instructions bottom up. Otherwise,
   /// apply the summarized bottom up information to the merged bottom up
@@ -200,7 +201,8 @@ public:
       LoopRegionFunctionInfo *LRFI, bool FreezeOwnedArgEpilogueReleases,
       ConsumedArgToEpilogueReleaseMatcher &ConsumedArgToReleaseMap,
       BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
-      llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);
+      llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
 
   void summarizeBlock(SILBasicBlock *BB);
 
@@ -217,23 +219,28 @@ public:
   void removeInterestingInst(SILInstruction *I);
 
 private:
-  void processBlockBottomUpPredTerminators(const LoopRegion *R,
-                                           AliasAnalysis *AA,
-                                           LoopRegionFunctionInfo *LRFI);
+  void processBlockBottomUpPredTerminators(
+      const LoopRegion *R, AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
   bool processBlockBottomUp(
       const LoopRegion *R, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
       LoopRegionFunctionInfo *LRFI, bool FreezeOwnedArgEpilogueReleases,
       ConsumedArgToEpilogueReleaseMatcher &ConsumedArgToReleaseMap,
-      BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap);
+      BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
   bool processLoopBottomUp(
       const LoopRegion *R, AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
-      llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo);
+      llvm::DenseMap<const LoopRegion *, ARCRegionState *> &RegionStateInfo,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
 
   bool processBlockTopDown(
       SILBasicBlock &BB, AliasAnalysis *AA, RCIdentityFunctionInfo *RCIA,
-      BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap);
-  bool processLoopTopDown(const LoopRegion *R, ARCRegionState *State,
-                          AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI);
+      BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
+  bool
+  processLoopTopDown(const LoopRegion *R, ARCRegionState *State,
+                     AliasAnalysis *AA, LoopRegionFunctionInfo *LRFI,
+                     ImmutablePointerSetFactory<SILInstruction> &SetFactory);
 
   void summarizeLoop(
       const LoopRegion *R, LoopRegionFunctionInfo *LRFI,

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -42,98 +42,6 @@ STATISTIC(NumRefCountOpsRemoved, "Total number of increments removed");
 llvm::cl::opt<bool> EnableLoopARC("enable-loop-arc", llvm::cl::init(true));
 
 //===----------------------------------------------------------------------===//
-//                            ARC Pairing Context
-//===----------------------------------------------------------------------===//
-
-bool ARCPairingContext::performMatching(CodeMotionOrDeleteCallback &Callback) {
-  bool MatchedPair = false;
-
-  DEBUG(llvm::dbgs() << "**** Computing ARC Matching Sets for " << F.getName()
-                     << " ****\n");
-
-  /// For each increment that we matched to a decrement, try to match it to a
-  /// decrement -> increment pair.
-  for (auto Pair : IncToDecStateMap) {
-    if (!Pair.hasValue())
-      continue;
-
-    SILInstruction *Increment = Pair->first;
-    if (!Increment)
-      continue; // blotted
-
-    DEBUG(llvm::dbgs() << "Constructing Matching Set For: " << *Increment);
-    ARCMatchingSetBuilder Builder(DecToIncStateMap, IncToDecStateMap, RCIA);
-    Builder.init(Increment);
-    if (Builder.matchUpIncDecSetsForPtr()) {
-      MatchedPair |= Builder.matchedPair();
-      auto &Set = Builder.getResult();
-      for (auto *I : Set.Increments)
-        IncToDecStateMap.blot(I);
-      for (auto *I : Set.Decrements)
-        DecToIncStateMap.blot(I);
-
-      // Add the Set to the callback. *NOTE* No instruction destruction can
-      // happen here since we may remove instructions that are insertion points
-      // for other instructions.
-      Callback.processMatchingSet(Set);
-    }
-  }
-
-  // Then finalize the callback. This is the only place instructions can be
-  // deleted.
-  Callback.finalize();
-  return MatchedPair;
-}
-
-//===----------------------------------------------------------------------===//
-//                                  Loop ARC
-//===----------------------------------------------------------------------===//
-
-void LoopARCPairingContext::runOnLoop(SILLoop *L) {
-  auto *Region = LRFI->getRegion(L);
-  if (processRegion(Region, false, false)) {
-    // We do not recompute for now since we only look at the top function level
-    // for post dominating releases.
-    processRegion(Region, true, false);
-  }
-
-  // Now that we have finished processing the loop, summarize the loop.
-  Evaluator.summarizeLoop(Region);
-}
-
-void LoopARCPairingContext::runOnFunction(SILFunction *F) {
-  if (processRegion(LRFI->getTopLevelRegion(), false, false)) {
-    // We recompute the final post dom release since we may have moved the final
-    // post dominated releases.
-    processRegion(LRFI->getTopLevelRegion(), true, true);
-  }
-}
-
-bool LoopARCPairingContext::processRegion(const LoopRegion *Region,
-                                          bool FreezePostDomReleases,
-                                          bool RecomputePostDomReleases) {
-  bool MadeChange = false;
-  bool NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases,
-                                             RecomputePostDomReleases);
-  bool MatchedPair = Context.performMatching(Callback);
-  MadeChange |= MatchedPair;
-  Evaluator.clearLoopState(Region);
-  Context.DecToIncStateMap.clear();
-  Context.IncToDecStateMap.clear();
-
-  while (NestingDetected && MatchedPair) {
-    NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases, false);
-    MatchedPair = Context.performMatching(Callback);
-    MadeChange |= MatchedPair;
-    Evaluator.clearLoopState(Region);
-    Context.DecToIncStateMap.clear();
-    Context.IncToDecStateMap.clear();
-  }
-
-  return MadeChange;
-}
-
-//===----------------------------------------------------------------------===//
 //                                Code Motion
 //===----------------------------------------------------------------------===//
 
@@ -170,15 +78,13 @@ static SILInstruction *createDecrement(SILValue Ptr, SILInstruction *InsertPt) {
   return B.createReleaseValue(Loc, Ptr);
 }
 
-//===----------------------------------------------------------------------===//
-//                             Mutating Callback
-//===----------------------------------------------------------------------===//
-
 // This routine takes in the ARCMatchingSet \p MatchSet and inserts new
 // increments, decrements at the insertion points and adds the old increment,
 // decrements to the delete list. Sets changed to true if anything was moved or
 // deleted.
-void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
+void ARCPairingContext::optimizeMatchingSet(
+    ARCMatchingSet &MatchSet,
+    llvm::SmallVectorImpl<SILInstruction *> &InstsToDelete) {
   DEBUG(llvm::dbgs() << "**** Optimizing Matching Set ****\n");
 
   // Insert the new increments.
@@ -189,7 +95,7 @@ void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
       continue;
     }
 
-    Changed = true;
+    MadeChange = true;
     SILInstruction *NewIncrement = createIncrement(MatchSet.Ptr, InsertPt);
     (void)NewIncrement;
     DEBUG(llvm::dbgs() << "    Inserting new increment: " << *NewIncrement
@@ -205,7 +111,7 @@ void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
       continue;
     }
 
-    Changed = true;
+    MadeChange = true;
     SILInstruction *NewDecrement = createDecrement(MatchSet.Ptr, InsertPt);
     (void)NewDecrement;
     DEBUG(llvm::dbgs() << "    Inserting new NewDecrement: " << *NewDecrement
@@ -215,19 +121,111 @@ void CodeMotionOrDeleteCallback::processMatchingSet(ARCMatchingSet &MatchSet) {
 
   // Add the old increments to the delete list.
   for (SILInstruction *Increment : MatchSet.Increments) {
-    Changed = true;
+    MadeChange = true;
     DEBUG(llvm::dbgs() << "    Deleting increment: " << *Increment);
-    InstructionsToDelete.push_back(Increment);
+    InstsToDelete.push_back(Increment);
     ++NumRefCountOpsRemoved;
   }
 
   // Add the old decrements to the delete list.
   for (SILInstruction *Decrement : MatchSet.Decrements) {
-    Changed = true;
+    MadeChange = true;
     DEBUG(llvm::dbgs() << "    Deleting decrement: " << *Decrement);
-    InstructionsToDelete.push_back(Decrement);
+    InstsToDelete.push_back(Decrement);
     ++NumRefCountOpsRemoved;
   }
+}
+
+bool ARCPairingContext::performMatching() {
+  bool MatchedPair = false;
+
+  DEBUG(llvm::dbgs() << "**** Computing ARC Matching Sets for " << F.getName()
+                     << " ****\n");
+
+  llvm::SmallVector<SILInstruction *, 8> InstructionsToDelete;
+
+  /// For each increment that we matched to a decrement, try to match it to a
+  /// decrement -> increment pair.
+  for (auto Pair : IncToDecStateMap) {
+    if (!Pair.hasValue())
+      continue;
+
+    SILInstruction *Increment = Pair->first;
+    if (!Increment)
+      continue; // blotted
+
+    DEBUG(llvm::dbgs() << "Constructing Matching Set For: " << *Increment);
+    ARCMatchingSetBuilder Builder(DecToIncStateMap, IncToDecStateMap, RCIA);
+    Builder.init(Increment);
+    if (Builder.matchUpIncDecSetsForPtr()) {
+      MatchedPair |= Builder.matchedPair();
+      auto &Set = Builder.getResult();
+      for (auto *I : Set.Increments)
+        IncToDecStateMap.blot(I);
+      for (auto *I : Set.Decrements)
+        DecToIncStateMap.blot(I);
+
+      // Add the Set to the callback. *NOTE* No instruction destruction can
+      // happen here since we may remove instructions that are insertion points
+      // for other instructions.
+      optimizeMatchingSet(Set, InstructionsToDelete);
+    }
+  }
+
+  // Then delete all of the instructions that we still have.
+  while (!InstructionsToDelete.empty()) {
+    InstructionsToDelete.pop_back_val()->eraseFromParent();
+  }
+
+  return MatchedPair;
+}
+
+//===----------------------------------------------------------------------===//
+//                                  Loop ARC
+//===----------------------------------------------------------------------===//
+
+void LoopARCPairingContext::runOnLoop(SILLoop *L) {
+  auto *Region = LRFI->getRegion(L);
+  if (processRegion(Region, false, false)) {
+    // We do not recompute for now since we only look at the top function level
+    // for post dominating releases.
+    processRegion(Region, true, false);
+  }
+
+  // Now that we have finished processing the loop, summarize the loop.
+  Evaluator.summarizeLoop(Region);
+}
+
+void LoopARCPairingContext::runOnFunction(SILFunction *F) {
+  if (processRegion(LRFI->getTopLevelRegion(), false, false)) {
+    // We recompute the final post dom release since we may have moved the final
+    // post dominated releases.
+    processRegion(LRFI->getTopLevelRegion(), true, true);
+  }
+}
+
+bool LoopARCPairingContext::processRegion(const LoopRegion *Region,
+                                          bool FreezePostDomReleases,
+                                          bool RecomputePostDomReleases) {
+  bool MadeChange = false;
+  bool NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases,
+                                             RecomputePostDomReleases);
+  bool MatchedPair = Context.performMatching();
+  MadeChange |= MatchedPair;
+  Evaluator.clearLoopState(Region);
+  Context.DecToIncStateMap.clear();
+  Context.IncToDecStateMap.clear();
+
+  while (NestingDetected && MatchedPair) {
+    NestingDetected = Evaluator.runOnLoop(Region, FreezePostDomReleases, false);
+    MatchedPair = Context.performMatching();
+    MadeChange |= MatchedPair;
+    Evaluator.clearLoopState(Region);
+    Context.DecToIncStateMap.clear();
+    Context.IncToDecStateMap.clear();
+  }
+
+  return MadeChange;
 }
 
 //===----------------------------------------------------------------------===//
@@ -250,7 +248,6 @@ processFunctionWithoutLoopSupport(SILFunction &F, bool FreezePostDomReleases,
 
   bool Changed = false;
   BlockARCPairingContext Context(F, AA, POTA, RCIA, PTFI);
-  CodeMotionOrDeleteCallback Callback;
   // Until we do not remove any instructions or have nested increments,
   // decrements...
   while (true) {
@@ -260,9 +257,9 @@ processFunctionWithoutLoopSupport(SILFunction &F, bool FreezePostDomReleases,
     // We need to blot pointers we remove after processing an individual pointer
     // so we don't process pairs after we have paired them up. Thus we pass in a
     // lambda that performs the work for us.
-    bool ShouldRunAgain = Context.run(FreezePostDomReleases, Callback);
+    bool ShouldRunAgain = Context.run(FreezePostDomReleases);
 
-    Changed |= Callback.madeChange();
+    Changed |= Context.madeChange();
 
     // If we did not remove any instructions or have any nested increments, do
     // not perform another iteration.

--- a/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
+++ b/lib/SILOptimizer/ARC/ARCSequenceOpts.cpp
@@ -218,19 +218,23 @@ bool LoopARCPairingContext::processRegion(const LoopRegion *Region,
                                           RecomputePostDomReleases);
     MatchedPair = Context.performMatching(NewInsts, DeadInsts);
 
-    DEBUG(llvm::dbgs() << "    Adding new interesting insts!\n");
-    while (!NewInsts.empty()) {
-      auto *I = NewInsts.pop_back_val();
-      DEBUG(llvm::dbgs() << "    " << *I);
-      Evaluator.addInterestingInst(I);
+    if (!NewInsts.empty()) {
+      DEBUG(llvm::dbgs() << "Adding new interesting insts!\n");
+      do {
+        auto *I = NewInsts.pop_back_val();
+        DEBUG(llvm::dbgs() << "    " << *I);
+        Evaluator.addInterestingInst(I);
+      } while (!NewInsts.empty());
     }
 
-    DEBUG(llvm::dbgs() << "Removing dead interesting insts!\n");
-    while (!DeadInsts.empty()) {
-      SILInstruction *I = DeadInsts.pop_back_val();
-      DEBUG(llvm::dbgs() << "    " << *I);
-      Evaluator.removeInterestingInst(I);
-      I->eraseFromParent();
+    if (!DeadInsts.empty()) {
+      DEBUG(llvm::dbgs() << "Removing dead interesting insts!\n");
+      do {
+        SILInstruction *I = DeadInsts.pop_back_val();
+        DEBUG(llvm::dbgs() << "    " << *I);
+        Evaluator.removeInterestingInst(I);
+        I->eraseFromParent();
+      } while (!DeadInsts.empty());
     }
 
     MadeChange |= MatchedPair;

--- a/lib/SILOptimizer/ARC/CMakeLists.txt
+++ b/lib/SILOptimizer/ARC/CMakeLists.txt
@@ -3,7 +3,7 @@ set(ARC_SOURCES
   ARC/ARCRegionState.cpp
   ARC/ARCLoopOpts.cpp
   ARC/ARCSequenceOpts.cpp
-  ARC/GlobalARCPairingAnalysis.cpp
+  ARC/ARCMatchingSet.cpp
   ARC/GlobalARCSequenceDataflow.cpp
   ARC/GlobalLoopARCSequenceDataflow.cpp
   ARC/RCStateTransition.cpp

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.h
@@ -60,6 +60,9 @@ private:
   /// The map from dataflow terminating increment -> decrement dataflow state.
   BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap;
 
+  llvm::BumpPtrAllocator Allocator;
+  ImmutablePointerSetFactory<SILInstruction> SetFactory;
+
   /// Stashed BB information.
   ARCBBStateInfo *BBStateInfo;
 
@@ -98,7 +101,7 @@ private:
 
   bool processBBBottomUp(ARCBBState &BBState,
                          bool FreezeOwnedArgEpilogueReleases);
-
+  bool processBBTopDown(ARCBBState &BBState);
   void computePostDominatingConsumedArgMap();
 
   llvm::Optional<ARCBBStateInfoHandle> getBottomUpBBState(SILBasicBlock *BB);

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -285,7 +285,28 @@ void LoopARCSequenceDataflowEvaluator::summarizeLoop(
   RegionStateInfo[R]->summarize(LRFI, RegionStateInfo);
 }
 
+void LoopARCSequenceDataflowEvaluator::summarizeSubregionBlocks(
+    const LoopRegion *R) {
+  for (unsigned SubregionID : R->getSubregions()) {
+    auto *Subregion = LRFI->getRegion(SubregionID);
+    if (!Subregion->isBlock())
+      continue;
+    RegionStateInfo[Subregion]->summarizeBlock(Subregion->getBlock());
+  }
+}
+
 void LoopARCSequenceDataflowEvaluator::clearLoopState(const LoopRegion *R) {
   for (unsigned SubregionID : R->getSubregions())
     getARCState(LRFI->getRegion(SubregionID)).clear();
+}
+
+void LoopARCSequenceDataflowEvaluator::addInterestingInst(SILInstruction *I) {
+  auto *Region = LRFI->getRegion(I->getParent());
+  RegionStateInfo[Region]->addInterestingInst(I);
+}
+
+void LoopARCSequenceDataflowEvaluator::removeInterestingInst(
+    SILInstruction *I) {
+  auto *Region = LRFI->getRegion(I->getParent());
+  RegionStateInfo[Region]->removeInterestingInst(I);
 }

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -109,7 +109,7 @@ bool LoopARCSequenceDataflowEvaluator::processLoopTopDown(const LoopRegion *R) {
 
     // Then perform the dataflow.
     NestingDetected |= SubregionData.processTopDown(
-        AA, RCFI, LRFI, DecToIncStateMap, RegionStateInfo);
+        AA, RCFI, LRFI, DecToIncStateMap, RegionStateInfo, SetFactory);
   }
 
   return NestingDetected;
@@ -218,7 +218,7 @@ bool LoopARCSequenceDataflowEvaluator::processLoopBottomUp(
     // Then perform the region optimization.
     NestingDetected |= SubregionData.processBottomUp(
         AA, RCFI, LRFI, FreezeOwnedArgEpilogueReleases, ConsumedArgToReleaseMap,
-        IncToDecStateMap, RegionStateInfo);
+        IncToDecStateMap, RegionStateInfo, SetFactory);
     --End;
   }
 
@@ -237,7 +237,7 @@ bool LoopARCSequenceDataflowEvaluator::processLoopBottomUp(
     // Then perform the region optimization.
     NestingDetected |= SubregionData.processBottomUp(
         AA, RCFI, LRFI, FreezeOwnedArgEpilogueReleases, ConsumedArgToReleaseMap,
-        IncToDecStateMap, RegionStateInfo);
+        IncToDecStateMap, RegionStateInfo, SetFactory);
   }
 
   return NestingDetected;
@@ -253,9 +253,9 @@ LoopARCSequenceDataflowEvaluator::LoopARCSequenceDataflowEvaluator(
     ProgramTerminationFunctionInfo *PTFI,
     BlotMapVector<SILInstruction *, TopDownRefCountState> &DecToIncStateMap,
     BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap)
-    : F(F), AA(AA), LRFI(LRFI), SLI(SLI), RCFI(RCFI),
-      DecToIncStateMap(DecToIncStateMap), IncToDecStateMap(IncToDecStateMap),
-      ConsumedArgToReleaseMap(RCFI, &F) {
+    : Allocator(), SetFactory(Allocator), F(F), AA(AA), LRFI(LRFI), SLI(SLI),
+      RCFI(RCFI), DecToIncStateMap(DecToIncStateMap),
+      IncToDecStateMap(IncToDecStateMap), ConsumedArgToReleaseMap(RCFI, &F) {
   for (auto *R : LRFI->getRegions()) {
     bool AllowsLeaks = false;
     if (R->isBlock())

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -18,6 +18,7 @@
 #include "swift/SILOptimizer/Analysis/ProgramTerminationAnalysis.h"
 #include "swift/Basic/BlotMapVector.h"
 #include "swift/Basic/NullablePtr.h"
+#include "swift/Basic/ImmutablePointerSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/Optional.h"
 
@@ -37,6 +38,9 @@ class ARCRegionState;
 class LoopARCSequenceDataflowEvaluator {
   /// The bump ptr allocator that is used to allocate memory in the allocator.
   llvm::BumpPtrAllocator Allocator;
+
+  /// The factory that we use to generate immutable pointer sets.
+  ImmutablePointerSetFactory<SILInstruction> SetFactory;
 
   /// The SILFunction that we are applying the dataflow to.
   SILFunction &F;

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.h
@@ -90,9 +90,21 @@ public:
   bool runOnLoop(const LoopRegion *R, bool FreezeOwnedArgEpilogueReleases,
                  bool RecomputePostDomReleases);
 
+  /// Summarize the subregions of \p R that are blocks.
+  ///
+  /// We assume that all subregions that are loops have already been summarized
+  /// since we are processing bottom up through the loop nest hierarchy.
+  void summarizeSubregionBlocks(const LoopRegion *R);
+
   /// Summarize the contents of the loop so that loops further up the loop tree
   /// can reason about the loop.
   void summarizeLoop(const LoopRegion *R);
+
+  /// Add \p I to the interesting instruction list of its parent block.
+  void addInterestingInst(SILInstruction *I);
+
+  /// Remove \p I from the interesting instruction list of its parent block.
+  void removeInterestingInst(SILInstruction *I);
 
 private:
   /// Merge in the BottomUp state of any successors of DataHandle.getBB() into

--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -160,7 +160,7 @@ bool RCStateTransition::merge(const RCStateTransition &Other) {
   if (!isMutator())
     return true;
 
-  Mutators.insert(Other.Mutators.begin(), Other.Mutators.end());
+  Mutators = Mutators->concat(Other.Mutators);
 
   return true;
 }

--- a/lib/SILOptimizer/ARC/RCStateTransition.h
+++ b/lib/SILOptimizer/ARC/RCStateTransition.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_ARC_RCSTATETRANSITION_H
 #define SWIFT_SILOPTIMIZER_PASSMANAGER_ARC_RCSTATETRANSITION_H
 
+#include "swift/Basic/ImmutablePointerSet.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -67,7 +68,8 @@ class RCStateTransition {
   /// An RCStateTransition can represent either an RC end point (i.e. an initial
   /// or terminal RC transition) or a ptr set of Mutators.
   ValueBase *EndPoint;
-  llvm::SmallPtrSet<SILInstruction *, 2> Mutators;
+  ImmutablePointerSet<SILInstruction> *Mutators =
+      ImmutablePointerSetFactory<SILInstruction>::getEmptySet();
   RCStateTransitionKind Kind;
 
   // Should only be constructed be default RefCountState.
@@ -77,15 +79,17 @@ public:
   ~RCStateTransition() {}
   RCStateTransition(const RCStateTransition &R);
 
-  RCStateTransition(SILInstruction *I) {
-    Kind = getRCStateTransitionKind(I);
+  RCStateTransition(ImmutablePointerSet<SILInstruction> *I) {
+    assert(I->size() == 1);
+    SILInstruction *Inst = *I->begin();
+    Kind = getRCStateTransitionKind(Inst);
     if (isRCStateTransitionEndPoint(Kind)) {
-      EndPoint = I;
+      EndPoint = Inst;
       return;
     }
 
     if (isRCStateTransitionMutator(Kind)) {
-      Mutators.insert(I);
+      Mutators = I;
       return;
     }
 
@@ -108,17 +112,17 @@ public:
   bool containsMutator(SILInstruction *I) const {
     assert(isMutator() && "This should only be called if we are of mutator "
                           "kind");
-    return Mutators.count(I);
+    return Mutators->count(I);
   }
 
-  using mutator_range = iterator_range<decltype(Mutators)::iterator>;
-  using const_mutator_range = iterator_range<decltype(Mutators)::const_iterator>;
+  using mutator_range =
+      iterator_range<std::remove_pointer<decltype(Mutators)>::type::iterator>;
 
   /// Returns a Range of Mutators. Asserts if this transition is not a mutator
   /// transition.
   mutator_range getMutators() const {
     assert(isMutator() && "This should never be called given mutators");
-    return {Mutators.begin(), Mutators.end()};
+    return {Mutators->begin(), Mutators->end()};
   }
 
   /// Return true if Inst is an instruction that causes a transition that can be

--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.h
@@ -22,6 +22,7 @@
 #include "ARCBBState.h"
 #include "ARCRegionState.h"
 #include "RCStateTransition.h"
+#include "swift/Basic/ImmutablePointerSet.h"
 #include "swift/Basic/BlotMapVector.h"
 
 //===----------------------------------------------------------------------===//
@@ -35,6 +36,7 @@ namespace swift {
 template <typename ImplTy, typename ResultTy>
 class RCStateTransitionKindVisitor {
   ImplTy &asImpl() { return *reinterpret_cast<ImplTy *>(this); }
+
 public:
 #define KIND(K) ResultTy visit ## K(ValueBase *) { return ResultTy(); }
 #include "RCStateTransition.def"
@@ -112,18 +114,21 @@ class BottomUpDataflowRCStateVisitor
   using IncToDecStateMapTy =
       BlotMapVector<SILInstruction *, BottomUpRefCountState>;
 
+public:
   RCIdentityFunctionInfo *RCFI;
   ARCState &DataflowState;
   bool FreezeOwnedArgEpilogueReleases;
   ConsumedArgToEpilogueReleaseMatcher &EpilogueReleaseMatcher;
   BlotMapVector<SILInstruction *, BottomUpRefCountState> &IncToDecStateMap;
+  ImmutablePointerSetFactory<SILInstruction> &SetFactory;
 
 public:
-  BottomUpDataflowRCStateVisitor(RCIdentityFunctionInfo *RCFI,
-                                 ARCState &DataflowState,
-                                 bool FreezeOwnedArgEpilogueReleases,
-                                 ConsumedArgToEpilogueReleaseMatcher &ERM,
-                                 IncToDecStateMapTy &IncToDecStateMap);
+  BottomUpDataflowRCStateVisitor(
+      RCIdentityFunctionInfo *RCFI, ARCState &DataflowState,
+      bool FreezeOwnedArgEpilogueReleases,
+      ConsumedArgToEpilogueReleaseMatcher &ERM,
+      IncToDecStateMapTy &IncToDecStateMap,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
   DataflowResult visitAutoreleasePoolCall(ValueBase *V);
   DataflowResult visitStrongDecrement(ValueBase *V);
   DataflowResult visitStrongIncrement(ValueBase *V);
@@ -152,11 +157,13 @@ class TopDownDataflowRCStateVisitor
   RCIdentityFunctionInfo *RCFI;
   ARCState &DataflowState;
   DecToIncStateMapTy &DecToIncStateMap;
+  ImmutablePointerSetFactory<SILInstruction> &SetFactory;
 
 public:
-  TopDownDataflowRCStateVisitor(RCIdentityFunctionInfo *RCFI,
-                                ARCState &State,
-                                DecToIncStateMapTy &DecToIncStateMap);
+  TopDownDataflowRCStateVisitor(
+      RCIdentityFunctionInfo *RCFI, ARCState &State,
+      DecToIncStateMapTy &DecToIncStateMap,
+      ImmutablePointerSetFactory<SILInstruction> &SetFactory);
   DataflowResult visitAutoreleasePoolCall(ValueBase *V);
   DataflowResult visitStrongDecrement(ValueBase *V);
   DataflowResult visitStrongIncrement(ValueBase *V);

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_unittest(SwiftBasicTests
   Unicode.cpp
   BlotMapVectorTest.cpp
   PointerIntEnumTest.cpp
+  ImmutablePointerSetTests.cpp
   ${generated_tests}
   )
 

--- a/unittests/Basic/ImmutablePointerSetTests.cpp
+++ b/unittests/Basic/ImmutablePointerSetTests.cpp
@@ -1,0 +1,100 @@
+#include "swift/Basic/ImmutablePointerSet.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Allocator.h"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace swift;
+
+TEST(ImmutableSortedSet, OneElementSets) {
+  llvm::BumpPtrAllocator BPA;
+  ImmutablePointerSetFactory<unsigned> F(BPA);
+
+  unsigned *ptr1 = (unsigned *)3;
+  auto *OneEltSet1 = F.get(ptr1);
+  EXPECT_EQ(OneEltSet1, F.get(ptr1));
+  EXPECT_EQ(OneEltSet1, F.concat(OneEltSet1, OneEltSet1));
+
+  unsigned *ptr2 = (unsigned *)2;
+  auto *OneEltSet2 = F.get(ptr2);
+  EXPECT_EQ(OneEltSet2, F.get(ptr2));
+  EXPECT_EQ(OneEltSet2, F.concat(OneEltSet2, OneEltSet2));
+  EXPECT_NE(OneEltSet2, OneEltSet1);
+
+  auto *Concat1 = F.concat(OneEltSet1, OneEltSet2);
+  auto *Concat2 = F.concat(OneEltSet2, OneEltSet1);
+  EXPECT_NE(OneEltSet1, Concat1);
+  EXPECT_NE(OneEltSet2, Concat1);
+  EXPECT_EQ(Concat1, Concat2);
+  EXPECT_EQ(Concat1, F.concat(Concat1, Concat1));
+  EXPECT_EQ(Concat2, F.concat(Concat2, Concat2));
+  EXPECT_EQ(Concat1, F.concat(Concat1, OneEltSet1));
+  EXPECT_EQ(Concat1, F.concat(Concat1, OneEltSet2));
+
+  EXPECT_EQ(Concat1->size(), 2U);
+  EXPECT_FALSE(Concat1->empty());
+  EXPECT_EQ(*Concat1->begin(), (unsigned *)2);
+  EXPECT_EQ(*std::next(Concat1->begin()), (unsigned *)3);
+
+  EXPECT_EQ(F.getEmptySet(), F.getEmptySet());
+  EXPECT_EQ(OneEltSet1, F.concat(F.getEmptySet(), OneEltSet1));
+  EXPECT_EQ(OneEltSet1, F.concat(OneEltSet1, F.getEmptySet()));
+}
+
+TEST(ImmutablePointerSet, MultipleElementSets) {
+  llvm::BumpPtrAllocator BPA;
+  ImmutablePointerSetFactory<unsigned> F(BPA);
+
+  unsigned *Ptr1 = (unsigned *)3;
+  unsigned *Ptr2 = (unsigned *)4;
+  unsigned *Ptr3 = (unsigned *)3;
+  unsigned *Ptr4 = (unsigned *)5;
+  unsigned *Ptr5 = (unsigned *)6;
+  std::vector<unsigned *> Data1;
+  Data1.push_back(Ptr1);
+  Data1.push_back(Ptr2);
+
+  auto *TwoEltSet = F.get(Data1);
+  EXPECT_FALSE(TwoEltSet->empty());
+  EXPECT_EQ(TwoEltSet->size(), 2u);
+  EXPECT_TRUE(TwoEltSet->count(Ptr1));
+  EXPECT_TRUE(TwoEltSet->count(Ptr2));
+  EXPECT_TRUE(TwoEltSet->count(Ptr3));
+  EXPECT_FALSE(TwoEltSet->count(Ptr4));
+  EXPECT_FALSE(TwoEltSet->count(Ptr5));
+
+  auto *ThreeEltSet = F.concat(F.get(Ptr4), TwoEltSet);
+  EXPECT_FALSE(ThreeEltSet->empty());
+  EXPECT_EQ(ThreeEltSet->size(), 3u);
+  EXPECT_NE(*ThreeEltSet, *TwoEltSet);
+  EXPECT_TRUE(ThreeEltSet->count(Ptr1));
+  EXPECT_TRUE(ThreeEltSet->count(Ptr2));
+  EXPECT_TRUE(ThreeEltSet->count(Ptr3));
+  EXPECT_TRUE(ThreeEltSet->count(Ptr4));
+  EXPECT_FALSE(ThreeEltSet->count(Ptr5));
+  EXPECT_EQ(ThreeEltSet, F.concat(TwoEltSet, ThreeEltSet));
+
+  std::vector<unsigned *> Data2 = {Ptr3, Ptr4, Ptr5};
+  auto *PartialOverlapSet = F.get(Data2);
+  EXPECT_FALSE(PartialOverlapSet->empty());
+  EXPECT_EQ(PartialOverlapSet->size(), 3u);
+  EXPECT_TRUE(PartialOverlapSet->count(Ptr1));
+  EXPECT_FALSE(PartialOverlapSet->count(Ptr2));
+  EXPECT_TRUE(PartialOverlapSet->count(Ptr3));
+  EXPECT_TRUE(PartialOverlapSet->count(Ptr4));
+  EXPECT_TRUE(PartialOverlapSet->count(Ptr5));
+  EXPECT_NE(*PartialOverlapSet, *ThreeEltSet);
+  EXPECT_NE(*PartialOverlapSet, *TwoEltSet);
+
+  auto *MixOfThreeAndPartialOverlap = ThreeEltSet->concat(PartialOverlapSet);
+  EXPECT_FALSE(MixOfThreeAndPartialOverlap->empty());
+  EXPECT_EQ(MixOfThreeAndPartialOverlap->size(), 4u);
+  EXPECT_TRUE(MixOfThreeAndPartialOverlap->count(Ptr1));
+  EXPECT_TRUE(MixOfThreeAndPartialOverlap->count(Ptr2));
+  EXPECT_TRUE(MixOfThreeAndPartialOverlap->count(Ptr3));
+  EXPECT_TRUE(MixOfThreeAndPartialOverlap->count(Ptr4));
+  EXPECT_TRUE(MixOfThreeAndPartialOverlap->count(Ptr5));
+  EXPECT_NE(*MixOfThreeAndPartialOverlap, *PartialOverlapSet);
+  EXPECT_NE(*MixOfThreeAndPartialOverlap, *ThreeEltSet);
+  EXPECT_NE(*MixOfThreeAndPartialOverlap, *TwoEltSet);
+}


### PR DESCRIPTION
This sequence of commits improves the speed and memory usage of ARC.

Specifically now:
1. We only visit instructions that are interesting from an ARC perspective. This should help for large CFGs with/without optimizations. Without optimizations this should help significantly by allowing us to not visit so many instructions (the tall pole).
2. We use immutable pointer sets when we transfer around sets of retainable pointers. This not only reduces compile time on large CFGs but also saves a significant amount of memory. On one pathological case (mentioned in one of the commits), this reduced the amount of memory/compile time by ~2.5x.
