### PR TITLE
[sil] Verify that the type lowering associated with SILTypes in a fun…

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -338,6 +338,10 @@ public:
     }
   }
 
+  // Visit this type lowering and all of its children type lowerings.
+  virtual void visit(SILModule &M,
+                     std::function<void(const TypeLowering &)> F) const = 0;
+
   /// Allocate a new TypeLowering using the TypeConverter's allocator.
   void *operator new(size_t size, TypeConverter &tc,
                      IsDependent_t dependent);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -567,20 +567,28 @@ public:
   }
 
   /// Check that the given type is a legal SIL value.
-  void checkLegalType(SILFunction *F, SILType type) {
-    auto rvalueType = type.getSwiftRValueType();
-    require(!isa<LValueType>(rvalueType),
-            "l-value types are not legal in SIL");
-    require(!isa<AnyFunctionType>(rvalueType),
+  void checkLegalType(SILFunction *F, SILType InputType) {
+    auto RValueType = InputType.getSwiftRValueType();
+    require(!isa<LValueType>(RValueType), "l-value types are not legal in SIL");
+    require(!isa<AnyFunctionType>(RValueType),
             "AST function types are not legal in SIL");
 
-    rvalueType.visit([&](Type t) {
+    auto VerifyArchetypes = [&](Type t) {
       auto *A = dyn_cast<ArchetypeType>(t.getPointer());
       if (!A)
         return;
       require(isArchetypeValidInFunction(A, F),
               "Operand is of an ArchetypeType that does not exist in the "
               "Caller's generic param list.");
+    };
+    RValueType.visit(VerifyArchetypes);
+
+    // Check all of our child type lowerings to make sure that types stored in
+    // type lowering has archetypes that are valid in this function.
+    auto &TL = F->getModule().getTypeLowering(InputType);
+    TL.getLoweredType().getSwiftRValueType().visit(VerifyArchetypes);
+    TL.visit(F->getModule(), [&](const Lowering::TypeLowering &ChildTL) {
+      ChildTL.getLoweredType().getSwiftRValueType().visit(VerifyArchetypes);
     });
   }
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -546,6 +546,11 @@ namespace {
                           SILValue value) const override {
       // Trivial
     }
+
+    void visit(SILModule &M,
+               std::function<void(const TypeLowering &)> F) const override {
+      // Trivial
+    }
   };
 
   class NonTrivialLoadableTypeLowering : public LoadableTypeLowering {
@@ -568,6 +573,11 @@ namespace {
       if (!isInit) oldValue = B.createLoad(loc, addr);
       B.createStore(loc, newValue, addr);
       if (!isInit) emitReleaseValue(B, loc, oldValue);
+    }
+
+    void visit(SILModule &M,
+               std::function<void(const TypeLowering &)> F) const override {
+      // Trivial
     }
   };
 
@@ -619,6 +629,15 @@ namespace {
       }
       return Children;
     }
+
+    void visit(SILModule &M,
+               std::function<void(const TypeLowering &)> F) const override {
+      for (auto &child : getChildren(M)) {
+        auto &childLowering = child.getLowering();
+        childLowering.visit(M, F);
+        F(childLowering);
+      }
+    };
 
     template <class T>
     void forEachNonTrivialChild(SILBuilder &B, SILLocation loc,
@@ -1009,6 +1028,11 @@ namespace {
                                  SILValue value,
                                  LoweringStyle style) const override {
       llvm_unreachable("type is not loadable!");
+    }
+
+    void visit(SILModule &M,
+               std::function<void(const TypeLowering &)> F) const override {
+      // Address only types do not have any sub type lowerings.
     }
   };
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Verify that the type lowering associated with SILTypes in a function have internal lowered types that have archetypes valid in this function.

Previously we only checked if the type itself, not the stack of types in the
type lowering did not have this problem. This just extends that to this stack of
SILTypes.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
