### PR TITLE
[Sema] Synthesize domain of @objc enums properly

### DIFF
--- a/lib/Sema/DerivedConformanceErrorType.cpp
+++ b/lib/Sema/DerivedConformanceErrorType.cpp
@@ -189,18 +189,21 @@ static void deriveBodyBridgedNSError_enum_NSErrorDomain(
   // enum SomeEnum {
   //   @derived
   //   static var _NSErrorDomain: String {
-  //     return "\(self)"
+  //     return "ModuleName.SomeEnum"
   //   }
   // }
 
-  auto &C = domainDecl->getASTContext();
+  auto M = domainDecl->getParentModule();
+  auto &C = M->getASTContext();
+  auto TC = domainDecl->getInnermostTypeContext();
+  auto ED = TC->getAsEnumOrEnumExtensionContext();
 
-  auto selfRef = createSelfDeclRef(domainDecl);
-  Expr *segmentElts[] = { selfRef };
-  auto segments = C.AllocateCopy(segmentElts);
-  auto string = new (C) InterpolatedStringLiteralExpr(SourceLoc(), segments);
-  string->setImplicit();
+  std::string buffer = M->getNameStr();
+  buffer += ".";
+  buffer += ED->getNameStr();
+  StringRef value(C.AllocateCopy(buffer));
 
+  auto string = new (C) StringLiteralExpr(value, SourceRange(), /*implicit*/ true);
   auto ret = new (C) ReturnStmt(SourceLoc(), string, /*implicit*/ true);
   auto body = BraceStmt::create(C, SourceLoc(),
                                 ASTNode(ret),

--- a/test/1_stdlib/ErrorTypeBridging.swift
+++ b/test/1_stdlib/ErrorTypeBridging.swift
@@ -231,7 +231,7 @@ ErrorTypeBridgingTests.test("enum-to-NSError round trip") {
   autoreleasepool {
     // Emulate throwing an error from Objective-C.
     func throwNSError(error: EnumError) throws {
-      throw NSError(domain: "\(EnumError.self)", code: error.rawValue,
+      throw NSError(domain: "main.EnumError", code: error.rawValue,
                     userInfo: [:])
     }
 


### PR DESCRIPTION
#### What's in this pull request?

This PR adjusts the derived implementation of `_NSErrorDomain` to match the format that PrintAsObjC uses.

The domain constant generated by PrintAsObjC always has the value `"ModuleName.TypeName"`, but the actual value of the derived `_NSErrorDomain` constant from the `_BridgedNSError` protocol was implemented as `"\(self)"`. This meant that any time that the default string representation of the enum type did not match the format `"ModuleName.TypeName"`, the generated domain constant did not match the actual error domain. This could happen when compiling programs at the command-line that define the error (as the module name is typically omitted there), or if the enum was nested inside another `@objc` declaration (as the qualified type name there includes the parent type declaration).
#### Resolved bug number: ([SR-700](https://bugs.swift.org/browse/SR-700))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
