### PR TITLE
[Parse] Don't error on overloads in a conditional compilation block

### DIFF
--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -78,7 +78,6 @@ enum class ScopeKind {
   CatchVars,
   WhileVars,
   IfVars,
-  ActiveConfigBlock,
 
   ClosureParams,
 };

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2673,7 +2673,8 @@ ParserResult<IfConfigDecl> Parser::parseDeclIfConfig(ParseDeclOptions Flags) {
 
     Optional<Scope> scope;
     if (!ConfigState.isConditionActive())
-      scope.emplace(this, ScopeKind::Brace, /*inactiveConfigBlock=*/true);
+      scope.emplace(this, getScopeInfo().getCurrentScope()->getKind(),
+                    /*inactiveConfigBlock=*/true);
     
     SmallVector<Decl*, 8> Decls;
     if (ConfigState.shouldParse()) {

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -38,7 +38,6 @@ static bool isResolvableScope(ScopeKind SK) {
   case ScopeKind::ConstructorBody:
   case ScopeKind::DestructorBody:
   case ScopeKind::Brace:
-  case ScopeKind::ActiveConfigBlock:
   case ScopeKind::ForVars:
   case ScopeKind::ForeachVars:
   case ScopeKind::ClosureParams:

--- a/test/Parse/ConditionalCompilation/basicDeclarations.swift
+++ b/test/Parse/ConditionalCompilation/basicDeclarations.swift
@@ -26,6 +26,11 @@ class D {
 		x = 1
 #endif
 	}
+
+#if !BAR
+    func overload(a: Int) {}
+    func overload(b: String) {} // should not result in an error
+#endif
 }
 
 var d = D()


### PR DESCRIPTION
#### What's in this pull request?

Modifies the parser to not throw an error on function overloads in a conditional compilation block. Previously, an error was thrown on the following:

``` swift
class MyClass {
   #if NOT_NOW
   func hello(one: Int, two: Int) {
   }
   func hello(one: Int, three: Int) {
   }
   #endif
}
```

This was because the conditional compilation block was being treated as a braced scope, which is a resolvable scope, and therefore it was hitting a code path intended for shadowed variables.

Note: I'm not entirely sure I understand what it means by a "resolvable" scope, and I don't understand the parser very well, so I'm mostly just assuming here that `Parser::parseDeclIfConfig` is only ever invoked when the current scope is non-resolvable.
#### Resolved bug number: ([SR-826](https://bugs.swift.org/browse/SR-826))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
