### PR TITLE
[Python] Argument names should be lowercase by convention

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -51,13 +51,13 @@ SortedPrefixes = sorted(Prefixes)
 SortedInfixes = sorted(Infixes)
 
 
-def addFunction(sizes, function, startAddr, endAddr, groupByPrefix):
-    if not function or startAddr is None or endAddr is None:
+def addFunction(sizes, function, start_addr, end_addr, group_by_prefix):
+    if not function or start_addr is None or end_addr is None:
         return
 
-    size = endAddr - startAddr
+    size = end_addr - start_addr
 
-    if groupByPrefix:
+    if group_by_prefix:
         for infix in SortedInfixes:
 	    if infix in function:
                if GenericFunctionPrefix not in function:
@@ -85,10 +85,10 @@ def flatten(*args):
             yield x
 
 
-def readSizes(sizes, fileName, functionDetails, groupByPrefix):
+def readSizes(sizes, file_name, function_details, group_by_prefix):
     # Check if multiple architectures are supported by the object file.
     # Prefer arm64 if available.
-    architectures = subprocess.check_output(["otool", "-V", "-f", fileName]).split("\n")
+    architectures = subprocess.check_output(["otool", "-V", "-f", file_name]).split("\n")
     arch = None
     archPattern = re.compile('architecture ([\S]+)')
     for architecture in architectures:
@@ -103,16 +103,16 @@ def readSizes(sizes, fileName, functionDetails, groupByPrefix):
     else:
       archParams = []
 
-    if functionDetails:
-        content = subprocess.check_output(flatten(["otool", archParams, "-l", "-v", "-t", fileName])).split("\n")
-        content += subprocess.check_output(flatten(["otool", archParams, "-v", "-s", "__TEXT", "__textcoal_nt", fileName])).split("\n")
+    if function_details:
+        content = subprocess.check_output(flatten(["otool", archParams, "-l", "-v", "-t", file_name])).split("\n")
+        content += subprocess.check_output(flatten(["otool", archParams, "-v", "-s", "__TEXT", "__textcoal_nt", file_name])).split("\n")
     else:
-        content = subprocess.check_output(flatten(["otool", archParams, "-l", fileName])).split("\n")
+        content = subprocess.check_output(flatten(["otool", archParams, "-l", file_name])).split("\n")
 
     sectName = None
     currFunc = None
-    startAddr = None
-    endAddr = None
+    start_addr = None
+    end_addr = None
 
     sectionPattern = re.compile(' +sectname ([\S]+)')
     sizePattern = re.compile(' +size ([\da-fx]+)')
@@ -123,9 +123,9 @@ def readSizes(sizes, fileName, functionDetails, groupByPrefix):
         asmlineMatch = asmlinePattern.match(line)
         if asmlineMatch:
             addr = int(asmlineMatch.group(1), 16)
-            if startAddr is None:
-                startAddr = addr
-            endAddr = addr
+            if start_addr is None:
+                start_addr = addr
+            end_addr = addr
         elif line == "Section":
             sectName = None
         else:
@@ -134,11 +134,11 @@ def readSizes(sizes, fileName, functionDetails, groupByPrefix):
             sectionMatch = sectionPattern.match(line)
             if labelMatch:
                 funcName = labelMatch.group(1)
-                addFunction(sizes, currFunc, startAddr, endAddr, groupByPrefix)
+                addFunction(sizes, currFunc, start_addr, end_addr, group_by_prefix)
                 currFunc = funcName
-                startAddr = None
-                endAddr = None
-            elif sizeMatch and sectName and groupByPrefix:
+                start_addr = None
+                end_addr = None
+            elif sizeMatch and sectName and group_by_prefix:
                 size = int(sizeMatch.group(1), 16)
                 sizes[sectName] += size
             elif sectionMatch:
@@ -146,74 +146,74 @@ def readSizes(sizes, fileName, functionDetails, groupByPrefix):
                 if sectName == "__textcoal_nt":
                     sectName = "__text"
 
-    addFunction(sizes, currFunc, startAddr, endAddr, groupByPrefix)
+    addFunction(sizes, currFunc, start_addr, end_addr, group_by_prefix)
 
 
-def compareSizes(oldSizes, newSizes, nameKey, title):
-    oldSize = oldSizes[nameKey]
-    newSize = newSizes[nameKey]
+def compareSizes(old_sizes, new_sizes, name_key, title):
+    oldSize = old_sizes[name_key]
+    newSize = new_sizes[name_key]
     if oldSize is not None and newSize is not None:
         if oldSize != 0:
             perc = "%.1f%%" % ((1.0 - float(newSize) / float(oldSize)) * 100.0)
         else:
             perc = "- "
-        print("%-26s%16s: %8d  %8d  %6s" % (title, nameKey, oldSize, newSize, perc))
+        print("%-26s%16s: %8d  %8d  %6s" % (title, name_key, oldSize, newSize, perc))
 
 
-def compareSizesOfFile(oldFiles, newFiles, allSections, listCategories):
-    oldSizes = collections.defaultdict(int)
-    newSizes = collections.defaultdict(int)
-    for oldFile in oldFiles:
-        readSizes(oldSizes, oldFile, listCategories, True)
-    for newFile in newFiles:
-        readSizes(newSizes, newFile, listCategories, True)
+def compareSizesOfFile(old_files, new_files, all_sections, list_categories):
+    old_sizes = collections.defaultdict(int)
+    new_sizes = collections.defaultdict(int)
+    for oldFile in old_files:
+        readSizes(old_sizes, oldFile, list_categories, True)
+    for newFile in new_files:
+        readSizes(new_sizes, newFile, list_categories, True)
 
-    if len(oldFiles) == 1 and len(newFiles) == 1:
-        oldBase = os.path.basename(oldFiles[0])
-        newBase = os.path.basename(newFiles[0])
+    if len(old_files) == 1 and len(new_files) == 1:
+        oldBase = os.path.basename(old_files[0])
+        newBase = os.path.basename(new_files[0])
         title = oldBase
         if oldBase != newBase:
             title += "-" + newBase
     else:
         title = "old-new"
 
-    compareSizes(oldSizes, newSizes, "__text", title)
-    if listCategories:
+    compareSizes(old_sizes, new_sizes, "__text", title)
+    if list_categories:
         prev = None
         for categoryName in sorted(Prefixes.values()) + sorted(Infixes.values()) + ["Unknown"]:
             if categoryName != prev:
-                compareSizes(oldSizes, newSizes, categoryName, "")
+                compareSizes(old_sizes, new_sizes, categoryName, "")
             prev = categoryName
 
-    if allSections:
+    if all_sections:
         sectionTitle = "    section"
-        compareSizes(oldSizes, newSizes, "__textcoal_nt", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__stubs", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__const", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__cstring", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__objc_methname", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__const", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__objc_const", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__data", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__swift1_proto", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__common", sectionTitle)
-        compareSizes(oldSizes, newSizes, "__bss", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__textcoal_nt", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__stubs", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__const", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__cstring", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__objc_methname", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__const", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__objc_const", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__data", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__swift1_proto", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__common", sectionTitle)
+        compareSizes(old_sizes, new_sizes, "__bss", sectionTitle)
 
 
-def listFunctionSizes(sizeArray):
-    for pair in sorted(sizeArray, key=itemgetter(1)):
+def listFunctionSizes(size_array):
+    for pair in sorted(size_array, key=itemgetter(1)):
         name = pair[0]
         size = pair[1]
         return "%8d %s" % (size, name)
 
 
-def compareFunctionSizes(oldFiles, newFiles):
-    oldSizes = collections.defaultdict(int)
-    newSizes = collections.defaultdict(int)
-    for name in oldFiles:
-        readSizes(oldSizes, name, True, False)
-    for name in newFiles:
-        readSizes(newSizes, name, True, False)
+def compareFunctionSizes(old_files, new_files):
+    old_sizes = collections.defaultdict(int)
+    new_sizes = collections.defaultdict(int)
+    for name in old_files:
+        readSizes(old_sizes, name, True, False)
+    for name in new_files:
+        readSizes(new_sizes, name, True, False)
 
     onlyInFile1 = []
     onlyInFile2 = []
@@ -223,16 +223,16 @@ def compareFunctionSizes(oldFiles, newFiles):
     onlyInFile2Size = 0
     inBothSize = 0
 
-    for func, oldSize in oldSizes.items():
-        newSize = newSizes[func]
+    for func, oldSize in old_sizes.items():
+        newSize = new_sizes[func]
         if newSize != 0:
             inBoth.append((func, oldSize, newSize))
         else:
             onlyInFile1.append((func, oldSize))
             onlyInFile1Size += oldSize
 
-    for func, newSize in newSizes.items():
-        oldSize = oldSizes[func]
+    for func, newSize in new_sizes.items():
+        oldSize = old_sizes[func]
         if oldSize == 0:
             onlyInFile2.append((func, newSize))
             onlyInFile2Size += newSize

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -54,14 +54,14 @@ def interpolate(string):
     frame = inspect.currentframe()
     return string % frame.f_back.f_locals
 
-# Given the bodyText of a protocol definition, return a list of
+# Given the body_text of a protocol definition, return a list of
 # associated type and operator requirements.
-def bodyLines(bodyText):
+def bodyLines(body_text):
     return [
         cgi.escape(b.group(0)) for b in
         re.finditer(
             r'(typealias\s*' + identifier + r'(\s*[:,]\s*' + identifier + ')?|' + operator + '.*)',
-            bodyText, reFlags)
+            body_text, reFlags)
     ]
 
 # Mapping from protocol to associated type / operator requirements

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -312,10 +312,10 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
 
 
 class Test:
-  def __init__(self, name, source, processedSource, binary):
+  def __init__(self, name, source, processed_source, binary):
     self.name = name
     self.source = source
-    self.processedSource = processedSource
+    self.processed_source = processed_source
     self.binary = binary
     self.status = ""
 


### PR DESCRIPTION
Fix 16 "argument name should be lowercase" violations.

As discussed with @modocache and @nadavrot in #1369.

Signature changes: 

```
-def addFunction(sizes, function, startAddr, endAddr, groupByPrefix):
+def addFunction(sizes, function, start_addr, end_addr, group_by_prefix):
-def readSizes(sizes, fileName, functionDetails, groupByPrefix):
+def readSizes(sizes, file_name, function_details, group_by_prefix):
-def compareSizes(oldSizes, newSizes, nameKey, title):
+def compareSizes(old_sizes, new_sizes, name_key, title):
-def compareSizesOfFile(oldFiles, newFiles, allSections, listCategories):
+def compareSizesOfFile(old_files, new_files, all_sections, list_categories):
-def listFunctionSizes(sizeArray):
+def listFunctionSizes(size_array):
-def compareFunctionSizes(oldFiles, newFiles):
+def compareFunctionSizes(old_files, new_files):
-def tokenPosToIndex(tokenPos, start, lineStarts):
+def tokenPosToIndex(token_pos, start, line_starts):
-def tokenizePythonToUnmatchedCloseCurly(sourceText, start, lineStarts):
+def tokenizePythonToUnmatchedCloseCurly(source_text, start, line_starts):
-def tokenizeTemplate(templateText):
+def tokenizeTemplate(template_text):
-def splitGybLines(sourceLines):
+def splitGybLines(source_lines):
-def codeStartsWithDedentKeyword(sourceLines):
+def codeStartsWithDedentKeyword(source_lines):
-    def tokenGenerator(self, baseTokens):
+    def tokenGenerator(self, base_tokens):
-    def __init__(self, lineDirective='// ###line', **localBindings):
+    def __init__(self, line_directive='// ###line', **local_bindings):
-def executeTemplate(ast, lineDirective='', **localBindings):
+def executeTemplate(ast, line_directive='', **local_bindings):
-def bodyLines(bodyText):
+def bodyLines(body_text):
-  def __init__(self, name, source, processedSource, binary):
+  def __init__(self, name, source, processed_source, binary):
```
