### PR TITLE
[stdlib] Rewrite UTF8._isValidUTF8()

### DIFF
--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -159,8 +159,7 @@ extension String {
       /// True iff the index is at the end of its view or if the next
       /// byte begins a new UnicodeScalar.
       internal var _isOnUnicodeScalarBoundary : Bool {
-        let next = UTF8.CodeUnit(truncatingBitPattern: _buffer)
-        return UTF8._numTrailingBytes(next) != 4 || _isAtEnd
+        return UTF8._isValidUTF8(UInt32(truncatingBitPattern: _buffer)) || _isAtEnd
       }
 
       /// True iff the index is at the end of its view

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -112,7 +112,7 @@ public struct UTF8 : UnicodeCodecType {
     }
 
     // Determine sequence length using high 5 bits of 1st byte. We use a
-    // look-up table to branch less. 1-byte sequence are handled above.
+    // look-up table to branch less. 1-byte sequences are handled above.
     //
     //  case | pattern | description
     // ----------------------------
@@ -156,7 +156,7 @@ public struct UTF8 : UnicodeCodecType {
         if buffer & 0x00003003 != 0x00000000 { return false }
       }
       return true
-    default: // Invalid sequence
+    default: // Invalid sequence.
       return false
     }
   }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -107,7 +107,8 @@ public struct UTF8 : UnicodeCodecType {
   /// space in `buffer` is filled with some value not matching the UTF-8
   /// continuation byte form (`0b10xxxxxx`).
   @warn_unused_result
-  public static func _isValidUTF8(buffer: UInt32) -> Bool {
+  public // @testable
+  static func _isValidUTF8(buffer: UInt32) -> Bool {
 
     if _fastPath(buffer & 0x80 == 0) {
       return true // 0x00 -- 0x7f: 1-byte sequences (ASCII).

--- a/validation-test/stdlib/Unicode.swift
+++ b/validation-test/stdlib/Unicode.swift
@@ -787,31 +787,40 @@ UnicodeScalarTests.test("init") {
 
 var UTF8Decoder = TestSuite("UTF8Decoder")
 
-UTF8Decoder.test("Internal/_numTrailingBytes") {
-  for i in UInt8(0x00)...UInt8(0x7f) {
-    expectEqual(0, UTF8._numTrailingBytes(i), "i=\(i)")
+UTF8Decoder.test("Internal/_isValidUTF8") {
+
+  // Ensure we accept all valid scalars
+  func ensureValid(scalar: UnicodeScalar) {
+    var data: UInt32 = 0
+    var i: UInt32 = 0
+    Swift.UTF8.encode(scalar) { cp in
+      data |= UInt32(cp) << (i*8)
+      i += 1
+    }
+    expectEqual(FastUTF8._isValidUTF8(data), true, "data=\(asHex(data))")
   }
-  for i in UInt8(0x80)...UInt8(0xc1) {
-    expectEqual(4, UTF8._numTrailingBytes(i), "i=\(i)")
+
+  for i in 0..<0xd800 { ensureValid(UnicodeScalar(i)) }
+  for i in 0xe000...0x10ffff { ensureValid(UnicodeScalar(i)) }
+
+  // Ensure we have no false positives
+  var n = 0
+  func countValidSequences(head head: Range<UInt32>, tail: Range<UInt32>) {
+    for cu0 in head {
+      for rest in tail {
+        let data = rest << 8 | cu0
+        if FastUTF8._isValidUTF8(data) { n += 1 }
+      }
+    }
   }
-  for i in UInt8(0xc2)...UInt8(0xdf) {
-    expectEqual(1, UTF8._numTrailingBytes(i), "i=\(i)")
-  }
-  for i in UInt8(0xe0)...UInt8(0xef) {
-    expectEqual(2, UTF8._numTrailingBytes(i), "i=\(i)")
-  }
-  for i in UInt8(0xf0)...UInt8(0xf4) {
-    expectEqual(3, UTF8._numTrailingBytes(i), "i=\(i)")
-  }
-  for i in UInt8(0xf5)...UInt8(0xfe) {
-    expectEqual(4, UTF8._numTrailingBytes(i), "i=\(i)")
-  }
-  // Separate test for 0xff because of:
-  // <rdar://problem/17376512> Range UInt8(0x00)...UInt8(0xff) invokes a
-  // runtime trap
-  var i = UInt8(0xff)
-  expectEqual(4, UTF8._numTrailingBytes(i), "i=\(i)")
+
+  countValidSequences(head: 0x00...0x7f, tail: 0...0)
+  countValidSequences(head: 0xc0...0xdf, tail: 0...0xff)
+  countValidSequences(head: 0xe0...0xef, tail: 0...0xffff)
+  countValidSequences(head: 0xf0...0xf7, tail: 0...0xffffff)
+  expectEqual(n, 0x10f800, "n=\(asHex(n))") // 0x10ffff minus surrogates
 }
+
 
 UTF8Decoder.test("Empty") {
   expectTrue(checkDecodeUTF8([], [], []))

--- a/validation-test/stdlib/Unicode.swift
+++ b/validation-test/stdlib/Unicode.swift
@@ -797,7 +797,7 @@ UTF8Decoder.test("Internal/_isValidUTF8") {
       data |= UInt32(cp) << (i*8)
       i += 1
     }
-    expectEqual(FastUTF8._isValidUTF8(data), true, "data=\(asHex(data))")
+    expectEqual(UTF8._isValidUTF8(data), true, "data=\(asHex(data))")
   }
 
   for i in 0..<0xd800 { ensureValid(UnicodeScalar(i)) }
@@ -809,7 +809,7 @@ UTF8Decoder.test("Internal/_isValidUTF8") {
     for cu0 in head {
       for rest in tail {
         let data = rest << 8 | cu0
-        if FastUTF8._isValidUTF8(data) { n += 1 }
+        if UTF8._isValidUTF8(data) { n += 1 }
       }
     }
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

A rewrite of `UTF8._isValidUTF8()`, which further improves performance (mainly by removing branches) and reduces code size.
- Non-ASCII: 35-45% speed-up
- Invalid sequences: ~15% speed-up
- ASCII: identical performance

Tested against original implementation for all input values (`0...0xffffffff`), results are identical.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI </summary>



The swift-ci is triggered by writing a comment on this PR addressed to the github user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
