### PR TITLE
[loop-utils] We always create pre-headers now before this step of loo…

### DIFF
--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -96,8 +96,8 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
 
   // For simplicity, assume a single preheader
   SILBasicBlock *Preheader = L->getLoopPreheader();
-  if (!Preheader)
-    return nullptr;
+  assert(Preheader && "A preheader should have been created before calling"
+         "this function");
 
   SILBasicBlock *Header = L->getHeader();
   SILFunction *F = Header->getParent();


### PR DESCRIPTION
…p canonicalization, so change an early exit to an assert.
