### PR TITLE
[IRGen] Adapt protocol resilience test for Linux ARM

### DIFF
--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -80,8 +80,8 @@ bb0(%0 : $*Self):
 
   // CHECK-NEXT: [[WTABLE:%.*]] = bitcast i8** %SelfWitnessTable to i8*
   // CHECK-NEXT: [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_allocObject({{.*}})
-  // CHECK-NEXT: [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, [16 x i8], i8* }>*
-  // CHECK:      [[WTABLE_ADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [16 x i8], i8* }>, <{ %swift.refcounted, [16 x i8], i8* }>* [[LAYOUT]], i32 0, i32 2
+  // CHECK-NEXT: [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, [{{8|16}} x i8], i8* }>*
+  // CHECK:      [[WTABLE_ADDR:%.*]] = getelementptr inbounds <{ %swift.refcounted, [{{8|16}} x i8], i8* }>, <{ %swift.refcounted, [{{8|16}} x i8], i8* }>* [[LAYOUT]], i32 0, i32 2
   // CHECK-NEXT: store i8* [[WTABLE]], i8** [[WTABLE_ADDR]]
 
   %fn3 = function_ref @defaultC : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
@@ -117,7 +117,7 @@ bb0(%0 : $*ConformingStruct):
   // might)
 
   // CHECK-NEXT: [[SELF:%.*]] = bitcast %V19protocol_resilience16ConformingStruct* %0 to %swift.opaque*
-  // CHECK-NEXT: call void @defaultC(%swift.opaque* noalias nocapture [[SELF]], %swift.type* bitcast (i64* {{.*}}) to %swift.type*), i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @_TWPV19protocol_resilience16ConformingStructS_17ResilientProtocolS_, i32 0, i32 0))
+  // CHECK-NEXT: call void @defaultC(%swift.opaque* noalias nocapture [[SELF]], %swift.type* bitcast ({{i32|i64}}* {{.*}}) to %swift.type*), i8** getelementptr inbounds ([4 x i8*], [4 x i8*]* @_TWPV19protocol_resilience16ConformingStructS_17ResilientProtocolS_, i32 0, i32 0))
   %fn1 = function_ref @defaultC : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
   %ignore1 = apply %fn1<ConformingStruct>(%0) : $@convention(witness_method) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> ()
 


### PR DESCRIPTION
This protocol resilience test passes on Linux 64-bit, but not Linux ARM, for the same reason as https://github.com/apple/swift/pull/1251. Fix the test for Linux ARM by allowing both bit-widths.

---

This test fails for me when targeting `android-armv7`. I assume once @hpux735 has a chance to rebase #1157 onto master, the test will fail for him as well!

/cc @slavapestov, who reviewed the `class_resilience.sil` test changes for Linux ARM.
