### PR TITLE
Run collection unit tests on array types

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -98,7 +98,8 @@ extension TestSuite {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     outOfBoundsSubscriptOffset: Int = 1,
-    withUnsafeMutableBufferPointerIsSupported: Bool
+    withUnsafeMutableBufferPointerIsSupported: Bool,
+    isFixedLengthCollection: Bool
   ) {
     var testNamePrefix = testNamePrefix
 
@@ -211,6 +212,39 @@ self.test("\(testNamePrefix).subscript(_: Range)/Set/semantics") {
         resiliencyChecks: .none) {
         extractValue($0).value == extractValue($1).value
       }
+    }
+  }
+}
+
+if isFixedLengthCollection {
+  self.test("\(testNamePrefix).subscript(_: Range)/Set/LargerRange") {
+    var c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
+    let newElements = makeWrappedCollection([ 91010, 92020, 93030, 94040 ].map(OpaqueValue.init))
+  
+    expectCrashLater()
+    c[c.indices] = newElements[newElements.indices]
+  }
+
+  self.test("\(testNamePrefix).subscript(_: Range)/Set/SmallerRange") {
+    var c = makeWrappedCollection([ 1010, 2020, 3030 ].map(OpaqueValue.init))
+    let newElements = makeWrappedCollection([ 91010, 92020 ].map(OpaqueValue.init))
+  
+    expectCrashLater()
+    c[c.indices] = newElements[newElements.indices]
+  }
+} else {
+  self.test("\(testNamePrefix).subscript(_: Range)/Set/DifferentlySizedRange") {
+    for test in replaceRangeTests {
+      var c = makeWrappedCollection(test.collection)
+      let newElements = makeWrappedCollection(test.newElements)
+      let rangeToReplace = test.rangeSelection.rangeOf(c)
+
+      c[rangeToReplace] = newElements[newElements.indices]
+            
+      expectEqualSequence(
+        test.expected,
+        c.map(extractValue).map { $0.value },
+        stackTrace: SourceLocStack().with(test.loc))
     }
   }
 }
@@ -403,7 +437,8 @@ self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementI
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     outOfBoundsSubscriptOffset: Int = 1,
-    withUnsafeMutableBufferPointerIsSupported: Bool
+    withUnsafeMutableBufferPointerIsSupported: Bool,
+    isFixedLengthCollection: Bool
   ) {
     var testNamePrefix = testNamePrefix
 
@@ -428,7 +463,8 @@ self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementI
       outOfBoundsIndexOffset: outOfBoundsIndexOffset,
       outOfBoundsSubscriptOffset: outOfBoundsSubscriptOffset,
       withUnsafeMutableBufferPointerIsSupported:
-        withUnsafeMutableBufferPointerIsSupported)
+        withUnsafeMutableBufferPointerIsSupported,
+      isFixedLengthCollection: isFixedLengthCollection)
 
     addBidirectionalCollectionTests(
       testNamePrefix,
@@ -521,7 +557,8 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .None {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     outOfBoundsSubscriptOffset: Int = 1,
-    withUnsafeMutableBufferPointerIsSupported: Bool
+    withUnsafeMutableBufferPointerIsSupported: Bool,
+    isFixedLengthCollection: Bool
   ) {
     var testNamePrefix = testNamePrefix
 
@@ -546,7 +583,8 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .None {
       outOfBoundsIndexOffset: outOfBoundsIndexOffset,
       outOfBoundsSubscriptOffset: outOfBoundsSubscriptOffset,
       withUnsafeMutableBufferPointerIsSupported:
-        withUnsafeMutableBufferPointerIsSupported)
+        withUnsafeMutableBufferPointerIsSupported,
+      isFixedLengthCollection: isFixedLengthCollection)
 
     addRandomAccessCollectionTests(
       testNamePrefix,

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -332,6 +332,44 @@ let appendContentsOfTests: [AppendContentsOfTest] = [
     expected: [1010, 2020, 3030, 4040, 5050, 6060, 7070, 8080]),
 ]
 
+let replaceRangeTests: [ReplaceRangeTest] = [
+  ReplaceRangeTest(
+    collection: [],
+    newElements: [],
+    rangeSelection: .EmptyRange,
+    expected: []),
+
+  ReplaceRangeTest(
+    collection: [],
+    newElements: [1010, 2020, 3030],
+    rangeSelection: .EmptyRange,
+    expected: [1010, 2020, 3030]),
+
+  ReplaceRangeTest(
+    collection: [4040],
+    newElements: [1010, 2020, 3030],
+    rangeSelection: .LeftEdge,
+    expected: [1010, 2020, 3030, 4040]),
+
+  ReplaceRangeTest(
+    collection: [1010],
+    newElements: [2020, 3030, 4040],
+    rangeSelection: .RightEdge,
+    expected: [1010, 2020, 3030, 4040]),
+
+  ReplaceRangeTest(
+    collection: [1010, 2020, 3030],
+    newElements: [4040],
+    rangeSelection: .RightEdge,
+    expected: [1010, 2020, 3030, 4040]),
+
+  ReplaceRangeTest(
+    collection: [1010, 2020, 3030, 4040, 5050],
+    newElements: [9090],
+    rangeSelection: .Middle,
+    expected: [1010, 9090, 5050]),
+]
+
 extension TestSuite {
   /// Adds a set of tests for `RangeReplaceableCollectionType`.
   ///
@@ -416,45 +454,7 @@ self.test("\(testNamePrefix).init(SequenceType)/semantics") {
 //===----------------------------------------------------------------------===//
 
 self.test("\(testNamePrefix).replaceRange()/semantics") {
-  let tests: [ReplaceRangeTest] = [
-    ReplaceRangeTest(
-      collection: [],
-      newElements: [],
-      rangeSelection: .EmptyRange,
-      expected: []),
-
-    ReplaceRangeTest(
-      collection: [],
-      newElements: [1010, 2020, 3030],
-      rangeSelection: .EmptyRange,
-      expected: [1010, 2020, 3030]),
-
-    ReplaceRangeTest(
-      collection: [4040],
-      newElements: [1010, 2020, 3030],
-      rangeSelection: .LeftEdge,
-      expected: [1010, 2020, 3030, 4040]),
-
-    ReplaceRangeTest(
-      collection: [1010],
-      newElements: [2020, 3030, 4040],
-      rangeSelection: .RightEdge,
-      expected: [1010, 2020, 3030, 4040]),
-
-    ReplaceRangeTest(
-      collection: [1010, 2020, 3030],
-      newElements: [4040],
-      rangeSelection: .RightEdge,
-      expected: [1010, 2020, 3030, 4040]),
-
-    ReplaceRangeTest(
-      collection: [1010, 2020, 3030, 4040, 5050],
-      newElements: [9090],
-      rangeSelection: .Middle,
-      expected: [1010, 9090, 5050]),
-  ]
-
-  for test in tests {
+  for test in replaceRangeTests {
     var c = makeWrappedCollection(test.collection)
     let rangeToReplace = test.rangeSelection.rangeOf(c)
     let newElements =

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -741,10 +741,10 @@ internal func _writeBackMutableSlice<
 
   _precondition(
     selfElementIndex == selfElementsEndIndex,
-    "Cannot replace a slice of a MutableCollectionType with a slice of a larger size")
+    "Cannot replace a slice of a MutableCollectionType with a slice of a smaller size")
   _precondition(
     newElementIndex == newElementsEndIndex,
-    "Cannot replace a slice of a MutableCollectionType with a slice of a smaller size")
+    "Cannot replace a slice of a MutableCollectionType with a slice of a larger size")
 }
 
 /// Returns the range of `x`'s valid index values.

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -1770,5 +1770,102 @@ ArrayTestSuite.tearDown {
   }
 }
 
+//===----------------------------------------------------------------------===//
+// MutableCollectionType and RangeReplaceableCollectionType conformance tests.
+//===----------------------------------------------------------------------===//
+
+% for array_type in all_array_types:
+%     collection_or_slice = 'Slice' if 'Slice' in array_type else 'Collection'
+
+do {
+  // `Array`, `ArraySlice`, and `ContiguousArrayBuffer` have no expectation of
+  // failure for advancing their indexes "out of bounds", because they are just
+  // `Int`.
+  var resiliencyChecks = CollectionMisuseResiliencyChecks.all
+  resiliencyChecks.creatingOutOfBoundsIndicesBehavior = .None
+  
+  // Test MutableCollectionType conformance with value type elements.
+  ArrayTestSuite.addRandomAccessMutableCollectionTests(
+    makeCollection: { (elements: [OpaqueValue<Int>]) in
+      return ${array_type}(elements)
+    },
+    wrapValue: identity,
+    extractValue: identity,
+    makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) in
+      return ${array_type}(elements)
+    },
+    wrapValueIntoEquatable: identityEq,
+    extractValueFromEquatable: identityEq,
+    makeCollectionOfComparable: { (elements: [MinimalComparableValue]) in
+      return ${array_type}(elements)
+    },
+    wrapValueIntoComparable: identityComp,
+    extractValueFromComparable: identityComp,
+    resiliencyChecks: resiliencyChecks,
+    withUnsafeMutableBufferPointerIsSupported: true,
+    isFixedLengthCollection: false)
+
+
+  // Test MutableCollectionType conformance with reference type elements.
+  ArrayTestSuite.addRandomAccessMutableCollectionTests(
+    makeCollection: { (elements: [LifetimeTracked]) in
+      return ${array_type}(elements)
+    },
+    wrapValue: { (element: OpaqueValue<Int>) in
+      LifetimeTracked(element.value, identity: element.identity)
+    },
+    extractValue: { (element: LifetimeTracked) in
+      OpaqueValue(element.value, identity: element.identity)
+    },
+    makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) in
+      // FIXME: use LifetimeTracked.
+      return ${array_type}(elements)
+    },
+    wrapValueIntoEquatable: identityEq,
+    extractValueFromEquatable: identityEq,
+    makeCollectionOfComparable: { (elements: [MinimalComparableValue]) in
+      // FIXME: use LifetimeTracked.
+      return ${array_type}(elements)
+    },
+    wrapValueIntoComparable: identityComp,
+    extractValueFromComparable: identityComp,
+    resiliencyChecks: resiliencyChecks,
+    withUnsafeMutableBufferPointerIsSupported: true,
+    isFixedLengthCollection: false)
+
+
+  // Test RangeReplaceableCollectionType conformance with value type elements.
+  ArrayTestSuite.addRandomAccessRangeReplaceable${collection_or_slice}Tests(
+    makeCollection: { (elements: [OpaqueValue<Int>]) in
+      return ${array_type}(elements)
+    },
+    wrapValue: identity,
+    extractValue: identity,
+    makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) in
+      return ${array_type}(elements)
+    },
+    wrapValueIntoEquatable: identityEq,
+    extractValueFromEquatable: identityEq,
+    resiliencyChecks: resiliencyChecks)
+
+
+  // Test RangeReplaceableCollectionType conformance with reference type elements.
+  ArrayTestSuite.addRandomAccessRangeReplaceable${collection_or_slice}Tests(
+    makeCollection: { (elements: [LifetimeTracked]) in
+      return ${array_type}(elements)
+    },
+    wrapValue: { (element: OpaqueValue<Int>) in LifetimeTracked(element.value) },
+    extractValue: { (element: LifetimeTracked) in OpaqueValue(element.value) },
+    makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) in
+      // FIXME: use LifetimeTracked.
+      return ${array_type}(elements)
+    },
+    wrapValueIntoEquatable: identityEq,
+    extractValueFromEquatable: identityEq,
+    resiliencyChecks: resiliencyChecks)
+}
+  
+% end
+
 runAllTests()
 

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -768,7 +768,8 @@ do {
     extractValueFromComparable: identityComp,
     checksAdded: checksAdded,
     resiliencyChecks: resiliencyChecks,
-    withUnsafeMutableBufferPointerIsSupported: false)
+    withUnsafeMutableBufferPointerIsSupported: false,
+    isFixedLengthCollection: true)
 %       end
 }
 
@@ -822,7 +823,8 @@ do {
     extractValueFromComparable: identityComp,
     checksAdded: checksAdded,
     resiliencyChecks: resiliencyChecks,
-    withUnsafeMutableBufferPointerIsSupported: false)
+    withUnsafeMutableBufferPointerIsSupported: false,
+    isFixedLengthCollection: true)
 %       end
 }
 

--- a/validation-test/stdlib/RangeReplaceable.swift.gyb
+++ b/validation-test/stdlib/RangeReplaceable.swift.gyb
@@ -114,35 +114,21 @@ func identityEq(element: MinimalEquatableValue) -> MinimalEquatableValue {
 %   ('Defaulted{}RangeReplaceableSlice'.format(traversal), traversal)
 %     for traversal in traversals
 % ]
-% other_array_types = [ 'Array', 'ArraySlice', 'ContiguousArray' ]
-% collections += [(array, 'RandomAccess') for array in other_array_types]
 
 % for Base, traversal in collections:
-%     oob_behavior = '.None' if Base in other_array_types else '.ExpectationFailure' 
 %     collection_or_slice = 'Slice' if 'Slice' in Base else 'Collection'
-if true {
+do {
   var resiliencyChecks = CollectionMisuseResiliencyChecks.all
-  // `Array`, `ArraySlice`, and `ContiguousArrayBuffer` have no expectation of
-  // failure for advancing their indexes "out of bounds", because they are just
-  // `Int`.
-  resiliencyChecks.creatingOutOfBoundsIndicesBehavior = ${oob_behavior}
+  resiliencyChecks.creatingOutOfBoundsIndicesBehavior = .ExpectationFailure
 
   RangeReplaceableTestSuite.add${traversal}RangeReplaceable${collection_or_slice}Tests(
     makeCollection: { (elements: [OpaqueValue<Int>]) in
-%     if Base in other_array_types:
-      return ${Base}(elements)
-%     else:
       return ${Base}(elements: elements)
-%     end
     },
     wrapValue: identity,
     extractValue: identity,
     makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) in
-%     if Base in other_array_types:
-      return ${Base}(elements)
-%     else:
       return ${Base}(elements: elements)
-%     end
     },
     wrapValueIntoEquatable: identityEq,
     extractValueFromEquatable: identityEq,
@@ -150,21 +136,13 @@ if true {
 
   RangeReplaceableTestSuite.add${traversal}RangeReplaceable${collection_or_slice}Tests(
     makeCollection: { (elements: [LifetimeTracked]) in
-%     if Base in other_array_types:
-      return ${Base}(elements)
-%     else:
       return ${Base}(elements: elements)
-%     end
     },
     wrapValue: { (element: OpaqueValue<Int>) in LifetimeTracked(element.value) },
     extractValue: { (element: LifetimeTracked) in OpaqueValue(element.value) },
     makeCollectionOfEquatable: { (elements: [MinimalEquatableValue]) in
       // FIXME: use LifetimeTracked.
-%     if Base in other_array_types:
-      return ${Base}(elements)
-%     else:
       return ${Base}(elements: elements)
-%     end
     },
     wrapValueIntoEquatable: identityEq,
     extractValueFromEquatable: identityEq,

--- a/validation-test/stdlib/Slice/Inputs/slice.gyb
+++ b/validation-test/stdlib/Slice/Inputs/slice.gyb
@@ -74,7 +74,8 @@ do {
     resiliencyChecks: resiliencyChecks,
     outOfBoundsIndexOffset: 6
 % if WrapperType == 'MutableSlice':
-    , withUnsafeMutableBufferPointerIsSupported: false
+    , withUnsafeMutableBufferPointerIsSupported: false,
+    isFixedLengthCollection: true
 % end
     )
 }


### PR DESCRIPTION
Per the discussion on pull request #1349:

Run the collection unit tests on the array types and group their invocation with the RangeReplaceableCollectionType tests run on the array types.

I've added them to `validation-test/stdlib/ArrayNew.swift.gyb` since it's only a small amount of code but let me know if it would make more sense to separate them into a different file.
