### PR TITLE
[Python] Improve Python consistency: Use function_name(…) throughout (PEP8)

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -62,7 +62,7 @@ def parse_results(res, optset):
             tests.append(mem_test)
     return tests
 
-def submit_to_LNT(data, url):
+def submit_to_lnt(data, url):
     print "\nSubmitting results to LNT server..."
     json_report = {'input_data': json.dumps(data), 'commit': '1'}
     data = urllib.urlencode(json_report)
@@ -224,7 +224,7 @@ def submit(args):
                    'Start Time': starttime}
     print "End time:\t", endtime
 
-    submit_to_LNT(data, args.lnt_host)
+    submit_to_lnt(data, args.lnt_host)
     return 0
 
 def run(args):

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -35,13 +35,13 @@ IsTime = 1
 ShowSpeedup = 1
 PrintAllScores = 0
 
-def parseInt(word):
+def parse_int(word):
     try:
         return int(word)
     except:
         raise Exception("Expected integer value, not " + word)
 
-def getScores(fname):
+def get_scores(fname):
     scores = {}
     worstscores = {}
     nums = {}
@@ -65,8 +65,8 @@ def getScores(fname):
             if not m.group(KEYGROUP) in scores:
                 scores[m.group(KEYGROUP)] = []
                 worstscores[m.group(KEYGROUP)] = []
-            scores[m.group(KEYGROUP)].append(parseInt(m.group(BESTGROUP)))
-            worstscores[m.group(KEYGROUP)].append(parseInt(m.group(WORSTGROUP)))
+            scores[m.group(KEYGROUP)].append(parse_int(m.group(BESTGROUP)))
+            worstscores[m.group(KEYGROUP)].append(parse_int(m.group(WORSTGROUP)))
             if is_total:
                 nums[m.group(KEYGROUP)] = ""
             else:
@@ -77,10 +77,10 @@ def getScores(fname):
         f.close()
     return scores, worstscores, runs, nums
 
-def isMaxScore(newscore, maxscore, invert):
+def is_max_score(newscore, maxscore, invert):
     return not maxscore or (newscore > maxscore if not invert else newscore < maxscore)
 
-def compareScores(key, score1, worstsample1, score2, worstsample2, runs, num):
+def compare_scores(key, score1, worstsample1, score2, worstsample2, runs, num):
     print num.rjust(3),
     print key.ljust(25),
     bestscore1 = None
@@ -91,25 +91,25 @@ def compareScores(key, score1, worstsample1, score2, worstsample2, runs, num):
     minworst = not minbest
     r = 0
     for score in score1:
-        if isMaxScore(newscore=score, maxscore=bestscore1, invert=minbest):
+        if is_max_score(newscore=score, maxscore=bestscore1, invert=minbest):
             bestscore1 = score
-        if isMaxScore(newscore=score, maxscore=worstscore1, invert=minworst):
+        if is_max_score(newscore=score, maxscore=worstscore1, invert=minworst):
             worstscore1 = score
         if PrintAllScores:
             print ("%d" % score).rjust(16),
     for score in worstsample1:
-        if isMaxScore(newscore=score, maxscore=worstscore1, invert=minworst):
+        if is_max_score(newscore=score, maxscore=worstscore1, invert=minworst):
             worstscore1 = score
     for score in score2:
-        if isMaxScore(newscore=score, maxscore=bestscore2, invert=minbest):
+        if is_max_score(newscore=score, maxscore=bestscore2, invert=minbest):
             bestscore2 = score
-        if isMaxScore(newscore=score, maxscore=worstscore2, invert=minworst):
+        if is_max_score(newscore=score, maxscore=worstscore2, invert=minworst):
             worstscore2 = score
         if PrintAllScores:
             print ("%d" % score).rjust(16),
         r += 1
     for score in worstsample2:
-        if isMaxScore(newscore=score, maxscore=worstscore2, invert=minworst):
+        if is_max_score(newscore=score, maxscore=worstscore2, invert=minworst):
             worstscore2 = score
     while r < runs:
         if PrintAllScores:
@@ -136,20 +136,20 @@ def compareScores(key, score1, worstsample1, score2, worstsample2, runs, num):
     # check if the worst->best interval for each configuration overlap.
     if minbest:
         if (bestscore1 < bestscore2 and bestscore2 < worstscore1) \
-        or (bestscore2 < bestscore1 and bestscore1 < worstscore2):
+           or (bestscore2 < bestscore1 and bestscore1 < worstscore2):
             print "(?)",
     else:
         if (worstscore1 < worstscore2 and worstscore2 < bestscore1) \
-        or (worstscore2 < worstscore1 and worstscore1 < bestscore2):
+           or (worstscore2 < worstscore1 and worstscore1 < bestscore2):
             print "(?)",
     print
 
-def printBestScores(key, scores):
+def print_best_scores(key, scores):
     print key,
     bestscore = None
     minbest = IsTime
     for score in scores:
-        if isMaxScore(newscore=score, maxscore=bestscore, invert=minbest):
+        if is_max_score(newscore=score, maxscore=bestscore, invert=minbest):
             bestscore = score
     print ", %d" % bestscore
 
@@ -163,19 +163,19 @@ if __name__ == '__main__':
         sys.exit(1)
     file1 = sys.argv[1]
     if len(sys.argv) < 3:
-        scores, worstscores, runs, nums = getScores(file1)
+        scores, worstscores, runs, nums = get_scores(file1)
         keys = list(set(scores.keys()))
         keys.sort()
         for key in keys:
-            printBestScores(key, scores[key])
+            print_best_scores(key, scores[key])
         sys.exit(0)
 
     file2 = sys.argv[2]
     if len(sys.argv) > 3:
         SCORERE = re.compile(sys.argv[3])
 
-    scores1, worstscores1, runs1, nums = getScores(file1)
-    scores2, worstscores2, runs2, nums = getScores(file2)
+    scores1, worstscores1, runs1, nums = get_scores(file1)
+    scores2, worstscores2, runs2, nums = get_scores(file2)
 
     runs = runs1
     if runs2 > runs:
@@ -213,4 +213,4 @@ if __name__ == '__main__':
         if key not in scores2:
             print key, "not in", file2
             continue
-        compareScores(key, scores1[key], worstscores1[key], scores2[key], worstscores2[key], runs, nums[key])
+        compare_scores(key, scores1[key], worstscores1[key], scores2[key], worstscores2[key], runs, nums[key])

--- a/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
+++ b/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
@@ -17,10 +17,10 @@
 
 %{
 
-from GYBUnicodeDataUtils import get_grapheme_cluster_break_tests_as_UTF8
+from GYBUnicodeDataUtils import get_grapheme_cluster_break_tests_as_utf8
 
 grapheme_cluster_break_tests = \
-    get_grapheme_cluster_break_tests_as_UTF8(unicodeGraphemeBreakTestFile)
+    get_grapheme_cluster_break_tests_as_utf8(unicodeGraphemeBreakTestFile)
 
 }%
 

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -210,10 +210,10 @@ class UnicodeTrieGenerator(object):
     supp_first_level_index_bits = 5
     supp_second_level_index_bits = 8
 
-    def get_BMP_first_level_index(self, cp):
+    def get_bmp_first_level_index(self, cp):
         return cp >> self.BMP_data_offset_bits
 
-    def get_BMP_data_offset(self, cp):
+    def get_bmp_data_offset(self, cp):
         return cp & ((1 << self.BMP_data_offset_bits) - 1)
 
     def get_supp_first_level_index(self, cp):
@@ -287,8 +287,8 @@ class UnicodeTrieGenerator(object):
 
     def set_value(self, cp, value):
         if cp <= 0xffff:
-            data_block_index = self.BMP_lookup[self.get_BMP_first_level_index(cp)]
-            self.BMP_data[data_block_index][self.get_BMP_data_offset(cp)] = value
+            data_block_index = self.BMP_lookup[self.get_bmp_first_level_index(cp)]
+            self.BMP_data[data_block_index][self.get_bmp_data_offset(cp)] = value
         else:
             second_lookup_index = self.supp_lookup1[self.get_supp_first_level_index(cp)]
             data_block_index = self.supp_lookup2[second_lookup_index][self.get_supp_second_level_index(cp)]
@@ -296,8 +296,8 @@ class UnicodeTrieGenerator(object):
 
     def get_value(self, cp):
         if cp <= 0xffff:
-            data_block_index = self.BMP_lookup[self.get_BMP_first_level_index(cp)]
-            return self.BMP_data[data_block_index][self.get_BMP_data_offset(cp)]
+            data_block_index = self.BMP_lookup[self.get_bmp_first_level_index(cp)]
+            return self.BMP_data[data_block_index][self.get_bmp_data_offset(cp)]
         else:
             second_lookup_index = self.supp_lookup1[self.get_supp_first_level_index(cp)]
             data_block_index = self.supp_lookup2[second_lookup_index][self.get_supp_second_level_index(cp)]
@@ -379,7 +379,7 @@ class UnicodeTrieGenerator(object):
                     j += 1
             i += 1
 
-    def _int_to_LE_bytes(self, data, width):
+    def _int_to_le_bytes(self, data, width):
         if width == 1:
             assert(data & ~0xff == 0)
             return [data]
@@ -388,11 +388,11 @@ class UnicodeTrieGenerator(object):
             return [data & 0xff, data & 0xff00]
         assert(False)
 
-    def _int_list_to_LE_bytes(self, ints, width):
+    def _int_list_to_le_bytes(self, ints, width):
         return [
             byte
             for elt in ints
-            for byte in self._int_to_LE_bytes(elt, width)]
+            for byte in self._int_to_le_bytes(elt, width)]
 
     def serialize(self, unicode_property):
         self.BMP_lookup_bytes_per_entry = 1 if len(self.BMP_data) < 256 else 2
@@ -415,16 +415,16 @@ class UnicodeTrieGenerator(object):
             for block in self.supp_data
             for elt in block]
 
-        BMP_lookup_bytes = self._int_list_to_LE_bytes(
+        BMP_lookup_bytes = self._int_list_to_le_bytes(
             BMP_lookup_words, self.BMP_lookup_bytes_per_entry)
-        BMP_data_bytes = self._int_list_to_LE_bytes(
+        BMP_data_bytes = self._int_list_to_le_bytes(
             BMP_data_words, self.BMP_data_bytes_per_entry)
 
-        supp_lookup1_bytes = self._int_list_to_LE_bytes(
+        supp_lookup1_bytes = self._int_list_to_le_bytes(
             supp_lookup1_words, self.supp_lookup1_bytes_per_entry)
-        supp_lookup2_bytes = self._int_list_to_LE_bytes(
+        supp_lookup2_bytes = self._int_list_to_le_bytes(
             supp_lookup2_words, self.supp_lookup2_bytes_per_entry)
-        supp_data_bytes = self._int_list_to_LE_bytes(
+        supp_data_bytes = self._int_list_to_le_bytes(
             supp_data_words, self.supp_data_bytes_per_entry)
 
         self.trie_bytes = []
@@ -502,7 +502,7 @@ def get_extended_grapheme_cluster_rules_matrix(grapheme_cluster_break_property_t
 
     return result
 
-def get_grapheme_cluster_break_tests_as_UTF8(grapheme_break_test_file_name):
+def get_grapheme_cluster_break_tests_as_utf8(grapheme_break_test_file_name):
     def _convert_line(line):
         # Strip comments.
         line = re.sub('#.*', '', line).strip()

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -82,7 +82,7 @@ def all_real_number_type_names():
 def all_numeric_type_names():
     return all_integer_type_names() + all_real_number_type_names()
 
-def numeric_type_names_Macintosh_only():
+def numeric_type_names_macintosh_only():
     return ['Float80']
 
 # Swift_Programming_Language/Expressions.html

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -51,7 +51,7 @@ SortedPrefixes = sorted(Prefixes)
 SortedInfixes = sorted(Infixes)
 
 
-def addFunction(sizes, function, start_addr, end_addr, group_by_prefix):
+def add_function(sizes, function, start_addr, end_addr, group_by_prefix):
     if not function or start_addr is None or end_addr is None:
         return
 
@@ -85,7 +85,7 @@ def flatten(*args):
             yield x
 
 
-def readSizes(sizes, file_name, function_details, group_by_prefix):
+def read_sizes(sizes, file_name, function_details, group_by_prefix):
     # Check if multiple architectures are supported by the object file.
     # Prefer arm64 if available.
     architectures = subprocess.check_output(["otool", "-V", "-f", file_name]).split("\n")
@@ -134,7 +134,7 @@ def readSizes(sizes, file_name, function_details, group_by_prefix):
             sectionMatch = sectionPattern.match(line)
             if labelMatch:
                 funcName = labelMatch.group(1)
-                addFunction(sizes, currFunc, start_addr, end_addr, group_by_prefix)
+                add_function(sizes, currFunc, start_addr, end_addr, group_by_prefix)
                 currFunc = funcName
                 start_addr = None
                 end_addr = None
@@ -146,10 +146,10 @@ def readSizes(sizes, file_name, function_details, group_by_prefix):
                 if sectName == "__textcoal_nt":
                     sectName = "__text"
 
-    addFunction(sizes, currFunc, start_addr, end_addr, group_by_prefix)
+    add_function(sizes, currFunc, start_addr, end_addr, group_by_prefix)
 
 
-def compareSizes(old_sizes, new_sizes, name_key, title):
+def compare_sizes(old_sizes, new_sizes, name_key, title):
     oldSize = old_sizes[name_key]
     newSize = new_sizes[name_key]
     if oldSize is not None and newSize is not None:
@@ -160,13 +160,13 @@ def compareSizes(old_sizes, new_sizes, name_key, title):
         print("%-26s%16s: %8d  %8d  %6s" % (title, name_key, oldSize, newSize, perc))
 
 
-def compareSizesOfFile(old_files, new_files, all_sections, list_categories):
+def compare_sizes_of_file(old_files, new_files, all_sections, list_categories):
     old_sizes = collections.defaultdict(int)
     new_sizes = collections.defaultdict(int)
     for oldFile in old_files:
-        readSizes(old_sizes, oldFile, list_categories, True)
+        read_sizes(old_sizes, oldFile, list_categories, True)
     for newFile in new_files:
-        readSizes(new_sizes, newFile, list_categories, True)
+        read_sizes(new_sizes, newFile, list_categories, True)
 
     if len(old_files) == 1 and len(new_files) == 1:
         oldBase = os.path.basename(old_files[0])
@@ -177,43 +177,43 @@ def compareSizesOfFile(old_files, new_files, all_sections, list_categories):
     else:
         title = "old-new"
 
-    compareSizes(old_sizes, new_sizes, "__text", title)
+    compare_sizes(old_sizes, new_sizes, "__text", title)
     if list_categories:
         prev = None
         for categoryName in sorted(Prefixes.values()) + sorted(Infixes.values()) + ["Unknown"]:
             if categoryName != prev:
-                compareSizes(old_sizes, new_sizes, categoryName, "")
+                compare_sizes(old_sizes, new_sizes, categoryName, "")
             prev = categoryName
 
     if all_sections:
         sectionTitle = "    section"
-        compareSizes(old_sizes, new_sizes, "__textcoal_nt", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__stubs", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__const", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__cstring", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__objc_methname", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__const", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__objc_const", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__data", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__swift1_proto", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__common", sectionTitle)
-        compareSizes(old_sizes, new_sizes, "__bss", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__textcoal_nt", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__stubs", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__const", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__cstring", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__objc_methname", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__const", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__objc_const", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__data", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__swift1_proto", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__common", sectionTitle)
+        compare_sizes(old_sizes, new_sizes, "__bss", sectionTitle)
 
 
-def listFunctionSizes(size_array):
+def list_function_sizes(size_array):
     for pair in sorted(size_array, key=itemgetter(1)):
         name = pair[0]
         size = pair[1]
         yield "%8d %s" % (size, name)
 
 
-def compareFunctionSizes(old_files, new_files):
+def compare_function_sizes(old_files, new_files):
     old_sizes = collections.defaultdict(int)
     new_sizes = collections.defaultdict(int)
     for name in old_files:
-        readSizes(old_sizes, name, True, False)
+        read_sizes(old_sizes, name, True, False)
     for name in new_files:
-        readSizes(new_sizes, name, True, False)
+        read_sizes(new_sizes, name, True, False)
 
     onlyInFile1 = []
     onlyInFile2 = []
@@ -239,13 +239,13 @@ def compareFunctionSizes(old_files, new_files):
 
     if onlyInFile1:
         print("Only in old file(s)")
-        print(os.linesep.join(listFunctionSizes(onlyInFile1)))
+        print(os.linesep.join(list_function_sizes(onlyInFile1)))
         print("Total size of functions only in old file: {}".format(onlyInFile1Size))
         print()
 
     if onlyInFile2:
         print("Only in new files(s)")
-        print(os.linesep.join(listFunctionSizes(onlyInFile2)))
+        print(os.linesep.join(list_function_sizes(onlyInFile2)))
         print("Total size of functions only in new file: {}".format(onlyInFile2Size))
         print()
 

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -18,7 +18,7 @@ import glob
 import collections
 
 from cmpcodesize.compare import \
-    compareFunctionSizes, compareSizesOfFile, listFunctionSizes, readSizes
+    compare_function_sizes, compare_sizes_of_file, list_function_sizes, read_sizes
 
 
 SHORTCUTS = {
@@ -176,16 +176,16 @@ How to specify files:
         if not newFiles:
             sizes = collections.defaultdict(int)
             for file in oldFiles:
-                readSizes(sizes, file, True, False)
-            print(os.linesep.join(listFunctionSizes(sizes.items())))
+                read_sizes(sizes, file, True, False)
+            print(os.linesep.join(list_function_sizes(sizes.items())))
         else:
-            compareFunctionSizes(oldFiles, newFiles)
+            compare_function_sizes(oldFiles, newFiles)
     else:
         print("%-26s%16s  %8s  %8s  %s" % ("", "Section", "Old", "New", "Percent"))
         if parsed_arguments.sum_sizes:
-            compareSizesOfFile(oldFiles, newFiles,
-                               parsed_arguments.all_sections,
-                               parsed_arguments.list_categories)
+            compare_sizes_of_file(oldFiles, newFiles,
+                                  parsed_arguments.all_sections,
+                                  parsed_arguments.list_categories)
         else:
             if len(oldFiles) != len(newFiles):
                 sys.exit("number of new files must be the same of old files")
@@ -195,9 +195,9 @@ How to specify files:
 
             for idx, oldFile in enumerate(oldFiles):
                 newFile = newFiles[idx]
-                compareSizesOfFile([oldFile], [newFile],
-                                   parsed_arguments.all_sections,
-                                   parsed_arguments.list_categories)
+                compare_sizes_of_file([oldFile], [newFile],
+                                      parsed_arguments.all_sections,
+                                      parsed_arguments.list_categories)
 
 if __name__ == '__main__':
     main()

--- a/utils/cmpcodesize/tests/test_list_function_sizes.py
+++ b/utils/cmpcodesize/tests/test_list_function_sizes.py
@@ -1,4 +1,4 @@
-# test_list_function_sizes.py - Unit tests for listFunctionSizes -*- python -*-
+# test_list_function_sizes.py - Unit tests for list_function_sizes -*- python -*-
 #
 # This source file is part of the Swift.org open source project
 #
@@ -10,16 +10,16 @@
 
 import unittest
 
-from cmpcodesize.compare import listFunctionSizes
+from cmpcodesize.compare import list_function_sizes
 
 
 class ListFunctionSizesTestCase(unittest.TestCase):
     def test_when_size_array_is_none_raises(self):
         with self.assertRaises(TypeError):
-            list(listFunctionSizes(None))
+            list(list_function_sizes(None))
 
     def test_when_size_array_is_empty_returns_none(self):
-        self.assertEqual(list(listFunctionSizes([])), [])
+        self.assertEqual(list(list_function_sizes([])), [])
 
     def test_lists_each_entry(self):
         sizes = {
@@ -27,7 +27,7 @@ class ListFunctionSizesTestCase(unittest.TestCase):
             'bar': 10,
             'baz': 100,
         }
-        self.assertEqual(list(listFunctionSizes(sizes.items())), [
+        self.assertEqual(list(list_function_sizes(sizes.items())), [
             '       1 foo',
             '      10 bar',
             '     100 baz',

--- a/utils/pass-pipeline/src/pass_pipeline.py
+++ b/utils/pass-pipeline/src/pass_pipeline.py
@@ -21,7 +21,7 @@ class PassList(object):
     def __iter__(self):
         return self.transforms.__iter__()
 
-    def addPass(self, p):
+    def add_pass(self, p):
         if isinstance(p, list):
             p = PassList(p)
         self.transforms.append(p)
@@ -45,8 +45,8 @@ class PassPipeline(object):
         self.action = action
         self.pass_list = PassList([])
 
-    def addPass(self, p):
-        self.pass_list.addPass(p)
+    def add_pass(self, p):
+        self.pass_list.add_pass(p)
 
     def __repr__(self):
         return "<passpipeline values=%s>" % self.pass_list

--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -104,27 +104,27 @@ def normal_passpipelines():
     result = []
 
     x = ppipe.PassPipeline('HighLevel', {'name': 'run_n_times', 'count': 2})
-    x.addPass(ssapass_passlist('high'))
+    x.add_pass(ssapass_passlist('high'))
     result.append(x)
 
     x = ppipe.PassPipeline('EarlyLoopOpt', {'name': 'run_n_times', 'count': 1})
-    x.addPass(highlevel_loopopt_passlist())
+    x.add_pass(highlevel_loopopt_passlist())
     result.append(x)
 
     x = ppipe.PassPipeline('MidLevelOpt', {'name': 'run_n_times', 'count': 2})
-    x.addPass(ssapass_passlist('mid'))
+    x.add_pass(ssapass_passlist('mid'))
     result.append(x)
 
     x = ppipe.PassPipeline('Lower', {'name': 'run_to_fixed_point'})
-    x.addPass(lower_passlist())
+    x.add_pass(lower_passlist())
     result.append(x)
 
     x = ppipe.PassPipeline('LowLevel', {'name': 'run_n_times', 'count': 1})
-    x.addPass(ssapass_passlist('low'))
+    x.add_pass(ssapass_passlist('low'))
     result.append(x)
 
     x = ppipe.PassPipeline('LateLoopOpt', {'name': 'run_n_times', 'count': 1})
-    x.addPass([lowlevel_loopopt_passlist(), p.DeadFunctionElimination])
+    x.add_pass([lowlevel_loopopt_passlist(), p.DeadFunctionElimination])
     result.append(x)
 
     return result

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -56,7 +56,7 @@ def interpolate(string):
 
 # Given the body_text of a protocol definition, return a list of
 # associated type and operator requirements.
-def bodyLines(body_text):
+def body_lines(body_text):
     return [
         cgi.escape(b.group(0)) for b in
         re.finditer(
@@ -81,7 +81,7 @@ with open(args[1]) as src:
 
 genericParameterConstraint = interpolate(r' (%(identifier)s) \s* : \s* (%(identifier)s) ')
 
-def parseGenericOperator(m):
+def parse_generic_operator(m):
     genericParams = m.group(5)
     genericOperator = cgi.escape(m.group(0).strip())
     functionParamStart = m.end(5) - m.start(0)
@@ -103,13 +103,13 @@ def parseGenericOperator(m):
 
         genericOperators.setdefault(protocol, set()).add(abbreviatedSignature)
 
-def parseProtocol(m):
+def parse_protocol(m):
     child = m.group(1)
     # skip irrelevant protocols
     if re.match(r'_Builtin.*Convertible', child):
         return
     graph.setdefault(child, set())
-    body[child] = bodyLines(m.group(3))
+    body[child] = body_lines(m.group(3))
     if m.group(2):
         for parent in m.group(2).strip().split(","):
             if re.match(r'_Builtin.*Convertible', parent):
@@ -127,9 +127,9 @@ protocolsAndOperators = interpolate(r'''
 # Main parsing loop
 for m in re.finditer(protocolsAndOperators, sourceSansComments, reFlags):
     if m.group(1):
-        parseProtocol(m)
+        parse_protocol(m)
     elif m.group(5):
-        parseGenericOperator(m)
+        parse_generic_operator(m)
     # otherwise we matched some non-generic operator
 
 # Find clusters of protocols that have the same name when underscores

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -117,7 +117,7 @@ def collect_submodules(common_args, module):
     return sorted(list(submodules))
 
 # Print out the command we're about to execute
-def printCommand(cmd, outfile=""):
+def print_command(cmd, outfile=""):
     str = " ".join(cmd)
     if outfile != "":
         str += " > " + outfile
@@ -138,7 +138,7 @@ def dump_module_api((cmd, extra_dump_args, output_dir, module, quiet, verbose)):
 
     top_level_cmd = cmd + extra_dump_args + ['-module-to-print=%s' % (module)]
     if verbose:
-        printCommand(top_level_cmd, output_file)
+        print_command(top_level_cmd, output_file)
 
     output_command_result_to_file(top_level_cmd, output_file)
 
@@ -152,7 +152,7 @@ def dump_module_api((cmd, extra_dump_args, output_dir, module, quiet, verbose)):
         submodule_cmd = cmd + extra_dump_args
         submodule_cmd = submodule_cmd + ['-module-to-print=%s' % (full_submodule)]
         if verbose:
-            printCommand(submodule_cmd, output_file)
+            print_command(submodule_cmd, output_file)
 
         output_command_result_to_file(submodule_cmd, output_file)
 

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -62,14 +62,14 @@ class Block:
                 if canPred:
                     self.preds.append(canPred)
 
-    def addLine(self, text):
+    def add_line(self, text):
         if self.content is None:
             self.content = ""
         escapedText = re.sub(r'([\\<>{}"|])', r'\\\1', text[0:80]).rstrip()
         self.content += escapedText + '\\l'
         self.lastLine = text
 
-    def getSuccs(self):
+    def get_succs(self):
         if self.succs is None:
             self.succs = []
             if self.lastLine is not None:
@@ -114,7 +114,7 @@ def main():
             preds = llvmBlockMatch2.group(2)
         elif line.startswith(' '):
             if curBlock is not None:
-                curBlock.addLine(line)
+                curBlock.add_line(line)
         elif not line[:1].isspace():
             if line.startswith('}') and blocks:
                 break
@@ -122,13 +122,13 @@ def main():
 
         if blockName is not None:
             curBlock = Block(blockName, preds)
-            curBlock.addLine(line)
+            curBlock.add_line(line)
             blocks[blockName] = curBlock
 
     # Add empty blocks which we didn't see, but which are referenced.
     newBlocks = {}
     for name, block in blocks.iteritems():
-        for adjName in (block.preds + block.getSuccs()):
+        for adjName in (block.preds + block.get_succs()):
             if adjName not in blocks:
                 newBlocks[adjName] = Block(adjName, None)
 
@@ -140,8 +140,8 @@ def main():
     for name, block in blocks.iteritems():
         for predName in block.preds:
             predBlock = blocks[predName]
-            if name not in predBlock.getSuccs():
-                predBlock.getSuccs().append(name)
+            if name not in predBlock.get_succs():
+                predBlock.get_succs().append(name)
 
     # Write the output dot file.
 
@@ -157,7 +157,7 @@ def main():
                     " [shape=record,color=gray,fontcolor=gray,label=\"{" +
                     block.name + "}\"];\n")
 
-            for succName in block.getSuccs():
+            for succName in block.get_succs():
                 succBlock = blocks[succName]
                 outFile.write("\tNode" + str(block.index) + " -> Node" +
                     str(succBlock.index) + ";\n")

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -326,8 +326,8 @@ CollectionTypeTests.test(
 // flatMap()
 //===----------------------------------------------------------------------===//
 
-% TLazyFlatMapTest = gyb.parseTemplate("{}/Inputs/flatMap.gyb".format(test_path))
-% LazyFlatMapTest = gyb.executeTemplate(TLazyFlatMapTest, Test='CollectionTypeTests', Kinds=['ForwardCollection', 'BidirectionalCollection'])
+% TLazyFlatMapTest = gyb.parse_template("{}/Inputs/flatMap.gyb".format(test_path))
+% LazyFlatMapTest = gyb.execute_template(TLazyFlatMapTest, Test='CollectionTypeTests', Kinds=['ForwardCollection', 'BidirectionalCollection'])
 ${LazyFlatMapTest}
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -76,7 +76,7 @@ def get_fixed_point_hash(bit_pattern, src_bits, word_bits):
 
 %{
 
-truncating_bit_pattern_test_template = gyb.parseTemplate("truncating_bit_pattern",
+truncating_bit_pattern_test_template = gyb.parse_template("truncating_bit_pattern",
 """
 % from SwiftIntTypes import all_integer_types, should_define_truncating_bit_pattern_init
 
@@ -119,7 +119,7 @@ FixedPoint.test("${Dst}(truncatingBitPattern:) from ${Src}(${bit_pattern})") {
 
 #if arch(i386) || arch(arm)
 
-  ${gyb.executeTemplate(
+  ${gyb.execute_template(
       truncating_bit_pattern_test_template,
       prepare_bit_pattern=prepare_bit_pattern,
       test_bit_patterns=test_bit_patterns,
@@ -127,7 +127,7 @@ FixedPoint.test("${Dst}(truncatingBitPattern:) from ${Src}(${bit_pattern})") {
 
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
 
-  ${gyb.executeTemplate(
+  ${gyb.execute_template(
       truncating_bit_pattern_test_template,
       prepare_bit_pattern=prepare_bit_pattern,
       test_bit_patterns=test_bit_patterns,
@@ -145,7 +145,7 @@ _UnimplementedError()
 
 %{
 
-bit_pattern_test_template = gyb.parseTemplate("bit_pattern",
+bit_pattern_test_template = gyb.parse_template("bit_pattern",
 """
 % from SwiftIntTypes import all_integer_types
 
@@ -191,7 +191,7 @@ FixedPoint.test("${Dst}(bitPattern:) from ${Src}(${bit_pattern})") {
 
 #if arch(i386) || arch(arm)
 
-  ${gyb.executeTemplate(
+  ${gyb.execute_template(
       bit_pattern_test_template,
       prepare_bit_pattern=prepare_bit_pattern,
       test_bit_patterns=test_bit_patterns,
@@ -199,7 +199,7 @@ FixedPoint.test("${Dst}(bitPattern:) from ${Src}(${bit_pattern})") {
 
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
 
-  ${gyb.executeTemplate(
+  ${gyb.execute_template(
       bit_pattern_test_template,
       prepare_bit_pattern=prepare_bit_pattern,
       test_bit_patterns=test_bit_patterns,
@@ -217,7 +217,7 @@ _UnimplementedError()
 
 %{
 
-hash_value_test_template = gyb.parseTemplate("hash_value",
+hash_value_test_template = gyb.parse_template("hash_value",
 """
 % from SwiftIntTypes import all_integer_types
 
@@ -248,7 +248,7 @@ FixedPoint.test("${Self}.hashValue") {
 
 #if arch(i386) || arch(arm)
 
-  ${gyb.executeTemplate(
+  ${gyb.execute_template(
       hash_value_test_template,
       prepare_bit_pattern=prepare_bit_pattern,
       get_fixed_point_hash=get_fixed_point_hash,
@@ -257,7 +257,7 @@ FixedPoint.test("${Self}.hashValue") {
 
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
 
-  ${gyb.executeTemplate(
+  ${gyb.execute_template(
       hash_value_test_template,
       prepare_bit_pattern=prepare_bit_pattern,
       get_fixed_point_hash=get_fixed_point_hash,

--- a/validation-test/stdlib/NumericDiagnostics.swift.gyb
+++ b/validation-test/stdlib/NumericDiagnostics.swift.gyb
@@ -2,7 +2,7 @@
 // RUN: %S/../../utils/line-directive %t/main.swift -- %target-build-swift -parse -Xfrontend -verify %t/main.swift
 // REQUIRES: executable_test
 
-% from SwiftIntTypes import all_numeric_type_names, numeric_type_names_Macintosh_only,  \
+% from SwiftIntTypes import all_numeric_type_names, numeric_type_names_macintosh_only, \
 %   all_integer_type_names,all_integer_binary_operator_names, all_integer_or_real_binary_operator_names, \
 %   all_arithmetic_comparison_operator_names, all_integer_assignment_operator_names, \
 %   all_integer_or_real_assignment_operator_names
@@ -22,8 +22,8 @@ func testIteratedOperations() {
 // typesToTest: ${typesToTest}, operatorsToTest: ${operatorsToTest}
   % for T1 in typesToTest:
     % for T2 in typesToTest:
-      ${ "\n\n#if arch(i386) || arch(x86_64)\n" if T1 in numeric_type_names_Macintosh_only() 
-        or T2 in numeric_type_names_Macintosh_only() else "" }
+      ${ "\n\n#if arch(i386) || arch(x86_64)\n" if T1 in numeric_type_names_macintosh_only()
+        or T2 in numeric_type_names_macintosh_only() else "" }
       % for op in operatorsToTest:
         % count += 1
         % theDiagnostic = "// expected-error{{of type}} expected-note*{{expected an argument list of type}} expected-note*{{exist with these partially matching parameter lists}} " if (T1 != T2) else \
@@ -36,8 +36,8 @@ func testIteratedOperations() {
       var result = x1_${T1} ${op} x2_${T2}  ${theDiagnostic} 
     }
       %end # op
-      ${ "\n#endif //arch(i386) || arch(x86_64)\n\n" if T1 in numeric_type_names_Macintosh_only() 
-        or T2 in numeric_type_names_Macintosh_only() else "" }
+      ${ "\n#endif //arch(i386) || arch(x86_64)\n\n" if T1 in numeric_type_names_macintosh_only()
+        or T2 in numeric_type_names_macintosh_only() else "" }
     %end # T2
   %end # T1
 %end # typesToTest

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -940,8 +940,8 @@ SequenceTypeTests.test("flatMap/SequenceType") {
   }
 }
 
-% TLazyFlatMapTest = gyb.parseTemplate("{}/Inputs/flatMap.gyb".format(test_path))
-% LazyFlatMapTest = gyb.executeTemplate(TLazyFlatMapTest, Test='SequenceTypeTests', Kinds=['Sequence'])
+% TLazyFlatMapTest = gyb.parse_template("{}/Inputs/flatMap.gyb".format(test_path))
+% LazyFlatMapTest = gyb.execute_template(TLazyFlatMapTest, Test='SequenceTypeTests', Kinds=['Sequence'])
 ${LazyFlatMapTest}
 
 SequenceTypeTests.test("flatMap/SequenceType/TransformProducesOptional") {

--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -48,8 +48,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{{}}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{{}}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='{traversal}',
 %   base_kind='{base_kind}',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedBidirectionalMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedForwardMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedRandomAccessMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalBidirectionalMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalForwardMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalRandomAccessMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedBidirectionalMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedForwardMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedRandomAccessMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Defaulted',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalBidirectionalMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Bidirectional',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalForwardMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='Forward',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_FullWidth.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_WithPrefix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalRandomAccessMutableCollection_WithSuffix.swift.gyb
@@ -25,8 +25,8 @@ import ObjectiveC
 var SliceTests = TestSuite("CollectionType")
 
 % import gyb
-% TSliceTest = gyb.parseTemplate("{}/Inputs/slice.gyb".format(test_path))
-% SliceTest = gyb.executeTemplate(
+% TSliceTest = gyb.parse_template("{}/Inputs/slice.gyb".format(test_path))
+% SliceTest = gyb.execute_template(
 %   TSliceTest,
 %   traversal='RandomAccess',
 %   base_kind='Minimal',


### PR DESCRIPTION
Background: See discussion with @modocache and @nadavrot in #1369. This is a follow-up to #1374.

The majority of Python function names in the repo are in lowercase with words separated by underscores (`snake_case_function`). This is also the form recommended by the [PEP8 function naming recommendations](https://www.python.org/dev/peps/pep-0008/#function-names) (Python Software Foundation).

This PR improves consistency by converting the remaning cases of `camelCaseFunction` to the PEP-8 form (`snake_case_function`) used by convention in the repo.

@modocache - do you have time to review? That would be really appreciated :-)
