### PR TITLE
add function to ASTContext to get the UInt32 decl

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -371,6 +371,9 @@ public:
 
   /// Retrieve the declaration of Swift.UInt.
   NominalTypeDecl *getUIntDecl() const;
+  
+  /// Retrieve the declaration of Swift.UInt32.
+  NominalTypeDecl *getUInt32Decl() const;
 
   /// Retrieve the declaration of Swift.Float.
   NominalTypeDecl *getFloatDecl() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -92,6 +92,9 @@ struct ASTContext::Implementation {
 
   /// The declaration of Swift.UInt.
   NominalTypeDecl *UIntDecl = nullptr;
+  
+  /// The declaration of Swift.UInt32.
+  NominalTypeDecl *UInt32Decl = nullptr;
 
   /// The declaration of Swift.Float.
   NominalTypeDecl *FloatDecl = nullptr;
@@ -534,6 +537,12 @@ NominalTypeDecl *ASTContext::getUIntDecl() const {
   if (!Impl.UIntDecl)
     Impl.UIntDecl = findStdlibType(*this, "UInt", 0);
   return Impl.UIntDecl;
+}
+
+NominalTypeDecl *ASTContext::getUInt32Decl() const {
+  if (!Impl.UInt32Decl)
+    Impl.UInt32Decl = findStdlibType(*this, "UInt32", 0);
+  return Impl.UInt32Decl;
 }
 
 NominalTypeDecl *ASTContext::getFloatDecl() const {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A new function in swift::ASTContext::getUInt32Decl() that returns the UInt32Decl in the standard library.

<!-- Description about pull request. -->

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
