### PR TITLE
Revert "[gardening] Fix typo: "nul-terminated" → "null-terminated""

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -48,7 +48,7 @@ enum class DeclRefKind {
 };
 
 /// Identifier - This is an instance of a uniqued identifier created by
-/// ASTContext.  It just wraps a null-terminated "const char*".
+/// ASTContext.  It just wraps a nul-terminated "const char*".
 class Identifier {
   friend class ASTContext;
   const char *Pointer;

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -48,7 +48,7 @@ class Lexer {
 
   /// Pointer to one past the end character of the buffer, even in a lexer
   /// that scans a subrange of the buffer.  Because the buffer is always
-  /// NULL-terminated, this points to the NUL terminator.
+  /// NUL-terminated, this points to the NUL terminator.
   const char *BufferEnd;
 
   /// Pointer to the artificial EOF that is located before BufferEnd.  Useful

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -594,7 +594,7 @@ extension String {
   /// `encoding`, without any allocations.  Does not NULL-terminate.
   ///
   /// - Parameter buffer: A buffer into which to store the bytes from
-  ///   the receiver. The returned bytes are not NULL-terminated.
+  ///   the receiver. The returned bytes are not NUL-terminated.
   ///
   /// - Parameter maxBufferCount: The maximum number of bytes to write
   ///   to buffer.

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -15,7 +15,7 @@
 import SwiftShims
 
 extension String {
-  /// Creates a new `String` by copying the null-terminated UTF-8 data
+  /// Creates a new `String` by copying the nul-terminated UTF-8 data
   /// referenced by a `CString`.
   ///
   /// Returns `nil` if the `CString` is `NULL` or if it contains ill-formed
@@ -30,7 +30,7 @@ extension String {
         input: UnsafeBufferPointer(start: UnsafeMutablePointer(cs), count: len))
   }
 
-  /// Creates a new `String` by copying the null-terminated UTF-8 data
+  /// Creates a new `String` by copying the nul-terminated UTF-8 data
   /// referenced by a `CString`.
   ///
   /// Returns `nil` if the `CString` is `NULL`.  If `CString` contains

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -31,7 +31,7 @@ public func withExtendedLifetime<T, Result>(
 extension String {
 
   /// Invoke `f` on the contents of this string, represented as
-  /// a null-terminated array of char, ensuring that the array's
+  /// a nul-terminated array of char, ensuring that the array's
   /// lifetime extends through the execution of `f`.
   public func withCString<Result>(
     @noescape f: UnsafePointer<Int8> throws -> Result

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -247,7 +247,7 @@ extension String {
     return _core.elementWidth == 1 ? _core.startASCII : nil
   }
 
-  /// A contiguously-stored null-terminated UTF-8 representation of
+  /// A contiguously-stored nul-terminated UTF-8 representation of
   /// `self`.
   ///
   /// To access the underlying memory, invoke

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -94,7 +94,7 @@ struct String {
     : String(ptr, strlen(ptr))
   {}
 
-  /// Create a Swift String from two concatenated null-terminated strings.
+  /// Create a Swift String from two concatenated nul-terminated strings.
   explicit String(const char *ptr1, const char *ptr2) {
     size_t len1 = strlen(ptr1);
     size_t len2 = strlen(ptr2);


### PR DESCRIPTION
Reverts apple/swift#1300

Sorry, but the comments were correct. The documentation is referring to the ASCII 'nul' character, not the NULL pointer.
