### PR TITLE
[Swift 2.2] Add missing abstracts for types and protocols.

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -165,7 +165,7 @@ if True:
 /// first element access.'''
 # FIXME: Write about Array up/down-casting.
     else:
-      raise AssertionError('Unhandled case: ' + Self)
+      raise ValueError('Unhandled case: ' + Self)
 }%
 
 ${SelfDocComment}

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -15,17 +15,16 @@ public func count <T : CollectionType>(x: T) -> T.Index.Distance {
   fatalError("unavailable function can't be called")
 }
 
-/// A protocol representing the minimal requirements of
-/// `CollectionType`.
+/// A type that provides subscript access to its elements.
 ///
-/// - Note: In most cases, it's best to ignore this protocol and use
+/// - Important: In most cases, it's best to ignore this protocol and use
 ///   `CollectionType` instead, as it has a more complete interface.
-//
-// This protocol is almost an implementation detail of the standard
-// library; it is used to deduce things like the `SubSequence` and
-// `Generator` type from a minimal collection, but it is also used in
-// exposed places like as a constraint on IndexingGenerator.
 public protocol Indexable {
+  // This protocol is almost an implementation detail of the standard
+  // library; it is used to deduce things like the `SubSequence` and
+  // `Generator` type from a minimal collection, but it is also used in
+  // exposed places like as a constraint on IndexingGenerator.
+
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
@@ -64,6 +63,7 @@ public protocol Indexable {
   subscript(position: Index) -> _Element {get}
 }
 
+/// A type that supports subscript assignment to a mutable collection.
 public protocol MutableIndexable {
   associatedtype Index : ForwardIndexType
 

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// The protocol for error values that can be thrown.
 // TODO: API review
+/// A type representing an error value that can be thrown.
 @swift3_migration(renamed="ErrorProtocol")
 public protocol ErrorType {
   var _domain: String { get }

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -118,6 +118,7 @@ extension LazySequenceType
 %   %(Base)sIndex : BidirectionalIndexType, 
 %   %(Base)sGenerator.Element.Index : BidirectionalIndexType'''
 %   Index = Collection + 'Index'
+/// A position in a `${Collection}`.
 public struct ${Index}<
   BaseElements: CollectionType where ${constraints % {'Base': 'BaseElements.'}}
 > : ${traversal}IndexType {

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -161,12 +161,29 @@ def getMinFloat(floatBits, intBits):
 }%
 
 % for bits in allFloatBits:
-%   Self = floatName(bits)
+%{
+Self = floatName(bits)
 
+if Self == 'Float':
+    SelfDocComment = '''\
+/// A single-precision floating-point value type.'''
+
+elif Self == 'Double':
+    SelfDocComment = '''\
+/// A double-precision floating-point value type.'''
+
+elif Self == 'Float80':
+    SelfDocComment = '''\
+/// An extended-precision floating-point value type.'''
+
+else:
+    raise ValueError('Unhandled float type.')
+}%
 % if bits == 80:
 #if arch(i386) || arch(x86_64)
 % end
 
+${SelfDocComment}
 public struct ${Self} {
   public // @testable
   var _value: Builtin.FPIEEE${bits}

--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -10,14 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An optional type that allows implicit member access (via compiler
-/// magic).
-///
-/// The compiler has special knowledge of the existence of
-/// `ImplicitlyUnwrappedOptional<Wrapped>`, but always interacts with it using
-/// the library intrinsics below.
+/// An optional type that allows implicit member access.
 public enum ImplicitlyUnwrappedOptional<Wrapped>
   : _Reflectable, NilLiteralConvertible {
+  // The compiler has special knowledge of the existence of
+  // `ImplicitlyUnwrappedOptional<Wrapped>`, but always interacts with it using
+  // the library intrinsics below.
+
   case None
   case Some(Wrapped)
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -10,9 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-// The compiler has special knowledge of Optional<Wrapped>, including the fact
-// that it is an enum with cases named 'None' and 'Some'.
+/// A type that can represent either a `Wrapped` value or `nil`, the absence
+/// of a value.
 public enum Optional<Wrapped> : _Reflectable, NilLiteralConvertible {
+  // The compiler has special knowledge of Optional<Wrapped>, including the fact
+  // that it is an `enum` with cases named `None` and `Some`.
+  
   case None
   case Some(Wrapped)
 

--- a/stdlib/public/core/Process.swift
+++ b/stdlib/public/core/Process.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Command-line arguments for the current process.
 public enum Process {
   /// The list of command-line arguments with which the current
   /// process was invoked.

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// An index that traverses the same positions as an underlying index,
+/// with inverted traversal direction.
 @swift3_migration(renamed="ReverseIndexProtocol")
 public protocol ReverseIndexType : BidirectionalIndexType {
   associatedtype Base : BidirectionalIndexType

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -16,6 +16,7 @@ extension String {
     : CollectionType, _Reflectable, CustomStringConvertible,
     CustomDebugStringConvertible {
 
+    /// A position in a string's collection of UTF-16 code units.
     public struct Index {
       // Foundation needs access to these fields so it can expose
       // random access


### PR DESCRIPTION
The missing part of #1327.
