### PR TITLE
[Swift 2.2][PrintAsObjC] Print argument names for function/block types

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -614,12 +614,11 @@ private:
 
     if (!clangTy.isNull() && isNSUInteger(clangTy)) {
       os << "NSUInteger " << objCName;
+      if (hasReservedName)
+        os << "_";
     } else {
-      print(ty, OTK_None, objCName.str());
+      print(ty, OTK_None, objCName);
     }
-
-    if (hasReservedName)
-      os << "_";
 
     os << ";\n";
   }
@@ -1123,8 +1122,10 @@ private:
       if (tupleTy->getNumElements() == 0) {
         os << "void";
       } else {
-        interleave(tupleTy->getElementTypes(),
-                   [this](Type ty) { print(ty, OTK_None); },
+        interleave(tupleTy->getElements(),
+                   [this](TupleTypeElt elt) {
+                     print(elt.getType(), OTK_None, elt.getName());
+                   },
                    [this] { os << ", "; });
       }
     } else {
@@ -1175,15 +1176,19 @@ private:
   /// visitPart().
 public:
   void print(Type ty, Optional<OptionalTypeKind> optionalKind, 
-             StringRef name = "") {
+             Identifier name = Identifier()) {
     PrettyStackTraceType trace(M.getASTContext(), "printing", ty);
 
     decltype(openFunctionTypes) savedFunctionTypes;
     savedFunctionTypes.swap(openFunctionTypes);
 
     visitPart(ty, optionalKind);
-    if (!name.empty())
+    if (!name.empty()) {
       os << ' ' << name;
+      if (isClangKeyword(name)) {
+        os << '_';
+      }
+    }
     while (!openFunctionTypes.empty()) {
       const FunctionType *openFunctionTy = openFunctionTypes.pop_back_val();
       finishFunctionType(openFunctionTy);

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -11,7 +11,8 @@
 
 import ObjectiveC
 
-typealias MyTuple = (a: Int, b: AnyObject?)
+typealias MyTuple = (Int, AnyObject?)
+typealias MyNamedTuple = (a: Int, b: AnyObject?)
 typealias MyInt = Int
 
 // CHECK-LABEL: @interface Callbacks
@@ -26,11 +27,21 @@ typealias MyInt = Int
 // CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull, NSObject * _Nonnull))returnsBlockWithTwoInputs;
 // CHECK-NEXT: - (void)blockWithTypealias:(NSInteger (^ _Nonnull)(NSInteger, id _Nullable))input;
 // CHECK-NEXT: - (void)blockWithSimpleTypealias:(NSInteger (^ _Nonnull)(NSInteger))input;
+// CHECK-NEXT: - (void)namedArguments:(void (^ _Nonnull)(float f1, float f2, double d1, double d2))input;
+// CHECK-NEXT: - (void)blockTakesNamedBlock:(void (^ _Nonnull)(void (^ _Nonnull block)(void)))input;
+// CHECK-NEXT: - (void (^ _Nullable)(NSObject * _Nonnull object))returnsBlockWithNamedInput;
+// CHECK-NEXT: - (void)blockWithTypealiasWithNames:(NSInteger (^ _Nonnull)(NSInteger a, id _Nullable b))input;
+// CHECK-NEXT: - (void)blockWithKeyword:(NSInteger (^ _Nonnull)(NSInteger class_))_Nullable_;
 // CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger))functionPointers:(NSInteger (* _Nonnull)(NSInteger))input;
 // CHECK-NEXT: - (void)functionPointerTakesAndReturnsFunctionPointer:(NSInteger (* _Nonnull (^ _Nonnull (* _Nonnull)(NSInteger))(NSInteger))(NSInteger))input;
+// CHECK-NEXT: - (NSInteger (* _Nonnull)(NSInteger result))functionPointersWithName:(NSInteger (* _Nonnull)(NSInteger value))input;
 // CHECK-NEXT: @property (nonatomic, copy) NSInteger (^ _Nullable savedBlock)(NSInteger);
+// CHECK-NEXT: @property (nonatomic, copy) NSInteger (^ _Nullable savedBlockWithName)(NSInteger x);
 // CHECK-NEXT: @property (nonatomic) NSInteger (* _Nonnull savedFunctionPointer)(NSInteger);
 // CHECK-NEXT: @property (nonatomic) NSInteger (* _Nullable savedFunctionPointer2)(NSInteger);
+// CHECK-NEXT: @property (nonatomic) NSInteger (* _Nonnull savedFunctionPointerWithName)(NSInteger x);
+// CHECK-NEXT: @property (nonatomic, copy, getter=this, setter=setThis:) NSInteger (^ _Nonnull this_)(NSInteger block);
+// CHECK-NEXT: @property (nonatomic, getter=class, setter=setClass:) NSInteger (* _Nonnull class_)(NSInteger function);
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class Callbacks {
@@ -62,6 +73,16 @@ typealias MyInt = Int
   func blockWithTypealias(input: MyTuple -> MyInt) {}
   func blockWithSimpleTypealias(input: MyInt -> MyInt) {}
 
+  func namedArguments(input: (f1: Float, f2: Float, d1: Double, d2: Double) -> ()) {}
+  func blockTakesNamedBlock(input: (block: () -> ()) -> ()) {}
+  func returnsBlockWithNamedInput() -> ((object: NSObject) -> ())? {
+    return nil
+  }
+
+  func blockWithTypealiasWithNames(input: MyNamedTuple -> MyInt) {}
+
+  func blockWithKeyword(_Nullable: (`class`: Int) -> Int) {}
+
   func functionPointers(input: @convention(c) Int -> Int)
       -> @convention(c) Int -> Int {
     return input
@@ -73,7 +94,18 @@ typealias MyInt = Int
   ) {
   }
 
+  func functionPointersWithName(input: @convention(c) (value: Int) -> Int)
+      -> @convention(c) (result: Int) -> Int {
+    return input
+  }
+
   var savedBlock: (Int -> Int)?
+  var savedBlockWithName: ((x: Int) -> Int)?
   var savedFunctionPointer: @convention(c) Int -> Int = { $0 }
   var savedFunctionPointer2: (@convention(c) Int -> Int)? = { $0 }
+  var savedFunctionPointerWithName: @convention(c) (x: Int) -> Int = { $0 }
+
+  // The following uses a clang keyword as the name.
+  var this: (block: Int) -> Int = { $0 }
+  var `class`: @convention(c) (function: Int) -> Int = { $0 }
 }


### PR DESCRIPTION
#### Explanation

This commit adds parameter names to function/block types printed as Obj-C, which is a pretty minor bugfix, but it also includes a more important fix where properties of block/function types with keyword names were handled incorrectly, e.g.

``` swift
var this: (Int -> Int)?
```

was being printed as

``` objc
@property (nonatomic, copy, getter=this, setter=setThis:) NSInteger (^ _Nullable this)(NSInteger)_;
```

instead of

``` objc
@property (nonatomic, copy, getter=this, setter=setThis:) NSInteger (^ _Nullable this_)(NSInteger);
```
#### Scope

It's a fairly minor bugfix, which I'm proposing simply because of the property fix as outlined above.
#### SR Issue

The parameter name issue is tracked in [SR-365](https://bugs.swift.org/browse/SR-365). There is no issue for the property issue as I discovered it while fixing the parameter names.
#### Risk

Very low.
#### Testing

I've run the regular tests myself, which I believe is sufficient as this only impacts Obj-C printing, which is sufficiently tested with the `FileCheck` tests.
