### PR TITLE
[stdlib] Use fwrite(3) in _Stdout.write()

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -45,7 +45,7 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_putchar_unlocked(int c);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
-		__swift_size_t nitems);
+                                           __swift_size_t nitems);
 
 // String handling <string.h>
 __attribute__((pure))

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -43,6 +43,9 @@ void _swift_stdlib_free(void *ptr);
 // Input/output <stdio.h>
 SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_putchar_unlocked(int c);
+SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
+		__swift_size_t nitems);
 
 // String handling <string.h>
 __attribute__((pure))

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -333,6 +333,8 @@ internal struct _Stdout : OutputStreamType {
     if string.isEmpty { return }
 
     if string._core.isASCII {
+      defer { _fixLifetime(string) }
+
       let result = _swift_stdlib_fwrite_stdout(
         UnsafePointer(string._core.startASCII), string._core.count, 1)
       if result != 1 {

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -333,16 +333,16 @@ internal struct _Stdout : OutputStreamType {
     if string.isEmpty { return }
 
     if string._core.isASCII {
-        let result = _swift_stdlib_fwrite_stdout(
-            UnsafePointer(string._core.startASCII), string._core.count, 1)
-        if result != 1 {
-            fatalError("fwrite() returned \(result), expected 1")
-        }
-        return
+      let result = _swift_stdlib_fwrite_stdout(
+        UnsafePointer(string._core.startASCII), string._core.count, 1)
+      if result != 1 {
+        fatalError("fwrite() returned \(result), expected 1")
+      }
+      return
     }
 
     for c in string.utf8 {
-        _swift_stdlib_putchar_unlocked(Int32(c))
+      _swift_stdlib_putchar_unlocked(Int32(c))
     }
   }
 }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -335,11 +335,8 @@ internal struct _Stdout : OutputStreamType {
     if string._core.isASCII {
       defer { _fixLifetime(string) }
 
-      let result = _swift_stdlib_fwrite_stdout(
-        UnsafePointer(string._core.startASCII), string._core.count, 1)
-      if result != 1 {
-        fatalError("fwrite() returned \(result), expected 1")
-      }
+      _swift_stdlib_fwrite_stdout(UnsafePointer(string._core.startASCII),
+                                  string._core.count, 1)
       return
     }
 

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -330,11 +330,14 @@ internal struct _Stdout : OutputStreamType {
   }
 
   mutating func write(string: String) {
-    // FIXME: buffering?
-    // It is important that we use stdio routines in order to correctly
-    // interoperate with stdio buffering.
-    for c in string.utf8 {
-      _swift_stdlib_putchar_unlocked(Int32(c))
+    let utf8 = string.nulTerminatedUTF8
+    utf8.withUnsafeBufferPointer {
+        (utf8) -> Void in
+        let result = _swift_stdlib_fwrite_stdout(UnsafePointer(utf8.baseAddress),
+            utf8.count - 1, 1)
+        if result < 0 {
+            fatalError("fwrite() returned an error")
+        }
     }
   }
 }

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -31,7 +31,7 @@ void _swift_stdlib_free(void *ptr) { free(ptr); }
 int _swift_stdlib_putchar_unlocked(int c) { return putchar_unlocked(c); }
 
 __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
-		__swift_size_t nitems) {
+                                           __swift_size_t nitems) {
   return fwrite(ptr, size, nitems, stdout);
 }
 

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -30,6 +30,11 @@ void _swift_stdlib_free(void *ptr) { free(ptr); }
 
 int _swift_stdlib_putchar_unlocked(int c) { return putchar_unlocked(c); }
 
+__swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
+		__swift_size_t nitems) {
+  return fwrite(ptr, size, nitems, stdout);
+}
+
 __swift_size_t _swift_stdlib_strlen(const char *s) { return strlen(s); }
 
 int _swift_stdlib_memcmp(const void *s1, const void *s2, __swift_size_t n) {


### PR DESCRIPTION
Add libc shim for calling fwrite() to stdout, and use this in _Stdout.write() instead of calling putchar() repeatedly.
