### PR TITLE
[SE-0031] Adjusting 'inout' Declarations for Type Decoration

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -145,6 +145,9 @@ WARNING(lex_editor_placeholder_in_playground,none,
 
 NOTE(note_in_decl_extension,none,
      "in %select{declaration|extension}0 of %1", (bool, Identifier))
+WARNING(inout_as_attr_deprecated,none,
+        "'inout' as parameter attribute is deprecated, prefix type with it instead.",
+        ())
 
 ERROR(declaration_same_line_without_semi,none,
       "consecutive declarations on a line must be separated by ';'", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -146,7 +146,7 @@ WARNING(lex_editor_placeholder_in_playground,none,
 NOTE(note_in_decl_extension,none,
      "in %select{declaration|extension}0 of %1", (bool, Identifier))
 WARNING(inout_as_attr_deprecated,none,
-        "'inout' as parameter attribute is deprecated, prefix type with it instead.",
+        "'inout' before a parameter name is deprecated, place it before the parameter type instead",
         ())
 
 ERROR(declaration_same_line_without_semi,none,

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -186,9 +186,10 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         status |= makeParserCodeCompletionStatus();
       }
     }
-
+    //SourceLoc deprecatedInoutLoc;
     // ('inout' | 'let' | 'var')?
     if (Tok.is(tok::kw_inout)) {
+      //deprecatedInoutLoc = Tok.getLoc();
       param.LetVarInOutLoc = consumeToken();
       param.SpecifierKind = ParsedParameter::InOut;
     } else if (Tok.is(tok::kw_let)) {
@@ -242,8 +243,28 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         param.SecondNameLoc = SourceLoc();
       }
 
-      // (':' type)?
+      // (':' ('inout')? type)?
       if (consumeIf(tok::colon)) {
+
+        SourceLoc postColonLoc = Tok.getLoc();
+
+        bool hasDeprecatedInOut =
+          param.SpecifierKind == ParsedParameter::InOut;
+
+        if (Tok.is(tok::kw_inout)) {
+          SourceLoc deprecatedInOutLoc = param.LetVarInOutLoc;
+          param.LetVarInOutLoc = consumeToken();
+          param.SpecifierKind = ParsedParameter::InOut;
+          if (hasDeprecatedInOut) {
+            diagnose(deprecatedInOutLoc, diag::inout_as_attr_deprecated)
+              .fixItRemove(deprecatedInOutLoc);
+          }
+        } else if (hasDeprecatedInOut) {
+          diagnose(param.LetVarInOutLoc, diag::inout_as_attr_deprecated)
+            .fixItRemove(param.LetVarInOutLoc)
+            .fixItInsert(postColonLoc, "inout ");
+        }
+
         auto type = parseType(diag::expected_parameter_type);
         status |= type;
         param.Type = type.getPtrOrNull();
@@ -252,16 +273,6 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         // was invalid.  Remember that.
         if (type.isParseError() && !type.hasCodeCompletion())
           param.isInvalid = true;
-       
-        // Only allow 'inout' before the parameter name.
-        if (auto InOutTy = dyn_cast_or_null<InOutTypeRepr>(param.Type)) {
-          SourceLoc InOutLoc = InOutTy->getInOutLoc();
-          SourceLoc NameLoc = param.FirstNameLoc;
-          diagnose(InOutLoc, diag::inout_must_appear_before_param)
-              .fixItRemove(InOutLoc)
-              .fixItInsert(NameLoc, "inout ");
-          param.Type = InOutTy->getBase();
-        }
       }
     } else {
       // Otherwise, we have invalid code.  Check to see if this looks like a

--- a/test/1_stdlib/Foundation_NewGenericAPIs.swift
+++ b/test/1_stdlib/Foundation_NewGenericAPIs.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-func expectType<T>(_: T.Type, inout _ x: T) {}
+func expectType<T>(_: T.Type, _ x: inout T) {}
 
 func test_NSCoder_decodeObject(coder: NSCoder) {
   var r = coder.decodeObject()

--- a/test/1_stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/1_stdlib/UnicodeScalarDiagnostics.swift
@@ -1,6 +1,6 @@
 // RUN: %target-parse-verify-swift
 
-func isString(inout s: String) {}
+func isString(s: inout String) {}
 
 func test_UnicodeScalarDoesNotImplementArithmetic(us: UnicodeScalar, i: Int) {
   var a1 = "a" + "b" // OK

--- a/test/ClangModules/blocks_parse.swift
+++ b/test/ClangModules/blocks_parse.swift
@@ -26,7 +26,7 @@ func testNoEscape(@noescape f: @convention(block) () -> Void, nsStr: NSString,
   _ = nsStr.enumerateLinesUsingBlock as Int // expected-error{{cannot convert value of type '(@noescape (String!) -> Void) -> Void' to type 'Int' in coercion}}
 }
 
-func checkTypeImpl<T>(inout a: T, _: T.Type) {}
+func checkTypeImpl<T>(a: inout T, _: T.Type) {}
 do {
   var block = blockWithoutNullability()
   checkTypeImpl(&block, ImplicitlyUnwrappedOptional<dispatch_block_t>.self)

--- a/test/ClangModules/cf.swift
+++ b/test/ClangModules/cf.swift
@@ -136,7 +136,7 @@ func nameCollisions() {
   otherAlias = cfAlias // expected-error {{cannot assign value of type 'MyProblematicAliasRef?' to type 'MyProblematicAlias?'}}
   cfAlias = otherAlias // expected-error {{cannot assign value of type 'MyProblematicAlias?' to type 'MyProblematicAliasRef?'}}
 
-  func isOptionalFloat(inout _: Optional<Float>) {}
+  func isOptionalFloat(_: inout Optional<Float>) {}
   isOptionalFloat(&otherAlias) // okay
 
   var np: NotAProblem?

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -20,7 +20,7 @@ func testNSSetBridging(hive: Hive) {
   _ = hive.allBees as Set<Bee>
 }
 
-public func expectType<T>(_: T.Type, inout _ x: T) {}
+public func expectType<T>(_: T.Type, _ x: inout T) {}
 
 func testNSMutableDictionarySubscript(
   dict: NSMutableDictionary, key: NSCopying, value: AnyObject) {

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -45,7 +45,7 @@ slice[7] = f // expected-error{{cannot assign value of type 'Y' to type 'X'}}
 slice[7] = _ // expected-error{{'_' can only appear in a pattern or on the left side of an assignment}}
 
 func value(x: Int) {}
-func value2(inout x: Int) {}
+func value2(x: inout Int) {}
 value2(&_) // expected-error{{'_' can only appear in a pattern or on the left side of an assignment}}
 value(_) // expected-error{{'_' can only appear in a pattern or on the left side of an assignment}}
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -28,13 +28,13 @@ struct BridgedStruct : Hashable, _ObjectiveCBridgeable {
   }
 
   static func _forceBridgeFromObjectiveC(
-    x: BridgedClass, 
-    inout result: BridgedStruct?) {
+    x: BridgedClass,
+    result: inout BridgedStruct?) {
   }
 
   static func _conditionallyBridgeFromObjectiveC(
     x: BridgedClass,
-    inout result: BridgedStruct?
+    result: inout BridgedStruct?
   ) -> Bool {
     return true
   }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -140,7 +140,7 @@ func r15998821() {
   func take_closure(x : (inout Int) -> ()) { }
 
   func test1() {
-    take_closure { (inout a : Int) in
+    take_closure { (a : inout Int) in
       a = 42
     }
   }

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -104,9 +104,9 @@ z as Z
 
 // Construction from inouts.
 struct FooRef { }
-struct BarRef { 
-  init(inout x: FooRef) {} 
-  init(inout x: Int) {} 
+struct BarRef {
+  init(x: inout FooRef) {}
+  init(x: inout Int) {}
 }
 var f = FooRef()
 var x = 0

--- a/test/Constraints/default_literals.swift
+++ b/test/Constraints/default_literals.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
-func acceptInt(inout _ : Int) {}
-func acceptDouble(inout _ : Double) {}
+func acceptInt(_ : inout Int) {}
+func acceptDouble(_ : inout Double) {}
 
 var i1 = 1
 acceptInt(&i1)

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -488,7 +488,7 @@ enum Color {
   static func overload(a a : Int) -> Color {}
   static func overload(b b : Int) -> Color {}
   
-  static func frob(a : Int, inout b : Int) -> Color {}
+  static func frob(a : Int, b : inout Int) -> Color {}
 }
 let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) }) // expected-error {{'map' produces '[T]', not the expected contextual result type '(Int, Color)'}}
 let _: [(Int, Color)] = [1,2].map({ ($0, .Unknown("")) })// expected-error {{missing argument label 'description:' in call}} {{51-51=description: }}
@@ -643,7 +643,7 @@ extension Array {
 }
 
 // <rdar://problem/22519983> QoI: Weird error when failing to infer archetype
-func safeAssign<T: RawRepresentable>(inout lhs: T) -> Bool {}
+func safeAssign<T: RawRepresentable>(lhs: inout T) -> Bool {}
 // expected-note @-1 {{in call to function 'safeAssign'}}
 let a = safeAssign // expected-error {{generic parameter 'T' could not be inferred}}
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -72,7 +72,7 @@ func forgotAnyObjectBang(obj: AnyObject) {
   _ = a
 }
 
-func increment(inout x: Int) { }
+func increment(x: inout Int) { }
 
 func forgotAmpersand() {
   var i = 5

--- a/test/Constraints/invalid_constraint_lookup.swift
+++ b/test/Constraints/invalid_constraint_lookup.swift
@@ -27,6 +27,6 @@ protocol _CollectionType {
 protocol CollectionType : _CollectionType, SequenceType {
   subscript(i: Index) -> Generator.Element {get set }
 }
-func insertionSort<C: Mutable> (inout elements: C, i: C.Index) { // expected-error {{use of undeclared type 'Mutable'}} expected-error {{'Index' is not a member type of 'C'}}
+func insertionSort<C: Mutable> (elements: inout C, i: C.Index) { // expected-error {{use of undeclared type 'Mutable'}} expected-error {{'Index' is not a member type of 'C'}}
   var x: C.Generator.Element = elements[i] // expected-error {{'Generator' is not a member type of 'C'}}
 }

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -1,9 +1,9 @@
 // RUN: %target-parse-verify-swift
 
-func f0(inout x: Int) {}
-func f1<T>(inout x: T) {}
-func f2(inout x: X) {}
-func f2(inout x: Double) {}
+func f0(x: inout Int) {}
+func f1<T>(x: inout T) {}
+func f2(x: inout X) {}
+func f2(x: inout Double) {}
 
 class Reftype {
   var property: Double { get {} set {} }
@@ -27,10 +27,10 @@ var f : Float
 var x : X
 var y : Y
 
-func +=(inout lhs: X, rhs : X) {}
-func +=(inout lhs: Double, rhs : Double) {}
-prefix func ++(inout rhs: X) {}
-postfix func ++(inout lhs: X) {}
+func +=(lhs: inout X, rhs : X) {}
+func +=(lhs: inout Double, rhs : Double) {}
+prefix func ++(rhs: inout X) {}
+postfix func ++(lhs: inout X) {}
 
 f0(&i)
 f1(&i)
@@ -154,7 +154,7 @@ func testFooStruct() {
 
 // Don't load from explicit lvalues.
 func takesInt(x: Int) {}
-func testInOut(inout arg: Int) {
+func testInOut(arg: inout Int) {
   var x : Int
   takesInt(&x) // expected-error{{'&' used with non-inout argument of type 'Int'}}
 }
@@ -166,7 +166,7 @@ var ir2 = ((&i)) // expected-error{{type 'inout Int' of variable is not material
                  // expected-error{{'&' can only appear immediately in a call argument list}}
 
 // <rdar://problem/17133089>
-func takeArrayRef(inout x:Array<String>) { }
+func takeArrayRef(x: inout Array<String>) { }
 
 // rdar://22308291
 takeArrayRef(["asdf", "1234"]) // expected-error{{contextual type 'inout Array<String>' cannot be used with array literal}}
@@ -224,11 +224,11 @@ func rdar23131768() {
   f2 { $0 = $0 + 1 } // previously error: Cannot convert value of type '_ -> ()' to expected type '(inout Int) -> Void'
 
   func f3(g: (inout Int) -> Void) { var a = 1; g(&a); print(a) }
-  f3 { (inout v: Int) -> Void in v += 1 }
+  f3 { (v: inout Int) -> Void in v += 1 }
 }
 
 // <rdar://problem/23331567> Swift: Compiler crash related to closures with inout parameter.
-func r23331567(fn: (inout x: Int) -> Void) {
+func r23331567(fn: (x: inout Int) -> Void) {
   var a = 0
   fn(x: &a)
 }

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -89,7 +89,7 @@ protocol P5 { }
 struct S7a {}
 
 protocol P6 {
-  func foo<Target: P5>(inout target: Target)
+  func foo<Target: P5>(target: inout Target)
 }
 
 protocol P7 : P6 {
@@ -101,7 +101,7 @@ func ~> <T:P6>(x: T, _: S7a) -> S7b { return S7b() }
 
 struct S7b : P7 {
   typealias Assoc = S7b
-  func foo<Target: P5>(inout target: Target) {}
+  func foo<Target: P5>(target: inout Target) {}
 }
 
 // <rdar://problem/14685674>

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -41,8 +41,8 @@ func useTwoIdentical(xi: Int, yi: Float) {
   twoIdentical(x, y) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
 }
 
-func mySwap<T>(inout x: T,
-               inout _ y: T) {
+func mySwap<T>(x: inout T,
+               _ y: inout T) {
   let tmp = x
   x = y
   y = tmp
@@ -99,8 +99,8 @@ func confusingArgAndParam<T, U>(f: (T) -> U, _ g: (U) -> T) {
 func acceptUnaryFn<T, U>(f: (T) -> U) { }
 func acceptUnaryFnSame<T>(f: (T) -> T) { }
 
-func acceptUnaryFnRef<T, U>(inout f: (T) -> U) { }
-func acceptUnaryFnSameRef<T>(inout f: (T) -> T) { }
+func acceptUnaryFnRef<T, U>(f: inout (T) -> U) { }
+func acceptUnaryFnSameRef<T>(f: inout (T) -> T) { }
 
 func unaryFnIntInt(_: Int) -> Int {}
 

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -86,7 +86,7 @@ protocol Comparable {
   func <(lhs: Self, rhs: Self) -> Bool
 }
 
-func sort<T : Comparable>(inout array: [T]) {
+func sort<T : Comparable>(array: inout [T]) {
   for i in 0..<array.count {
     for j in i+1..<array.count {
       if array[j] < array[i] {

--- a/test/IDE/Inputs/comment_extensions.swift
+++ b/test/IDE/Inputs/comment_extensions.swift
@@ -34,7 +34,7 @@ struct Invariant {
 func note() {}
 
 /// - postcondition: x is unchanged
-func postcondition(inout x: Int) {}
+func postcondition(x: inout Int) {}
 
 /// - precondition: `x < 100`
 func precondition(x: Int) {

--- a/test/IDE/comment_extensions.swift
+++ b/test/IDE/comment_extensions.swift
@@ -25,7 +25,7 @@
 
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>note()</Name><USR>s:F14swift_ide_test4noteFT_T_</USR><Declaration>func note()</Declaration><Discussion><Note><Para>This function is very hip and exciting.</Para></Note></Discussion></Function>]
 
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>postcondition(_:)</Name><USR>s:F14swift_ide_test13postconditionFRSiT_</USR><Declaration>func postcondition(inout x: Int)</Declaration><Discussion><Postcondition><Para>x is unchanged</Para></Postcondition></Discussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>postcondition(_:)</Name><USR>s:F14swift_ide_test13postconditionFRSiT_</USR><Declaration>func postcondition(x: inout Int)</Declaration><Discussion><Postcondition><Para>x is unchanged</Para></Postcondition></Discussion></Function>]
 
 // CHECK: {{.*}}DocCommentAsXML=none
 

--- a/test/IDE/complete_members_optional.swift
+++ b/test/IDE/complete_members_optional.swift
@@ -14,7 +14,7 @@ protocol HasOptionalMembers1 {
 }
 
 func sanityCheck1(a: HasOptionalMembers1) {
-  func isOptionalInt(inout a: Int?) {}
+  func isOptionalInt(a: inout Int?) {}
 
   var result1 = a.optionalInstanceFunc?()
   isOptionalInt(&result1)

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -178,11 +178,11 @@ struct FooStruct {
   mutating
   func instanceFunc1(a: Int) {}
   mutating
-  func instanceFunc2(a: Int, inout b: Double) {}
+  func instanceFunc2(a: Int, b: inout Double) {}
   mutating
   func instanceFunc3(a: Int, _: (Float, Double)) {}
   mutating
-  func instanceFunc4(a: Int?, b: Int!, inout c: Int?, inout d: Int!) {}
+  func instanceFunc4(a: Int?, b: Int!, c: inout Int?, d: inout Int!) {}
   mutating
   func instanceFunc5() -> Int? {}
   mutating
@@ -410,9 +410,9 @@ var fooObject: FooStruct
 // FOO_STRUCT_DOT: Begin completions
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0({#self: &FooStruct#})[#() -> Void#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc1({#self: &FooStruct#})[#(Int) -> Void#]{{; name=.+$}}
-// FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc2({#self: &FooStruct#})[#(Int, inout b: Double) -> Void#]{{; name=.+$}}
+// FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc2({#self: &FooStruct#})[#(Int, b: inout Double) -> Void#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc3({#self: &FooStruct#})[#(Int, (Float, Double)) -> Void#]{{; name=.+$}}
-// FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc4({#self: &FooStruct#})[#(Int?, b: Int!, inout c: Int?, inout d: Int!) -> Void#]{{; name=.+$}}
+// FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc4({#self: &FooStruct#})[#(Int?, b: Int!, c: inout Int?, d: inout Int!) -> Void#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc5({#self: &FooStruct#})[#() -> Int?#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc6({#self: &FooStruct#})[#() -> Int!#]{{; name=.+$}}
 // FOO_STRUCT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc7({#self: &FooStruct#})[#(a: Int) -> Void#]{{; name=.+$}}
@@ -467,9 +467,9 @@ var fooObject: FooStruct
 // FOO_STRUCT_NO_DOT: Begin completions
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc0({#self: &FooStruct#})[#() -> Void#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc1({#self: &FooStruct#})[#(Int) -> Void#]{{; name=.+$}}
-// FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc2({#self: &FooStruct#})[#(Int, inout b: Double) -> Void#]{{; name=.+$}}
+// FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc2({#self: &FooStruct#})[#(Int, b: inout Double) -> Void#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc3({#self: &FooStruct#})[#(Int, (Float, Double)) -> Void#]{{; name=.+$}}
-// FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc4({#self: &FooStruct#})[#(Int?, b: Int!, inout c: Int?, inout d: Int!) -> Void#]{{; name=.+$}}
+// FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc4({#self: &FooStruct#})[#(Int?, b: Int!, c: inout Int?, d: inout Int!) -> Void#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc5({#self: &FooStruct#})[#() -> Int?#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc6({#self: &FooStruct#})[#() -> Int!#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc7({#self: &FooStruct#})[#(a: Int) -> Void#]{{; name=.+$}}

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -123,8 +123,8 @@ struct d0100_FooStruct {
   func instanceFunc1(a: Int) {}
 // PASS_COMMON-NEXT: {{^}}  func instanceFunc1(a: Int){{$}}
 
-  func instanceFunc2(a: Int, inout b: Double) {}
-// PASS_COMMON-NEXT: {{^}}  func instanceFunc2(a: Int, inout b: Double){{$}}
+  func instanceFunc2(a: Int, b: inout Double) {}
+// PASS_COMMON-NEXT: {{^}}  func instanceFunc2(a: Int, b: inout Double){{$}}
 
   func instanceFunc3(a: Int, let b: Double) { var a = a; a = 1; _ = a }
 // PASS_COMMON-NEXT: {{^}}  func instanceFunc3(a: Int, b: Double){{$}}
@@ -1088,14 +1088,14 @@ protocol d2600_ProtocolWithOperator1 {
 
 struct d2601_TestAssignment {}
 infix operator %%% { }
-func %%%(inout lhs: d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int {
+func %%%(lhs: inout d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int {
   return 0
 }
 // PASS_2500-LABEL: {{^}}infix operator %%% {
 // PASS_2500-NOT: associativity
 // PASS_2500-NOT: precedence
 // PASS_2500-NOT: assignment
-// PASS_2500: {{^}}func %%%(inout lhs: d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int{{$}}
+// PASS_2500: {{^}}func %%%(lhs: inout d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int{{$}}
 
 infix operator %%< {
 // PASS_2500-LABEL: {{^}}infix operator %%< {{{$}}

--- a/test/IDE/print_types.swift
+++ b/test/IDE/print_types.swift
@@ -8,9 +8,9 @@ typealias MyInt = Int
 // CHECK: TypeAliasDecl '''MyInt''' MyInt.Type{{$}}
 // FULL:  TypeAliasDecl '''MyInt''' swift_ide_test.MyInt.Type{{$}}
 
-func testVariableTypes(param: Int, inout param2: Double) {
-// CHECK: FuncDecl '''testVariableTypes''' (Int, inout param2: Double) -> (){{$}}
-// FULL:  FuncDecl '''testVariableTypes''' (Swift.Int, inout param2: Swift.Double) -> (){{$}}
+func testVariableTypes(param: Int, param2: inout Double) {
+// CHECK: FuncDecl '''testVariableTypes''' (Int, param2: inout Double) -> (){{$}}
+// FULL:  FuncDecl '''testVariableTypes''' (Swift.Int, param2: inout Swift.Double) -> (){{$}}
 
   var a1 = 42
 // CHECK: VarDecl '''a1''' Int{{$}}

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -57,11 +57,11 @@ extension String : _ObjectiveCBridgeable {
     return NSString()
   }
   public static func _forceBridgeFromObjectiveC(x: NSString,
-                                                inout result: String?) {
+                                                result: inout String?) {
   }
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSString,
-    inout result: String?
+    result: inout String?
   ) -> Bool {
     return true
   }
@@ -80,12 +80,12 @@ extension Int : _ObjectiveCBridgeable {
   }
   public static func _forceBridgeFromObjectiveC(
     x: NSNumber, 
-    inout result: Int?
+    result: inout Int?
   ) {
   }
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSNumber,
-    inout result: Int?
+    result: inout Int?
   ) -> Bool {
     return true
   }
@@ -104,12 +104,12 @@ extension Array : _ObjectiveCBridgeable {
   }
   public static func _forceBridgeFromObjectiveC(
     x: NSArray,
-    inout result: Array?
+    result: inout Array?
   ) {
   }
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSArray,
-    inout result: Array?
+    result: inout Array?
   ) -> Bool {
     return true
   }
@@ -128,12 +128,12 @@ extension Dictionary : _ObjectiveCBridgeable {
   }
   public static func _forceBridgeFromObjectiveC(
     x: NSDictionary,
-    inout result: Dictionary?
+    result: inout Dictionary?
   ) {
   }
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSDictionary,
-    inout result: Dictionary?
+    result: inout Dictionary?
   ) -> Bool {
     return true
   }
@@ -152,12 +152,12 @@ extension Set : _ObjectiveCBridgeable {
   }
   public static func _forceBridgeFromObjectiveC(
     x: NSSet,
-    inout result: Set?
+    result: inout Set?
   ) {
   }
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSSet,
-    inout result: Set?
+    result: inout Set?
   ) -> Bool {
     return true
   }
@@ -176,12 +176,12 @@ extension CGFloat : _ObjectiveCBridgeable {
   }
   public static func _forceBridgeFromObjectiveC(
     x: NSNumber,
-    inout result: CGFloat?
+    result: inout CGFloat?
   ) {
   }
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSNumber,
-    inout result: CGFloat?
+    result: inout CGFloat?
   ) -> Bool {
     return true
   }
@@ -202,14 +202,14 @@ extension NSRange : _ObjectiveCBridgeable {
 
   public static func _forceBridgeFromObjectiveC(
     x: NSValue,
-    inout result: NSRange?
+    result: inout NSRange?
   ) {
     result = x.rangeValue
   }
   
   public static func _conditionallyBridgeFromObjectiveC(
     x: NSValue,
-    inout result: NSRange?
+    result: inout NSRange?
   ) -> Bool {
     self._forceBridgeFromObjectiveC(x, result: &result)
     return true

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -90,7 +90,7 @@ func ==(lhs:MyBadReturnClass, rhs:MyBadReturnClass) {
 func testIS1() -> Int { return 0 }
 let _: String = testIS1() // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
 
-func insertA<T>(inout array : [T], elt : T) {
+func insertA<T>(array : inout [T], elt : T) {
   array.append(T); // expected-error {{cannot invoke 'append' with an argument list of type '((T).Type)'}} expected-note {{expected an argument list of type '(T)'}}
 }
 

--- a/test/NameBinding/multi-file.swift
+++ b/test/NameBinding/multi-file.swift
@@ -16,7 +16,7 @@ func test() {
   var _: Bool = 1 + 2 ~~ 3 + 4 // (1 + 2) ~~ (3 + 4)
 }
 
-func conformsToItself(inout x: P3, y: P3) {
+func conformsToItself(x: inout P3, y: P3) {
   x = y
 }
 

--- a/test/NameBinding/name-binding.swift
+++ b/test/NameBinding/name-binding.swift
@@ -176,8 +176,8 @@ postfix operator +++ {}
 prefix operator ++ {}
 postfix operator ++ {}
 
-prefix func +++(inout a: Int) { a += 2 }
-postfix func +++(inout a: Int) { a += 2 }
+prefix func +++(a: inout Int) { a += 2 }
+postfix func +++(a: inout Int) { a += 2 }
 
 var test = 0
 +++test

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -17,7 +17,7 @@ func statement_starts() {
 }
 
 // Within a function
-func test(inout i: Int, inout j: Int) {
+func test(i: inout Int, j: inout Int) {
   // Okay
   let q : Int; i = j; j = i; _ = q
 

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -9,7 +9,9 @@ func foo(a: Int) {
 
 // rdar://15946844
 func test1(inout var x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
+// expected-warning @-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
 func test2(inout let x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
+// expected-warning @-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
 
 func test3() {
   undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}} expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{19-19=,}}
@@ -26,8 +28,6 @@ func foo() {
     skview!
     // expected-error @-1 {{use of unresolved identifier 'skview'}}
 } // expected-error {{expected expression in list of expressions}} expected-error {{expected ')' in expression list}}
-
-func test3(a: inout Int) {} // expected-error {{'inout' must appear before the parameter name}}{{12-12=inout }}{{15-21=}}
 
 super.init() // expected-error {{'super' cannot be used outside of class members}}
 

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -32,7 +32,7 @@ var b = true ? try! foo() : try! bar() + 0
 var c = true ? try! foo() : try! bar() %%% 0 // expected-error {{'try!' following conditional operator does not cover everything to its right}}
 
 infix operator ?+= { associativity right precedence 90 assignment }
-func ?+=(inout lhs: Int?, rhs: Int?) {
+func ?+=(lhs: inout Int?, rhs: Int?) {
   lhs = lhs! + rhs!
 }
 

--- a/test/SIL/Parser/where.swift
+++ b/test/SIL/Parser/where.swift
@@ -5,5 +5,5 @@ protocol P {
   typealias CodeUnit
   mutating func decode<
     G : GeneratorType where G.Element == CodeUnit
-  >(inout next: G) -> Int
+  >(next: inout G) -> Int
 }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -485,7 +485,7 @@ protocol Buildable {
   var firstStructure: Structure { get set }
   subscript(name: String) -> Structure { get set }
 }
-func supportFirstStructure<B: Buildable>(inout b: B) throws {
+func supportFirstStructure<B: Buildable>(b: inout B) throws {
   try b.firstStructure.support()
 }
 // CHECK-LABEL: sil hidden @_TF6errors21supportFirstStructure{{.*}} : $@convention(thin) <B where B : Buildable, B.Structure : Supportable> (@inout B) -> @error ErrorType {
@@ -515,7 +515,7 @@ func supportFirstStructure<B: Buildable>(inout b: B) throws {
 // CHECK: dealloc_stack [[MATBUFFER]]
 // CHECK: throw [[ERROR]]
 
-func supportStructure<B: Buildable>(inout b: B, name: String) throws {
+func supportStructure<B: Buildable>(b: inout B, name: String) throws {
   try b[name].support()
 }
 // CHECK-LABEL: sil hidden @_TF6errors16supportStructure
@@ -561,7 +561,7 @@ struct Bridge {
     set {}
   }
 }
-func supportStructure(inout b: Bridge, name: String) throws {
+func supportStructure(b: inout Bridge, name: String) throws {
   try b[name].support()
 }
 // CHECK:    sil hidden @_TF6errors16supportStructureFzTRVS_6Bridge4nameSS_T_ :
@@ -614,7 +614,7 @@ struct OwnedBridge {
     mutableAddressWithOwner { return (nil, owner) }
   }
 }
-func supportStructure(inout b: OwnedBridge, name: String) throws {
+func supportStructure(b: inout OwnedBridge, name: String) throws {
   try b[name].support()
 }
 // CHECK: sil hidden @_TF6errors16supportStructureFzTRVS_11OwnedBridge4nameSS_T_ :
@@ -650,7 +650,7 @@ struct PinnedBridge {
     mutableAddressWithPinnedNativeOwner { return (nil, owner) }
   }
 }
-func supportStructure(inout b: PinnedBridge, name: String) throws {
+func supportStructure(b: inout PinnedBridge, name: String) throws {
   try b[name].support()
 }
 // CHECK: sil hidden @_TF6errors16supportStructureFzTRVS_12PinnedBridge4nameSS_T_ :

--- a/test/SILGen/polymorphic_inout_aliasing.swift
+++ b/test/SILGen/polymorphic_inout_aliasing.swift
@@ -21,6 +21,6 @@ protocol StoriedType {
   var protocolRequirement: [Block] { get set }
 }
 
-func testProtocol<T: StoriedType>(inout x: T) {
+func testProtocol<T: StoriedType>(x: inout T) {
   swap(&x.protocolRequirement[0], &x.protocolRequirement[1])
 }

--- a/test/SILGen/writeback_conflict_diagnostics.swift
+++ b/test/SILGen/writeback_conflict_diagnostics.swift
@@ -2,7 +2,7 @@
 
 
 struct MutatorStruct {
-  mutating func f(inout x : MutatorStruct) {}
+  mutating func f(x : inout MutatorStruct) {}
 }
 
 var global_property : MutatorStruct { get {} set {} }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -13,7 +13,7 @@ func test1() -> Int {
   return a     // expected-error {{variable 'a' used before being initialized}}
 }
 
-func takes_inout(inout a: Int) {}
+func takes_inout(a: inout Int) {}
 func takes_closure(fn: () -> ()) {}
 
 class SomeClass { 
@@ -162,7 +162,7 @@ func test4() {
   markUsed(t6.b)
 }
 
-func tupleinout(inout a: (lo: Int, hi: Int)) {
+func tupleinout(a: inout (lo: Int, hi: Int)) {
   markUsed(a.0)   // ok
   markUsed(a.1)   // ok
 }
@@ -284,7 +284,7 @@ func emptyStructTest() {
   useEmptyStruct(g.1)
 }
 
-func takesTuplePair(inout a : (SomeClass, SomeClass)) {}
+func takesTuplePair(a : inout (SomeClass, SomeClass)) {}
 
 // This tests cases where a store might be an init or assign based on control
 // flow path reaching it.
@@ -1018,7 +1018,7 @@ struct StructMutatingMethodTest {
 }
 
 @_transparent
-func myTransparentFunction(inout x : Int) {}
+func myTransparentFunction(x : inout Int) {}
 
 
 // <rdar://problem/19782264> Immutable, optional class members can't have their subproperties read from during init()

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -20,7 +20,7 @@ final class DerivedClass : BaseClass {
 
 func something(x: Int) {}
 
-func something(inout x: Int) {}
+func something(x: inout Int) {}
 
 func something(x: AnyObject) {}
 

--- a/test/Sema/accessibility_multi.swift
+++ b/test/Sema/accessibility_multi.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -parse -primary-file %s %S/Inputs/accessibility_multi_other.swift -verify
 func read(value: Int) {}
-func reset(inout value: Int) { value = 0 }
+func reset(value: inout Int) { value = 0 }
 
 func testGlobals() {
   read(privateSetGlobal)

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -497,7 +497,7 @@ func accessUnavailableProperties(o: ClassWithUnavailableProperties) {
   
   // Inout requires access to both getter and setter
   
-  func takesInout(inout i : Int) { }
+  func takesInout(i : inout Int) { }
   
   takesInout(&o.propWithGetterOnlyAvailableOn10_51) // expected-error {{cannot pass as inout because getter for 'propWithGetterOnlyAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing global function}}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -332,11 +332,12 @@ func testSelectorStyleArguments2(let x: Int,
 }
 
 func invalid_inout(inout var x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{26-30=}}
+// expected-warning@-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
 }
 
 
 
-func updateInt(inout x : Int) {}
+func updateInt(x : inout Int) {}
 
 // rdar://15785677 - allow 'let' declarations in structs/classes be initialized in init()
 class LetClassMembers {

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -2556,3 +2556,24 @@
     ]
   }
 ]
+[
+  {
+    key.line: 137,
+    key.column: 12,
+    key.filepath: "/Users/drchrono/swift/swift/test/SourceKit/DocSupport/Inputs/main.swift",
+    key.severity: source.diagnostic.severity.warning,
+    key.description: "'inout' before a parameter name is deprecated, place it before the parameter type instead",
+    key.fixits: [
+      {
+        key.offset: 1687,
+        key.length: 5,
+        key.sourcetext: ""
+      },
+      {
+        key.offset: 1696,
+        key.length: 0,
+        key.sourcetext: "inout "
+      }
+    ]
+  }
+]

--- a/test/TypeCoercion/overload_member.swift
+++ b/test/TypeCoercion/overload_member.swift
@@ -34,7 +34,7 @@ func test_method_overload(a: A, x: X, y: Y) {
   _ = y1
 }
 
-func test_method_overload_coerce(a: A, inout x: X, inout y: Y, z: Z) {
+func test_method_overload_coerce(a: A, x: inout X, y: inout Y, z: Z) {
   var fail = a.g(z: z) // expected-error{{ambiguous use of 'g(z:)'}}
   x = a.g(z: z)
   y = a.g(z: z)
@@ -55,7 +55,7 @@ func test_static_method_overload(a: A, x: X, y: Y) {
   _ = y1
 }
 
-func test_static_method_overload_coerce(a: A, inout x: X, inout y: Y, z: Z) {
+func test_static_method_overload_coerce(a: A, x: inout X, y: inout Y, z: Z) {
   var fail = A.sg(z: z) // expected-error{{ambiguous use of 'sg(z:)'}}
   x = A.sg(z: z)
   y = A.sg(z: z)
@@ -78,7 +78,7 @@ func test_mixed_overload(a: A, x: X, y: Y) {
   y2 = y
 }
 
-func test_mixed_overload_coerce(a: A, inout x: X, y: Y, z: Z) {
+func test_mixed_overload_coerce(a: A, x: inout X, y: Y, z: Z) {
   a.mixed2(z: z)
   var y1 = A.mixed2(z: z)
   y1 = y
@@ -111,7 +111,7 @@ extension A {
     _ = y2
   }
 
-  func test_method_overload_coerce(inout x x: X, inout y: Y, z: Z) {
+  func test_method_overload_coerce(x x:inout  X, y: inout Y, z: Z) {
     var fail = g(z: z) // expected-error{{ambiguous use of 'g(z:)'}}
     x = g(z: z)
     y = g(z: z)
@@ -123,7 +123,7 @@ extension A {
     var _ : (A) -> (X) -> X = A.f
   }
 
-  func test_mixed_overload_coerce(inout x x: X, y: Y, z: Z) {
+  func test_mixed_overload_coerce(x x: inout X, y: Y, z: Z) {
     mixed2(z: z)
     x = mixed2(z: z)
   }
@@ -145,7 +145,7 @@ extension A {
     _ = y1
   }
 
-  class func test_method_overload_coerce_static(inout x x: X, inout y: Y, z: Z) {
+  class func test_method_overload_coerce_static(x x: inout X, y: inout Y, z: Z) {
     var fail = sg(z: z) // expected-error{{ambiguous use of 'sg(z:)'}}
     x = sg(z: z)
     y = sg(z: z)

--- a/test/TypeCoercion/overload_noncall.swift
+++ b/test/TypeCoercion/overload_noncall.swift
@@ -37,10 +37,10 @@ func test_conv() {
 var xy : X // expected-note {{previously declared here}}
 var xy : Y // expected-error {{invalid redeclaration of 'xy'}}
 
-func accept_X(inout x: X) { }
-func accept_XY(inout x: X) -> X { }
-func accept_XY(inout y: Y) -> Y { }
-func accept_Z(inout z: Z) -> Z { }
+func accept_X(x: inout X) { }
+func accept_XY(x: inout X) -> X { }
+func accept_XY(y: inout Y) -> Y { }
+func accept_Z(z: inout Z) -> Z { }
 
 func test_inout() {
   var x : X
@@ -56,7 +56,7 @@ func test_inout() {
   accept_Z(&xy); // expected-error{{cannot convert value of type 'X' to expected argument type 'Z'}}
 }
 
-func lvalue_or_rvalue(inout x: X) -> X { }
+func lvalue_or_rvalue(x: inout X) -> X { }
 func lvalue_or_rvalue(x: X) -> Y { }
 
 func test_lvalue_or_rvalue() {

--- a/test/TypeCoercion/overload_parens.swift
+++ b/test/TypeCoercion/overload_parens.swift
@@ -12,7 +12,7 @@ struct Y {
   func f1() -> Float { return 0.0 }
 }
 
-func testParenOverloads(inout x: Int, y: Y) {
+func testParenOverloads(x: inout Int, y: Y) {
   x = f0(x)
   x = (f0)(x)
   x = ((f0))(x)

--- a/test/TypeCoercion/protocols.swift
+++ b/test/TypeCoercion/protocols.swift
@@ -85,9 +85,9 @@ struct NotFormattedPrintable1 {
 
 func testFormattedPrintableCoercion(ip1: IsPrintable1,
                                     ip2: IsPrintable2,
-                                    inout fp: FormattedPrintable,
-                                    inout p: MyPrintable,
-                                    inout op: OtherPrintable,
+                                    fp: inout FormattedPrintable,
+                                    p: inout MyPrintable,
+                                    op: inout OtherPrintable,
                                     nfp1: NotFormattedPrintable1) {
   fp = ip1
   fp = ip2 // expected-error{{value of type 'IsPrintable2' does not conform to 'FormattedPrintable' in assignment}}
@@ -100,20 +100,20 @@ func testFormattedPrintableCoercion(ip1: IsPrintable1,
 protocol Document : Titled, MyPrintable {
 }
 
-func testMethodsAndVars(fp: FormattedPrintable, f: TestFormat, inout doc: Document) {
+func testMethodsAndVars(fp: FormattedPrintable, f: TestFormat, doc: inout Document) {
   fp.print(f)
   fp.print()
   doc.title = "Gone with the Wind"
   doc.print()
 }
 
-func testDocumentCoercion(inout doc: Document, ip1: IsPrintable1, l: Lackey) {
+func testDocumentCoercion(doc: inout Document, ip1: IsPrintable1, l: Lackey) {
   doc = ip1
   doc = l // expected-error{{value of type 'Lackey' does not conform to 'Document' in assignment}}
 }
 
 // Check coercion of references.
-func refCoercion(inout p: MyPrintable) { }
+func refCoercion(p: inout MyPrintable) { }
 var p : MyPrintable = IsPrintable1()
 var fp : FormattedPrintable = IsPrintable1()
 var ip1 : IsPrintable1
@@ -138,7 +138,7 @@ struct IsIntToStringSubscriptable {
   subscript(i: Int) -> String { get {} set {} }
 }
 
-func testIntSubscripting(inout i_s: IntSubscriptable,
+func testIntSubscripting(i_s: inout IntSubscriptable,
                          iis: IsIntSubscriptable,
                          ids: IsDoubleSubscriptable,
                          iiss: IsIntToStringSubscriptable) {

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -18,7 +18,7 @@ func func6(@autoclosure _: () -> Int) {func6(0)}
 func func7(@autoclosure _: @noreturn () -> Int) {func7(0)}
 
 // autoclosure + inout don't make sense.
-func func8(@autoclosure inout x: () -> Bool) -> Bool {  // expected-error {{@autoclosure may only be applied to values of function type}}
+func func8(@autoclosure x: inout () -> Bool) -> Bool {  // expected-error {{@autoclosure may only be applied to values of function type}}
 }
 
 

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -196,7 +196,7 @@ func someFuncUsingOldAttribute() { }
 
 
 // <rdar://problem/23853709> Compiler crash on call to unavailable "print"
-func OutputStreamTest(message: String, inout to: OutputStreamType) {
+func OutputStreamTest(message: String, to: inout OutputStreamType) {
   print(message, &to)  // expected-error {{'print' is unavailable: Please use the 'toStream' label for the target stream: 'print((...), toStream: &...)'}}
 }
 

--- a/test/attr/attr_inout.swift
+++ b/test/attr/attr_inout.swift
@@ -9,3 +9,5 @@ func ff(x: (inout Int, inout Float)) { } //  expected-error {{'inout' is only va
 enum inout_carrier {
   case carry(inout Int) // expected-error {{'inout' is only valid in parameter lists}}
 }
+
+func deprecated(inout x: Int) {} // expected-warning {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}

--- a/test/attr/attr_inout.swift
+++ b/test/attr/attr_inout.swift
@@ -1,8 +1,8 @@
 // RUN: %target-parse-verify-swift
 
-func f(inout x : Int) { } // okay
+func f(x : inout Int) { } // okay
 
-func h(inout _ : Int) -> (inout Int) -> (inout Int) -> Int { }
+func h(_ : inout Int) -> (inout Int) -> (inout Int) -> Int { }
 
 func ff(x: (inout Int, inout Float)) { } //  expected-error {{'inout' is only valid in parameter lists}}  
 

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -8,7 +8,7 @@ enum binary {
   init() { self = .Zero }
 }
 
-func f5(inout x: binary) {}
+func f5(x: inout binary) {}
 
 //===---
 //===--- IB attributes

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -121,6 +121,8 @@ func testObjCMethodCurry(a : ClassWithObjCMethod) -> (Int) -> () {
 
 // We used to crash on this.
 func rdar16786220(inout let c: Int) -> () { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{25-29=}}
+// expected-warning@-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+
   c = 42
 }
 
@@ -135,6 +137,7 @@ func !!!<T>(lhs: UnsafePointer<T>, rhs: UnsafePointer<T>) -> Bool { return false
 
 // <rdar://problem/16786168> Functions currently permit 'var inout' parameters
 func var_inout_error(inout var x : Int) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{28-32=}}
+// expected-warning@-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
 
 // Unnamed parameters require the name "_":
 func unnamed(Int) { } // expected-error{{unnamed parameters must be written with the empty name '_'}}{{14-14=_: }}

--- a/test/decl/func/vararg.swift
+++ b/test/decl/func/vararg.swift
@@ -19,7 +19,7 @@ f3({ print($0) })
 func f4(a: Int..., b: Int) { }
 
 // rdar://16008564
-func inoutVariadic(inout i: Int...) {  // expected-error {{inout arguments cannot be variadic}}
+func inoutVariadic(i: inout Int...) {  // expected-error {{inout arguments cannot be variadic}}
 }
 
 // rdar://19722429

--- a/test/decl/operators.swift
+++ b/test/decl/operators.swift
@@ -87,10 +87,10 @@ infix operator +-+= {}
 infix func +-+ (x: Int, y: Int) -> Int {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}}
 prefix func +-+ (x: Int) -> Int {}
 
-prefix func -+- (inout y: Int) -> Int {} // expected-note 2{{found this candidate}}
-postfix func -+- (inout x: Int) -> Int {} // expected-note 2{{found this candidate}}
+prefix func -+- (y: inout Int) -> Int {} // expected-note 2{{found this candidate}}
+postfix func -+- (x: inout Int) -> Int {} // expected-note 2{{found this candidate}}
 
-infix func +-+= (inout x: Int, y: Int) -> Int {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}}
+infix func +-+= (x: inout Int, y: Int) -> Int {} // expected-error {{'infix' modifier is not required or allowed on func declarations}} {{1-7=}}
 
 var n = 0
 
@@ -167,7 +167,7 @@ infix operator ? {}  // expected-error {{expected operator name in operator decl
 
 infix operator ??= {}
 
-func ??= <T>(inout result : T?, rhs : Int) {  // ok
+func ??= <T>(result : inout T?, rhs : Int) {  // ok
 }
 
 

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -252,7 +252,7 @@ func autoclosure(@autoclosure f f: () -> Int) { }
 
 // inout
 func inout2(x x: Int) { }
-func inout2(inout x x: Int) { }
+func inout2(x x: inout Int) { }
 
 // optionals
 func optional(x x: Int?) { } // expected-note{{previously declared}}

--- a/test/decl/protocol/operators_in_protocols.swift
+++ b/test/decl/protocol/operators_in_protocols.swift
@@ -3,6 +3,6 @@
 protocol P {
   func << (lhs: Self, rhs: Self) -> Self
   func >> (lhs: Self, rhs: Self) -> Self
-  func <<= (inout lhs: Self, rhs: Self)
-  func >>= (inout lhs: Self, rhs: Self)
+  func <<= (lhs: inout Self, rhs: Self)
+  func >>= (lhs: inout Self, rhs: Self)
 }

--- a/test/decl/protocol/protocol_overload_selection.swift
+++ b/test/decl/protocol/protocol_overload_selection.swift
@@ -30,7 +30,7 @@ protocol MutableCollectionType : CollectionType {
 func insertionSort<
 C: MutableCollectionType 
 >(
-  inout elements: C,
+  elements: inout C,
   i: C.Index
 ) {
   var _: C.Generator.Element = elements[i] // should not error

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -180,8 +180,8 @@ struct MissingGetterSubscript2 {
   }
 }
 
-func test_subscript(inout x2: X2, i: Int, j: Int, inout value: Int, no: NoSubscript,
-                    inout ovl: OverloadedSubscript, inout ret: RetOverloadedSubscript) {
+func test_subscript(x2: inout X2, i: Int, j: Int, value: inout Int, no: NoSubscript,
+                    ovl: inout OverloadedSubscript, ret: inout RetOverloadedSubscript) {
   no[i] = value // expected-error{{type 'NoSubscript' has no subscript members}}
 
   value = x2[i]
@@ -201,7 +201,7 @@ func test_subscript(inout x2: X2, i: Int, j: Int, inout value: Int, no: NoSubscr
   ret[i] = value
 }
 
-func subscript_rvalue_materialize(inout i: Int) {
+func subscript_rvalue_materialize(i: inout Int) {
   i = X1(stored: 0)[i]
 }
 

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -66,7 +66,7 @@ var a5: X {
 
 // Reading/writing properties
 func accept_x(x: X) { }
-func accept_x_inout(inout x: X) { }
+func accept_x_inout(x: inout X) { }
 
 func test_global_properties(x: X) {
   accept_x(a1)
@@ -479,7 +479,7 @@ func getS() -> S {
   return s
 }
 
-func test_extension_properties(inout s: S, inout x: X) {
+func test_extension_properties(s: inout S, x: inout X) {
   accept_x(s.x)
   accept_x(s.x2)
   accept_x(s.x3)
@@ -511,7 +511,7 @@ func test_extension_properties(inout s: S, inout x: X) {
 
 extension S {
   mutating
-  func test(inout other_x: X) {
+  func test(other_x: inout X) {
     x = other_x
     x2 = other_x
     x3 = other_x // expected-error{{cannot assign to property: 'x3' is a get-only property}}
@@ -536,7 +536,7 @@ struct Beth {
   var c: Int
 }
 
-func accept_int_inout(inout c: Int) { }
+func accept_int_inout(c: inout Int) { }
 func accept_int(c: Int) { }
 
 func test_settable_of_nonsettable(a: Aleph) {
@@ -884,7 +884,7 @@ class Box {
   }
 }
 
-func double(inout val: Int) {
+func double(val: inout Int) {
   val *= 2
 }
 

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -76,7 +76,7 @@ func property() -> Int {
 }
 
 
-func testInOut(inout x : Int) {  // Ok.
+func testInOut(x : inout Int) {  // Ok.
 }
 
 struct TestStruct {

--- a/test/expr/capture/inout.swift
+++ b/test/expr/capture/inout.swift
@@ -1,7 +1,7 @@
 // RUN: %target-parse-verify-swift
 
 // An inout parameter can be captured.
-func foo(inout x: Int) {
+func foo(x: inout Int) {
   func bar() -> Int {
     return x
   }

--- a/test/expr/cast/array_bridge.swift
+++ b/test/expr/cast/array_bridge.swift
@@ -19,12 +19,12 @@ struct B : _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: A,
-    inout result: B?
+    result: inout B?
   ){
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: A,
-    inout result: B?
+    result: inout B?
   ) -> Bool {
     return true
   }
@@ -63,12 +63,12 @@ struct F : _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: E,
-    inout result: F?
+    result: inout F?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: E,
-    inout result: F?
+    result: inout F?
   ) -> Bool {
     return true
   }
@@ -93,12 +93,12 @@ struct H : _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: G,
-    inout result: H?
+    result: inout H?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: G,
-    inout result: H?
+    result: inout H?
   ) -> Bool {
     return true
   }
@@ -126,12 +126,12 @@ struct I : _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: AnyObject,
-    inout result: I?
+    result: inout I?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: AnyObject,
-    inout result: I?
+    result: inout I?
   ) -> Bool {
     return true
   }

--- a/test/expr/cast/array_downcast.swift
+++ b/test/expr/cast/array_downcast.swift
@@ -43,12 +43,12 @@ struct B : _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: A,
-    inout result: B?
+    result: inout B?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: A,
-    inout result: B?
+    result: inout B?
   ) -> Bool {
     return true
   }

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -28,7 +28,7 @@ class C : B { }
 class D : C { }
 
 
-func prefer_coercion(inout c: C) {
+func prefer_coercion(c: inout C) {
   let d = c as! D
   c = d
 }

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -26,12 +26,12 @@ struct BridgedStruct : _ObjectiveCBridgeable {
 
   static func _forceBridgeFromObjectiveC(
     x: BridgedClass,
-    inout result: BridgedStruct?
+    result: inout BridgedStruct?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: BridgedClass,
-    inout result: BridgedStruct?
+    result: inout BridgedStruct?
   ) -> Bool {
     return true
   }

--- a/test/expr/cast/dictionary_bridge.swift
+++ b/test/expr/cast/dictionary_bridge.swift
@@ -29,12 +29,12 @@ struct BridgedToObjC : Hashable, _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: ObjC,
-    inout result: BridgedToObjC?
+    result: inout BridgedToObjC?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: ObjC,
-    inout result: BridgedToObjC?
+    result: inout BridgedToObjC?
   ) -> Bool {
     return true
   }

--- a/test/expr/cast/set_bridge.swift
+++ b/test/expr/cast/set_bridge.swift
@@ -29,12 +29,12 @@ struct BridgedToObjC : Hashable, _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: ObjC,
-    inout result: BridgedToObjC?
+    result: inout BridgedToObjC?
   ) {
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: ObjC,
-    inout result: BridgedToObjC?
+    result: inout BridgedToObjC?
   ) -> Bool {
     return true
   }

--- a/test/expr/closure/basic.swift
+++ b/test/expr/closure/basic.swift
@@ -31,7 +31,7 @@ func variadic() {
 
 // Closures with attributes in the parameter list.
 func attrs() {
-  _ = {(inout z: Int) -> Int in z }
+  _ = {(z: inout Int) -> Int in z }
 }
 
 // Closures with argument and parameter names.

--- a/test/expr/delayed-ident/static_var.swift
+++ b/test/expr/delayed-ident/static_var.swift
@@ -6,7 +6,7 @@ struct X1 {
   static var NotAnX1 = 42
 }
 
-func acceptInOutX1(inout x1: X1) { }
+func acceptInOutX1(x1: inout X1) { }
 
 var x1: X1 = .AnX1
 x1 = .AnX1

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -465,9 +465,9 @@ s.appendContentsOf(["x"])
 //===----------------------------------------------------------------------===//
 
 func takesInt(x: Int) {}
-func takesExplicitInt(inout x: Int) { }
+func takesExplicitInt(x: inout Int) { }
 
-func testInOut(inout arg: Int) {
+func testInOut(arg: inout Int) {
   var x: Int
   takesExplicitInt(x) // expected-error{{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{20-20=&}}
   takesExplicitInt(&x)
@@ -501,7 +501,7 @@ extension Empty {
   init(_ f: Float) { }
 }
 
-func conversionTest(inout a: Double, inout b: Int) {
+func conversionTest(a: inout Double, b: inout Int) {
   var f: Float
   var d: Double
   a = Double(b)
@@ -550,7 +550,7 @@ _ = C(other: 3) // expected-error {{cannot convert value of type 'Int' to expect
 // Unary Operators
 //===----------------------------------------------------------------------===//
 
-func unaryOps(inout i8: Int8, inout i64: Int64) {
+func unaryOps(i8: inout Int8, i64: inout Int64) {
   i8 = ~i8
   i64 += 1
   i8 -= 1
@@ -599,7 +599,7 @@ func magic_literals() {
 
 
 infix operator +-+= {}
-func +-+= (inout x: Int, y: Int) -> Int { return 0}
+func +-+= (x: inout Int, y: Int) -> Int { return 0}
 
 func lvalue_processing() {
   var i = 0
@@ -746,7 +746,7 @@ public struct TestPropMethodOverloadGroup {
 
 
 // <rdar://problem/18496742> Passing ternary operator expression as inout crashes Swift compiler
-func inoutTests(inout arr: Int) {
+func inoutTests(arr: inout Int) {
   var x = 1, y = 2
   (true ? &x : &y)  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
   let a = (true ? &x : &y)  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
@@ -775,7 +775,7 @@ func inoutTests(inout arr: Int) {
 
 // <rdar://problem/20802757> Compiler crash in default argument & inout expr
 var g20802757 = 2
-func r20802757(inout z: Int = &g20802757) { // expected-error {{'&' can only appear immediately in a call argument list}}
+func r20802757(z: inout Int = &g20802757) { // expected-error {{'&' can only appear immediately in a call argument list}}
   print(z)
 }
 

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -3,7 +3,7 @@
 func foo() -> Int? { return .None }
 func nonOptional() -> Int { return 0 }
 func use(x: Int) {}
-func modify(inout x: Int) {}
+func modify(x: inout Int) {}
 
 if let x = foo() {
   use(x)

--- a/test/type/infer/instance_variables.swift
+++ b/test/type/infer/instance_variables.swift
@@ -6,7 +6,7 @@ struct X {
   var d : Dictionary = [0 : "Zero", 1 : "One", 2 : "Two"]
 }
 
-func testX(inout x: X) {
+func testX(x: inout X) {
   x.b = false
   x.i = 5
   x.d[3] = "Three"


### PR DESCRIPTION
As the title indicates, this PR implements [SE-0031](https://github.com/apple/swift-evolution/blob/master/proposals/0031-adjusting-inout-declarations.md).
- [x] A warning is added for old `inout` position.
- [x] fixit for removing old inout position and inserting it in new position specified in `SE-0031`
- [x] when `inout` appears in both position, only the fixit for removal is issued
- [x] various places where inout declaration is printed
- [x] all tests are updated and passing.
