### PR TITLE
[CMakeLists] Remove unused DARWIN_ICU_INCLUDE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,6 @@ option(SWIFT_RUNTIME_CRASH_REPORTER_CLIENT
 set(SWIFT_DARWIN_XCRUN_TOOLCHAIN "XcodeDefault" CACHE STRING
     "The name of the toolchain to pass to 'xcrun'")
 
-set(SWIFT_DARWIN_ICU_INCLUDE_PATH "" CACHE STRING
-    "Path to the directory where the ICU headers are located")
-
 set(SWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR "@rpath" CACHE STRING
     "The directory of the install_name for standard library dylibs")
 


### PR DESCRIPTION
This CMake variable was introduced in f6224bd3f, but its only usage was subsequently removed in d9bbb6caf. Remove the obsolete variable to avoid confusion.
