### PR TITLE
[Serialization] Don't serialize non-public documentation

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -649,6 +649,10 @@ public:
   /// for instance, self.
   bool isUserAccessible() const;
 
+  /// Determine if the decl can have a comment.  If false, a comment will
+  /// not be serialized.
+  bool canHaveComment() const;
+
   DeclContext *getDeclContext() const {
     if (auto dc = Context.dyn_cast<DeclContext *>())
       return dc;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -301,6 +301,13 @@ bool Decl::isUserAccessible() const {
   return true;
 }
 
+bool Decl::canHaveComment() const {
+  return !this->hasClangNode() &&
+         (isa<ValueDecl>(this) || isa<ExtensionDecl>(this)) &&
+         !isa<ParamDecl>(this) &&
+         (!isa<AbstractTypeParamDecl>(this) || isa<AssociatedTypeDecl>(this));
+}
+
 Module *Decl::getModuleContext() const {
   return getDeclContext()->getParentModule();
 }

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -67,13 +67,6 @@ SingleRawComment::SingleRawComment(StringRef RawText, unsigned StartColumn)
     : RawText(RawText), Kind(static_cast<unsigned>(getCommentKind(RawText))),
       StartColumn(StartColumn), StartLine(0), EndLine(0) {}
 
-static bool canHaveComment(const Decl *D) {
-  return !D->hasClangNode() &&
-         (isa<ValueDecl>(D) || isa<ExtensionDecl>(D)) &&
-         !isa<ParamDecl>(D) &&
-         (!isa<AbstractTypeParamDecl>(D) || isa<AssociatedTypeDecl>(D));
-}
-
 static void addCommentToList(SmallVectorImpl<SingleRawComment> &Comments,
                              const SingleRawComment &SRC) {
   // TODO: consider producing warnings when we decide not to merge comments.
@@ -131,7 +124,7 @@ static RawComment toRawComment(ASTContext &Context, CharSourceRange Range) {
 }
 
 RawComment Decl::getRawComment() const {
-  if (!canHaveComment(this))
+  if (!this->canHaveComment())
     return RawComment();
 
   // Check the cache in ASTContext.
@@ -195,7 +188,7 @@ static StringRef extractBriefComment(ASTContext &Context, RawComment RC,
                                      const Decl *D) {
   PrettyStackTraceDecl StackTrace("extracting brief comment for", D);
 
-  if (!canHaveComment(D))
+  if (!D->canHaveComment())
     return StringRef();
 
   llvm::markup::MarkupContext MC;
@@ -217,7 +210,7 @@ static StringRef extractBriefComment(ASTContext &Context, RawComment RC,
 }
 
 StringRef Decl::getBriefComment() const {
-  if (!canHaveComment(this))
+  if (!this->canHaveComment())
     return StringRef();
 
   auto &Context = getASTContext();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3748,10 +3748,28 @@ static void writeDeclCommentTable(
       if (!VD)
         return true;
 
-      // Skip the decl if it does not have a comment.
       RawComment Raw = VD->getRawComment();
-      if (Raw.Comments.empty() && !GroupContext.isEnable())
-        return true;
+      // When building the stdlib we intend to
+      // serialize unusual comments.  This situation is represented by
+      // GroupContext.isEnable().  In that case, we perform fewer serialization checks.
+      if (!GroupContext.isEnable()) {
+        // Skip the decl if it cannot have a comment.
+        if (!VD->canHaveComment()) {
+          return true;
+        }
+
+        // Skip the decl if it does not have a comment.
+        if (Raw.Comments.empty())
+          return true;
+
+        // Skip the decl if it's not visible to clients.
+        // The use of getEffectiveAccess is unusual here;
+        // we want to take the testability state into account
+        // and emit documentation if and only if they are visible to clients
+        // (which means public ordinarily, but public+internal when testing enabled).
+        if (VD->getEffectiveAccess() != Accessibility::Public)
+          return true;
+      }
 
       // Compute USR.
       {

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -2,20 +2,20 @@
 //
 // Please keep this file in alphabetical order!
 
-@objc class A000 {}
+@objc public class A000 {}
 // CHECK: {{.*}}DocCommentAsXML=none
 
 /// Aaa.  A010.  Bbb.
-@objc class A010_AttachToEntities {
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A010_AttachToEntities</Name><USR>s:C14swift_ide_test21A010_AttachToEntities</USR><Declaration>@objc class A010_AttachToEntities</Declaration><Abstract><Para>Aaa.  A010.  Bbb.</Para></Abstract></Class>]
+@objc public class A010_AttachToEntities {
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A010_AttachToEntities</Name><USR>s:C14swift_ide_test21A010_AttachToEntities</USR><Declaration>@objc public class A010_AttachToEntities</Declaration><Abstract><Para>Aaa.  A010.  Bbb.</Para></Abstract></Class>]
 
 /// Aaa.  init().
-init() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>init()</Name><USR>s:FC14swift_ide_test21A010_AttachToEntitiescFT_S0_</USR><Declaration>init()</Declaration><Abstract><Para>Aaa.  init().</Para></Abstract></Function>]
+public init() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>init()</Name><USR>s:FC14swift_ide_test21A010_AttachToEntitiescFT_S0_</USR><Declaration>public init()</Declaration><Abstract><Para>Aaa.  init().</Para></Abstract></Function>]
 
 /// Aaa.  subscript(i: Int).
-subscript(i: Int) -> Int {
-// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>subscript(_:)</Name><USR>s:iC14swift_ide_test21A010_AttachToEntities9subscriptFSiSi</USR><Declaration>subscript(i: Int) -&gt; Int { get set }</Declaration><Abstract><Para>Aaa.  subscript(i: Int).</Para></Abstract></Other>]
+public subscript(i: Int) -> Int {
+// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>subscript(_:)</Name><USR>s:iC14swift_ide_test21A010_AttachToEntities9subscriptFSiSi</USR><Declaration>public subscript(i: Int) -&gt; Int { get set }</Declaration><Abstract><Para>Aaa.  subscript(i: Int).</Para></Abstract></Other>]
     get {
 // CHECK: {{.*}}DocCommentAsXML=none
       return 0
@@ -26,188 +26,188 @@ subscript(i: Int) -> Int {
 // CHECK: {{.*}}DocCommentAsXML=none
 
 /// Aaa.  v1.
-var v1: Int = 0
-// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v1</Name><USR>s:vC14swift_ide_test21A010_AttachToEntities2v1Si</USR><Declaration>var v1: Int</Declaration><Abstract><Para>Aaa.  v1.</Para></Abstract></Other>]
+public var v1: Int = 0
+// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v1</Name><USR>s:vC14swift_ide_test21A010_AttachToEntities2v1Si</USR><Declaration>public var v1: Int</Declaration><Abstract><Para>Aaa.  v1.</Para></Abstract></Other>]
 
 /// Aaa.  v2.
-class var v2: Int { return 0 }
-// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v2</Name><USR>s:ZvC14swift_ide_test21A010_AttachToEntities2v2Si</USR><Declaration>class var v2: Int { get }</Declaration><Abstract><Para>Aaa.  v2.</Para></Abstract></Other>]
+public class var v2: Int { return 0 }
+// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>v2</Name><USR>s:ZvC14swift_ide_test21A010_AttachToEntities2v2Si</USR><Declaration>public class var v2: Int { get }</Declaration><Abstract><Para>Aaa.  v2.</Para></Abstract></Other>]
 // CHECK: {{.*}}DocCommentAsXML=none
 }
 
 /// Aaa.  A011.
-struct A011_AttachToEntities {
+public struct A011_AttachToEntities {
 }
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A011_AttachToEntities</Name><USR>s:V14swift_ide_test21A011_AttachToEntities</USR><Declaration>struct A011_AttachToEntities</Declaration><Abstract><Para>Aaa.  A011.</Para></Abstract></Class>]
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A011_AttachToEntities</Name><USR>s:V14swift_ide_test21A011_AttachToEntities</USR><Declaration>public struct A011_AttachToEntities</Declaration><Abstract><Para>Aaa.  A011.</Para></Abstract></Class>]
 
 /// Aaa.  A012.
-enum A012_AttachToEntities {
+public enum A012_AttachToEntities {
   case A
 }
-// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A012_AttachToEntities</Name><USR>s:O14swift_ide_test21A012_AttachToEntities</USR><Declaration>enum A012_AttachToEntities</Declaration><Abstract><Para>Aaa.  A012.</Para></Abstract></Other>]
+// CHECK: {{.*}}DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A012_AttachToEntities</Name><USR>s:O14swift_ide_test21A012_AttachToEntities</USR><Declaration>public enum A012_AttachToEntities</Declaration><Abstract><Para>Aaa.  A012.</Para></Abstract></Other>]
 // CHECK: {{.*}}DocCommentAsXML=none
 
 /// Aaa.  A013.
-@objc protocol A013_AttachToEntities {}
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A013_AttachToEntities</Name><USR>s:P14swift_ide_test21A013_AttachToEntities</USR><Declaration>@objc protocol A013_AttachToEntities</Declaration><Abstract><Para>Aaa.  A013.</Para></Abstract></Class>]
+@objc public protocol A013_AttachToEntities {}
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>A013_AttachToEntities</Name><USR>s:P14swift_ide_test21A013_AttachToEntities</USR><Declaration>@objc public protocol A013_AttachToEntities</Declaration><Abstract><Para>Aaa.  A013.</Para></Abstract></Class>]
 
-@objc class AutomaticLink {
+@objc public class AutomaticLink {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// And now for a URL.
   ///
   /// <http://developer.apple.com/swift/>
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13AutomaticLink2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>And now for a URL.</Para></Abstract><Discussion><Para><Link href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</Link></Para></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13AutomaticLink2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>And now for a URL.</Para></Abstract><Discussion><Para><Link href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</Link></Para></Discussion></Function>]
 }
 
-@objc class BlockQuote {
+@objc public class BlockQuote {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa.
   ///
   /// > Bbb.
   ///
   /// > Ccc.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10BlockQuote2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para><Para>Ccc.</Para></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10BlockQuote2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para><Para>Ccc.</Para></Discussion></Function>]
 }
 
-@objc class ATXHeaders {
+@objc public class ATXHeaders {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// LEVEL ONE
   /// =========
   ///
   /// LEVEL TWO
   /// ---------
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10ATXHeaders2f0FT_T_</USR><Declaration>func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10ATXHeaders2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></Function>]
 }
 
-@objc class Brief {
+@objc public class Brief {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test5Brief2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test5Brief2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
 
   /// Aaa.
   ///
   /// Bbb.
-  func f1() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test5Brief2f1FT_T_</USR><Declaration>func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
+  public func f1() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test5Brief2f1FT_T_</USR><Declaration>public func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 
   /// Aaa.
   ///
   ///> Bbb.
-  func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test5Brief2f2FT_T_</USR><Declaration>func f2()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
+  public func f2() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test5Brief2f2FT_T_</USR><Declaration>public func f2()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 
   /// Aaa.
   ///
   /// Bbb.
-  func f3() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>s:FC14swift_ide_test5Brief2f3FT_T_</USR><Declaration>func f3()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
+  public func f3() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>s:FC14swift_ide_test5Brief2f3FT_T_</USR><Declaration>public func f3()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 }
 
-@objc class CodeBlock {
+@objc public class CodeBlock {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// This is how you use this code.
   ///
   ///     f0() // WOW!
   ///     f0() // WOW!
   ///     f0() // WOW!
-  func f0() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test9CodeBlock2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>This is how you use this code.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+  public func f0() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test9CodeBlock2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>This is how you use this code.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[f0() // WOW!]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
 }
 
-@objc class EmptyComments {
+@objc public class EmptyComments {
 // CHECK: {{.*}}DocCommentAsXML=none
 
   ///
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13EmptyComments2f0FT_T_</USR><Declaration>func f0()</Declaration></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13EmptyComments2f0FT_T_</USR><Declaration>public func f0()</Declaration></Function>]
 
   /// Aaa.
-  func f1() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test13EmptyComments2f1FT_T_</USR><Declaration>func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
+  public func f1() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test13EmptyComments2f1FT_T_</USR><Declaration>public func f1()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
 
   /** */
-  func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test13EmptyComments2f2FT_T_</USR><Declaration>func f2()</Declaration></Function>]
+  public func f2() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test13EmptyComments2f2FT_T_</USR><Declaration>public func f2()</Declaration></Function>]
 
   /**
    */
-  func f3() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>s:FC14swift_ide_test13EmptyComments2f3FT_T_</USR><Declaration>func f3()</Declaration></Function>]
+  public func f3() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>s:FC14swift_ide_test13EmptyComments2f3FT_T_</USR><Declaration>public func f3()</Declaration></Function>]
 
   /**
    * Aaa.
    */
-  func f4() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>s:FC14swift_ide_test13EmptyComments2f4FT_T_</USR><Declaration>func f4()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
+  public func f4() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>s:FC14swift_ide_test13EmptyComments2f4FT_T_</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.</Para></Abstract></Function>]
 }
 
-@objc class Emphasis {
+@objc public class Emphasis {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa *bbb* ccc.
   /// Aaa _bbb_ ccc.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test8Emphasis2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Aaa <emphasis>bbb</emphasis> ccc. Aaa <emphasis>bbb</emphasis> ccc.</Para></Abstract></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test8Emphasis2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <emphasis>bbb</emphasis> ccc. Aaa <emphasis>bbb</emphasis> ccc.</Para></Abstract></Function>]
 }
 
-@objc class HasThrowingFunction {
+@objc public class HasThrowingFunction {
 // CHECK: {{.*}}DocCommentAsXML=none
 
   /// Might throw something.
   ///
   /// - parameter x: A number
   /// - throws: An error if `x == 0`
-  @objc func f1(x: Int) /*throws*/ {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>s:FC14swift_ide_test19HasThrowingFunction2f1FSiT_</USR><Declaration>@objc func f1(x: Int)</Declaration><Abstract><Para>Might throw something.</Para></Abstract><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><ThrowsDiscussion><Para>An error if <codeVoice>x == 0</codeVoice></Para></ThrowsDiscussion></Function>]
+  @objc public func f1(x: Int) /*throws*/ {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>s:FC14swift_ide_test19HasThrowingFunction2f1FSiT_</USR><Declaration>@objc public func f1(x: Int)</Declaration><Abstract><Para>Might throw something.</Para></Abstract><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><ThrowsDiscussion><Para>An error if <codeVoice>x == 0</codeVoice></Para></ThrowsDiscussion></Function>]
 }
 
-@objc class HorizontalRules {
+@objc public class HorizontalRules {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Briefly.
   ///
   /// ------------------------------------
   ///
   /// The end.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test15HorizontalRules2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Briefly.</Para></Abstract><Discussion><rawHTML><![CDATA[<hr/>]]></rawHTML><Para>The end.</Para></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test15HorizontalRules2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Briefly.</Para></Abstract><Discussion><rawHTML><![CDATA[<hr/>]]></rawHTML><Para>The end.</Para></Discussion></Function>]
 }
 
-@objc class ImplicitNameLink {
+@objc public class ImplicitNameLink {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// [Apple][]
   ///
   /// [Apple]: https://www.apple.com/
-  func f0() {}
+  public func f0() {}
 }
 
-@objc class InlineCode {
+@objc public class InlineCode {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa `bbb` ccc.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10InlineCode2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Aaa <codeVoice>bbb</codeVoice> ccc.</Para></Abstract></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10InlineCode2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <codeVoice>bbb</codeVoice> ccc.</Para></Abstract></Function>]
 }
 
-@objc class InlineLink {
+@objc public class InlineLink {
 // CHECK: {{.*}}DocCommentAsXML=none
 /// Aaa [bbb](/path/to/something) ccc.
-func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10InlineLink2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Aaa <Link href="/path/to/something">bbb</Link> ccc.</Para></Abstract></Function>]
+public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test10InlineLink2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <Link href="/path/to/something">bbb</Link> ccc.</Para></Abstract></Function>]
 }
 
 /// - parameter x: A number
-@objc class ParamAndReturns {
-// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>ParamAndReturns</Name><USR>s:C14swift_ide_test15ParamAndReturns</USR><Declaration>@objc class ParamAndReturns</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Class>]
+@objc public class ParamAndReturns {
+// CHECK: {{.*}}DocCommentAsXML=[<Class file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>ParamAndReturns</Name><USR>s:C14swift_ide_test15ParamAndReturns</USR><Declaration>@objc public class ParamAndReturns</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Class>]
 /// Aaa.  f0.
 ///
 /// - parameter first: Bbb.
 ///
 /// - parameter second: Ccc.  Ddd.
 ///   Eee.
-func f0(first: Int, second: Double) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:second:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f0FTSi6secondSd_T_</USR><Declaration>func f0(first: Int, second: Double)</Declaration><Abstract><Para>Aaa.  f0.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.  Ddd. Eee.</Para></Discussion></Parameter></Parameters></Function>]
+public func f0(first: Int, second: Double) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:second:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f0FTSi6secondSd_T_</USR><Declaration>public func f0(first: Int, second: Double)</Declaration><Abstract><Para>Aaa.  f0.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.  Ddd. Eee.</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 
@@ -217,8 +217,8 @@ func f0(first: Int, second: Double) {}
 ///
 /// - returns: Ccc.
 ///   Ddd.
-func f1(first: Int) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f1FSiT_</USR><Declaration>func f1(first: Int)</Declaration><Abstract><Para>Aaa.  f1.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>Ccc. Ddd.</Para></ResultDiscussion></Function>]
+public func f1(first: Int) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1(_:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f1FSiT_</USR><Declaration>public func f1(first: Int)</Declaration><Abstract><Para>Aaa.  f1.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>Ccc. Ddd.</Para></ResultDiscussion></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 
 /// Aaa.  f2.
@@ -229,8 +229,8 @@ func f1(first: Int) {}
 ///
 /// - parameter third:
 ///   Bbb.
-func f2(first: Int, second: Double, third: Float) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2(_:second:third:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f2FTSi6secondSd5thirdSf_T_</USR><Declaration>func f2(first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f2.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para></Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Aaa.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para> Bbb.</Para></Discussion></Parameter></Parameters></Function>]
+public func f2(first: Int, second: Double, third: Float) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2(_:second:third:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f2FTSi6secondSd5thirdSf_T_</USR><Declaration>public func f2(first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f2.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para></Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Aaa.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para> Bbb.</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -240,8 +240,8 @@ func f2(first: Int, second: Double, third: Float) {}
 /// - parameter first: Bbb.
 /// - parameter second: Ccc.
 /// - parameter third: Ddd.
-func f3(first: Int, second: Double, third: Float) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3(_:second:third:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f3FTSi6secondSd5thirdSf_T_</USR><Declaration>func f3(first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f3.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ddd.</Para></Discussion></Parameter></Parameters></Function>]
+public func f3(first: Int, second: Double, third: Float) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3(_:second:third:)</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f3FTSi6secondSd5thirdSf_T_</USR><Declaration>public func f3(first: Int, second: Double, third: Float)</Declaration><Abstract><Para>Aaa.  f3.</Para></Abstract><Parameters><Parameter><Name>first</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Bbb.</Para></Discussion></Parameter><Parameter><Name>second</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ccc.</Para></Discussion></Parameter><Parameter><Name>third</Name><Direction isExplicit="0">in</Direction><Discussion><Para>Ddd.</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
@@ -254,21 +254,21 @@ func f3(first: Int, second: Double, third: Float) {}
 ///
 /// - returns: Eee.
 ///   Fff.
-func f4() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f4FT_T_</USR><Declaration>func f4()</Declaration><Abstract><Para>Aaa.  f4.</Para></Abstract><ResultDiscussion><Para>Eee. Fff.</Para></ResultDiscussion></Function>]
+public func f4() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>s:FC14swift_ide_test15ParamAndReturns2f4FT_T_</USR><Declaration>public func f4()</Declaration><Abstract><Para>Aaa.  f4.</Para></Abstract><ResultDiscussion><Para>Eee. Fff.</Para></ResultDiscussion></Function>]
 }
 
-@objc class OrderedList {
+@objc public class OrderedList {
 // CHECK: {{.*}}DocCommentAsXML=none
 /// 1. Aaa.
 ///
 /// 2. Bbb.
 ///    Ccc.
-func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test11OrderedList2f0FT_T_</USR><Declaration>func f0()</Declaration><Discussion><List-Number><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Number></Discussion></Function>]
+public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test11OrderedList2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><List-Number><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Number></Discussion></Function>]
 }
 
-@objc class ParameterOutline{
+@objc public class ParameterOutline{
 // CHECK: {{.*}}DocCommentAsXML=none
 /// - Parameters:
 ///   - x: A number
@@ -276,14 +276,14 @@ func f0() {}
 ///
 /// - PARAMETERS:
 ///   - z: A number
-func f0(x: Int, y: Int, z: Int) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>s:FC14swift_ide_test16ParameterOutline2f0FTSi1ySi1zSi_T_</USR><Declaration>func f0(x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
+public func f0(x: Int, y: Int, z: Int) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>s:FC14swift_ide_test16ParameterOutline2f0FTSi1ySi1zSi_T_</USR><Declaration>public func f0(x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 }
 
-@objc class ParameterOutlineMiddle {
+@objc public class ParameterOutlineMiddle {
 // CHECK: {{.*}}DocCommentAsXML=none
 /// - This line should remain.
 /// - Parameters:
@@ -291,14 +291,14 @@ func f0(x: Int, y: Int, z: Int) {}
 ///   - y: A number
 /// - This line should also remain.
 /// - parameter z: A number
-func f0(x: Int, y: Int, z: Int) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>s:FC14swift_ide_test22ParameterOutlineMiddle2f0FTSi1ySi1zSi_T_</USR><Declaration>func f0(x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><Discussion><List-Bullet><Item><Para>This line should remain.</Para></Item><Item><Para>This line should also remain.</Para></Item></List-Bullet></Discussion></Function>]
+public func f0(x: Int, y: Int, z: Int) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:z:)</Name><USR>s:FC14swift_ide_test22ParameterOutlineMiddle2f0FTSi1ySi1zSi_T_</USR><Declaration>public func f0(x: Int, y: Int, z: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>y</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter><Parameter><Name>z</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters><Discussion><List-Bullet><Item><Para>This line should remain.</Para></Item><Item><Para>This line should also remain.</Para></Item></List-Bullet></Discussion></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 }
 
-@objc class ReferenceLink {
+@objc public class ReferenceLink {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// This is [a reference link] [1].
   ///
@@ -306,25 +306,25 @@ func f0(x: Int, y: Int, z: Int) {}
 }
 
 
-@objc class Returns {
+@objc public class Returns {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// - returns: A number
-  func f0() -> Int {
+  public func f0() -> Int {
     return 0
   }
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test7Returns2f0FT_Si</USR><Declaration>func f0() -&gt; Int</Declaration><ResultDiscussion><Para>A number</Para></ResultDiscussion></Function>]
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test7Returns2f0FT_Si</USR><Declaration>public func f0() -&gt; Int</Declaration><ResultDiscussion><Para>A number</Para></ResultDiscussion></Function>]
 }
 
-@objc class SeparateParameters {
+@objc public class SeparateParameters {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// - Parameter x: A number
-  func f0(x: Int, y: Int) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:)</Name><USR>s:FC14swift_ide_test18SeparateParameters2f0FTSi1ySi_T_</USR><Declaration>func f0(x: Int, y: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
+  public func f0(x: Int, y: Int) {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0(_:y:)</Name><USR>s:FC14swift_ide_test18SeparateParameters2f0FTSi1ySi_T_</USR><Declaration>public func f0(x: Int, y: Int)</Declaration><Parameters><Parameter><Name>x</Name><Direction isExplicit="0">in</Direction><Discussion><Para>A number</Para></Discussion></Parameter></Parameters></Function>]
 // CHECK: {{.*}}DocCommentAsXML=none
 // CHECK: {{.*}}DocCommentAsXML=none
 }
 
-@objc class SetextHeaders {
+@objc public class SetextHeaders {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// # LEVEL ONE
   ///
@@ -337,19 +337,19 @@ func f0(x: Int, y: Int, z: Int) {}
   /// ##### LEVEL FIVE
   ///
   /// ##### LEVEL SIX
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13SetextHeaders2f0FT_T_</USR><Declaration>func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML><rawHTML><![CDATA[<h3>]]></rawHTML>LEVEL THREE<rawHTML><![CDATA[</h3>]]></rawHTML><rawHTML><![CDATA[<h4>]]></rawHTML>LEVEL FOUR<rawHTML><![CDATA[</h4>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL FIVE<rawHTML><![CDATA[</h5>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL SIX<rawHTML><![CDATA[</h5>]]></rawHTML></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13SetextHeaders2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML><rawHTML><![CDATA[<h3>]]></rawHTML>LEVEL THREE<rawHTML><![CDATA[</h3>]]></rawHTML><rawHTML><![CDATA[<h4>]]></rawHTML>LEVEL FOUR<rawHTML><![CDATA[</h4>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL FIVE<rawHTML><![CDATA[</h5>]]></rawHTML><rawHTML><![CDATA[<h5>]]></rawHTML>LEVEL SIX<rawHTML><![CDATA[</h5>]]></rawHTML></Discussion></Function>]
 }
 
-@objc class StrongEmphasis {
+@objc public class StrongEmphasis {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// Aaa **bbb** ccc.
   /// Aaa __bbb__ ccc.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test14StrongEmphasis2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Aaa <bold>bbb</bold> ccc. Aaa <bold>bbb</bold> ccc.</Para></Abstract></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test14StrongEmphasis2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Aaa <bold>bbb</bold> ccc. Aaa <bold>bbb</bold> ccc.</Para></Abstract></Function>]
 }
 
-@objc class UnorderedList {
+@objc public class UnorderedList {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// * Aaa.
   ///
@@ -359,11 +359,11 @@ func f0(x: Int, y: Int, z: Int) {}
   /// - Ddd.
   /// - Eee.
   ///   - Fff.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13UnorderedList2f0FT_T_</USR><Declaration>func f0()</Declaration><Discussion><List-Bullet><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Bullet><List-Bullet><Item><Para>Ddd.</Para></Item><Item><Para>Eee.</Para><List-Bullet><Item><Para>Fff.</Para></Item></List-Bullet></Item></List-Bullet></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test13UnorderedList2f0FT_T_</USR><Declaration>public func f0()</Declaration><Discussion><List-Bullet><Item><Para>Aaa.</Para></Item><Item><Para>Bbb. Ccc.</Para></Item></List-Bullet><List-Bullet><Item><Para>Ddd.</Para></Item><Item><Para>Eee.</Para><List-Bullet><Item><Para>Fff.</Para></Item></List-Bullet></Item></List-Bullet></Discussion></Function>]
 }
 
-@objc class IndentedBlockComment {
+@objc public class IndentedBlockComment {
 // CHECK: {{.*}}DocCommentAsXML=none
   /**
       Brief.
@@ -377,8 +377,8 @@ func f0(x: Int, y: Int, z: Int) {}
           // var y = 2
           var z = 3
   */
-  func f1() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f1FT_T_</USR><Declaration>func f1()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+  public func f1() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f1()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f1FT_T_</USR><Declaration>public func f1()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
   /**
                         Hugely indented brief.
 
@@ -391,19 +391,19 @@ func f0(x: Int, y: Int, z: Int) {}
                             // var y = 2
                             var z = 3
   */
-  func f2() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f2FT_T_</USR><Declaration>func f2()</Declaration><Abstract><Para>Hugely indented brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+  public func f2() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f2()</Name><USR>s:FC14swift_ide_test20IndentedBlockComment2f2FT_T_</USR><Declaration>public func f2()</Declaration><Abstract><Para>Hugely indented brief.</Para></Abstract><Discussion><Para>First paragraph line. Second paragraph line.</Para><Para>Now for a code sample:</Para><CodeListing language="swift"><zCodeLineNumbered><![CDATA[var x = 1]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// var y = 2]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var z = 3]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
 }
 
-@objc class MultiLineBrief {
+@objc public class MultiLineBrief {
 // CHECK: {{.*}}DocCommentAsXML=none
 
   /// Brief first line.
   /// Brief after softbreak.
   ///
   /// Some paragraph text.
-  func f0() {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test14MultiLineBrief2f0FT_T_</USR><Declaration>func f0()</Declaration><Abstract><Para>Brief first line. Brief after softbreak.</Para></Abstract><Discussion><Para>Some paragraph text.</Para></Discussion></Function>]
+  public func f0() {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>s:FC14swift_ide_test14MultiLineBrief2f0FT_T_</USR><Declaration>public func f0()</Declaration><Abstract><Para>Brief first line. Brief after softbreak.</Para></Abstract><Discussion><Para>Some paragraph text.</Para></Discussion></Function>]
 }
 
 /// Brief.
@@ -411,8 +411,8 @@ func f0(x: Int, y: Int, z: Int) {}
 /// ```
 /// thisIsASwiftCodeExample()
 /// ```
-func codeListingWithDefaultLanguage() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}} line="{{.*}}" column="{{.*}}"><Name>codeListingWithDefaultLanguage()</Name><USR>s:F14swift_ide_test30codeListingWithDefaultLanguageFT_T_</USR><Declaration>func codeListingWithDefaultLanguage()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[thisIsASwiftCodeExample()]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>] CommentXMLValid
+public func codeListingWithDefaultLanguage() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}} line="{{.*}}" column="{{.*}}"><Name>codeListingWithDefaultLanguage()</Name><USR>s:F14swift_ide_test30codeListingWithDefaultLanguageFT_T_</USR><Declaration>public func codeListingWithDefaultLanguage()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><CodeListing language="swift"><zCodeLineNumbered><![CDATA[thisIsASwiftCodeExample()]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>] CommentXMLValid
 
 
 /// Brief.
@@ -420,5 +420,5 @@ func codeListingWithDefaultLanguage() {}
 /// ```c++
 /// Something::Something::create();
 /// ```
-func codeListingWithOtherLanguage() {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>codeListingWithOtherLanguage()</Name><USR>s:F14swift_ide_test28codeListingWithOtherLanguageFT_T_</USR><Declaration>func codeListingWithOtherLanguage()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><CodeListing language="c++"><zCodeLineNumbered><![CDATA[Something::Something::create();]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+public func codeListingWithOtherLanguage() {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>codeListingWithOtherLanguage()</Name><USR>s:F14swift_ide_test28codeListingWithOtherLanguageFT_T_</USR><Declaration>public func codeListingWithOtherLanguage()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><CodeListing language="c++"><zCodeLineNumbered><![CDATA[Something::Something::create();]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -13,7 +13,7 @@
 
 /// What a nightmare!
 @_cdecl("block_nightmare")
-func block_nightmare(x: @convention(block) Int -> Float)
+public func block_nightmare(x: @convention(block) Int -> Float)
   -> @convention(block) CChar -> Double { return { _ in 0 } }
 
 // CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y);

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -78,7 +78,7 @@ import Foundation
 // CHECK-NEXT: };
 
 /// Foo: A feer, a female feer.
-@objc enum FooComments: Int {
+@objc public enum FooComments: Int {
   /// Zim: A zeer, a female zeer.
   case Zim
   case Zang, Zung

--- a/test/Serialization/comments-framework.swift
+++ b/test/Serialization/comments-framework.swift
@@ -10,19 +10,19 @@
 // XFAIL: linux
 
 /// first_decl_class_1 Aaa.
-class first_decl_class_1 {
+public class first_decl_class_1 {
 
   /// decl_func_1 Aaa.
-  func decl_func_1() {}
+  public func decl_func_1() {}
 
   /**
    * decl_func_3 Aaa.
    */
-  func decl_func_2() {}
+  public func decl_func_2() {}
 
   /// decl_func_3 Aaa.
   /** Bbb. */
-  func decl_func_3() {}
+  public func decl_func_3() {}
 }
 
 // CHECK: Class/first_decl_class_1 RawComment=[/// first_decl_class_1 Aaa.\n]

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -1,0 +1,55 @@
+// Test the case when we compile normally
+//
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %s
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t > %t.normal.txt
+// RUN: FileCheck %s -check-prefix=NORMAL < %t.normal.txt
+// RUN: FileCheck %s -check-prefix=NORMAL-NEGATIVE < %t.normal.txt
+
+// Test the case when we compile with -enable-testing
+//
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend -enable-testing -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc %s
+// RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t > %t.testing.txt
+// RUN: FileCheck %s -check-prefix=TESTING < %t.testing.txt
+// RUN: FileCheck %s -check-prefix=TESTING-NEGATIVE < %t.testing.txt
+
+/// PublicClass Documentation
+public class PublicClass {
+  /// Public Function Documentation
+  public func f_public() { }
+  /// Internal Function Documentation NotForNormal
+  internal func f_internal() { }
+  /// Private Function Documentation NotForNormal NotForTesting
+  private func f_private() { }
+}
+
+/// InternalClass Documentation NotForNormal
+internal class InternalClass {
+  /// Internal Function Documentation NotForNormal
+  internal func f_internal() { }
+  /// Private Function Documentation NotForNormal NotForTesting
+  private func f_private() { }
+}
+
+/// PrivateClass Documentation NotForNormal NotForTesting
+private class PrivateClass {
+  /// Private Function Documentation NotForNormal NotForTesting
+  private func f_private() { }
+}
+
+// NORMAL-NEGATIVE-NOT: NotForNormal
+// NORMAL-NEGATIVE-NOT: NotForTesting
+// NORMAL: PublicClass Documentation
+// NORMAL: Public Function Documentation
+
+// TESTING-NEGATIVE-NOT: NotForTesting
+// TESTING: InternalClass Documentation
+// TESTING: Internal Function Documentation
+// TESTING: PublicClass Documentation
+// TESTING: Public Function Documentation
+// TESTING: Internal Function Documentation
+
+

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -23,26 +23,26 @@
 // BCANALYZER-NOT: UnknownCode
 
 /// first_decl_generic_class_1 Aaa.
-class first_decl_generic_class_1<T> {
+public class first_decl_generic_class_1<T> {
   /// deinit of first_decl_generic_class_1 Aaa.
   deinit {
   }
 }
 
 /// first_decl_class_1 Aaa.
-class first_decl_class_1 {
+public class first_decl_class_1 {
 
   /// decl_func_1 Aaa.
-  func decl_func_1() {}
+  public func decl_func_1() {}
 
   /**
    * decl_func_3 Aaa.
    */
-  func decl_func_2() {}
+  public func decl_func_2() {}
 
   /// decl_func_3 Aaa.
   /** Bbb. */
-  func decl_func_3() {}
+  public func decl_func_3() {}
 }
 
 /// Comment for bar1


### PR DESCRIPTION
Let's say I am a good citizen and document my private symbols:

```
/** My TOP SECRET DOCUMENTATION */
private class Foo {
}
```

When I go to distribute the compiled binary, I find out my private
documentation is distributed as well:

```
$ swiftc test.swift -emit-module -module-name "test"
$ strings test.swiftdoc
My TOP SECRET DOCUMENTATION
/** My TOP SECRET DOCUMENTATION */
```

If a client can't use a symbol (e.g. it's private [or internal and not
-enable-testing]) don't emit the documentation for a symbol in the
swiftdoc.

Fixes: SR-762, rdar://21453624

The test coverage implements this truth table:

| visibility | -enable-testing | documentation? |
| --- | --- | --- |
| private | no | ❌ |
| internal | no | ❌ |
| public | no | ✅ |
| private | yes | ❌ |
| internal | yes | ✅ |
| public | yes | ✅ |

Modified the existing comments test coverage to expect non-public
documentation not to be emitted.
