### PR TITLE
[validation-test] More granular FixedPoint tests

### DIFF
--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -82,23 +82,20 @@ truncating_bit_pattern_test_template = gyb.parseTemplate("truncating_bit_pattern
 
 % for dst_ty in all_integer_types(word_bits):
 %   Dst = dst_ty.stdlib_name
-
-FixedPoint.test("${Dst}(truncatingBitPattern:)") {
-
 %   for src_ty in all_integer_types(word_bits):
 %     Src = src_ty.stdlib_name
 %     if should_define_truncating_bit_pattern_init(src_ty=src_ty, dst_ty=dst_ty):
 %
 %       for bit_pattern in test_bit_patterns:
 
-  do {
+FixedPoint.test("${Dst}(truncatingBitPattern:) from ${Src}(${bit_pattern})") {
 %       input = prepare_bit_pattern(bit_pattern, src_ty.bits, src_ty.is_signed)
-    let input = get${Src}(${input})
+  let input = get${Src}(${input})
 %       input = prepare_bit_pattern(input, src_ty.bits, False)
-    let output = get${Dst}(${Dst}(truncatingBitPattern: input))
-    let expected = get${Dst}(${prepare_bit_pattern(input, dst_ty.bits, dst_ty.is_signed)})
-    expectEqual(expected, output)
-  }
+  let output = get${Dst}(${Dst}(truncatingBitPattern: input))
+  let expected = get${Dst}(${prepare_bit_pattern(input, dst_ty.bits, dst_ty.is_signed)})
+  expectEqual(expected, output)
+}
 
 %       end
 
@@ -112,7 +109,8 @@ FixedPoint.test("${Dst}(truncatingBitPattern:)") {
 
 %   end
 
-}
+// This comment prevents gyb from miscompiling this file.
+// <rdar://problem/17548877> gyb miscompiles a certain for loop
 
 % end
 """)
@@ -157,11 +155,9 @@ bit_pattern_test_template = gyb.parseTemplate("bit_pattern",
 %   # Source is the same as destination, but of different signedness.
 %   src_ty = dst_ty.get_opposite_signedness()
 %   Src = src_ty.stdlib_name
-
-FixedPoint.test("${Dst}(bitPattern: ${Src})") {
-
 %   for bit_pattern in test_bit_patterns:
 
+FixedPoint.test("${Dst}(bitPattern:) from ${Src}(${bit_pattern})") {
   do {
 %     input = prepare_bit_pattern(bit_pattern, src_ty.bits, src_ty.is_signed)
     let input = get${Src}(${input})
@@ -184,11 +180,9 @@ FixedPoint.test("${Dst}(bitPattern: ${Src})") {
     expectEqual(expected, literalOutput)
     expectEqual(expected, output)
   }
-
-%   end
-
 }
 
+%   end
 % end
 
 """)


### PR DESCRIPTION
`FixedPoint.swift.gyb` generates a massive amount of assertions: one for each `Int` type (such as `UInt8` and `Int64`) as a source, to one of each `Int` type as a destination, for each of 27 bit patterns. By my math that's 8 \* 8 \* 27 == 1728 assertions. As a result, when one of those assertions fails, it's difficult to
tell what went wrong.

Split each assertion into its own test case. This makes the test take a little longer to run, but it produces much more valuable output when it fails.
