### PR TITLE
stdlib: Audit API for Swift 3 preposition, first-arg label rules

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -450,7 +450,7 @@ func _stdlib_installTrapInterceptor()
 func _childProcess() {
   _stdlib_installTrapInterceptor()
   while let line = _stdlib_getline() {
-    let parts = line._split(";")
+    let parts = line._split(separator: ";")
     let testSuiteName = parts[0]
     let testName = parts[1]
 
@@ -559,7 +559,8 @@ struct _ParentProcess {
         _childStdout.read()
         while var line = _childStdout.getline() {
           if let index = findSubstring(line, _stdlibUnittestStreamPrefix) {
-            let controlMessage = line[index..<line.endIndex]._split(";")
+            let controlMessage =
+                line[index..<line.endIndex]._split(separator: ";")
             switch controlMessage[1] {
             case "expectCrash":
               stdoutSeenCrashDelimiter = true
@@ -586,7 +587,8 @@ struct _ParentProcess {
         _childStderr.read()
         while var line = _childStderr.getline() {
           if let index = findSubstring(line, _stdlibUnittestStreamPrefix) {
-            let controlMessage = line[index..<line.endIndex]._split(";")
+            let controlMessage =
+                line[index..<line.endIndex]._split(separator: ";")
             switch controlMessage[1] {
             case "expectCrash":
               stderrSeenCrashDelimiter = true
@@ -1060,7 +1062,7 @@ public enum OSVersion : CustomStringConvertible {
 }
 
 func _parseDottedVersion(s: String) -> [Int] {
-  return Array(s._split(".").lazy.map { Int($0)! })
+  return Array(s._split(separator: ".").lazy.map { Int($0)! })
 }
 
 public func _parseDottedVersionTriple(s: String) -> (Int, Int, Int) {

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -68,7 +68,7 @@ extension String {
       start: cString, count: len)
 
     let (stringBuffer, hadError) = _StringBuffer.fromCodeUnits(
-      encoding, input: buffer, repairIllFormedSequences: isReparing)
+      buffer, encoding: encoding, repairIllFormedSequences: isReparing)
     return stringBuffer.map {
       (result: String(_storage: $0), repairsMade: hadError)
     }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -143,7 +143,7 @@ extension String {
     encoding: Encoding.Type, input: Input
   ) -> String? {
     let (stringBufferOptional, _) =
-        _StringBuffer.fromCodeUnits(encoding, input: input,
+        _StringBuffer.fromCodeUnits(input, encoding: encoding,
             repairIllFormedSequences: false)
     if let stringBuffer = stringBufferOptional {
       return String(_storage: stringBuffer)
@@ -161,7 +161,7 @@ extension String {
     encoding: Encoding.Type, input: Input
   ) -> (String, hadError: Bool) {
     let (stringBuffer, hadError) =
-        _StringBuffer.fromCodeUnits(encoding, input: input,
+        _StringBuffer.fromCodeUnits(input, encoding: encoding,
             repairIllFormedSequences: true)
     return (String(_storage: stringBuffer!), hadError)
   }

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -84,10 +84,11 @@ public struct _StringBuffer {
 
   @warn_unused_result
   static func fromCodeUnits<
-    Encoding : UnicodeCodec, Input : Collection // Sequence?
+    Input : Collection, // Sequence?
+    Encoding : UnicodeCodec
     where Input.Iterator.Element == Encoding.CodeUnit
   >(
-    encoding: Encoding.Type, input: Input, repairIllFormedSequences: Bool,
+    input: Input, encoding: Encoding.Type, repairIllFormedSequences: Bool,
     minimumCapacity: Int = 0
   ) -> (_StringBuffer?, hadError: Bool) {
     // Determine how many UTF-16 code units we'll need
@@ -194,7 +195,7 @@ public struct _StringBuffer {
   ///   to extend.
   /// - parameter newUsedCount: The desired size of the substring.
   mutating func grow(
-    bounds: Range<UnsafePointer<_RawByte>>, newUsedCount: Int
+    oldBounds bounds: Range<UnsafePointer<_RawByte>>, newUsedCount: Int
   ) -> Bool {
     var newUsedCount = newUsedCount
     // The substring to be grown could be pointing in the middle of this

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -81,7 +81,8 @@ extension String.CharacterView : Collection {
     public // SPI(Foundation)    
     init(_base: String.UnicodeScalarView.Index) {
       self._base = _base
-      self._countUTF16 = Index._measureExtendedGraphemeClusterForward(_base)
+      self._countUTF16 =
+          Index._measureExtendedGraphemeClusterForward(from: _base)
     }
 
     internal init(_base: UnicodeScalarView.Index, _countUTF16: Int) {
@@ -104,7 +105,7 @@ extension String.CharacterView : Collection {
       _precondition(_base != _base._viewStartIndex,
           "cannot decrement startIndex")
       let predecessorLengthUTF16 =
-          Index._measureExtendedGraphemeClusterBackward(_base)
+          Index._measureExtendedGraphemeClusterBackward(from: _base)
       return Index(
         _base: UnicodeScalarView.Index(
           _utf16Index - predecessorLengthUTF16, _base._core))
@@ -132,7 +133,7 @@ extension String.CharacterView : Collection {
     /// code units.
     @warn_unused_result
     internal static func _measureExtendedGraphemeClusterForward(
-        start: UnicodeScalarView.Index
+        from start: UnicodeScalarView.Index
     ) -> Int {
       var start = start
       let end = start._viewEndIndex
@@ -173,7 +174,7 @@ extension String.CharacterView : Collection {
     /// code units.
     @warn_unused_result
     internal static func _measureExtendedGraphemeClusterBackward(
-        end: UnicodeScalarView.Index
+        from end: UnicodeScalarView.Index
     ) -> Int {
       let start = end._viewStartIndex
       if start == end {

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -34,11 +34,11 @@ extension String {
   }
   
   public var _lines : [String] {
-    return _split("\n")
+    return _split(separator: "\n")
   }
   
   @warn_unused_result
-  public func _split(separator: UnicodeScalar) -> [String] {
+  public func _split(separator separator: UnicodeScalar) -> [String] {
     let scalarSlices = unicodeScalars.split { $0 == separator }
     return scalarSlices.map { String($0) }
   }
@@ -141,7 +141,7 @@ extension String {
 extension String {
   /// Produce a substring of the given string from the given character
   /// index to the end of the string.
-  func _substr(start: Int) -> String {
+  func _substr(from start: Int) -> String {
     let rng = unicodeScalars
     var startIndex = rng.startIndex
     for _ in 0..<start {
@@ -153,7 +153,7 @@ extension String {
   /// Split the given string at the given delimiter character, returning the
   /// strings before and after that character (neither includes the character
   /// found) and a boolean value indicating whether the delimiter was found.
-  public func _splitFirst(delim: UnicodeScalar)
+  public func _splitFirst(separator delim: UnicodeScalar)
     -> (before: String, after: String, wasFound : Bool)
   {
     let rng = unicodeScalars

--- a/test/1_stdlib/StringReallocation.swift
+++ b/test/1_stdlib/StringReallocation.swift
@@ -3,7 +3,7 @@
 
 // CHECK-NOT: Reallocations exceeded 30
 func testReallocation() {
-  var x = "The quick brown fox jumped over the lazy dog\n"._split(" ")
+  var x = "The quick brown fox jumped over the lazy dog\n"._split(separator: " ")
 
   var story = "Let me tell you a story:"
   var laps = 1000

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -235,7 +235,7 @@ StringTests.test("ForeignIndexes/removeSubrange/OutOfBoundsTrap/2") {
 }
 
 StringTests.test("_splitFirst") {
-  var (before, after, found) = "foo.bar"._splitFirst(".")
+  var (before, after, found) = "foo.bar"._splitFirst(separator: ".")
   expectTrue(found)
   expectEqual("foo", before)
   expectEqual("bar", after)


### PR DESCRIPTION
This commit is the result of auditing the following files:
- StringBuffer.swift
- StringCharacterView.swift
- StringCore.swift
- StringInterpolation.swift.gyb
- StringLegacy.swift
