### PR TITLE
[swift-api-dump] Omit 'python' in usage (NFC)

### DIFF
--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -73,7 +73,7 @@ def create_parser():
     parser = argparse.ArgumentParser(
         description="Dumps imported Swift APIs for a module or SDK",
         prog='swift-api-dump.py',
-        usage='python swift-api-dump.py -s iphoneos')
+        usage='%(prog)s -s iphoneos')
     parser.add_argument('-m', '--module', help='The module name.')
     parser.add_argument('-j', '--jobs', type=int, help='The number of parallel jobs to execute')
     parser.add_argument('-s', '--sdk', nargs='+', required=True, help="The SDKs to use.")


### PR DESCRIPTION
- Since this file has a Python shebang (`#!/usr/bin/env python`) at the top, it can be invoked directly, without specifying which Python interpreter to use on the command line.
- Use the `%(prog)s` substitution instead of writing the program name again explicitly.
