### PR TITLE
[stdlib] Fix precondition messages for MutableCollectionType slice replacing

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -98,7 +98,8 @@ extension TestSuite {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     outOfBoundsSubscriptOffset: Int = 1,
-    withUnsafeMutableBufferPointerIsSupported: Bool
+    withUnsafeMutableBufferPointerIsSupported: Bool,
+    isFixedLengthCollection: Bool
   ) {
     var testNamePrefix = testNamePrefix
 
@@ -211,6 +212,39 @@ self.test("\(testNamePrefix).subscript(_: Range)/Set/semantics") {
         resiliencyChecks: .none) {
         extractValue($0).value == extractValue($1).value
       }
+    }
+  }
+}
+
+if isFixedLengthCollection {
+  self.test("\(testNamePrefix).subscript(_: Range)/Set/LargerRange") {
+    var c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
+    let newElements = makeWrappedCollection([ 91010, 92020, 93030, 94040 ].map(OpaqueValue.init))
+  
+    expectCrashLater()
+    c[c.indices] = newElements[newElements.indices]
+  }
+
+  self.test("\(testNamePrefix).subscript(_: Range)/Set/SmallerRange") {
+    var c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
+    let newElements = makeWrappedCollection([ 91010, 92020 ].map(OpaqueValue.init))
+  
+    expectCrashLater()
+    c[c.indices] = newElements[newElements.indices]
+  }
+} else {
+  self.test("\(testNamePrefix).subscript(_: Range)/Set/DifferentlySizedRange") {
+    for test in replaceRangeTests {
+      var c = makeWrappedCollection(test.collection)
+      let newElements = makeWrappedCollection(test.newElements)
+      let rangeToReplace = test.rangeSelection.rangeOf(c)
+
+      c[rangeToReplace] = newElements[newElements.indices]
+            
+      expectEqualSequence(
+        test.expected,
+        c.map(extractValue).map { $0.value },
+        stackTrace: SourceLocStack().with(test.loc))
     }
   }
 }
@@ -403,7 +437,8 @@ self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementI
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     outOfBoundsSubscriptOffset: Int = 1,
-    withUnsafeMutableBufferPointerIsSupported: Bool
+    withUnsafeMutableBufferPointerIsSupported: Bool,
+    isFixedLengthCollection: Bool
   ) {
     var testNamePrefix = testNamePrefix
 
@@ -428,7 +463,8 @@ self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementI
       outOfBoundsIndexOffset: outOfBoundsIndexOffset,
       outOfBoundsSubscriptOffset: outOfBoundsSubscriptOffset,
       withUnsafeMutableBufferPointerIsSupported:
-        withUnsafeMutableBufferPointerIsSupported)
+        withUnsafeMutableBufferPointerIsSupported,
+      isFixedLengthCollection: isFixedLengthCollection)
 
     addBidirectionalCollectionTests(
       testNamePrefix,
@@ -521,7 +557,8 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .None {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     outOfBoundsSubscriptOffset: Int = 1,
-    withUnsafeMutableBufferPointerIsSupported: Bool
+    withUnsafeMutableBufferPointerIsSupported: Bool,
+    isFixedLengthCollection: Bool
   ) {
     var testNamePrefix = testNamePrefix
 
@@ -546,7 +583,8 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .None {
       outOfBoundsIndexOffset: outOfBoundsIndexOffset,
       outOfBoundsSubscriptOffset: outOfBoundsSubscriptOffset,
       withUnsafeMutableBufferPointerIsSupported:
-        withUnsafeMutableBufferPointerIsSupported)
+        withUnsafeMutableBufferPointerIsSupported,
+      isFixedLengthCollection: isFixedLengthCollection)
 
     addRandomAccessCollectionTests(
       testNamePrefix,

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -332,6 +332,44 @@ let appendContentsOfTests: [AppendContentsOfTest] = [
     expected: [1010, 2020, 3030, 4040, 5050, 6060, 7070, 8080]),
 ]
 
+let replaceRangeTests: [ReplaceRangeTest] = [
+  ReplaceRangeTest(
+    collection: [],
+    newElements: [],
+    rangeSelection: .EmptyRange,
+    expected: []),
+
+  ReplaceRangeTest(
+    collection: [],
+    newElements: [1010, 2020, 3030],
+    rangeSelection: .EmptyRange,
+    expected: [1010, 2020, 3030]),
+
+  ReplaceRangeTest(
+    collection: [4040],
+    newElements: [1010, 2020, 3030],
+    rangeSelection: .LeftEdge,
+    expected: [1010, 2020, 3030, 4040]),
+
+  ReplaceRangeTest(
+    collection: [1010],
+    newElements: [2020, 3030, 4040],
+    rangeSelection: .RightEdge,
+    expected: [1010, 2020, 3030, 4040]),
+
+  ReplaceRangeTest(
+    collection: [1010, 2020, 3030],
+    newElements: [4040],
+    rangeSelection: .RightEdge,
+    expected: [1010, 2020, 3030, 4040]),
+
+  ReplaceRangeTest(
+    collection: [1010, 2020, 3030, 4040, 5050],
+    newElements: [9090],
+    rangeSelection: .Middle,
+    expected: [1010, 9090, 5050]),
+]
+
 extension TestSuite {
   /// Adds a set of tests for `RangeReplaceableCollectionType`.
   ///
@@ -416,45 +454,7 @@ self.test("\(testNamePrefix).init(SequenceType)/semantics") {
 //===----------------------------------------------------------------------===//
 
 self.test("\(testNamePrefix).replaceRange()/semantics") {
-  let tests: [ReplaceRangeTest] = [
-    ReplaceRangeTest(
-      collection: [],
-      newElements: [],
-      rangeSelection: .EmptyRange,
-      expected: []),
-
-    ReplaceRangeTest(
-      collection: [],
-      newElements: [1010, 2020, 3030],
-      rangeSelection: .EmptyRange,
-      expected: [1010, 2020, 3030]),
-
-    ReplaceRangeTest(
-      collection: [4040],
-      newElements: [1010, 2020, 3030],
-      rangeSelection: .LeftEdge,
-      expected: [1010, 2020, 3030, 4040]),
-
-    ReplaceRangeTest(
-      collection: [1010],
-      newElements: [2020, 3030, 4040],
-      rangeSelection: .RightEdge,
-      expected: [1010, 2020, 3030, 4040]),
-
-    ReplaceRangeTest(
-      collection: [1010, 2020, 3030],
-      newElements: [4040],
-      rangeSelection: .RightEdge,
-      expected: [1010, 2020, 3030, 4040]),
-
-    ReplaceRangeTest(
-      collection: [1010, 2020, 3030, 4040, 5050],
-      newElements: [9090],
-      rangeSelection: .Middle,
-      expected: [1010, 9090, 5050]),
-  ]
-
-  for test in tests {
+  for test in replaceRangeTests {
     var c = makeWrappedCollection(test.collection)
     let rangeToReplace = test.rangeSelection.rangeOf(c)
     let newElements =

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -741,10 +741,10 @@ internal func _writeBackMutableSlice<
 
   _precondition(
     selfElementIndex == selfElementsEndIndex,
-    "Cannot replace a slice of a MutableCollectionType with a slice of a larger size")
+    "Cannot replace a slice of a MutableCollectionType with a slice of a smaller size")
   _precondition(
     newElementIndex == newElementsEndIndex,
-    "Cannot replace a slice of a MutableCollectionType with a slice of a smaller size")
+    "Cannot replace a slice of a MutableCollectionType with a slice of a larger size")
 }
 
 /// Returns the range of `x`'s valid index values.

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -768,7 +768,8 @@ do {
     extractValueFromComparable: identityComp,
     checksAdded: checksAdded,
     resiliencyChecks: resiliencyChecks,
-    withUnsafeMutableBufferPointerIsSupported: false)
+    withUnsafeMutableBufferPointerIsSupported: false,
+    isFixedLengthCollection: true)
 %       end
 }
 
@@ -822,7 +823,8 @@ do {
     extractValueFromComparable: identityComp,
     checksAdded: checksAdded,
     resiliencyChecks: resiliencyChecks,
-    withUnsafeMutableBufferPointerIsSupported: false)
+    withUnsafeMutableBufferPointerIsSupported: false,
+    isFixedLengthCollection: true)
 %       end
 }
 

--- a/validation-test/stdlib/Slice/Inputs/slice.gyb
+++ b/validation-test/stdlib/Slice/Inputs/slice.gyb
@@ -74,7 +74,8 @@ do {
     resiliencyChecks: resiliencyChecks,
     outOfBoundsIndexOffset: 6
 % if WrapperType == 'MutableSlice':
-    , withUnsafeMutableBufferPointerIsSupported: false
+    , withUnsafeMutableBufferPointerIsSupported: false,
+    isFixedLengthCollection: true
 % end
     )
 }


### PR DESCRIPTION
The precondition messages in `_writeBackMutableSlice` seem to be inverted in their respective meaning.

You can test the current behaviour as follows:

``` swift
let ptr = UnsafeMutablePointer<Int>.alloc(100)
ptr.initializeFrom(0..<100)
let ptr2 = UnsafeMutablePointer<Int>.alloc(20)
ptr2.initializeFrom(0..<20)

var dest = UnsafeMutableBufferPointer(start: ptr, count: 100)
let source = UnsafeMutableBufferPointer(start: ptr2, count: 20)

// fatal error: Cannot replace a slice of a MutableCollectionType with a slice of a larger size
dest[20..<50] = source[0..<20]

// Cannot replace a slice of a MutableCollectionType with a slice of a smaller size
dest[20..<30] = source[0..<20]
```

(I'm using `UnsafeMutableBufferPointer` since its the only type in the stdlib that uses the default slicing behaviour from `MutableCollectionType`)

I also looked into adding tests for this but I don't think its currently possible to test for specific trap messages? However CollectionType currently has no trap tests at all so I'm open to adding some as a separate pull request if that makes sense.
