### PR TITLE
libdispatch: also build tests during build phase

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1795,6 +1795,8 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 fi
                 pushd "${LIBDISPATCH_BUILD_DIR}"
                 make
+                cd tests
+                make build-tests
                 popd
                 { set +x; } 2>/dev/null
 


### PR DESCRIPTION
A tweak to match the Swift CI pattern; build the test cases during the build phase.  
Change to swift-corelibs-libdispatch to define the build-tests target was merged earlier today.
