### PR TITLE
[gardening] Fix recently introduced typo: "getLofForEndOfToken" → "getLocForEndOfToken"

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -140,7 +140,7 @@ public:
   ///   need to take a LangOptions explicitly.
   /// \param InSILMode - whether we're parsing a SIL source file.
   ///   Unlike language options, this does affect primitive lexing, which
-  ///   means that APIs like getLofForEndOfToken really ought to take
+  ///   means that APIs like getLocForEndOfToken really ought to take
   ///   this flag; it's just that we don't care that much about fidelity
   ///   when parsing SIL files.
   Lexer(const LangOptions &Options,


### PR DESCRIPTION
Thanks to @AlexDenisov for noticing: https://twitter.com/1101_debian/status/698963656130850821 ッ
