### PR TITLE
@autoreleased fix for Swift 2.2

### DIFF
--- a/lib/SIL/Verifier.cpp
+++ b/lib/SIL/Verifier.cpp
@@ -877,6 +877,18 @@ public:
       require(resultInfo->getResult() == expectedResult,
               "result type of result function type for partially applied "
               "@unowned_inner_pointer function should have @unowned convention");
+
+    // The "autoreleased" convention doesn't survive through a
+    // partial application, since the thunk takes responsibility for
+    // retaining the return value.
+    } else if (expectedResult.getConvention() == ResultConvention::Autoreleased)
+    {
+      expectedResult = SILResultInfo(expectedResult.getType(),
+                                     ResultConvention::Owned);
+      require(resultInfo->getResult() == expectedResult,
+              "result type of result function type for partially applied "
+              "@autoreleased function should have @owned convention");
+
     } else {
       require(resultInfo->getResult() == expectedResult,
               "result type of result function type does not match original "

--- a/test/Interpreter/SDK/objc_protocol_lookup.swift
+++ b/test/Interpreter/SDK/objc_protocol_lookup.swift
@@ -37,3 +37,44 @@ func check(x: AnyObject) {
 check(NSString()) // CHECK: true true
 check(C()) // CHECK: true true
 check(D()) // CHECK: true true
+
+// Make sure partial application of methods with @autoreleased
+// return values works
+
+var count = 0
+
+class Juice : NSObject {
+  override init() {
+    count += 1
+  }
+
+  deinit {
+    count -= 1
+  }
+}
+
+@objc protocol Fruit {
+  optional var juice: Juice { get }
+}
+
+class Durian : NSObject, Fruit {
+  init(juice: Juice) {
+    self.juice = juice
+  }
+
+  var juice: Juice
+}
+
+func consume(fruit: Fruit) {
+  _ = fruit.juice
+}
+
+autoreleasepool {
+  let tasty = Durian(juice: Juice())
+  print(count) // CHECK: 1
+  consume(tasty)
+}
+
+do {
+  print(count) // CHECK: 0
+}

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -84,7 +84,7 @@ func curry_pod_AnyObject(x: AnyObject) -> Int -> Int {
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.normalOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (ImplicitlyUnwrappedOptional<CurryTest>, @opened({{.*}}) AnyObject) -> @autoreleased ImplicitlyUnwrappedOptional<CurryTest>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo9CurryTest__aGSQS___XFo_oGSQS___oGSQS___
+// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo9CurryTest__oGSQS___XFo_oGSQS___oGSQS___
 // CHECK:         partial_apply [[THUNK]]([[PA]])
 func curry_normalOwnership_AnyObject(x: AnyObject) -> CurryTest! -> CurryTest! {
   return x.normalOwnership!
@@ -105,7 +105,7 @@ func curry_weirdOwnership_AnyObject(x: AnyObject) -> CurryTest! -> CurryTest! {
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.bridged!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (ImplicitlyUnwrappedOptional<NSString>, @opened({{.*}}) AnyObject) -> @autoreleased ImplicitlyUnwrappedOptional<NSString>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo8NSString__aGSQS___XFo_oGSQSS__oGSQSS__ 
+// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo8NSString__oGSQS___XFo_oGSQSS__oGSQSS__
 // CHECK:         partial_apply [[THUNK]]([[PA]])
 func curry_bridged_AnyObject(x: AnyObject) -> String! -> String! {
   return x.bridged!
@@ -117,7 +117,7 @@ func curry_bridged_AnyObject(x: AnyObject) -> String! -> String! {
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsSelf!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased ImplicitlyUnwrappedOptional<AnyObject>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo__aGSQPs9AnyObject___XFo__oGSQPS____
+// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo__oGSQPs9AnyObject___XFo_iT__iGSQPS____
 // CHECK:         partial_apply [[THUNK]]([[PA]])
 func curry_returnsSelf_AnyObject(x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!


### PR DESCRIPTION
In IRGen, @autoreleased return values are always converted to +1 by
calling objc_retainAutoreleasedReturnValue(), so a partial application
thunk cannot have a result with @autoreleased convention. Just turn
it into @owned instead, since that's what it is, using similar logic
as the @unowned_inner_pointer => @unowned case.

Fixes rdar://problem/24805609.
