### PR TITLE
Implement a more light-weight approach to perform lookups of existing pre-specializations

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -227,6 +227,9 @@ public:
   /// Erase a function from the module.
   void eraseFunction(SILFunction *F);
 
+  /// Invalidate a function in SILLoader cache.
+  void invalidateFunctionInSILCache(SILFunction *F);
+
   /// Specialization can cause a function that was erased before by dead function
   /// elimination to become alive again. If this happens we need to remove it
   /// from the list of zombies.
@@ -426,6 +429,13 @@ public:
   /// \return false if the linking failed.
   bool linkFunction(StringRef Name,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
+
+  /// Check if a given function exists in the module,
+  /// i.e. it can be linked by linkFunction.
+  ///
+  /// \return null if this module has no such function. Otherwise
+  /// the declaration of a function.
+  SILFunction *hasFunction(StringRef Name, SILLinkage Linkage);
 
   /// Link in all Witness Tables in the module.
   void linkAllWitnessTables();

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -16,6 +16,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Identifier.h"
 #include "swift/SIL/SILDeclRef.h"
+#include "swift/SIL/SILLinkage.h"
 #include <memory>
 #include <vector>
 
@@ -81,7 +82,9 @@ public:
 
   SILFunction *lookupSILFunction(SILFunction *Callee);
   SILFunction *lookupSILFunction(SILDeclRef Decl);
-  SILFunction *lookupSILFunction(StringRef Name);
+  SILFunction *
+  lookupSILFunction(StringRef Name, bool declarationOnly = false,
+                    SILLinkage linkage = SILLinkage::Private);
   SILVTable *lookupVTable(Identifier Name);
   SILVTable *lookupVTable(const ClassDecl *C) {
     return lookupVTable(C->getName());
@@ -90,6 +93,8 @@ public:
 
   /// Invalidate the cached entries for deserialized SILFunctions.
   void invalidateCaches();
+
+  bool invalidateFunction(SILFunction *F);
 
   /// Deserialize all SILFunctions, VTables, and WitnessTables in all
   /// SILModules.

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -125,6 +125,22 @@ bool SILLinkerVisitor::processFunction(StringRef Name) {
   return true;
 }
 
+/// Process Decl, recursively deserializing any thing Decl may reference.
+SILFunction *SILLinkerVisitor::lookupFunction(StringRef Name,
+                                              SILLinkage Linkage) {
+
+  auto *NewFn = Loader->lookupSILFunction(Name, /* declarationOnly */ true,
+                                          Linkage);
+
+  if (!NewFn)
+    return nullptr;
+
+  assert(NewFn->isExternalDeclaration() &&
+         "SIL function lookup should never read function bodies");
+
+  return NewFn;
+}
+
 
 /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
 /// transitively references.

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -54,6 +54,10 @@ public:
   /// may reference.
   bool processFunction(StringRef Name);
 
+  /// Process Name, try to deserialize a declaration of a function with
+  /// this Name.
+  SILFunction *lookupFunction(StringRef Name, SILLinkage Linkage);
+
   /// Process Decl, recursively deserializing any thing that
   /// the SILFunction corresponding to Decl may reference.
   bool processDeclRef(SILDeclRef Decl);

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -468,6 +468,15 @@ bool SILModule::linkFunction(StringRef Name, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Name);
 }
 
+SILFunction *SILModule::hasFunction(StringRef Name, SILLinkage Linkage) {
+  assert(!lookUpFunction(Name) && "hasFunction should be only called for "
+                                  "functions that are not contained in the "
+                                  "SILModule yet");
+  return SILLinkerVisitor(*this, getSILLoader(),
+                          SILModule::LinkingMode::LinkNormal)
+      .lookupFunction(Name, Linkage);
+}
+
 void SILModule::linkAllWitnessTables() {
   getSILLoader()->getAllWitnessTables();
 }
@@ -514,6 +523,10 @@ void SILModule::eraseFunction(SILFunction *F) {
     FunctionTable.erase(F->getName());
     getFunctionList().erase(F);
   }
+}
+
+void SILModule::invalidateFunctionInSILCache(SILFunction *F) {
+  getSILLoader()->invalidateFunction(F);
 }
 
 /// Erase a global SIL variable from the module.

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -185,49 +185,39 @@ static SILFunction *lookupExistingSpecialization(SILModule &M,
   // Try to link existing specialization only in -Onone mode.
   // All other compilation modes perform specialization themselves.
   // TODO: Cache optimized specializations and perform lookup here?
-  // TODO: Only check that this function exists, but don't read
+  // Only check that this function exists, but don't read
   // its body. It can save some compile-time.
-  if (isWhitelistedSpecialization(FunctionName) &&
-      M.linkFunction(FunctionName, SILOptions::LinkingMode::LinkNormal))
-    return M.lookUpFunction(FunctionName);
+  if (isWhitelistedSpecialization(FunctionName))
+    return M.hasFunction(FunctionName, SILLinkage::PublicExternal);
 
   return nullptr;
 }
 
 SILFunction *swift::getExistingSpecialization(SILModule &M,
                                               StringRef FunctionName) {
-  auto *Specialization = lookupExistingSpecialization(M, FunctionName);
+  // First check if the module contains a required specialization already.
+  auto *Specialization = M.lookUpFunction(FunctionName);
+  if (Specialization)
+    return Specialization;
+
+  // Then check if the required specialization can be found elsewhere.
+  Specialization = lookupExistingSpecialization(M, FunctionName);
   if (!Specialization)
     return nullptr;
-  if (hasPublicVisibility(Specialization->getLinkage())) {
-    // The bodies of existing specializations cannot be used,
-    // as they may refer to non-public symbols.
-    if (Specialization->isDefinition())
-      Specialization->convertToDeclaration();
-    Specialization->setLinkage(SILLinkage::PublicExternal);
-    // Ignore body for -Onone and -Odebug.
-    assert((Specialization->isExternalDeclaration() ||
-            convertExternalDefinitionIntoDeclaration(Specialization)) &&
-           "Could not remove body of the found specialization");
-    if (!Specialization->isExternalDeclaration() &&
-        !convertExternalDefinitionIntoDeclaration(Specialization)) {
-      DEBUG(
-          llvm::dbgs() << "Could not remove body of specialization: "
-                       << FunctionName << '\n');
-    }
 
-    DEBUG(
-        llvm::dbgs() << "Found existing specialization for: "
-                     << FunctionName << '\n';
+  assert(hasPublicVisibility(Specialization->getLinkage()) &&
+         "Pre-specializations should have public visibility");
+
+  Specialization->setLinkage(SILLinkage::PublicExternal);
+
+  assert(Specialization->isExternalDeclaration()  &&
+         "Specialization should be a public external declaration");
+
+  DEBUG(llvm::dbgs() << "Found existing specialization for: " << FunctionName
+                     << '\n';
         llvm::dbgs() << swift::Demangle::demangleSymbolAsString(
-                            Specialization->getName()) << "\n\n");
-  } else {
-    // Forget about this function.
-    DEBUG(llvm::dbgs() << "Cannot reuse the specialization: "
-           << swift::Demangle::demangleSymbolAsString(Specialization->getName())
-           <<"\n");
-    return nullptr;
-  }
+                            Specialization->getName())
+                     << "\n\n");
 
   return Specialization;
 }

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -109,12 +109,16 @@ public:
       return MF->getFile();
     }
     SILFunction *lookupSILFunction(SILFunction *InFunc);
-    SILFunction *lookupSILFunction(StringRef Name);
+    SILFunction *lookupSILFunction(StringRef Name,
+                                   bool declarationOnly = false);
     SILVTable *lookupVTable(Identifier Name);
     SILWitnessTable *lookupWitnessTable(SILWitnessTable *wt);
 
     /// Invalidate all cached SILFunctions.
     void invalidateFunctionCache();
+
+    /// Invalidate a specific cached SILFunction.
+    bool invalidateFunction(SILFunction *F);
 
     /// Deserialize all SILFunctions, VTables, and WitnessTables inside the
     /// module and add them to SILMod.


### PR DESCRIPTION
Introduce and use new APIs to perform lookups of existing pre-specializations in a more light-weight way. Don't serialize and don't even try to read bodies of pre-specialized functions. Just check if they exist.
