### PR TITLE
Use the new LLVM cmake paths

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -147,11 +147,21 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
   find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" "${${product}_NATIVE_LLVM_TOOLS_PATH}"
     NO_DEFAULT_PATH)
 
-  set(LLVM_CMAKE_PATH "${LLVM_BINARY_DIR}/share/llvm/cmake")
-  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_PATH}")
+  set(LLVM_CMAKE_PATHS
+      "${LLVM_BINARY_DIR}/share/llvm/cmake"
+      "${LLVM_BINARY_DIR}/lib/cmake/llvm")
 
-  set(LLVMCONFIG_FILE "${LLVM_CMAKE_PATH}/LLVMConfig.cmake")
-  if(NOT EXISTS ${LLVMCONFIG_FILE})
+  set(LLVMCONFIG_FILE)
+  foreach(CMAKE_PATH ${LLVM_CMAKE_PATHS})
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_PATH}")
+
+    if(EXISTS "${CMAKE_PATH}/LLVMConfig.cmake")
+      set(LLVMCONFIG_FILE "${CMAKE_PATH}/LLVMConfig.cmake")
+      break()
+    endif()
+  endforeach()
+
+  if(${LLVMCONFIG_FILE} STREQUAL "")
     message(FATAL_ERROR "Not found: ${LLVMCONFIG_FILE}")
   endif()
 


### PR DESCRIPTION
Update the paths that we look in for the cmake modules from LLVM which changed
recently on SVN trunk.  Check the old paths first, and if that fails, check the
new path.  This permits building against either layout.
