### PR TITLE
Remove unused function convertExternalDefinitionIntoDeclaration(…)

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -211,28 +211,6 @@ replaceWithSpecializedFunction(ApplySite AI, SILFunction *NewF,
   return replaceWithSpecializedCallee(AI, FRI, Builder, ReInfo);
 }
 
-/// Try to convert definition into declaration.
-static bool convertExternalDefinitionIntoDeclaration(SILFunction *F) {
-  // Bail if it is a declaration already.
-  if (!F->isDefinition())
-    return false;
-  // Bail if there is no external implementation of this function.
-  if (!F->isAvailableExternally())
-    return false;
-  // Bail if has a shared visibility, as there are no guarantees
-  // that an implementation is available elsewhere.
-  if (hasSharedVisibility(F->getLinkage()))
-    return false;
-  // Make this definition a declaration by removing the body of a function.
-  F->convertToDeclaration();
-  assert(F->isExternalDeclaration() &&
-         "Function should be an external declaration");
-
-  DEBUG(llvm::dbgs() << "  removed external function " << F->getName() << "\n");
-
-  return true;
-}
-
 /// Check of a given name could be a name of a white-listed
 /// specialization.
 bool swift::isWhitelistedSpecialization(StringRef SpecName) {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A commit which remove the unused function convertExternalDefinitionIntoDeclaration(…).
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI </summary>



The swift-ci is triggered by writing a comment on this PR addressed to the github user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
