### PR TITLE
Prefer original spelling of 'static' vs. 'class'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1588,7 +1588,10 @@ ERROR(attr_only_only_one_decl_kind,none,
 
 
 ERROR(override_final,none,
-      "%0 overrides a 'final' %0", (DescriptiveDeclKind))
+      "%0 overrides a 'final' %1", (DescriptiveDeclKind, DescriptiveDeclKind))
+
+ERROR(override_static,none,
+      "cannot override %0", (DescriptiveDeclKind))
 
 ERROR(member_cannot_be_final,none,
       "only classes and class members may be marked with 'final'",

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -711,10 +711,33 @@ public:
 };
 } // unnamed namespace
 
+static StaticSpellingKind getCorrectStaticSpelling(const Decl *D) {
+  if (auto *VD = dyn_cast<VarDecl>(D)) {
+    return VD->getCorrectStaticSpelling();
+  } else if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
+    return PBD->getCorrectStaticSpelling();
+  } else if (auto *FD = dyn_cast<FuncDecl>(D)) {
+    return FD->getCorrectStaticSpelling();
+  } else {
+    return StaticSpellingKind::None;
+  }
+}
+
 void PrintAST::printAttributes(const Decl *D) {
   if (Options.SkipAttributes)
     return;
+
+  // Don't print a redundant 'final' if we are printing a 'static' decl.
+  unsigned originalExcludeAttrCount = Options.ExcludeAttrList.size();
+  if (Options.PrintImplicitAttrs &&
+      D->getDeclContext()->getAsClassOrClassExtensionContext() &&
+      getCorrectStaticSpelling(D) == StaticSpellingKind::KeywordStatic) {
+    Options.ExcludeAttrList.push_back(DAK_Final);
+  }
+
   D->getAttrs().print(Printer, Options);
+
+  Options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 
 void PrintAST::printTypedPattern(const TypedPattern *TP) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -952,14 +952,17 @@ SourceRange PatternBindingDecl::getSourceRange() const {
 }
 
 static StaticSpellingKind getCorrectStaticSpellingForDecl(const Decl *D) {
-  if (D->getDeclContext()->getAsClassOrClassExtensionContext())
-    return StaticSpellingKind::KeywordClass;
-  return StaticSpellingKind::KeywordStatic;
+  if (!D->getDeclContext()->getAsClassOrClassExtensionContext())
+    return StaticSpellingKind::KeywordStatic;
+
+  return StaticSpellingKind::KeywordClass;
 }
 
 StaticSpellingKind PatternBindingDecl::getCorrectStaticSpelling() const {
   if (!isStatic())
     return StaticSpellingKind::None;
+  if (getStaticSpelling() != StaticSpellingKind::None)
+    return getStaticSpelling();
 
   return getCorrectStaticSpellingForDecl(this);
 }
@@ -3351,6 +3354,10 @@ bool VarDecl::isAnonClosureParam() const {
 StaticSpellingKind VarDecl::getCorrectStaticSpelling() const {
   if (!isStatic())
     return StaticSpellingKind::None;
+  if (auto *PBD = getParentPatternBinding()) {
+    if (PBD->getStaticSpelling() != StaticSpellingKind::None)
+      return PBD->getStaticSpelling();
+  }
 
   return getCorrectStaticSpellingForDecl(this);
 }
@@ -4079,6 +4086,8 @@ StaticSpellingKind FuncDecl::getCorrectStaticSpelling() const {
   assert(getDeclContext()->isTypeContext());
   if (!isStatic())
     return StaticSpellingKind::None;
+  if (getStaticSpelling() != StaticSpellingKind::None)
+    return getStaticSpelling();
 
   return getCorrectStaticSpellingForDecl(this);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5122,8 +5122,19 @@ public:
       }
 
       // FIXME: Customize message to the kind of thing.
-      TC.diagnose(Override, diag::override_final, 
-                  Override->getDescriptiveKind());
+      auto baseKind = Base->getDescriptiveKind();
+      switch (baseKind) {
+      case DescriptiveDeclKind::StaticLet:
+      case DescriptiveDeclKind::StaticVar:
+      case DescriptiveDeclKind::StaticMethod:
+        TC.diagnose(Override, diag::override_static, baseKind);
+        break;
+      default:
+        TC.diagnose(Override, diag::override_final,
+                    Override->getDescriptiveKind(), baseKind);
+        break;
+      }
+
       TC.diagnose(Base, diag::overridden_here);
     }
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -422,6 +422,26 @@ class d0120_TestClassBase {
     return 0
   }
 // PASS_COMMON-NEXT: {{^}}  subscript(i: Int) -> Int { get }{{$}}
+
+  class var baseClassVar1: Int { return 0 }
+// PASS_COMMON-NEXT: {{^}}  class var baseClassVar1: Int { get }{{$}}
+
+  // FIXME: final class var not allowed to have storage, but static is?
+  // final class var baseClassVar2: Int = 0
+
+  final class var baseClassVar3: Int { return 0 }
+// PASS_COMMON-NEXT: {{^}}  final class var baseClassVar3: Int { get }{{$}}
+  static var baseClassVar4: Int = 0
+// PASS_COMMON-NEXT: {{^}}  static var baseClassVar4: Int{{$}}
+  static var baseClassVar5: Int { return 0 }
+// PASS_COMMON-NEXT: {{^}}  static var baseClassVar5: Int { get }{{$}}
+
+  class func baseClassFunc1() {}
+// PASS_COMMON-NEXT: {{^}}  class func baseClassFunc1(){{$}}
+  final class func baseClassFunc2() {}
+// PASS_COMMON-NEXT: {{^}}  final class func baseClassFunc2(){{$}}
+  static func baseClassFunc3() {}
+// PASS_COMMON-NEXT: {{^}}  static func baseClassFunc3(){{$}}
 }
 
 class d0121_TestClassDerived : d0120_TestClassBase {

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1312,7 +1312,7 @@ class ClassForFixit {
 
   static var fixitForReferenceInStaticPropertyType: ClassAvailableOn10_51? = nil
       // expected-error@-1 {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
-      // expected-note@-2 {{add @available attribute to enclosing class var}} {{3-3=@available(OSX 10.51, *)\n  }}
+      // expected-note@-2 {{add @available attribute to enclosing static var}} {{3-3=@available(OSX 10.51, *)\n  }}
       // expected-note@-3 {{add @available attribute to enclosing class}} {{1-1=@available(OSX 10.51, *)\n}}
 
   var fixitForReferenceInPropertyTypeMultiple: ClassAvailableOn10_51? = nil, other: Int = 7

--- a/test/SourceKit/SourceDocInfo/cursor_info.swift
+++ b/test/SourceKit/SourceDocInfo/cursor_info.swift
@@ -103,6 +103,13 @@ func refEnumElements() {
   let z: E3 = .C
 }
 
+class C4 {
+  static var v1: Int = 0
+  final class var v2: Int = 0
+  static func f1() {}
+  final class func f2() {}
+}
+
 // RUN: rm -rf %t.tmp
 // RUN: mkdir %t.tmp
 // RUN: %swiftc_driver -emit-module -o %t.tmp/FooSwiftModule.swiftmodule %S/Inputs/FooSwiftModule.swift
@@ -404,3 +411,19 @@ func refEnumElements() {
 // CHECK46-NEXT: C
 // CHECK46: <Declaration>case C</Declaration>
 // CHECK46-NEXT: <decl.enumelement>case <decl.name>C</decl.name></decl.enumelement>
+
+// RUN: %sourcekitd-test -req=cursor -pos=107:14 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck %s -check-prefix=CHECK47
+// CHECK47: source.lang.swift.decl.var.static (107:14-107:16)
+// CHECK47: <decl.var.static>static var
+
+// RUN: %sourcekitd-test -req=cursor -pos=108:19 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck %s -check-prefix=CHECK48
+// CHECK48: source.lang.swift.decl.var.class (108:19-108:21)
+// CHECK48: <decl.var.class>final class var
+
+// RUN: %sourcekitd-test -req=cursor -pos=109:15 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck %s -check-prefix=CHECK49
+// CHECK49: source.lang.swift.decl.function.method.static (109:15-109:19)
+// CHECK49: <decl.function.method.static>static func
+
+// RUN: %sourcekitd-test -req=cursor -pos=110:20 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck %s -check-prefix=CHECK50
+// CHECK50: source.lang.swift.decl.function.method.class (110:20-110:24)
+// CHECK50: <decl.function.method.class>final class func

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -61,12 +61,13 @@ extension E {
 }
 
 class C {
-  static func f1() {} // expected-note {{overridden declaration is here}}
+  static func f1() {} // expected-note 3{{overridden declaration is here}}
   class func f2() {}
   class func f3() {}
   class func f4() {} // expected-note {{overridden declaration is here}}
   class func f5() {} // expected-note {{overridden declaration is here}}
   static final func f6() {} // expected-error {{static declarations are already final}} {{10-16=}}
+  final class func f7() {} // expected-note 3{{overridden declaration is here}}
 }
 
 extension C {
@@ -78,12 +79,22 @@ extension C {
 }
 
 class C_Derived : C {
-  override static func f1() {} // expected-error {{class method overrides a 'final' class method}}
+  override static func f1() {} // expected-error {{cannot override static method}}
   override class func f2() {}
   class override func f3() {}
 
   override class func ef2() {} // expected-error {{declarations from extensions cannot be overridden yet}}
   class override func ef3() {} // expected-error {{declarations from extensions cannot be overridden yet}}
+  override static func f7() {} // expected-error {{static method overrides a 'final' class method}}
+}
+
+class C_Derived2 : C {
+  override final class func f1() {} // expected-error {{cannot override static method}}
+  override final class func f7() {} // expected-error {{class method overrides a 'final' class method}}
+}
+class C_Derived3 : C {
+  override class func f1() {} // expected-error {{cannot override static method}}
+  override class func f7() {} // expected-error {{class method overrides a 'final' class method}}
 }
 
 extension C_Derived {

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -212,15 +212,25 @@ class C2 {
 }
 
 class ClassHasVars {
-  static var computedStatic: Int { return 0 } // expected-note {{overridden declaration is here}}
+  static var computedStatic: Int { return 0 } // expected-note 3{{overridden declaration is here}}
+  final class var computedFinalClass: Int { return 0 } // expected-note 3{{overridden declaration is here}}
   class var computedClass: Int { return 0 }
   var computedInstance: Int { return 0 }
 }
 
 class ClassOverridesVars : ClassHasVars {
-  override static var computedStatic: Int { return 1 } // expected-error {{class var overrides a 'final' class var}}
+  override static var computedStatic: Int { return 1 } // expected-error {{cannot override static var}}
+  override static var computedFinalClass: Int { return 1 } // expected-error {{static var overrides a 'final' class var}}
   override class var computedClass: Int { return 1 }
   override var computedInstance: Int { return 1 }
+}
+class ClassOverridesVars2 : ClassHasVars {
+  override final class var computedStatic: Int { return 1 } // expected-error {{cannot override static var}}
+  override final class var computedFinalClass: Int { return 1 } // expected-error {{class var overrides a 'final' class var}}
+}
+class ClassOverridesVars3 : ClassHasVars {
+  override class var computedStatic: Int { return 1 } // expected-error {{cannot override static var}}
+  override class var computedFinalClass: Int { return 1 } // expected-error {{class var overrides a 'final' class var}}
 }
 
 struct S2 {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Try to match the original spelling of static/class in diagnostics and
when printing the AST. Also fixes cases with
PrintOptions.PrintImplicitAttrs = false, where we would just print
'class', which was not valid code.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
