### PR TITLE
[Sema][SR-845] Don't crash when using mutating getters on constants

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3863,9 +3863,8 @@ bool FailureDiagnosis::visitSubscriptExpr(SubscriptExpr *SE) {
   // If we have unviable candidates (e.g. because of access control or some
   // other problem) we should diagnose the problem.
   if (result.ViableCandidates.empty()) {
-    diagnoseUnviableLookupResults(result, baseType, /*no base expr*/nullptr,
-                                  subscriptName, DeclNameLoc(SE->getLoc()),
-                                  SE->getLoc());
+    diagnoseUnviableLookupResults(result, baseType, baseExpr, subscriptName,
+                                  DeclNameLoc(SE->getLoc()), SE->getLoc());
     return true;
   }
 

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -69,6 +69,16 @@ struct Y1 {
   }
 }
 
+// Mutating getters on constants (https://bugs.swift.org/browse/SR-845)
+struct Y2 {
+  subscript(_: Int) -> Int {
+    mutating get { return 0 }
+  }
+}
+
+let y2 = Y2() // expected-note{{change 'let' to 'var' to make it mutable}}{{1-4=var}}
+_ = y2[0] // expected-error{{cannot use mutating getter on immutable value: 'y2' is a 'let' constant}}
+
 // Parsing errors
 // FIXME: Recovery here is horrible
 struct A0 { // expected-note{{in declaration of 'A0'}}
@@ -163,4 +173,3 @@ struct A8 { // expected-note{{in declaration of 'A8'}}
     }
   }
 } // expected-error{{extraneous '}' at top level}} {{1-3=}}
-


### PR DESCRIPTION
#### What's in this pull request?

Previously accessing mutating getters on constants crashed inside CSDiag, now the correct error diagnostic and fixit hint is emitted. All the parts were already there, just instead of the actual subscript's base expression, `nullptr` was passed leading to the crash.
#### Resolved bug number: [SR-845](https://bugs.swift.org/browse/SR-845)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

With this change the base expression of the subscript (beeing already revalidated earlier in the function) is passed to `diagnoseUnviableLookupResults` to emit a fitting diagnostic.
