### PR TITLE
[Parse/Sema/SILGen] Variables in 'case' labels with multiple patterns.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -644,6 +644,8 @@ WARNING(let_on_param_is_redundant, none,
 ERROR(var_pattern_in_var,none,
       "'%select{var|let}0' cannot appear nested inside another 'var' or "
       "'let' pattern", (unsigned))
+ERROR(extra_var_in_multiple_pattern_list,none,
+      "%0 must be bound in every pattern", (Identifier))
 ERROR(let_pattern_in_immutable_context,none,
       "'let' pattern cannot appear nested in an already immutable context", ())
 ERROR(inout_must_have_type,none,
@@ -887,9 +889,6 @@ ERROR(expected_case_colon,PointsToFirstBadToken,
       "expected ':' after '%0'", (StringRef))
 ERROR(default_with_where,none,
       "'default' cannot be used with a 'where' guard expression",
-      ())
-ERROR(var_binding_with_multiple_case_patterns,none,
-      "'case' labels with multiple patterns cannot declare variables",
       ())
 ERROR(case_stmt_without_body,none,
       "%select{'case'|'default'}0 label in a 'switch' should have at least one "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2154,6 +2154,9 @@ ERROR(fallthrough_into_case_with_var_binding,none,
 ERROR(unnecessary_cast_over_optionset,none,
       "unnecessary cast over raw value of %0", (Type))
 
+ERROR(type_mismatch_multiple_pattern_list,none,
+      "pattern variable bound to type %0, expected type %1", (Type, Type))
+
 //------------------------------------------------------------------------------
 // Type Check Patterns
 //------------------------------------------------------------------------------

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -858,7 +858,8 @@ namespace {
 static void parseGuardedPattern(Parser &P, GuardedPattern &result,
                                 ParserStatus &status,
                                 SmallVectorImpl<VarDecl *> &boundDecls,
-                                GuardedPatternContext parsingContext) {
+                                GuardedPatternContext parsingContext,
+                                bool isFirstPattern) {
   ParserResult<Pattern> patternResult;
   auto setErrorResult = [&] () {
     patternResult = makeParserErrorResult(new (P.Context)
@@ -945,14 +946,64 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
   status |= patternResult;
   result.ThePattern = patternResult.get();
 
-  // Add variable bindings from the pattern to the case scope.  We have
-  // to do this with a full AST walk, because the freshly parsed pattern
-  // represents tuples and var patterns as tupleexprs and
-  // unresolved_pattern_expr nodes, instead of as proper pattern nodes.
-  patternResult.get()->forEachVariable([&](VarDecl *VD) {
-    if (VD->hasName()) P.addToScope(VD);
-    boundDecls.push_back(VD);
-  });
+  if (isFirstPattern) {
+    // Add variable bindings from the pattern to the case scope.  We have
+    // to do this with a full AST walk, because the freshly parsed pattern
+    // represents tuples and var patterns as tupleexprs and
+    // unresolved_pattern_expr nodes, instead of as proper pattern nodes.
+    patternResult.get()->forEachVariable([&](VarDecl *VD) {
+      if (VD->hasName()) P.addToScope(VD);
+      boundDecls.push_back(VD);
+    });
+  } else {
+    // If boundDecls already contains variables, then we must match the
+    // same number and same names in this pattern as were declared in a
+    // previous pattern (and later we will make sure they have the same
+    // types).
+    SmallVector<VarDecl*, 4> repeatedDecls;
+    patternResult.get()->forEachVariable([&](VarDecl *VD) {
+      if (!VD->hasName())
+        return;
+      
+      for (auto repeat : repeatedDecls)
+        if (repeat->getName() == VD->getName())
+          P.addToScope(VD); // will diagnose a duplicate declaration
+
+      bool found = false;
+      for (auto previous : boundDecls) {
+        if (previous->hasName() && previous->getName() == VD->getName()) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        // Diagnose a declaration that doesn't match a previous pattern.
+        P.diagnose(VD->getLoc(), diag::extra_var_in_multiple_pattern_list, VD->getName());
+        status.setIsParseError();
+      }
+      repeatedDecls.push_back(VD);
+    });
+    
+    for (auto previous : boundDecls) {
+      bool found = false;
+      for (auto repeat : repeatedDecls) {
+        if (previous->hasName() && previous->getName() == repeat->getName()) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        // Diagnose a previous declaration that is missing in this pattern.
+        P.diagnose(previous->getLoc(), diag::extra_var_in_multiple_pattern_list, previous->getName());
+        status.setIsParseError();
+      }
+    }
+    
+    for (auto VD : repeatedDecls) {
+      VD->setHasNonPatternBindingInit();
+      VD->setImplicit();
+    }
+  }
   
   // Now that we have them, mark them as being initialized without a PBD.
   for (auto VD : boundDecls)
@@ -2004,7 +2055,7 @@ ParserResult<CatchStmt> Parser::parseStmtCatch() {
   ParserStatus status;
   GuardedPattern pattern;
   parseGuardedPattern(*this, pattern, status, boundDecls,
-                      GuardedPatternContext::Catch);
+                      GuardedPatternContext::Catch, /* isFirst */ true);
   if (status.hasCodeCompletion()) {
     return makeParserCodeCompletionResult<CatchStmt>();
   }
@@ -2509,17 +2560,19 @@ static ParserStatus parseStmtCase(Parser &P, SourceLoc &CaseLoc,
                                   SmallVectorImpl<VarDecl *> &BoundDecls,
                                   SourceLoc &ColonLoc) {
   ParserStatus Status;
-
+  bool isFirst = true;
+  
   CaseLoc = P.consumeToken(tok::kw_case);
 
   do {
     GuardedPattern PatternResult;
     parseGuardedPattern(P, PatternResult, Status, BoundDecls,
-                        GuardedPatternContext::Case);
+                        GuardedPatternContext::Case, isFirst);
     LabelItems.push_back(CaseLabelItem(/*IsDefault=*/false,
                                        PatternResult.ThePattern,
                                        PatternResult.WhereLoc,
                                        PatternResult.Guard));
+    isFirst = false;
   } while (P.consumeIf(tok::comma));
 
   ColonLoc = P.Tok.getLoc();
@@ -2585,11 +2638,6 @@ ParserResult<CaseStmt> Parser::parseStmtCase() {
   }
 
   assert(!CaseLabelItems.empty() && "did not parse any labels?!");
-
-  // Case blocks with multiple patterns cannot bind variables.
-  if (!BoundDecls.empty() && CaseLabelItems.size() > 1)
-    diagnose(BoundDecls[0]->getLoc(),
-             diag::var_binding_with_multiple_case_patterns);
 
   SmallVector<ASTNode, 8> BodyItems;
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -938,6 +938,8 @@ public:
 
   void emitConditionalPBD(PatternBindingDecl *PBD, SILBasicBlock *FailBB);
 
+  void usingImplicitVariablesForPattern(Pattern *pattern, CaseStmt *stmt,
+                                        const llvm::function_ref<void(void)> &f);
   void emitSwitchStmt(SwitchStmt *S);
   void emitSwitchFallthrough(FallthroughStmt *S);
 

--- a/test/IDE/complete_pattern.swift
+++ b/test/IDE/complete_pattern.swift
@@ -20,6 +20,11 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AFTER_PATTERN_IS | FileCheck %s -check-prefix=AFTER_PATTERN_IS
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_1 | FileCheck %s -check-prefix=MULTI_PATTERN_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_2 | FileCheck %s -check-prefix=MULTI_PATTERN_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_3 | FileCheck %s -check-prefix=MULTI_PATTERN_3
+
+
 //===--- Helper types that are used in this test
 
 struct FooStruct {
@@ -142,3 +147,39 @@ func test<T>(x: T) {
     #^AFTER_PATTERN_IS^#
   }
 }
+
+func test_multiple_patterns1(x: Int) {
+    switch (x, x) {
+    case (0, let a), #^MULTI_PATTERN_1^#
+    }
+}
+
+// MULTI_PATTERN_1: Begin completions
+// FIXME: ideally we wouldn't offer 'a' here, without 'let' first:
+// xxxMULTI_PATTERN_1-NOT: Decl[LocalVar]/Local: a[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_1: End completions
+
+func test_multiple_patterns2(x: Int) {
+    switch (x, x) {
+    case let (0, let a), (let a, 0):
+        #^MULTI_PATTERN_2^#
+    }
+}
+
+// MULTI_PATTERN_2: Begin completions
+// MULTI_PATTERN_2-DAG: Decl[LocalVar]/Local: a[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_2-DAG: Decl[LocalVar]/Local: x[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_2: End completions
+
+func test_multiple_patterns3(x: Int) {
+    switch (x, x) {
+    case let (0, let a), (let b, 0):
+        #^MULTI_PATTERN_3^#
+    }
+}
+
+// MULTI_PATTERN_3: Begin completions
+// MULTI_PATTERN_3-DAG: Decl[LocalVar]/Local: x[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_3: End completions
+
+

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -197,13 +197,13 @@ default:
 var t = (1, 2)
 
 switch t {
-case (var a, 2), (1, _): // expected-error {{'case' labels with multiple patterns cannot declare variables}}
+case (var a, 2), (1, _): // expected-error {{'a' must be bound in every pattern}}
   ()
 
-case (_, 2), (var a, _): // expected-error {{'case' labels with multiple patterns cannot declare variables}}
+case (_, 2), (var a, _): // expected-error {{'a' must be bound in every pattern}}
   ()
 
-case (var a, 2), (1, var b): // expected-error {{'case' labels with multiple patterns cannot declare variables}}
+case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}}
   ()
 
 case (var a, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{17-17= break}}
@@ -221,16 +221,30 @@ case (1, var b):
 case (1, let b): // let bindings
   ()
 
-case (_, 2), (let a, _): // expected-error {{'case' labels with multiple patterns cannot declare variables}}
+case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}}
   ()
 
 // OK
 case (_, 2), (1, _):
   ()
+  
+case (_, var a), (_, var a):
+  ()
+  
+case (var a, var b), (var b, var a):
+  ()
 
 case (_, 2): // expected-error {{'case' label in a 'switch' should have at least one executable statement}} {{13-13= break}}
 case (1, _):
   ()
+}
+
+func patternVarUsedInAnotherPattern(x: Int) {
+  switch x {
+  case let a, // expected-error {{'a' must be bound in every pattern}}
+       a:
+    break
+  }
 }
 
 // Fallthroughs can't transfer control into a case label with bindings.

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -461,3 +461,177 @@ func test_mixed_let_var() {
     d()
   }
 }
+
+// CHECK-LABEL: sil hidden @_TF10switch_var23test_multiple_patterns1FT_T_ : $@convention(thin) () -> () {
+func test_multiple_patterns1() {
+  // CHECK:   function_ref @_TF10switch_var6foobarFT_TSiSi_
+  switch foobar() {
+  // CHECK-NOT: br
+  case (0, let x), (let x, 0):
+    // CHECK:   cond_br {{%.*}}, [[FIRST_MATCH_CASE:bb[0-9]+]], [[FIRST_FAIL:bb[0-9]+]]
+    // CHECK:   [[FIRST_MATCH_CASE]]:
+    // CHECK:     debug_value [[FIRST_X:%.*]] :
+    // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[FIRST_X]] : $Int)
+    // CHECK:   [[FIRST_FAIL]]:
+    // CHECK:     cond_br {{%.*}}, [[SECOND_MATCH_CASE:bb[0-9]+]], [[SECOND_FAIL:bb[0-9]+]]
+    // CHECK:   [[SECOND_MATCH_CASE]]:
+    // CHECK:     debug_value [[SECOND_X:%.*]] :
+    // CHECK:     br [[CASE_BODY]]([[SECOND_X]] : $Int)
+    // CHECK:   [[CASE_BODY]]([[BODY_VAR:%.*]] : $Int):
+    // CHECK:     [[A:%.*]] = function_ref @_TF10switch_var1aFT1xSi_T_
+    // CHECK:     apply [[A]]([[BODY_VAR]])
+    a(x: x)
+  default:
+    // CHECK:   [[SECOND_FAIL]]:
+    // CHECK:     function_ref @_TF10switch_var1bFT_T_
+    b()
+  }
+}
+
+// CHECK-LABEL: sil hidden @_TF10switch_var23test_multiple_patterns2FT_T_ : $@convention(thin) () -> () {
+func test_multiple_patterns2() {
+  let t1 = 2
+  let t2 = 4
+  // CHECK:   debug_value [[T1:%.*]] :
+  // CHECK:   debug_value [[T2:%.*]] :
+  switch (0,0) {
+    // CHECK-NOT: br
+  case (_, let x) where x > t1, (let x, _) where x > t2:
+    // CHECK:   [[FIRST_X:%.*]] = tuple_extract {{%.*}} : $(Int, Int), 1
+    // CHECK:   debug_value [[FIRST_X]] :
+    // CHECK:   apply {{%.*}}([[FIRST_X]], [[T1]])
+    // CHECK:   cond_br {{%.*}}, [[FIRST_MATCH_CASE:bb[0-9]+]], [[FIRST_FAIL:bb[0-9]+]]
+    // CHECK:   [[FIRST_MATCH_CASE]]:
+    // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[FIRST_X]] : $Int)
+    // CHECK:   [[FIRST_FAIL]]:
+    // CHECK:     debug_value [[SECOND_X:%.*]] :
+    // CHECK:     apply {{%.*}}([[SECOND_X]], [[T2]])
+    // CHECK:     cond_br {{%.*}}, [[SECOND_MATCH_CASE:bb[0-9]+]], [[SECOND_FAIL:bb[0-9]+]]
+    // CHECK:   [[SECOND_MATCH_CASE]]:
+    // CHECK:     br [[CASE_BODY]]([[SECOND_X]] : $Int)
+    // CHECK:   [[CASE_BODY]]([[BODY_VAR:%.*]] : $Int):
+    // CHECK:     [[A:%.*]] = function_ref @_TF10switch_var1aFT1xSi_T_
+    // CHECK:     apply [[A]]([[BODY_VAR]])
+    a(x: x)
+  default:
+    // CHECK:   [[SECOND_FAIL]]:
+    // CHECK:     function_ref @_TF10switch_var1bFT_T_
+    b()
+  }
+}
+
+enum Foo {
+  case A(Int, Double)
+  case B(Double, Int)
+  case C(Int, Int, Double)
+}
+
+// CHECK-LABEL: sil hidden @_TF10switch_var23test_multiple_patterns3FT_T_ : $@convention(thin) () -> () {
+func test_multiple_patterns3() {
+  let f = Foo.C(0, 1, 2.0)
+  switch f {
+    // CHECK:   switch_enum {{%.*}} : $Foo, case #Foo.A!enumelt.1: [[A:bb[0-9]+]], case #Foo.B!enumelt.1: [[B:bb[0-9]+]], case #Foo.C!enumelt.1: [[C:bb[0-9]+]]
+  case .A(let x, let n), .B(let n, let x), .C(_, let x, let n):
+    // CHECK:   [[A]]({{%.*}} : $(Int, Double)):
+    // CHECK:     [[A_X:%.*]] = tuple_extract
+    // CHECK:     [[A_N:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[A_X]] : $Int, [[A_N]] : $Double)
+    
+    // CHECK:   [[B]]({{%.*}} : $(Double, Int)):
+    // CHECK:     [[B_N:%.*]] = tuple_extract
+    // CHECK:     [[B_X:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY]]([[B_X]] : $Int, [[B_N]] : $Double)
+
+    // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
+    // CHECK:     [[C__:%.*]] = tuple_extract
+    // CHECK:     [[C_X:%.*]] = tuple_extract
+    // CHECK:     [[C_N:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY]]([[C_X]] : $Int, [[C_N]] : $Double)
+
+    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int, [[BODY_N:%.*]] : $Double):
+    // CHECK:     [[FUNC_A:%.*]] = function_ref @_TF10switch_var1aFT1xSi_T_
+    // CHECK:     apply [[FUNC_A]]([[BODY_X]])
+    a(x: x)
+  }
+}
+
+enum Bar {
+  case Y(Foo, Int)
+  case Z(Int, Foo)
+}
+
+// CHECK-LABEL: sil hidden @_TF10switch_var23test_multiple_patterns4FT_T_ : $@convention(thin) () -> () {
+func test_multiple_patterns4() {
+  let b = Bar.Y(.C(0, 1, 2.0), 3)
+  switch b {
+    // CHECK:   switch_enum {{%.*}} : $Bar, case #Bar.Y!enumelt.1: [[Y:bb[0-9]+]], case #Bar.Z!enumelt.1: [[Z:bb[0-9]+]]
+  case .Y(.A(let x, _), _), .Y(.B(_, let x), _), .Y(.C, let x), .Z(let x, _):
+    // CHECK:   [[Y]]({{%.*}} : $(Foo, Int)):
+    // CHECK:     [[Y_F:%.*]] = tuple_extract
+    // CHECK:     [[Y_X:%.*]] = tuple_extract
+    // CHECK:     switch_enum [[Y_F]] : $Foo, case #Foo.A!enumelt.1: [[A:bb[0-9]+]], case #Foo.B!enumelt.1: [[B:bb[0-9]+]], case #Foo.C!enumelt.1: [[C:bb[0-9]+]]
+    
+    // CHECK:   [[A]]({{%.*}} : $(Int, Double)):
+    // CHECK:     [[A_X:%.*]] = tuple_extract
+    // CHECK:     [[A_N:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[A_X]] : $Int)
+    
+    // CHECK:   [[B]]({{%.*}} : $(Double, Int)):
+    // CHECK:     [[B_N:%.*]] = tuple_extract
+    // CHECK:     [[B_X:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY]]([[B_X]] : $Int)
+    
+    // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
+    // CHECK:     br [[CASE_BODY]]([[Y_X]] : $Int)
+
+    // CHECK:   [[Z]]({{%.*}} : $(Int, Foo)):
+    // CHECK:     [[Z_X:%.*]] = tuple_extract
+    // CHECK:     [[Z_F:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY]]([[Z_X]] : $Int)
+
+    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int):
+    // CHECK:     [[FUNC_A:%.*]] = function_ref @_TF10switch_var1aFT1xSi_T_
+    // CHECK:     apply [[FUNC_A]]([[BODY_X]])
+    a(x: x)
+  }
+}
+
+func aaa(inout x x: Int) {}
+
+// CHECK-LABEL: sil hidden @_TF10switch_var23test_multiple_patterns5FT_T_ : $@convention(thin) () -> () {
+func test_multiple_patterns5() {
+  let b = Bar.Y(.C(0, 1, 2.0), 3)
+  switch b {
+    // CHECK:   switch_enum {{%.*}} : $Bar, case #Bar.Y!enumelt.1: [[Y:bb[0-9]+]], case #Bar.Z!enumelt.1: [[Z:bb[0-9]+]]
+  case .Y(.A(var x, _), _), .Y(.B(_, var x), _), .Y(.C, var x), .Z(var x, _):
+    // CHECK:   [[Y]]({{%.*}} : $(Foo, Int)):
+    // CHECK:     [[Y_F:%.*]] = tuple_extract
+    // CHECK:     [[Y_X:%.*]] = tuple_extract
+    // CHECK:     switch_enum [[Y_F]] : $Foo, case #Foo.A!enumelt.1: [[A:bb[0-9]+]], case #Foo.B!enumelt.1: [[B:bb[0-9]+]], case #Foo.C!enumelt.1: [[C:bb[0-9]+]]
+    
+    // CHECK:   [[A]]({{%.*}} : $(Int, Double)):
+    // CHECK:     [[A_X:%.*]] = tuple_extract
+    // CHECK:     [[A_N:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[A_X]] : $Int)
+    
+    // CHECK:   [[B]]({{%.*}} : $(Double, Int)):
+    // CHECK:     [[B_N:%.*]] = tuple_extract
+    // CHECK:     [[B_X:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY]]([[B_X]] : $Int)
+    
+    // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
+    // CHECK:     br [[CASE_BODY]]([[Y_X]] : $Int)
+    
+    // CHECK:   [[Z]]({{%.*}} : $(Int, Foo)):
+    // CHECK:     [[Z_X:%.*]] = tuple_extract
+    // CHECK:     [[Z_F:%.*]] = tuple_extract
+    // CHECK:     br [[CASE_BODY]]([[Z_X]] : $Int)
+    
+    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int):
+    // CHECK:     store [[BODY_X]] to [[BOX_X:%.*]] : $*Int
+    // CHECK:     [[FUNC_AAA:%.*]] = function_ref @_TF10switch_var3aaaFT1xRSi_T_
+    // CHECK:     apply [[FUNC_AAA]]([[BOX_X]])
+    aaa(x: &x)
+  }
+}
+

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -281,6 +281,15 @@ func brokenSwitch(x: Int) -> Int {
   }
 }
 
+func switchWithVarsNotMatchingTypes(x: Int, y: Int, z: String) -> Int {
+  switch (x,y,z) {
+  case (let a, 0, _), (0, let a, _): // OK
+    return a
+  case (let a, _, _), (_, _, let a): // expected-error {{pattern variable bound to type 'String', expected type 'Int'}}
+    return a
+  }
+}
+
 func breakContinue(x : Int) -> Int {
 
 Outer:


### PR DESCRIPTION
There was a thread on swift-evolution back on Jan 23rd about adding this, and the response from the team was that it was something desirable but that you just hadn’t had time to do it so far.

Parser now accepts multiple patterns in switch cases that contain variables. Every pattern must contain the same variable names, but can be in arbitrary positions. New error for variable that doesn't exist in all patterns.

Sema now checks cases with multiple patterns that each occurrence of a variable name is bound to the same type. New error for unexpected types.

SILGen now shares a basic block for a switch case that contains multiple patterns even if there are variables. That BB takes incoming arguments from each applicable pattern match emission with the specific variables for the pattern that matched.

Added simple tests for the Parse and Sema functionality. I’d greatly appreciate suggestions on what sort of SILGen tests would be helpful. (The existing dominator assertions of variable usage and BB assertions on predecessor args caught a bunch of my mistakes along the way, so I’m pretty confident this all works, but how do I help make everyone else be confident too…)

I’m also not terribly happy with the managed value cleanup stuff between the pattern BBs and case body BBs, which works, but seems like the code could be cleaner. Again, suggestions greatly appreciated.
