### PR TITLE
[sil] Use FullApplySite instead of ApplyInst in SILInstruction::getMe…

### DIFF
--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -463,7 +463,7 @@ struct Callee_match<SILFunction &> {
     if (!AI)
       return false;
 
-    return AI->getCalleeFunction() == &Fun;
+    return AI->getReferencedFunction() == &Fun;
   }
 };
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -40,6 +40,10 @@ PASS(ArrayCountPropagation, "array-count-propagation",
      "Propagate the count of arrays")
 PASS(ArrayElementPropagation, "array-element-propagation",
      "Propagate the value of array elements")
+PASS(BasicInstructionPropertyDumper, "basic-instruction-property-dump",
+     "Dump MemBehavior and ReleaseBehavior results from calling "
+     "SILInstruction::{getMemoryBehavior,getReleasingBehavior}()"
+     " on all instructions")
 PASS(BasicCalleePrinter, "basic-callee-printer",
      "Construct basic callee analysis and use it to print callees "
      "for testing purposes")

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -182,7 +182,7 @@ bool SILLinkerVisitor::linkInVTable(ClassDecl *D) {
 
 bool SILLinkerVisitor::visitApplyInst(ApplyInst *AI) {
   // Ok we have a function ref inst, grab the callee.
-  SILFunction *Callee = AI->getCalleeFunction();
+  SILFunction *Callee = AI->getReferencedFunction();
   if (!Callee)
     return false;
 
@@ -199,7 +199,7 @@ bool SILLinkerVisitor::visitApplyInst(ApplyInst *AI) {
 }
 
 bool SILLinkerVisitor::visitPartialApplyInst(PartialApplyInst *PAI) {
-  SILFunction *Callee = PAI->getCalleeFunction();
+  SILFunction *Callee = PAI->getReferencedFunction();
   if (!Callee)
     return false;
   if (!isLinkAll() && !Callee->isTransparent() &&

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -702,12 +702,16 @@ SILInstruction::MemoryBehavior SILInstruction::getMemoryBehavior() const {
     }
   }
 
-  // Handle functions that have an effects attribute.
-  if (auto *AI = dyn_cast<ApplyInst>(this))
-    if (auto *F = AI->getCalleeFunction())
+  // Handle full apply sites that have a resolveable callee function with an
+  // effects attribute.
+  if (isa<FullApplySite>(this)) {
+    FullApplySite Site(const_cast<SILInstruction *>(this));
+    if (auto *F = Site.getCalleeFunction()) {
       return F->getEffectsKind() == EffectsKind::ReadNone
                  ? MemoryBehavior::None
                  : MemoryBehavior::MayHaveSideEffects;
+    }
+  }
 
   switch (getKind()) {
 #define INST(CLASS, PARENT, MEMBEHAVIOR, RELEASINGBEHAVIOR) \
@@ -937,6 +941,16 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
       return OS << "MayReadWrite";
     case SILInstruction::MemoryBehavior::MayHaveSideEffects:
       return OS << "MayHaveSideEffects";
+  }
+}
+
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
+                                     SILInstruction::ReleasingBehavior B) {
+  switch (B) {
+  case SILInstruction::ReleasingBehavior::DoesNotRelease:
+    return OS << "DoesNotRelease";
+  case SILInstruction::ReleasingBehavior::MayRelease:
+    return OS << "MayRelease";
   }
 }
 #endif

--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -29,7 +29,7 @@ static bool isAutoreleasePoolCall(SILInstruction *I) {
   if (!AI)
     return false;
 
-  auto *Fn = AI->getCalleeFunction();
+  auto *Fn = AI->getReferencedFunction();
   if (!Fn)
     return false;
 

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -890,7 +890,7 @@ bool swift::getFinalReleasesForValue(SILValue V, ReleaseTracker &Tracker) {
 //===----------------------------------------------------------------------===//
 
 static bool ignorableApplyInstInUnreachableBlock(const ApplyInst *AI) {
-  const auto *Fn = AI->getCalleeFunction();
+  const auto *Fn = AI->getReferencedFunction();
   if (!Fn)
     return false;
 

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -85,7 +85,7 @@ bool swift::ArraySemanticsCall::isValidSignature() {
       if (!AllocBufferAI)
         return false;
 
-      auto *AllocFn = AllocBufferAI->getCalleeFunction();
+      auto *AllocFn = AllocBufferAI->getReferencedFunction();
       if (!AllocFn)
         return false;
 
@@ -109,7 +109,7 @@ swift::ArraySemanticsCall::ArraySemanticsCall(ValueBase *V,
                                               StringRef SemanticStr,
                                               bool MatchPartialName) {
   if (auto *AI = dyn_cast<ApplyInst>(V))
-    if (auto *Fn = AI->getCalleeFunction())
+    if (auto *Fn = AI->getReferencedFunction())
       if ((MatchPartialName &&
            Fn->hasSemanticsAttrThatStartsWith(SemanticStr)) ||
           (!MatchPartialName && Fn->hasSemanticsAttr(SemanticStr))) {

--- a/lib/SILOptimizer/Analysis/CFG.cpp
+++ b/lib/SILOptimizer/Analysis/CFG.cpp
@@ -40,7 +40,7 @@ static bool isSafeNonExitTerminator(TermInst *TI) {
 static bool isTrapNoReturnFunction(ApplyInst *AI) {
   const char *fatalName =
       "_TFs18_fatalErrorMessageFTVs12StaticStringS_S_Su_T_";
-  auto *Fn = AI->getCalleeFunction();
+  auto *Fn = AI->getReferencedFunction();
 
   // We use endswith here since if we specialize fatal error we will always
   // prepend the specialization records to fatalName.

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -55,8 +55,8 @@ static BranchHint getBranchHint(SILValue Cond) {
   auto AI = dyn_cast<ApplyInst>(Cond);
   if (!AI)
     return BranchHint::None;
-  
-  if (auto *F = AI->getCalleeFunction()) {
+
+  if (auto *F = AI->getReferencedFunction()) {
     if (F->hasSemanticsAttrs()) {
       if (F->hasSemanticsAttr("branchhint")) {
         // A "branchint" model takes a Bool expected value as the second

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1171,7 +1171,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
       }
     }
 
-    if (auto *Fn = FAS.getCalleeFunction()) {
+    if (auto *Fn = FAS.getReferencedFunction()) {
       if (Fn->getName() == "swift_bufferAllocate")
         // The call is a buffer allocation, e.g. for Array.
         return;

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -288,7 +288,7 @@ void SideEffectAnalysis::analyzeInstruction(FunctionInfo *FInfo,
       }
     }
 
-    if (SILFunction *SingleCallee = FAS.getCalleeFunction()) {
+    if (SILFunction *SingleCallee = FAS.getReferencedFunction()) {
       // Does the function have any @effects?
       if (getDefinedEffects(FInfo->FE, SingleCallee))
         return;
@@ -467,7 +467,7 @@ void SideEffectAnalysis::getEffects(FunctionEffects &ApplyEffects, FullApplySite
       return;
   }
 
-  if (SILFunction *SingleCallee = FAS.getCalleeFunction()) {
+  if (SILFunction *SingleCallee = FAS.getReferencedFunction()) {
     // Does the function have any @effects?
     if (getDefinedEffects(ApplyEffects, SingleCallee))
       return;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -749,7 +749,7 @@ examineAllocBoxInst(AllocBoxInst *ABI, ReachabilityInfo &RI,
       // index so is not stored separately);
       unsigned Index = OpNo - 1 + closureType->getNumSILArguments();
 
-      auto *Fn = PAI->getCalleeFunction();
+      auto *Fn = PAI->getReferencedFunction();
       if (!Fn || !Fn->isDefinition())
         return false;
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -739,7 +739,7 @@ void ClosureSpecializer::gatherCallSites(
 
         // If AI does not have a function_ref definition as its callee, we can
         // not do anything here... so continue...
-        SILFunction *ApplyCallee = AI.getCalleeFunction();
+        SILFunction *ApplyCallee = AI.getReferencedFunction();
         if (!ApplyCallee || ApplyCallee->isExternalDeclaration())
           continue;
 

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -151,7 +151,7 @@ class InstructionsCloner : public SILClonerWithScopes<InstructionsCloner> {
 
 /// If this is a call to a global initializer, map it.
 void SILGlobalOpt::collectGlobalInitCall(ApplyInst *AI) {
-  SILFunction *F = AI->getCalleeFunction();
+  SILFunction *F = AI->getReferencedFunction();
   if (!F || !F->isGlobalInit())
     return;
 
@@ -347,8 +347,8 @@ static bool isAvailabilityCheck(SILBasicBlock *BB) {
   ApplyInst *AI = dyn_cast<ApplyInst>(CBR->getCondition());
   if (!AI)
     return false;
-  
-  SILFunction *F = AI->getCalleeFunction();
+
+  SILFunction *F = AI->getReferencedFunction();
   if (!F || !F->hasSemanticsAttrs())
     return false;
 

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -71,7 +71,7 @@ bool UsePrespecialized::replaceByPrespecialized(SILFunction &F) {
   collectApplyInst(F, NewApplies);
 
   for (auto &AI : NewApplies) {
-    auto *ReferencedF = AI.getCalleeFunction();
+    auto *ReferencedF = AI.getReferencedFunction();
     if (!ReferencedF)
       continue;
 

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -284,7 +284,7 @@ static bool isRelease(SILInstruction *Inst, SILValue RetainedValue,
       }
 
   if (auto *AI = dyn_cast<ApplyInst>(Inst)) {
-    if (auto *F = AI->getCalleeFunction()) {
+    if (auto *F = AI->getReferencedFunction()) {
       auto Params = F->getLoweredFunctionType()->getParameters();
       auto Args = AI->getArguments();
       for (unsigned ArgIdx = 0, ArgEnd = Params.size(); ArgIdx != ArgEnd;

--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -745,7 +745,7 @@ static bool isApplyOfBuiltin(SILInstruction &I, BuiltinValueKind kind) {
 
 static bool isApplyOfStringConcat(SILInstruction &I) {
   if (auto *AI = dyn_cast<ApplyInst>(&I))
-    if (auto *Fn = AI->getCalleeFunction())
+    if (auto *Fn = AI->getReferencedFunction())
       if (Fn->hasSemanticsAttr("string.concat"))
         return true;
   return false;

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1032,7 +1032,7 @@ static SILInstruction *isSuperInitUse(UpcastInst *Inst) {
       // super.init call as a hack to allow us to write testcases.
       auto *AI = dyn_cast<ApplyInst>(inst);
       if (AI && inst->getLoc().isSILFile())
-        if (auto *Fn = AI->getCalleeFunction())
+        if (auto *Fn = AI->getReferencedFunction())
           if (Fn->getName() == "superinit")
             return inst;
       continue;
@@ -1072,7 +1072,7 @@ static bool isSelfInitUse(SILInstruction *I) {
   // self.init call as a hack to allow us to write testcases.
   if (I->getLoc().isSILFile()) {
     if (auto *AI = dyn_cast<ApplyInst>(I))
-      if (auto *Fn = AI->getCalleeFunction())
+      if (auto *Fn = AI->getReferencedFunction())
         if (Fn->getName().startswith("selfinit"))
           return true;
     

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -974,7 +974,7 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
         FD = dyn_cast<FuncDecl>(WMI->getMember().getDecl());
       
       // If this is a direct/devirt method application, check the location info.
-      if (auto *Fn = Apply->getCalleeFunction()) {
+      if (auto *Fn = Apply->getReferencedFunction()) {
         if (Fn->hasLocation()) {
           auto SILLoc = Fn->getLocation();
           FD = SILLoc.getAsASTNode<FuncDecl>();
@@ -1242,7 +1242,7 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
       Method = dyn_cast<FuncDecl>(CMI->getMember().getDecl());
 
     // If this is a direct/devirt method application, check the location info.
-    if (auto *Fn = cast<ApplyInst>(Inst)->getCalleeFunction()) {
+    if (auto *Fn = cast<ApplyInst>(Inst)->getReferencedFunction()) {
       if (Fn->hasLocation())
         Method = Fn->getLocation().getAsASTNode<FuncDecl>();
     }
@@ -1270,7 +1270,7 @@ bool LifetimeChecker::diagnoseMethodCall(const DIMemoryUse &Use,
       }
       
       if (TheApply) {
-        if (auto *Fn = TheApply->getCalleeFunction())
+        if (auto *Fn = TheApply->getReferencedFunction())
           if (Fn->hasLocation())
             Method = Fn->getLocation().getAsASTNode<FuncDecl>();
       }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -873,7 +873,7 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite AI) {
   // Check if it is legal to perform the propagation.
   if (!AI.hasSubstitutions())
     return nullptr;
-  auto *Callee = AI.getCalleeFunction();
+  auto *Callee = AI.getReferencedFunction();
   if (!Callee || !Callee->getDeclContext())
     return nullptr;
 
@@ -1187,7 +1187,7 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
         }
 
   // Optimize readonly functions with no meaningful users.
-  SILFunction *SF = AI->getCalleeFunction();
+  SILFunction *SF = AI->getReferencedFunction();
   if (SF && SF->getEffectsKind() < EffectsKind::ReadWrite) {
     UserListTy Users;
     if (recursivelyCollectARCUsers(Users, AI)) {
@@ -1321,7 +1321,7 @@ SILInstruction *SILCombiner::visitTryApplyInst(TryApplyInst *AI) {
   }
 
   // Optimize readonly functions with no meaningful users.
-  SILFunction *Fn = AI->getCalleeFunction();
+  SILFunction *Fn = AI->getReferencedFunction();
   if (Fn && Fn->getEffectsKind() < EffectsKind::ReadWrite) {
     UserListTy Users;
     if (isTryApplyResultNotUsed(Users, AI)) {

--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -96,7 +96,7 @@ bool Devirtualizer::devirtualizeAppliesInFunction(SILFunction &F,
   while (!NewApplies.empty()) {
     auto Apply = NewApplies.pop_back_val();
 
-    auto *CalleeFn = Apply.getCalleeFunction();
+    auto *CalleeFn = Apply.getReferencedFunction();
     assert(CalleeFn && "Expected devirtualized callee!");
 
     // FIXME: Until we link everything in up front we need to ensure

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -64,7 +64,7 @@ bool GenericSpecializer::specializeAppliesInFunction(SILFunction &F) {
       if (!Apply || !Apply.hasSubstitutions())
         continue;
 
-      auto *Callee = Apply.getCalleeFunction();
+      auto *Callee = Apply.getReferencedFunction();
       if (!Callee || !Callee->isDefinition())
         continue;
 

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -145,7 +145,7 @@ devirtualizeReleaseOfBuffer(SILInstruction *ReleaseInst,
   DEBUG(llvm::dbgs() << "  try to devirtualize " << *ReleaseInst);
 
   // Is this a deallocation of a buffer?
-  SILFunction *DeallocFn = DeallocCall->getCalleeFunction();
+  SILFunction *DeallocFn = DeallocCall->getReferencedFunction();
   if (!DeallocFn || DeallocFn->getName() != "swift_bufferDeallocateFromStack")
     return false;
 
@@ -154,7 +154,7 @@ devirtualizeReleaseOfBuffer(SILInstruction *ReleaseInst,
   if (!AllocAI || AllocAI->getNumArguments() < 1)
     return false;
 
-  SILFunction *AllocFunc = AllocAI->getCalleeFunction();
+  SILFunction *AllocFunc = AllocAI->getReferencedFunction();
   if (!AllocFunc || AllocFunc->getName() != "swift_bufferAllocateOnStack")
     return false;
 

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -167,7 +167,7 @@ static bool isPromotableAllocInst(SILInstruction *I) {
   // Check for array buffer allocation.
   auto *AI = dyn_cast<ApplyInst>(I);
   if (AI && AI->getNumArguments() == 3) {
-    if (auto *Callee = AI->getCalleeFunction()) {
+    if (auto *Callee = AI->getReferencedFunction()) {
       if (Callee->getName() == "swift_bufferAllocate")
         return true;
     }

--- a/lib/SILOptimizer/UtilityPasses/BasicInstructionPropertyDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BasicInstructionPropertyDumper.cpp
@@ -1,0 +1,49 @@
+//===--- BasicInstructionPropertyDumper.cpp -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+namespace {
+
+class BasicInstructionPropertyDumper : public SILModuleTransform {
+  void run() override {
+    for (auto &Fn : *getModule()) {
+      unsigned Count = 0;
+      llvm::outs() << "@" << Fn.getName() << "\n";
+      for (auto &BB : Fn) {
+        for (auto &I : BB) {
+          llvm::outs() << "Inst #: " << Count++ << "\n    " << I;
+          llvm::outs() << "    Mem Behavior: " << I.getMemoryBehavior() << "\n";
+          llvm::outs() << "    Release Behavior: " << I.getReleasingBehavior()
+                       << "\n";
+        }
+      }
+    }
+  }
+
+  llvm::StringRef getName() override {
+    return "BasicInstructionPropertyDumper";
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createBasicInstructionPropertyDumper() {
+  return new BasicInstructionPropertyDumper();
+}

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(UTILITYPASSES_SOURCES
   UtilityPasses/AADumper.cpp
   UtilityPasses/BasicCalleePrinter.cpp
+  UtilityPasses/BasicInstructionPropertyDumper.cpp
   UtilityPasses/ComputeDominanceInfo.cpp
   UtilityPasses/ComputeLoopInfo.cpp
   UtilityPasses/CFGPrinter.cpp

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -236,7 +236,7 @@ SILValue swift::isPartialApplyOfReabstractionThunk(PartialApplyInst *PAI) {
   if (PAI->getNumArguments() != 1)
     return SILValue();
 
-  auto *Fun = PAI->getCalleeFunction();
+  auto *Fun = PAI->getReferencedFunction();
   if (!Fun)
     return SILValue();
 
@@ -732,7 +732,7 @@ public:
 /// Returns false if optimization is not possible.
 /// Returns true and initializes internal fields if optimization is possible.
 bool StringConcatenationOptimizer::extractStringConcatOperands() {
-  auto *Fn = AI->getCalleeFunction();
+  auto *Fn = AI->getReferencedFunction();
   if (!Fn)
     return false;
 

--- a/test/SILOptimizer/basic-instruction-properties.sil
+++ b/test/SILOptimizer/basic-instruction-properties.sil
@@ -1,0 +1,72 @@
+// RUN: %target-sil-opt %s -basic-instruction-property-dump -o /dev/null | FileCheck %s
+
+// REQUIRES: asserts
+
+import Builtin
+
+class X {
+  @sil_stored var a: Builtin.Int32
+  @sil_stored var x: X
+
+  init()
+  func foo()
+}
+
+sil_vtable X {}
+
+sil [readnone] @full_apply_site_effects_callee_1 : $@convention(thin) (@owned X) -> ()
+sil [readnone] @full_apply_site_effects_callee_2 : $@convention(thin) (@owned X, @owned X, @owned X) -> ()
+
+// CHECK-LABEL: @full_apply_site_effects
+// CHECK: Inst #: 8
+// CHECK:     apply
+// CHECK:     Mem Behavior: None
+// CHECK:     Release Behavior: MayRelease
+// CHECK: Inst #: 9
+// CHECK:     apply
+// CHECK:     Mem Behavior: None
+// CHECK:     Release Behavior: MayRelease
+// CHECK: Inst #: 10
+// CHECK:     apply
+// CHECK:     Mem Behavior: None
+// CHECK:     Release Behavior: MayRelease
+// CHECK: Inst #: 11
+// CHECK:     apply
+// CHECK:     Mem Behavior: None
+// CHECK:     Release Behavior: MayRelease
+// CHECK: Inst #: 12
+// CHECK:     apply
+// CHECK:     Mem Behavior: None
+// CHECK:     Release Behavior: MayRelease
+// CHECK: Inst #: 13
+// CHECK:     apply
+// CHECK:     Mem Behavior: None
+// CHECK:     Release Behavior: MayRelease
+// CHECK: Inst #: 14
+// CHECK:     apply
+// CHECK:     Mem Behavior: MayHaveSideEffects
+// CHECK:     Release Behavior: MayRelease
+sil @full_apply_site_effects : $@convention(thin) (@owned X) ->  () {
+bb0(%0 : $X):
+  %1 = function_ref @full_apply_site_effects_callee_1 : $@convention(thin) (@owned X) -> ()
+  %2 = partial_apply %1(%0) : $@convention(thin) (@owned X) -> ()
+  %3 = thin_to_thick_function %1 : $@convention(thin) (@owned X) -> () to $@callee_owned @convention(thick) (@owned X) -> ()
+  %4 = function_ref @full_apply_site_effects_callee_2 : $@convention(thin) (@owned X, @owned X, @owned X) -> ()
+  %5 = partial_apply %4(%0) : $@convention(thin) (@owned X, @owned X, @owned X) -> ()
+  %6 = partial_apply %5(%0) : $@callee_owned @convention(thick) (@owned X, @owned X) -> ()
+  %7 = partial_apply %6(%0) : $@callee_owned @convention(thick) (@owned X) -> ()
+  %8 = class_method %0 : $X, #X.foo!1 : X -> () -> (), $@convention(method) (@guaranteed X) -> ()
+
+  apply %1(%0) : $@convention(thin) (@owned X) -> ()
+  apply %2() : $@callee_owned @convention(thick) () -> ()
+  apply %3(%0) : $@callee_owned @convention(thick) (@owned X) -> ()
+
+  apply %5(%0, %0) : $@callee_owned @convention(thick) (@owned X, @owned X) -> ()
+  apply %6(%0) : $@callee_owned @convention(thick) (@owned X) -> () 
+  apply %7() : $@callee_owned @convention(thick) () -> ()
+
+  // Make sure we properly handle full apply sites for whcih we can not
+  // trivially find an absolute referenced function.
+  apply %8(%0) : $@convention(method) (@guaranteed X) -> ()
+  return undef : $()
+}


### PR DESCRIPTION
…moryBehavior().

We were giving special handling to ApplyInst when we were attempting to use
getMemoryBehavior(). This commit changes the special handling to work on all
full apply sites instead of just AI.
