### PR TITLE
[SILOptimizer/stdlib] Emit failing _preconditions as compiler errors

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -243,11 +243,10 @@ ERROR(wrong_non_negative_assumption,none,
 ERROR(shifting_all_significant_bits,none,
       "shift amount is greater than or equal to type size in bits", ())
 
-// FIXME: We won't need this as it will be replaced with user-generated strings.
-// staticReport diagnostics.
 ERROR(static_report_error, none,
-      "static report error", ())
-
+      "unknown static error", ())
+ERROR(static_report_error_message, none,
+      "static error: %0", (StringRef))
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -133,8 +133,14 @@ static void diagnoseStaticReports(const SILInstruction *I,
       if (!V || V->getValue() != 1)
         return;
 
-      diagnose(M.getASTContext(), I->getLoc().getSourceLoc(),
-               diag::static_report_error);
+      auto message = dyn_cast<StringLiteralInst>(Args[2]);
+      if (!message || message->getValue().empty()) {
+        diagnose(M.getASTContext(), I->getLoc().getSourceLoc(),
+                 diag::static_report_error);
+      } else {
+        diagnose(M.getASTContext(), I->getLoc().getSourceLoc(),
+                 diag::static_report_error_message, message->getValue());
+      }
     }
   }
 }

--- a/test/1_stdlib/RangeStaticError.swift
+++ b/test/1_stdlib/RangeStaticError.swift
@@ -1,0 +1,13 @@
+// % RUN: %target-swift-frontend -emit-sil -verify %s
+
+func f1() {
+  _ = 1..<0 //expected-error{{static error: Can't form Range with end < start}}
+}
+
+func f2() {
+  _ = 1...0 //expected-error{{static error: Can't form Range with end < start}}
+}
+
+func f3() {
+  _ = 0...Int.max //expected-error{{static error: Range end index has no valid successor}}
+}

--- a/test/1_stdlib/RangeTraps.swift
+++ b/test/1_stdlib/RangeTraps.swift
@@ -37,9 +37,9 @@ RangeTraps.test("HalfOpen")
   .code {
   var range = 1..<1
   expectType(Range<Int>.self, &range)
-  
+
   expectCrashLater()
-  1..<0
+  1..<getInt(0)
 }
 
 RangeTraps.test("Closed")
@@ -51,7 +51,7 @@ RangeTraps.test("Closed")
   expectType(Range<Int>.self, &range)
 
   expectCrashLater()
-  1...0
+  1...getInt(0)
 }
 
 RangeTraps.test("OutOfRange")
@@ -68,9 +68,9 @@ RangeTraps.test("OutOfRange")
   expectCrashLater()
 #if arch(i386)  ||  arch(arm)
   // FIXME <rdar://17670791> Range<Int> bounds checking not enforced in optimized 32-bit
-  1...0  // crash some other way
+  1...getInt(0)  // crash some other way
 #else
-  0...Int.max
+  0...getInt(Int.max)
 #endif
 }
 

--- a/test/SILOptimizer/static_report.sil
+++ b/test/SILOptimizer/static_report.sil
@@ -6,6 +6,10 @@ import Builtin
 sil @sil_test_static_report : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
 bb0(%0 : $Builtin.RawPointer):
   %1 = integer_literal $Builtin.Int1, 1
-  %3 = builtin "staticReport"(%1 : $Builtin.Int1, %1 : $Builtin.Int1, %0 : $Builtin.RawPointer) : $() // expected-error {{static report error}}
+  %2 = string_literal utf8 ""
+  %3 = string_literal utf8 "foo bar"
+  %4 = builtin "staticReport"(%1 : $Builtin.Int1, %1 : $Builtin.Int1, %0 : $Builtin.RawPointer) : $() // expected-error {{unknown static error}}
+  %5 = builtin "staticReport"(%1 : $Builtin.Int1, %1 : $Builtin.Int1, %2 : $Builtin.RawPointer) : $() // expected-error {{unknown static error}}
+  %6 = builtin "staticReport"(%1 : $Builtin.Int1, %1 : $Builtin.Int1, %3 : $Builtin.RawPointer) : $() // expected-error {{static error: foo bar}}
   return %0 : $Builtin.RawPointer
 }


### PR DESCRIPTION
#### What's in this pull request?

This change allows failing `_precondition`s inside `@_transparent` functions to be emitted as errors.
#### What's not in this pull request?

Only the preconditions in inlined functions can be folded to a constant true/false value, so the only functions taking full leverage of this change are the range returning overloads where `Pos` is `Comparable` of `...` and `..<`.
#### Resolved bug number: [SR-707](https://bugs.swift.org/browse/SR-707)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI </summary>



The swift-ci is triggered by writing a comment on this PR addressed to the github user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
