### PR TITLE
[build-script] Skip option for non-Darwin stdlib tests

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -497,6 +497,15 @@ build the Debug variant of the Swift standard library and SDK overlay""",
     run_tests_group.add_argument("-B", "--benchmark",
         help="run the Swift Benchmark Suite after building",
         action="store_true")
+    run_tests_group.add_argument("--skip-test-linux",
+        help="skip testing Swift stdlibs for Linux",
+        action="store_true")
+    run_tests_group.add_argument("--skip-test-freebsd",
+        help="skip testing Swift stdlibs for FreeBSD",
+        action="store_true")
+    run_tests_group.add_argument("--skip-test-cygwin",
+        help="skip testing Swift stdlibs for Cygwin",
+        action="store_true")
 
     parser.add_argument("-o", "--test-optimized",
         help="run the test suite in optimized mode too (implies --test)",
@@ -506,6 +515,15 @@ build the Debug variant of the Swift standard library and SDK overlay""",
         title="Run build")
     run_build_group.add_argument("-S", "--skip-build",
         help="generate build directory only without building",
+        action="store_true")
+    run_build_group.add_argument("--skip-build-linux",
+        help="skip building Swift stdlibs for Linux",
+        action="store_true")
+    run_build_group.add_argument("--skip-build-freebsd",
+        help="skip building Swift stdlibs for FreeBSD",
+        action="store_true")
+    run_build_group.add_argument("--skip-build-cygwin",
+        help="skip building Swift stdlibs for Cygwin",
         action="store_true")
 
     run_build_group.add_argument("--skip-build-benchmarks",
@@ -686,6 +704,10 @@ the number of parallel build jobs to use""",
             "--skip-test-xctest",
             "--skip-test-foundation",
             "--skip-test-libdispatch",
+            "--skip-test-linux",
+            "--skip-test-freebsd",
+            "--skip-test-cygwin",
+            "--skip-test-osx",
             "--skip-test-ios",
             "--skip-test-tvos",
             "--skip-test-watchos",
@@ -764,6 +786,9 @@ the number of parallel build jobs to use""",
             "--skip-build-cmark",
             "--skip-build-llvm",
             "--skip-build-swift",
+            "--skip-build-linux",
+            "--skip-build-freebsd",
+            "--skip-build-cygwin",
             "--skip-build-osx",
             "--skip-build-ios",
             "--skip-build-ios-device",
@@ -890,6 +915,18 @@ the number of parallel build jobs to use""",
     if args.cmake_generator == 'Ninja' and \
        not swift_build_support.ninja.is_ninja_installed():
         build_script_impl_args += ["--build-ninja"]
+    if args.skip_build_linux:
+        build_script_impl_args += ["--skip-build-linux"]
+    if args.skip_build_freebsd:
+        build_script_impl_args += ["--skip-build-freebsd"]
+    if args.skip_build_cygwin:
+        build_script_impl_args += ["--skip-build-cygwin"]
+    if args.skip_test_linux:
+        build_script_impl_args += ["--skip-test-linux"]
+    if args.skip_test_freebsd:
+        build_script_impl_args += ["--skip-test-freebsd"]
+    if args.skip_test_cygwin:
+        build_script_impl_args += ["--skip-test-cygwin"]
     build_script_impl_args += build_script_impl_inferred_args
 
     # If we have extra_swift_args, combine all of them together and then add

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -104,6 +104,9 @@ KNOWN_SETTINGS=(
     skip-build-cmark            ""               "set to skip building CommonMark"
     skip-build-llvm             ""               "set to skip building LLVM/Clang"
     skip-build-swift            ""               "set to skip building Swift"
+    skip-build-linux            ""               "set to skip building Swift stdlibs for Linux"
+    skip-build-freebsd          ""               "set to skip building Swift stdlibs for FreeBSD"
+    skip-build-cygwin           ""               "set to skip building Swift stdlibs for Cygwin"
     skip-build-osx              ""               "set to skip building Swift stdlibs for OSX"
     skip-build-ios              ""               "set to skip building Swift stdlibs for iOS"
     skip-build-ios-device       ""               "set to skip building Swift stdlibs for iOS devices (i.e. build simulators only)"
@@ -129,6 +132,9 @@ KNOWN_SETTINGS=(
     skip-test-xctest            ""               "set to skip testing xctest"
     skip-test-foundation        ""               "set to skip testing foundation"
     skip-test-libdispatch       ""               "set to skip testing libdispatch"
+    skip-test-linux             ""               "set to skip testing Swift stdlibs for Linux"
+    skip-test-freebsd           ""               "set to skip testing Swift stdlibs for FreeBSD"
+    skip-test-cygwin            ""               "set to skip testing Swift stdlibs for Cygwin"
     skip-test-osx               ""               "set to skip testing Swift stdlibs for OSX"
     skip-test-ios               ""               "set to skip testing Swift stdlibs for iOS"
     skip-test-ios-simulator     ""               "set to skip testing Swift stdlibs for iOS simulators (i.e. test devices only)"
@@ -906,16 +912,16 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
     test_benchmark_this_target=
     case ${deployment_target} in
         linux-*)
-            build_for_this_target=1
-            test_this_target=1
+            build_for_this_target=$(not ${SKIP_BUILD_LINUX})
+            test_this_target=$(not ${SKIP_TEST_LINUX})
             ;;
         freebsd-*)
-            build_for_this_target=1
-            test_this_target=1
+            build_for_this_target=$(not ${SKIP_BUILD_FREEBSD})
+            test_this_target=$(not ${SKIP_TEST_FREEBSD})
             ;;
         cygwin-*)
-            build_for_this_target=1
-            test_this_target=1
+            build_for_this_target=$(not ${SKIP_BUILD_CYGWIN})
+            test_this_target=$(not ${SKIP_TEST_CYGWIN})
             ;;
         macosx-*)
             build_for_this_target=$(not ${SKIP_BUILD_OSX})


### PR DESCRIPTION
## What's in this pull request?

It's possible to cross-compile for iOS while skipping stdlib tests on OS X:

```
$ utils/build-script --ios -- --skip-test-osx
```

The same is not possible on Linux. Add options to skip builds and tests on non-Darwin platforms: Linux, FreeBSD, and Cygwin. This makes the following possible:

```
$ utils/build-script --some-other-platform --skip-test-linux
```
## Why merge this pull request?
- This ports functionality that exists for OS X to Linux, FreeBSD, and Cygwin.
- Although none of these platforms are currently capable of cross-compiling, the [Android fork](a14ecfbaef7e6ce178f52395d6f66acee6ec288d) cross-compiles from Linux to Android. These options would immensely useful there, since otherwise there is no easy way to only run the tests for Android when building on Linux.
## What downsides are there to merging this pull request?
- One could argue that it should be merged alongside the [Android fork](a14ecfbaef7e6ce178f52395d6f66acee6ec288d). However, that would conflate that set of changes (a port of Swift to a new platform) with these (more options for the build script).
