### PR TITLE
Fix closure capture boxes regression

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -577,11 +577,11 @@ static CanSILFunctionType getSILFunctionType(SILModule &M,
       auto *VD = capture.getDecl();
       auto type = VD->getType()->getCanonicalType();
       
-      type = Types.getInterfaceTypeOutOfContext(type,
+      auto interfaceType = Types.getInterfaceTypeOutOfContext(type,
                                                 function->getAsDeclContext());
       
       auto &loweredTL = Types.getTypeLowering(
-                                    AbstractionPattern(genericSig, type), type);
+                                    AbstractionPattern(type), interfaceType);
       auto loweredTy = loweredTL.getLoweredType();
       switch (Types.getDeclCaptureKind(capture)) {
       case CaptureKind::None:

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -150,3 +150,18 @@ func shmassert(@autoclosure f: () -> Bool) {}
 func capture_generic_param<A: Fooable>(x: A) {
   shmassert(A.foo())
 }
+
+// Make sure we use the correct convention when capturing class-constrained
+// member types: <rdar://problem/24470533>
+class Class {}
+
+protocol HasClassAssoc { associatedtype Assoc : Class }
+
+// CHECK-LABEL: sil hidden @_TF16generic_closures34captures_class_constrained_genericuRxS_13HasClassAssocrFTx1fFwx5AssocwxS1__T_
+// CHECK: bb0(%0 : $*T, %1 : $@callee_owned (@owned T.Assoc) -> @owned T.Assoc):
+// CHECK: [[GENERIC_FN:%.*]] = function_ref @_TFF16generic_closures34captures_class_constrained_genericuRxS_13HasClassAssocrFTx1fFwx5AssocwxS1__T_U_FT_FQQ_5AssocS2_
+// CHECK: [[CONCRETE_FN:%.*]] = partial_apply [[GENERIC_FN]]<T, T.Assoc>(%1)
+
+func captures_class_constrained_generic<T : HasClassAssoc>(x: T, f: T.Assoc -> T.Assoc) {
+  let _: () -> T.Assoc -> T.Assoc = { f }
+}


### PR DESCRIPTION
This is broken in Swift 2.2 and was only fixed in master. It looks like
passing of the interface type into type lowering was introduced by this
commit from a recent redesign of closure captures:

https://github.com/apple/swift/commit/b76c0abc37c86236ade80db033b14fe095658479

Fixes rdar://problem/24470533.
