### PR TITLE
Rewrite joinWithSeparator's zero count separator if/else statement with an early-return if check 

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -644,19 +644,19 @@ extension SequenceType where Generator.Element == String {
       result.reserveCapacity(n)
     }
 
-    if separatorSize != 0 {
-      var gen = generate()
-      if let first = gen.next() {
-        result.appendContentsOf(first)
-        while let next = gen.next() {
-          result.appendContentsOf(separator)
-          result.appendContentsOf(next)
-        }
-      }
-    }
-    else {
+    if separatorSize == 0 {
       for x in self {
         result.appendContentsOf(x)
+      }
+      return result
+    }
+    
+    var gen = generate()
+    if let first = gen.next() {
+      result.appendContentsOf(first)
+      while let next = gen.next() {
+        result.appendContentsOf(separator)
+        result.appendContentsOf(next)
       }
     }
 


### PR DESCRIPTION
Since the majority of the time this function is called, it is called with the intention of inserting a separator 
the case of the separator not existing is less common, therefore it might make intent clearer if the if/else check in this code was rewritten with a guard statement. 
