### PR TITLE
[benchmark][SR-871] Convert duration strings to integers before calculating min/max

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -106,9 +106,9 @@ def instrument_test(driver_path, test, num_samples):
                                        float(len(test_outputs))))
     avg_test_output[num_samples_index] = num_samples
     avg_test_output[min_index] = min(test_outputs,
-                                     key=lambda x: x[min_index])[min_index]
+                                     key=lambda x: int(x[min_index]))[min_index]
     avg_test_output[max_index] = max(test_outputs,
-                                     key=lambda x: x[max_index])[max_index]
+                                     key=lambda x: int(x[max_index]))[max_index]
     avg_test_output = map(str, avg_test_output)
 
     return avg_test_output


### PR DESCRIPTION
#### What's in this pull request?

`benchmark/scripts/Benchmark_Driver` uses string comparison to calculate the minimum and maximum
of durations in benchmark results, sometimes leading to wildly inaccurate reports.
#### Resolved bug number: ([SR-871](https://bugs.swift.org/browse/SR-871))

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
