### PR TITLE
Adjust UTF8Decode benchmark to run in <1s

### DIFF
--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -27,7 +27,7 @@ public func run_UTF8Decode(N: Int) {
 
   let strings = [ ascii, russian, japanese, emoji ].map { Array($0.utf8) }
 
-  for _ in 1...1000*N {
+  for _ in 1...200*N {
     for string in strings {
       var generator = string.generate()
       var utf8 = UTF8()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Ammendment for #1493 not running under 1s in Debug -Onone configuration.
