### PR TITLE
Enable cross-compiling

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -167,6 +167,10 @@ function(_add_variant_swift_compile_flags
       "-sdk" "${SWIFT_SDK_${sdk}_PATH}"
       "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")
 
+  if (CMAKE_CROSSCOMPILING)
+    list(APPEND result "-resource-dir" "${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift")
+  endif ()
+
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     list(APPEND result
         "-F" "${SWIFT_SDK_${sdk}_PATH}/../../../Developer/Library/Frameworks")

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -113,11 +113,12 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
 
   if(${is_cross_compiling})
     # Can't run llvm-config from the cross-compiled LLVM.
-    set(LLVM_TOOLS_BINARY_DIR "" CACHE PATH "Path to llvm/bin")
-    set(LLVM_LIBRARY_DIR "" CACHE PATH "Path to llvm/lib")
-    set(LLVM_MAIN_INCLUDE_DIR "" CACHE PATH "Path to llvm/include")
-    set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM build tree")
+    set(LLVM_TOOLS_BINARY_DIR "${SWIFT_NATIVE_LLVM_TOOLS_PATH}" CACHE PATH "Path to llvm/bin")
+    set(LLVM_LIBRARY_DIR "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/../lib" CACHE PATH "Path to llvm/lib")
+    set(LLVM_MAIN_INCLUDE_DIR "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/../include" CACHE PATH "Path to llvm/include")
+    set(LLVM_BINARY_DIR "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/../" CACHE PATH "Path to LLVM build tree")
     set(LLVM_MAIN_SRC_DIR "" CACHE PATH "Path to LLVM source tree")
+    set(SWIFT_PATH_TO_CLANG_BUILD "${LLVM_BINARY_DIR}")
   else()
     # Rely on llvm-config.
     _swift_llvm_config_info(

--- a/cmake/modules/Toolchain-linux-arm.cmake
+++ b/cmake/modules/Toolchain-linux-arm.cmake
@@ -1,0 +1,48 @@
+message(STATUS "Using Linux-arm toolchain file")
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR "armv7l")
+set(CMAKE_LIBRARY_ARCHITECTURE "arm-linux-gnueabihf") # for Glibc/CMakeLists.txt
+set(CMAKE_EXECUTABLE_FORMAT "ELF")
+
+include(CMakeForceCompiler)
+
+# 1) Get a sysroot, e.g. by running debootstrap, or this script: https://gist.github.com/froody/de6846f3455451f81992
+# 2) Download https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2
+# 3) Untar gcc, and in gcc-arm-none-eabi-4_9-2015q3/bin/
+# 4) Get the android NDK from http://developer.android.com/ndk/downloads/index.html
+#    and copy ld.gold to the gcc bin dir in (3) from:
+#    toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/arm-linux-androideabi/bin/ld.gold
+# 5) Run
+#    ./utils/build-script -R --cross-compile-stdlib-targets linux-armv7 --
+#    --cross-compile-sysroot=<sysroot path from (1)>
+#    --cross-compile-toolchain-bin=<bin directory from (3)>
+
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+  set(CMAKE_AR ${CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN}/arm-none-eabi-ar CACHE FILEPATH "Archiver") # https://cmake.org/Bug/view.php?id=13038
+endif ()
+
+set(COMMON_C_FLAGS "-B ${CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN}")
+set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -B ${CMAKE_SYSROOT}/usr/lib/gcc/arm-linux-gnueabihf/4.8")
+set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -fuse-ld=gold")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_C_FLAGS}" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_C_FLAGS}" CACHE STRING "" FORCE)
+
+set(CMAKE_CXX_COMPILER_VERSION 3.6)
+
+link_directories(${CMAKE_SYSROOT}/usr/lib/arm-linux-gnueabihf/
+                 ${CMAKE_SYSROOT}/usr/lib/gcc/arm-linux-gnueabihf/4.8/)
+include_directories(SYSTEM
+                ${CMAKE_SYSROOT}/usr/include/c++/4.8/
+                ${CMAKE_SYSROOT}/usr/include/arm-linux-gnueabihf/c++/4.8/
+                ${CMAKE_SYSROOT}/usr/lib/gcc/arm-linux-gnueabihf/4.8/include/)
+
+# Used to find BSD and ICU among other things
+set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+
+set(CMAKE_C_COMPILER_TARGET arm-linux-gnueabihf)
+set(CMAKE_CXX_COMPILER_TARGET arm-linux-gnueabihf)
+CMAKE_FORCE_C_COMPILER("${CMAKE_C_COMPILER}" Clang)
+CMAKE_FORCE_CXX_COMPILER("${CMAKE_CXX_COMPILER}" Clang)
+

--- a/stdlib/public/Glibc/CMakeLists.txt
+++ b/stdlib/public/Glibc/CMakeLists.txt
@@ -6,7 +6,8 @@ set(sources
 set(output_dir "${SWIFTLIB_DIR}/glibc")
 
 # Set correct paths to glibc headers
-set(GLIBC_INCLUDE_PATH "/usr/include")
+set(GLIBC_INCLUDE_PATH "${CMAKE_SYSROOT}/usr/include")
+
 if(CMAKE_LIBRARY_ARCHITECTURE)
   set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
 else()
@@ -40,7 +41,14 @@ swift_install_in_component(stdlib
     FILES "${output_dir}/module.map"
     DESTINATION "lib/swift/glibc")
 
+# Include directories passed to include_directories command
+get_directory_property(include_dirs INCLUDE_DIRECTORIES)
+foreach(dir ${include_dirs})
+    set(GLIBC_EXTRA_FLAGS ${GLIBC_EXTRA_FLAGS} "-I" ${dir})
+endforeach()
+
 add_swift_library(swiftGlibc IS_SDK_OVERLAY
     ${sources}
     FILE_DEPENDS copy_glibc_module "${output_dir}"
+    SWIFT_COMPILE_FLAGS "-I" "${GLIBC_INCLUDE_PATH}" "-I" "${GLIBC_ARCH_INCLUDE_PATH}" ${GLIBC_EXTRA_FLAGS}
     INSTALL_IN_COMPONENT stdlib-experimental)

--- a/utils/build-script
+++ b/utils/build-script
@@ -888,11 +888,55 @@ the number of parallel build jobs to use""",
             "--skip-build-benchmarks",
         ]
 
-    if platform.system() == 'Darwin':
+    system = platform.system()
+    machine = platform.machine()
+
+    if system == 'Darwin':
         build_script_impl_inferred_args += [
             "--toolchain-prefix",
             swift_build_support.targets.darwin_toolchain_prefix(args.install_prefix),
         ]
+        stdlib_deployment_targets = [
+            "macosx-x86_64",
+            "iphonesimulator-i386",
+            "iphonesimulator-x86_64",
+            "appletvsimulator-x86_64",
+            "watchsimulator-i386",
+
+            # Put iOS native targets last so that we test them last (it takes a
+            # long time).
+            "iphoneos-arm64",
+            "iphoneos-armv7",
+            "appletvos-arm64",
+            "watchos-armv7k"
+        ]
+        stdlib_cross_targets = [
+            "linux-armv7"
+        ]
+    elif system == 'Linux':
+        arch_mapping = [
+            ('x86_64' , 'x86_64'),
+            ('armv6' , 'armv6'),
+            ('armv7' , 'armv7'),
+            ('aarch64' , 'aarch64'),
+            ('ppc64' , 'powerpc64'),
+            ('ppc64le' , 'powerpc64le')
+        ]
+        arch_mapping = [(x, 'linux-'+y) for (x,y) in arch_mapping]
+
+        host_target = next(t for (s,t) in arch_mapping if machine.startswith(s))
+        stdlib_deployment_targets = [host_target]
+
+        # All other linux-* targets
+        stdlib_cross_targets = [t for (_,t) in arch_mapping]
+        stdlib_cross_targets.remove(host_target)
+    elif system == 'FreeBSD' and machine == 'amd64':
+        stdlib_deployment_targets = ["freebsd-x86_64"]
+    elif system == 'CYGWIN_NT-10' and machine == 'x86_64':
+        stdlib_deployment_targets = ["cygwin-x86_64"]
+    else:
+        print_with_argv0("Unknown operating system")
+        return 1
 
     if args.build_subdir is None:
         # Create a name for the build directory.
@@ -1043,16 +1087,15 @@ the number of parallel build jobs to use""",
             'watchsimulator',
         ])
 
-    host_build_script_impl_args = []
-
-    if platform.system() != 'Linux':
-        host_build_script_impl_args += [
-            "--skip-build-linux"
+    host_build_script_impl_args = [
+        "--stdlib-deployment-targets=" + " ".join(stdlib_deployment_targets)
         ]
 
     check_call(build_script_impl_args + host_build_script_impl_args)
 
     if args.cross_compile_stdlib_targets:
+        # Filter cross_compile_stdlib_targets by those supported for this host
+        stdlib_cross_targets = set(stdlib_cross_targets).intersection(args.cross_compile_stdlib_targets)
         # Currently only cross-compiling the swift libraries is supported.
         # Building the swift compiler would require building llvm too.
         llvm_path = os.path.join(build_dir, "llvm-"+args.host_target, 'bin')
@@ -1067,9 +1110,10 @@ the number of parallel build jobs to use""",
             "--build-swift-tools=0"
             ]
 
-        for target in args.cross_compile_stdlib_targets:
+        for target in stdlib_cross_targets:
             check_call(build_script_impl_args +
-                    ["--cross-compile-deployment-targets=" + target])
+                    ["--cross-compile-deployment-targets=" + target,
+                     "--stdlib-deployment-targets=" + target])
 
     if args.symbols_package:
         print('--- Creating symbols package ---')

--- a/utils/build-script
+++ b/utils/build-script
@@ -302,6 +302,12 @@ details of the setups of other systems or automated environments.""")
              "target. The built LLVM and Clang will be used to compile Swift "
              "for the cross-compilation targets.",
         default=swift_build_support.targets.host_target())
+    targets_group.add_argument(
+        "--cross-compile-stdlib-targets",
+        help="The cross-compliation targets. The Swift stdlib will be built for"
+             "these targets using the host-target LLVM, Clang and Swift",
+        metavar="TARGET",
+        nargs='*')
 
     projects_group = parser.add_argument_group(
         title="Options to select projects")
@@ -1037,7 +1043,33 @@ the number of parallel build jobs to use""",
             'watchsimulator',
         ])
 
-    check_call(build_script_impl_args)
+    host_build_script_impl_args = []
+
+    if platform.system() != 'Linux':
+        host_build_script_impl_args += [
+            "--skip-build-linux"
+        ]
+
+    check_call(build_script_impl_args + host_build_script_impl_args)
+
+    if args.cross_compile_stdlib_targets:
+        # Currently only cross-compiling the swift libraries is supported.
+        # Building the swift compiler would require building llvm too.
+        llvm_path = os.path.join(build_dir, "llvm-"+args.host_target, 'bin')
+        swift_path = os.path.join(build_dir, "swift-"+args.host_target, 'bin')
+        build_script_impl_args += [
+            "--native-llvm-tools-path=" + llvm_path,
+            "--native-clang-tools-path=" + llvm_path,
+            "--native-swift-tools-path=" + swift_path,
+            "--skip-build-cmark=1",
+            "--skip-build-llvm=1",
+            "--skip-build-osx=1", # FIXME only if host is osx
+            "--build-swift-tools=0"
+            ]
+
+        for target in args.cross_compile_stdlib_targets:
+            check_call(build_script_impl_args +
+                    ["--cross-compile-deployment-targets=" + target])
 
     if args.symbols_package:
         print('--- Creating symbols package ---')

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -181,6 +181,7 @@ KNOWN_SETTINGS=(
     install-libdispatch         ""               "whether to install libdispatch"
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
     host-target                 ""               "The host target. LLVM, Clang, and Swift will be built for this target. The built LLVM and Clang will be used to compile Swift for the cross-compilation targets. **This argument is required**"
+    stdlib-deployment-targets   ""               "The space separated list of stdlib targets to build"
     cross-compile-deployment-targets ""          "space-separated list of targets to cross-compile Swift for"
     cross-compile-sysroot       ""               "sysroot to use when cross-compiling"
     cross-compile-toolchain-bin ""               "toolchain binary dir to use when cross-compiling"
@@ -816,76 +817,6 @@ function is_cross_tools_deployment_target() {
     done
 }
 
-# A list of deployment targets that we compile or cross-compile the
-# Swift standard library for.
-STDLIB_DEPLOYMENT_TARGETS=()
-case "$(uname -s -m)" in
-    Linux\ x86_64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-x86_64"
-        )
-        ;;
-    Linux\ armv6*)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-armv6"
-        )
-        ;;
-    Linux\ armv7*)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-armv7"
-        )
-        ;;
-    Linux\ aarch64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-aarch64"
-        )
-        ;;
-    Linux\ ppc64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-powerpc64"
-        )
-        ;;
-    Linux\ ppc64le)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-powerpc64le"
-        )
-        ;;
-    Darwin\ x86_64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "macosx-x86_64"
-            "iphonesimulator-i386"
-            "iphonesimulator-x86_64"
-            "appletvsimulator-x86_64"
-            "watchsimulator-i386"
-
-            # Put iOS native targets last so that we test them last (it takes a
-            # long time).
-            "iphoneos-arm64"
-            "iphoneos-armv7"
-            "appletvos-arm64"
-            "watchos-armv7k"
-            "linux-armv7"
-        )
-        ;;
-
-    FreeBSD\ amd64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "freebsd-x86_64"
-        )
-        ;;
-
-    CYGWIN_NT-10.0\ x86_64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "cygwin-x86_64"
-        )
-        ;;
-
-    *)
-        echo "Unknown operating system"
-        exit 1
-        ;;
-esac
-
 #
 # Calculate source directories for each product.
 #
@@ -978,6 +909,7 @@ SWIFT_STDLIB_TARGETS=()
 SWIFT_BENCHMARK_TARGETS=()
 SWIFT_RUN_BENCHMARK_TARGETS=()
 SWIFT_TEST_TARGETS=()
+STDLIB_DEPLOYMENT_TARGETS=($STDLIB_DEPLOYMENT_TARGETS)
 for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
     build_for_this_target=1
     test_this_target=1

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -181,7 +181,9 @@ KNOWN_SETTINGS=(
     install-libdispatch         ""               "whether to install libdispatch"
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
     host-target                 ""               "The host target. LLVM, Clang, and Swift will be built for this target. The built LLVM and Clang will be used to compile Swift for the cross-compilation targets. **This argument is required**"
-    cross-compile-tools-deployment-targets ""    "space-separated list of targets to cross-compile host Swift tools for"
+    cross-compile-deployment-targets ""          "space-separated list of targets to cross-compile Swift for"
+    cross-compile-sysroot       ""               "sysroot to use when cross-compiling"
+    cross-compile-toolchain-bin ""               "toolchain binary dir to use when cross-compiling"
     skip-merge-lipo-cross-compile-tools ""       "set to skip running merge-lipo after installing cross-compiled host Swift tools"
     darwin-deployment-version-osx     "10.9"     "minimum deployment target version for OS X"
     darwin-deployment-version-ios     "7.0"      "minimum deployment target version for iOS"
@@ -203,6 +205,7 @@ KNOWN_SETTINGS=(
     build-jobs                         ""        "The number of parallel build jobs to use"
     darwin-toolchain-alias             ""        "Swift alias for toolchain"
     export-compile-commands            ""        "set to generate JSON compilation databases for each build product"
+    pkg-config-paths                   ""        "Colon-separate list of paths to add to PKG_CONFIG_PATH"
 )
 
 function toupper() {
@@ -779,22 +782,24 @@ function cmake_needs_to_specify_standard_computed_defaults() {
     fi
 }
 
-# A list of deployment targets to cross-compile the Swift host tools for.
+# A list of deployment targets to cross-compile the Swift host tools/stdlib for.
 # We can't run the resulting binaries on the build machine.
-CROSS_TOOLS_DEPLOYMENT_TARGETS=()
+CROSS_COMPILE_DEPLOYMENT_TARGETS=($CROSS_COMPILE_DEPLOYMENT_TARGETS)
+
+if [[ ! -z "${NATIVE_LLVM_TOOLS_PATH}" && ! -z "${NATIVE_CLANG_TOOLS_PATH}" && !  -z "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
+    BUILD_HOST_TARGET=""
+else
+    BUILD_HOST_TARGET=${HOST_TARGET}
+fi
 
 # Sanitize the list of cross-compilation targets.
-for t in ${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS} ; do
+for t in "${CROSS_COMPILE_DEPLOYMENT_TARGETS[@]}" ; do
     case ${t} in
         iphonesimulator-i386 | iphonesimulator-x86_64 | \
         iphoneos-arm64 | iphoneos-armv7 | \
         appletvos-arm64 | appletvsimulator-x86_64 | \
-        watchos-armv7k | watchsimulator-i386)
-            CROSS_TOOLS_DEPLOYMENT_TARGETS=(
-                "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
-                "${t}"
-            )
-            ;;
+        watchos-armv7k | watchsimulator-i386 | linux-armv7)
+            ;; # pass
         *)
             echo "Unknown deployment target: ${t}"
             exit 1
@@ -804,7 +809,7 @@ done
 
 function is_cross_tools_deployment_target() {
     local deployment_target="$1"
-    for t in "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}" ; do
+    for t in "${CROSS_COMPILE_DEPLOYMENT_TARGETS[@]}" ; do
         if [ "${deployment_target}" == "${t}" ] ; then
             echo 1
         fi
@@ -859,6 +864,7 @@ case "$(uname -s -m)" in
             "iphoneos-armv7"
             "appletvos-arm64"
             "watchos-armv7k"
+            "linux-armv7"
         )
         ;;
 
@@ -937,7 +943,18 @@ if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
     ln -sf "${WORKSPACE}/clang" "${CLANG_SOURCE_DIR}"
 fi
 
-PRODUCTS=(cmark llvm swift)
+PRODUCTS=()
+
+if [[ ! "${SKIP_BUILD_CMARK}" ]] ; then
+     PRODUCTS=("${PRODUCTS[@]}" cmark)
+fi
+
+if [[ ! "${SKIP_BUILD_LLVM}" ]] ; then
+     PRODUCTS=("${PRODUCTS[@]}" llvm)
+fi
+
+PRODUCTS=("${PRODUCTS[@]}" swift)
+
 if [[ ! "${SKIP_BUILD_LLDB}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" lldb)
 fi
@@ -1362,6 +1379,33 @@ function set_swiftpm_bootstrap_command() {
     fi
 }
 
+function get_pkg_config_path() {
+    eval ARG=$1
+    FIND_RESULT=$(find $ARG -name pkgconfig -type d -print0 | xargs -0 printf '%s:')
+    IFS=':'
+    for e in $PKG_CONFIG_PATHS; do
+        eval e=$e # expand ~ in path
+        EXTRA+="$(realpath $e):"
+    done
+    IFS=
+    for p in $FIND_RESULT $EXTRA; do
+        RESULT+="${p}"
+    done
+    echo $RESULT | sed 's/:$//'
+}
+
+function toolchain_file() {
+    case ${1} in
+        linux-armv7)
+            echo "${SWIFT_SOURCE_DIR}/cmake/modules/Toolchain-linux-arm.cmake"
+            ;;
+        *)
+            echo "unknown cross target"
+            exit 1
+            ;;
+    esac
+}
+
 mkdir -p "${BUILD_DIR}"
 
 #
@@ -1403,7 +1447,7 @@ fi
 # Configure and build each product
 #
 # Start with native deployment targets because the resulting tools are used during cross-compilation.
-for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
+for deployment_target in ${BUILD_HOST_TARGET} ${CROSS_COMPILE_DEPLOYMENT_TARGETS[@]}; do
     set_deployment_target_based_options
 
     case "${COMPILER_VENDOR}" in
@@ -1498,6 +1542,21 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
         unset skip_build
         build_dir=$(build_directory ${deployment_target} ${product})
         build_targets=(all)
+
+        if [[ $(is_cross_tools_deployment_target ${deployment_target}) ]] ; then
+            # Allows find_package to find packages in the sysroot
+            PKG_CONFIG_PATH=$(get_pkg_config_path ${CROSS_COMPILE_SYSROOT})
+            export PKG_CONFIG_PATH
+
+            COMMON_CMAKE_OPTIONS=(
+                "${COMMON_CMAKE_OPTIONS[@]}"
+                -DCMAKE_TOOLCHAIN_FILE=$(toolchain_file ${deployment_target})
+                -DLLVM_NATIVE_BUILD="${NATIVE_LLVM_TOOLS_PATH}/../"
+                -DCMAKE_SYSROOT:PATH="${CROSS_COMPILE_SYSROOT}"
+                -DCMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN:PATH="${CROSS_COMPILE_TOOLCHAIN_BIN}"
+            )
+        fi
+
         cmake_options=("${COMMON_CMAKE_OPTIONS[@]}")
 
         # Add in gold linker support if requested.
@@ -1561,6 +1620,9 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     build_targets=(clean)
                 fi
                 if [ "${SKIP_BUILD_LLVM}" ] ; then
+                    if [ -n "${BUILD_HOST_TARGET}" ] ; then
+                        skip_build=1
+                    fi
                     # We can't skip the build completely because the standalone
                     # build of Swift depend on these.
                     build_targets=(llvm-config llvm-tblgen clang-headers)
@@ -1623,10 +1685,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
 
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DLLVM_TOOLS_BINARY_DIR:PATH=$(build_directory ${deployment_target} llvm)/bin
-                        -DLLVM_LIBRARY_DIR:PATH=$(build_directory ${deployment_target} llvm)/lib
-                        -DLLVM_MAIN_INCLUDE_DIR:PATH=$(build_directory ${deployment_target} llvm)/include
-                        -DLLVM_BINARY_DIR:PATH=$(build_directory ${deployment_target} llvm)
                         -DLLVM_MAIN_SRC_DIR:PATH="${LLVM_SOURCE_DIR}"
                     )
                 else
@@ -1637,13 +1695,13 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 # Command-line parameters override any autodetection that we
                 # might have done.
                 if [[ "${NATIVE_LLVM_TOOLS_PATH}" ]] ; then
-                    native_llvm_tools_path="${NATIVE_LLVM_TOOLS_PATH}"
+                    native_llvm_tools_path=$(realpath "${NATIVE_LLVM_TOOLS_PATH}")
                 fi
                 if [[ "${NATIVE_CLANG_TOOLS_PATH}" ]] ; then
-                    native_clang_tools_path="${NATIVE_CLANG_TOOLS_PATH}"
+                    native_clang_tools_path=$(realpath "${NATIVE_CLANG_TOOLS_PATH}")
                 fi
                 if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
-                    native_swift_tools_path="${NATIVE_SWIFT_TOOLS_PATH}"
+                    native_swift_tools_path=$(realpath "${NATIVE_SWIFT_TOOLS_PATH}")
                 fi
 
                 if [ "${BUILD_LLVM}" == "0" ] ; then
@@ -2211,7 +2269,7 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
     done
 done
 
-for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
+for deployment_target in ${BUILD_HOST_TARGET} ${CROSS_COMPILE_DEPLOYMENT_TARGETS[@]}; do
     set_deployment_target_based_options
 
     for product in "${PRODUCTS[@]}"; do
@@ -2357,7 +2415,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             exit 1
         fi
 
-        if [ "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS}" ] ; then
+        if [ "${CROSS_COMPILE_DEPLOYMENT_TARGETS}" ] ; then
             # If cross compiling tools, install into a deployment target specific subdirectory.
             if [[ ! "${SKIP_MERGE_LIPO_CROSS_COMPILE_TOOLS}" ]] ; then
                 target_install_destdir="${BUILD_DIR}"/intermediate-install/"${deployment_target}"
@@ -2379,10 +2437,10 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
 
 done
 
-if [[ "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS}" ]] && [[ ! "${SKIP_MERGE_LIPO_CROSS_COMPILE_TOOLS}" ]] ; then
-    echo "--- Merging and running lipo for ${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]} ---"
+if [[ "${CROSS_COMPILE_DEPLOYMENT_TARGETS}" ]] && [[ ! "${SKIP_MERGE_LIPO_CROSS_COMPILE_TOOLS}" ]] ; then
+    echo "--- Merging and running lipo for ${CROSS_COMPILE_DEPLOYMENT_TARGETS[@]} ---"
     lipo_src_dirs=()
-    for deployment_target in "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"; do
+    for deployment_target in "${CROSS_COMPILE_DEPLOYMENT_TARGETS[@]}"; do
         lipo_src_dirs=(
             "${lipo_src_dirs[@]}"
             "${BUILD_DIR}"/intermediate-install/"${deployment_target}"


### PR DESCRIPTION
Allow using and OS X build of swift to build libraries and binaries for another
platform, only linux-armv7 is supported in this patch. Doesn't currently support
building the tools (llvm, swiftc) or the tests for linux-armv7.
- Added --cross-compile-stdlib-targets to build-script
- Added --cross-compile-sysroot to build-script-impl
- Added --cross-compile-toolchain-bin to build-script-impl
- Set -resource-dir when cross-compiling
- Use BUILD_HOST_TARGET instead of HOST_TARGET, allow it to be empty when
  cross-compiling to just build cross target
- Derive PKG_CONFIG_PATH from --cross-compile-sysroot to allow find_package to
  work
- Skip cmark and llvm builds completely when --native-*-tools-path flags are set

See instructions in cmake/modules/Toolchain-linux-arm.cmake. To build
linux-armv7 on osx run:

`./utils/build-script -R --cross-compile-stdlib-targets linux-armv7 --
--cross-compile-sysroot=$MY_SYSROOT
--cross-compile-toolchain-bin=$MY_TOOLCHAIN_BIN`
