### PR TITLE
Use the method raw_ostream::resetColor instead of the escape code string

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -67,7 +67,7 @@ namespace {
     
     ~PrintWithColorRAII() {
       if (ShowColors) {
-        OS << llvm::sys::Process::ResetColor();
+        OS.resetColor();
       }
     }
     
@@ -249,7 +249,7 @@ namespace {
       OS << Name;
 
       if (ShowColors)
-        OS << llvm::sys::Process::ResetColor();
+        OS.resetColor();
 
       if (P->isImplicit())
         OS << " implicit";
@@ -404,7 +404,7 @@ namespace {
       OS << Name;
 
       if (ShowColors)
-        OS << llvm::sys::Process::ResetColor();
+        OS.resetColor();
 
       if (D->isImplicit())
         OS << " implicit";
@@ -2262,7 +2262,7 @@ public:
     OS << Name;
 
     if (ShowColors)
-      OS << llvm::sys::Process::ResetColor();
+      OS.resetColor();
     return OS;
   }
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -802,7 +802,7 @@ public:
         OS << CStr;
       }
     } else {
-      OS << llvm::sys::Process::ResetColor();
+      OS.resetColor();
     }
   }
 
@@ -1264,7 +1264,7 @@ private:
       OS << CStr;
     }
     OS << Text;
-    OS << llvm::sys::Process::ResetColor();
+    OS.resetColor();
     return true;
   }
 };


### PR DESCRIPTION
The `Process::ResetColor()` may return `NULL` if the LLVM library is built for Windows.
So, unguarded passing the return value to the `raw_ostream` may generate a crash.
The `raw_ostream::resetColor()` checks `NULL` and is used many time in the Clang.
