### PR TITLE
[gardening] Fix recently introduced typos

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -138,7 +138,7 @@
 // Bring in visibility attribute macros for library visibility.
 #include "llvm/Support/Compiler.h"
 
-// Generates a name of the runtime enrty's implementation by
+// Generates a name of the runtime entry's implementation by
 // adding an underscore as a prefix and a suffix.
 #define SWIFT_RT_ENTRY_IMPL(Name) _##Name##_
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1036,7 +1036,7 @@ FUNCTION(GetErrorValue, swift_getErrorValue, C_CC,
 #if SWIFT_OBJC_INTEROP || !defined(SWIFT_RUNTIME_GENERATE_GLOBAL_SYMBOLS)
 
 // Put here all definitions of runtime functions which are:
-// - only only available when SWIFT_OBJC_INTEROP is enabled
+// - only available when SWIFT_OBJC_INTEROP is enabled
 // - need a global function pointer referring to their implementation,
 //   e.g. those defined FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL or using
 //   the RegisterPreservingCC calling convention.

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -253,7 +253,7 @@ public:
     /// a critical edges.
     AllowToModifyCFG,
     
-    /// Ignore exit exit edges from the lifetime region at all.
+    /// Ignore exit edges from the lifetime region at all.
     IgnoreExitEdges
   };
 

--- a/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/IPO/FunctionSignatureOpts.cpp
@@ -793,7 +793,7 @@ static void addRetainsForConvertedDirectResults(SILBuilder &Builder,
       IsSelfRecursionEpilogueRetain |= (AI == X);
     }
 
-    // We do not create an retain if this ApplyInst is a self-recursion.
+    // We do not create a retain if this ApplyInst is a self-recursion.
     if (IsSelfRecursionEpilogueRetain)
       continue;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2946,7 +2946,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
                 behaviorProto->getName());
   }
   
-  // If the property was declared with an parameter, but the behavior didn't
+  // If the property was declared with a parameter, but the behavior didn't
   // use it, complain.
   // TODO: The initializer could eventually be consumed by DI-style
   // initialization.

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -81,7 +81,7 @@ bb0(%0 : $TrivialDestructor):
   return %18 : $()
 }
 
-// CHECK-LABEL: sil @not_all_pathes_release_the_dead_array
+// CHECK-LABEL: sil @not_all_paths_release_the_dead_array
 // CHECK: bb0(%0 : $TrivialDestructor):
 // CHECK-NEXT: cond_br
 // CHECK: bb1:
@@ -90,7 +90,7 @@ bb0(%0 : $TrivialDestructor):
 // CHECK-NEXT: strong_retain %0
 // CHECK-NEXT: strong_release %0
 // CHECK: return
-sil @not_all_pathes_release_the_dead_array : $@convention(thin) (@owned TrivialDestructor) -> () {
+sil @not_all_paths_release_the_dead_array : $@convention(thin) (@owned TrivialDestructor) -> () {
 bb0(%0 : $TrivialDestructor):
   %2 = integer_literal $Builtin.Word, 2
   // function_ref Swift._allocateUninitializedArray <A> (Builtin.Word) -> (Swift.Array<A>, Builtin.RawPointer)

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -115,7 +115,7 @@ bb2:
   return %18 : $()
 }
 
-// CHECK-LABEL: sil @releaese_dead_array_on_two_branches
+// CHECK-LABEL: sil @release_dead_array_on_two_branches
 // CHECK: bb0(%0 : $TrivialDestructor, %1 : $TrivialDestructor):
 // CHECK-NEXT: cond_br
 // CHECK: bb1:
@@ -125,7 +125,7 @@ bb2:
 // CHECK-NEXT: strong_retain %1
 // CHECK-NEXT: strong_release %1
 // CHECK: return
-sil @releaese_dead_array_on_two_branches : $@convention(thin) (@owned TrivialDestructor, @owned TrivialDestructor) -> () {
+sil @release_dead_array_on_two_branches : $@convention(thin) (@owned TrivialDestructor, @owned TrivialDestructor) -> () {
 bb0(%0 : $TrivialDestructor, %1 : $TrivialDestructor):
   %2 = integer_literal $Builtin.Word, 2
   // function_ref Swift._allocateUninitializedArray <A> (Builtin.Word) -> (Swift.Array<A>, Builtin.RawPointer)

--- a/test/SILOptimizer/let_properties_opts_runtime.swift
+++ b/test/SILOptimizer/let_properties_opts_runtime.swift
@@ -19,7 +19,7 @@ public class Foo1 {
     // Initialize Prop4 unconditionally and only once.
     Prop4 = 300
     // There are two different assignments to Prop1 and Prop2
-    // on different branchs of the if-statement.
+    // on different branches of the if-statement.
     if count < 2 {
       // Initialize Prop1 and Prop2 conditionally.
       // Use other properties in the definition of Prop1 and Prop2.

--- a/test/SILOptimizer/let_properties_opts_runtime.swift
+++ b/test/SILOptimizer/let_properties_opts_runtime.swift
@@ -16,7 +16,7 @@ public class Foo1 {
 
   @inline(never)
   init(_ count: Int32) {
-    // Intialize Prop4 unconditionally and only once.
+    // Initialize Prop4 unconditionally and only once.
     Prop4 = 300
     // There are two different assignments to Prop1 and Prop2
     // on different branchs of the if-statement.

--- a/test/SILOptimizer/let_properties_opts_runtime.swift
+++ b/test/SILOptimizer/let_properties_opts_runtime.swift
@@ -4,7 +4,7 @@
 // REQUIRES: executable_test
 
 // Check that in optimized builds the compiler generates correct code for
-// initializations of let properties, which is assigned multipe times inside
+// initializations of let properties, which is assigned multiple times inside
 // initializers.
 
 public class Foo1 {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Typo fixes:
- "an parameter" → "a parameter"
- "an retain" → "a retain"
- "branchs" → "branches"
- "enrty" → "entry"
- "exit exit" → "exit"
- "intialize" → "initialize"
- "multipe" → "multiple"
- "only only" → "only"
- "pathes" → "paths"
- "releaese" → "release"
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
