### PR TITLE
Rewrite _copyToNativeArrayBuffer to use early return if separator count is zero

### DIFF
--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -134,18 +134,19 @@ public struct JoinSequence<
       result.reserveCapacity(numericCast(n))
     }
 
-    if separatorSize != 0 {
-      var gen = _base.generate()
-      if let first = gen.next() {
-        result.appendContentsOf(first)
-        while let next = gen.next() {
-          result.appendContentsOf(_separator)
-          result.appendContentsOf(next)
-        }
-      }
-    } else {
+    if separatorSize == 0 {
       for x in _base {
         result.appendContentsOf(x)
+      }
+      return result._buffer
+    }
+
+    var gen = _base.generate()
+    if let first = gen.next() {
+      result.appendContentsOf(first)
+      while let next = gen.next() {
+        result.appendContentsOf(_separator)
+        result.appendContentsOf(next)
       }
     }
 


### PR DESCRIPTION
Since the majority of the time this function is called, it is called with the intention of inserting a separator.
The case of the separator not existing is less common, therefore it might make intent clearer.

And, negative-else is hard to read. Like following code:

``` swift
if separatorSize != 0 {
  // case not 0
} else {
  // case 0
}
```

↓

``` swift
if separatorSize == 0 {
  // case 0
} else {
  // case not 0
}
```
