### PR TITLE
IRGen: Fix calling convention for functions with multiple indirect re…

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -851,6 +851,10 @@ llvm::Type *SignatureExpansion::addIndirectResult() {
 
 /// Expand all of the direct and indirect result types.
 llvm::Type *SignatureExpansion::expandResult() {
+    // Disable the use of sret if we have multiple indirect results.
+    if (FnType->getNumIndirectResults() > 1)
+      CanUseSRet = false;
+
   // Expand the direct result.
   llvm::Type *resultType = expandDirectResult();
 

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -49,3 +49,11 @@ entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Hu
 // CHECK-LABEL: declare void @arguments_in_decl_huge_ret(%V14argument_attrs4Huge* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
 sil @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
 
+
+// rdar://problem/24727411 - Incorrect 'sret' attribute applied to function with multiple indirect
+// returns, causing problems when calling runtime functions
+sil @multiple_out_params : $@convention(thin) <T, U> () -> (@out T, @out U) {
+bb0(%0 : $*T, %1 : $*U):
+  %result = tuple ()
+  return %result : $()
+}

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -11,7 +11,7 @@
 // CHECK: %swift.tuple_element_type = type { [[TYPE]]*, i64 }
 
 func dup<T>(x: T) -> (T, T) { var x = x; return (x,x) }
-// CHECK:    define hidden void @_TF14generic_tuples3dup{{.*}}(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK:    define hidden void @_TF14generic_tuples3dup{{.*}}(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 // CHECK:    entry:
 //   Allocate a local variable for 'x'.
 // CHECK-NEXT: [[XBUF:%.*]] = alloca [[BUFFER:.*]], align 8
@@ -73,7 +73,7 @@ func callDupC(let c: C) { _ = dupC(c) }
 func lump<T>(x: T) -> (Int, T, T) { return (0,x,x) }
 // CHECK: define hidden { i64, i64 } @_TF14generic_tuples5lump2{{.*}}(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 func lump2<T>(x: T) -> (Int, Int, T) { return (0,0,x) }
-// CHECK: define hidden void @_TF14generic_tuples5lump3{{.*}}(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK: define hidden void @_TF14generic_tuples5lump3{{.*}}(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 func lump3<T>(x: T) -> (T, T, T) { return (x,x,x) }
 // CHECK: define hidden i64 @_TF14generic_tuples5lump4{{.*}}(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 func lump4<T>(x: T) -> (T, Int, T) { return (x,0,x) }


### PR DESCRIPTION
…turns

The recent change to destructure tuples in SIL function return types
introduced some runtime changes where it was assumed that a SIL
function type like

$@convention(thin) () -> (@out X, @out Y)

Would have the same calling convention as the following C function:

void foo(void *X, void *Y);

Unfortunately, this only worked on x86-64, because the first @out
parameter in a SIL function type was lowered with the LLVM
'sret' attribute, which on i386 and ARM64 is not the same as the
first parameter to a function.

On i386, this manifested as a crash in a variety of executable tests
with a misaligned stack; on ARM64, a similar crash would occur because
the return value was initialized through the wrong register.

Hack around this by simply disabling 'sret' if a SIL function type
has multiple indirect return values.

Fixes rdar://problem/24727411.
