### PR TITLE
[SR-832][Sema] Fix for function type args passed to @autoclosure params

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -174,3 +174,9 @@ func typeCheckMultiStmtClosureCrash() {
     return 1
   }
 }
+
+// SR-832 - both these should be ok
+func someFunc(foo: (String -> String)?, bar: String -> String) {
+    let _: String -> String = foo != nil ? foo! : bar
+    let _: String -> String = foo ?? bar
+}


### PR DESCRIPTION
Passing a function type to an @autoclosure param would always fail to type check because of the attempt to decompose the parallel structure of the two (both being functions). In this case, though, we don’t want to do any such thing, we want to allow the ExprRewriter to explicitly insert an AutoClosureExpr in coerceToType, as it would do with any other non-function arg type.
