### PR TITLE
Add a test for enablement of fixed enum on non-Darwin targets

### DIFF
--- a/test/ClangModules/Inputs/enum-c.h
+++ b/test/ClangModules/Inputs/enum-c.h
@@ -1,0 +1,11 @@
+typedef long NSInteger;
+
+#define SWIFT_ENUM_EXTRA
+#define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
+#define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); enum SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_EXTRA _name : _type
+
+typedef SWIFT_ENUM_NAMED(NSInteger, CEnum, "SwiftEnum") {
+    CEnumOne = 1,
+    CEnumTwo,
+    CEnumThree
+};

--- a/test/ClangModules/enum-c.swift
+++ b/test/ClangModules/enum-c.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/enum-c.h -verify
+
+func test(value: SwiftEnum) {
+    switch value {
+    case .One: break
+    case .Two: break
+    case .Three: break
+    } // no error
+}


### PR DESCRIPTION
There is a patch at swift-clang that enables CF_ENUM and CF_OPTIONS for swift on non-darwin targets https://github.com/apple/swift-clang/pull/8 This patch adds a test for that change.
