### PR TITLE
Add .zero convenience static vars for UIEdgeInsets and UIOffset

### DIFF
--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -13,6 +13,23 @@
 import Foundation
 @_exported import UIKit
 
+//===----------------------------------------------------------------------===//
+// UIGeometry
+//===----------------------------------------------------------------------===//
+
+public extension UIEdgeInsets {
+  static var zero: UIEdgeInsets {
+    @_transparent // @fragile
+    get { return UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0) }
+  }
+}
+
+public extension UIOffset {
+  static var zero: UIOffset {
+    @_transparent // @fragile
+    get { return UIOffset(horizontal: 0.0, vertical: 0.0) }
+  }
+}
 
 //===----------------------------------------------------------------------===//
 // Equatable types.

--- a/test/1_stdlib/UIKit.swift
+++ b/test/1_stdlib/UIKit.swift
@@ -56,6 +56,8 @@ print("inset1 == inset2: \(inset1 == inset2)")
 // CHECK: inset1 != inset1: false
 // CHECK: inset1 == inset2: false
 
+assert(inset1 != UIEdgeInsets.zero)
+
 var offset1 = UIOffset(horizontal: 1.0, vertical: 2.0)
 var offset2 = UIOffset(horizontal: 1.0, vertical: 3.0)
 print("offset1 == offset1: \(offset1 == offset1)")
@@ -65,3 +67,13 @@ print("offset1 == offset2: \(offset1 == offset2)")
 // CHECK: offset1 != offset1: false
 // CHECK: offset1 == offset2: false
 
+assert(offset1 != UIOffset.zero)
+
+var inset0 = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
+var insetDot0 = UIEdgeInsets.zero
+print("inset0 == insetDot0: \(inset0 == insetDot0)")
+// CHECK: inset0 != insetDot0: true
+
+var offset0 = UIOffset(horizontal: 0.0, vertical: 0.0)
+var offsetDot0 = UIOffset.zero
+print("offset0 == offsetDot0: \(offset0 == offsetDot0)")

--- a/test/1_stdlib/UIKit.swift
+++ b/test/1_stdlib/UIKit.swift
@@ -69,8 +69,9 @@ print("offset1 == offset2: \(offset1 == offset2)")
 var inset0 = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
 var insetDot0 = UIEdgeInsets.zero
 print("inset0 == insetDot0: \(inset0 == insetDot0)")
-// CHECK: inset0 != insetDot0: true
+// CHECK: inset0 == insetDot0: true
 
 var offset0 = UIOffset(horizontal: 0.0, vertical: 0.0)
 var offsetDot0 = UIOffset.zero
 print("offset0 == offsetDot0: \(offset0 == offsetDot0)")
+// CHECK: offset0 == offsetDot0: true

--- a/test/1_stdlib/UIKit.swift
+++ b/test/1_stdlib/UIKit.swift
@@ -56,8 +56,6 @@ print("inset1 == inset2: \(inset1 == inset2)")
 // CHECK: inset1 != inset1: false
 // CHECK: inset1 == inset2: false
 
-assert(inset1 != UIEdgeInsets.zero)
-
 var offset1 = UIOffset(horizontal: 1.0, vertical: 2.0)
 var offset2 = UIOffset(horizontal: 1.0, vertical: 3.0)
 print("offset1 == offset1: \(offset1 == offset1)")
@@ -67,7 +65,6 @@ print("offset1 == offset2: \(offset1 == offset2)")
 // CHECK: offset1 != offset1: false
 // CHECK: offset1 == offset2: false
 
-assert(offset1 != UIOffset.zero)
 
 var inset0 = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
 var insetDot0 = UIEdgeInsets.zero


### PR DESCRIPTION
Using UIEdgeInsetsZero instead of UIEdgeInsets.zero was annoying.
Copied the style from '/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift'

I think this is the logical place to put all the bits. Was unsure whether to use the `print(…) … // CHECK: …` style tests or just an `assert` so I did both.
