### PR TITLE
test: remove `ulimit -c unlimited`

### DIFF
--- a/test/Interpreter/fractal.swift
+++ b/test/Interpreter/fractal.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t  &&  mkdir %t
-// RUN: ulimit -c unlimited && %target-jit-run %s -I %S -enable-source-import | FileCheck %s
+// RUN: %target-jit-run %s -I %S -enable-source-import | FileCheck %s
 // REQUIRES: executable_test
 
 // REQUIRES: swift_interpreter


### PR DESCRIPTION
The core limit adjustment was added in SVN r17964 (fad87470) by Ted Kremenek.
This is problematic in bash where if a `ulimit -c 0` was invoked prior to the
test running, it would fail due to the failure to set the core limit to
unlimited.  Interestingly enough, this will be different across bash and zsh.
