### PR TITLE
Improve var decl completion in switch cases

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -985,6 +985,9 @@ public:
 
   SourceLoc getStartLoc() const { return getLoc(); }
   SourceLoc getEndLoc() const { return getBody()->getEndLoc(); }
+  SourceRange getLabelItemsRange() const {
+    return ColonLoc.isValid() ? SourceRange(getLoc(), ColonLoc) : getSourceRange();
+  }
 
   bool isDefault() { return getCaseLabelItems()[0].isDefault(); }
 

--- a/test/IDE/complete_pattern.swift
+++ b/test/IDE/complete_pattern.swift
@@ -23,6 +23,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_1 | FileCheck %s -check-prefix=MULTI_PATTERN_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_2 | FileCheck %s -check-prefix=MULTI_PATTERN_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_3 | FileCheck %s -check-prefix=MULTI_PATTERN_3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_4 | FileCheck %s -check-prefix=MULTI_PATTERN_4
 
 
 //===--- Helper types that are used in this test
@@ -155,13 +156,13 @@ func test_multiple_patterns1(x: Int) {
 }
 
 // MULTI_PATTERN_1: Begin completions
-// FIXME: ideally we wouldn't offer 'a' here, without 'let' first:
-// xxxMULTI_PATTERN_1-NOT: Decl[LocalVar]/Local: a[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_1-NOT: Decl[LocalVar]/Local: a[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_1-DAG: Decl[LocalVar]/Local: x[#Int#]{{; name=.+$}}
 // MULTI_PATTERN_1: End completions
 
 func test_multiple_patterns2(x: Int) {
     switch (x, x) {
-    case let (0, let a), (let a, 0):
+    case (0, let a), (let a, 0):
         #^MULTI_PATTERN_2^#
     }
 }
@@ -173,7 +174,7 @@ func test_multiple_patterns2(x: Int) {
 
 func test_multiple_patterns3(x: Int) {
     switch (x, x) {
-    case let (0, let a), (let b, 0):
+    case (0, let a), (let b, 0):
         #^MULTI_PATTERN_3^#
     }
 }
@@ -182,4 +183,15 @@ func test_multiple_patterns3(x: Int) {
 // MULTI_PATTERN_3-DAG: Decl[LocalVar]/Local: x[#Int#]{{; name=.+$}}
 // MULTI_PATTERN_3: End completions
 
+func test_multiple_patterns4(x: Int) {
+    switch (x, x) {
+    case (0, let a) where #^MULTI_PATTERN_4^#
+        
+    }
+}
+
+// MULTI_PATTERN_4: Begin completions
+// MULTI_PATTERN_4-DAG: Decl[LocalVar]/Local: a[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_4-DAG: Decl[LocalVar]/Local: x[#Int#]{{; name=.+$}}
+// MULTI_PATTERN_4: End completions
 


### PR DESCRIPTION
Variables bound in the case item pattern should be available inside the case body and in the where clause, but not elsewhere within the statement (e.g. other case items). The added accessor
CaseStmt.getLabelItemsRange() is needed to be able to determine the difference between a completion location after a colon and one where the colon doesn’t exist (in both cases this would be in the — implicit
— body statement range).

This is the follow up to completions discussed in https://github.com/apple/swift/pull/1383.
