### PR TITLE
Make String conform to ErrorType

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -264,6 +264,9 @@ extension String : CustomDebugStringConvertible {
   }
 }
 
+// Make it possible to `throw` strings as errors
+extension String: ErrorType {}
+
 extension String {
   /// Returns the number of code units occupied by this string
   /// in the given encoding.


### PR DESCRIPTION
This makes it possible to `throw` strings, making it easier to model trivial error types.
