### PR TITLE
[Sema] An initializer in a protocol extension is effectively 'required'.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2218,6 +2218,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         if (((classDecl = Adoptee->getClassOrBoundGenericClass()) &&
              !classDecl->isFinal()) &&
             !witnessCtor->isRequired() &&
+            !witnessCtor->getDeclContext()
+               ->isProtocolOrProtocolExtensionContext() &&
             !witnessCtor->hasClangNode()) {
           // FIXME: We're not recovering (in the AST), so the Fix-It
           // should move.

--- a/test/decl/protocol/conforms/init.swift
+++ b/test/decl/protocol/conforms/init.swift
@@ -45,3 +45,25 @@ extension C2c : P1 {
   convenience init() { self.init(x: 0) } // expected-error{{initializer requirement 'init()' can only be satisfied by a `required` initializer in the definition of non-final class 'C2c'}}
 }
 
+// rdar://problem/24575507
+protocol P2 {
+  init()
+  init(int: Int)
+}
+
+extension P2 {
+  init() {
+    self.init(int: 17)
+  }
+}
+
+
+class Foo : P2 {
+  var value: Int
+
+  // okay: init() requirement satisfied by protocol extension
+
+  required init(int value: Int) {
+    self.value = value
+  }
+}


### PR DESCRIPTION
Fixes rdar://problem/24575507.
