### PR TITLE
Changed uint to unsigned int

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4192,12 +4192,12 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
   return new (ctx) ErasureExpr(expr, toType, conformances);
 }
 
-static uint getOptionalBindDepth(const BoundGenericType *bgt) {
+static unsigned int getOptionalBindDepth(const BoundGenericType *bgt) {
   
   if (bgt->getDecl()->classifyAsOptionalType()) {
     auto tyarg = bgt->getGenericArgs()[0];
     
-    uint innerDepth = 0;
+    unsigned int innerDepth = 0;
     
     if (auto wrappedBGT = dyn_cast<BoundGenericType>(tyarg->
                                                      getCanonicalType())) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -75,9 +75,9 @@ namespace {
   /// Internal struct for tracking information about types within a series
   /// of "linked" expressions. (Such as a chain of binary operator invocations.)
   struct LinkedTypeInfo {
-    uint haveIntLiteral : 1;
-    uint haveFloatLiteral : 1;
-    uint haveStringLiteral : 1;
+    unsigned int haveIntLiteral : 1;
+    unsigned int haveFloatLiteral : 1;
+    unsigned int haveStringLiteral : 1;
     
     llvm::SmallSet<TypeBase*, 16> collectedTypes;
 


### PR DESCRIPTION
The `uint` is not a standard C/C++ type.
Some compiler environment may fail with it. For example, MS Visual C++ Run time environment.
It will be better to replace with `unsigned int` rather than insert `typedef unsigned int uint;`.
