### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::resolveTypeWitness(…)

### DIFF
--- a/validation-test/compiler_crashers/28257-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers/28257-swift-typechecker-resolvetypewitness.swift
@@ -1,0 +1,14 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A{
+class A:a{
+}
+typealias e:a
+protocol a{
+typealias r
+}
+typealias e:A


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A new crash case.

Stack trace:

```
5  swift           0x0000000000e41101 swift::TypeChecker::resolveTypeWitness(swift::NormalProtocolConformance const*, swift::AssociatedTypeDecl*) + 225
6  swift           0x00000000010341a6 swift::NormalProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 150
7  swift           0x00000000010340e8 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 40
8  swift           0x00000000010348e6 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
11 swift           0x0000000000f1f058 swift::ArchetypeBuilder::addSuperclassRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::Type, swift::RequirementSource) + 248
14 swift           0x0000000000f20d4f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
15 swift           0x0000000000f1eb4a swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
16 swift           0x0000000000f1eed7 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 471
19 swift           0x0000000000f20d4f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
20 swift           0x0000000000f1eb4a swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
21 swift           0x0000000000f1e97c swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
22 swift           0x0000000000e34427 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 375
23 swift           0x0000000000e35b37 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
24 swift           0x0000000000e35ee4 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
25 swift           0x0000000000df9bd4 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1300
28 swift           0x0000000000dff206 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
29 swift           0x0000000000e22092 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1026
30 swift           0x0000000000c97b9f swift::CompilerInstance::performSema() + 3167
32 swift           0x000000000077705b frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2523
33 swift           0x0000000000771b25 main + 2773
Stack dump:
0.  Program arguments: /usr/local/bin/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28257-swift-typechecker-resolvetypewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28257-swift-typechecker-resolvetypewitness-eec025.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28257-swift-typechecker-resolvetypewitness.swift:7:1
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
