### PR TITLE
[gardening] Remove redundant assignments in tests: "var foo: Foo? = nil" → "var foo: Foo?"

### DIFF
--- a/test/1_stdlib/Builtins.swift
+++ b/test/1_stdlib/Builtins.swift
@@ -51,7 +51,7 @@ tests.test("_isUniquelyReferenced/OptionalNativeObject") {
   var b = a
   expectFalse(_getBool(Builtin.isUnique(&a)))
   expectFalse(_getBool(Builtin.isUnique(&b)))
-  var x: Builtin.NativeObject? = nil
+  var x: Builtin.NativeObject?
   expectFalse(_getBool(Builtin.isUnique(&x)))
 }
 

--- a/test/1_stdlib/ErrorType.swift
+++ b/test/1_stdlib/ErrorType.swift
@@ -137,7 +137,7 @@ enum LifetimeError : ErrorType {
 ErrorTypeTests.test("existential in lvalue") {
   expectEqual(0, LifetimeTracked.instances)
   do {
-    var e: ErrorType? = nil
+    var e: ErrorType?
     do {
       throw LifetimeError.MistakeOfALifetime(LifetimeTracked(0),
                                              yearsIncarcerated: 25)

--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -41,7 +41,7 @@ extension ImplicitlyUnwrappedOptional where Wrapped : TestProtocol1 {
 }
 
 OptionalTests.test("nil comparison") {
-  var x: Int? = nil
+  var x: Int?
   expectFalse(x != nil)
 
   switch x {

--- a/test/1_stdlib/PrintStruct.swift
+++ b/test/1_stdlib/PrintStruct.swift
@@ -39,7 +39,7 @@ PrintTests.test("Printable") {
 
 PrintTests.test("custom string convertible structs") {
   struct Wrapper : CustomStringConvertible {
-    var x: CustomStringConvertible? = nil
+    var x: CustomStringConvertible?
     
     var description: String {
       return "Wrapper(\(x.debugDescription))"

--- a/test/1_stdlib/RuntimeObjC.swift
+++ b/test/1_stdlib/RuntimeObjC.swift
@@ -760,7 +760,7 @@ Reflection.test("CGRect") {
 
 Reflection.test("Unmanaged/nil") {
   var output = ""
-  var optionalURL: Unmanaged<CFURL>? = nil
+  var optionalURL: Unmanaged<CFURL>?
   dump(optionalURL, &output)
 
   let expected = "- nil\n"

--- a/test/ClangModules/CoreServices_test.swift
+++ b/test/ClangModules/CoreServices_test.swift
@@ -12,7 +12,7 @@ func test(url: CFURL, ident: CSIdentity) {
 
   _ = kCollectionNoAttributes // expected-error{{use of unresolved identifier 'kCollectionNoAttributes'}}
 
-  var name: Unmanaged<CFString>? = nil
+  var name: Unmanaged<CFString>?
   _ = LSCopyDisplayNameForURL(url, &name) as OSStatus // okay
 
   let unicharArray: [UniChar] = [ 0x61, 0x62, 0x63, 0x2E, 0x64 ]

--- a/test/ClangModules/Security_test.swift
+++ b/test/ClangModules/Security_test.swift
@@ -12,7 +12,7 @@ func testIntegration() {
   // Based on code in <rdar://problem/17162475>.
   let query = [kSecClass as NSString: kSecClassGenericPassword] as NSDictionary as CFDictionary
 
-  var dataTypeRef: Unmanaged<AnyObject>? = nil
+  var dataTypeRef: Unmanaged<AnyObject>?
   let status = SecItemCopyMatching(query, &dataTypeRef)
   
   if status == errSecSuccess {

--- a/test/ClangModules/optional.swift
+++ b/test/ClangModules/optional.swift
@@ -56,6 +56,6 @@ class A {
 
 // rdar://15144951
 class TestWeak : NSObject {
-  weak var b : WeakObject? = nil
+  weak var b : WeakObject?
 }
 class WeakObject : NSObject {}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -420,7 +420,7 @@ func ident<T>(t: T) -> T {}
 var c = ident({1.DOESNT_EXIST}) // error: expected-error {{value of type 'Int' has no member 'DOESNT_EXIST'}}
 
 // <rdar://problem/20712541> QoI: Int/UInt mismatch produces useless error inside a block
-var afterMessageCount : Int? = nil
+var afterMessageCount : Int?
 
 func uintFunc() -> UInt {}
 func takeVoidVoidFn(a : () -> ()) {}

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -111,7 +111,7 @@ class T {
 class C {
   var a: Int = 1
 }
-var co: C? = nil
+var co: C?
 var ciuo: C! = nil 
 
 if co {} // expected-error{{optional type 'C?' cannot be used as a boolean; test for '!= nil' instead}}{{4-4=(}} {{6-6= != nil)}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -106,7 +106,7 @@ func test10(i: Int, io: Int?) {
   var _: Double = result2
 }
 
-var z: Int? = nil
+var z: Int?
 z = z ?? 3
 
 var fo: Float? = 3.14159

--- a/test/Generics/associated_self_constraints.swift
+++ b/test/Generics/associated_self_constraints.swift
@@ -19,9 +19,9 @@ class Subject<T>: Observer, Observable {
     
     // Observer implementation
     
-    var onNextFunc: ((T) -> Void)? = nil
-    var onCompletedFunc: (() -> Void)? = nil
-    var onErrorFunc: ((String) -> Void)? = nil
+    var onNextFunc: ((T) -> Void)?
+    var onCompletedFunc: (() -> Void)?
+    var onErrorFunc: ((String) -> Void)?
     
     func onNext(item: T) -> Void {
         onNextFunc?(item)

--- a/test/IRGen/objc_property_attrs.swift
+++ b/test/IRGen/objc_property_attrs.swift
@@ -37,7 +37,7 @@ class Foo: NSManagedObject {
   var f: NSData = NSData()
   // nonatomic, weak, assign, ivar g
   // CHECK: private unnamed_addr constant {{.*}} c"T@\22NSData\22,N,W,Vg\00"
-  weak var g: NSData? = nil
+  weak var g: NSData?
   // nonatomic, copy, ivar h
   // CHECK: private unnamed_addr constant {{.*}} c"T@\22NSData\22,N,C,Vh\00"
   @NSCopying var h: NSData! = nil

--- a/test/Interpreter/SDK/objc_nil.swift
+++ b/test/Interpreter/SDK/objc_nil.swift
@@ -5,8 +5,8 @@
 
 import Foundation
 
-var str : NSString? = nil
-var url : NSURL? = nil
+var str : NSString?
+var url : NSURL?
 
 print("\(str == nil) \(nil == url) \(str == url)")
 // CHECK: true true true

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -176,7 +176,7 @@ if true {
   print(sizeof(Optional<Builtin.BridgeObject>.self)
             == sizeof(Builtin.BridgeObject.self))
 
-  var bo: Builtin.BridgeObject? = nil
+  var bo: Builtin.BridgeObject?
 
   // CHECK-NEXT: None
   hitOptionalSpecifically(bo)

--- a/test/Interpreter/enum.swift
+++ b/test/Interpreter/enum.swift
@@ -467,13 +467,13 @@ print((NoPayload.x as NoPayload?) == NoPayload.y)
 class Foo {}
 
 struct Oof {
-  weak var foo: Foo? = nil
+  weak var foo: Foo?
 }
 
 protocol Boo {}
 
 struct Goof {
-  var boo: Boo? = nil
+  var boo: Boo?
 }
 
 let oofs = [Oof()]

--- a/test/Interpreter/generic_objc_subclass.swift
+++ b/test/Interpreter/generic_objc_subclass.swift
@@ -25,7 +25,7 @@ protocol PP {
 
 class A<T> : HasHiddenIvars, P {
   var first: Int = 16
-  var second: T? = nil
+  var second: T?
   var third: Int = 61
 
   override var description: String {

--- a/test/Interpreter/optional.swift
+++ b/test/Interpreter/optional.swift
@@ -90,7 +90,7 @@ if nil == x_foo { print("x_foo is nil") }
 if nil != x_foo { print("x_foo is not nil") } else { print("x_foo is nil") }
 // CHECK: x_foo is nil
 
-var y_foo: Foo? = nil
+var y_foo: Foo?
 if y_foo == nil { print("y_foo is nil") }
 // CHECK: y_foo is nil
 if y_foo != nil { print("y_foo is not nil") } else { print("y_foo is nil") }
@@ -100,9 +100,9 @@ if nil == y_foo { print("y_foo is nil") }
 if nil != y_foo { print("y_foo is not nil") } else { print("y_foo is nil") }
 // CHECK: y_foo is nil
 
-var x : Int? = nil
+var x : Int?
 var y : Int?? = x
-var z : Int?? = nil
+var z : Int??
 
 switch y {
   case nil:  print("y is nil")
@@ -120,7 +120,7 @@ switch z {
 
 // Validate nil equality comparisons with non-equatable optional types
 class C {}
-var c: C? = nil
+var c: C?
 
 print(c == nil)
 // CHECK: true

--- a/test/Interpreter/optional_lvalues.swift
+++ b/test/Interpreter/optional_lvalues.swift
@@ -17,6 +17,6 @@ print(sequences) // CHECK-NEXT: ["fibonacci": [1, 1, 2, 3, 5, 8]]
 func printAndReturn(x: Int) -> Int { print(x); return x }
 
 print("optional binding") // CHECK-NEXT: optional binding
-var y: Int? = nil
+var y: Int?
 y? += printAndReturn(4)
 print("done with binding test") // CHECK-NEXT: done with binding test

--- a/test/Interpreter/pinning.swift
+++ b/test/Interpreter/pinning.swift
@@ -9,7 +9,7 @@ import SwiftShims
 typealias _HeapObject = SwiftShims.HeapObject
 
 class C {
-  var value: AnyObject? = nil
+  var value: AnyObject?
   deinit { print("deallocated") }
 }
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -5,7 +5,7 @@
 import Foundation
 import CoreGraphics
 
-var roomName : String? = nil
+var roomName : String?
 
 if let realRoomName = roomName as! NSString { // expected-error {{initializer for conditional binding must have Optional type, not 'NSString'}} expected-warning {{cast from 'String?' to unrelated type 'NSString' always fails}}
 			

--- a/test/Parse/optional_chain_lvalues.swift
+++ b/test/Parse/optional_chain_lvalues.swift
@@ -10,7 +10,7 @@ struct S {
 }
 
 struct T {
-  var mutS: S? = nil
+  var mutS: S?
   let immS: S? = nil  // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}}
 
   mutating func mutateT() {}

--- a/test/Parse/optional_lvalues.swift
+++ b/test/Parse/optional_lvalues.swift
@@ -8,7 +8,7 @@ struct S {
 }
 
 struct T {
-  var mutS: S? = nil
+  var mutS: S?
   let immS: S? = nil // expected-note 10 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}}
 
   init() {}

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -243,7 +243,7 @@ typealias AliasForNSRect = NSRect
   func cf(x: CFTree, str: CFString, str2: CFMutableString, obj: CFAliasForType) -> CFTypeRef? { return nil }
 
   func appKitInImplementation() {
-    let _ : NSResponder? = nil
+    let _ : NSResponder?
   }
 
   func returnsURL() -> NSURL? { return nil }
@@ -314,18 +314,18 @@ class MyObject : NSObject {}
   // CHECK-NEXT: init
   // CHECK-NEXT: @end
   @objc class Inner2 {
-    var ref: NestedMembers? = nil
+    var ref: NestedMembers?
   }
 
-  var ref2: Inner2? = nil
-  var ref3: Inner3? = nil
+  var ref2: Inner2?
+  var ref3: Inner3?
 
   // CHECK-LABEL: @interface Inner3
   // CHECK-NEXT: @property (nonatomic, strong) NestedMembers * _Nullable ref;
   // CHECK-NEXT: init
   // CHECK-NEXT: @end
   @objc class Inner3 {
-    var ref: NestedMembers? = nil
+    var ref: NestedMembers?
   }
 }
 

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -422,7 +422,7 @@ final class _ForkJoinWorkerThread {
   }
 
   internal func startAsync() {
-    var queue: dispatch_queue_t? = nil
+    var queue: dispatch_queue_t?
     if #available(OSX 10.10, iOS 8.0, *) {
       queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)
     } else {
@@ -535,7 +535,7 @@ internal protocol _FutureType {
 }
 
 public class ForkJoinTaskBase {
-  final internal var _pool: ForkJoinPool? = nil
+  final internal var _pool: ForkJoinPool?
 
   // FIXME(performance): there is no need to create heavy-weight
   // synchronization primitives every time.  We could start with a lightweight
@@ -578,7 +578,7 @@ public class ForkJoinTaskBase {
 
 final public class ForkJoinTask<Result> : ForkJoinTaskBase, _FutureType {
   internal let _task: () -> Result
-  internal var _result: Result? = nil
+  internal var _result: Result?
 
   public init(_task: () -> Result) {
     self._task = _task

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -228,7 +228,7 @@ class HasStoredDidSet {
 // CHECK: }
 
 class HasWeak {
-  weak var weakvar: HasWeak? = nil
+  weak var weakvar: HasWeak?
 }
 // CHECK-LABEL: sil hidden [transparent] @_TFC17materializeForSet7HasWeakm7weakvarXwGSqS0__ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasWeak) -> (Builtin.RawPointer, Optional<@convention(thin) (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer, inout HasWeak, @thick HasWeak.Type) -> ()>) {
 // CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasWeak):

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -108,8 +108,8 @@ class TestNSCopying {
   @NSCopying var optionalProperty : NSString?
   @NSCopying var uncheckedOptionalProperty : NSString!
 
-  @NSCopying weak var weakProperty : NSString? = nil
-//  @NSCopying unowned var unownedProperty : NSString? = nil
+  @NSCopying weak var weakProperty : NSString?
+//  @NSCopying unowned var unownedProperty : NSString?
 
   init(s : NSString) { property = s }
 }

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -736,7 +736,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
   lazy var unavailablePropertyOfUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
   
   @available(OSX, introduced=10.51)
-  lazy var unavailablePropertyOfOptionalUnavailableType: ClassAvailableOn10_51? = nil
+  lazy var unavailablePropertyOfOptionalUnavailableType: ClassAvailableOn10_51?
 
   @available(OSX, introduced=10.51)
   lazy var unavailablePropertyOfUnavailableTypeWithInitializer: ClassAvailableOn10_51 = ClassAvailableOn10_51()
@@ -1217,7 +1217,7 @@ functionAvailableOn10_51()
     // expected-error@-1 {{'functionAvailableOn10_51()' is only available on OS X 10.51 or newer}}
     // expected-note@-2 {{add 'if #available' version check}} {{1-27=if #available(OSX 10.51, *) {\n    functionAvailableOn10_51()\n} else {\n    // Fallback on earlier versions\n}}}
 
-let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil
+let declForFixitAtTopLevel: ClassAvailableOn10_51?
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add 'if #available' version check}} {{1-57=if #available(OSX 10.51, *) {\n    let declForFixitAtTopLevel: ClassAvailableOn10_51? = nil\n} else {\n    // Fallback on earlier versions\n}}}
 
@@ -1291,31 +1291,31 @@ class ClassForFixit {
     }
   }
 
-  var fixitForReferenceInPropertyType: ClassAvailableOn10_51? = nil
+  var fixitForReferenceInPropertyType: ClassAvailableOn10_51?
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 
-  lazy var fixitForReferenceInLazyPropertyType: ClassAvailableOn10_51? = nil
+  lazy var fixitForReferenceInLazyPropertyType: ClassAvailableOn10_51?
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
       // expected-note@-3 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 
-  private lazy var fixitForReferenceInPrivateLazyPropertyType: ClassAvailableOn10_51? = nil
+  private lazy var fixitForReferenceInPrivateLazyPropertyType: ClassAvailableOn10_51?
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
       // expected-note@-3 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 
-  lazy private var fixitForReferenceInLazyPrivatePropertyType: ClassAvailableOn10_51? = nil
+  lazy private var fixitForReferenceInLazyPrivatePropertyType: ClassAvailableOn10_51?
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing var}} {{3-3=@available(OSX 10.51, *)\n  }}
       // expected-note@-3 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 
-  static var fixitForReferenceInStaticPropertyType: ClassAvailableOn10_51? = nil
+  static var fixitForReferenceInStaticPropertyType: ClassAvailableOn10_51?
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing class var}} {{3-3=@available(OSX 10.51, *)\n  }}
       // expected-note@-3 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 
-  var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn10_51? = nil, other: Int = 7
+  var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn10_51?, other: Int = 7
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-2 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -123,7 +123,7 @@ func annotatedHasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 {
 var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 
 @available(OSX, introduced=10.8, deprecated=10.51)
-var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51? = nil
+var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51?
 
 
 enum EnumWithDeprecatedCasePayload {

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -524,7 +524,7 @@ struct TestBangMutability {
 
 // <rdar://problem/21176945> mutation through ? not considered a mutation
 func testBindOptional() {
-  var a : TestStruct2? = nil  // Mutated through optional chaining.
+  var a : TestStruct2?  // Mutated through optional chaining.
   a?.mutatingfunc()
 }
 

--- a/test/expr/cast/nil_value_to_optional.swift
+++ b/test/expr/cast/nil_value_to_optional.swift
@@ -21,7 +21,7 @@ func test(c: C) {
 class D {}
 
 var d = D()
-var dopt: D? = nil
+var dopt: D?
 var diuopt: D! = nil
 
 _ = d == nil // expected-error{{value of type 'D' can never be nil, comparison isn't allowed}}

--- a/validation-test/stdlib/AtomicInt.swift
+++ b/validation-test/stdlib/AtomicInt.swift
@@ -705,7 +705,7 @@ struct AtomicInitializeARCRefRaceTest : RaceTestWithPerTrialDataType {
   }
 
   class RaceData {
-    var _atomicReference: AnyObject? = nil
+    var _atomicReference: AnyObject?
 
     var atomicReferencePtr: UnsafeMutablePointer<AnyObject?> {
       return UnsafeMutablePointer(_getUnsafePointerToStoredProperties(self))

--- a/validation-test/stdlib/StdlibUnittest.swift
+++ b/validation-test/stdlib/StdlibUnittest.swift
@@ -489,7 +489,7 @@ AssertionsTestSuite.test("UnexpectedCrash/NullPointerDereference") {
 // CHECK: [     FAIL ] Assertions.UnexpectedCrash/NullPointerDereference
 
 var TestSuiteLifetimeTracked = TestSuite("TestSuiteLifetimeTracked")
-var leakMe: LifetimeTracked? = nil
+var leakMe: LifetimeTracked?
 TestSuiteLifetimeTracked.test("failsIfLifetimeTrackedAreLeaked") {
   leakMe = LifetimeTracked(0)
 }


### PR DESCRIPTION
This is a follow-up to #1367. This time covering `test/` and `validation-test/`.

@gribozavr Please let me know if you disagree with any of those changes and I'll update accordingly :-)
