### PR TITLE
[Sema] Remove a superfluous diagnosis

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -395,6 +395,7 @@ Type TypeChecker::applyGenericArguments(Type type, SourceLoc loc,
     if (!type->is<ErrorType>())
       diagnose(loc, diag::not_a_generic_type, type)
           .fixItRemove(generic->getAngleBrackets());
+    generic->setInvalid();
     return type;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -969,16 +969,6 @@ static Type resolveNestedIdentTypeComponent(
                                                            parentRange,
                                                            comp);
     assert(memberType && "Received null dependent member type");
-
-    if (isa<GenericIdentTypeRepr>(comp) && !memberType->is<ErrorType>()) {
-      // FIXME: Highlight generic arguments and introduce a Fix-It to
-      // remove them.
-      if (diagnoseErrors)
-        TC.diagnose(comp->getIdLoc(), diag::not_a_generic_type, memberType);
-
-      // Drop the arguments.
-    }
-
     // If we know what type declaration we're referencing, store it.
     if (auto typeDecl = memberType->getDirectlyReferencedTypeDecl()) {
       comp->setValue(typeDecl);

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -38,7 +38,4 @@ public class A<X> {
 
 protocol P { associatedtype A }
 
-// FIXME: only emit this diagnostic once
-func f12<T : P>(x: T) -> T.A<Int> {}
-// expected-error @-1 {{cannot specialize non-generic type 'T.A'}}
-// expected-error @-2 {{cannot specialize non-generic type 'T.A'}}
+func f12<T : P>(x: T) -> T.A<Int> {} //expected-error{{cannot specialize non-generic type 'T.A'}}{{29-34=}}

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -35,3 +35,10 @@ public class A<X> {
   public func f10(x:Int) {}
   public func f11<T, U>(x:X, y:T) {} //expected-error{{generic parameter 'U' is not used in function signature}}
 }
+
+protocol P { associatedtype A }
+
+// FIXME: only emit this diagnostic once
+func f12<T : P>(x: T) -> T.A<Int> {}
+// expected-error @-1 {{cannot specialize non-generic type 'T.A'}}
+// expected-error @-2 {{cannot specialize non-generic type 'T.A'}}


### PR DESCRIPTION
The same diagnostic (but including a Fix-It hint) is already issued twice (!) in `applyGenericArguments`.
