### PR TITLE
[stdlib] Use write(2) in print()

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -60,6 +60,9 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_ssize_t _swift_stdlib_write(int fd, const void *buf,
                                     __swift_size_t nbyte);
 SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_ssize_t _swift_stdlib_write_stdout(const void *buf,
+                                    __swift_size_t nbyte);
+SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_close(int fd);
 
 // Non-standard extensions

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -45,6 +45,11 @@ __swift_ssize_t _swift_stdlib_write(int fd, const void *buf,
   return write(fd, buf, nbyte);
 }
 
+__swift_ssize_t _swift_stdlib_write_stdout(const void *buf,
+                                    __swift_size_t nbyte) {
+  return write(STDOUT_FILENO, buf, nbyte);
+}
+
 int _swift_stdlib_close(int fd) { return close(fd); }
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Opening for feedback/comment.

Use write(2) instead of iterating calling putchar_unlocked() repeatedly, in print()
