### PR TITLE
[build-script] Build & test XCTest (on OS X, too)

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1746,11 +1746,17 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 continue
                 ;;
             xctest)
-                SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
-                SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
-                set -x
-                "${XCTEST_SOURCE_DIR}"/build_script.py --swiftc="${SWIFTC_BIN}" --build-dir="${build_dir}" --swift-build-dir="${SWIFT_BUILD_PATH}" --arch="${SWIFT_HOST_VARIANT_ARCH}"
-                { set +x; } 2>/dev/null
+                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                    set -x
+                    xcodebuild -project "${XCTEST_SOURCE_DIR}"/XCTest.xcodeproj -scheme SwiftXCTest SKIP_INSTALL=NO DEPLOYMENT_LOCATION=YES DSTROOT="${build_dir}" INSTALL_PATH="/"
+                    { set +x; } 2>/dev/null
+                else
+                    SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
+                    SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
+                    set -x
+                    "${XCTEST_SOURCE_DIR}"/build_script.py --swiftc="${SWIFTC_BIN}" --build-dir="${build_dir}" --swift-build-dir="${SWIFT_BUILD_PATH}" --arch="${SWIFT_HOST_VARIANT_ARCH}"
+                    { set +x; } 2>/dev/null
+                fi
 
                 # XCTest builds itself and doesn't rely on cmake
                 continue
@@ -1991,7 +1997,21 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 if [[ "${SKIP_TEST_XCTEST}" ]]; then
                     continue
                 fi
-                # FIXME: We don't test xctest, yet...
+                echo "--- Running tests for ${product} ---"
+                if [[ "$(uname -s)" == "Darwin" ]] ; then
+                    set -x
+                    xcodebuild -project "${XCTEST_SOURCE_DIR}"/XCTest.xcodeproj -scheme SwiftXCTestFunctionalTests
+                    { set +x; } 2>/dev/null
+                else
+                    SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
+                    SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
+                    set -x
+                    # FIXME: This re-builds swift-corelibs-xctest. Instead, 'build_script.py' should take
+                    # a top-level 'test' command that only tests an already built XCTest.
+                    "${XCTEST_SOURCE_DIR}"/build_script.py --swiftc="${SWIFTC_BIN}" --build-dir="${build_dir}" --swift-build-dir="${SWIFT_BUILD_PATH}" --arch="${SWIFT_HOST_VARIANT_ARCH}" --test
+                    { set +x; } 2>/dev/null
+                fi
+                echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
             foundation)


### PR DESCRIPTION
# What's in this pull request?

Allow swift-corelibs-xctest to be built and tested on Linux and OS X, via `utils/build-script --xctest --test`.

On OS X, XCTest is built via `xcodebuild`, which has been possible since https://github.com/apple/swift-corelibs-xctest/pull/47. It's tested via the "SwiftXCTestFunctionalTests" Xcode target. Keep in mind that `xcodebuild` must be configured on the host machine to use a Swift toolchain that can build XCTest--as of https://github.com/apple/swift-corelibs-xctest/pull/48, that would be `swift-DEVELOPMENT-SNAPSHOT-2016-02-08` or later.

On Linux, XCTest is built and tested via the project's `build_script.py`, which has been possible since https://github.com/apple/swift-corelibs-xctest/pull/46.
# Why merge this pull request?

Although swift-corelibs-xctest has been added to Apple CI in https://github.com/apple/swift-corelibs-xctest/pull/45#issuecomment-181749005, the build script triggered doesn't actually run the test suite. Because the project has lacked CI that can run the test suite, pull requests that break the tests have been merged in the past (https://github.com/apple/swift-corelibs-xctest/pull/33 and https://github.com/apple/swift-corelibs-xctest/pull/44, for example). Allowing the build script to test swift-corelibs-xctest will keep swift-corelibs-xctest more stable.
# What are the downsides of merging this pull request?
- On OS X, `xcodebuild` must be invoked with a toolchain capable of building swift-corelibs-xctest. The build script changes in this pull request do not enforce a specific toolchain (I'm not sure if this is possible). Invoking the build script with the wrong toolchain will cause the build script to fail. Keep in mind that this is still better than the current situation, in which OS X will attempt to run the Linux-only swift-corelibs-xctest build script.
- There are some situations in which both swift-corelibs-xctest and this build script will need to be updated at the same time. For example, https://github.com/apple/swift-corelibs-xctest/pull/43 adds a dependency on swift-corelibs-foundation, which necessitates a change in how swift-corelibs-xctest is built.
