### PR TITLE
[Sema] Extend callee diagnosis to multiple generics

### DIFF
--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -14,8 +14,7 @@ func min<T : Comparable>(x: T, y: T) -> T {
 func weirdConcat<T : ConcatToAnything, U>(t: T, u: U) {
   t +++ u
   t +++ 1
-  u +++ t // expected-error{{binary operator '+++' cannot be applied to operands of type 'U' and 'T'}}
-  // expected-note @-1 {{expected an argument list of type '(Self, T)'}}
+  u +++ t // expected-error{{argument type 'U' does not conform to expected type 'ConcatToAnything'}}
 }
 
 // Make sure that the protocol operators don't get in the way.

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -65,7 +65,7 @@ func takeTuples<T, U>(_: (T, U), _: (U, T)) {
 func useTuples(x: Int, y: Float, z: (Float, Int)) {
   takeTuples((x, y), (y, x))
 
-  takeTuples((x, y), (x, y)) // expected-error{{cannot convert value of type '(Int, Float)' to expected argument type '(_, _)'}}
+  takeTuples((x, y), (x, y)) // expected-error{{cannot convert value of type 'Int' to expected argument type 'Float'}}
 
   // FIXME: Use 'z', which requires us to fix our tuple-conversion
   // representation.
@@ -75,7 +75,7 @@ func acceptFunction<T, U>(f: (T) -> U, _ t: T, _ u: U) {}
 
 func passFunction(f: (Int) -> Float, x: Int, y: Float) {
    acceptFunction(f, x, y)
-   acceptFunction(f, y, y) // expected-error{{cannot convert value of type '(Int) -> Float' to expected argument type '(_) -> _'}}
+   acceptFunction(f, y, y) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
 }
 
 func returnTuple<T, U>(_: T) -> (T, U) { } // expected-note {{in call to function 'returnTuple'}}

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -75,8 +75,8 @@ protocol Overload {
   associatedtype B
   func getA() -> A
   func getB() -> B
-  func f1(_: A) -> A // expected-note{{found this candidate}}
-  func f1(_: B) -> B // expected-note{{found this candidate}}
+  func f1(_: A) -> A
+  func f1(_: B) -> B
   func f2(_: Int) -> A // expected-note{{found this candidate}}
   func f2(_: Int) -> B // expected-note{{found this candidate}}
   func f3(_: Int) -> Int // expected-note {{found this candidate}}
@@ -106,7 +106,8 @@ func testOverload<Ovl : Overload, OtherOvl : Overload>(ovl: Ovl, ovl2: Ovl,
   a = ovl2.f2(17)
   a = ovl2.f1(a)
 
-  other.f1(a) // expected-error{{ambiguous reference to member 'f1'}}
+  other.f1(a) // expected-error{{cannot invoke 'f1' with an argument list of type '(Ovl.A)'}}
+  // expected-note @-1 {{overloads for 'f1' exist with these partially matching parameter lists: (Self.A), (Self.B)}}
                                                         
   // Overloading based on context
   var f3i : (Int) -> Int = ovl.f3
@@ -132,7 +133,7 @@ protocol Subscriptable {
   func getIndex() -> Index
   func getValue() -> Value
 
-  subscript (index : Index) -> Value { get set } // expected-note{{found this candidate}}
+  subscript (index : Index) -> Value { get set }
 }
 
 protocol IntSubscriptable {
@@ -140,7 +141,7 @@ protocol IntSubscriptable {
 
   func getElement() -> ElementType
 
-  subscript (index : Int) -> ElementType { get  } // expected-note{{found this candidate}}
+  subscript (index : Int) -> ElementType { get  }
 }
 
 func subscripting<T : protocol<Subscriptable, IntSubscriptable>>(t: T) {
@@ -153,7 +154,8 @@ func subscripting<T : protocol<Subscriptable, IntSubscriptable>>(t: T) {
   element = t[17]
   t[42] = element // expected-error{{cannot assign through subscript: subscript is get-only}}
 
-  t[value] = 17 // expected-error{{ambiguous reference to member 'subscript'}}
+  // Suggests the Int form because we prefer concrete matches to generic matches in diagnosis.
+  t[value] = 17 // expected-error{{cannot convert value of type 'T.Value' to expected argument type 'Int'}}
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -200,8 +200,7 @@ func useNested(ii: Int, hni: HasNested<Int>,
 
   // Generic constructor of a generic struct
   HNI(1, 2.71828) // expected-warning{{unused}}
-  // FIXME: Should report this error: {{cannot convert the expression's type 'HNI' to type 'Int'}}
-  HNI(1.5, 2.71828) // expected-error{{cannot invoke initializer for type 'HNI' with an argument list of type '(Double, Double)'}} expected-note{{expected an argument list of type '(T, U)'}}
+  HNI(1.5, 2.71828) // expected-error{{'Double' is not convertible to 'Int'}}
 
   // Generic function in a nested generic struct
   var ids = xis.g(1, u: "Hello", v: 3.14159)


### PR DESCRIPTION
Straightforward extension of the previous work here (last pull was https://github.com/apple/swift/pull/1229) to handle callees with multiple generic parameters. Same type requirements are already handled by the ArchetypeBuilder, and protocol conformance is handled explicitly. This is still bailing on nested archetypes.

Pre-existing tests updated that now give better diagnoses.
