### PR TITLE
[gardening] Fix recently introduced typos: "agains" → "against", "corrseponding" → "corresponding", "precessor" → "predecessor"

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -246,7 +246,7 @@ public:
 
   /// Computes the lifetime frontier for the value.
   /// Returns true on success. It can fail if the lifetime frontier is located
-  /// on a critical edge. Which means that getting the corrseponding frontier
+  /// on a critical edge. Which means that getting the corresponding frontier
   /// instruction would require splitting that critical edge.
   bool computeFrontier(Frontier &Fr) {
     switch (computeFrontierImpl(Fr, true)) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1185,7 +1185,7 @@ bool ValueLifetimeAnalysis::isWithinLifetime(SILInstruction *Inst) {
   for (const SILSuccessor &Succ : BB->getSuccessors()) {
     // If the value is live at the beginning of any successor block it is also
     // live at the end of BB and therefore Inst is definitely in the lifetime
-    // region (Note that we don't check in upward direction agains the value's
+    // region (Note that we don't check in upward direction against the value's
     // definition).
     if (LiveBlocks.count(Succ))
       return true;

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1146,7 +1146,7 @@ computeFrontierImpl(Frontier &Fr, bool AllowedToModifyCFG) {
   // Handle "exit" edges from the lifetime region.
   for (SILBasicBlock *FrontierBB: FrontierBlocks) {
     bool needSplit = false;
-    // If the value is live only in part of the precessor blocks we have to
+    // If the value is live only in part of the predecessor blocks we have to
     // split those predecessor edges.
     for (SILBasicBlock *Pred : FrontierBB->getPreds()) {
       if (!LiveBlocks.count(Pred) || NotLiveOutBlocks.count(Pred)) {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix three newly introduced typos.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI </summary>



The swift-ci is triggered by writing a comment on this PR addressed to the github user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
