### PR TITLE
[arc] Put back in the RCIdentity cache. This shaves of ~0.5 seconds f…

### DIFF
--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -54,6 +54,12 @@ static bool isRCIdentityPreservingCast(ValueKind Kind) {
 //                    RC Identity Root Instruction Casting
 //===----------------------------------------------------------------------===//
 
+static SILValue stripRCIdentityPreservingCasts(SILValue V) {
+  while (isRCIdentityPreservingCast(V->getKind()))
+    V = cast<SILInstruction>(V)->getOperand(0);
+  return V;
+}
+
 static SILValue stripRCIdentityPreservingInsts(SILValue V) {
   // First strip off RC identity preserving casts.
   if (isRCIdentityPreservingCast(V->getKind()))
@@ -445,14 +451,30 @@ SILValue RCIdentityFunctionInfo::getRCIdentityRootInner(SILValue V,
 }
 
 SILValue RCIdentityFunctionInfo::getRCIdentityRoot(SILValue V) {
-  SILValue Root = getRCIdentityRootInner(V, 0);
+  // We save some memory here by stripping off casts from any V. This is good to
+  // do since stripping off casts is the cheap part of
+  // stripRCIdentityPreservingInsts and reduces the number of possible values we
+  // can track.
+  //
+  // The expensive parts of stripRCIdentityPreservingInsts function are the
+  // unique non trivial elt calls. It should be investigated if they fit well
+  // here as well.
+  SILValue NoCastV = stripRCIdentityPreservingCasts(V);
+  auto Iter = Cache.find(NoCastV);
+  if (Iter != Cache.end())
+    return Iter->second;
+
+  SILValue Root = getRCIdentityRootInner(NoCastV, 0);
   VisitedArgs.clear();
 
-  // If we fail to find a root, return V.
+  // If we fail to find a root, return NoCastV.
+  //
+  // We know that stripping off RC identical preserving casts is always safe, so
+  // since NoCastV is "better" information, we can return it without issue.
   if (!Root)
-    return V;
+    return NoCastV;
 
-  return Root;
+  return Cache[NoCastV] = Root;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
…rom ARC when compiling the stdlib on my machine.

I wired up the cache to the delete notification trigger so we are still memory
sense.
