### PR TITLE
Simplify the logic of getting the platform name from a triple.

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -58,14 +58,5 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     return "watchos";
   }
 
-  if (triple.isMacOSX())
-    return "macosx";
-
-  if (triple.isOSLinux())
-    return "linux";
-
-  if (triple.isOSFreeBSD())
-    return "freebsd";
-
-  return "";
+  return StringRef(triple.getOSTypeName(triple.getOS()));
 }


### PR DESCRIPTION
Outside of iOS, tvOS and watchOS the platform names don't seem to diverge.
I thought it might be better to take advantage of llvm's `getOSTypeName` to grab the platform name.

Hope it helps!
