### PR TITLE
IRGen: adjust for clang API change

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1025,6 +1025,14 @@ inline bool isBuiltinTypeOverloaded(Type T, OverloadedBuiltinKind OK) {
   llvm_unreachable("bad overloaded builtin kind");
 }
 
+/// Table of string intrinsic names indexed by enum value.
+static const char *const IntrinsicNameTable[] = {
+    "not_intrinsic",
+#define GET_INTRINSIC_NAME_TABLE
+#include "llvm/IR/Intrinsics.gen"
+#undef GET_INTRINSIC_NAME_TABLE
+};
+
 /// getLLVMIntrinsicID - Given an LLVM IR intrinsic name with argument types
 /// removed (e.g. like "bswap") return the LLVM IR IntrinsicID for the intrinsic
 /// or 0 if the intrinsic name doesn't match anything.
@@ -1045,11 +1053,10 @@ unsigned swift::getLLVMIntrinsicID(StringRef InName, bool hasArgTypes) {
     NameS.push_back('.');
   
   const char *Name = NameS.c_str();
-  unsigned Len = NameS.size();
-#define GET_FUNCTION_RECOGNIZER
-#include "llvm/IR/Intrinsics.gen"
-#undef GET_FUNCTION_RECOGNIZER
-  return llvm::Intrinsic::not_intrinsic;
+  ArrayRef<const char *> NameTable(&IntrinsicNameTable[1],
+                                   std::end(IntrinsicNameTable));
+  int Idx = Intrinsic::lookupLLVMIntrinsicByName(NameTable, Name);
+  return static_cast<Intrinsic::ID>(Idx + 1);
 }
 
 llvm::Intrinsic::ID

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -857,7 +857,6 @@ namespace {
       }
 
       auto dataPtr = emitROData(ForMetaClass);
-      dataPtr = llvm::ConstantExpr::getPtrToInt(dataPtr, IGM.IntPtrTy);
 
       llvm::Constant *fields[] = {
         rootPtr,
@@ -1037,12 +1036,15 @@ namespace {
 
       return llvm::ConstantStruct::getAnon(IGM.getLLVMContext(), fields);
     }
-    
+
     llvm::Constant *emitROData(ForMetaClass_t forMeta) {
       auto fields = emitRODataFields(forMeta);
-      
+
       auto dataSuffix = forMeta ? "_METACLASS_DATA_" : "_DATA_";
-      return buildGlobalVariable(fields, dataSuffix);
+      llvm::Constant *DataVar = buildGlobalVariable(fields, dataSuffix);
+      return llvm::ConstantExpr::getBitCast(
+          DataVar,
+          IGM.getModule()->getTypeByName("struct._class_ro_t")->getPointerTo());
     }
 
   private:

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -86,13 +86,13 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   CGO.DisableFPElim = Opts.DisableFPElim;
   switch (Opts.DebugInfoKind) {
   case IRGenDebugInfoKind::None:
-    CGO.setDebugInfo(clang::CodeGenOptions::DebugInfoKind::NoDebugInfo);
+    CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::NoDebugInfo);
     break;
   case IRGenDebugInfoKind::LineTables:
-    CGO.setDebugInfo(clang::CodeGenOptions::DebugInfoKind::DebugLineTablesOnly);
+    CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::DebugLineTablesOnly);
     break;
  case IRGenDebugInfoKind::Normal:
-    CGO.setDebugInfo(clang::CodeGenOptions::DebugInfoKind::FullDebugInfo);
+    CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::FullDebugInfo);
     break;
   }
   if (Opts.DebugInfoKind != IRGenDebugInfoKind::None) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -393,13 +393,15 @@ public:
     llvm::PointerType *UnknownRefCountedPtrTy;
   };
   llvm::PointerType *BridgeObjectPtrTy; /// %swift.bridge*
-  llvm::PointerType *OpaquePtrTy;      /// %swift.opaque*
-  llvm::StructType *ObjCClassStructTy; /// %objc_class
-  llvm::PointerType *ObjCClassPtrTy;   /// %objc_class*
-  llvm::StructType *ObjCSuperStructTy; /// %objc_super
-  llvm::PointerType *ObjCSuperPtrTy;   /// %objc_super*
-  llvm::StructType *ObjCBlockStructTy; /// %objc_block
-  llvm::PointerType *ObjCBlockPtrTy;   /// %objc_block*
+  llvm::PointerType *OpaquePtrTy;       /// %swift.opaque*
+  llvm::StructType *ObjCCacheStructTy;  /// %objc_cache
+  llvm::PointerType *ObjCCachePtrTy;    /// %objc_cache*
+  llvm::StructType *ObjCClassStructTy;  /// %objc_class
+  llvm::PointerType *ObjCClassPtrTy;    /// %objc_class*
+  llvm::StructType *ObjCSuperStructTy;  /// %objc_super
+  llvm::PointerType *ObjCSuperPtrTy;    /// %objc_super*
+  llvm::StructType *ObjCBlockStructTy;  /// %objc_block
+  llvm::PointerType *ObjCBlockPtrTy;    /// %objc_block*
   llvm::StructType *ProtocolConformanceRecordTy;
   llvm::PointerType *ProtocolConformanceRecordPtrTy;
   llvm::StructType *NominalTypeDescriptorTy;

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -55,7 +55,7 @@ protected:
 
   llvm::SmallSetVector<SILFunction *, 16> Worklist;
 
-  llvm::SmallPtrSet<SILFunction *, 100> AliveFunctions;
+  llvm::SmallPtrSet<SILFunction *, 32> AliveFunctions;
 
   /// Checks is a function is alive, e.g. because it is visible externally.
   bool isAnchorFunction(SILFunction *F) {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -51,9 +51,9 @@ STATISTIC(NumDeadInst, "Number of dead insts eliminated");
 /// worklist (this significantly speeds up SILCombine on code where many
 /// instructions are dead or constant).
 void SILCombiner::addReachableCodeToWorklist(SILBasicBlock *BB) {
-  llvm::SmallVector<SILBasicBlock*, 256> Worklist;
-  llvm::SmallVector<SILInstruction*, 128> InstrsForSILCombineWorklist;
-  llvm::SmallPtrSet<SILBasicBlock*, 64> Visited;
+  llvm::SmallVector<SILBasicBlock *, 256> Worklist;
+  llvm::SmallVector<SILInstruction *, 128> InstrsForSILCombineWorklist;
+  llvm::SmallPtrSet<SILBasicBlock *, 32> Visited;
 
   Worklist.push_back(BB);
   do {

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -136,12 +136,12 @@ enum MultipleEmptyRefcounted {
 // CHECK:     i64 0, label %5
 // CHECK:     i64 2, label %5
 // CHECK:   ]
-// CHECK: ; <label>:3                                       ; preds = %entry
+// CHECK: ; <label>:3{{:?}}                                 ; preds = %entry
 // CHECK:   %4 = bitcast %O34enum_value_semantics_special_cases23MultipleEmptyRefcounted* %0 to %swift.refcounted**
 // CHECK:   %toDestroy = load %swift.refcounted*, %swift.refcounted** %4, align 8
 // CHECK:   call void @swift_release(%swift.refcounted* %toDestroy) {{#[0-9]+}}
 // CHECK:   br label %5
-// CHECK: ; <label>:5                                       ; preds = %3, %entry, %entry
+// CHECK: ; <label>:5{{:?}}                                 ; preds = %3, %entry, %entry
 // CHECK:   ret void
 // CHECK: }
 

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -12,6 +12,7 @@ add_swift_executable(swift
     swiftFrontend
     swiftClangImporter
     swiftOption
+    LLVMDebugInfoCodeView
 )
 
 target_link_libraries(swift edit)

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_executable(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
   LINK_LIBRARIES
-    swiftASTSectionImporter swiftFrontend swiftClangImporter
+    swiftASTSectionImporter swiftFrontend swiftClangImporter LLVMDebugInfoCodeView
     )
 
 swift_install_in_component(testsuite-tools

--- a/tools/sil-extract/CMakeLists.txt
+++ b/tools/sil-extract/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_executable(sil-extract
     swiftSILOptimizer
     swiftSerialization
     swiftClangImporter
+    LLVMDebugInfoCodeView
 )
 
 swift_install_in_component(tools

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_executable(sil-opt
     swiftIRGen
     swiftSILGen
     swiftSILOptimizer
+    LLVMDebugInfoCodeView
 )
 
 swift_install_in_component(tools

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_executable(swift-ide-test
     swiftDriver
     swiftFrontend
     swiftIDE
+    LLVMDebugInfoCodeView
 )
 
 # If libxml2 is available, make it available for swift-ide-test.

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -10,6 +10,8 @@ add_swift_executable(swift-llvm-opt
   # Clang libraries included to appease the linker on linux.
   clangBasic
   clangCodeGen
+
+  LLVMDebugInfoCodeView
 )
 
 swift_install_in_component(tools


### PR DESCRIPTION
NOTE: This patch is incomplete, but is meant to see if this general approach is reasonable.

When building with assertions, a recent change would cause the GlobalVariable
constructor to trip over the assertion:
  `InitVal->getType() == Ty`.

This was caused by the types used in swift differing from the types in clang.
In particular, the class global constructor was using `struct objc_class *` and
expecting a bitcast to coerce the type into the constructor type
(struct._class_t *).

A similar issue arose during the creation of the metaclass where the empty
vtable struct mismatched due to use of an opaque pointer, and the RO data type.

The RO type is a complicated and this change takes a shortcut of assuming that
it will be initialized by clang into the same module and querying the type
rather than trying to re-create it.'
