### PR TITLE
WIP: [coverage] Added coverage comparison visualization tool

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -210,9 +210,10 @@ if(PYTHONINTERP_FOUND)
         if(SWIFT_ANALYZE_CODE_COVERAGE STREQUAL "MERGED")
           set(command_profdata_merge_start
             COMMAND "${PYTHON_EXECUTABLE}" "${profdata_merge_worker}"
-                -l "${swift_test_results_dir}/profdata_merge.log"
-                start
-                -o "${swift_test_results_dir}")
+              -l "${swift_test_results_dir}/profdata_merge.log"
+              -s "${CMAKE_BINARY_DIR}/bin"
+              start
+              -o "${swift_test_results_dir}")
           set(command_profdata_merge_stop
             COMMAND "${PYTHON_EXECUTABLE}" "${profdata_merge_worker}" stop)
         else()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,6 +7,10 @@ add_subdirectory(sil-extract)
 add_subdirectory(swift-llvm-opt)
 add_subdirectory(swift-reflection-test)
 
+if(SWIFT_ANALYZE_CODE_COVERAGE)
+  add_subdirectory(cov-compare)
+endif()
+
 if(SWIFT_BUILD_SOURCEKIT)
   add_subdirectory(SourceKit)
 endif()

--- a/tools/cov-compare/CMakeLists.txt
+++ b/tools/cov-compare/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_swift_executable(cov-compare
+  ProfdataCompare.cpp
+  HTMLWriter.cpp
+  MarkdownWriter.cpp
+  YAMLWriter.cpp
+  Utils.cpp
+  main.cpp
+  COMPONENT_DEPENDS support object profiledata "option" core)
+
+swift_install_in_component(compiler
+    TARGETS cov-compare
+    RUNTIME DESTINATION "bin")
+

--- a/tools/cov-compare/HTMLWriter.cpp
+++ b/tools/cov-compare/HTMLWriter.cpp
@@ -1,0 +1,254 @@
+//===--------- HTMLWriter.cpp - Tools for comparing llvm profdata ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "HTMLWriter.hpp"
+#include "MarkdownWriter.hpp"
+#include "ProfdataCompare.hpp"
+#include <libgen.h>
+#include <sys/stat.h>
+#include <chrono>
+
+using namespace std;
+using namespace llvm;
+namespace html {
+  /// \returns An HTML-escaped string.
+  string escape(string s) {
+    string result;
+    for (size_t i = 0; i < s.size(); ++i) {
+      string token = s.substr(i,1);
+      if (token == "&")
+        token = "&amp;";
+      else if (token == "<")
+        token = "&lt;";
+      else if (token == "\"")
+        token = "&quot;";
+      else if (token == ">")
+        token = "&gt;";
+      result += token;
+    }
+    return result;
+  }
+  
+  /// \returns A tag around the provided text
+  /// (expects the value to be properly escaped).
+  string tag(string name, string text) {
+    return "<" + name + ">" + text + "</" + name + ">";
+  }
+  
+  /// \returns An anchor tag with the provided destination and text.
+  string a(string dest, string text) {
+    return "<a href='" + dest + "'>" + text + "</a>";
+  }
+  
+  /// \returns Headers of an HTML table, corresponding to the passed-in strings.
+  string headerRow(vector<string> headers) {
+    string final;
+    for (auto &val : headers) {
+      final += tag("th", val);
+    }
+    return tag("tr", final);
+  }
+  
+  /// \returns An HTML table row with the provided strings as td rows inside.
+  string tr(vector<string> data) {
+    string final;
+    for (auto &val : data) {
+      final += tag("td", val);
+    }
+    return tag("tr", final);
+  }
+  
+  /// \returns A span with the provided class, with the provided text inside.
+  string span(string _class, string text) {
+    return "<span class='" + _class + "'>" + text + "</span>";
+  }
+}
+
+namespace covcompare {
+  typedef enum {
+    Bad,
+    Warning,
+    Good
+  } CoverageStatus;
+  
+  /// \returns The class name corresponding to a CoverageStatus.
+  string coverageStatusString(CoverageStatus status) {
+    switch (status) {
+      case Bad:
+        return "bad";
+      case Warning:
+        return "warning";
+      case Good:
+        return "good";
+    }
+  }
+  
+  CoverageStatus statusForDiff(double diff) {
+    bool isSmallDiff = fabs(diff) < 5.0;
+    bool isNegative = diff < 0;
+    if (isNegative) {
+      return isSmallDiff ? Warning : Bad;
+    } else {
+      return Good;
+    }
+  }
+  
+  void HTMLWriter::writeTable(vector<Column> columns, llvm::raw_ostream &os) {
+    os << "<table>";
+    vector<string> headers;
+    for (auto &column : columns) {
+      headers.push_back(column.header);
+    }
+    os << html::headerRow(headers);
+    for (size_t i = 0; i < columns[0].elements.size(); i++) {
+      vector<string> elements;
+      for (auto &column : columns) {
+        elements.push_back(column.elements[i]);
+      }
+      os << html::tr(elements);
+    }
+    os << "</table>";
+  }
+  
+  void HTMLWriter::write(ProfdataCompare &comparer) {
+    sys::fs::create_directories(dirname);
+    writeCSS();
+    writeSummary(comparer);
+    for (auto &comparison : comparer.comparisons) {
+      writeComparisonReport(*comparison);
+    }
+  }
+  
+  void HTMLWriter::writeComparisonReport(FileComparison &comparison) {
+    auto newName = dirname + "/" + comparison.newItem->name + ".html";
+    error_code error;
+    raw_fd_ostream os(newName,
+                      error, sys::fs::F_RW);
+    if (error) exitWithErrorCode(error);
+    wrapHTMLOutput(os, comparison.newItem->name, [this, &comparison, &os] {
+      Column functionCol("Function");
+      Column oldCovCol("Previous Coverage", Column::Alignment::Center);
+      Column newCovCol("Current Coverage", Column::Alignment::Center);
+      Column diffCol("Coverage Difference", Column::Alignment::Center);
+      for (auto &funcComparison : comparison.functionComparisons()) {
+        double newCoverage = funcComparison.newItem->coveragePercentage();
+        string newCovString = formattedDouble(newCoverage);
+        string oldCovString = "N/A";
+        string diffString = "N/A";
+        string _class = "";
+        if (auto func = funcComparison.oldItem) {
+          double oldCoverage = func->coveragePercentage();
+          oldCovString = formattedDouble(oldCoverage);
+          diffString = funcComparison.formattedCoverageDifference();
+          
+          CoverageStatus status =
+            statusForDiff(funcComparison.coverageDifference());
+          _class = coverageStatusString(status);
+        }
+        string symbol = funcComparison.functionName();
+        functionCol.add(html::escape(symbol));
+        oldCovCol.add(oldCovString);
+        newCovCol.add(newCovString);
+        diffCol.add(html::span(_class, diffString));
+      }
+      this->writeTable({ functionCol, oldCovCol, newCovCol, diffCol }, os);
+    });
+  }
+  
+  void HTMLWriter::writeSummary(ProfdataCompare &comparer) {
+    error_code error;
+    raw_fd_ostream os(dirname + "/index.html", error, sys::fs::F_RW);
+    if (error) exitWithErrorCode(error);
+    
+    string oldFn = sys::path::filename(comparer.oldFile);
+    string newFn = sys::path::filename(comparer.newFile);
+    auto title = oldFn + " vs. " + newFn;
+    
+    wrapHTMLOutput(os, title, [this, &comparer, &os] {
+      Column fnCol("Filename");
+      Column prevCol("Previous Coverage", Column::Alignment::Center);
+      Column currCol("Current Coverage", Column::Alignment::Center);
+      Column diffCol("Coverage Difference", Column::Alignment::Center);
+      for (auto &cmp : comparer.comparisons) {
+        
+        string oldPercentage = cmp->oldItem ?
+          formattedDouble(cmp->oldItem->coveragePercentage()) : "N/A";
+        
+        string newPercentage =
+          formattedDouble(cmp->newItem->coveragePercentage());
+        
+        auto fn = html::escape(cmp->newItem->name);
+        CoverageStatus status = statusForDiff(cmp->coverageDifference());
+        string _class = coverageStatusString(status);
+        fnCol.add(html::a(fn + ".html", fn));
+        prevCol.add(oldPercentage);
+        currCol.add(newPercentage);
+        diffCol.add(html::span(_class,
+                        html::escape(cmp->formattedCoverageDifference())));
+      }
+      this->writeTable({ fnCol, prevCol, currCol, diffCol }, os);
+    });
+  }
+  
+  void HTMLWriter::writeCSS() {
+    string css = "body {"
+                 "  font-family: -apple-system, sans-serif;"
+                 "}"
+                 "footer {"
+                 "  padding: 15px;"
+                 "}"
+                 "a {"
+                 "  text-decoration: none;"
+                 "}"
+                 "table, th, td {"
+                 "  padding: 10px;"
+                 "  text-align: left;"
+                 "  border: 1px solid #ddd;"
+                 "  border-collapse: collapse;"
+                 "}"
+                 ".warning {"
+                 "  color: #f9a03f;"
+                 "  font-weight: normal;"
+                 "}"
+                 ".bad {"
+                 "  color: #ba1b1d;"
+                 "  font-weight: bold;"
+                 "}"
+                 ".good {"
+                 "  color: #1cc000;"
+                 "  font-weight: normal;"
+                 "}";
+    error_code error;
+    raw_fd_ostream out(dirname + "/style.css", error, sys::fs::F_RW);
+    if (error) exitWithErrorCode(error);
+    out << css;
+  }
+  
+  void HTMLWriter::wrapHTMLOutput(raw_ostream &out,
+                                  string title,
+                                  HTMLOutputFunction innerGen) {
+    out << "<!DOCTYPE html><html><head>" <<
+           html::tag("title", title) <<
+           "<meta name='viewport'"
+           "content='width=device-width, initial-scale=1'>";
+    out << "<link rel='stylesheet' href='style.css' type='text/css'>";
+    out << "</head><body>";
+    innerGen();
+    
+    auto end = chrono::system_clock::now();
+    auto end_time = chrono::system_clock::to_time_t(end);
+    auto date_str = ctime(&end_time);
+    out << html::tag("footer",
+                     "Generated by cov-compare on " + html::escape(date_str));
+    out << "</body></html>";
+  }
+}

--- a/tools/cov-compare/HTMLWriter.hpp
+++ b/tools/cov-compare/HTMLWriter.hpp
@@ -1,0 +1,73 @@
+//===--------- HTMLWriter.hpp - Tools for comparing llvm profdata ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HTMLWriter_hpp
+#define HTMLWriter_hpp
+
+#include <stdio.h>
+#include "ProfdataCompare.hpp"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/FormattedStream.h"
+
+namespace covcompare {
+    struct Column;
+    
+    /// A typedef for a function that purely executes side effects.
+    typedef std::function<void ()> HTMLOutputFunction;
+    
+    /// A struct that writes a directory of HTML files
+    /// representing a ProfdataCompare object.
+    ///
+    /// The directory structure looks like:
+    ///
+    ///   - main directory:
+    ///     - index.html [a summary of each file and the coverage diff]
+    ///     - file1.cpp.html
+    ///     - file2.cpp.html
+    ///     - ...
+    ///     - fileN.cpp.html
+    struct HTMLWriter {
+        /// The path to the output directory.
+        std::string dirname;
+        
+        /// Writes a basic CSS file that has CSS classes
+        /// for good, okay, and bad coverage.
+        void writeCSS();
+        
+        /// Writes a detailed list of functions within a comparison,
+        /// and their current coverage status.
+        void writeComparisonReport(FileComparison &comparison);
+        
+        /// Writes a list of \a Columns as an HTML table.
+        void writeTable(std::vector<Column> columns, llvm::raw_ostream &os);
+        
+        /// Writes a summary of each file with a link to the in-depth file page,
+        /// and a simple diff of the coverage.
+        void writeSummary(ProfdataCompare &comparer);
+        
+        /// Writes the skeleton of an HTML file, and calls the callback that
+        /// is intended to output the body of the HTML.
+        void wrapHTMLOutput(llvm::raw_ostream &os,
+                            std::string title,
+                            HTMLOutputFunction innerGen);
+    public:
+        /// Writes a full directory corresponding to the
+        /// provided ProfdataCompare object.
+        void write(ProfdataCompare &comparer);
+        
+        HTMLWriter(std::string dirname)
+        : dirname(dirname) {}
+    private:
+    };
+}
+
+#endif /* HTMLWriter_hpp */

--- a/tools/cov-compare/MarkdownWriter.cpp
+++ b/tools/cov-compare/MarkdownWriter.cpp
@@ -1,0 +1,49 @@
+//===------- MarkdownWriter.cpp - Tools for analyzing llvm profdata -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "MarkdownWriter.hpp"
+
+using namespace llvm;
+using namespace std;
+namespace covcompare {
+  void MarkdownWriter::write(llvm::raw_ostream &os) {
+    os << "| ";
+    for (auto &column : columns) {
+      os << column.header << " | ";
+    }
+    os << "\n|";
+    for (auto &column : columns) {
+      auto leftMark = "-";
+      auto rightMark = "-";
+      switch (column.alignment) {
+        case Column::Left:
+          leftMark = ":";
+          break;
+        case Column::Right:
+          rightMark = ":";
+          break;
+        case Column::Center:
+          leftMark = ":";
+          rightMark = ":";
+          break;
+      }
+      os << leftMark << std::string(column.header.size(), '-') << rightMark
+         << "|";
+    }
+    for (size_t i = 0; i < columns[0].elements.size(); i++) {
+      os << "\n| ";
+      for (auto &column : columns) {
+        os << column.elements[i] << " | ";
+      }
+    }
+  }
+}

--- a/tools/cov-compare/MarkdownWriter.hpp
+++ b/tools/cov-compare/MarkdownWriter.hpp
@@ -1,0 +1,64 @@
+//===------- MarkdownWriter.hpp - Tools for analyzing llvm profdata -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MarkdownWriter_hpp
+#define MarkdownWriter_hpp
+
+#include <stdio.h>
+#include "ProfdataCompare.hpp"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/FormattedStream.h"
+
+namespace covcompare {
+  /// A struct that holds a 'column' of information, as represented in a table.
+  struct Column {
+    /// The alignment of the column,
+    /// respected if possible in the output medium.
+    typedef enum {
+      Left,
+      Center,
+      Right
+    } Alignment;
+    
+    /// The 'header' at the top of the column in a table.
+    std::string header;
+    
+    /// The individual elements per row of this column.
+    std::vector<std::string> elements;
+    
+    /// The alignment of the values in this column.
+    Alignment alignment;
+    
+    /// A shortcut to add a value to this column.
+    void add(std::string val) {
+      elements.push_back(val);
+    }
+    
+    Column(std::string header, Alignment alignment = Left,
+           std::vector<std::string> elements = {})
+    : header(header), elements(elements), alignment(alignment) {}
+  };
+  
+  /// A class that wraps multiple columns and outputs them as a Markdown table.
+  class MarkdownWriter {
+  public:
+    /// The columns this writer will write.
+    std::vector<Column> columns;
+    
+    /// Writes this table to a stream.
+    void write(llvm::raw_ostream &os);
+    
+    MarkdownWriter(std::vector<Column> columns) : columns(columns) {}
+  };
+}
+
+#endif /* MarkdownWriter_hpp */

--- a/tools/cov-compare/ProfdataCompare.cpp
+++ b/tools/cov-compare/ProfdataCompare.cpp
@@ -1,0 +1,228 @@
+//===------ ProfdataCompare.cpp - Tools for comparing llvm profdata -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ProfdataCompare.hpp"
+#include "llvm/Support/CommandLine.h"
+#include "HTMLWriter.hpp"
+#include "MarkdownWriter.hpp"
+#include "YAMLWriter.hpp"
+
+using namespace std;
+using namespace llvm;
+using namespace coverage;
+
+namespace covcompare {
+  
+  double File::coveragePercentage() {
+    if (functions.empty()) return 100.0;
+    double totalPercentagePoints = 0;
+    for (auto &func : functions) {
+      totalPercentagePoints += func.coveragePercentage();
+    }
+    return (totalPercentagePoints / (double)functions.size());
+  }
+  
+  vector<FunctionComparison> FileComparison::functionComparisons() {
+    vector<FunctionComparison> funcComparisons;
+    for (auto &function : newItem->functions) {
+      shared_ptr<Function> oldFunction;
+      if (oldItem) {
+        auto pair = oldItem->functionMap()->find(function.name);
+        if (pair != oldItem->functionMap()->end()) {
+          oldFunction = pair->second;
+        }
+      }
+      auto func = FunctionComparison(oldFunction,
+               make_shared<Function>(function));
+      funcComparisons.push_back(func);
+    }
+    return funcComparisons;
+  }
+  
+  unique_ptr<CoverageMapping> CoverageFilePair::coverageMapping() {
+    auto map = CoverageMapping::load(binary, filename);
+    
+    if (auto error = map.getError()) {
+      exitWithErrorCode(error);
+    }
+    
+    return move(map.get());
+  }
+  
+  shared_ptr<map<string, shared_ptr<Function>>> File::functionMap() {
+    if (_functionMap) return _functionMap;
+    _functionMap = make_shared<map<string, shared_ptr<Function>>>();
+    for (auto &function : functions) {
+      (*_functionMap)[function.name] = make_shared<Function>(function);
+    }
+    return _functionMap;
+  }
+
+  map<string, shared_ptr<File>> CoverageFilePair::fileMap() {
+    auto mapping = coverageMapping();
+    map<string, shared_ptr<File>> files;
+    for (auto &filename : mapping->getUniqueSourceFiles()) {
+      vector<Function> functions;
+      for (auto &func : mapping->getCoveredFunctions(filename)) {
+        functions.push_back(func);
+      }
+      files[filename] = make_shared<File>(filename, functions);
+    }
+    return files;
+  }
+  
+  map<string, File> fileMapFromYAML(string yamlFile) {
+    auto buffer = MemoryBuffer::getFile(yamlFile);
+    if (auto error = buffer.getError()) {
+      exitWithErrorCode(error);
+    }
+    yaml::Input yin(buffer.get()->getBuffer());
+    vector<File> files;
+    yin >> files;
+    if (auto error = yin.error()) {
+      exitWithErrorCode(error);
+    }
+    map<string, File> fileMap;
+    for (auto &file : files) {
+      fileMap[file.name] = file;
+    }
+    return fileMap;
+  }
+  
+  string FunctionComparison::functionName() {
+    auto name = extractSymbol(newItem->name);
+    return demangled(name);
+  }
+
+  vector<shared_ptr<FileComparison>>
+  ProfdataCompare::genComparisons() {
+    vector<shared_ptr<FileComparison>> comparisons;
+    auto oldFiles = fileMapFromYAML(oldFile);
+    auto newFiles = fileMapFromYAML(newFile);
+    for (auto &iter : newFiles) {
+      auto idx = find(options.coveredFiles.begin(),
+                      options.coveredFiles.end(),
+                      iter.first);
+      if (options.coveredFiles.size() && idx == options.coveredFiles.end()) {
+        continue;
+      }
+      shared_ptr<File> oldFile;
+      auto old = oldFiles.find(iter.first);
+      if (old != oldFiles.end()) {
+        oldFile = make_shared<File>(old->second);
+      }
+      auto c = make_shared<FileComparison>(oldFile, make_shared<File>(iter.second));
+      comparisons.push_back(c);
+    }
+
+    sort(comparisons.begin(), comparisons.end(),
+         [](shared_ptr<FileComparison> a, shared_ptr<FileComparison> b) {
+           if (!a) return true;
+           if (!b) return false;
+           return a->coverageDifference() < b->coverageDifference();
+         });
+    return comparisons;
+  }
+
+  void ProfdataCompare::compare() {
+    auto output = options.output;
+    
+    if (output == Options::HTML) {
+      HTMLWriter(options.outputFilename).write(*this);
+      return;
+    }
+    
+    Column fnCol("Filename");
+    Column prevCol("Previous Coverage", Column::Alignment::Center);
+    Column currCol("Current Coverage", Column::Alignment::Center);
+    Column diffCol("Coverage Difference", Column::Alignment::Center);
+    for (auto &cmp : comparisons) {
+      string oldPercentage = cmp->oldItem ?
+      formattedDouble(cmp->oldItem->coveragePercentage()) : "N/A";
+      string newPercentage =
+      formattedDouble(cmp->newItem->coveragePercentage());
+      fnCol.add(cmp->newItem->name);
+      prevCol.add(oldPercentage);
+      currCol.add(newPercentage);
+      diffCol.add(cmp->formattedCoverageDifference());
+    }
+    
+    MarkdownWriter({ fnCol, prevCol, currCol, diffCol }).write(*os);
+  }
+  
+  int compareMain(int argc, const char *argv[]) {
+    cl::opt<std::string> output("o",
+                                cl::desc("<output filename>"),
+                                cl::value_desc("The output file to write. "
+                                               "If targeting HTML, this will "
+                                               "be the name of the output "
+                                               "directory."));
+    cl::opt<std::string> oldFile(cl::Positional,
+                                 cl::desc("<old yaml file>"), cl::Required);
+    cl::opt<std::string> newFile(cl::Positional,
+                                 cl::desc("<new yaml file>"), cl::Required);
+    cl::list<std::string> coveredFiles("c", cl::Positional,
+                                       cl::PositionalEatsArgs,
+                                       cl::desc("Restrict output to a certain "
+                                                "set of covered files"),
+                                       cl::ZeroOrMore);
+    cl::opt<Options::Format> format("f",
+                                    cl::desc("Format to output comparison"),
+                                    cl::values(clEnumValN(Options::HTML,
+                                                          "html",
+                                                          "HTML output"),
+                                               clEnumValN(Options::Markdown,
+                                                          "markdown",
+                                                          "Markdown table output"),
+                                               clEnumValEnd),
+                                    cl::init(Options::Markdown));
+    cl::ParseCommandLineOptions(argc, argv);
+    
+    Options options(coveredFiles,
+                    format.getValue(),
+                    output);
+    
+    ProfdataCompare comparer(oldFile, newFile, options);
+    
+    comparer.compare();
+    return 0;
+  }
+  
+  int yamlMain(int argc, const char *argv[]) {
+    cl::opt<std::string> output("o",
+                                cl::desc("<output filename>"),
+                                cl::value_desc("The output file to write. "
+                                               "If targeting HTML, this will "
+                                               "be the name of the output "
+                                               "directory."),
+                                cl::init(""));
+    cl::opt<std::string> file(cl::Positional,
+                              cl::desc("<profdata file>"), cl::Required);
+    cl::opt<std::string> binary(cl::Positional,
+                                cl::desc("<binary file>"), cl::Required);
+    cl::ParseCommandLineOptions(argc, argv);
+    
+    CoverageFilePair filePair(file, binary);
+    auto map = filePair.fileMap();
+    vector<File> files;
+    for (auto &pair : map) {
+      files.push_back(*pair.second);
+    }
+    
+    unique_ptr<raw_ostream> os = streamForFile(output);
+    
+    yaml::Output yout(*os);
+    yout << files;
+    
+    return 0;
+  }
+}

--- a/tools/cov-compare/ProfdataCompare.hpp
+++ b/tools/cov-compare/ProfdataCompare.hpp
@@ -1,0 +1,259 @@
+//===------ ProfdataCompare.hpp - Tools for analyzing llvm profdata -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ProfdataCompare_hpp
+#define ProfdataCompare_hpp
+
+#include <stdio.h>
+#include <iostream>
+#include "llvm/ProfileData/InstrProfReader.h"
+#include "llvm/ProfileData/CoverageMappingReader.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormattedStream.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Path.h"
+#include "Utils.hpp"
+#include <map>
+
+using namespace llvm;
+using namespace coverage;
+
+namespace covcompare {
+  
+  /// A struct that stores output options.
+  struct Options {
+  public:
+    /// The output formats supported by this tool.
+    typedef enum {
+      HTML,
+      Markdown
+    } Format;
+    
+    /// The files that this program should consider when comparing coverage.
+    std::vector<std::string> coveredFiles;
+    
+    /// The output format.
+    Format output;
+    
+    /// The filename (or directory, if the output format is HTML) to output.
+    std::string outputFilename;
+    
+    Options(std::vector<std::string> coveredFiles, Format output,
+            std::string outputFilename)
+    : coveredFiles(coveredFiles), output(output),
+    outputFilename(outputFilename) {}
+  };
+  
+  struct Region {
+  public:
+    unsigned columnStart, columnEnd, lineStart, lineEnd;
+    uint64_t executionCount;
+    Region(unsigned columnStart, unsigned columnEnd,
+           unsigned lineStart, unsigned lineEnd, uint64_t executionCount)
+    : columnStart(columnStart), columnEnd(columnEnd), lineStart(lineStart),
+      lineEnd(lineEnd), executionCount(executionCount) {}
+    Region(llvm::coverage::CountedRegion &region)
+    : Region(region.ColumnStart, region.ColumnEnd,
+             region.LineStart, region.LineEnd, region.ExecutionCount) {}
+    Region() {}
+  };
+  
+  struct Function {
+  public:
+    std::string name;
+    std::vector<Region> regions;
+    uint64_t executionCount;
+    double coveragePercentage() {
+      int counted = 0;
+      for (auto &region : regions) {
+        if (region.executionCount > 0) {
+          counted++;
+        }
+      }
+      return ((double)counted / (double)regions.size()) * 100;
+    }
+    Function(std::string name, std::vector<Region> regions,
+             uint64_t executionCount)
+    : name(name), regions(regions), executionCount(executionCount) {}
+    
+    Function(llvm::coverage::FunctionRecord record) {
+      this->name = extractSymbol(record.Name);
+      for (auto &region : record.CountedRegions) {
+        this->regions.push_back(region);
+      }
+      this->executionCount = record.ExecutionCount;
+    }
+    
+    Function(const Function &copy): name(copy.name), regions(copy.regions),
+    executionCount(copy.executionCount) {}
+    
+    Function(Function &copy): name(copy.name), regions(copy.regions),
+    executionCount(copy.executionCount) {}
+    
+    Function() {}
+  };
+  
+  /// A struct that stores all functions associated with a given source file.
+  struct File {
+    
+    std::shared_ptr<std::map<std::string, std::shared_ptr<Function>>>
+    _functionMap;
+  public:
+    std::string name;
+    std::vector<Function> functions;
+    
+    /// \returns The percentage of functions with a non-zero execution count.
+    double coveragePercentage();
+    
+    /// \returns A map of function symbols to the
+    /// corresponding Functions.
+    std::shared_ptr<std::map<std::string, std::shared_ptr<Function>>>
+    functionMap();
+    
+    File(std::string name,
+         std::vector<Function> functions)
+    : name(sys::path::filename(name)), functions(functions) {
+    }
+    
+    File(File &copy)
+    : _functionMap(copy._functionMap), name(copy.name),
+      functions(copy.functions) {}
+    
+    File(const File &copy)
+    : _functionMap(copy._functionMap), name(copy.name),
+      functions(copy.functions) {}
+    
+    File() {}
+  };
+  
+  /// A class that representd a comparison between the old and new versions of
+  /// a file in the two coverage profiles.
+  template<typename Compared>
+  class Comparison {
+  public:
+    /// The old and new files.
+    std::shared_ptr<Compared> oldItem, newItem;
+    
+    /// \returns The difference in coverage between these two files.
+    double coverageDifference() {
+      double oldPercentage = oldItem ? oldItem->coveragePercentage()
+      : 0.0;
+      double diff = newItem->coveragePercentage() - oldPercentage;
+      return fabs(diff) < 0.01 ? 0 : diff;
+    }
+    
+    /// \returns A percent-formatted string representing the coverage difference
+    /// between the two items in this comparison.
+    std::string formattedCoverageDifference() {
+      double diff = coverageDifference();
+      return (diff > 0 ? "+" : "") + formattedDouble(diff);
+    }
+    
+    Comparison(std::shared_ptr<Compared> oldItem,
+               std::shared_ptr<Compared> newItem)
+    : oldItem(oldItem), newItem(newItem) {
+      assert(newItem && "New item must not be null");
+      if (oldItem) {
+        assert(oldItem->name == newItem->name
+               && "Names must match.");
+      }
+    }
+  };
+  
+  /// A class that represents a comparison between the old and new versions of
+  /// a function in the two coverage profiles.
+  class FunctionComparison: public Comparison<Function> {
+  public:
+    /// \returns The attempted-demangled symbol name for this function.
+    std::string functionName();
+    
+    FunctionComparison(std::shared_ptr<Function> oldFunction,
+                       std::shared_ptr<Function> newFunction)
+    : Comparison(oldFunction, newFunction) {}
+  };
+  
+  /// A class that represents a comparison between the old and new versions of
+  /// a file in the two coverage profiles.
+  class FileComparison: public Comparison<File> {
+  public:
+    /// \returns A list of function comparisons between each of the functions
+    /// in the new file (the old file's functions are ignored, as they are no
+    /// longer relevant from a coverage perspective.)
+    std::vector<FunctionComparison> functionComparisons();
+    
+    FileComparison(std::shared_ptr<File> oldFile,
+                   std::shared_ptr<File> newFile)
+    : Comparison(oldFile, newFile) {}
+  };
+  
+  /// A struct that represents a pair of binary file and profdata file,
+  /// which reads and digests the contents of those files.
+  struct CoverageFilePair {
+  public:
+    /// The .profdata file path.
+    std::string filename;
+    
+    /// The binary file path that generated the .profdata.
+    std::string binary;
+    
+    /// \returns A CoverageMapping object corresponding
+    /// to the binary and profdata.
+    std::unique_ptr<CoverageMapping> coverageMapping();
+    
+    /// \returns A map of filenames to File
+    /// objects that are covered in this profdata.
+    std::map<std::string, std::shared_ptr<File>> fileMap();
+    
+    CoverageFilePair(std::string filename, std::string binary) :
+    filename(filename), binary(binary) {}
+  };
+  
+  /// A class that handles comparing two coverage profiles and outputting an
+  /// analysis of the difference.
+  class ProfdataCompare {
+    /// The options passed-into this object.
+    Options options;
+    
+    /// \returns A list of file comparisons based on all the files inside the
+    /// new coverage data (functions that exist in the old, but not the new,
+    /// are ignored as they are no longer relevant.)
+    std::vector<std::shared_ptr<FileComparison>> genComparisons();
+    
+  public:
+    /// The old and new YAML files for coverage data.
+    std::string oldFile, newFile;
+    
+    /// The output stream that will be used to output Markdown if Markdown
+    /// is the selected output format.
+    std::unique_ptr<llvm::raw_ostream> os;
+    
+    /// A cached list of comparisons between all files in the
+    /// new coverage profile.
+    std::vector<std::shared_ptr<FileComparison>> comparisons;
+    
+    ProfdataCompare(std::string oldFile, std::string newFile, Options options)
+    : options(options), oldFile(oldFile), newFile(newFile) {
+      comparisons = genComparisons();
+      if (options.output != Options::HTML) {
+        os = streamForFile(options.outputFilename);
+      }
+    }
+    
+    void compare();
+  };
+  
+  int compareMain(int argc, const char *argv[]);
+  int yamlMain(int argc, const char *argv[]);
+  
+} // namespace covcompare;
+
+#endif /* ProfdataCompare_hpp */

--- a/tools/cov-compare/README.md
+++ b/tools/cov-compare/README.md
@@ -1,0 +1,19 @@
+# Coverage Compare
+
+Coverage Compare generates coverage diffs between two coverage snapshots. It has two subcommands:
+
+```bash
+compare [-f {html|markdown}] [-o output-file-or-dir] <path-to-old-coverage-yaml> <path-to-new-coverage-yaml>
+```
+
+- Generates either an HTML or Markdown representation of the difference in coverage between the two files
+- If HTML, the `output-file-or-dir` must be a directory name; if markdown, it must be a file.
+    - Markdown outputs a summary which lists coverage percentages for the files covered by the profile data
+    - HTML outputs a directory containing a summary, but with a detailed function-level diff for each of those files.
+
+```bash
+yaml [-o output-file] <path-to-coverage-swiftc> <path-to-profdata>
+```
+
+- Generates a YAML file containing coverage information that's normally split between the binary and profdata
+- Suitable for a comparison by the `compare` subcommand

--- a/tools/cov-compare/Utils.cpp
+++ b/tools/cov-compare/Utils.cpp
@@ -1,0 +1,68 @@
+//===----------- Utils.cpp - Tools for analyzing llvm profdata ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utils.hpp"
+#include "llvm/Support/Path.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/FileSystem.h"
+#include <cxxabi.h>
+#include <unistd.h>
+
+using namespace std;
+using namespace llvm;
+
+namespace covcompare {
+  string extractSymbol(string name) {
+    auto pair = StringRef(name).split(':');
+    if (pair.second == "") {
+      return pair.first;
+    } else {
+      return pair.second;
+    }
+  }
+  
+  string demangled(string symbol) {
+    int status;
+    auto demangled = abi::__cxa_demangle(symbol.c_str(), 0, 0, &status);
+    if (demangled) {
+      string s(demangled);
+      free(demangled);
+      return s;
+    }
+    errs() << "warning: Could not demangle " << symbol << ".\n";
+    return symbol;
+  }
+  
+  void exitWithErrorCode(error_code error) {
+    errs() << "error: " << error.message() << "\n";
+    exit(error.value());
+  }
+  
+  string formattedDouble(double n) {
+    char buf[12];
+    snprintf(buf, 12, "%.02f%%", n);
+    return buf;
+  }
+  
+  unique_ptr<raw_ostream> streamForFile(string file) {
+    if (file.size()) {
+      error_code error;
+      auto os = make_unique<raw_fd_ostream>(file,
+                                            error, sys::fs::F_RW);
+      if (error) exitWithErrorCode(error);
+      return move(os);
+    } else {
+      return make_unique<raw_fd_ostream>(STDOUT_FILENO,
+                                         /* shouldClose = */false);
+    }
+  }
+}

--- a/tools/cov-compare/Utils.hpp
+++ b/tools/cov-compare/Utils.hpp
@@ -1,0 +1,38 @@
+//===----------- Utils.hpp - Tools for analyzing llvm profdata ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef Utils_hpp
+#define Utils_hpp
+
+#include <stdio.h>
+#include <string>
+#include <system_error>
+#include "llvm/Support/raw_ostream.h"
+
+namespace covcompare {
+  std::string extractSymbol(std::string symbol);
+  
+  /// Attempts to demangle a C++ symbol, returning
+  /// the mangled symbol if it fails.
+  std::string demangled(std::string symbol);
+  
+  /// Prints an error message and exits.
+  void exitWithErrorCode(std::error_code error);
+  
+  /// Formats a double as xxx.xx%
+  std::string formattedDouble(double n);
+  
+  /// Either reads the provided file or returns stdout if the file is empty.
+  std::unique_ptr<llvm::raw_ostream> streamForFile(std::string file);
+}
+
+#endif /* Utils_hpp */

--- a/tools/cov-compare/YAMLWriter.cpp
+++ b/tools/cov-compare/YAMLWriter.cpp
@@ -1,0 +1,14 @@
+//===--------- YAMLWriter.cpp - Tools for analyzing llvm profdata ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "YAMLWriter.hpp"
+#include "ProfdataCompare.hpp"

--- a/tools/cov-compare/YAMLWriter.hpp
+++ b/tools/cov-compare/YAMLWriter.hpp
@@ -1,0 +1,63 @@
+//===--------- YAMLWriter.hpp - Tools for analyzing llvm profdata ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef YAMLWriter_hpp
+#define YAMLWriter_hpp
+
+#include <stdio.h>
+#include "llvm/Support/YAMLTraits.h"
+#include "ProfdataCompare.hpp"
+
+template<typename U>
+struct llvm::yaml::SequenceTraits<std::vector<U>> {
+    static size_t size(IO &io, std::vector<U> &seq) {
+        return seq.size();
+    }
+    static U &element(IO &, std::vector<U> &seq, size_t index) {
+        if (seq.size() <= index) {
+            seq.resize(index + 1);
+        }
+        return seq[index];
+    }
+};
+
+template <>
+struct llvm::yaml::MappingTraits<covcompare::Region> {
+    static void mapping(IO &io, covcompare::Region &region) {
+        io.mapRequired("column-start", region.columnStart);
+        io.mapRequired("column-end", region.columnEnd);
+        io.mapRequired("line-start", region.lineStart);
+        io.mapRequired("line-end", region.lineEnd);
+        io.mapRequired("count", region.executionCount);
+    }
+    static const bool flow = true;
+};
+
+template <>
+struct llvm::yaml::MappingTraits<covcompare::Function> {
+    static void mapping(IO &io, covcompare::Function &function) {
+        io.mapRequired("name", function.name);
+        io.mapRequired("regions", function.regions);
+        io.mapRequired("count", function.executionCount);
+    }
+    static const bool flow = true;
+};
+
+template <>
+struct llvm::yaml::MappingTraits<covcompare::File> {
+    static void mapping(IO &io, covcompare::File &file) {
+        io.mapRequired("filename", file.name);
+        io.mapRequired("functions", file.functions);
+    }
+};
+
+#endif /* YAMLWriter_hpp */

--- a/tools/cov-compare/main.cpp
+++ b/tools/cov-compare/main.cpp
@@ -1,0 +1,45 @@
+//===--------=- main.cpp - Tools for analyzing llvm profdata --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "ProfdataCompare.hpp"
+
+using namespace llvm;
+using namespace covcompare;
+using namespace std;
+
+typedef function<int (int, const char **)> MainFunction;
+
+/// \brief Top level help.
+static int helpMain(int argc, const char *argv[]) {
+  errs() << "Usage: cov-compare {compare|yaml} [OPTION]...\n\n"
+         << "Compares code coverage information.\n\n"
+         << "Subcommands:\n"
+         << "  coverage: Compare two YAML files and generate a report.\n"
+         << "  yaml: Convert a profdata file and binary into a YAML file.\n";
+  return EXIT_FAILURE;
+}
+
+int main(int argc, const char **argv) {
+  if (argc < 2) {
+    return helpMain(argc, argv);
+  }
+  auto function = StringSwitch<MainFunction>(argv[1])
+                    .Case("compare", compareMain)
+                    .Case("yaml", yamlMain)
+                    .Default(helpMain);
+  
+  string invocation = string(argv[0]) + " " + argv[1];
+  argv[1] = invocation.c_str();
+  return function(argc - 1, argv + 1);
+}

--- a/utils/changedfiles
+++ b/utils/changedfiles
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+# utils/changedfiles.py - Show changed files between the current HEAD and
+# master -*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+from SwiftBuildSupport import check_output
+import os
+
+current_branch = check_output(["git", "rev-parse",
+                               "--abbrev-ref", "HEAD"]).strip()
+merge_base = check_output(["git", "merge-base",
+                           current_branch, "master"]).strip()
+
+files = check_output(["git", "--no-pager", "diff", "--name-only",
+                    merge_base, "HEAD"]).splitlines()
+
+
+source_file_exts = {".swift", ".cpp", ".m", ".mm", ".h", ".hpp"}
+source_files = [os.path.basename(f) for f in files
+                if os.path.splitext(f)[1] in source_file_exts]
+
+print(" ".join(source_files))

--- a/utils/profdata_merge/config.py
+++ b/utils/profdata_merge/config.py
@@ -19,9 +19,10 @@ class Config():
     """A class to store configuration information specified by command-line
     arguments.
     """
-
-    def __init__(self, out_dir, no_remove_files):
+    def __init__(self, out_dir, swift_dir, no_remove_files):
         self.out_dir = out_dir
+        self.swift_bin_path = os.path.join(swift_dir, "swift")
+        self.cov_compare_path = os.path.join(swift_dir, "cov-compare")
         self.tmp_dir = tempfile.mkdtemp()
         self.pid_file_path = os.path.join(self.out_dir,
                                           "profdata_merge_worker.pid")

--- a/utils/profdata_merge/main.py
+++ b/utils/profdata_merge/main.py
@@ -33,6 +33,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-l", "--log-file",
                         help="The file to write logs in debug mode.")
+    parser.add_argument("-s", "--swift-bin-dir",
+                        help="The directory to look for the cov-compare tool")
 
     subparsers = parser.add_subparsers()
 

--- a/utils/profdata_merge/runner.py
+++ b/utils/profdata_merge/runner.py
@@ -15,13 +15,40 @@ import os
 import socket
 import sys
 import logging
-
+import subprocess
+import tarfile
 from multiprocessing import JoinableQueue
 from process import ProfdataMergerProcess
 from server import ProfdataServer
 from main import SERVER_ADDRESS, TESTS_FINISHED_SENTINEL
 from config import Config
 
+
+# hack to import SwiftBuildSupport
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from SwiftBuildSupport import WorkingDirectory, check_call
+
+def cleanup(config):
+    if not config.swift_bin_path and config.cov_compare_path:
+        return
+    yaml_path = os.path.join("coverage.yaml")
+    cov_compare_cmd = ("%s yaml \"%s\" \"%s\" -o \"%s\"" %
+        (config.cov_compare_path,
+         config.final_profdata_path,
+         config.swift_bin_path,
+         yaml_path)
+    )
+    result = subprocess.call(cov_compare_cmd, shell=True)
+    if result != 0:
+        return
+    tarfile_name = os.path.join(config.out_dir, 'coverage.tar.gz')
+    logging.info("creating tar file at %s..." % tarfile_name)
+    tf = tarfile.open(tarfile_name, mode='w:gz', compresslevel=9)
+    logging.info("adding yaml file at %s..."
+                 % yaml_path)
+    tf.add('coverage.yaml')
+    logging.info("writing tarfile...")
+    tf.close()
 
 def run_server(config):
     pid = os.getpid()
@@ -61,7 +88,15 @@ def run_server(config):
         if os.path.exists(p.profdata_path):
             logging.info("merging " + p.profdata_path + "...")
             merge_final.filename_buffer.append(p.profdata_path)
+
+    if not merge_final.filename_buffer:
+        merge_final.abort("no profraw files found, aborting.")
+        return
+
     merge_final.merge_file_buffer()
+
+    with WorkingDirectory(config.out_dir):
+        cleanup(config)
 
 
 def stop_server(args):
@@ -72,7 +107,7 @@ def stop_server(args):
 
 
 def start_server(args):
-    config = Config(args.output_dir, args.no_remove)
+    config = Config(args.output_dir, args.swift_bin_dir, args.no_remove)
     if not args.debug:
         pid = os.fork()
         if pid != 0:


### PR DESCRIPTION
Adds a tool, `cov-compare`, in the `/bin` directory that either:
- Generates a YAML file representing code coverage for a specific covered build, or
- Compares two historical YAML files and produces either a Markdown summary (suitable for a PR comment) or a detailed HTML report of the difference of coverage between two commits.
