### PR TITLE
[README] Changed sphinx install to require version 1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ modules, eliminating the need for headers and the code duplication they entail.
 
 To read the documentation, start by installing the
 [Sphinx](http://sphinx-doc.org) documentation generator tool (just run
-`easy_install -U Sphinx` from the command line and you're good to go). Once you
+`easy_install -U Sphinx==1.3.4` (more recent versions are currently not supported) 
+from the command line and you're good to go). Once you
  have that, you can build the Swift documentation by going into `docs` and
 typing `make`. This compiles the `.rst` files in the `docs` directory into
 HTML in the `docs/_build/html` directory.


### PR DESCRIPTION
Newer versions (including current version 1.3.5) currently don't work (SR-620) and it seems like the underlying issue is not fixed in the near future, so I think it’s better to let people install the old sphinx version instead of letting them run into this issue.
