### PR TITLE
Move pre-specializations of popular types away from the stdlib

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1355,6 +1355,28 @@ function(add_swift_library name)
         Core)
   endif()
 
+  is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" optimized)
+  if(NOT optimized)
+    # All Swift code depends on the SwiftOnoneSupport in non-optmized mode,
+    # except for the standard library itself.
+    if(SWIFTLIB_TARGET_LIBRARY AND NOT SWIFTLIB_IS_STDLIB_CORE)
+      list(APPEND SWIFTLIB_SWIFT_MODULE_DEPENDS SwiftOnoneSupport)
+    endif()
+  endif()
+
+  if((NOT "${SWIFT_BUILD_STDLIB}") AND
+    (NOT "${SWIFTLIB_SWIFT_MODULE_DEPENDS}" STREQUAL ""))
+    list(REMOVE_ITEM SWIFTLIB_SWIFT_MODULE_DEPENDS
+        SwiftOnoneSupport)
+  endif()
+
+  # swiftSwiftOnoneSupport does not depend on itself,
+  # obviously.
+  if("${name}" STREQUAL "swiftSwiftOnoneSupport")
+    list(REMOVE_ITEM SWIFTLIB_SWIFT_MODULE_DEPENDS
+        SwiftOnoneSupport)
+  endif()
+
   translate_flags(SWIFTLIB "${SWIFTLIB_options}")
 
   if("${SWIFTLIB_INSTALL_IN_COMPONENT}" STREQUAL "")

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -27,6 +27,8 @@ namespace swift {
   static const char LLVM_IR_EXTENSION[] = "ll";
   /// The name of the standard library, which is a reserved module name.
   static const char STDLIB_NAME[] = "Swift";
+  /// The name of the Onone support library, which is a reserved module name.
+  static const char SWIFT_ONONE_SUPPORT[] = "SwiftOnoneSupport";
   /// The name of the SwiftShims module, which contains private stdlib decls.
   static const char SWIFT_SHIMS_NAME[] = "SwiftShims";
   /// The prefix of module names used by LLDB to capture Swift expressions

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -273,6 +273,20 @@ void CompilerInstance::performSema() {
       return;
     }
 
+    const auto &silOptions = Invocation.getSILOptions();
+    if ((silOptions.Optimization <= SILOptions::SILOptMode::None &&
+         (options.RequestedAction == FrontendOptions::EmitObject ||
+          options.RequestedAction == FrontendOptions::Immediate ||
+          options.RequestedAction == FrontendOptions::EmitSIL)) ||
+        (silOptions.Optimization == SILOptions::SILOptMode::None &&
+         options.RequestedAction >= FrontendOptions::EmitSILGen)) {
+      // Implicitly import the SwiftOnoneSupport module in non-optimized
+      // builds. This allows for use of popular specialized functions
+      // from the standard library, which makes the non-optimized builds
+      // execute much faster.
+      Invocation.getFrontendOptions()
+                .ImplicitImportModuleNames.push_back(SWIFT_ONONE_SUPPORT);
+    }
     break;
   }
   }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -145,7 +145,7 @@ static bool cacheSpecialization(SILModule &M, SILFunction *F) {
 
   if (M.getOptions().Optimization >= SILOptions::SILOptMode::Optimize &&
       F->getLinkage() != SILLinkage::Public &&
-      F->getModule().getSwiftModule()->getName().str() == STDLIB_NAME) {
+      F->getModule().getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT) {
     if (F->getLinkage() != SILLinkage::Public &&
         isWhitelistedSpecialization(F->getName())) {
 
@@ -209,7 +209,8 @@ SILFunction *swift::getExistingSpecialization(SILModule &M,
     assert((Specialization->isExternalDeclaration() ||
             convertExternalDefinitionIntoDeclaration(Specialization)) &&
            "Could not remove body of the found specialization");
-    if (!convertExternalDefinitionIntoDeclaration(Specialization)) {
+    if (!Specialization->isExternalDeclaration() &&
+        !convertExternalDefinitionIntoDeclaration(Specialization)) {
       DEBUG(
           llvm::dbgs() << "Could not remove body of specialization: "
                        << FunctionName << '\n');

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -30,6 +30,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(runtime)
   add_subdirectory(stubs)
   add_subdirectory(core)
+  add_subdirectory(SwiftOnoneSupport)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_swift_library(swiftSwiftOnoneSupport SHARED IS_STDLIB
+  # This file should be listed the first.  Module name is inferred from the
+  # filename.
+  SwiftOnoneSupport.swift
+  SWIFT_COMPILE_FLAGS ${STDLIB_SIL_SERIALIZE_ALL} "-parse-stdlib"
+  INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -11,12 +11,64 @@
 //===----------------------------------------------------------------------===//
 // Pre-specialization of some popular generic classes and functions.
 //===----------------------------------------------------------------------===//
+import Swift
 
 struct _Prespecialize {
+  class C {}
+
   // Create specializations for the arrays of most
   // popular builtin integer and floating point types.
   static internal func _specializeArrays() {
     func _createArrayUser<Element : Comparable>(sampleValue: Element) {
+      // Initializers.
+      let _: [Element] = [ sampleValue ]
+      var a = [Element](count: 1, repeatedValue: sampleValue)
+
+      // Read array element
+      let _ =  a[0]
+
+      // Set array elements
+      for j in 1..<a.count {
+        a[0] = a[j]
+        a[j-1] = a[j]
+      }
+
+      for i1 in 0..<a.count {
+        for i2 in 0..<a.count {
+          a[i1] = a[i2]
+        }
+      }
+
+      a[0] = sampleValue
+
+      // Get length and capacity
+      let _ = a.count + a.capacity
+
+      // Iterate over array
+      for e in a {
+        print(e)
+        print("Value: \(e)")
+      }
+
+      print(a)
+
+      // Reserve capacity
+      a.removeAll()
+      a.reserveCapacity(100)
+
+      // Sort array
+      let _ = a.sort { (a:Element, b:Element) in a < b }
+      a.sortInPlace { (a:Element, b:Element) in a < b }
+
+      // force specialization of append.
+      a.append(a[0])
+
+      // force specialization of print<Element>
+      print(sampleValue)
+      print("Element:\(sampleValue)")
+    }
+
+    func _createArrayUserWithoutSorting<Element>(sampleValue: Element) {
       // Initializers.
       let _: [Element] = [ sampleValue ]
       var a = [Element](count: 1, repeatedValue: sampleValue)
@@ -52,16 +104,17 @@ struct _Prespecialize {
       a.removeAll()
       a.reserveCapacity(100)
 
-      // Sort array
-      let _ = a.sort { (a:Element, b:Element) in a < b }
-      a.sortInPlace { (a:Element, b:Element) in a < b }
 
+      // force specialization of append.
+      a.append(a[0])
 
       // force specialization of print<Element>
       print(sampleValue)
       print("Element:\(sampleValue)")
     }
 
+    // Force pre-specialization of arrays with elements of different
+    // integer types.
     _createArrayUser(1 as Int)
     _createArrayUser(1 as Int8)
     _createArrayUser(1 as Int16)
@@ -72,9 +125,23 @@ struct _Prespecialize {
     _createArrayUser(1 as UInt16)
     _createArrayUser(1 as UInt32)
     _createArrayUser(1 as UInt64)
-    _createArrayUser("a" as String)
+
+    // Force pre-specialization of arrays with elements of different
+    // floating point types.
     _createArrayUser(1.5 as Float)
     _createArrayUser(1.5 as Double)
+
+    // Force pre-specialization of string arrays
+    _createArrayUser("a" as String)
+
+    // Force pre-specialization of arrays with elements of different
+    // character and unicode scalar types.
+    _createArrayUser("a" as Character)
+    _createArrayUser("a" as UnicodeScalar)
+    _createArrayUserWithoutSorting("a".utf8)
+    _createArrayUserWithoutSorting("a".utf16)
+    _createArrayUserWithoutSorting("a".unicodeScalars)
+    _createArrayUserWithoutSorting("a".characters)
   }
 
   // Force pre-specialization of Range<Int>

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -127,7 +127,6 @@ set(SWIFTLIB_SOURCES
   Tuple.swift.gyb
   VarArgs.swift
   Zip.swift
-  Prespecialized.swift
   )
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)
 set(swift_core_link_flags)

--- a/test/Driver/emit-sib-single-file.swift
+++ b/test/Driver/emit-sib-single-file.swift
@@ -1,16 +1,16 @@
-// RUN: %target-build-swift -emit-sib %s -o %t.sib
+// RUN: %target-build-swift -Onone -emit-sib %s -o %t.sib
 // RUN: %target-build-swift %t.sib -o %t
 // RUN: %target-run %t | FileCheck %s
 
-// RUN: %target-build-swift -c %t.sib -o %t.o
+// RUN: %target-build-swift -Onone -c %t.sib -o %t.o
 // RUN: %target-build-swift %t.o -o %t
 // RUN: %target-run %t | FileCheck %s
 
-// RUN: %target-build-swift -emit-sibgen %s -o %t.sib
+// RUN: %target-build-swift -Onone -emit-sibgen %s -o %t.sib
 // RUN: %target-build-swift %t.sib -o %t
 // RUN: %target-run %t | FileCheck %s
 
-// RUN: %target-build-swift -c %t.sib -o %t.o
+// RUN: %target-build-swift -Onone -c %t.sib -o %t.o
 // RUN: %target-build-swift %t.o -o %t
 // RUN: %target-run %t | FileCheck %s
 // REQUIRES: executable_test


### PR DESCRIPTION
Pre-specializations were only used by Onone builds, but were kept inside the standard library dylyb anyways. This commit moves all the pre-specializations into a dedicated Swift module and a dynamic library, which are only used by Onone builds.

This reduces the code size of libswiftCore.dylib by 4%-5%.

This PR fixes some problems discovered when trying to merge the PR #1392:
- There were some issues with debug builds
  - The new library was not using -parse-stdlib
  - CMake rules for Swift files were not making sure that they always depend on SwiftOnoneSupport
- Not all pre-specializations available when Prespecialized.swift was part of the stdlib were available in this new dedicated library for Onone.
