### PR TITLE
[gardening] When using C style comments, stick to the one line form.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -596,8 +596,7 @@ llvm::Constant *swift::getWrapperFn(llvm::Module &Module,
                                          ARGS, ATTRS)                          \
   llvm::Constant *IRGenModule::get##ID##Fn() {                                 \
     using namespace RuntimeConstants;                                          \
-    /* Add an underscore in JIT mode under Linux to enable proper symbol       \
-     * lookup */                                                               \
+    /* Add underscore in JIT mode under Linux to enable proper symbol lookup */\
     const char *Symbol =                                                       \
         (Opts.UseJIT && TargetInfo.OutputObjectFormat == llvm::Triple::ELF)    \
             ? "_" STR(SYMBOL_NAME)                                             \


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

In the rare cases where C style comments are needed sticking with the one line form is preferred to allow for quick comment analysis by simple methods such as:

```
$ git grep -E '(//|/\*.*\*/)'
```

When using the single line form the command above is guaranteed to include all comment content (+ some non-comment content), which greatly simplifies quick comment analysis.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
