### PR TITLE
Unify usage of shorthand

### DIFF
--- a/stdlib/public/core/Index.swift
+++ b/stdlib/public/core/Index.swift
@@ -219,7 +219,7 @@ extension ForwardIndexType {
     var i : Distance = 0
     while i != n {
       p._successorInPlace()
-      i = i + 1
+      i += 1
     }
     return p
   }
@@ -235,7 +235,7 @@ extension ForwardIndexType {
     while i != n {
       if p == limit { break }
       p._successorInPlace()
-      i = i + 1
+      i += 1
     }
     return p
   }


### PR DESCRIPTION
Use plus-equals shorthand instead of longhand throughout Index.swift
