### PR TITLE
Logic simplification of next() function in JoinGenerator Struct.

### DIFF
--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -55,18 +55,12 @@ public struct JoinGenerator<
         if _fastPath(result != nil) {
           return result
         }
-        if _separatorData.isEmpty {
-          _inner = _base.next()?.generate()
-          if _inner == nil {
-            _state = .End
-            return nil
-          }
-        } else {
-          _inner = _base.next()?.generate()
-          if _inner == nil {
-            _state = .End
-            return nil
-          }
+        _inner = _base.next()?.generate()
+        if _inner == nil {
+          _state = .End
+          return nil
+        }
+        if !_separatorData.isEmpty {
           _separator = _separatorData.generate()
           _state = .GeneratingSeparator
         }


### PR DESCRIPTION
Since the only code difference between these two conditions are the two lines:

``` swift
_separator = _separatorData.generate()
_state = .GeneratingSeparator
```

it might be better to just break out only that part out into an `if` statement that checks to see if `_separatorData` is empty.
