### PR TITLE
[WIP][Parser][SE-0031] adjust inout declaration for type decoration

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -143,6 +143,10 @@ WARNING(lex_editor_placeholder_in_playground,none,
 // Declaration parsing diagnostics
 //------------------------------------------------------------------------------
 
+WARNING(inout_as_attr_deprecated,none,
+        "'inout' as parameter attribute is deprecated, prefix type with it instead.",
+        ())
+
 ERROR(declaration_same_line_without_semi,none,
       "consecutive declarations on a line must be separated by ';'", ())
 


### PR DESCRIPTION
This PR implements [SE-0031](//github.com/apple/swift-evolution/blob/master/proposals/0031-adjusting-inout-declarations.md).
When `inout` appears before parameter name, the parser issues a warning and
suggests the correct alternate location for it.

`inout` prefixing the paramter type is now valid.

_Work in progress:_
- [x] Make new location for `inout` valid
- [x] Add warning and fixits.
- [x] Update tests.
- [ ] Make ASTPrinter print the new syntax
