### PR TITLE
[Python] Update .pep8 with ignored docstring rules

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,3 @@
 [flake8]
 filename = *.py,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,gyb,line-directive,ns-html2rst,recursive-lipo,rth,submit-benchmark-results,update-checkout,viewcfg
-ignore = E101,E111,E128,E302,E402,E501,W191
+ignore = D100,D101,D102,D103,D104,D105,E101,E111,E128,E302,E402,E501,W191


### PR DESCRIPTION
Suppress warnings for [Python docstring linting rules (PEP-0257)](https://www.python.org/dev/peps/pep-0257/) that deviate from the coding conventions in active use in the project.

By ignoring known violations `flake8` can be used to catch new types of violations.

docstring rules ignored:
- D100: Missing docstring in public module
- D101: Missing docstring in public class
- D102: Missing docstring in public method
- D103: Missing docstring in public function
- D104: Missing docstring in public package
- D105: Missing docstring in magic method
- D400: First line should end with a period
- D401: First line should be in imperative mood
- D402: First line should not be the function’s “signature”
