### PR TITLE
[build-presets] Add corelibs-xctest CI preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -256,6 +256,24 @@ skip-test-osx
 skip-test-ios
 skip-test-watchos
 
+# This preset is used by CI to test swift-corelibs-xctest.
+[preset: buildbot_incremental,tools=RA,stdlib=RA,XCTest]
+# We don't use buildbot_incremental_base_all_platforms because we don't need to
+# build for iOS/tvOS.
+mixin-preset=buildbot_incremental_base
+
+# Build Foundation, then build and test XCTest.
+foundation
+xctest
+
+dash-dash
+
+# This preset is meant to test XCTest, not Swift or Foundation. We don't
+# want stochastic failures in those test suites to prevent XCTest tests from
+# being run.
+skip-test-cmark
+skip-test-swift
+skip-test-foundation
 
 [preset: buildbot_incremental_asan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This preset will be used to test swift-corelibs-xctest on Apple CI. It's also pretty handy for contributors to swift-corelibs-xctest.

This change should be reviewed by @shahmishal, who's helping me get XCTest CI in tip-top shape! Thanks @shahmishal! :+1: 
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
