### PR TITLE
[upstream-update] dexonsmith in an upstream commit realized he missed an

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -966,7 +966,7 @@ void SILGenModule::visitTopLevelCodeDecl(TopLevelCodeDecl *td) {
 }
 
 static void emitTopLevelProlog(SILGenFunction &gen, SILLocation loc) {
-  assert(gen.B.getInsertionBB() == gen.F.begin()
+  assert(gen.B.getInsertionBB()->getIterator() == gen.F.begin()
          && "not at entry point?!");
 
   SILBasicBlock *entry = gen.B.getInsertionBB();

--- a/lib/SILOptimizer/Mandatory/InOutDeshadowing.cpp
+++ b/lib/SILOptimizer/Mandatory/InOutDeshadowing.cpp
@@ -199,7 +199,7 @@ static void analyzeUseOfInOut(Operand *UI, StackSlotState &state) {
   switch (UI->getOperandNumber()) {
   case 0: { // Source
     // Is this copy in the entry block?
-    if (CAI->getParent() != CAI->getFunction()->begin())
+    if (CAI->getParent()->getIterator() != CAI->getFunction()->begin())
       // Any copy from the inout outside of the entry block fails the analysis.
       // We don't need full flow-sensitive analysis for SILGen-ed code.
       return state.setFailed("inout is loaded outside of the entry block");

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -371,7 +371,7 @@ areEquivalentConditionsAlongSomePaths(CheckedCastBranchInst *DomCCBI,
   // Incoming values for the BBArg.
   SmallVector<SILValue, 4> IncomingValues;
 
-  if (ArgBB != ArgBB->getParent()->begin() &&
+  if (ArgBB->getIterator() != ArgBB->getParent()->begin() &&
       (!Arg->getIncomingValues(IncomingValues) || IncomingValues.empty()))
     return false;
 


### PR DESCRIPTION
iterator/pointer comparison issue that yields undefined behavior. This updates
Swift for the landing of this change in swift-llvm/stable.

I am going to cherry-pick the given change into swift-llvm/stable since there is no
reason not to do this now and it will prevent more of these conversions from
creeping into the code base.

We really want to avoid as much undefined behavior as we possibly can.
