### PR TITLE
[arc] Make all *RefCountStates and RCStateTransition trivially destru…

### DIFF
--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -121,18 +121,6 @@ raw_ostream &llvm::operator<<(raw_ostream &os, RCStateTransitionKind Kind) {
   }
 #include "RCStateTransition.def"
 
-RCStateTransition::RCStateTransition(const RCStateTransition &R) {
-  Kind = R.Kind;
-  if (R.isEndPoint()) {
-    EndPoint = R.EndPoint;
-    return;
-  }
-
-  if (!R.isMutator())
-    return;
-  Mutators = R.Mutators;
-}
-
 bool RCStateTransition::matchingInst(SILInstruction *Inst) const {
   // We only pair mutators for now.
   if (!isMutator())

--- a/lib/SILOptimizer/ARC/RCStateTransition.def
+++ b/lib/SILOptimizer/ARC/RCStateTransition.def
@@ -43,6 +43,8 @@
 /// Misc |
 ///-------
 ///
+/// An invalid transition kind. This must always be first so that it is zero.
+KIND(Invalid)
 /// An unknown kind.
 KIND(Unknown)
 /// An autorelease pool call.

--- a/lib/SILOptimizer/ARC/RCStateTransition.h
+++ b/lib/SILOptimizer/ARC/RCStateTransition.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SILOPTIMIZER_PASSMANAGER_ARC_RCSTATETRANSITION_H
 #define SWIFT_SILOPTIMIZER_PASSMANAGER_ARC_RCSTATETRANSITION_H
 
+#include "swift/Basic/type_traits.h"
 #include "swift/Basic/ImmutablePointerSet.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
@@ -60,10 +61,14 @@ RCStateTransitionKind getRCStateTransitionKind(ValueBase *V);
 //===----------------------------------------------------------------------===//
 
 class RefCountState;
+class BottomUpRefCountState;
+class TopDownRefCountState;
 
 /// Represents a transition in the RC history of a ref count.
 class RCStateTransition {
   friend class RefCountState;
+  friend class BottomUpRefCountState;
+  friend class TopDownRefCountState;
 
   /// An RCStateTransition can represent either an RC end point (i.e. an initial
   /// or terminal RC transition) or a ptr set of Mutators.
@@ -73,11 +78,11 @@ class RCStateTransition {
   RCStateTransitionKind Kind;
 
   // Should only be constructed be default RefCountState.
-  RCStateTransition() {}
+  RCStateTransition() = default;
 
 public:
-  ~RCStateTransition() {}
-  RCStateTransition(const RCStateTransition &R);
+  ~RCStateTransition() = default;
+  RCStateTransition(const RCStateTransition &R) = default;
 
   RCStateTransition(ImmutablePointerSet<SILInstruction> *I) {
     assert(I->size() == 1);
@@ -132,7 +137,14 @@ public:
   /// Attempt to merge \p Other into \p this. Returns true if we succeeded,
   /// false otherwise.
   bool merge(const RCStateTransition &Other);
+
+  /// Return true if the kind of this RCStateTransition is not 'Invalid'.
+  bool isValid() const { return getKind() != RCStateTransitionKind::Invalid; }
 };
+
+// These static assert checks are here for performance reasons.
+static_assert(IsTriviallyCopyable<RCStateTransition>::value,
+              "RCStateTransitions must be trivially copyable");
 
 } // end swift namespace
 


### PR DESCRIPTION
…ctable and constructable.

Tested via static assert.

There is no reason for these data structures to not have these properties.
Adding these properties will improve the compile time efficiency of ARC by
allowing for cheaper copying and 0 cost destruction.
