### PR TITLE
Remove @warn_unused_result from |=, &= and ^=

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -302,17 +302,14 @@ public protocol BitwiseOperationsType {
   static var allZeros: Self { get }
 }
 
-@warn_unused_result
 public func |= <T : BitwiseOperationsType>(inout lhs: T, rhs: T) {
   lhs = lhs | rhs
 }
 
-@warn_unused_result
 public func &= <T : BitwiseOperationsType>(inout lhs: T, rhs: T) {
   lhs = lhs & rhs
 }
 
-@warn_unused_result
 public func ^= <T : BitwiseOperationsType>(inout lhs: T, rhs: T) {
   lhs = lhs ^ rhs
 }


### PR DESCRIPTION
These functions modify their left operand in place and return nothing but `Void`.
