### PR TITLE
Runtime: Fix crash with non-pointer isa in swift_deallocPartialClassI…

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -445,7 +445,7 @@ extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
     return;
 
   // Destroy ivars
-  auto *objectMetadata = object->metadata;
+  auto *objectMetadata = _swift_getClassOfAllocated(object);
   while (objectMetadata != metadata) {
     auto classMetadata = objectMetadata->getClassObject();
     assert(classMetadata && "Not a class?");


### PR DESCRIPTION
…nstance()

Deallocation of partially-initialized instances of @objc classes
isn't supported yet, but let's avoid a regression compared to
Swift 2.1 behavior by fixing the one case that used to work,
where the early return occurs after all stored properties have
been initialized.

Fixes SR-704.
