### PR TITLE
[stdlib] add minimumCapacity when creating intersect result

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -562,7 +562,8 @@ public struct Set<Element : Hashable> :
     S : SequenceType where S.Generator.Element == Element
   >(sequence: S) -> Set<Element> {
     let other = sequence as? Set<Element> ?? Set(sequence)
-    var newSet = Set<Element>()
+    var newSet = Set<Element>(
+      minimumCapacity: min(self.count, sequence.underestimateCount()))
     for member in self {
       if other.contains(member) {
         newSet.insert(member)


### PR DESCRIPTION
This is a micro performance optimization.

Here's _build-script -R --benchmark_ compared to master on my machine:

```
Comparing master/Benchmark_O-20160214013442.log init_set_with_capacity/Benchmark_O-20160214031647.log ...
  # TEST                      BEST_OLD_MIN(μs) BEST_NEW_MIN(μs)     DELTA    %DELTA   SPEEDUP
  1 AngryPhonebook                        3980             3722      -258     -6.5%     1.07x
  2 Array2D                             760682           741716    -18966     -2.5%     1.03x
  3 ArrayAppend                          70062            67797     -2265     -3.2%     1.03x
  4 ArrayAppendReserved                  70216            67519     -2697     -3.8%     1.04x
  5 ArrayInClass                         14152            13660      -492     -3.5%     1.04x
  6 ArrayLiteral                          2448             2295      -153     -6.2%     1.07x
  7 ArrayOfGenericPOD                      230              222        -8     -3.5%     1.04x
  8 ArrayOfGenericRef                     9438             9105      -333     -3.5%     1.04x
  9 ArrayOfPOD                             190              191        +1     +0.5%     0.99x (!)
 10 ArrayOfRef                            9330             8925      -405     -4.3%     1.05x
 11 ArraySubscript                        7430             7094      -336     -4.5%     1.05x
 12 ArrayValueProp                        8141            10094     +1953    +24.0%     0.81x (!)
 13 ArrayValueProp2                       7029             6499      -530     -7.5%     1.08x
 14 ArrayValueProp3                       6987             6529      -458     -6.6%     1.07x
 15 ArrayValueProp4                       8060             7653      -407     -5.0%     1.05x
 16 BitCount                                16               17        +1     +6.2%     0.94x (!)
 17 ByteSwap                                 1                1        +0     +0.0%     1.00x
 18 Calculator                              68               67        -1     -1.5%     1.01x
 19 CaptureProp                           6117             6150       +33     +0.5%     0.99x (!)
 20 Chars                                12158            12156        -2     -0.0%     1.00x
 21 ClassArrayGetter                       430              398       -32     -7.4%     1.08x
 22 DeadArray                              771              769        -2     -0.3%     1.00x
 23 Dictionary                            2694             2597       -97     -3.6%     1.04x
 24 Dictionary2                           4454             4294      -160     -3.6%     1.04x
 25 Dictionary3                           1621             1548       -73     -4.5%     1.05x
 26 DictionaryBridge                      3929             3932        +3     +0.1%     1.00x (!)
 27 DictionaryLiteral                    10218             9547      -671     -6.6%     1.07x
 28 DictionaryRemove                     11500            10482     -1018     -8.9%     1.10x
 29 DictionarySwap                        3500             3225      -275     -7.9%     1.09x
 30 ErrorHandling                         9660             8915      -745     -7.7%     1.08x
 31 GlobalClass                              0                0        +0         *         *
 32 Hanoi                                23166            21915     -1251     -5.4%     1.06x
 33 HashTest                             12579            11904      -675     -5.4%     1.06x
 34 Histogram                             3351             3152      -199     -5.9%     1.06x
 35 Integrate                              265              249       -16     -6.0%     1.06x
 36 Join                                  1867             1812       -55     -2.9%     1.03x
 37 LinkedList                           11717            11245      -472     -4.0%     1.04x
 38 MapReduce                            10406            10115      -291     -2.8%     1.03x
 39 Memset                              105463           102947     -2516     -2.4%     1.02x
 40 MonteCarloE                          39183            39244       +61     +0.2%     1.00x (!)
 41 MonteCarloPi                         47769            48665      +896     +1.9%     0.98x (!)
 42 NSDictionaryCastToSwift              13334            12641      -693     -5.2%     1.05x
 43 NSError                                297              296        -1     -0.3%     1.00x
 44 NSStringConversion                     733             1062      +329    +44.9%     0.69x (!)
 45 NopDeinit                            40458            40942      +484     +1.2%     0.99x (!)
 46 ObjectAllocation                       278              283        +5     +1.8%     0.98x (!)
 47 OpenClose                               74               73        -1     -1.4%     1.01x
 48 Phonebook                            11506            11109      -397     -3.5%     1.04x
 49 PolymorphicCalls                       114              111        -3     -2.6%     1.03x
 50 PopFrontArray                         6444             6279      -165     -2.6%     1.03x
 51 PopFrontArrayGeneric                  6019             5993       -26     -0.4%     1.00x
 52 PopFrontUnsafePointer                12683            12399      -284     -2.2%     1.02x
 53 Prims                                 6637             6621       -16     -0.2%     1.00x
 54 ProtocolDispatch                      3217             3186       -31     -1.0%     1.01x
 55 RC4                                  28707            27691     -1016     -3.5%     1.04x
 56 RGBHistogram                         11625            11431      -194     -1.7%     1.02x
 57 RangeAssignment                        924              907       -17     -1.8%     1.02x
 58 RecursiveOwnedParameter              13027            12765      -262     -2.0%     1.02x
 59 SetExclusiveOr                       10029            10102       +73     +0.7%     0.99x (!)
 60 SetIntersect                          4149             4044      -105     -2.5%     1.03x
 61 SetIsSubsetOf                         1380             1354       -26     -1.9%     1.02x
 62 SetUnion                              7896             7559      -337     -4.3%     1.04x
 63 SevenBoom                             1518             1473       -45     -3.0%     1.03x
 64 Sim2DArray                           62484            61249     -1235     -2.0%     1.02x
 65 SortLettersInPlace                    1274             1265        -9     -0.7%     1.01x
 66 SortStrings                           1837             1800       -37     -2.0%     1.02x
 67 StaticArray                           2835             3050      +215     +7.6%     0.93x (!)
 68 StrComplexWalk                        7294             7300        +6     +0.1%     1.00x (!)
 69 StrToInt                             10214            10336      +122     +1.2%     0.99x (!)
 70 StringBuilder                        10003             9719      -284     -2.8%     1.03x
 71 StringInterpolation                  25510            25907      +397     +1.6%     0.98x (!)
 72 StringWalk                            6326             6290       -36     -0.6%     1.01x
 73 StringWithCString                   229990           227691     -2299     -1.0%     1.01x
 74 SuperChars                          942739           942183      -556     -0.1%     1.00x
    Totals                             2888363          2847257    -41106     -1.4%     1.01x
 75 TwoSum                                4849             4783       -66     -1.4%     1.01x
 76 TypeFlood                                0                0        +0         *         *
 77 Walsh                                41798            40535     -1263     -3.0%     1.03x
 78 XorLoop                              58883            58461      -422     -0.7%     1.01x
```
