### PR TITLE
Remove unused variable SourceOrder

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3558,7 +3558,6 @@ static void writeDeclCommentTable(
     llvm::SmallString<512> USRBuffer;
     llvm::OnDiskChainedHashTableGenerator<DeclCommentTableInfo> generator;
     DeclGroupNameContext &GroupContext;
-    unsigned SourceOrder = 0;
 
     DeclCommentTableWriter(DeclGroupNameContext &GroupContext) :
       GroupContext(GroupContext) {}


### PR DESCRIPTION
Context: https://github.com/apple/swift/commit/9aa3d011015637f01ecffb9e62fd750fcc47a47b

After this commit:

```
$ git grep SourceOrder
$
```

/cc @nkcsgexi
