### PR TITLE
[WIP][Parser][Qol] improve diagnostic with missing "self." in init

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -346,6 +346,8 @@ ERROR(subscript_static,none,
       "subscript cannot be marked %0", (StaticSpellingKind))
 
 // initializer
+ERROR(invalid_nested_init,none,
+      "missing '%select{super.|self.}0' at initializer invocation", (bool))
 ERROR(initializer_decl_wrong_scope,none,
       "initializers may only be declared within a type", ())
 ERROR(expected_lparen_initializer,PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1741,6 +1741,11 @@ static bool isParenthesizedUnowned(Parser &P) {
 bool Parser::isStartOfDecl() {
   // If this is obviously not the start of a decl, then we're done.
   if (!isKeywordPossibleDeclStart(Tok)) return false;
+
+  // 'init' invocation is not start of a declaration
+  if (Tok.is(tok::kw_init)) {
+    return !isa<ConstructorDecl>(CurDeclContext);
+  }
   
   // The protocol keyword needs more checking to reject "protocol<Int>".
   if (Tok.is(tok::kw_protocol)) {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -410,22 +410,32 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       }
     } else {
       SourceLoc StartLoc = Tok.getLoc();
-      ParserStatus ExprOrStmtStatus = parseExprOrStmt(Result);
-      BraceItemsStatus |= ExprOrStmtStatus;
-      if (ExprOrStmtStatus.isError())
-        NeedParseErrorRecovery = true;
-      diagnoseDiscardedClosure(*this, Result);
-      if (ExprOrStmtStatus.isSuccess() && IsTopLevel) {
-        // If this is a normal library, you can't have expressions or statements
-        // outside at the top level.
-        diagnose(StartLoc,
-                 Result.is<Stmt*>() ? diag::illegal_top_level_stmt
-                                    : diag::illegal_top_level_expr);
-        Result = ASTNode();
-      }
+      if (Tok.is(tok::kw_init)) {
+        if (auto CD = dyn_cast<ConstructorDecl>(CurDeclContext)) {
+          // Hint at missing 'self.' or 'super.' then skip this statement.
+          bool isConvenient = CD->isConvenienceInit();
+          diagnose(StartLoc, diag::invalid_nested_init, isConvenient)
+            .fixItInsert(StartLoc, isConvenient ? "self." : "super.");
+          NeedParseErrorRecovery = true;
+        }
+      } else {
+        ParserStatus ExprOrStmtStatus = parseExprOrStmt(Result);
+        BraceItemsStatus |= ExprOrStmtStatus;
+        if (ExprOrStmtStatus.isError())
+          NeedParseErrorRecovery = true;
+        diagnoseDiscardedClosure(*this, Result);
+        if (ExprOrStmtStatus.isSuccess() && IsTopLevel) {
+          // If this is a normal library, you can't have expressions or
+          // statements outside at the top level.
+          diagnose(StartLoc,
+                   Result.is<Stmt*>() ? diag::illegal_top_level_stmt
+                                      : diag::illegal_top_level_expr);
+          Result = ASTNode();
+        }
 
-      if (!Result.isNull())
-        Entries.push_back(Result);
+        if (!Result.isNull())
+          Entries.push_back(Result);
+      }
     }
 
     if (!NeedParseErrorRecovery && !PreviousHadSemi && Tok.is(tok::semi)) {

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -100,3 +100,14 @@ func barFunc() {
   } ()
 }
 
+// SR-852
+class Aaron {
+  init(x: Int) {}
+  convenience init() { init(x: 1) } // expected-error {{missing 'self.' at initializer invocation}}
+}
+
+class Theodosia: Aaron {
+  init() {
+    init(x: 2) // expected-error {{missing 'super.' at initializer invocation}}
+  }
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

before:

```
$ cat t.swift
class A {
    init(x: Int) {}

    convenience init() { init(x: 1) }
}

$ swiftc -c t.swift
t.swift:6:13: error: initializers may only be declared within a type
    init(x: 1)
        ^
t.swift:6:17: error: expected parameter type following ':'
    init(x: 1)
            ^
t.swift:6:17: error: expected ',' separator
    init(x: 1)
            ^
           ,
t.swift:6:17: error: expected parameter type following ':'
    init(x: 1)
            ^
t.swift:6:17: error: expected ',' separator
    init(x: 1)
            ^
                                                                                                                                                       ,
```

after:

```
t.swift:6:9: error: missing 'self.' at initializer invocation
    init(x: 1)
    ^
    self.
```
#### Resolved bug number: ([SR-852](https://bugs.swift.org/browse/SR-852))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
