### PR TITLE
Revert "Runtime: Remove retainCount entry points."

### DIFF
--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -89,6 +89,14 @@ Rename with a non-`stdlib` naming scheme.
 
 ## Reference counting
 
+### swift\_retainCount
+
+```
+@convention(c) (@unowned NativeObject) -> UInt
+```
+
+Returns a random number. Only used by allocation profiling tools.
+
 ### TODO
 
 ```

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -206,6 +206,10 @@ extern "C" void swift_release(HeapObject *object);
 /// count reaches zero, the object is destroyed
 extern "C" void swift_release_n(HeapObject *object, uint32_t n);
 
+// Refcounting observation hooks for memory tools. Don't use these.
+extern "C" size_t swift_retainCount(HeapObject *object);
+extern "C" size_t swift_unownedRetainCount(HeapObject *object);
+
 /// Is this pointer a non-null unique reference to an object
 /// that uses Swift reference counting?
 extern "C" bool swift_isUniquelyReferencedNonObjC(const void *);

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -296,6 +296,14 @@ static void _swift_release_n_(HeapObject *object, uint32_t n) {
 }
 auto swift::_swift_release_n = _swift_release_n_;
 
+size_t swift::swift_retainCount(HeapObject *object) {
+  return object->refCount.getCount();
+}
+
+size_t swift::swift_unownedRetainCount(HeapObject *object) {
+  return object->weakRefCount.getCount();
+}
+
 void swift::swift_unownedRetain(HeapObject *object) {
   if (!object) return;
 

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -256,7 +256,7 @@ static NSString *_getClassDescription(Class cls) {
   return _objc_rootAutorelease(self);
 }
 - (NSUInteger)retainCount {
-  return reinterpret_cast<HeapObject *>(self)->refCount.getCount();
+  return swift::swift_retainCount(reinterpret_cast<HeapObject *>(self));
 }
 - (BOOL)_isDeallocating {
   return swift_isDeallocating(reinterpret_cast<HeapObject *>(self));

--- a/unittests/runtime/Refcounting.cpp
+++ b/unittests/runtime/Refcounting.cpp
@@ -98,13 +98,6 @@ TEST(RefcountingTest, pin_pin_unpin_unpin) {
   EXPECT_EQ(1u, value);
 }
 
-static unsigned _retainCount(HeapObject *object) {
-  return object->refCount.getCount();
-}
-static unsigned _unownedRetainCount(HeapObject *object) {
-  return object->weakRefCount.getCount();
-}
-
 TEST(RefcountingTest, retain_release_n) {
   size_t value = 0;
   auto object = allocTestObject(&value, 1);
@@ -112,18 +105,16 @@ TEST(RefcountingTest, retain_release_n) {
   swift_retain_n(object, 32);
   swift_retain(object);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(34u, _retainCount(object));
+  EXPECT_EQ(34u, swift_retainCount(object));
   swift_release_n(object, 31);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(3u, _retainCount(object));
+  EXPECT_EQ(3u, swift_retainCount(object));
   swift_release(object);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(2u, _retainCount(object));
+  EXPECT_EQ(2u, swift_retainCount(object));
   swift_release_n(object, 1);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(1u, _retainCount(object));
-  swift_release(object);
-  EXPECT_EQ(1u, value);
+  EXPECT_EQ(1u, swift_retainCount(object));
 }
 
 TEST(RefcountingTest, unknown_retain_release_n) {
@@ -133,18 +124,16 @@ TEST(RefcountingTest, unknown_retain_release_n) {
   swift_unknownRetain_n(object, 32);
   swift_unknownRetain(object);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(34u, _retainCount(object));
+  EXPECT_EQ(34u, swift_retainCount(object));
   swift_unknownRelease_n(object, 31);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(3u, _retainCount(object));
+  EXPECT_EQ(3u, swift_retainCount(object));
   swift_unknownRelease(object);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(2u, _retainCount(object));
+  EXPECT_EQ(2u, swift_retainCount(object));
   swift_unknownRelease_n(object, 1);
   EXPECT_EQ(0u, value);
-  EXPECT_EQ(1u, _retainCount(object));
-  swift_unknownRelease(object);
-  EXPECT_EQ(1u, value);
+  EXPECT_EQ(1u, swift_retainCount(object));
 }
 
 TEST(RefcountingTest, unowned_retain_release_n) {
@@ -153,13 +142,13 @@ TEST(RefcountingTest, unowned_retain_release_n) {
   EXPECT_EQ(0u, value);
   swift_unownedRetain_n(object, 32);
   swift_unownedRetain(object);
-  EXPECT_EQ(34u, _unownedRetainCount(object));
+  EXPECT_EQ(34u, swift_unownedRetainCount(object));
   swift_unownedRelease_n(object, 31);
-  EXPECT_EQ(3u, _unownedRetainCount(object));
+  EXPECT_EQ(3u, swift_unownedRetainCount(object));
   swift_unownedRelease(object);
-  EXPECT_EQ(2u, _unownedRetainCount(object));
+  EXPECT_EQ(2u, swift_unownedRetainCount(object));
   swift_unownedRelease_n(object, 1);
-  EXPECT_EQ(1u, _unownedRetainCount(object));
+  EXPECT_EQ(1u, swift_unownedRetainCount(object));
   swift_release(object);
   EXPECT_EQ(1u, value);
 }

--- a/unittests/runtime/weak.mm
+++ b/unittests/runtime/weak.mm
@@ -40,7 +40,7 @@ static HeapObject *make_objc_object() {
 extern "C" HeapObject *make_swift_object();
 
 static unsigned getUnownedRetainCount(HeapObject *object) {
-  return object->weakRefCount.getCount() - 1;
+  return swift_unownedRetainCount(object) - 1;
 }
 
 static void unknown_release(void *value) {


### PR DESCRIPTION
This reverts commit 51e0594e1cdadc6beec7cf4dfb01bd32bf9dbd58. The retainCount
entry points are used by Instruments.
