### PR TITLE
[SILGen] Handle #function in defer blocks correctly

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -66,10 +66,15 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
     return getMagicFunctionName(closure->getParent());
   }
   if (auto absFunc = dyn_cast<AbstractFunctionDecl>(dc)) {
-    // If this is an accessor, use the name of the storage.
     if (auto func = dyn_cast<FuncDecl>(absFunc)) {
-      if (auto storage = func->getAccessorStorageDecl())
+      // If this is an accessor, use the name of the storage.
+      if (auto storage = func->getAccessorStorageDecl()) {
         return storage->getFullName();
+      }
+      // If this is a defer body, use the parent name.
+      if (func->isDeferBody()) {
+        return getMagicFunctionName(func->getParent());
+      }
     }
 
     return absFunc->getFullName();

--- a/test/Interpreter/defer.swift
+++ b/test/Interpreter/defer.swift
@@ -1,11 +1,33 @@
 // RUN: %target-run-simple-swift | FileCheck %s
 // REQUIRES: executable_test
 
-defer { print("deferred 1") }
-defer { print("deferred 2") }
-print("start!")
+do {
+    defer { print("deferred 1") }
+    defer { print("deferred 2") }
+    print("start!")
 
-// CHECK-NOT: deferred
-// CHECK-LABEL: start!
-// CHECK-NEXT: deferred 2
-// CHECK-NEXT: deferred 1
+    // CHECK-NOT: deferred
+    // CHECK-LABEL: start!
+    // CHECK-NEXT: deferred 2
+    // CHECK-NEXT: deferred 1
+}
+
+// ensure #function ignores defer blocks
+do {
+    print("top-level #function")
+    let name = #function
+    defer { print(name == #function ? "good" : "bad") }
+
+    // CHECK-LABEL: top-level #function
+    // CHECK-NEXT: good
+}
+
+func foo() {
+    print("foo()")
+    let name = #function
+    defer { print(name == #function ? "good" : "bad") }
+
+    // CHECK-LABEL: foo()
+    // CHECK-NEXT: good
+}
+foo()


### PR DESCRIPTION
Using `#function` in a `defer` block should return the enclosing
function name rather than the string `$defer()`.

Fixes [SR-819](https://bugs.swift.org/browse/SR-819).
