### PR TITLE
Add benchmark for UTF-8 decoding

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SWIFT_BENCH_MODULES
     single-source/SuperChars
     single-source/TwoSum
     single-source/TypeFlood
+    single-source/UTF8Decode
     single-source/Walsh
     single-source/XorLoop
 )

--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -1,0 +1,26 @@
+//===--- UTF8Decode.swift -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+@inline(never)
+public func run_UTF8Decode(N: Int) {
+  // Use test data with UTF-8 sequences of all lengths, but mainly ASCII.
+  let string = "Mainly ASCII but also some 2-byte sequences (пример),"
+    + " some 3-bytes sequences (성능 테스트) and occasionally a 🐼 (4 bytes)"
+  let data = Array(string.utf8)
+  for _ in 1...N {
+    var generator = data.generate()
+    var utf8 = UTF8()
+    while !utf8.decode(&generator).isEmptyInput() { }
+  }
+}

--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -27,7 +27,7 @@ public func run_UTF8Decode(N: Int) {
 
   let strings = [ ascii, russian, japanese, emoji ].map { Array($0.utf8) }
 
-  for _ in 1...N {
+  for _ in 1...1000*N {
     for string in strings {
       var generator = string.generate()
       var utf8 = UTF8()

--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -14,13 +14,24 @@ import TestsUtils
 
 @inline(never)
 public func run_UTF8Decode(N: Int) {
-  // Use test data with UTF-8 sequences of all lengths, but mainly ASCII.
-  let string = "Mainly ASCII but also some 2-byte sequences (пример),"
-    + " some 3-bytes sequences (성능 테스트) and occasionally a 🐼 (4 bytes)"
-  let data = Array(string.utf8)
+  // 1-byte sequences
+  // This test case is the longest as it's the most perfomance sensitive.
+  let ascii = "Swift is a multi-paradigm, compiled programming language created for iOS, OS X, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
+  // 2-byte sequences
+  let russian = "Ру́сский язы́к один из восточнославянских языков, национальный язык русского народа."
+  // 3-byte sequences
+  let japanese = "日本語（にほんご、にっぽんご）は、主に日本国内や日本人同士の間で使われている言語である。"
+  // 4-byte sequences
+  // Most commonly emoji, which are usually mixed with other text.
+  let emoji = "Panda 🐼, Dog 🐶, Cat 🐱, Mouse 🐭."
+
+  let strings = [ ascii, russian, japanese, emoji ].map { Array($0.utf8) }
+
   for _ in 1...N {
-    var generator = data.generate()
-    var utf8 = UTF8()
-    while !utf8.decode(&generator).isEmptyInput() { }
+    for string in strings {
+      var generator = string.generate()
+      var utf8 = UTF8()
+      while !utf8.decode(&generator).isEmptyInput() { }
+    }
   }
 }

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -90,6 +90,7 @@ import StringWalk
 import SuperChars
 import TwoSum
 import TypeFlood
+import UTF8Decode
 import Walsh
 import XorLoop
 
@@ -171,6 +172,7 @@ precommitTests = [
   "SuperChars": run_SuperChars,
   "TwoSum": run_TwoSum,
   "TypeFlood": run_TypeFlood,
+  "UTF8Decode": run_UTF8Decode,
   "Walsh": run_Walsh,
   "XorLoop": run_XorLoop,
 ]


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Adds a performance test for UTF-8 decoding.

I didn't pre-multiply N, since the [README](https://github.com/apple/swift/blob/master/benchmark/README.md) suggest that, but the other benchmarks all seem to be premultiplying it. What's the preferred approach here? 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
