### PR TITLE
[perftest][cmake] Standardize on using ${source} instead of ${srcdir}…

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -107,7 +107,7 @@ function (swift_benchmark_compile_archopts)
           "-module-name" "${module_name}"
           "-emit-sib"
           "-o" "${sibfile}"
-          "${srcdir}/${module_name_path}.swift" ${extra_sources})
+          "${source}" ${extra_sources})
     endif()
   endforeach()
 
@@ -116,6 +116,7 @@ function (swift_benchmark_compile_archopts)
 
     set(objfile "${objdir}/${module_name}.o")
     set(swiftmodule "${objdir}/${module_name}.swiftmodule")
+    set(source "${srcdir}/${module_name_path}.swift")
     list(APPEND bench_library_objects "${objfile}")
     add_custom_command(
         OUTPUT "${objfile}"
@@ -129,7 +130,7 @@ function (swift_benchmark_compile_archopts)
         "-module-name" "${module_name}"
         "-emit-module" "-emit-module-path" "${swiftmodule}"
         "-o" "${objfile}"
-        "${srcdir}/${module_name_path}.swift" ${extra_sources})
+        "${source}" ${extra_sources})
     if (SWIFT_BENCHMARK_EMIT_SIB)
       set(sibfile "${objdir}/${module_name}.sib")
       list(APPEND bench_library_sibfiles "${sibfile}")
@@ -145,7 +146,7 @@ function (swift_benchmark_compile_archopts)
           "-module-name" "${module_name}"
           "-emit-sib"
           "-o" "${sibfile}"
-          "${srcdir}/${module_name_path}.swift" ${extra_sources})
+          "${source}" ${extra_sources})
     endif()
   endforeach()
 
@@ -157,6 +158,7 @@ function (swift_benchmark_compile_archopts)
     if(module_name)
       set(objfile "${objdir}/${module_name}.o")
       set(swiftmodule "${objdir}/${module_name}.swiftmodule")
+      set(source "${srcdir}/${module_name_path}.swift")
       list(APPEND SWIFT_BENCH_OBJFILES "${objfile}")
       add_custom_command(
           OUTPUT "${objfile}"
@@ -171,7 +173,7 @@ function (swift_benchmark_compile_archopts)
           "-emit-module" "-emit-module-path" "${swiftmodule}"
           "-I" "${objdir}"
           "-o" "${objfile}"
-          "${srcdir}/${module_name_path}.swift")
+          "${source}")
       if (SWIFT_BENCHMARK_EMIT_SIB)
         set(sibfile "${objdir}/${module_name}.sib")
         list(APPEND SWIFT_BENCH_SIBFILES "${sibfile}")
@@ -188,7 +190,7 @@ function (swift_benchmark_compile_archopts)
             "-I" "${objdir}"
             "-emit-sib"
             "-o" "${sibfile}"
-            "${srcdir}/${module_name_path}.swift")
+            "${source}")
       endif()
     endif()
   endforeach()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This performs some small simplifications to the cmake files for compiling the swift perf test suite. I want to eventually unite the code paths for emitting SIL and *.o files to reduce the code duplication.

The specific refactoring is that in this file we are not consistent about using ${source} or full paths. I switch to use ${source} since that provides a natural anchor point for future refactoring of these code paths into functions where ${source} would be an argument to the function.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI </summary>



The swift-ci is triggered by writing a comment on this PR addressed to the github user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

---

…/${module_name_path}.swift.

This is an intermediate commit in a series of commits towards being able to
build the perf test suite from *.sib files.

Doing so will enable us to:
1. Stress the serialization pipeline.
2. Provide an interesting test case for verifying that executables compiled
   from *.sib yield the same object files as if we compiled directly to *.o files.

Keep in mind this is a longer term effort that I am doing on the side.
