### PR TITLE
[swiftc] Add test case for crash triggered in swift::Decl::dump(…)

### DIFF
--- a/validation-test/compiler_crashers/28255-swift-decl-dump.swift
+++ b/validation-test/compiler_crashers/28255-swift-decl-dump.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func Q<Tere{class a:a{init(){extension{class A


### PR DESCRIPTION
Stack trace:

```
13 swift           0x0000000000f2f1a8 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const + 152
18 swift           0x0000000000f2f1a8 swift::Decl::dump(llvm::raw_ostream&, unsigned int) const + 152
27 swift           0x0000000000f6d024 swift::Decl::walk(swift::ASTWalker&) + 20
28 swift           0x0000000001000a6e swift::SourceFile::walk(swift::ASTWalker&) + 174
29 swift           0x0000000000f53324 swift::verify(swift::SourceFile&) + 52
30 swift           0x0000000000dcd4e4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1492
31 swift           0x0000000000c8023f swift::CompilerInstance::performSema() + 2975
33 swift           0x0000000000774691 frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2481
34 swift           0x000000000076f1d5 main + 2773
Stack dump:
0.  Program arguments: /path/to/build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28255-swift-decl-dump.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28255-swift-decl-dump-ac2682.o
1.  While walking into decl 'Q' at validation-test/compiler_crashers/28255-swift-decl-dump.swift:8:1
2.  While walking into body of 'Q' at validation-test/compiler_crashers/28255-swift-decl-dump.swift:8:1
3.  While verifying overridden 'init' at validation-test/compiler_crashers/28255-swift-decl-dump.swift:8:23
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
