### PR TITLE
Refactor code duplication in inspecting dylibs

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -91,7 +91,18 @@ namespace {
   };
 }
 
+#if defined(__APPLE__) && defined(__MACH__)
 static void _initializeCallbacksToInspectDylib();
+#else
+namespace swift {
+  void _swift_initializeCallbacksToInspectDylib(
+    void (*fnAddImageBlock)(const uint8_t *, size_t),
+    const char *sectionName);
+}
+
+static void _addImageTypeMetadataRecordsBlock(const uint8_t *records,
+                                              size_t recordsSize);
+#endif
 
 struct TypeMetadataState {
   ConcurrentMap<TypeMetadataCacheEntry> Cache;
@@ -101,7 +112,13 @@ struct TypeMetadataState {
   TypeMetadataState() {
     SectionsToScan.reserve(16);
     pthread_mutex_init(&SectionsToScanLock, nullptr);
+#if defined(__APPLE__) && defined(__MACH__)
     _initializeCallbacksToInspectDylib();
+#else
+    _swift_initializeCallbacksToInspectDylib(
+      _addImageTypeMetadataRecordsBlock,
+      SWIFT_TYPE_METADATA_SECTION);
+#endif
   }
 };
 
@@ -155,72 +172,14 @@ static void _addImageTypeMetadataRecords(const mach_header *mh,
 
   _addImageTypeMetadataRecordsBlock(records, recordsSize);
 }
-#elif defined(__ELF__)
-static int _addImageTypeMetadataRecords(struct dl_phdr_info *info,
-                                        size_t size, void * /*data*/) {
-  void *handle;
-  if (!info->dlpi_name || info->dlpi_name[0] == '\0') {
-    handle = dlopen(nullptr, RTLD_LAZY);
-  } else
-    handle = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
-  auto records = reinterpret_cast<const uint8_t*>(
-      dlsym(handle, SWIFT_TYPE_METADATA_SECTION));
-
-  if (!records) {
-    // if there are no type metadata records, don't hold this handle open.
-    dlclose(handle);
-    return 0;
-  }
-
-  // Extract the size of the type metadata block from the head of the section
-  auto recordsSize = *reinterpret_cast<const uint64_t*>(records);
-  records += sizeof(recordsSize);
-
-  _addImageTypeMetadataRecordsBlock(records, recordsSize);
-
-  dlclose(handle);
-  return 0;
-}
-#elif defined(__CYGWIN__)
-static int _addImageTypeMetadataRecords(struct dl_phdr_info *info,
-                                        size_t size, void * /*data*/) {
-  void *handle;
-  if (!info->dlpi_name || info->dlpi_name[0] == '\0') {
-    handle = dlopen(nullptr, RTLD_LAZY);
-  } else
-    handle = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
-
-  unsigned long recordsSize;
-  const uint8_t *records =
-    _swift_getSectionDataPE(handle, SWIFT_TYPE_METADATA_SECTION,
-                           &recordsSize);
-
-  if (records) {
-    _addImageTypeMetadataRecordsBlock(records, recordsSize);
-  }
-  dlclose(handle);
-  return 0;
-}
-#endif
 
 static void _initializeCallbacksToInspectDylib() {
-#if defined(__APPLE__) && defined(__MACH__)
   // Install our dyld callback.
   // Dyld will invoke this on our behalf for all images that have already
   // been loaded.
   _dyld_register_func_for_add_image(_addImageTypeMetadataRecords);
-#elif defined(__ELF__)
-  // Search the loaded dls. Unlike the above, this only searches the already
-  // loaded ones.
-  // FIXME: Find a way to have this continue to happen after.
-  // rdar://problem/19045112
-  dl_iterate_phdr(_addImageTypeMetadataRecords, nullptr);
-#elif defined(__CYGWIN__)
-  _swift_dl_iterate_phdr(_addImageTypeMetadataRecords, nullptr);
-#else
-# error No known mechanism to inspect dynamic libraries on this platform.
-#endif
 }
+#endif
 
 void
 swift::swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -224,8 +224,18 @@ namespace {
 }
 
 // Conformance Cache.
-
+#if defined(__APPLE__) && defined(__MACH__)
 static void _initializeCallbacksToInspectDylib();
+#else
+namespace swift {
+  void _swift_initializeCallbacksToInspectDylib(
+    void (*fnAddImageBlock)(const uint8_t *, size_t),
+    const char *sectionName);
+}
+
+static void _addImageProtocolConformancesBlock(const uint8_t *conformances,
+                                               size_t conformancesSize);
+#endif
 
 struct ConformanceState {
   ConcurrentMap<ConformanceCacheEntry> Cache;
@@ -235,7 +245,13 @@ struct ConformanceState {
   ConformanceState() {
     SectionsToScan.reserve(16);
     pthread_mutex_init(&SectionsToScanLock, nullptr);
+#if defined(__APPLE__) && defined(__MACH__)
     _initializeCallbacksToInspectDylib();
+#else
+    _swift_initializeCallbacksToInspectDylib(
+      _addImageProtocolConformancesBlock,
+      SWIFT_PROTOCOL_CONFORMANCES_SECTION);
+#endif
   }
 
   void cacheSuccess(const void *type, const ProtocolDescriptor *proto,
@@ -295,6 +311,14 @@ static void _addImageProtocolConformancesBlock(const uint8_t *conformances,
                                 recordsBegin, recordsEnd);
 }
 
+#if !defined(__APPLE__) || !defined(__MACH__)
+// Common Structure
+struct InspectArgs {
+  void (*fnAddImageBlock)(const uint8_t *, size_t);
+  const char *sectionName;
+};
+#endif
+
 #if defined(__APPLE__) && defined(__MACH__)
 static void _addImageProtocolConformances(const mach_header *mh,
                                           intptr_t vmaddr_slide) {
@@ -317,16 +341,27 @@ static void _addImageProtocolConformances(const mach_header *mh,
   
   _addImageProtocolConformancesBlock(conformances, conformancesSize);
 }
+
+static void _initializeCallbacksToInspectDylib() {
+  // Install our dyld callback.
+  // Dyld will invoke this on our behalf for all images that have already
+  // been loaded.
+  _dyld_register_func_for_add_image(_addImageProtocolConformances);
+}
+
 #elif defined(__ELF__)
 static int _addImageProtocolConformances(struct dl_phdr_info *info,
-                                          size_t size, void * /*data*/) {
+                                          size_t size, void *data) {
+  // inspectArgs contains addImage*Block function and the section name
+  InspectArgs *inspectArgs = reinterpret_cast<InspectArgs *>(data);
+
   void *handle;
   if (!info->dlpi_name || info->dlpi_name[0] == '\0') {
     handle = dlopen(nullptr, RTLD_LAZY);
   } else
     handle = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
   auto conformances = reinterpret_cast<const uint8_t*>(
-      dlsym(handle, SWIFT_PROTOCOL_CONFORMANCES_SECTION));
+      dlsym(handle, inspectArgs->sectionName));
 
   if (!conformances) {
     // if there are no conformances, don't hold this handle open.
@@ -338,14 +373,29 @@ static int _addImageProtocolConformances(struct dl_phdr_info *info,
   auto conformancesSize = *reinterpret_cast<const uint64_t*>(conformances);
   conformances += sizeof(conformancesSize);
 
-  _addImageProtocolConformancesBlock(conformances, conformancesSize);
+  inspectArgs->fnAddImageBlock(conformances, conformancesSize);
 
   dlclose(handle);
   return 0;
 }
+
+void swift::_swift_initializeCallbacksToInspectDylib(
+    void (*fnAddImageBlock)(const uint8_t *, size_t),
+    const char *sectionName) {
+  InspectArgs inspectArgs = {fnAddImageBlock, sectionName};
+
+  // Search the loaded dls. Unlike the above, this only searches the already
+  // loaded ones.
+  // FIXME: Find a way to have this continue to happen after.
+  // rdar://problem/19045112
+  dl_iterate_phdr(_addImageProtocolConformances, &inspectArgs);
+}
 #elif defined(__CYGWIN__)
 static int _addImageProtocolConformances(struct dl_phdr_info *info,
-                                          size_t size, void * /*data*/) {
+                                          size_t size, void *data) {
+  InspectArgs *inspectArgs = (InspectArgs *)data;
+  // inspectArgs contains addImage*Block function and the section name
+
   void *handle;
   if (!info->dlpi_name || info->dlpi_name[0] == '\0') {
     handle = dlopen(nullptr, RTLD_LAZY);
@@ -354,40 +404,26 @@ static int _addImageProtocolConformances(struct dl_phdr_info *info,
 
   unsigned long conformancesSize;
   const uint8_t *conformances =
-    _swift_getSectionDataPE(handle, SWIFT_PROTOCOL_CONFORMANCES_SECTION,
+    _swift_getSectionDataPE(handle, inspectArgs->sectionName,
                            &conformancesSize);
 
-  if (!conformances) {
-    // if there are no conformances, don't hold this handle open.
-    dlclose(handle);
-    return 0;
-  }
-
-  _addImageProtocolConformancesBlock(conformances, conformancesSize);
+  if (conformances)
+    inspectArgs->fnAddImageBlock(conformances, conformancesSize);
 
   dlclose(handle);
   return 0;
 }
-#endif
 
-static void _initializeCallbacksToInspectDylib() {
-#if defined(__APPLE__) && defined(__MACH__)
-  // Install our dyld callback.
-  // Dyld will invoke this on our behalf for all images that have already
-  // been loaded.
-  _dyld_register_func_for_add_image(_addImageProtocolConformances);
-#elif defined(__ELF__)
-  // Search the loaded dls. Unlike the above, this only searches the already
-  // loaded ones.
-  // FIXME: Find a way to have this continue to happen after.
-  // rdar://problem/19045112
-  dl_iterate_phdr(_addImageProtocolConformances, nullptr);
-#elif defined(__CYGWIN__)
-  _swift_dl_iterate_phdr(_addImageProtocolConformances, nullptr);
+void swift::_swift_initializeCallbacksToInspectDylib(
+    void (*fnAddImageBlock)(const uint8_t *, size_t),
+    const char *sectionName) {
+  InspectArgs inspectArgs = {fnAddImageBlock, sectionName};
+
+  _swift_dl_iterate_phdr(_addImageProtocolConformances, &inspectArgs);
+}
 #else
 # error No known mechanism to inspect dynamic libraries on this platform.
 #endif
-}
 
 // This variable is used to signal when a cache was generated and
 // it is correct to avoid a new scan.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

MetadataLookup.cpp and ProtocolConformance.cpp has same part for inspecting dynamic libraries.
This PR remove some duplicated code for ELF and Cygwin.
The common code exist in one file and other uses it.
This uses the argument passing to callback in Linux/Cygwin and not applied to OS X.
#### Resolved bug number: N/A

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI </summary>



The swift-ci is triggered by writing a comment on this PR addressed to the github user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
