### PR TITLE
[stdlib] Remove workaround for static initialization in Hashing.swift

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -37,8 +37,6 @@ struct _SwiftEmptyArrayStorage {
 
 extern struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
 
-extern __swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride;
-
 #ifdef __cplusplus
 }} // extern "C", namespace swift
 #endif

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -27,17 +27,7 @@ public // @testable
 struct _HashingDetail {
 
   public // @testable
-  static var fixedSeedOverride: UInt64 {
-    get {
-      // HACK: the variable itself is defined in C++ code so that it is
-      // guaranteed to be statically initialized.  This is a temporary
-      // workaround until the compiler can do the same for Swift.
-      return _swift_stdlib_HashingDetail_fixedSeedOverride
-    }
-    set {
-      _swift_stdlib_HashingDetail_fixedSeedOverride = newValue
-    }
-  }
+  static var fixedSeedOverride: UInt64 = 0
 
   @_transparent
   @warn_unused_result

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -38,10 +38,6 @@ extern "C" _SwiftEmptyArrayStorage _swiftEmptyArrayStorage = {
   }
 };
 
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
-uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride = 0;
-
 }
 
 namespace llvm { namespace hashing { namespace detail {


### PR DESCRIPTION
@gribozavr I think that this workaround isn't needed nowadays. 
I saw that this section was written before 1.2 was released but now I think its safe to just set this variable to zero directly with: 

``` swift
static var fixedSeedOverride: UInt64 = 0
```

I saw that you wrote the comment so I wanted to check with you first if I was off the mark. 
