### PR TITLE
[SE-0040] Replace '=' with ':' before attribute argument.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1070,10 +1070,10 @@ public:
 ///
 /// \code
 /// struct X {
-///   @warn_unused_result(message="this string affects your health")
+///   @warn_unused_result(message: "this string affects your health")
 ///   func methodA() -> String { ... }
 ///
-///   @warn_unused_result(mutable_variant="jumpInPlace")
+///   @warn_unused_result(mutable_variant: "jumpInPlace")
 ///   func jump() -> X { ... }
 ///
 ///   mutating func jumpInPlace() { ... }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1071,6 +1071,9 @@ ERROR(expr_selector_expected_rparen,PointsToFirstBadToken,
 //------------------------------------------------------------------------------
 // Attribute-parsing diagnostics
 //------------------------------------------------------------------------------
+
+WARNING(replace_equal_with_colon_for_value,none,
+        "'=' is deprecated in favor of ':' before an attribute argument", ())
 ERROR(expected_attribute_name,none,
       "expected an attribute name", ())
 ERROR(unknown_attribute,none,
@@ -1114,8 +1117,8 @@ ERROR(attr_interpolated_string,none,
 ERROR(attr_only_at_non_local_scope, none,
       "attribute '%0' can only be used in a non-local scope", (StringRef))
 
-ERROR(attr_expected_equal_separator,none,
-      "expected '=' following '%0' argument of '%1'",
+ERROR(attr_expected_colon_separator,none,
+      "expected ':' following '%0' argument of '%1'",
       (StringRef, StringRef))
 
 ERROR(attr_expected_string_literal_arg,none,
@@ -1144,7 +1147,7 @@ ERROR(attr_availability_expected_option,none,
       "'obsoleted', 'message', or 'renamed'", (StringRef))
 
 ERROR(attr_availability_expected_equal,none,
-      "expected '=' after '%1' in '%0' attribute", (StringRef, StringRef))
+      "expected ':' after '%1' in '%0' attribute", (StringRef, StringRef))
 
 ERROR(attr_availability_expected_version,none,
       "expected version number in '%0' attribute", (StringRef))
@@ -1214,10 +1217,10 @@ WARNING(attr_warn_unused_result_expected_name,none,
         "expected parameter 'message' or 'mutable_variant'", ())
 WARNING(attr_warn_unused_result_duplicate_parameter,none,
       "duplicate '%0' parameter; previous value will be ignored", (StringRef))
-ERROR(attr_warn_unused_result_expected_eq,none,
-      "expected '=' following '%0' parameter", (StringRef))
+ERROR(attr_warn_unused_result_expected_colon,none,
+      "expected ':' following '%0' parameter", (StringRef))
 ERROR(attr_warn_unused_result_expected_string,none,
-      "expected a string following '=' for '%0' parameter", (StringRef))
+      "expected a string following ':' for '%0' parameter", (StringRef))
 WARNING(attr_warn_unused_result_unknown_parameter,none,
         "unknown parameter '%0' in 'warn_unused_result' attribute", (StringRef))
 ERROR(attr_warn_unused_result_expected_rparen,none,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -180,8 +180,8 @@ static bool isShortAvailable(const DeclAttribute *DA) {
 /// Print the short-form @available() attribute for an array of long-form
 /// AvailableAttrs that can be represented in the short form.
 /// For example, for:
-///   @available(OSX, introduced=10.10)
-///   @available(iOS, introduced=8.0)
+///   @available(OSX, introduced: 10.10)
+///   @available(iOS, introduced: 8.0)
 /// this will print:
 ///   @available(OSX 10.10, iOS 8.0, *)
 static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
@@ -346,23 +346,23 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
       Printer << ", deprecated";
 
     if (Attr->Introduced)
-      Printer << ", introduced=" << Attr->Introduced.getValue().getAsString();
+      Printer << ", introduced: " << Attr->Introduced.getValue().getAsString();
     if (Attr->Deprecated)
-      Printer << ", deprecated=" << Attr->Deprecated.getValue().getAsString();
+      Printer << ", deprecated: " << Attr->Deprecated.getValue().getAsString();
     if (Attr->Obsoleted)
-      Printer << ", obsoleted=" << Attr->Obsoleted.getValue().getAsString();
+      Printer << ", obsoleted: " << Attr->Obsoleted.getValue().getAsString();
 
     if (!Attr->Rename.empty())
-      Printer << ", renamed=\"" << Attr->Rename << "\"";
+      Printer << ", renamed: \"" << Attr->Rename << "\"";
 
     // If there's no message, but this is specifically an imported
     // "unavailable in Swift" attribute, synthesize a message to look good in
     // the generated interface.
     if (!Attr->Message.empty())
-      Printer << ", message=\"" << Attr->Message << "\"";
+      Printer << ", message: \"" << Attr->Message << "\"";
     else if (Attr->getUnconditionalAvailability()
                == UnconditionalAvailabilityKind::UnavailableInSwift)
-      Printer << ", message=\"Not available in Swift\"";
+      Printer << ", message: \"Not available in Swift\"";
 
     Printer << ")";
     break;
@@ -407,12 +407,12 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
 
     if (attr->getRenamed()) {
       printSeparator();
-      Printer << "renamed=\"" << attr->getRenamed() << "\"";
+      Printer << "renamed: \"" << attr->getRenamed() << "\"";
     }
 
     if (!attr->getMessage().empty()) {
       printSeparator();
-      Printer << "message=\"";
+      Printer << "message: \"";
       Printer << attr->getMessage();
       Printer << "\"";
     }
@@ -426,7 +426,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
     auto *attr = cast<WarnUnusedResultAttr>(this);
     bool printedParens = false;
     if (!attr->getMessage().empty()) {
-      Printer << "(message=\"" << attr->getMessage() << "\"";
+      Printer << "(message: \"" << attr->getMessage() << "\"";
       printedParens = true;
     }
     if (!attr->getMutableVariant().empty()) {
@@ -434,7 +434,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
         Printer << ", ";
       else
         Printer << "(";
-      Printer << "mutable_variant=\"" << attr->getMutableVariant() << "\"";
+      Printer << "mutable_variant: \"" << attr->getMutableVariant() << "\"";
       printedParens = true;
     }
     if (printedParens)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -813,7 +813,7 @@ static void diagnoseImplicitSelfUseInClosure(TypeChecker &TC, const Expr *E,
 //===----------------------------------------------------------------------===//
 
 /// Emit a diagnostic for references to declarations that have been
-/// marked as unavailable, either through "unavailable" or "obsoleted=".
+/// marked as unavailable, either through "unavailable" or "obsoleted:".
 bool TypeChecker::diagnoseExplicitUnavailability(const ValueDecl *D,
                                                  SourceRange R,
                                                  const DeclContext *DC) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1550,7 +1550,7 @@ public:
                                    LookupTypeResult &lookup);
 
   /// Emit a diagnostic for references to declarations that have been
-  /// marked as unavailable, either through "unavailable" or "obsoleted=".
+  /// marked as unavailable, either through "unavailable" or "obsoleted:".
   bool diagnoseExplicitUnavailability(const ValueDecl *D,
                                       SourceRange R,
                                       const DeclContext *DC);

--- a/stdlib/public/SDK/AppKit/NSError.swift
+++ b/stdlib/public/SDK/AppKit/NSError.swift
@@ -41,39 +41,39 @@ extension NSCocoaError {
 }
 
 extension NSCocoaError {
-  @swift3_migration(renamed="textReadInapplicableDocumentTypeError")
+  @swift3_migration(renamed: "textReadInapplicableDocumentTypeError")
   public static var TextReadInapplicableDocumentTypeError: NSCocoaError {
     return NSCocoaError(rawValue: 65806)
   }
-  @swift3_migration(renamed="textWriteInapplicableDocumentTypeError")
+  @swift3_migration(renamed: "textWriteInapplicableDocumentTypeError")
   public static var TextWriteInapplicableDocumentTypeError: NSCocoaError {
     return NSCocoaError(rawValue: 66062)
   }
-  @swift3_migration(renamed="serviceApplicationNotFoundError")
+  @swift3_migration(renamed: "serviceApplicationNotFoundError")
   public static var ServiceApplicationNotFoundError: NSCocoaError {
     return NSCocoaError(rawValue: 66560)
   }
-  @swift3_migration(renamed="serviceApplicationLaunchFailedError")
+  @swift3_migration(renamed: "serviceApplicationLaunchFailedError")
   public static var ServiceApplicationLaunchFailedError: NSCocoaError {
     return NSCocoaError(rawValue: 66561)
   }
-  @swift3_migration(renamed="serviceRequestTimedOutError")
+  @swift3_migration(renamed: "serviceRequestTimedOutError")
   public static var ServiceRequestTimedOutError: NSCocoaError {
     return NSCocoaError(rawValue: 66562)
   }
-  @swift3_migration(renamed="serviceInvalidPasteboardDataError")
+  @swift3_migration(renamed: "serviceInvalidPasteboardDataError")
   public static var ServiceInvalidPasteboardDataError: NSCocoaError {
     return NSCocoaError(rawValue: 66563)
   }
-  @swift3_migration(renamed="serviceMalformedServiceDictionaryError")
+  @swift3_migration(renamed: "serviceMalformedServiceDictionaryError")
   public static var ServiceMalformedServiceDictionaryError: NSCocoaError {
     return NSCocoaError(rawValue: 66564)
   }
-  @swift3_migration(renamed="serviceMiscellaneousError")
+  @swift3_migration(renamed: "serviceMiscellaneousError")
   public static var ServiceMiscellaneousError: NSCocoaError {
     return NSCocoaError(rawValue: 66800)
   }
-  @swift3_migration(renamed="sharingServiceNotConfiguredError")
+  @swift3_migration(renamed: "sharingServiceNotConfiguredError")
   public static var SharingServiceNotConfiguredError: NSCocoaError {
     return NSCocoaError(rawValue: 67072)
   }

--- a/stdlib/public/SDK/CloudKit/CloudKit.swift
+++ b/stdlib/public/SDK/CloudKit/CloudKit.swift
@@ -1,7 +1,7 @@
 @_exported import CloudKit
 import Foundation
 
-@available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+@available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
 extension CKErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return CKErrorDomain }
 }

--- a/stdlib/public/SDK/Contacts/Contacts.swift
+++ b/stdlib/public/SDK/Contacts/Contacts.swift
@@ -13,8 +13,8 @@
 @_exported import Contacts
 import Foundation
 
-@available(OSX, introduced=10.11)
-@available(iOS, introduced=9.0)
+@available(OSX, introduced: 10.11)
+@available(iOS, introduced: 9.0)
 extension CNErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return CNErrorDomain }
 }

--- a/stdlib/public/SDK/CoreData/CoreData.swift
+++ b/stdlib/public/SDK/CoreData/CoreData.swift
@@ -131,171 +131,171 @@ extension NSCocoaError {
 }
 
 extension NSCocoaError {
-  @available(*, unavailable, renamed="managedObjectValidationError")
+  @available(*, unavailable, renamed: "managedObjectValidationError")
   public static var ManagedObjectValidationError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationMultipleErrorsError")
+  @available(*, unavailable, renamed: "validationMultipleErrorsError")
   public static var ValidationMultipleErrorsError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationMissingMandatoryPropertyError")
+  @available(*, unavailable, renamed: "validationMissingMandatoryPropertyError")
   public static var ValidationMissingMandatoryPropertyError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationRelationshipLacksMinimumCountError")
+  @available(*, unavailable, renamed: "validationRelationshipLacksMinimumCountError")
   public static var ValidationRelationshipLacksMinimumCountError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationRelationshipExceedsMaximumCountError")
+  @available(*, unavailable, renamed: "validationRelationshipExceedsMaximumCountError")
   public static var ValidationRelationshipExceedsMaximumCountError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationRelationshipDeniedDevareError")
+  @available(*, unavailable, renamed: "validationRelationshipDeniedDevareError")
   public static var ValidationRelationshipDeniedDevareError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationNumberTooLargeError")
+  @available(*, unavailable, renamed: "validationNumberTooLargeError")
   public static var ValidationNumberTooLargeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationNumberTooSmallError")
+  @available(*, unavailable, renamed: "validationNumberTooSmallError")
   public static var ValidationNumberTooSmallError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationDateTooLateError")
+  @available(*, unavailable, renamed: "validationDateTooLateError")
   public static var ValidationDateTooLateError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationDateTooSoonError")
+  @available(*, unavailable, renamed: "validationDateTooSoonError")
   public static var ValidationDateTooSoonError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationInvalidDateError")
+  @available(*, unavailable, renamed: "validationInvalidDateError")
   public static var ValidationInvalidDateError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationStringTooLongError")
+  @available(*, unavailable, renamed: "validationStringTooLongError")
   public static var ValidationStringTooLongError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationStringTooShortError")
+  @available(*, unavailable, renamed: "validationStringTooShortError")
   public static var ValidationStringTooShortError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="validationStringPatternMatchingError")
+  @available(*, unavailable, renamed: "validationStringPatternMatchingError")
   public static var ValidationStringPatternMatchingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="managedObjectContextLockingError")
+  @available(*, unavailable, renamed: "managedObjectContextLockingError")
   public static var ManagedObjectContextLockingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreCoordinatorLockingError")
+  @available(*, unavailable, renamed: "persistentStoreCoordinatorLockingError")
   public static var PersistentStoreCoordinatorLockingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="managedObjectReferentialIntegrityError")
+  @available(*, unavailable, renamed: "managedObjectReferentialIntegrityError")
   public static var ManagedObjectReferentialIntegrityError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="managedObjectExternalRelationshipError")
+  @available(*, unavailable, renamed: "managedObjectExternalRelationshipError")
   public static var ManagedObjectExternalRelationshipError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="managedObjectMergeError")
+  @available(*, unavailable, renamed: "managedObjectMergeError")
   public static var ManagedObjectMergeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="managedObjectConstraintMergeError")
+  @available(*, unavailable, renamed: "managedObjectConstraintMergeError")
   public static var ManagedObjectConstraintMergeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreInvalidTypeError")
+  @available(*, unavailable, renamed: "persistentStoreInvalidTypeError")
   public static var PersistentStoreInvalidTypeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreTypeMismatchError")
+  @available(*, unavailable, renamed: "persistentStoreTypeMismatchError")
   public static var PersistentStoreTypeMismatchError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreIncompatibleSchemaError")
+  @available(*, unavailable, renamed: "persistentStoreIncompatibleSchemaError")
   public static var PersistentStoreIncompatibleSchemaError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreSaveError")
+  @available(*, unavailable, renamed: "persistentStoreSaveError")
   public static var PersistentStoreSaveError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreIncompvareSaveError")
+  @available(*, unavailable, renamed: "persistentStoreIncompvareSaveError")
   public static var PersistentStoreIncompvareSaveError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreSaveConflictsError")
+  @available(*, unavailable, renamed: "persistentStoreSaveConflictsError")
   public static var PersistentStoreSaveConflictsError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="coreDataError")
+  @available(*, unavailable, renamed: "coreDataError")
   public static var CoreDataError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreOperationError")
+  @available(*, unavailable, renamed: "persistentStoreOperationError")
   public static var PersistentStoreOperationError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreOpenError")
+  @available(*, unavailable, renamed: "persistentStoreOpenError")
   public static var PersistentStoreOpenError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreTimeoutError")
+  @available(*, unavailable, renamed: "persistentStoreTimeoutError")
   public static var PersistentStoreTimeoutError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreUnsupportedRequestTypeError")
+  @available(*, unavailable, renamed: "persistentStoreUnsupportedRequestTypeError")
   public static var PersistentStoreUnsupportedRequestTypeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="persistentStoreIncompatibleVersionHashError")
+  @available(*, unavailable, renamed: "persistentStoreIncompatibleVersionHashError")
   public static var PersistentStoreIncompatibleVersionHashError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="migrationError")
+  @available(*, unavailable, renamed: "migrationError")
   public static var MigrationError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="migrationCancelledError")
+  @available(*, unavailable, renamed: "migrationCancelledError")
   public static var MigrationCancelledError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="migrationMissingSourceModelError")
+  @available(*, unavailable, renamed: "migrationMissingSourceModelError")
   public static var MigrationMissingSourceModelError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="migrationMissingMappingModelError")
+  @available(*, unavailable, renamed: "migrationMissingMappingModelError")
   public static var MigrationMissingMappingModelError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="migrationManagerSourceStoreError")
+  @available(*, unavailable, renamed: "migrationManagerSourceStoreError")
   public static var MigrationManagerSourceStoreError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="migrationManagerDestinationStoreError")
+  @available(*, unavailable, renamed: "migrationManagerDestinationStoreError")
   public static var MigrationManagerDestinationStoreError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="entityMigrationPolicyError")
+  @available(*, unavailable, renamed: "entityMigrationPolicyError")
   public static var EntityMigrationPolicyError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="sqliteError")
+  @available(*, unavailable, renamed: "sqliteError")
   public static var SQLiteError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="inferredMappingModelError")
+  @available(*, unavailable, renamed: "inferredMappingModelError")
   public static var InferredMappingModelError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
-  @available(*, unavailable, renamed="externalRecordImportError")
+  @available(*, unavailable, renamed: "externalRecordImportError")
   public static var ExternalRecordImportError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -135,12 +135,12 @@ extension CGFloat {
   }
 }
 
-@available(*,unavailable,message="use CGFloat.min")
+@available(*,unavailable,message: "use CGFloat.min")
 public var CGFLOAT_MIN: CGFloat {
   fatalError("can't retrieve unavailable property")
 }
 
-@available(*,unavailable,message="use CGFloat.max")
+@available(*,unavailable,message: "use CGFloat.max")
 public var CGFLOAT_MAX: CGFloat {
   fatalError("can't retrieve unavailable property")
 }

--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -223,7 +223,7 @@ public extension CGRect {
   }
 
   @_transparent // @fragile
-  @warn_unused_result(mutable_variant="insetInPlace")
+  @warn_unused_result(mutable_variant: "insetInPlace")
   func insetBy(dx dx: CGFloat, dy: CGFloat) -> CGRect {
     return CGRectInset(self, dx, dy)
   }
@@ -234,7 +234,7 @@ public extension CGRect {
   }
 
   @_transparent // @fragile
-  @warn_unused_result(mutable_variant="offsetInPlace")
+  @warn_unused_result(mutable_variant: "offsetInPlace")
   func offsetBy(dx dx: CGFloat, dy: CGFloat) -> CGRect {
     return CGRectOffset(self, dx, dy)
   }
@@ -245,7 +245,7 @@ public extension CGRect {
   }
 
   @_transparent // @fragile
-  @warn_unused_result(mutable_variant="unionInPlace")
+  @warn_unused_result(mutable_variant: "unionInPlace")
   func union(rect: CGRect) -> CGRect {
     return CGRectUnion(self, rect)
   }
@@ -256,7 +256,7 @@ public extension CGRect {
   }
 
   @_transparent // @fragile
-  @warn_unused_result(mutable_variant="intersectInPlace")
+  @warn_unused_result(mutable_variant: "intersectInPlace")
   func intersect(rect: CGRect) -> CGRect {
     return CGRectIntersection(self, rect)
   }

--- a/stdlib/public/SDK/CoreImage/CoreImage.swift
+++ b/stdlib/public/SDK/CoreImage/CoreImage.swift
@@ -33,8 +33,8 @@ extension CIFilter {
   }
 #endif
 
-  @available(iOS, introduced=8.0)
-  @available(OSX, introduced=10.10)
+  @available(iOS, introduced: 8.0)
+  @available(OSX, introduced: 10.10)
   convenience init?(
     name: String!, elements: (String, AnyObject)...
   ) {

--- a/stdlib/public/SDK/Darwin/Darwin.swift
+++ b/stdlib/public/SDK/Darwin/Darwin.swift
@@ -277,12 +277,12 @@ public var S_IEXEC: mode_t  { return S_IXUSR }
 // unistd.h
 //===----------------------------------------------------------------------===//
 
-@available(*, unavailable, message="Please use threads or posix_spawn*()")
+@available(*, unavailable, message: "Please use threads or posix_spawn*()")
 public func fork() -> Int32 {
   fatalError("unavailable function can't be called")
 }
 
-@available(*, unavailable, message="Please use threads or posix_spawn*()")
+@available(*, unavailable, message: "Please use threads or posix_spawn*()")
 public func vfork() -> Int32 {
   fatalError("unavailable function can't be called")
 }

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -62,10 +62,10 @@ extension NSObject : CustomDebugStringConvertible {}
 // Strings
 //===----------------------------------------------------------------------===//
 
-@available(*, unavailable, message="Please use String or NSString")
+@available(*, unavailable, message: "Please use String or NSString")
 public class NSSimpleCString {}
 
-@available(*, unavailable, message="Please use String or NSString")
+@available(*, unavailable, message: "Please use String or NSString")
 public class NSConstantString {}
 
 @warn_unused_result
@@ -1006,19 +1006,19 @@ public func NSLog(format: String, _ args: CVarArg...) {
 // have CGRectEdge type.  This is not correct for Swift (as there is no
 // implicit conversion to NSRectEdge).
 
-@available(*, unavailable, renamed="NSRectEdge.MinX")
+@available(*, unavailable, renamed: "NSRectEdge.MinX")
 public var NSMinXEdge: NSRectEdge {
   fatalError("unavailable property can't be accessed")
 }
-@available(*, unavailable, renamed="NSRectEdge.MinY")
+@available(*, unavailable, renamed: "NSRectEdge.MinY")
 public var NSMinYEdge: NSRectEdge {
   fatalError("unavailable property can't be accessed")
 }
-@available(*, unavailable, renamed="NSRectEdge.MaxX")
+@available(*, unavailable, renamed: "NSRectEdge.MaxX")
 public var NSMaxXEdge: NSRectEdge {
   fatalError("unavailable property can't be accessed")
 }
-@available(*, unavailable, renamed="NSRectEdge.MaxY")
+@available(*, unavailable, renamed: "NSRectEdge.MaxY")
 public var NSMaxYEdge: NSRectEdge {
   fatalError("unavailable property can't be accessed")
 }

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -177,12 +177,12 @@ public extension NSCocoaError {
     return NSCocoaError(rawValue: 262)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var fileReadTooLargeError: NSCocoaError {
     return NSCocoaError(rawValue: 263)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var fileReadUnknownStringEncodingError: NSCocoaError {
     return NSCocoaError(rawValue: 264)
   }
@@ -197,7 +197,7 @@ public extension NSCocoaError {
     return NSCocoaError(rawValue: 514)
   }
 
-  @available(OSX, introduced=10.7) @available(iOS, introduced=5.0)
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 5.0)
   public static var fileWriteFileExistsError: NSCocoaError {
     return NSCocoaError(rawValue: 516)
   }
@@ -212,17 +212,17 @@ public extension NSCocoaError {
     return NSCocoaError(rawValue: 640)
   }
 
-  @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
+  @available(OSX, introduced: 10.6) @available(iOS, introduced: 4.0)
   public static var fileWriteVolumeReadOnlyError: NSCocoaError {
     return NSCocoaError(rawValue: 642)
   }
 
-  @available(OSX, introduced=10.11) @available(iOS, unavailable)
+  @available(OSX, introduced: 10.11) @available(iOS, unavailable)
   public static var fileManagerUnmountUnknownError: NSCocoaError {
     return NSCocoaError(rawValue: 768)
   }
 
-  @available(OSX, introduced=10.11) @available(iOS, unavailable)
+  @available(OSX, introduced: 10.11) @available(iOS, unavailable)
   public static var fileManagerUnmountBusyError: NSCocoaError {
     return NSCocoaError(rawValue: 769)
   }
@@ -237,128 +237,128 @@ public extension NSCocoaError {
     return NSCocoaError(rawValue: 3072)
   }
 
-  @available(OSX, introduced=10.8) @available(iOS, introduced=6.0)
+  @available(OSX, introduced: 10.8) @available(iOS, introduced: 6.0)
   public static var featureUnsupportedError: NSCocoaError {
     return NSCocoaError(rawValue: 3328)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var executableNotLoadableError: NSCocoaError {
     return NSCocoaError(rawValue: 3584)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var executableArchitectureMismatchError: NSCocoaError {
     return NSCocoaError(rawValue: 3585)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var executableRuntimeMismatchError: NSCocoaError {
     return NSCocoaError(rawValue: 3586)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var executableLoadError: NSCocoaError {
     return NSCocoaError(rawValue: 3587)
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public static var executableLinkError: NSCocoaError {
     return NSCocoaError(rawValue: 3588)
   }
 
-  @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
+  @available(OSX, introduced: 10.6) @available(iOS, introduced: 4.0)
   public static var propertyListReadCorruptError: NSCocoaError {
     return NSCocoaError(rawValue: 3840)
   }
 
-  @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
+  @available(OSX, introduced: 10.6) @available(iOS, introduced: 4.0)
   public static var propertyListReadUnknownVersionError: NSCocoaError {
     return NSCocoaError(rawValue: 3841)
   }
 
-  @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
+  @available(OSX, introduced: 10.6) @available(iOS, introduced: 4.0)
   public static var propertyListReadStreamError: NSCocoaError {
     return NSCocoaError(rawValue: 3842)
   }
 
-  @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
+  @available(OSX, introduced: 10.6) @available(iOS, introduced: 4.0)
   public static var propertyListWriteStreamError: NSCocoaError {
     return NSCocoaError(rawValue: 3851)
   }
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   public static var propertyListWriteInvalidError: NSCocoaError {
     return NSCocoaError(rawValue: 3852)
   }
 
-  @available(OSX, introduced=10.8) @available(iOS, introduced=6.0)
+  @available(OSX, introduced: 10.8) @available(iOS, introduced: 6.0)
   public static var xpcConnectionInterrupted: NSCocoaError {
     return NSCocoaError(rawValue: 4097)
   }
 
-  @available(OSX, introduced=10.8) @available(iOS, introduced=6.0)
+  @available(OSX, introduced: 10.8) @available(iOS, introduced: 6.0)
   public static var xpcConnectionInvalid: NSCocoaError {
     return NSCocoaError(rawValue: 4099)
   }
 
-  @available(OSX, introduced=10.8) @available(iOS, introduced=6.0)
+  @available(OSX, introduced: 10.8) @available(iOS, introduced: 6.0)
   public static var xpcConnectionReplyInvalid: NSCocoaError {
     return NSCocoaError(rawValue: 4101)
   }
 
-  @available(OSX, introduced=10.9) @available(iOS, introduced=7.0)
+  @available(OSX, introduced: 10.9) @available(iOS, introduced: 7.0)
   public static var ubiquitousFileUnavailableError: NSCocoaError {
     return NSCocoaError(rawValue: 4353)
   }
 
-  @available(OSX, introduced=10.9) @available(iOS, introduced=7.0)
+  @available(OSX, introduced: 10.9) @available(iOS, introduced: 7.0)
   public static var ubiquitousFileNotUploadedDueToQuotaError: NSCocoaError {
     return NSCocoaError(rawValue: 4354)
   }
 
-  @available(OSX, introduced=10.9) @available(iOS, introduced=7.0)
+  @available(OSX, introduced: 10.9) @available(iOS, introduced: 7.0)
   public static var ubiquitousFileUbiquityServerNotAvailable: NSCocoaError {
     return NSCocoaError(rawValue: 4355)
   }
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   public static var userActivityHandoffFailedError: NSCocoaError {
     return NSCocoaError(rawValue: 4608)
   }
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   public static var userActivityConnectionUnavailableError: NSCocoaError {
     return NSCocoaError(rawValue: 4609)
   }
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   public static var userActivityRemoteApplicationTimedOutError: NSCocoaError {
     return NSCocoaError(rawValue: 4610)
   }
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   public static var userActivityHandoffUserInfoTooLargeError: NSCocoaError {
     return NSCocoaError(rawValue: 4611)
   }
 
-  @available(OSX, introduced=10.11) @available(iOS, introduced=9.0)
+  @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public static var coderReadCorruptError: NSCocoaError {
     return NSCocoaError(rawValue: 4864)
   }
 
-  @available(OSX, introduced=10.11) @available(iOS, introduced=9.0)
+  @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public static var coderValueNotFoundError: NSCocoaError {
     return NSCocoaError(rawValue: 4865)
   }
 
 
-  @available(OSX, introduced=10.11) @available(iOS, introduced=9.0)
+  @available(OSX, introduced: 10.11) @available(iOS, introduced: 9.0)
   public var isCoderError: Bool {
     return rawValue >= 4864 && rawValue <= 4991
   }
 
-  @available(OSX, introduced=10.5) @available(iOS, introduced=2.0)
+  @available(OSX, introduced: 10.5) @available(iOS, introduced: 2.0)
   public var isExecutableError: Bool {
     return rawValue >= 3584 && rawValue <= 3839
   }
@@ -371,17 +371,17 @@ public extension NSCocoaError {
     return rawValue >= 2048 && rawValue <= 2559
   }
 
-  @available(OSX, introduced=10.6) @available(iOS, introduced=4.0)
+  @available(OSX, introduced: 10.6) @available(iOS, introduced: 4.0)
   public var isPropertyListError: Bool {
     return rawValue >= 3840 && rawValue <= 4095
   }
 
-  @available(OSX, introduced=10.9) @available(iOS, introduced=7.0)
+  @available(OSX, introduced: 10.9) @available(iOS, introduced: 7.0)
   public var isUbiquitousFileError: Bool {
     return rawValue >= 4352 && rawValue <= 4607
   }
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   public var isUserActivityError: Bool {
     return rawValue >= 4608 && rawValue <= 4863
   }
@@ -390,244 +390,244 @@ public extension NSCocoaError {
     return rawValue >= 1024 && rawValue <= 2047
   }
 
-  @available(OSX, introduced=10.8) @available(iOS, introduced=6.0)
+  @available(OSX, introduced: 10.8) @available(iOS, introduced: 6.0)
   public var isXPCConnectionError: Bool {
     return rawValue >= 4096 && rawValue <= 4224
   }
 }
 
 extension NSCocoaError {
-  @available(*, unavailable, renamed="fileNoSuchFileError")
+  @available(*, unavailable, renamed: "fileNoSuchFileError")
   public static var FileNoSuchFileError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileLockingError")
+  @available(*, unavailable, renamed: "fileLockingError")
   public static var FileLockingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadUnknownError")
+  @available(*, unavailable, renamed: "fileReadUnknownError")
   public static var FileReadUnknownError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadNoPermissionError")
+  @available(*, unavailable, renamed: "fileReadNoPermissionError")
   public static var FileReadNoPermissionError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadInvalidFileNameError")
+  @available(*, unavailable, renamed: "fileReadInvalidFileNameError")
   public static var FileReadInvalidFileNameError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadCorruptFileError")
+  @available(*, unavailable, renamed: "fileReadCorruptFileError")
   public static var FileReadCorruptFileError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadNoSuchFileError")
+  @available(*, unavailable, renamed: "fileReadNoSuchFileError")
   public static var FileReadNoSuchFileError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadInapplicableStringEncodingError")
+  @available(*, unavailable, renamed: "fileReadInapplicableStringEncodingError")
   public static var FileReadInapplicableStringEncodingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadUnsupportedSchemeError")
+  @available(*, unavailable, renamed: "fileReadUnsupportedSchemeError")
   public static var FileReadUnsupportedSchemeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadTooLargeError")
+  @available(*, unavailable, renamed: "fileReadTooLargeError")
   public static var FileReadTooLargeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileReadUnknownStringEncodingError")
+  @available(*, unavailable, renamed: "fileReadUnknownStringEncodingError")
   public static var FileReadUnknownStringEncodingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteUnknownError")
+  @available(*, unavailable, renamed: "fileWriteUnknownError")
   public static var FileWriteUnknownError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteNoPermissionError")
+  @available(*, unavailable, renamed: "fileWriteNoPermissionError")
   public static var FileWriteNoPermissionError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteInvalidFileNameError")
+  @available(*, unavailable, renamed: "fileWriteInvalidFileNameError")
   public static var FileWriteInvalidFileNameError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteFileExistsError")
+  @available(*, unavailable, renamed: "fileWriteFileExistsError")
   public static var FileWriteFileExistsError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteInapplicableStringEncodingError")
+  @available(*, unavailable, renamed: "fileWriteInapplicableStringEncodingError")
   public static var FileWriteInapplicableStringEncodingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteUnsupportedSchemeError")
+  @available(*, unavailable, renamed: "fileWriteUnsupportedSchemeError")
   public static var FileWriteUnsupportedSchemeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteOutOfSpaceError")
+  @available(*, unavailable, renamed: "fileWriteOutOfSpaceError")
   public static var FileWriteOutOfSpaceError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileWriteVolumeReadOnlyError")
+  @available(*, unavailable, renamed: "fileWriteVolumeReadOnlyError")
   public static var FileWriteVolumeReadOnlyError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileManagerUnmountUnknownError")
+  @available(*, unavailable, renamed: "fileManagerUnmountUnknownError")
   public static var FileManagerUnmountUnknownError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileManagerUnmountBusyError")
+  @available(*, unavailable, renamed: "fileManagerUnmountBusyError")
   public static var FileManagerUnmountBusyError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="keyValueValidationError")
+  @available(*, unavailable, renamed: "keyValueValidationError")
   public static var KeyValueValidationError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="formattingError")
+  @available(*, unavailable, renamed: "formattingError")
   public static var FormattingError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userCancelledError")
+  @available(*, unavailable, renamed: "userCancelledError")
   public static var UserCancelledError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="featureUnsupportedError")
+  @available(*, unavailable, renamed: "featureUnsupportedError")
   public static var FeatureUnsupportedError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="executableNotLoadableError")
+  @available(*, unavailable, renamed: "executableNotLoadableError")
   public static var ExecutableNotLoadableError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="executableArchitectureMismatchError")
+  @available(*, unavailable, renamed: "executableArchitectureMismatchError")
   public static var ExecutableArchitectureMismatchError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="executableRuntimeMismatchError")
+  @available(*, unavailable, renamed: "executableRuntimeMismatchError")
   public static var ExecutableRuntimeMismatchError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="executableLoadError")
+  @available(*, unavailable, renamed: "executableLoadError")
   public static var ExecutableLoadError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="executableLinkError")
+  @available(*, unavailable, renamed: "executableLinkError")
   public static var ExecutableLinkError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="propertyListReadCorruptError")
+  @available(*, unavailable, renamed: "propertyListReadCorruptError")
   public static var PropertyListReadCorruptError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="propertyListReadUnknownVersionError")
+  @available(*, unavailable, renamed: "propertyListReadUnknownVersionError")
   public static var PropertyListReadUnknownVersionError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="propertyListReadStreamError")
+  @available(*, unavailable, renamed: "propertyListReadStreamError")
   public static var PropertyListReadStreamError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="propertyListWriteStreamError")
+  @available(*, unavailable, renamed: "propertyListWriteStreamError")
   public static var PropertyListWriteStreamError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="propertyListWriteInvalidError")
+  @available(*, unavailable, renamed: "propertyListWriteInvalidError")
   public static var PropertyListWriteInvalidError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="xpcConnectionInterrupted")
+  @available(*, unavailable, renamed: "xpcConnectionInterrupted")
   public static var XPCConnectionInterrupted: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="xpcConnectionInvalid")
+  @available(*, unavailable, renamed: "xpcConnectionInvalid")
   public static var XPCConnectionInvalid: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="xpcConnectionReplyInvalid")
+  @available(*, unavailable, renamed: "xpcConnectionReplyInvalid")
   public static var XPCConnectionReplyInvalid: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="ubiquitousFileUnavailableError")
+  @available(*, unavailable, renamed: "ubiquitousFileUnavailableError")
   public static var UbiquitousFileUnavailableError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="ubiquitousFileNotUploadedDueToQuotaError")
+  @available(*, unavailable, renamed: "ubiquitousFileNotUploadedDueToQuotaError")
   public static var UbiquitousFileNotUploadedDueToQuotaError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="ubiquitousFileUbiquityServerNotAvailable")
+  @available(*, unavailable, renamed: "ubiquitousFileUbiquityServerNotAvailable")
   public static var UbiquitousFileUbiquityServerNotAvailable: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userActivityHandoffFailedError")
+  @available(*, unavailable, renamed: "userActivityHandoffFailedError")
   public static var UserActivityHandoffFailedError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userActivityConnectionUnavailableError")
+  @available(*, unavailable, renamed: "userActivityConnectionUnavailableError")
   public static var UserActivityConnectionUnavailableError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userActivityRemoteApplicationTimedOutError")
+  @available(*, unavailable, renamed: "userActivityRemoteApplicationTimedOutError")
   public static var UserActivityRemoteApplicationTimedOutError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userActivityHandoffUserInfoTooLargeError")
+  @available(*, unavailable, renamed: "userActivityHandoffUserInfoTooLargeError")
   public static var UserActivityHandoffUserInfoTooLargeError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="coderReadCorruptError")
+  @available(*, unavailable, renamed: "coderReadCorruptError")
   public static var CoderReadCorruptError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="coderValueNotFoundError")
+  @available(*, unavailable, renamed: "coderValueNotFoundError")
   public static var CoderValueNotFoundError: NSCocoaError {
     fatalError("unavailable accessor can't be called")
   }
@@ -676,257 +676,257 @@ extension NSCocoaError {
   case downloadDecodingFailedMidStream = -3006
   case downloadDecodingFailedToComplete = -3007
 
-  @available(OSX, introduced=10.7) @available(iOS, introduced=3.0)
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
   case internationalRoamingOff = -1018
 
-  @available(OSX, introduced=10.7) @available(iOS, introduced=3.0)
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
   case callIsActive = -1019
 
-  @available(OSX, introduced=10.7) @available(iOS, introduced=3.0)
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
   case dataNotAllowed = -1020
 
-  @available(OSX, introduced=10.7) @available(iOS, introduced=3.0)
+  @available(OSX, introduced: 10.7) @available(iOS, introduced: 3.0)
   case requestBodyStreamExhausted = -1021
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   case backgroundSessionRequiresSharedContainer = -995
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   case backgroundSessionInUseByAnotherProcess = -996
 
-  @available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+  @available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
   case backgroundSessionWasDisconnected = -997
 
   public static var _nsErrorDomain: String { return NSURLErrorDomain }
 }
 
 extension NSURLError {
-  @available(*, unavailable, renamed="unknown")
+  @available(*, unavailable, renamed: "unknown")
   static var Unknown: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cancelled")
+  @available(*, unavailable, renamed: "cancelled")
   static var Cancelled: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="badURL")
+  @available(*, unavailable, renamed: "badURL")
   static var BadURL: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="timedOut")
+  @available(*, unavailable, renamed: "timedOut")
   static var TimedOut: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="unsupportedURL")
+  @available(*, unavailable, renamed: "unsupportedURL")
   static var UnsupportedURL: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotFindHost")
+  @available(*, unavailable, renamed: "cannotFindHost")
   static var CannotFindHost: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotConnectToHost")
+  @available(*, unavailable, renamed: "cannotConnectToHost")
   static var CannotConnectToHost: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="networkConnectionLost")
+  @available(*, unavailable, renamed: "networkConnectionLost")
   static var NetworkConnectionLost: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="dnsLookupFailed")
+  @available(*, unavailable, renamed: "dnsLookupFailed")
   static var DNSLookupFailed: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="httpTooManyRedirects")
+  @available(*, unavailable, renamed: "httpTooManyRedirects")
   static var HTTPTooManyRedirects: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="resourceUnavailable")
+  @available(*, unavailable, renamed: "resourceUnavailable")
   static var ResourceUnavailable: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="notConnectedToInternet")
+  @available(*, unavailable, renamed: "notConnectedToInternet")
   static var NotConnectedToInternet: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="redirectToNonExistentLocation")
+  @available(*, unavailable, renamed: "redirectToNonExistentLocation")
   static var RedirectToNonExistentLocation: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="badServerResponse")
+  @available(*, unavailable, renamed: "badServerResponse")
   static var BadServerResponse: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userCancelledAuthentication")
+  @available(*, unavailable, renamed: "userCancelledAuthentication")
   static var UserCancelledAuthentication: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="userAuthenticationRequired")
+  @available(*, unavailable, renamed: "userAuthenticationRequired")
   static var UserAuthenticationRequired: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="zeroByteResource")
+  @available(*, unavailable, renamed: "zeroByteResource")
   static var ZeroByteResource: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotDecodeRawData")
+  @available(*, unavailable, renamed: "cannotDecodeRawData")
   static var CannotDecodeRawData: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotDecodeContentData")
+  @available(*, unavailable, renamed: "cannotDecodeContentData")
   static var CannotDecodeContentData: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotParseResponse")
+  @available(*, unavailable, renamed: "cannotParseResponse")
   static var CannotParseResponse: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileDoesNotExist")
+  @available(*, unavailable, renamed: "fileDoesNotExist")
   static var FileDoesNotExist: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="fileIsDirectory")
+  @available(*, unavailable, renamed: "fileIsDirectory")
   static var FileIsDirectory: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="noPermissionsToReadFile")
+  @available(*, unavailable, renamed: "noPermissionsToReadFile")
   static var NoPermissionsToReadFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="secureConnectionFailed")
+  @available(*, unavailable, renamed: "secureConnectionFailed")
   static var SecureConnectionFailed: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="serverCertificateHasBadDate")
+  @available(*, unavailable, renamed: "serverCertificateHasBadDate")
   static var ServerCertificateHasBadDate: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="serverCertificateUntrusted")
+  @available(*, unavailable, renamed: "serverCertificateUntrusted")
   static var ServerCertificateUntrusted: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="serverCertificateHasUnknownRoot")
+  @available(*, unavailable, renamed: "serverCertificateHasUnknownRoot")
   static var ServerCertificateHasUnknownRoot: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="serverCertificateNotYetValid")
+  @available(*, unavailable, renamed: "serverCertificateNotYetValid")
   static var ServerCertificateNotYetValid: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="clientCertificateRejected")
+  @available(*, unavailable, renamed: "clientCertificateRejected")
   static var ClientCertificateRejected: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="clientCertificateRequired")
+  @available(*, unavailable, renamed: "clientCertificateRequired")
   static var ClientCertificateRequired: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotLoadFromNetwork")
+  @available(*, unavailable, renamed: "cannotLoadFromNetwork")
   static var CannotLoadFromNetwork: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotCreateFile")
+  @available(*, unavailable, renamed: "cannotCreateFile")
   static var CannotCreateFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotOpenFile")
+  @available(*, unavailable, renamed: "cannotOpenFile")
   static var CannotOpenFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotCloseFile")
+  @available(*, unavailable, renamed: "cannotCloseFile")
   static var CannotCloseFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotWriteToFile")
+  @available(*, unavailable, renamed: "cannotWriteToFile")
   static var CannotWriteToFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotRemoveFile")
+  @available(*, unavailable, renamed: "cannotRemoveFile")
   static var CannotRemoveFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="cannotMoveFile")
+  @available(*, unavailable, renamed: "cannotMoveFile")
   static var CannotMoveFile: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="downloadDecodingFailedMidStream")
+  @available(*, unavailable, renamed: "downloadDecodingFailedMidStream")
   static var DownloadDecodingFailedMidStream: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="downloadDecodingFailedToComplete")
+  @available(*, unavailable, renamed: "downloadDecodingFailedToComplete")
   static var DownloadDecodingFailedToComplete: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="internationalRoamingOff")
+  @available(*, unavailable, renamed: "internationalRoamingOff")
   static var InternationalRoamingOff: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="callIsActive")
+  @available(*, unavailable, renamed: "callIsActive")
   static var CallIsActive: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="dataNotAllowed")
+  @available(*, unavailable, renamed: "dataNotAllowed")
   static var DataNotAllowed: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="requestBodyStreamExhausted")
+  @available(*, unavailable, renamed: "requestBodyStreamExhausted")
   static var RequestBodyStreamExhausted: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="backgroundSessionRequiresSharedContainer")
+  @available(*, unavailable, renamed: "backgroundSessionRequiresSharedContainer")
   static var BackgroundSessionRequiresSharedContainer: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="backgroundSessionInUseByAnotherProcess")
+  @available(*, unavailable, renamed: "backgroundSessionInUseByAnotherProcess")
   static var BackgroundSessionInUseByAnotherProcess: NSURLError {
     fatalError("unavailable accessor can't be called")
   }
 
-  @available(*, unavailable, renamed="backgroundSessionWasDisconnected")
+  @available(*, unavailable, renamed: "backgroundSessionWasDisconnected")
   static var BackgroundSessionWasDisconnected: NSURLError {
     fatalError("unavailable accessor can't be called")
   }

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -182,7 +182,7 @@ extension String {
 
   /// Returns a string built from the strings in a given array
   /// by concatenating them with a path separator between each pair.
-  @available(*, unavailable, message="Use fileURL(withPathComponents:) on NSURL instead.")
+  @available(*, unavailable, message: "Use fileURL(withPathComponents:) on NSURL instead.")
   public static func path(withComponents components: [String]) -> String {
     return NSString.path(withComponents: components)
   }
@@ -574,7 +574,7 @@ extension String {
   // - (const char *)fileSystemRepresentation
 
   /// Returns a file system-specific representation of the `String`.
-  @available(*, unavailable, message="Use getFileSystemRepresentation on NSURL instead.")
+  @available(*, unavailable, message: "Use getFileSystemRepresentation on NSURL instead.")
   public var fileSystemRepresentation: [CChar] {
     return _persistCString(_ns.fileSystemRepresentation)!
   }
@@ -664,7 +664,7 @@ extension String {
   /// fills a buffer with a C-string in a format and encoding suitable
   /// for use with file-system calls.
   /// - Note: will store a maximum of `min(buffer.count, maxLength)` bytes.
-  @available(*, unavailable, message="Use getFileSystemRepresentation on NSURL instead.")
+  @available(*, unavailable, message: "Use getFileSystemRepresentation on NSURL instead.")
   public func getFileSystemRepresentation(
     buffer: inout [CChar], maxLength: Int) -> Bool {
     return _ns.getFileSystemRepresentation(
@@ -975,7 +975,7 @@ extension String {
   // @property NSString lastPathComponent;
 
   /// Returns the last path component of the `String`.
-  @available(*, unavailable, message="Use lastPathComponent on NSURL instead.")
+  @available(*, unavailable, message: "Use lastPathComponent on NSURL instead.")
   public var lastPathComponent: String {
     return _ns.lastPathComponent
   }
@@ -985,7 +985,7 @@ extension String {
 
   /// Returns the number of Unicode characters in the `String`.
   @available(*, unavailable,
-    message="Take the count of a UTF-16 view instead, i.e. str.utf16.count")
+    message: "Take the count of a UTF-16 view instead, i.e. str.utf16.count")
   public var utf16Count: Int {
     return _ns.length
   }
@@ -1113,7 +1113,7 @@ extension String {
 
   /// Returns an array of NSString objects containing, in
   /// order, each path component of the `String`.
-  @available(*, unavailable, message="Use pathComponents on NSURL instead.")
+  @available(*, unavailable, message: "Use pathComponents on NSURL instead.")
   public var pathComponents: [String] {
     return _ns.pathComponents
   }
@@ -1122,7 +1122,7 @@ extension String {
 
   /// Interprets the `String` as a path and returns the
   /// `String`'s extension, if any.
-  @available(*, unavailable, message="Use pathExtension on NSURL instead.")
+  @available(*, unavailable, message: "Use pathExtension on NSURL instead.")
   public var pathExtension: String {
     return _ns.pathExtension
   }
@@ -1300,7 +1300,7 @@ extension String {
   /// Returns a new string that replaces the current home
   /// directory portion of the current path with a tilde (`~`)
   /// character.
-  @available(*, unavailable, message="Use abbreviatingWithTildeInPath on NSString instead.")
+  @available(*, unavailable, message: "Use abbreviatingWithTildeInPath on NSString instead.")
   public var abbreviatingWithTildeInPath: String {
     return _ns.abbreviatingWithTildeInPath
   }
@@ -1336,7 +1336,7 @@ extension String {
   /// Returns a representation of the `String` using a given
   /// encoding to determine the percent escapes necessary to convert
   /// the `String` into a legal URL string.
-  @available(*, deprecated, message="Use addingPercentEncoding(withAllowedCharacters:) instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent since each URL component or subcomponent has different rules for what characters are valid.")
+  @available(*, deprecated, message: "Use addingPercentEncoding(withAllowedCharacters:) instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent since each URL component or subcomponent has different rules for what characters are valid.")
   public func addingPercentEscapes(
     usingEncoding encoding: NSStringEncoding
   ) -> String? {
@@ -1359,7 +1359,7 @@ extension String {
   // - (NSString *)stringByAppendingPathComponent:(NSString *)aString
 
   /// Returns a new string made by appending to the `String` a given string.
-  @available(*, unavailable, message="Use appendingPathComponent on NSURL instead.")
+  @available(*, unavailable, message: "Use appendingPathComponent on NSURL instead.")
   public func appendingPathComponent(aString: String) -> String {
     return _ns.appendingPathComponent(aString)
   }
@@ -1368,7 +1368,7 @@ extension String {
 
   /// Returns a new string made by appending to the `String` an
   /// extension separator followed by a given extension.
-  @available(*, unavailable, message="Use appendingPathExtension on NSURL instead.")
+  @available(*, unavailable, message: "Use appendingPathExtension on NSURL instead.")
   public func appendingPathExtension(ext: String) -> String? {
     // FIXME: This method can return nil in practice, for example when self is
     // an empty string.  OTOH, this is not documented, documentation says that
@@ -1393,7 +1393,7 @@ extension String {
   /// Returns a new string made by deleting the last path
   /// component from the `String`, along with any final path
   /// separator.
-  @available(*, unavailable, message="Use deletingLastPathComponent on NSURL instead.")
+  @available(*, unavailable, message: "Use deletingLastPathComponent on NSURL instead.")
   public var deletingLastPathComponent: String {
     return _ns.deletingLastPathComponent
   }
@@ -1402,7 +1402,7 @@ extension String {
 
   /// Returns a new string made by deleting the extension (if
   /// any, and only the last) from the `String`.
-  @available(*, unavailable, message="Use deletingPathExtension on NSURL instead.")
+  @available(*, unavailable, message: "Use deletingPathExtension on NSURL instead.")
   public var deletingPathExtension: String {
     return _ns.deletingPathExtension
   }
@@ -1411,7 +1411,7 @@ extension String {
 
   /// Returns a new string made by expanding the initial
   /// component of the `String` to its full path value.
-  @available(*, unavailable, message="Use expandingTildeInPath on NSString instead.")
+  @available(*, unavailable, message: "Use expandingTildeInPath on NSString instead.")
   public var expandingTildeInPath: String {
     return _ns.expandingTildeInPath
   }
@@ -1504,7 +1504,7 @@ extension String {
   /// Returns a new string made by replacing in the `String`
   /// all percent escapes with the matching characters as determined
   /// by a given encoding.
-  @available(*, deprecated, message="Use removingPercentEncoding instead, which always uses the recommended UTF-8 encoding.")
+  @available(*, deprecated, message: "Use removingPercentEncoding instead, which always uses the recommended UTF-8 encoding.")
   public func replacingPercentEscapes(
     usingEncoding encoding: NSStringEncoding
   ) -> String? {
@@ -1515,7 +1515,7 @@ extension String {
 
   /// Returns a new string made from the `String` by resolving
   /// all symbolic links and standardizing path.
-  @available(*, unavailable, message="Use resolvingSymlinksInPath on NSURL instead.")
+  @available(*, unavailable, message: "Use resolvingSymlinksInPath on NSURL instead.")
   public var resolvingSymlinksInPath: String {
     return _ns.resolvingSymlinksInPath
   }
@@ -1524,7 +1524,7 @@ extension String {
 
   /// Returns a new string made by removing extraneous path
   /// components from the `String`.
-  @available(*, unavailable, message="Use standardizingPath on NSURL instead.")
+  @available(*, unavailable, message: "Use standardizingPath on NSURL instead.")
   public var standardizingPath: String {
     return _ns.standardizingPath
   }
@@ -1542,7 +1542,7 @@ extension String {
 
   /// Returns an array of strings made by separately appending
   /// to the `String` each string in a given array.
-  @available(*, unavailable, message="Map over paths with appendingPathComponent instead.")
+  @available(*, unavailable, message: "Map over paths with appendingPathComponent instead.")
   public func strings(byAppendingPaths paths: [String]) -> [String] {
     fatalError("This function is not available")
   }
@@ -1684,35 +1684,35 @@ extension String {
 // Pre-Swift-3 method names
 extension String {
 
-  @available(*, unavailable, renamed="localizedName(ofStringEncoding:)")
+  @available(*, unavailable, renamed: "localizedName(ofStringEncoding:)")
   public static func localizedNameOfStringEncoding(
     encoding: NSStringEncoding
   ) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Use fileURL(withPathComponents:) on NSURL instead.")
+  @available(*, unavailable, message: "Use fileURL(withPathComponents:) on NSURL instead.")
   public static func pathWithComponents(components: [String]) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="canBeConverted(toEncoding:)")
+  @available(*, unavailable, renamed: "canBeConverted(toEncoding:)")
   public func canBeConvertedToEncoding(encoding: NSStringEncoding) -> Bool {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="capitalizedString(with:)")
+  @available(*, unavailable, renamed: "capitalizedString(with:)")
   public func capitalizedStringWith(locale: NSLocale?) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="commonPrefix(with:options:)")
+  @available(*, unavailable, renamed: "commonPrefix(with:options:)")
   public func commonPrefixWith(
     aString: String, options: NSStringCompareOptions) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="completePath(into:outputName:caseSensitive:matchesInto:filterTypes:)")
+  @available(*, unavailable, renamed: "completePath(into:outputName:caseSensitive:matchesInto:filterTypes:)")
   public func completePathInto(
     outputName: UnsafeMutablePointer<String> = nil,
     caseSensitive: Bool,
@@ -1722,24 +1722,24 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="componentsSeparatedByCharacters(in:)")
+  @available(*, unavailable, renamed: "componentsSeparatedByCharacters(in:)")
   public func componentsSeparatedByCharactersIn(
     separator: NSCharacterSet
   ) -> [String] {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="componentsSeparated(by:)")
+  @available(*, unavailable, renamed: "componentsSeparated(by:)")
   public func componentsSeparatedBy(separator: String) -> [String] {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="cString(usingEncoding:)")
+  @available(*, unavailable, renamed: "cString(usingEncoding:)")
   public func cStringUsingEncoding(encoding: NSStringEncoding) -> [CChar]? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="data(usingEncoding:allowLossyConversion:)")
+  @available(*, unavailable, renamed: "data(usingEncoding:allowLossyConversion:)")
   public func dataUsingEncoding(
     encoding: NSStringEncoding,
     allowLossyConversion: Bool = false
@@ -1747,7 +1747,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="enumerateLinguisticTags(in:scheme:options:orthography:_:)")
+  @available(*, unavailable, renamed: "enumerateLinguisticTags(in:scheme:options:orthography:_:)")
   public func enumerateLinguisticTagsIn(
     range: Range<Index>,
     scheme tagScheme: String,
@@ -1759,7 +1759,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="enumerateSubstrings(in:options:_:)")
+  @available(*, unavailable, renamed: "enumerateSubstrings(in:options:_:)")
   public func enumerateSubstringsIn(
     range: Range<Index>,
     options opts:NSStringEnumerationOptions = [],
@@ -1771,7 +1771,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="getBytes(_:maxLength:usedLength:encoding:options:range:remaining:)")
+  @available(*, unavailable, renamed: "getBytes(_:maxLength:usedLength:encoding:options:range:remaining:)")
   public func getBytes(
     buffer: inout [UInt8],
     maxLength maxBufferCount: Int,
@@ -1784,7 +1784,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="getLineStart(_:end:contentsEnd:for:)")
+  @available(*, unavailable, renamed: "getLineStart(_:end:contentsEnd:for:)")
   public func getLineStart(
     start: UnsafeMutablePointer<Index>,
     end: UnsafeMutablePointer<Index>,
@@ -1794,7 +1794,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="getParagraphStart(_:end:contentsEnd:for:)")
+  @available(*, unavailable, renamed: "getParagraphStart(_:end:contentsEnd:for:)")
   public func getParagraphStart(
     start: UnsafeMutablePointer<Index>,
     end: UnsafeMutablePointer<Index>,
@@ -1804,17 +1804,17 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="lengthOfBytes(usingEncoding:)")
+  @available(*, unavailable, renamed: "lengthOfBytes(usingEncoding:)")
   public func lengthOfBytesUsingEncoding(encoding: NSStringEncoding) -> Int {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="lineRange(for:)")
+  @available(*, unavailable, renamed: "lineRange(for:)")
   public func lineRangeFor(aRange: Range<Index>) -> Range<Index> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="linguisticTags(in:scheme:options:orthography:tokenRanges:)")
+  @available(*, unavailable, renamed: "linguisticTags(in:scheme:options:orthography:tokenRanges:)")
   public func linguisticTagsIn(
     range: Range<Index>,
     scheme tagScheme: String,
@@ -1825,23 +1825,23 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="lowercaseString(with:)")
+  @available(*, unavailable, renamed: "lowercaseString(with:)")
   public func lowercaseStringWith(locale: NSLocale?) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="maximumLengthOfBytes(usingEncoding:)")
+  @available(*, unavailable, renamed: "maximumLengthOfBytes(usingEncoding:)")
   public
   func maximumLengthOfBytesUsingEncoding(encoding: NSStringEncoding) -> Int {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="paragraphRange(for:)")
+  @available(*, unavailable, renamed: "paragraphRange(for:)")
   public func paragraphRangeFor(aRange: Range<Index>) -> Range<Index> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="rangeOfCharacter(from:options:range:)")
+  @available(*, unavailable, renamed: "rangeOfCharacter(from:options:range:)")
   public func rangeOfCharacterFrom(
     aSet: NSCharacterSet,
     options mask:NSStringCompareOptions = [],
@@ -1850,20 +1850,20 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="rangeOfComposedCharacterSequence(at:)")
+  @available(*, unavailable, renamed: "rangeOfComposedCharacterSequence(at:)")
   public
   func rangeOfComposedCharacterSequenceAt(anIndex: Index) -> Range<Index> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="rangeOfComposedCharacterSequences(for:)")
+  @available(*, unavailable, renamed: "rangeOfComposedCharacterSequences(for:)")
   public func rangeOfComposedCharacterSequencesFor(
     range: Range<Index>
   ) -> Range<Index> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="range(of:options:range:locale:)")
+  @available(*, unavailable, renamed: "range(of:options:range:locale:)")
   public func rangeOf(
     aString: String,
     options mask: NSStringCompareOptions = [],
@@ -1873,54 +1873,54 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="localizedStandardRange(of:)")
+  @available(*, unavailable, renamed: "localizedStandardRange(of:)")
   public func localizedStandardRangeOf(string: String) -> Range<Index>? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="addingPercentEncoding(withAllowedCharacters:")
+  @available(*, unavailable, renamed: "addingPercentEncoding(withAllowedCharacters:")
   public func addingPercentEncodingWithAllowedCharacters(
     allowedCharacters: NSCharacterSet
   ) -> String? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="addingPercentEscapes(usingEncoding:)")
+  @available(*, unavailable, renamed: "addingPercentEscapes(usingEncoding:)")
   public func addingPercentEscapesUsingEncoding(
     encoding: NSStringEncoding
   ) -> String? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="stringByAppendingFormat")
+  @available(*, unavailable, renamed: "stringByAppendingFormat")
   public func appendingFormat(
     format: String, _ arguments: CVarArg...
   ) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="folding(_:locale:)")
+  @available(*, unavailable, renamed: "folding(_:locale:)")
   public func folding(
     options options: NSStringCompareOptions = [], locale: NSLocale?
   ) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="padding(toLength:with:startingAt:)")
+  @available(*, unavailable, renamed: "padding(toLength:with:startingAt:)")
   public func byPaddingToLength(
     newLength: Int, withString padString: String, startingAt padIndex: Int
   ) -> String {
     fatalError("unavailable function can't be called")
   }
   
-  @available(*, unavailable, renamed="replacingCharacters(in:with:)")
+  @available(*, unavailable, renamed: "replacingCharacters(in:with:)")
   public func replacingCharactersIn(
     range: Range<Index>, withString replacement: String
   ) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="replacingOccurrences(of:with:options:range:)")
+  @available(*, unavailable, renamed: "replacingOccurrences(of:with:options:range:)")
   public func replacingOccurrencesOf(
     target: String,
     withString replacement: String,
@@ -1930,44 +1930,44 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="replacingPercentEscapes(usingEncoding:)")
+  @available(*, unavailable, renamed: "replacingPercentEscapes(usingEncoding:)")
   public func replacingPercentEscapesUsingEncoding(
     encoding: NSStringEncoding
   ) -> String? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="trimmingCharacters(in:)")
+  @available(*, unavailable, renamed: "trimmingCharacters(in:)")
   public func byTrimmingCharactersIn(set: NSCharacterSet) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="strings(byAppendingPaths:)")
+  @available(*, unavailable, renamed: "strings(byAppendingPaths:)")
   public func stringsByAppendingPaths(paths: [String]) -> [String] {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="substring(from:)")
+  @available(*, unavailable, renamed: "substring(from:)")
   public func substringFrom(index: Index) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="substring(to:)")
+  @available(*, unavailable, renamed: "substring(to:)")
   public func substringTo(index: Index) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="substring(with:)")
+  @available(*, unavailable, renamed: "substring(with:)")
   public func substringWith(aRange: Range<Index>) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="uppercaseString(with:)")
+  @available(*, unavailable, renamed: "uppercaseString(with:)")
   public func uppercaseStringWith(locale: NSLocale?) -> String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="write(toFile:atomically:encoding:)")
+  @available(*, unavailable, renamed: "write(toFile:atomically:encoding:)")
   public func writeToFile(
     path: String, atomically useAuxiliaryFile:Bool,
     encoding enc: NSStringEncoding
@@ -1975,7 +1975,7 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="write(to:atomically:encoding:)")
+  @available(*, unavailable, renamed: "write(to:atomically:encoding:)")
   public func writeToURL(
     url: NSURL, atomically useAuxiliaryFile: Bool,
     encoding enc: NSStringEncoding

--- a/stdlib/public/SDK/GameplayKit/GameplayKit.swift
+++ b/stdlib/public/SDK/GameplayKit/GameplayKit.swift
@@ -18,9 +18,9 @@ internal func GK_Swift_GKEntity_componentForClass(
   self_: AnyObject,
   _ componentClass: AnyObject) -> AnyObject?
 
-@available(iOS, introduced=9.0)
-@available(OSX, introduced=10.11)
-@available(tvOS, introduced=9.0)
+@available(iOS, introduced: 9.0)
+@available(OSX, introduced: 10.11)
+@available(tvOS, introduced: 9.0)
 extension GKEntity {
   /// Returns the component instance of the indicated class contained by the
   /// entity. Returns nil if entity does not have this component.
@@ -38,9 +38,9 @@ internal func GK_Swift_GKStateMachine_stateForClass(
   self_: AnyObject,
   _ stateClass: AnyObject) -> AnyObject?
 
-@available(iOS, introduced=9.0)
-@available(OSX, introduced=10.11)
-@available(tvOS, introduced=9.0)
+@available(iOS, introduced: 9.0)
+@available(OSX, introduced: 10.11)
+@available(tvOS, introduced: 9.0)
 extension GKStateMachine {
   /// Returns the state instance of the indicated class contained by the state
   /// machine. Returns nil if state machine does not have this state.

--- a/stdlib/public/SDK/MultipeerConnectivity/MultipeerConnectivity.swift
+++ b/stdlib/public/SDK/MultipeerConnectivity/MultipeerConnectivity.swift
@@ -1,7 +1,7 @@
 @_exported import MultipeerConnectivity
 import Foundation
 
-@available(OSX, introduced=10.10) @available(iOS, introduced=7.0)
+@available(OSX, introduced: 10.10) @available(iOS, introduced: 7.0)
 extension MCErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return MCErrorDomain }
 }

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -212,11 +212,11 @@ public func autoreleasepool(@noescape code: () -> Void) {
 // Mark YES and NO unavailable.
 //===----------------------------------------------------------------------===//
 
-@available(*, unavailable, message="Use 'Bool' value 'true' instead")
+@available(*, unavailable, message: "Use 'Bool' value 'true' instead")
 public var YES: ObjCBool {
   fatalError("can't retrieve unavailable property")
 }
-@available(*, unavailable, message="Use 'Bool' value 'false' instead")
+@available(*, unavailable, message: "Use 'Bool' value 'false' instead")
 public var NO: ObjCBool {
   fatalError("can't retrieve unavailable property")
 }

--- a/stdlib/public/SDK/OpenCL/OpenCL.swift
+++ b/stdlib/public/SDK/OpenCL/OpenCL.swift
@@ -12,7 +12,7 @@
 
 @_exported import OpenCL // Clang module
 
-@available(OSX, introduced=10.7)
+@available(OSX, introduced: 10.7)
 public func clSetKernelArgsListAPPLE(
   kernel: cl_kernel, _ uint: cl_uint, _ args: CVarArg...
 ) -> cl_int {

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift
@@ -143,8 +143,8 @@ extension double4x4 {
 
 // MARK: APIs refined for Swift
 
-@available(iOS, introduced=8.0)
-@available(OSX, introduced=10.8)
+@available(iOS, introduced: 8.0)
+@available(OSX, introduced: 10.8)
 extension SCNGeometryElement {
   public convenience init<IndexType : Integer>(
     indices: [IndexType], primitiveType: SCNGeometryPrimitiveType
@@ -176,8 +176,8 @@ internal func SCN_Swift_SCNSceneSource_entryWithIdentifier(
   _ uid: NSString,
   _ entryClass: AnyObject) -> AnyObject?
 
-@available(iOS, introduced=8.0)
-@available(OSX, introduced=10.8)
+@available(iOS, introduced: 8.0)
+@available(OSX, introduced: 10.8)
 extension SCNSceneSource {
   @warn_unused_result
   public func entryWithIdentifier<T>(uid: String, withClass entryClass: T.Type) -> T? {

--- a/stdlib/public/SDK/WebKit/WebKit.swift
+++ b/stdlib/public/SDK/WebKit/WebKit.swift
@@ -1,7 +1,7 @@
 @_exported import WebKit
 import Foundation
 
-@available(OSX, introduced=10.10) @available(iOS, introduced=8.0)
+@available(OSX, introduced: 10.10) @available(iOS, introduced: 8.0)
 extension WKErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return WKErrorDomain }
 }

--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -622,56 +622,56 @@ public func cross(x: ${ctype[type]}3,
 // Integer vector types only support wrapping arithmetic. Make the non-wrapping
 // operators unavailable so that fixits guide users to the unchecked operations.
 
-@available(*, unavailable, renamed="&+",
-           message="integer vector types do not support checked arithmetic; use the wrapping operations instead")
+@available(*, unavailable, renamed: "&+",
+           message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
 public func +(x: ${vectype}, y: ${vectype}) -> ${vectype} {
   fatalError("unavailable function cannot be called")
 }
 
-@available(*, unavailable, renamed="&-",
-           message="integer vector types do not support checked arithmetic; use the wrapping operations instead")
+@available(*, unavailable, renamed: "&-",
+           message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
 public func -(x: ${vectype}, y: ${vectype}) -> ${vectype} {
   fatalError("unavailable function cannot be called")
 }
 
-@available(*, unavailable, renamed="&*",
-           message="integer vector types do not support checked arithmetic; use the wrapping operations instead")
+@available(*, unavailable, renamed: "&*",
+           message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
 public func *(x: ${vectype}, y: ${vectype}) -> ${vectype} {
   fatalError("unavailable function cannot be called")
 }
 
-@available(*, unavailable, renamed="&*",
-           message="integer vector types do not support checked arithmetic; use the wrapping operations instead")
+@available(*, unavailable, renamed: "&*",
+           message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
 public func *(x: ${vectype}, y: ${type}) -> ${vectype} {
   fatalError("unavailable function cannot be called")
 }
 
-@available(*, unavailable, renamed="&*",
-           message="integer vector types do not support checked arithmetic; use the wrapping operations instead")
+@available(*, unavailable, renamed: "&*",
+           message: "integer vector types do not support checked arithmetic; use the wrapping operations instead")
 public func *(x: ${type}, y: ${vectype}) -> ${vectype} {
   fatalError("unavailable function cannot be called")
 }
 
 @available(*, unavailable,
-           message="integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &+ y' instead")
+           message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &+ y' instead")
 public func +=(x: inout ${vectype}, y: ${vectype}) {
   fatalError("unavailable function cannot be called")
 }
 
 @available(*, unavailable,
-           message="integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &- y' instead")
+           message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &- y' instead")
 public func -=(x: inout ${vectype}, y: ${vectype}) {
   fatalError("unavailable function cannot be called")
 }
 
 @available(*, unavailable,
-           message="integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &* y' instead")
+           message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &* y' instead")
 public func *=(x: inout ${vectype}, y: ${vectype}) {
   fatalError("unavailable function cannot be called")
 }
 
 @available(*, unavailable,
-           message="integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &* y' instead")
+           message: "integer vector types do not support checked arithmetic; use the wrapping operation 'x = x &* y' instead")
 public func *=(x: inout ${vectype}, y: ${type}) {
   fatalError("unavailable function cannot be called")
 }

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -119,21 +119,21 @@ public struct EnumeratedSequence<Base : Sequence> : Sequence {
   }
 }
 
-@available(*, unavailable, renamed="EnumeratedIterator")
+@available(*, unavailable, renamed: "EnumeratedIterator")
 public struct EnumerateGenerator<Base : IteratorProtocol> { }
 
-@available(*, unavailable, renamed="EnumeratedSequence")
+@available(*, unavailable, renamed: "EnumeratedSequence")
 public struct EnumerateSequence<Base : Sequence> {}
 
 extension EnumeratedIterator {
-  @available(*, unavailable, message="use the 'enumerated()' method on the sequence")
+  @available(*, unavailable, message: "use the 'enumerated()' method on the sequence")
   public init(_ base: Base) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension EnumeratedSequence {
-  @available(*, unavailable, message="use the 'enumerated()' method on the sequence")
+  @available(*, unavailable, message: "use the 'enumerated()' method on the sequence")
   public init(_ base: Base) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1424,24 +1424,24 @@ extension ContiguousArray {
 
 %for (Self, a_Self) in arrayTypes:
 extension ${Self} {
-  @available(*, unavailable, message="Please use init(repeating:count:) instead")
+  @available(*, unavailable, message: "Please use init(repeating:count:) instead")
   init(count: Int, repeatedValue: Element) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="remove")
+  @available(*, unavailable, renamed: "remove")
   public mutating func removeAtIndex(index: Int) -> Element {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange")
   public mutating func replaceRange<
     C : Collection where C.Iterator.Element == _Buffer.Element
   >(subRange: Range<Int>, with newElements: C) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="append(contentsOf:)")
+  @available(*, unavailable, renamed: "append(contentsOf:)")
   public mutating func appendContentsOf<
     S : Sequence
     where

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -488,15 +488,15 @@ internal struct _CocoaFastEnumerationStackBuf {
 }
 
 extension AutoreleasingUnsafeMutablePointer {
-  @available(*, unavailable, renamed="Pointee")
+  @available(*, unavailable, renamed: "Pointee")
   public typealias Memory = Pointee
 
-  @available(*, unavailable, renamed="pointee")
+  @available(*, unavailable, renamed: "pointee")
   public var memory: Pointee {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Removed in Swift 3. Please use nil literal instead.")
+  @available(*, unavailable, message: "Removed in Swift 3. Please use nil literal instead.")
   public init() {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -206,7 +206,7 @@ public func unsafeAddress(of object: AnyObject) -> UnsafePointer<Void> {
   return UnsafePointer(Builtin.bridgeToRawPointer(object))
 }
 
-@available(*, unavailable, renamed="unsafeAddress(of:)")
+@available(*, unavailable, renamed: "unsafeAddress(of:)")
 public func unsafeAddressOf(object: AnyObject) -> UnsafePointer<Void> {
   fatalError("unavailable function can't be called")
 }
@@ -564,7 +564,7 @@ func _isOptional<T>(type: T.Type) -> Bool {
   return Bool(Builtin.isOptional(type))
 }
 
-@available(*, unavailable, message="Removed in Swift 3. Please use Optional.unsafelyUnwrapped instead.")
+@available(*, unavailable, message: "Removed in Swift 3. Please use Optional.unsafelyUnwrapped instead.")
 public func unsafeUnwrap<T>(nonEmpty: T?) -> T {
   fatalError("unavailable function can't be called")
 }

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -93,13 +93,13 @@ public func _persistCString(s: UnsafePointer<CChar>) -> [CChar]? {
 }
 
 extension String {
-  @available(*, unavailable, message="Please use String.init?(validatingUTF8:) instead. Note that it no longer accepts NULL as a valid input. Also consider using String(cString:), that will attempt to repair ill-formed code units.")
+  @available(*, unavailable, message: "Please use String.init?(validatingUTF8:) instead. Note that it no longer accepts NULL as a valid input. Also consider using String(cString:), that will attempt to repair ill-formed code units.")
   @warn_unused_result
   public static func fromCString(cs: UnsafePointer<CChar>) -> String? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Please use String.init(cString:) instead. Note that it no longer accepts NULL as a valid input. See also String.decodeCString if you need more control.")
+  @available(*, unavailable, message: "Please use String.init(cString:) instead. Note that it no longer accepts NULL as a valid input. See also String.decodeCString if you need more control.")
   @warn_unused_result
   public static func fromCStringRepairingIllFormedUTF8(
     cs: UnsafePointer<CChar>

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -188,5 +188,5 @@ func _memcpy(
     /*volatile:*/ false._value)
 }
 
-@available(*, unavailable, renamed="OpaquePointer")
+@available(*, unavailable, renamed: "OpaquePointer")
 public struct COpaquePointer {}

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -731,30 +731,30 @@ internal func _writeBackMutableSlice<
     "Cannot replace a slice of a MutableCollection with a slice of a larger size")
 }
 
-@available(*, unavailable, message="Bit enum has been deprecated. Please use Int instead.")
+@available(*, unavailable, message: "Bit enum has been deprecated. Please use Int instead.")
 public enum Bit {}
 
-@available(*, unavailable, renamed="IndexingIterator")
+@available(*, unavailable, renamed: "IndexingIterator")
 public struct IndexingGenerator<Elements : Indexable> {}
 
-@available(*, unavailable, renamed="Collection")
+@available(*, unavailable, renamed: "Collection")
 public typealias CollectionType = Collection
 
 extension Collection {
-  @available(*, unavailable, renamed="Iterator")
+  @available(*, unavailable, renamed: "Iterator")
   public typealias Generator = Iterator
 
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> Iterator {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Removed in Swift 3. Please use underestimatedCount property.")
+  @available(*, unavailable, message: "Removed in Swift 3. Please use underestimatedCount peoperty.")
   public func underestimateCount() -> Int {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Please use split(_:omittingEmptySubsequences:isSeparator:) instead")
+  @available(*, unavailable, message: "Please use split(_:omittingEmptySubsequences:isSeparator:) instead")
   public func split(
     maxSplit: Int = Int.max,
     allowEmptySlices: Bool = false,
@@ -765,7 +765,7 @@ extension Collection {
 }
 
 extension Collection where Iterator.Element : Equatable {
-  @available(*, unavailable, message="Please use split(separator:maxSplits:omittingEmptySubsequences:) instead")
+  @available(*, unavailable, message: "Please use split(separator:maxSplits:omittingEmptySubsequences:) instead")
   public func split(
     separator: Iterator.Element,
     maxSplit: Int = Int.max,
@@ -774,11 +774,11 @@ extension Collection where Iterator.Element : Equatable {
     fatalError("unavailable function can't be called")
   }
 }
-@available(*, unavailable, renamed="MutableCollection")
+@available(*, unavailable, renamed: "MutableCollection")
 public typealias MutableCollectionType = MutableCollection
 
-@available(*, unavailable, message="PermutationGenerator has been removed in Swift 3")
+@available(*, unavailable, message: "PermutationGenerator has been removed in Swift 3")
 public struct PermutationGenerator<C : Collection, Indices : Sequence> {}
 
-@available(*, unavailable, message="Please use 'Collection where SubSequence : MutableCollection'")
+@available(*, unavailable, message: "Please use 'Collection where SubSequence : MutableCollection'")
 public typealias MutableSliceable = Collection

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -214,7 +214,7 @@ ${sortedDocCommentForComparable}
 ${sortIsUnstableForComparable}
   ///
 ${orderingRequirementForComparable}
-  @warn_unused_result(${'mutable_variant="sort"' if Self == 'MutableCollection' else ''})
+  @warn_unused_result(${'mutable_variant: "sort"' if Self == 'MutableCollection' else ''})
   public func sorted() -> [Iterator.Element] {
     var result = ContiguousArray(self)
     result.sort()
@@ -228,7 +228,7 @@ ${sortedDocCommentForPredicate}
 ${sortIsUnstableForPredicate}
   ///
 ${orderingRequirementForPredicate}
-  @warn_unused_result(${'mutable_variant="sort"' if Self == 'MutableCollection' else ''})
+  @warn_unused_result(${'mutable_variant: "sort"' if Self == 'MutableCollection' else ''})
   public func sorted(
     @noescape isOrderedBefore isOrderedBefore:
       (${IElement}, ${IElement}) -> Bool
@@ -301,7 +301,7 @@ ${orderingRequirementForPredicate}
 extension MutableCollection
   where Index : RandomAccessIndex {
 
-  @available(*, unavailable, message="slice the collection using the range, and call partition(isOrderedBefore:)")
+  @available(*, unavailable, message: "slice the collection using the range, and call partition(isOrderedBefore:)")
   public mutating func partition(
     range: Range<Index>,
     isOrderedBefore: (${IElement}, ${IElement}) -> Bool
@@ -313,7 +313,7 @@ extension MutableCollection
 extension MutableCollection
   where Index : RandomAccessIndex, ${IElement} : Comparable {
 
-  @available(*, unavailable, message="slice the collection using the range, and call partition()")
+  @available(*, unavailable, message: "slice the collection using the range, and call partition()")
   public mutating func partition(range: Range<Index>) -> Index {
     fatalError("unavailable function can't be called")
   }
@@ -321,12 +321,12 @@ extension MutableCollection
 
 % for Self in [ 'Sequence', 'MutableCollection' ]:
 extension ${Self} where Self.Iterator.Element : Comparable {
-  @available(*, unavailable, renamed="sorted")
+  @available(*, unavailable, renamed: "sorted")
   public func sort() -> [Iterator.Element] {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="sorted(isOrderedBefore:)")
+  @available(*, unavailable, renamed: "sorted(isOrderedBefore:)")
   public func sort(
     @noescape isOrderedBefore: (Iterator.Element, Iterator.Element) -> Bool
   ) -> [Iterator.Element] {
@@ -340,14 +340,14 @@ extension MutableCollection
   Self.Index : RandomAccessIndex,
   Self.Iterator.Element : Comparable {
 
-  @available(*, unavailable, renamed="sort")
+  @available(*, unavailable, renamed: "sort")
   public mutating func sortInPlace() {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension MutableCollection where Self.Index : RandomAccessIndex {
-  @available(*, unavailable, renamed="sort(isOrderedBefore:)")
+  @available(*, unavailable, renamed: "sort(isOrderedBefore:)")
   public mutating func sortInPlace(
     @noescape isOrderedBefore: (Iterator.Element, Iterator.Element) -> Bool
   ) {
@@ -356,7 +356,7 @@ extension MutableCollection where Self.Index : RandomAccessIndex {
 }
 
 extension Collection where ${IElement} : Equatable {
-  @available(*, unavailable, renamed="index(of:)")
+  @available(*, unavailable, renamed: "index(of:)")
   @warn_unused_result
   public func indexOf(element: ${IElement}) -> Index? {
     fatalError("unavailable function can't be called")
@@ -364,7 +364,7 @@ extension Collection where ${IElement} : Equatable {
 }
 
 extension Collection {
-  @available(*, unavailable, renamed="index(where:)")
+  @available(*, unavailable, renamed: "index(where:)")
   @warn_unused_result
   public func indexOf(
     @noescape predicate: (${IElement}) throws -> Bool

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -84,11 +84,11 @@ extension CollectionOfOne : CustomReflectable {
   }
 }
 
-@available(*, unavailable, renamed="IteratorOverOne")
+@available(*, unavailable, renamed: "IteratorOverOne")
 public struct GeneratorOfOne<Element> {}
 
 extension IteratorOverOne {
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> IteratorOverOne<Element> {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -226,5 +226,5 @@ public protocol _FileReferenceLiteralConvertible {
 public protocol _DestructorSafeContainer {
 }
 
-@available(*, unavailable, renamed="Boolean")
+@available(*, unavailable, renamed: "Boolean")
 public typealias BooleanType = Boolean

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -71,11 +71,11 @@ public struct EmptyCollection<Element> : Collection {
   }
 }
 
-@available(*, unavailable, renamed="EmptyIterator")
+@available(*, unavailable, renamed: "EmptyIterator")
 public struct EmptyGenerator<Element> {}
 
 extension EmptyIterator {
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> EmptyIterator<Element> {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -59,5 +59,5 @@ public func _errorInMain(error: ErrorProtocol) {
   fatalError("Error raised at top level: \(String(reflecting: error))")
 }
 
-@available(*, unavailable, renamed="ErrorProtocol")
+@available(*, unavailable, renamed: "ErrorProtocol")
 public typealias ErrorType = ErrorProtocol

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -229,7 +229,7 @@ internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
 ///
 /// - SeeAlso: `AnyIterator<Element>`.
 public struct AnySequence<Element> : Sequence {
-  @available(*, unavailable, renamed="Element")
+  @available(*, unavailable, renamed: "Element")
   public typealias T = Element
 
   /// Wrap and forward operations to `base`.
@@ -674,11 +674,11 @@ public struct Any${Traversal}Collection<Element> : AnyCollectionProtocol {
 }
 % end
 
-@available(*, unavailable, renamed="AnyIterator")
+@available(*, unavailable, renamed: "AnyIterator")
 public struct AnyGenerator<Element> {}
 
 extension AnyIterator {
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> AnyIterator<Element> {
     fatalError("unavailable function can't be called")
   }
@@ -687,18 +687,18 @@ extension AnyIterator {
 % for Kind in ['Sequence'] + [t + 'Collection' for t in traversals]:
 extension Any${Kind} {
 
-  @available(*, unavailable, message="Please use underestimatedCount property instead.")
+  @available(*, unavailable, message: "Please use underestimatedCount property instead.")
   public var underestimateCount: Int {
     fatalError("unavailable function can't be called")
   }
 }
 %end
 
-@available(*, unavailable, renamed="AnyCollectionProtocol")
+@available(*, unavailable, renamed: "AnyCollectionProtocol")
 public typealias AnyCollectionType = AnyCollectionProtocol
 
 extension AnyCollectionProtocol {
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> AnyIterator<Iterator.Element> {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -255,11 +255,11 @@ extension LazyCollectionProtocol {
   }
 }
 
-@available(*, unavailable, renamed="LazyFilterIterator")
+@available(*, unavailable, renamed: "LazyFilterIterator")
 public struct LazyFilterGenerator<Base : IteratorProtocol> {}
 
 extension LazyFilterIterator {
-  @available(*, unavailable, message="use '.lazy.filter' on the sequence")
+  @available(*, unavailable, message: "use '.lazy.filter' on the sequence")
   public init(
     _ base: Base,
     whereElementsSatisfy predicate: (Base.Element) -> Bool
@@ -269,7 +269,7 @@ extension LazyFilterIterator {
 }
 
 extension LazyFilterSequence {
-  @available(*, unavailable, message="use '.lazy.filter' on the sequence")
+  @available(*, unavailable, message: "use '.lazy.filter' on the sequence")
   public init(
     _ base: Base,
     whereElementsSatisfy predicate: (Base.Iterator.Element) -> Bool
@@ -277,14 +277,14 @@ extension LazyFilterSequence {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> LazyFilterIterator<Base.Iterator> {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension LazyFilterCollection {
-  @available(*, unavailable, message="use '.lazy.filter' on the collection")
+  @available(*, unavailable, message: "use '.lazy.filter' on the collection")
   public init(
     _ base: Base,
     whereElementsSatisfy predicate: (Base.Iterator.Element) -> Bool
@@ -292,7 +292,7 @@ extension LazyFilterCollection {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> LazyFilterIterator<Base.Iterator> {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -615,14 +615,14 @@ public func ${op}=(lhs: inout ${Self}, rhs: ${Self}) {
 // FIXME: After <rdar://problem/20226526> is fixed, we should be able
 //        to remove these.
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public prefix func ++ (x: inout ${Self}) -> ${Self} {
   x = x + 1
   return x
 }
 
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public postfix func ++ (x: inout ${Self}) -> ${Self} {
   let ret = x
   x = x + 1
@@ -630,14 +630,14 @@ public postfix func ++ (x: inout ${Self}) -> ${Self} {
 }
 
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public prefix func -- (x: inout ${Self}) -> ${Self} {
   x = x - 1
   return x
 }
 
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public postfix func -- (x: inout ${Self}) -> ${Self} {
   let ret = x
   x = x - 1
@@ -668,13 +668,13 @@ public func _leadingZeros(x: Builtin.Int${bits}) -> Builtin.Int${bits} {
 
 //===--- End loop over all integer types ----------------------------------===//
 
-@available(*, unavailable, renamed="Integer")
+@available(*, unavailable, renamed: "Integer")
 public typealias IntegerType = Integer
 
-@available(*, unavailable, renamed="SignedInteger")
+@available(*, unavailable, renamed: "SignedInteger")
 public typealias SignedIntegerType = SignedInteger
 
-@available(*, unavailable, renamed="UnsignedInteger")
+@available(*, unavailable, renamed: "UnsignedInteger")
 public typealias UnsignedIntegerType = UnsignedInteger
 
 // ${'Local Variables'}:

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -325,13 +325,13 @@ extension LazyCollectionProtocol
 
 % end
 
-@available(*, unavailable, renamed="FlattenIterator")
+@available(*, unavailable, renamed: "FlattenIterator")
 public struct FlattenGenerator<
   Base : IteratorProtocol where Base.Element : Sequence
 > {}
 
 extension FlattenSequence {
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> FlattenIterator<Base.Iterator> {
     fatalError("unavailable function can't be called")
   }
@@ -341,7 +341,7 @@ extension FlattenSequence {
 %   t = '' if traversal == 'Forward' else traversal
 %   Collection = 'Flatten%sCollection' % t
 extension ${Collection} {
-  @available(*, unavailable, message="Please use underestimatedCount property instead.")
+  @available(*, unavailable, message: "Please use underestimatedCount property instead.")
   public func underestimateCount() -> Int {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -585,16 +585,16 @@ extension ${Self} {
 //===----------------------------------------------------------------------===//
 
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public prefix func ++ (rhs: inout ${Self}) -> ${Self} { rhs += 1.0; return rhs }
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public prefix func -- (rhs: inout ${Self}) -> ${Self} { rhs -= 1.0; return rhs }
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public postfix func ++ (lhs: inout ${Self}) -> ${Self} { let tmp = lhs; lhs += 1.0; return tmp }
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public postfix func -- (lhs: inout ${Self}) -> ${Self} { let tmp = lhs; lhs -= 1.0; return tmp }
 
 

--- a/stdlib/public/core/FloatingPointOperations.swift.gyb
+++ b/stdlib/public/core/FloatingPointOperations.swift.gyb
@@ -97,5 +97,5 @@ public protocol FloatingPoint : Strideable {
   // func isCanonical() -> Bool
 }
 
-@available(*, unavailable, renamed="FloatingPoint")
+@available(*, unavailable, renamed: "FloatingPoint")
 public typealias FloatingPointType = FloatingPoint

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -4219,39 +4219,39 @@ extension Set {
 }
 
 extension Set {
-  @available(*, unavailable, renamed="remove(at:)")
+  @available(*, unavailable, renamed: "remove(at:)")
   public mutating func removeAtIndex(index: Index) -> Element {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> SetIterator<Element> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="index(of:)")
+  @available(*, unavailable, renamed: "index(of:)")
   public func indexOf(member: Element) -> Index? {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension Dictionary {
-  @available(*, unavailable, renamed="remove(at:)")
+  @available(*, unavailable, renamed: "remove(at:)")
   public mutating func removeAtIndex(index: Index) -> Element {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="index(forKey:)")
+  @available(*, unavailable, renamed: "index(forKey:)")
   public func indexForKey(key: Key) -> Index? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="removeValue(forKey:)")
+  @available(*, unavailable, renamed: "removeValue(forKey:)")
   public mutating func removeValueForKey(key: Key) -> Value? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> DictionaryIterator<Key, Value> {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -119,19 +119,19 @@ extension ImplicitlyUnwrappedOptional : _ObjectiveCBridgeable {
 #endif
 
 extension ImplicitlyUnwrappedOptional {
-  @available(*, unavailable, message="Please use nil literal instead.")
+  @available(*, unavailable, message: "Please use nil literal instead.")
   public init() {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Has been removed in Swift 3.")
+  @available(*, unavailable, message: "Has been removed in Swift 3.")
   public func map<U>(
     @noescape f: (Wrapped) throws -> U
   ) rethrows -> ImplicitlyUnwrappedOptional<U> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Has been removed in Swift 3.")
+  @available(*, unavailable, message: "Has been removed in Swift 3.")
   public func flatMap<U>(
       @noescape f: (Wrapped) throws -> ImplicitlyUnwrappedOptional<U>
   ) rethrows -> ImplicitlyUnwrappedOptional<U> {

--- a/stdlib/public/core/Index.swift
+++ b/stdlib/public/core/Index.swift
@@ -53,7 +53,7 @@ public struct _DisabledRangeIndex_ {
 /// Replace `i` with its `successor()` and return the updated value of
 /// `i`.
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public prefix func ++ <T : _Incrementable> (i: inout T) -> T {
   i._successorInPlace()
   return i
@@ -62,7 +62,7 @@ public prefix func ++ <T : _Incrementable> (i: inout T) -> T {
 /// Replace `i` with its `successor()` and return the original
 /// value of `i`.
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public postfix func ++ <T : _Incrementable> (i: inout T) -> T {
   let ret = i
   i._successorInPlace()
@@ -307,7 +307,7 @@ extension BidirectionalIndex {
 /// Replace `i` with its `predecessor()` and return the updated value
 /// of `i`.
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public prefix func -- <T : BidirectionalIndex> (i: inout T) -> T {
   i._predecessorInPlace()
   return i
@@ -317,7 +317,7 @@ public prefix func -- <T : BidirectionalIndex> (i: inout T) -> T {
 /// Replace `i` with its `predecessor()` and return the original
 /// value of `i`.
 @_transparent
-@available(*, deprecated, message="it will be removed in Swift 3")
+@available(*, deprecated, message: "it will be removed in Swift 3")
 public postfix func -- <T : BidirectionalIndex> (i: inout T) -> T {
   let ret = i
   i._predecessorInPlace()
@@ -399,11 +399,11 @@ extension RandomAccessIndex {
   }
 }
 
-@available(*, unavailable, renamed="ForwardIndex")
+@available(*, unavailable, renamed: "ForwardIndex")
 public typealias ForwardIndexType = ForwardIndex
 
-@available(*, unavailable, renamed="BidirectionalIndex")
+@available(*, unavailable, renamed: "BidirectionalIndex")
 public typealias BidirectionalIndexType = BidirectionalIndex
 
-@available(*, unavailable, renamed="RandomAccessIndex")
+@available(*, unavailable, renamed: "RandomAccessIndex")
 public typealias RandomAccessIndexType = RandomAccessIndex

--- a/stdlib/public/core/IntegerArithmetic.swift.gyb
+++ b/stdlib/public/core/IntegerArithmetic.swift.gyb
@@ -156,10 +156,10 @@ public func abs<T : SignedNumber>(x: T) -> T {
   return x~>_abs()
 }
 
-@available(*, unavailable, renamed="IntegerArithmetic")
+@available(*, unavailable, renamed: "IntegerArithmetic")
 public typealias IntegerArithmeticType = IntegerArithmetic
 
-@available(*, unavailable, renamed="SignedNumber")
+@available(*, unavailable, renamed: "SignedNumber")
 public typealias SignedNumberType = SignedNumber
 
 // ${'Local Variables'}:

--- a/stdlib/public/core/Interval.swift.gyb
+++ b/stdlib/public/core/Interval.swift.gyb
@@ -196,18 +196,18 @@ public func ~= <I: Interval>(pattern: I, value: I.Bound) -> Bool {
   return pattern.contains(value)
 }
 
-@available(*, unavailable, renamed="Interval")
+@available(*, unavailable, renamed: "Interval")
 public typealias IntervalType = Interval
 
 extension HalfOpenInterval {
-  @available(*, unavailable, message="Please use the '..<' operator instead.")
+  @available(*, unavailable, message: "Please use the '..<' operator instead.")
   public init(_ start: Bound, _ end: Bound) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension ClosedInterval {
-  @available(*, unavailable, message="Please use the '...' operator instead.")
+  @available(*, unavailable, message: "Please use the '...' operator instead.")
   public init(_ start: Bound, _ end: Bound) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -175,20 +175,20 @@ extension Sequence where Iterator.Element : Sequence {
   }
 }
 
-@available(*, unavailable, renamed="JoinedIterator")
+@available(*, unavailable, renamed: "JoinedIterator")
 public struct JoinGenerator<
   Base : IteratorProtocol where Base.Element : Sequence
 > {}
 
 extension JoinedSequence {
-  @available(*, unavailable, renamed="iterator")
+  @available(*, unavailable, renamed: "iterator")
   public func generate() -> JoinedIterator<Base.Iterator> {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension Sequence where Iterator.Element : Sequence {
-  @available(*, unavailable, renamed="joined")
+  @available(*, unavailable, renamed: "joined")
   public func joinWithSeparator<
     Separator : Sequence
     where

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -185,7 +185,7 @@ extension LazyCollectionProtocol {
   }
 }
 
-@available(*, unavailable, renamed="LazyCollectionProtocol")
+@available(*, unavailable, renamed: "LazyCollectionProtocol")
 public typealias LazyCollectionType = LazyCollectionProtocol
 
 // ${'Local Variables'}:

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -197,11 +197,11 @@ extension LazySequenceProtocol {
   }
 }
 
-@available(*, unavailable, renamed="LazyCollectionProtocol")
+@available(*, unavailable, renamed: "LazyCollectionProtocol")
 public typealias LazySequenceType = LazySequenceProtocol
 
 extension LazySequenceProtocol {
-  @available(*, unavailable, message="Please use Array initializer instead.")
+  @available(*, unavailable, message: "Please use Array initializer instead.")
   public var array: [Iterator.Element] {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -539,7 +539,7 @@ public func isUniquelyReferencedNonObjC<T : AnyObject>(
 }
 
 extension ManagedBufferPointer {
-  @available(*, unavailable, renamed="capacity")
+  @available(*, unavailable, renamed: "capacity")
   public var allocatedElementCount: Int {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -152,18 +152,18 @@ extension LazyCollectionProtocol {
   }
 }
 
-@available(*, unavailable, renamed="LazyMapIterator")
+@available(*, unavailable, renamed: "LazyMapIterator")
 public struct LazyMapGenerator<Base : IteratorProtocol, Element> {}
 
 extension LazyMapSequence {
-  @available(*, unavailable, message="use '.lazy.map' on the sequence")
+  @available(*, unavailable, message: "use '.lazy.map' on the sequence")
   public init(_ base: Base, transform: (Base.Iterator.Element) -> Element) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension LazyMapCollection {
-  @available(*, unavailable, message="use '.lazy.map' on the collection")
+  @available(*, unavailable, message: "use '.lazy.map' on the collection")
   public init(_ base: Base, transform: (Base.Iterator.Element) -> Element) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -810,5 +810,5 @@ extension Mirror : CustomReflectable {
   }
 }
 
-@available(*, unavailable, renamed="MirrorPath")
+@available(*, unavailable, renamed: "MirrorPath")
 public typealias MirrorPathType = MirrorPath

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -162,6 +162,6 @@ extension OptionSet where RawValue : BitwiseOperations {
   }
 }
 
-@available(*, unavailable, renamed="OptionSet")
+@available(*, unavailable, renamed: "OptionSet")
 public typealias OptionSetType = OptionSet
 

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -399,5 +399,5 @@ internal struct _TeeStream<
   mutating func _unlock() { right._unlock(); left._unlock() }
 }
 
-@available(*, unavailable, renamed="OutputStream")
+@available(*, unavailable, renamed: "OutputStream")
 public typealias OutputStreamType = OutputStream

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -445,6 +445,6 @@ infix operator  |= { associativity right precedence 90 assignment }
 // from users.
 infix operator ~> { associativity left precedence 255 }
 
-@available(*, unavailable, renamed="BitwiseOperations")
+@available(*, unavailable, renamed: "BitwiseOperations")
 public typealias BitwiseOperationsType = BitwiseOperations
 

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -159,21 +159,21 @@ internal func _debugPrint<Target : OutputStream>(
 //===----------------------------------------------------------------------===//
 //===--- Migration Aids ---------------------------------------------------===//
 
-@available(*, unavailable, message="Please use 'terminator: \"\"' instead of 'appendNewline: false': 'print((...), terminator: \"\")'")
+@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false': 'print((...), terminator: \"\")'")
 public func print<T>(_: T, appendNewline: Bool = true) {}
-@available(*, unavailable, message="Please use 'terminator: \"\"' instead of 'appendNewline: false': 'debugPrint((...), terminator: \"\")'")
+@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false': 'debugPrint((...), terminator: \"\")'")
 public func debugPrint<T>(_: T, appendNewline: Bool = true) {}
 
 
 //===--- FIXME: Not working due to <rdar://22101775> ----------------------===//
-@available(*, unavailable, message="Please use the 'to' label for the target stream: 'print((...), to: &...)'")
+@available(*, unavailable, message: "Please use the 'to' label for the target stream: 'print((...), to: &...)'")
 public func print<T>(_: T, _: inout OutputStream) {}
-@available(*, unavailable, message="Please use the 'to' label for the target stream: 'debugPrint((...), to: &...))'")
+@available(*, unavailable, message: "Please use the 'to' label for the target stream: 'debugPrint((...), to: &...))'")
 public func debugPrint<T>(_: T, _: inout OutputStream) {}
 
-@available(*, unavailable, message="Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'toStream' label for the target stream: 'print((...), terminator: \"\", toStream: &...)'")
+@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'toStream' label for the target stream: 'print((...), terminator: \"\", toStream: &...)'")
 public func print<T>(_: T, _: inout OutputStream, appendNewline: Bool = true) {}
-@available(*, unavailable, message="Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'toStream' label for the target stream: 'debugPrint((...), terminator: \"\", toStream: &...)'")
+@available(*, unavailable, message: "Please use 'terminator: \"\"' instead of 'appendNewline: false' and use the 'toStream' label for the target stream: 'debugPrint((...), terminator: \"\", toStream: &...)'")
 public func debugPrint<T>(
   _: T, _: inout OutputStream, appendNewline: Bool = true
 ) {}

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -229,18 +229,18 @@ public func ~= <I : ForwardIndex where I : Comparable> (
   return pattern.contains(value)
 }
 
-@available(*, unavailable, renamed="RangeIterator")
+@available(*, unavailable, renamed: "RangeIterator")
 public struct RangeGenerator<Element : ForwardIndex> {}
 
 extension RangeIterator {
-  @available(*, unavailable, message="use the 'makeIterator()' method on the collection")
+  @available(*, unavailable, message: "use the 'makeIterator()' method on the collection")
   public init(_ bounds: Range<Element>) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension Range {
-  @available(*, unavailable, message="use the '..<' operator")
+  @available(*, unavailable, message: "use the '..<' operator")
   public init(start: Element, end: Element) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -394,11 +394,11 @@ public func +<
   return lhs
 }
 
-@available(*, unavailable, renamed="RangeReplaceableCollection")
+@available(*, unavailable, renamed: "RangeReplaceableCollection")
 public typealias RangeReplaceableCollectionType = RangeReplaceableCollection
 
 extension RangeReplaceableCollection {
-  @available(*, unavailable, renamed="replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange")
   public mutating func replaceRange<
     C : Collection where C.Iterator.Element == Iterator.Element
   >(
@@ -407,16 +407,16 @@ extension RangeReplaceableCollection {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="removeAt")
+  @available(*, unavailable, renamed: "removeAt")
   public mutating func removeAtIndex(i: Index) -> Iterator.Element {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="removeSubrange")
+  @available(*, unavailable, renamed: "removeSubrange")
   public mutating func removeRange(subRange: Range<Index>) {
   }
 
-  @available(*, unavailable, renamed="append(contentsOf:)")
+  @available(*, unavailable, renamed: "append(contentsOf:)")
   public mutating func appendContentsOf<
     S : Sequence
     where
@@ -425,7 +425,7 @@ extension RangeReplaceableCollection {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="insert(contentsOf:at:)")
+  @available(*, unavailable, renamed: "insert(contentsOf:at:)")
   public mutating func insertContentsOf<
     C : Collection where C.Iterator.Element == Iterator.Element
   >(newElements: C, at i: Index) {

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -579,7 +579,7 @@ struct _MetatypeMirror : _Mirror {
 }
 
 extension ObjectIdentifier {
-  @available(*, unavailable, message="use the 'UInt(_:)' initializer")
+  @available(*, unavailable, message: "use the 'UInt(_:)' initializer")
   public var uintValue: UInt {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -59,11 +59,11 @@ public func repeatElement<T>(element: T, count n: Int) -> Repeated<T> {
   return Repeated(_repeating: element, count: n)
 }
 
-@available(*, unavailable, renamed="Repeated")
+@available(*, unavailable, renamed: "Repeated")
 public struct Repeat<Element> {}
 
 extension Repeated {
-  @available(*, unavailable, renamed="repeatElement")
+  @available(*, unavailable, renamed: "repeatElement")
   public init(count: Int, repeatedValue: Element) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -245,28 +245,28 @@ extension LazyCollectionProtocol
 }
 
 extension ReverseCollection {
-  @available(*, unavailable, message="use the 'reversed()' method on the collection")
+  @available(*, unavailable, message: "use the 'reversed()' method on the collection")
   public init(_ base: Base) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension ReverseRandomAccessCollection {
-  @available(*, unavailable, message="use the 'reversed()' method on the collection")
+  @available(*, unavailable, message: "use the 'reversed()' method on the collection")
   public init(_ base: Base) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension Collection where Index : BidirectionalIndex {
-  @available(*, unavailable, renamed="reversed")
+  @available(*, unavailable, renamed: "reversed")
   public func reverse() -> ReverseCollection<Self> {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension Collection where Index : RandomAccessIndex {
-  @available(*, unavailable, renamed="reversed")
+  @available(*, unavailable, renamed: "reversed")
   public func reverse() -> ReverseRandomAccessCollection<Self> {
     fatalError("unavailable function can't be called")
   }
@@ -274,7 +274,7 @@ extension Collection where Index : RandomAccessIndex {
 
 extension LazyCollectionProtocol
 where Index : BidirectionalIndex, Elements.Index : BidirectionalIndex {
-  @available(*, unavailable, renamed="reversed")
+  @available(*, unavailable, renamed: "reversed")
   public func reverse() -> LazyCollection<
     ReverseCollection<Elements>
   > {
@@ -284,7 +284,7 @@ where Index : BidirectionalIndex, Elements.Index : BidirectionalIndex {
 
 extension LazyCollectionProtocol
 where Index : RandomAccessIndex, Elements.Index : RandomAccessIndex {
-  @available(*, unavailable, renamed="reversed")
+  @available(*, unavailable, renamed: "reversed")
   public func reverse() -> LazyCollection<
     ReverseRandomAccessCollection<Elements>
   > {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -63,7 +63,7 @@ public protocol IteratorProtocol {
 /// A conforming sequence that is not a collection is allowed to
 /// produce an arbitrary sequence of elements from the second iterator.
 public protocol Sequence {
-  //@available(*, unavailable, renamed="Iterator")
+  //@available(*, unavailable, renamed: "Iterator")
   //typealias Generator = ()
 
   /// A type that provides the *sequence*'s iteration interface and
@@ -650,24 +650,24 @@ public struct IteratorSequence<
   internal var _base: Base
 }
 
-@available(*, unavailable, renamed="IteratorProtocol")
+@available(*, unavailable, renamed: "IteratorProtocol")
 public typealias GeneratorType = IteratorProtocol
 
-@available(*, unavailable, renamed="Sequence")
+@available(*, unavailable, renamed: "Sequence")
 public typealias SequenceType = Sequence
 
 extension Sequence {
-  @available(*, unavailable, renamed="makeIterator()")
+  @available(*, unavailable, renamed: "makeIterator()")
   func generate() -> Iterator {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="it became a property 'underestimatedCount'")
+  @available(*, unavailable, message: "it became a property 'underestimatedCount'")
   func underestimateCount() -> Int {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="call 'split(_:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
+  @available(*, unavailable, message: "call 'split(_:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
   func split(maxSplit: Int, allowEmptySlices: Bool,
     @noescape isSeparator: (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence] {
@@ -676,7 +676,7 @@ extension Sequence {
 }
 
 extension Sequence where Iterator.Element : Equatable {
-  @available(*, unavailable, message="call 'split(separator:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
+  @available(*, unavailable, message: "call 'split(separator:omittingEmptySubsequences:isSeparator:)' and invert the 'allowEmptySlices' argument")
   public func split(
     separator: Iterator.Element,
     maxSplit: Int = Int.max,
@@ -686,5 +686,5 @@ extension Sequence where Iterator.Element : Equatable {
   }
 }
 
-@available(*, unavailable, renamed="IteratorSequence")
+@available(*, unavailable, renamed: "IteratorSequence")
 public struct GeneratorSequence<Base : IteratorProtocol> {}

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -423,31 +423,31 @@ extension Sequence {
 }
 
 extension Sequence {
-  @available(*, unavailable, renamed="enumerated")
+  @available(*, unavailable, renamed: "enumerated")
   public func enumerate() -> EnumeratedSequence<Self> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="min")
+  @available(*, unavailable, renamed: "min")
   public func minElement(
     @noescape isOrderedBefore: (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="max")
+  @available(*, unavailable, renamed: "max")
   public func maxElement(
     @noescape isOrderedBefore: (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="reversed")
+  @available(*, unavailable, renamed: "reversed")
   public func reverse() -> [Iterator.Element] {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="starts")
+  @available(*, unavailable, renamed: "starts")
   public func startsWith<
     PossiblePrefix : Sequence where PossiblePrefix.Iterator.Element == Iterator.Element
   >(
@@ -457,7 +457,7 @@ extension Sequence {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="lexicographicallyPrecedes")
+  @available(*, unavailable, renamed: "lexicographicallyPrecedes")
   public func lexicographicalCompare<
     OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
   >(
@@ -469,17 +469,17 @@ extension Sequence {
 }
 
 extension Sequence where Iterator.Element : Comparable {
-  @available(*, unavailable, renamed="min")
+  @available(*, unavailable, renamed: "min")
   public func minElement() -> Iterator.Element? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="max")
+  @available(*, unavailable, renamed: "max")
   public func maxElement() -> Iterator.Element? {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="starts")
+  @available(*, unavailable, renamed: "starts")
   public func startsWith<
     PossiblePrefix : Sequence where PossiblePrefix.${GElement} == ${GElement}
   >(
@@ -488,7 +488,7 @@ extension Sequence where Iterator.Element : Comparable {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="lexicographicallyPrecedes")
+  @available(*, unavailable, renamed: "lexicographicallyPrecedes")
   public func lexicographicalCompare<
     OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
   >(

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -242,6 +242,6 @@ extension SetAlgebra {
   }
 }
 
-@available(*, unavailable, renamed="SetAlgebra")
+@available(*, unavailable, renamed: "SetAlgebra")
 public typealias SetAlgebraType = SetAlgebra
 

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -129,14 +129,14 @@ public struct MutableSlice<Base : MutableIndexable> : MutableCollection {
 }
 
 extension Slice {
-  @available(*, unavailable, message="use the slicing syntax")
+  @available(*, unavailable, message: "use the slicing syntax")
   public init(base: Base, bounds: Range<Index>) {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension MutableSlice {
-  @available(*, unavailable, message="use the slicing syntax")
+  @available(*, unavailable, message: "use the slicing syntax")
   public init(base: Base, bounds: Range<Index>) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -240,12 +240,12 @@ extension StaticString {
 }
 
 extension StaticString {
-  @available(*, unavailable, renamed="utf8CodeUnitCount")
+  @available(*, unavailable, renamed: "utf8CodeUnitCount")
   public var byteSize: Int {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="use the 'String(_:)' initializer")
+  @available(*, unavailable, message: "use the 'String(_:)' initializer")
   public var stringValue: String {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -246,19 +246,19 @@ public func stride<T : Strideable>(
   return StrideThrough(_start: start, end: end, stride: stride)
 }
 
-@available(*, unavailable, renamed="StrideToIterator")
+@available(*, unavailable, renamed: "StrideToIterator")
 public struct StrideToGenerator<Element : Strideable> {}
 
-@available(*, unavailable, renamed="StrideThroughIterator")
+@available(*, unavailable, renamed: "StrideThroughIterator")
 public struct StrideThroughGenerator<Element : Strideable> {}
 
 extension Strideable {
-  @available(*, unavailable, message="Use stride(from:to:by:) free function instead")
+  @available(*, unavailable, message: "Use stride(from:to:by:) free function instead")
   public func stride(to end: Self, by stride: Stride) -> StrideTo<Self> {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Use stride(from:through:by:) free function instead")
+  @available(*, unavailable, message: "Use stride(from:through:by:) free function instead")
   public func stride(
     through end: Self, by stride: Stride
   ) -> StrideThrough<Self> {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -987,26 +987,26 @@ extension String.Index {
 }
 
 extension String {
-  @available(*, unavailable, renamed="append")
+  @available(*, unavailable, renamed: "append")
   public mutating func appendContentsOf(other: String) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="append(contentsOf:)")
+  @available(*, unavailable, renamed: "append(contentsOf:)")
   public mutating func appendContentsOf<
     S : Sequence where S.Iterator.Element == Character
   >(newElements: S) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="insert(contentsOf:at:)")
+  @available(*, unavailable, renamed: "insert(contentsOf:at:)")
   public mutating func insertContentsOf<
     S : Collection where S.Iterator.Element == Character
   >(newElements: S, at i: Index) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange")
   public mutating func replaceRange<
     C : Collection where C.Iterator.Element == Character
   >(
@@ -1015,36 +1015,36 @@ extension String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange")
   public mutating func replaceRange(
     subRange: Range<Index>, with newElements: String
   ) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="removeAt")
+  @available(*, unavailable, renamed: "removeAt")
   public mutating func removeAtIndex(i: Index) -> Character {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="removeSubrange")
+  @available(*, unavailable, renamed: "removeSubrange")
   public mutating func removeRange(subRange: Range<Index>) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="lowercased()")
+  @available(*, unavailable, renamed: "lowercased()")
   public var lowercaseString: String {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="uppercased()")
+  @available(*, unavailable, renamed: "uppercased()")
   public var uppercaseString: String {
     fatalError("unavailable function can't be called")
   }
 }
 
 extension Sequence where Iterator.Element == String {
-  @available(*, unavailable, renamed="joined")
+  @available(*, unavailable, renamed: "joined")
   public func joinWithSeparator(separator: String) -> String {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -317,7 +317,7 @@ extension String.CharacterView {
 }
 
 extension String.CharacterView {
-  @available(*, unavailable, renamed="replaceSubrange")
+  @available(*, unavailable, renamed: "replaceSubrange")
   public mutating func replaceRange<
     C : Collection where C.Iterator.Element == Character
   >(
@@ -326,7 +326,7 @@ extension String.CharacterView {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="append(contentsOf:)")
+  @available(*, unavailable, renamed: "append(contentsOf:)")
   public mutating func appendContentsOf<
     S : Sequence where S.Iterator.Element == Character
   >(newElements: S) {

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -164,12 +164,12 @@ extension String {
 }
 
 extension String {
-  @available(*, unavailable, message="Renamed to init(repeating:count:) and reordered parameters")
+  @available(*, unavailable, message: "Renamed to init(repeating:count:) and reordered parameters")
   public init(count: Int, repeatedValue c: Character) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="Renamed to init(repeating:count:) and reordered parameters")
+  @available(*, unavailable, message: "Renamed to init(repeating:count:) and reordered parameters")
   public init(count: Int, repeatedValue c: UnicodeScalar) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -86,14 +86,14 @@ extension String {
 
     @available(
       *, unavailable,
-      message="Indexing a String's UTF16View requires a String.UTF16View.Index, which can be constructed from Int when Foundation is imported")
+      message: "Indexing a String's UTF16View requires a String.UTF16View.Index, which can be constructed from Int when Foundation is imported")
     public subscript(i: Int) -> UTF16.CodeUnit {
       fatalError("unavailable function can't be called")
     }
 
     @available(
       *, unavailable,
-      message="Slicing a String's UTF16View requires a Range<String.UTF16View.Index>, String.UTF16View.Index can be constructed from Int when Foundation is imported")
+      message: "Slicing a String's UTF16View requires a Range<String.UTF16View.Index>, String.UTF16View.Index can be constructed from Int when Foundation is imported")
     public subscript(bounds: Range<Int>) -> UTF16View {
       fatalError("unavailable function can't be called")
     }

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -55,7 +55,7 @@ extension String {
 ${stringSubscriptComment}
   @available(
     *, unavailable,
-    message="cannot subscript String with an Int, see the documentation comment for discussion")
+    message: "cannot subscript String with an Int, see the documentation comment for discussion")
   public subscript(i: Int) -> Character {
     fatalError("unavailable function can't be called")
   }
@@ -63,7 +63,7 @@ ${stringSubscriptComment}
 ${stringSubscriptComment}
   @available(
     *, unavailable,
-    message="cannot subscript String with a Range<Int>, see the documentation comment for discussion")
+    message: "cannot subscript String with a Range<Int>, see the documentation comment for discussion")
   public subscript(bounds: Range<Int>) -> String {
     fatalError("unavailable function can't be called")
   }
@@ -103,7 +103,7 @@ ${stringSubscriptComment}
   ///   number of user-perceived characters in the string.
   @available(
     *, unavailable,
-    message="there is no universally good answer, see the documentation comment for discussion")
+    message: "there is no universally good answer, see the documentation comment for discussion")
   public var count: Int {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -905,10 +905,10 @@ extension UTF16 {
   }
 }
 
-@available(*, unavailable, renamed="UnicodeCodec")
+@available(*, unavailable, renamed: "UnicodeCodec")
 public typealias UnicodeCodecType = UnicodeCodec
 
-@available(*, unavailable, message="use 'transcode(_:from:to:stoppingOnError:sendingOutputTo:)'")
+@available(*, unavailable, message: "use 'transcode(_:from:to:stoppingOnError:sendingOutputTo:)'")
 public func transcode<
   Input : IteratorProtocol,
   InputEncoding : UnicodeCodec,
@@ -923,7 +923,7 @@ public func transcode<
 }
 
 extension UTF16 {
-  @available(*, unavailable, message="use 'transcodedLength(of:decodedAs:repairingIllFormedSequences:)'")
+  @available(*, unavailable, message: "use 'transcodedLength(of:decodedAs:repairingIllFormedSequences:)'")
   public static func measure<
     Encoding : UnicodeCodec, Input : IteratorProtocol
     where Encoding.CodeUnit == Input.Element

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -281,12 +281,12 @@ func _ascii16(c: UnicodeScalar) -> UTF16.CodeUnit {
 
 extension UnicodeScalar {
   /// Creates an instance of the NUL scalar value.
-  @available(*, unavailable, message="use the 'UnicodeScalar(\"\\0\")'")
+  @available(*, unavailable, message: "use the 'UnicodeScalar(\"\\0\")'")
   public init() {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="escaped")
+  @available(*, unavailable, renamed: "escaped")
   public func escape(asASCII forceASCII: Bool) -> String {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -106,7 +106,7 @@ extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
 }
 %end
 
-@available(*, unavailable, renamed="UnsafeBufferPointerIterator")
+@available(*, unavailable, renamed: "UnsafeBufferPointerIterator")
 public struct UnsafeBufferPointerGenerator<Element> {}
 
 // ${'Local Variables'}:

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -541,25 +541,25 @@ public func -= <Pointee>(lhs: inout ${Self}<Pointee>, rhs: Int) {
 }
 
 extension ${Self} {
-  @available(*, unavailable, renamed="Pointee")
+  @available(*, unavailable, renamed: "Pointee")
   public typealias Memory = Pointee
 
-  @available(*, unavailable, message="use 'nil' literal")
+  @available(*, unavailable, message: "use 'nil' literal")
   public init() {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message="use the '${Self}(allocatingCapacity:)' initializer")
+  @available(*, unavailable, message: "use the '${Self}(allocatingCapacity:)' initializer")
   public static func alloc(num: Int) -> ${Self} {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="deallocateCapacity")
+  @available(*, unavailable, renamed: "deallocateCapacity")
   public func dealloc(num: Int) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="pointee")
+  @available(*, unavailable, renamed: "pointee")
   public var memory: Pointee {
     get {
       fatalError("unavailable function can't be called")
@@ -569,17 +569,17 @@ extension ${Self} {
     }
   }
 
-  @available(*, unavailable, renamed="initialize(with:)")
+  @available(*, unavailable, renamed: "initialize(with:)")
   public func initialize(newvalue: Pointee) {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="deinitialize(count:)")
+  @available(*, unavailable, renamed: "deinitialize(count:)")
   public func destroy() {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, renamed="deinitialize(count:)")
+  @available(*, unavailable, renamed: "deinitialize(count:)")
   public func destroy(count: Int) {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -441,7 +441,7 @@ final internal class _VaListBuilder {
 
 #endif
 
-@available(*, unavailable, renamed="CVarArg")
+@available(*, unavailable, renamed: "CVarArg")
 public typealias CVarArgType = CVarArg
 
 @available(*, unavailable)

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -74,7 +74,7 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence>
   /// sequence, in order.
   public typealias Iterator = Zip2Iterator<Stream1, Stream2>
 
-  @available(*, unavailable, renamed="Iterator")
+  @available(*, unavailable, renamed: "Iterator")
   public typealias Generator = Iterator
 
   /// Construct an instance that makes pairs of elements from `sequence1` and

--- a/test/1_stdlib/Foundation_NewGenericAPIs.swift
+++ b/test/1_stdlib/Foundation_NewGenericAPIs.swift
@@ -11,8 +11,8 @@ func test_NSCoder_decodeObject(coder: NSCoder) {
   expectType(Optional<AnyObject>.self, &r)
 }
 
-@available(iOS, introduced=9.0)
-@available(OSX, introduced=10.11)
+@available(iOS, introduced: 9.0)
+@available(OSX, introduced: 10.11)
 func test_NSCoder_decodeTopLevelObject(coder: NSCoder) throws {
   var r = try coder.decodeTopLevelObject()
   expectType(Optional<AnyObject>.self, &r)
@@ -30,8 +30,8 @@ func test_NSCoder_decodeObjectOfClasses_forKey(
   expectType(Optional<AnyObject>.self, &r)
 }
 
-@available(iOS, introduced=9.0)
-@available(OSX, introduced=10.11)
+@available(iOS, introduced: 9.0)
+@available(OSX, introduced: 10.11)
 func test_NSCoder_decodeTopLevelObjectOfClasses_forKey_error(
   coder: NSCoder, classes: NSSet?, key: String
 ) throws {
@@ -48,8 +48,8 @@ func test_NSKeyedUnarchiver_unarchiveObjectWithData(data: NSData) {
 /*
 The API is unavailable and it is not possible to overload on 'throws'.
 
-@available(iOS, introduced=9.0)
-@available(OSX, introduced=10.11)
+@available(iOS, introduced: 9.0)
+@available(OSX, introduced: 10.11)
 func test_NSKeyedUnarchiver_unarchiveObjectWithData_error(data: NSData) throws {
   var r = NSKeyedUnarchiver.unarchiveObjectWithData(data)
   expectType(Optional<AnyObject>.self, &r)

--- a/test/ClangModules/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangModules/Inputs/SwiftPrivateAttr.txt
@@ -10,13 +10,13 @@ class Foo : NSObject, __PrivProto {
   class func __foo() -> Self!
   class func __withNoArgs() -> Self!
   convenience init!(__oneArg arg: Int32)
-  @available(*, unavailable, message="use object construction 'Foo(__oneArg:)'")
+  @available(*, unavailable, message: "use object construction 'Foo(__oneArg:)'")
   class func __withOneArg(arg: Int32) -> Self!
   convenience init!(__twoArgs arg: Int32, other arg2: Int32)
-  @available(*, unavailable, message="use object construction 'Foo(__twoArgs:other:)'")
+  @available(*, unavailable, message: "use object construction 'Foo(__twoArgs:other:)'")
   class func __withTwoArgs(arg: Int32, other arg2: Int32) -> Self!
   convenience init!(__ arg: Int32)
-  @available(*, unavailable, message="use object construction 'Foo(__:)'")
+  @available(*, unavailable, message: "use object construction 'Foo(__:)'")
   class func __foo(arg: Int32) -> Self!
   func objectForKeyedSubscript(index: AnyObject!) -> AnyObject!
   func __setObject(object: AnyObject!, forKeyedSubscript index: AnyObject!)
@@ -94,11 +94,11 @@ struct NSOptions : OptionSet {
   static var __privA: NSOptions { get }
   static var B: NSOptions { get }
 }
-@available(*, unavailable, renamed="__PrivCFType", message="Not available in Swift")
+@available(*, unavailable, renamed: "__PrivCFType", message: "Not available in Swift")
 typealias __PrivCFTypeRef = __PrivCFType
 class __PrivCFType {
 }
-@available(*, unavailable, renamed="__PrivCFSub", message="Not available in Swift")
+@available(*, unavailable, renamed: "__PrivCFSub", message: "Not available in Swift")
 typealias __PrivCFSubRef = __PrivCFSub
 typealias __PrivCFSub = __PrivCFType
 typealias __PrivInt = Int32

--- a/test/ClangModules/Inputs/availability_implicit_macosx_other.swift
+++ b/test/ClangModules/Inputs/availability_implicit_macosx_other.swift
@@ -1,12 +1,12 @@
 class OtherWithInit {
-  @available(OSX, introduced=10.11)
+  @available(OSX, introduced: 10.11)
   init(withInt i: Int) { }
 }
 
 class SubOfOtherWithInit : OtherWithInit {
   // A trapping version of init(withInt:) will be synthesized here.
 
-  @available(OSX, introduced=10.11)
+  @available(OSX, introduced: 10.11)
   init() {
     super.init(withInt:77)
   }

--- a/test/ClangModules/availability_implicit_macosx.swift
+++ b/test/ClangModules/availability_implicit_macosx.swift
@@ -37,7 +37,7 @@ func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDep
 }
 
 class SuperClassWithDeprecatedInitializer {
-  @available(OSX, introduced=10.9, deprecated=10.51)
+  @available(OSX, introduced: 10.9, deprecated: 10.51)
   init() { }
 }
 
@@ -52,7 +52,7 @@ func callImplicitInitializerOnSubClassWithSynthesizedDesignedInitializerOverride
   _ = SubClassWithSynthesizedDesignedInitializerOverride() // expected-warning {{'init()' was deprecated in OS X 10.51}}
 }
 
-@available(OSX, introduced=10.9, deprecated=10.51)
+@available(OSX, introduced: 10.9, deprecated: 10.51)
 class DeprecatedSuperClass {
   var i : Int = 7 // Causes initializer to be synthesized
 }
@@ -67,21 +67,21 @@ func callImplicitInitializerOnNotDeprecatedSubClassOfDeprecatedSuperClass() {
   _ = NotDeprecatedSubClassOfDeprecatedSuperClass()
 }
 
-@available(OSX, introduced=10.9, deprecated=10.51)
+@available(OSX, introduced: 10.9, deprecated: 10.51)
 class DeprecatedSubClassOfDeprecatedSuperClass : DeprecatedSuperClass {
 }
 
 // Tests synthesis of materializeForSet
 class ClassWithLimitedAvailabilityAccessors {
   var limitedGetter: Int {
-    @available(OSX, introduced=10.52)
+    @available(OSX, introduced: 10.52)
     get { return 10 }
     set(newVal) {}
   }
 
   var limitedSetter: Int {
     get { return 10 }
-    @available(OSX, introduced=10.52)
+    @available(OSX, introduced: 10.52)
     set(newVal) {}
   }
 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -139,14 +139,14 @@ infix operator ***~ {
 func ***~(_: Int, _: String) { }
 i ***~ i // expected-error{{cannot convert value of type 'Int' to expected argument type 'String'}}
 
-@available(*, unavailable, message="call the 'map()' method on the sequence")
+@available(*, unavailable, message: "call the 'map()' method on the sequence")
 public func myMap<C : Collection, T>(
   source: C, _ transform: (C.Iterator.Element) -> T
 ) -> [T] {
   fatalError("unavailable function can't be called")
 }
 
-@available(*, unavailable, message="call the 'map()' method on the optional value")
+@available(*, unavailable, message: "call the 'map()' method on the optional value")
 public func myMap<T, U>(x: T?, @noescape _ f: (T)->U) -> U? {
   fatalError("unavailable function can't be called")
 }
@@ -640,7 +640,7 @@ func r22470302(c: r22470302Class) {
 
 // <rdar://problem/21928143> QoI: Pointfree reference to generic initializer in generic context does not compile
 extension String {
-  @available(*, unavailable, message="calling this is unwise")
+  @available(*, unavailable, message: "calling this is unwise")
   func unavail<T : Sequence where T.Iterator.Element == String> // expected-note 2 {{'unavail' has been explicitly marked unavailable here}}
     (a : T) -> String {}
 }

--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -112,7 +112,7 @@ func <loc>fooFuncWithComment5()</loc></decl>
 
 <decl:Func>/// Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.
 func <loc>redeclaredInMultipleModulesFunc1(<decl:Param>a: <ref:Struct>Int32</ref></decl>)</loc> -> <ref:Struct>Int32</ref></decl>
-<decl:Func>@available(*, unavailable, message="Variadic function is unavailable")
+<decl:Func>@available(*, unavailable, message: "Variadic function is unavailable")
 func <loc>fooFuncUsingVararg(<decl:Param>a: <ref:Struct>Int32</ref></decl>, <decl:Param>_ varargs: <ref:TypeAlias>Any</ref>...</decl>)</loc> -> <ref:Struct>Int32</ref></decl>
 
 <decl:Protocol>/// Aaa.  FooProtocolBase.  Bbb.
@@ -149,7 +149,7 @@ protocol <loc>FooProtocolBase</loc> {
   <decl:Func>func <loc>fooBaseInstanceFuncOverridden()</loc></decl>
   <decl:Func>class func <loc>fooBaseClassFunc0()</loc></decl>
   <decl:Constructor>/*not inherited*/ <loc>init!(<decl:Param>_ x: <ref:Struct>Int32</ref></decl>)</loc></decl>
-  <decl:Func>@available(*, unavailable, message="use object construction 'FooClassBase(_:)'")
+  <decl:Func>@available(*, unavailable, message: "use object construction 'FooClassBase(_:)'")
   class func <loc>fooClassBase(<decl:Param>x: <ref:Struct>Int32</ref></decl>)</loc> -> <ref:Class>FooClassBase</ref>!</decl>
 }</decl>
 
@@ -226,38 +226,38 @@ class <loc>FooClassDerived</loc> : <ref:Class>FooClassBase</ref>, <ref:Protocol>
 }</decl>
 <decl:Class>class <loc>FooUnavailableMembers</loc> : <ref:Class>FooClassBase</ref> {
   <decl:Constructor>convenience <loc>init!(<decl:Param>int i: <ref:Struct>Int32</ref></decl>)</loc></decl>
-  <decl:Func>@available(*, unavailable, message="use object construction 'FooUnavailableMembers(int:)'")
+  <decl:Func>@available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")
   class func <loc>withInt(<decl:Param>i: <ref:Struct>Int32</ref></decl>)</loc> -> Self!</decl>
-  <decl:Func>@available(*, unavailable, message="x")
+  <decl:Func>@available(*, unavailable, message: "x")
   func <loc>unavailable()</loc></decl>
-  <decl:Func>@available(*, unavailable, message="Not available in Swift")
+  <decl:Func>@available(*, unavailable, message: "Not available in Swift")
   func <loc>swiftUnavailable()</loc></decl>
-  <decl:Func>@available(*, deprecated, message="x")
+  <decl:Func>@available(*, deprecated, message: "x")
   func <loc>deprecated()</loc></decl>
   <decl:Func>@available(OSX 10.1, *)
   func <loc>availabilityIntroduced()</loc></decl>
-  <decl:Func>@available(OSX, unavailable, deprecated=10.1, message="APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift")
+  <decl:Func>@available(OSX, unavailable, deprecated: 10.1, message: "APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift")
   func <loc>availabilityDeprecated()</loc></decl>
-  <decl:Func>@available(OSX, obsoleted=10.1)
+  <decl:Func>@available(OSX, obsoleted: 10.1)
   func <loc>availabilityObsoleted()</loc></decl>
   <decl:Func>@available(OSX, unavailable)
   func <loc>availabilityUnavailable()</loc></decl>
-  <decl:Func>@available(OSX, introduced=10.1, message="x")
+  <decl:Func>@available(OSX, introduced: 10.1, message: "x")
   func <loc>availabilityIntroducedMsg()</loc></decl>
-  <decl:Func>@available(OSX, unavailable, deprecated=10.1, message="x")
+  <decl:Func>@available(OSX, unavailable, deprecated: 10.1, message: "x")
   func <loc>availabilityDeprecatedMsg()</loc></decl>
-  <decl:Func>@available(OSX, obsoleted=10.1, message="x")
+  <decl:Func>@available(OSX, obsoleted: 10.1, message: "x")
   func <loc>availabilityObsoletedMsg()</loc></decl>
-  <decl:Func>@available(OSX, unavailable, message="x")
+  <decl:Func>@available(OSX, unavailable, message: "x")
   func <loc>availabilityUnavailableMsg()</loc></decl>
   <decl:Constructor><loc>init!()</loc></decl>
   <decl:Constructor>convenience <loc>init!(<decl:Param>float f: <ref:Struct>Float</ref></decl>)</loc></decl>
 }</decl>
 <decl:Class>class <loc>FooCFType</loc> {
 }</decl>
-<decl:TypeAlias>@available(*, unavailable, renamed="FooCFType", message="Not available in Swift")
+<decl:TypeAlias>@available(*, unavailable, renamed: "FooCFType", message: "Not available in Swift")
 typealias <loc>FooCFTypeRef</loc> = <ref:Class>FooCFType</ref></decl>
-<decl:Func>@available(*, unavailable, message="Core Foundation objects are automatically memory managed")
+<decl:Func>@available(*, unavailable, message: "Core Foundation objects are automatically memory managed")
 func <loc>FooCFTypeRelease(<decl:Param>_: <ref:Class>FooCFType</ref>!</decl>)</loc></decl>
 <decl:Class>class <loc>FooRepeatedMembers</loc> : <ref:Class>FooClassBase</ref> {
   <decl:Func>func <loc>repeatedMethod()</loc></decl>

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -112,7 +112,7 @@ func fooFuncWithComment5()
 
 /// Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.
 func redeclaredInMultipleModulesFunc1(a: Int32) -> Int32
-@available(*, unavailable, message="Variadic function is unavailable")
+@available(*, unavailable, message: "Variadic function is unavailable")
 func fooFuncUsingVararg(a: Int32, _ varargs: Any...) -> Int32
 
 /// Aaa.  FooProtocolBase.  Bbb.
@@ -149,7 +149,7 @@ class FooClassBase {
   func fooBaseInstanceFuncOverridden()
   class func fooBaseClassFunc0()
   /*not inherited*/ init!(_ x: Int32)
-  @available(*, unavailable, message="use object construction 'FooClassBase(_:)'")
+  @available(*, unavailable, message: "use object construction 'FooClassBase(_:)'")
   class func fooClassBase(x: Int32) -> FooClassBase!
 }
 
@@ -226,38 +226,38 @@ class FooClassPropertyOwnership : FooClassBase {
 }
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
-  @available(*, unavailable, message="use object construction 'FooUnavailableMembers(int:)'")
+  @available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")
   class func withInt(i: Int32) -> Self!
-  @available(*, unavailable, message="x")
+  @available(*, unavailable, message: "x")
   func unavailable()
-  @available(*, unavailable, message="Not available in Swift")
+  @available(*, unavailable, message: "Not available in Swift")
   func swiftUnavailable()
-  @available(*, deprecated, message="x")
+  @available(*, deprecated, message: "x")
   func deprecated()
   @available(OSX 10.1, *)
   func availabilityIntroduced()
-  @available(OSX, unavailable, deprecated=10.1, message="APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift")
+  @available(OSX, unavailable, deprecated: 10.1, message: "APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift")
   func availabilityDeprecated()
-  @available(OSX, obsoleted=10.1)
+  @available(OSX, obsoleted: 10.1)
   func availabilityObsoleted()
   @available(OSX, unavailable)
   func availabilityUnavailable()
-  @available(OSX, introduced=10.1, message="x")
+  @available(OSX, introduced: 10.1, message: "x")
   func availabilityIntroducedMsg()
-  @available(OSX, unavailable, deprecated=10.1, message="x")
+  @available(OSX, unavailable, deprecated: 10.1, message: "x")
   func availabilityDeprecatedMsg()
-  @available(OSX, obsoleted=10.1, message="x")
+  @available(OSX, obsoleted: 10.1, message: "x")
   func availabilityObsoletedMsg()
-  @available(OSX, unavailable, message="x")
+  @available(OSX, unavailable, message: "x")
   func availabilityUnavailableMsg()
   init!()
   convenience init!(float f: Float)
 }
 class FooCFType {
 }
-@available(*, unavailable, renamed="FooCFType", message="Not available in Swift")
+@available(*, unavailable, renamed: "FooCFType", message: "Not available in Swift")
 typealias FooCFTypeRef = FooCFType
-@available(*, unavailable, message="Core Foundation objects are automatically memory managed")
+@available(*, unavailable, message: "Core Foundation objects are automatically memory managed")
 func FooCFTypeRelease(_: FooCFType!)
 class FooRepeatedMembers : FooClassBase {
   func repeatedMethod()

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -137,7 +137,7 @@ func fooFuncWithComment5()
 /// Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.
 func redeclaredInMultipleModulesFunc1(a: Int32) -> Int32
 
-@available(*, unavailable, message="Variadic function is unavailable")
+@available(*, unavailable, message: "Variadic function is unavailable")
 func fooFuncUsingVararg(a: Int32, _ varargs: Any...) -> Int32 // This comment should not show without decl.
 
 /// Aaa.  FooProtocolBase.  Bbb.
@@ -179,7 +179,7 @@ class FooClassBase {
   
   class func fooBaseClassFunc0()
   /*not inherited*/ init!(_ x: Int32)
-  @available(*, unavailable, message="use object construction 'FooClassBase(_:)'")
+  @available(*, unavailable, message: "use object construction 'FooClassBase(_:)'")
   class func fooClassBase(x: Int32) -> FooClassBase!
 }
 
@@ -276,32 +276,32 @@ class FooClassPropertyOwnership : FooClassBase {
 
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
-  @available(*, unavailable, message="use object construction 'FooUnavailableMembers(int:)'")
+  @available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")
   class func withInt(i: Int32) -> Self!
   
-  @available(*, unavailable, message="x")
+  @available(*, unavailable, message: "x")
   func unavailable() // This comment should not show without decl. rdar://20092567
-  @available(*, unavailable, message="Not available in Swift")
+  @available(*, unavailable, message: "Not available in Swift")
   func swiftUnavailable()
-  @available(*, deprecated, message="x")
+  @available(*, deprecated, message: "x")
   func deprecated()
   
   @available(OSX 10.1, *)
   func availabilityIntroduced()
-  @available(OSX, unavailable, deprecated=10.1, message="APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift")
+  @available(OSX, unavailable, deprecated: 10.1, message: "APIs deprecated as of OS X 10.9 and earlier are unavailable in Swift")
   func availabilityDeprecated()
-  @available(OSX, obsoleted=10.1)
+  @available(OSX, obsoleted: 10.1)
   func availabilityObsoleted()
   @available(OSX, unavailable)
   func availabilityUnavailable()
   
-  @available(OSX, introduced=10.1, message="x")
+  @available(OSX, introduced: 10.1, message: "x")
   func availabilityIntroducedMsg()
-  @available(OSX, unavailable, deprecated=10.1, message="x")
+  @available(OSX, unavailable, deprecated: 10.1, message: "x")
   func availabilityDeprecatedMsg()
-  @available(OSX, obsoleted=10.1, message="x")
+  @available(OSX, obsoleted: 10.1, message: "x")
   func availabilityObsoletedMsg()
-  @available(OSX, unavailable, message="x")
+  @available(OSX, unavailable, message: "x")
   func availabilityUnavailableMsg()
   init!()
   convenience init!(float f: Float)
@@ -309,9 +309,9 @@ class FooUnavailableMembers : FooClassBase {
 
 class FooCFType {
 }
-@available(*, unavailable, renamed="FooCFType", message="Not available in Swift")
+@available(*, unavailable, renamed: "FooCFType", message: "Not available in Swift")
 typealias FooCFTypeRef = FooCFType
-@available(*, unavailable, message="Core Foundation objects are automatically memory managed")
+@available(*, unavailable, message: "Core Foundation objects are automatically memory managed")
 func FooCFTypeRelease(_: FooCFType!)
 
 class FooRepeatedMembers : FooClassBase {

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -518,9 +518,9 @@ class d0170_TestAvailability {
 // PASS_COMMON-NEXT: {{^}}  @available(*, unavailable){{$}}
 // PASS_COMMON-NEXT: {{^}}  func f1(){{$}}
 
-  @available(*, unavailable, message="aaa \"bbb\" ccc\nddd\0eee")
+  @available(*, unavailable, message: "aaa \"bbb\" ccc\nddd\0eee")
   func f2() {}
-// PASS_COMMON-NEXT: {{^}}  @available(*, unavailable, message="aaa \"bbb\" ccc\nddd\0eee"){{$}}
+// PASS_COMMON-NEXT: {{^}}  @available(*, unavailable, message: "aaa \"bbb\" ccc\nddd\0eee"){{$}}
 // PASS_COMMON-NEXT: {{^}}  func f2(){{$}}
 
   @available(iOS, unavailable)
@@ -536,8 +536,8 @@ class d0170_TestAvailability {
 // PASS_COMMON-NEXT: {{^}}  func f4(){{$}}
 
 // Convert long-form @available() to short form when possible.
-  @available(iOS, introduced=8.0)
-  @available(OSX, introduced=10.10)
+  @available(iOS, introduced: 8.0)
+  @available(OSX, introduced: 10.10)
   func f5() {}
 // PASS_COMMON-NEXT: {{^}}  @available(iOS 8.0, OSX 10.10, *){{$}}
 // PASS_COMMON-NEXT: {{^}}  func f5(){{$}}
@@ -1286,16 +1286,16 @@ struct d2900_TypeSugar1 {
 
 // @warn_unused_result attribute
 public struct ArrayThingy {
-    // PASS_PRINT_AST: @warn_unused_result(mutable_variant="sort")
+    // PASS_PRINT_AST: @warn_unused_result(mutable_variant: "sort")
     // PASS_PRINT_AST-NEXT: public func sort() -> ArrayThingy
-    @warn_unused_result(mutable_variant="sort")
+    @warn_unused_result(mutable_variant: "sort")
     public func sort() -> ArrayThingy { return self }
 
     public mutating func sort() { }
 
-    // PASS_PRINT_AST: @warn_unused_result(message="dummy", mutable_variant="reverseInPlace")
+    // PASS_PRINT_AST: @warn_unused_result(message: "dummy", mutable_variant: "reverseInPlace")
     // PASS_PRINT_AST-NEXT: public func reverse() -> ArrayThingy
-    @warn_unused_result(message="dummy", mutable_variant="reverseInPlace")
+    @warn_unused_result(message: "dummy", mutable_variant: "reverseInPlace")
     public func reverse() -> ArrayThingy { return self }
 
     public mutating func reverseInPlace() { }
@@ -1305,9 +1305,9 @@ public struct ArrayThingy {
     @warn_unused_result
     public func mineGold() -> Int { return 0 }
 
-    // PASS_PRINT_AST: @warn_unused_result(message="oops")
+    // PASS_PRINT_AST: @warn_unused_result(message: "oops")
     // PASS_PRINT_AST-NEXT: public func mineCopper() -> Int
-    @warn_unused_result(message="oops")
+    @warn_unused_result(message: "oops")
     public func mineCopper() -> Int { return 0 }
 }
 

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -100,7 +100,7 @@
 // FOUNDATION-NEXT: {{^}}}{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Unavailable Global Functions{{$}}
-// FOUNDATION-NEXT: @available(*, unavailable, message="Zone-based memory management is unavailable")
+// FOUNDATION-NEXT: @available(*, unavailable, message: "Zone-based memory management is unavailable")
 // FOUNDATION-NEXT: NSSetZoneName(zone: NSZone, _ name: String)
 
 // CTYPESBITS-NOT: FooStruct1

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -12,27 +12,27 @@
 class Test : NSObject {
   
   // "Factory methods" that we'd rather have as initializers.
-  @available(*, unavailable, message="superseded by import of -[NSObject init]")
+  @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
-  @available(*, unavailable, message="use object construction 'Test()'")
+  @available(*, unavailable, message: "use object construction 'Test()'")
   class func a() -> Self
   convenience init(dummyParam: ())
-  @available(*, unavailable, message="use object construction 'Test(dummyParam:)'")
+  @available(*, unavailable, message: "use object construction 'Test(dummyParam:)'")
   class func b() -> Self
   
   convenience init(cc x: AnyObject)
-  @available(*, unavailable, message="use object construction 'Test(cc:)'")
+  @available(*, unavailable, message: "use object construction 'Test(cc:)'")
   class func c(x: AnyObject) -> Self
   convenience init(_ x: AnyObject)
-  @available(*, unavailable, message="use object construction 'Test(_:)'")
+  @available(*, unavailable, message: "use object construction 'Test(_:)'")
   class func d(x: AnyObject) -> Self
   
   convenience init(aa a: AnyObject, _ b: AnyObject, cc c: AnyObject)
-  @available(*, unavailable, message="use object construction 'Test(aa:_:cc:)'")
+  @available(*, unavailable, message: "use object construction 'Test(aa:_:cc:)'")
   class func e(a: AnyObject, e b: AnyObject, e c: AnyObject) -> Self
   
   /*not inherited*/ init(fixedType: ())
-  @available(*, unavailable, message="use object construction 'Test(fixedType:)'")
+  @available(*, unavailable, message: "use object construction 'Test(fixedType:)'")
   class func f() -> Test
   
   // Would-be initializers.
@@ -46,26 +46,26 @@ class Test : NSObject {
 class TestError : NSObject {
   // Factory methods with NSError.
   convenience init(error: ()) throws
-  @available(*, unavailable, message="use object construction 'TestError(error:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(error:)'")
   class func err1() throws -> Self
   convenience init(aa x: AnyObject?, error: ()) throws
-  @available(*, unavailable, message="use object construction 'TestError(aa:error:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(aa:error:)'")
   class func err2(x: AnyObject?) throws -> Self
   convenience init(aa x: AnyObject?, error: (), block: () -> Void) throws
-  @available(*, unavailable, message="use object construction 'TestError(aa:error:block:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(aa:error:block:)'")
   class func err3(x: AnyObject?, callback block: () -> Void) throws -> Self
   convenience init(error: (), block: () -> Void) throws
-  @available(*, unavailable, message="use object construction 'TestError(error:block:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(error:block:)'")
   class func err4(callback block: () -> Void) throws -> Self
   
   convenience init(aa x: AnyObject?) throws
-  @available(*, unavailable, message="use object construction 'TestError(aa:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(aa:)'")
   class func err5(x: AnyObject?) throws -> Self
   convenience init(aa x: AnyObject?, block: () -> Void) throws
-  @available(*, unavailable, message="use object construction 'TestError(aa:block:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(aa:block:)'")
   class func err6(x: AnyObject?, callback block: () -> Void) throws -> Self
   convenience init(block: () -> Void) throws
-  @available(*, unavailable, message="use object construction 'TestError(block:)'")
+  @available(*, unavailable, message: "use object construction 'TestError(block:)'")
   class func err7(callback block: () -> Void) throws -> Self
   
   // Would-be initializers.
@@ -77,7 +77,7 @@ class TestError : NSObject {
 }
 
 class TestSub : Test {
-  @available(*, unavailable, message="superseded by import of -[NSObject init]")
+  @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
   convenience init(dummyParam: ())
   convenience init(cc x: AnyObject)

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -229,7 +229,7 @@
 // CHECK-CORECOOLING: func CFBottom() ->
 
 // Note: "Ref" variants are unavailable.
-// CHECK-CORECOOLING: @available(*, unavailable, renamed="CCPowerSupply", message="Not available in Swift")
+// CHECK-CORECOOLING: @available(*, unavailable, renamed: "CCPowerSupply", message: "Not available in Swift")
 // CHECK-CORECOOLING-NEXT: typealias CCPowerSupplyRef = CCPowerSupply
 
 // Note: Skipping over "Ref"

--- a/test/Interpreter/SDK/submodules_smoke_test.swift
+++ b/test/Interpreter/SDK/submodules_smoke_test.swift
@@ -11,7 +11,7 @@ _ = OpenGL.glGetString
 
 import AppKit.NSPanGestureRecognizer
 
-@available(OSX, introduced=10.10)
+@available(OSX, introduced: 10.10)
 typealias PanRecognizer = NSPanGestureRecognizer
 typealias PanRecognizer2 = AppKit.NSPanGestureRecognizer
 

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -3,12 +3,12 @@
 // validate declarations when resolving declaration signatures.
 // This file relies on the minimum deployment target for OS X being 10.9.
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 private class PrivateIntroduced10_52 { }
 
 class OtherIntroduced10_9 { }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class OtherIntroduced10_51 {
   func uses10_52() {
     // If this were the primary file then the below would emit an error, because
@@ -27,7 +27,7 @@ class OtherIntroduced10_51 {
     return OtherIntroduced10_52()
   }
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func returns10_52Introduced10_52() -> OtherIntroduced10_52 {
     return OtherIntroduced10_52()
   }
@@ -35,7 +35,7 @@ class OtherIntroduced10_51 {
   func takes10_52(o: OtherIntroduced10_52) { 
   }
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func takes10_52Introduced10_52(o: OtherIntroduced10_52) {
   }
 
@@ -44,25 +44,25 @@ class OtherIntroduced10_51 {
 
       OtherIntroduced10_52() // We don't expect an error here because the initializer is not type checked (by design).
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   var propOf10_52Introduced10_52: OtherIntroduced10_52 = OtherIntroduced10_52()
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   class NestedIntroduced10_52 : OtherIntroduced10_52 {
     override func returns10_52() -> OtherIntroduced10_52 {
     }
 
-    @available(OSX, introduced=10.53)
+    @available(OSX, introduced: 10.53)
     func returns10_53() -> OtherIntroduced10_53 {
     }
   }
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class SubOtherIntroduced10_51 : OtherIntroduced10_51 {
 }
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 class OtherIntroduced10_52 : OtherIntroduced10_51 {
 }
 
@@ -71,19 +71,19 @@ extension OtherIntroduced10_51 { // expected-error {{'OtherIntroduced10_51' is o
 }
 
 extension OtherIntroduced10_9 {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func extensionMethodOnOtherIntroduced10_9AvailableOn10_51(p: OtherIntroduced10_51) { }
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 extension OtherIntroduced10_51 {
   func extensionMethodOnOtherIntroduced10_51() { }
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func extensionMethodOnOtherIntroduced10_51AvailableOn10_52() { }
 }
 
-@available(OSX, introduced=10.53)
+@available(OSX, introduced: 10.53)
 class OtherIntroduced10_53 {
 }
 

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -9,7 +9,7 @@ func test() {
   unavailable_foo() // expected-error {{'unavailable_foo()' is unavailable}}
 }
 
-@available(*,unavailable,message="use 'Int' instead")
+@available(*,unavailable,message: "use 'Int' instead")
 struct NSUInteger {} // expected-note 2 {{explicitly marked unavailable here}}
 
 func foo(x : NSUInteger) { // expected-error {{'NSUInteger' is unavailable: use 'Int' instead}}

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -8,13 +8,13 @@
 
 func markUsed<T>(t: T) {}
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 func globalFuncAvailableOn10_9() -> Int { return 9 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 func globalFuncAvailableOn10_51() -> Int { return 10 }
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 func globalFuncAvailableOn10_52() -> Int { return 11 }
 
 // Top level should reflect the minimum deployment target.
@@ -40,13 +40,13 @@ func functionWithoutAvailability() {
 }
 
 // Functions with annotations should refine their bodies.
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 func functionAvailableOn10_51() {
   let _: Int = globalFuncAvailableOn10_9()
   let _: Int = globalFuncAvailableOn10_51()
 
   // Nested functions should get their own refinement context.
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func innerFunctionAvailableOn10_52() {
     let _: Int = globalFuncAvailableOn10_9()
     let _: Int = globalFuncAvailableOn10_51()
@@ -59,11 +59,11 @@ func functionAvailableOn10_51() {
 
 // Don't allow script-mode globals to marked potentially unavailable. Their
 // initializers are eagerly executed.
-@available(OSX, introduced=10.51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
+@available(OSX, introduced: 10.51) // expected-error {{global variable cannot be marked potentially unavailable with '@available' in script mode}}
 var potentiallyUnavailableGlobalInScriptMode: Int = globalFuncAvailableOn10_51()
 
 // Still allow other availability annotations on script-mode globals
-@available(OSX, deprecated=10.51)
+@available(OSX, deprecated: 10.51)
 var deprecatedGlobalInScriptMode: Int = 5
 
 if #available(OSX 10.51, *) {
@@ -82,8 +82,8 @@ if #available(OSX 10.51, *) {
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX, introduced=10.51)
-@available(iOS, introduced=8.0)
+@available(OSX, introduced: 10.51)
+@available(iOS, introduced: 8.0)
 func globalFuncAvailableOnOSX10_51AndiOS8_0() -> Int { return 10 }
 
 if #available(OSX 10.51, iOS 8.0, *) {
@@ -110,10 +110,10 @@ globalFuncAvailableOn10_51() // expected-error {{'globalFuncAvailableOn10_51()' 
     // expected-note@-1 {{add 'if #available' version check}}
 
 // Overloaded global functions
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 func overloadedFunction() {}
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 func overloadedFunction(on1010: Int) {}
 
 overloadedFunction()
@@ -123,13 +123,13 @@ overloadedFunction(0) // expected-error {{'overloadedFunction' is only available
 // Unavailable methods
 
 class ClassWithUnavailableMethod {
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   func methAvailableOn10_9() {}
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func methAvailableOn10_51() {}
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   class func classMethAvailableOn10_51() {}
   
   func someOtherMethod() {
@@ -222,10 +222,10 @@ class SubClassOverridingUnavailableMethod : ClassWithUnavailableMethod {
 }
 
 class ClassWithUnavailableOverloadedMethod {
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   func overloadedMethod() {}
 
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func overloadedMethod(on1010: Int) {}
 }
 
@@ -239,10 +239,10 @@ func callUnavailableOverloadedMethod(o: ClassWithUnavailableOverloadedMethod) {
 // Initializers
 
 class ClassWithUnavailableInitializer {
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   required init() {  }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   required init(_ val: Int) {  }
   
   convenience init(s: String) {
@@ -252,7 +252,7 @@ class ClassWithUnavailableInitializer {
         // expected-note@-3 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   convenience init(onlyOn1010: String) {
     self.init(5)
   }
@@ -272,10 +272,10 @@ func callUnavailableInitializer() {
 }
 
 class SuperWithWithUnavailableInitializer {
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   init() {  }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   init(_ val: Int) {  }
 }
 
@@ -291,7 +291,7 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
     super.init()
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   init(on1010: Int) {
     super.init(22)
   }
@@ -301,13 +301,13 @@ class SubOfClassWithUnavailableInitializer : SuperWithWithUnavailableInitializer
 
 class ClassWithUnavailableProperties {
 
-  @available(OSX, introduced=10.9) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  @available(OSX, introduced: 10.9) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   var nonLazyAvailableOn10_9Stored: Int = 9
 
-  @available(OSX, introduced=10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   var nonLazyAvailableOn10_51Stored : Int = 10
 
-  @available(OSX, introduced=10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
+  @available(OSX, introduced: 10.51) // expected-error {{stored properties cannot be marked potentially unavailable with '@available'}}
   let nonLazyLetAvailableOn10_51Stored : Int = 10
 
   // Make sure that we don't emit a Fix-It to mark a stored property as potentially unavailable.
@@ -315,13 +315,13 @@ class ClassWithUnavailableProperties {
   var storedPropertyOfUnavailableType: ClassAvailableOn10_51? = nil // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   lazy var availableOn10_9Stored: Int = 9
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   lazy var availableOn10_51Stored : Int = 10
 
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   var availableOn10_9Computed: Int {
     get {
       let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available on OS X 10.51 or newer}}
@@ -339,7 +339,7 @@ class ClassWithUnavailableProperties {
     }
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   var availableOn10_51Computed: Int {
     get {
       return availableOn10_51Stored
@@ -357,14 +357,14 @@ class ClassWithUnavailableProperties {
           // expected-note@-3 {{add 'if #available' version check}}
       return 0
     }
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     set(newVal) {
     globalFuncAvailableOn10_51()
     }
   }
   
   var propWithGetterOnlyAvailableOn10_51 : Int {
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     get {
       globalFuncAvailableOn10_51()
       return 0
@@ -378,11 +378,11 @@ class ClassWithUnavailableProperties {
   }
   
   var propWithGetterAndSetterOnlyAvailableOn10_51 : Int {
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     get {
       return 0
     }
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     set(newVal) {
     }
   }
@@ -391,13 +391,13 @@ class ClassWithUnavailableProperties {
     get {
       return ClassWithUnavailableProperties()
     }
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     set(newVal) {
     }
   }
   
   var propWithGetterOnlyAvailableOn10_51ForNestedMemberRef : ClassWithUnavailableProperties {
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     get {
       return ClassWithUnavailableProperties()
     }
@@ -406,7 +406,7 @@ class ClassWithUnavailableProperties {
   }
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class ClassWithReferencesInInitializers {
   var propWithInitializer10_51: Int = globalFuncAvailableOn10_51()
 
@@ -520,36 +520,36 @@ func accessUnavailableProperties(o: ClassWithUnavailableProperties) {
 // _silgen_name
 
 @_silgen_name("SomeName")
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 func funcWith_silgen_nameAvailableOn10_51(p: ClassAvailableOn10_51?) -> ClassAvailableOn10_51
 
 // Enums
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 enum EnumIntroducedOn10_51 {
  case Element
 }
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 enum EnumIntroducedOn10_52 {
  case Element
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 enum CompassPoint {
   case North
   case South
   case East
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   case West
 
   case WithAvailableByEnumPayload(p : EnumIntroducedOn10_51)
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   case WithAvailableByEnumElementPayload(p : EnumIntroducedOn10_52)
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   case WithAvailableByEnumElementPayload1(p : EnumIntroducedOn10_52), WithAvailableByEnumElementPayload2(p : EnumIntroducedOn10_52)
 
   case WithUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available on OS X 10.52 or newer}}
@@ -559,7 +559,7 @@ enum CompassPoint {
       // expected-note@-1 2{{add @available attribute to enclosing case}}
 }
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 func functionTakingEnumIntroducedOn10_52(e: EnumIntroducedOn10_52) { }
 
 func useEnums() {
@@ -603,14 +603,14 @@ func useEnums() {
 
 // Classes
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 class ClassAvailableOn10_9 {
   func someMethod() {}
   class func someClassMethod() {}
   var someProp : Int = 22
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
   func someMethod() {}
   class func someClassMethod() {
@@ -618,12 +618,12 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
   }
   var someProp : Int = 22
 
-  @available(OSX, introduced=10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
+  @available(OSX, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
   func someMethodAvailableOn10_9() { }
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   var propWithGetter: Int { // expected-note{{enclosing scope here}}
-    @available(OSX, introduced=10.51) // expected-error {{declaration cannot be more available than enclosing scope}}
+    @available(OSX, introduced: 10.51) // expected-error {{declaration cannot be more available than enclosing scope}}
     get { return 0 }
   }
 }
@@ -669,7 +669,7 @@ protocol Creatable {
   init()
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class ClassAvailableOn10_51_Creatable : Creatable {
   required init() {}
 }
@@ -723,7 +723,7 @@ func classViaTypeParameter() {
 
 class ClassWithDeclarationsOfUnavailableClasses {
 
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   init() {
     unavailablePropertyOfUnavailableType = ClassAvailableOn10_51()
     unavailablePropertyOfUnavailableType = ClassAvailableOn10_51()
@@ -732,19 +732,19 @@ class ClassWithDeclarationsOfUnavailableClasses {
   var propertyOfUnavailableType: ClassAvailableOn10_51 // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-1 {{add @available attribute to enclosing class}}
 
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   lazy var unavailablePropertyOfUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   lazy var unavailablePropertyOfOptionalUnavailableType: ClassAvailableOn10_51? = nil
 
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   lazy var unavailablePropertyOfUnavailableTypeWithInitializer: ClassAvailableOn10_51 = ClassAvailableOn10_51()
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   static var unavailableStaticPropertyOfUnavailableType: ClassAvailableOn10_51 = ClassAvailableOn10_51()
 
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   static var unavailableStaticPropertyOfOptionalUnavailableType: ClassAvailableOn10_51?
 
   func methodWithUnavailableParameterType(o : ClassAvailableOn10_51) { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
@@ -753,7 +753,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
 
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func unavailableMethodWithUnavailableParameterType(o : ClassAvailableOn10_51) {
   }
   
@@ -767,7 +767,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
       // expected-note@-3 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func unavailableMethodWithUnavailableReturnType() -> ClassAvailableOn10_51 {
     return ClassAvailableOn10_51()
   }
@@ -779,7 +779,7 @@ class ClassWithDeclarationsOfUnavailableClasses {
       // expected-note@-3 {{add 'if #available' version check}}
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func unavailableMethodWithUnavailableLocalDeclaration() {
     let _ : ClassAvailableOn10_51 = methodWithUnavailableReturnType()
   }
@@ -796,7 +796,7 @@ class ClassExtendingUnavailableClass : ClassAvailableOn10_51 { // expected-error
 
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class UnavailableClassExtendingUnavailableClass : ClassAvailableOn10_51 {
 }
 
@@ -823,11 +823,11 @@ class SuperWithAlwaysAvailableMembers {
 }
 
 class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   override func shouldAlwaysBeAvailableMethod() { // expected-error {{overriding 'shouldAlwaysBeAvailableMethod' must be as available as declaration it overrides}}
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   override var shouldAlwaysBeAvailableProperty: Int { // expected-error {{overriding 'shouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     get { return 10 }
     set(newVal) {}
@@ -835,24 +835,24 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
 
   override var setterShouldAlwaysBeAvailableProperty: Int {
     get { return 9 }
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     set(newVal) {} // expected-error {{overriding setter for 'setterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     // This is a terrible diagnostic. rdar://problem/20427938
   }
 
   override var getterShouldAlwaysBeAvailableProperty: Int {
-    @available(OSX, introduced=10.51)
+    @available(OSX, introduced: 10.51)
     get { return 9 } // expected-error {{overriding getter for 'getterShouldAlwaysBeAvailableProperty' must be as available as declaration it overrides}}
     set(newVal) {}
   }
 }
 
 class SuperWithLimitedMemberAvailability {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func someMethod() {
   }
   
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   var someProperty: Int {
     get { return 10 }
     set(newVal) {}
@@ -860,7 +860,7 @@ class SuperWithLimitedMemberAvailability {
 }
 
 class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   override func someMethod() {
     super.someMethod() // expected-error {{'someMethod()' is only available on OS X 10.51 or newer}}
         // expected-note@-1 {{add @available attribute to enclosing class}}
@@ -871,7 +871,7 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
     }
   }
   
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   override var someProperty: Int {
     get { 
       let _ = super.someProperty // expected-error {{'someProperty' is only available on OS X 10.51 or newer}}
@@ -890,28 +890,28 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
 
 // Inheritance and availability
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 protocol ProtocolAvailableOn10_9 {
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 protocol ProtocolAvailableOn10_51 {
 }
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 protocol ProtocolAvailableOn10_9InheritingFromProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 {
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 protocol ProtocolAvailableOn10_51InheritingFromProtocolAvailableOn10_9 : ProtocolAvailableOn10_9 {
 }
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
 }
 
 // We allow nominal types to conform to protocols that are less available than the types themselves.
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 class ClassAvailableOn10_9AdoptingProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 {
 }
 
@@ -927,13 +927,13 @@ func castToUnavailableProtocol() {
       // expected-note@-2 {{add 'if #available' version check}}
 }
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
 }
 
 class SomeGenericClass<T> { }
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available on OS X 10.51 or newer}}
 }
 
@@ -950,7 +950,7 @@ func GenericSignature<T : ProtocolAvailableOn10_51>(t: T) { // expected-error * 
 extension ClassAvailableOn10_51 { } // expected-error {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing extension}}
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 extension ClassAvailableOn10_51 {
   func m() {
     let _ = globalFuncAvailableOn10_51()
@@ -962,12 +962,12 @@ extension ClassAvailableOn10_51 {
 
 class ClassToExtend { }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 extension ClassToExtend {
 
   func extensionMethod() { }
 
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func extensionMethod10_52() { }
 
   class ExtensionClass { }
@@ -984,9 +984,9 @@ extension ClassToExtend : ProtocolAvailableOn10_51 {
 
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 extension ClassToExtend { // expected-note {{enclosing scope here}}
-  @available(OSX, introduced=10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
+  @available(OSX, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
   func extensionMethod10_9() { }
 }
 
@@ -1081,7 +1081,7 @@ func functionWithUnavailableInDeadBranch() {
   }
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 func functionWithSpecifiedAvailabilityAndUselessCheck() { // expected-note 2{{enclosing scope here}}
   if #available(OSX 10.9, *) { // expected-warning {{unnecessary check for 'OSX'; enclosing scope ensures guard will always be true}}
     let _ = globalFuncAvailableOn10_9()
@@ -1400,7 +1400,7 @@ protocol HasMethodF {
 }
 
 class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func f(p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
 
@@ -1408,12 +1408,12 @@ class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF { // expected-not
 class ConformsWithFunctionIntroducedOnMinimumDeploymentTarget : HasMethodF {
   // Even though this function is less available than its requirement,
   // it is available on a deployment targets, so the conformance is safe.
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   func f(p: Int) { }
 }
 
 class SuperHasMethodF {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
     func f(p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
 
@@ -1421,7 +1421,7 @@ class TriesToConformWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMe
   // The conformance here is generating an error on f in the super class.
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class ConformsWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF {
   // Limiting this class to only be available on 10.51 and newer means that
   // the witness in SuperHasMethodF is safe for the requirement on HasMethodF.
@@ -1440,69 +1440,69 @@ class ConformsByOverridingFunctionInSuperClass : SuperHasMethodF, HasMethodF {
 // in extension
 class HasNoMethodF1 { }
 extension HasNoMethodF1 : HasMethodF { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func f(p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
 
 class HasNoMethodF2 { }
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 extension HasNoMethodF2 : HasMethodF { // expected-note {{conformance introduced here}}
   func f(p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class HasNoMethodF3 { }
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 extension HasNoMethodF3 : HasMethodF {
   // We expect this conformance to succeed because on every version where HasNoMethodF3
   // is available, HasNoMethodF3's f() is as available as the protocol requirement
   func f(p: Int) { }
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 protocol HasMethodFOn10_51 {
   func f(p: Int) // expected-note {{protocol requirement here}}
 }
 
 class ConformsToUnavailableProtocolWithUnavailableWitness : HasMethodFOn10_51 {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func f(p: Int) { }
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 class HasNoMethodF4 { }
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 extension HasNoMethodF4 : HasMethodFOn10_51 { // expected-note {{conformance introduced here}}
   func f(p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available on OS X 10.51 and newer}}
 }
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 protocol HasTakesClassAvailableOn10_51 {
   func takesClassAvailableOn10_51(o: ClassAvailableOn10_51) // expected-note 2{{protocol requirement here}}
 }
 
 class AttemptsToConformToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func takesClassAvailableOn10_51(o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
   }
 }
 
 class ConformsToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func takesClassAvailableOn10_51(o: ClassAvailableOn10_51) {
   }
 }
 
 class TakesClassAvailableOn10_51_A { }
 extension TakesClassAvailableOn10_51_A : HasTakesClassAvailableOn10_51 { // expected-note {{conformance introduced here}}
-  @available(OSX, introduced=10.52)
+  @available(OSX, introduced: 10.52)
   func takesClassAvailableOn10_51(o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
   }
 }
 
 class TakesClassAvailableOn10_51_B { }
 extension TakesClassAvailableOn10_51_B : HasTakesClassAvailableOn10_51 {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func takesClassAvailableOn10_51(o: ClassAvailableOn10_51) {
   }
 }
@@ -1517,19 +1517,19 @@ class TestAvailabilityDoesNotAffectWitnessCandidacy : HasMethodF { // expected-n
   // less available than the protocol requires and there is a less specialized
   // witness that has suitable availability.
 
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func f(p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 
   func f<T>(p: T) { }
 }
 
 protocol HasUnavailableMethodF {
-  @available(OSX, introduced=10.51)
+  @available(OSX, introduced: 10.51)
   func f(p: String)
 }
 
 class ConformsWithUnavailableFunction : HasUnavailableMethodF {
-  @available(OSX, introduced=10.9)
+  @available(OSX, introduced: 10.9)
   func f(p: String) { }
 }
 

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -5,13 +5,13 @@ func callToEnsureNotInScriptMode() { }
 // Add an expected error to express expectation that we're not in script mode
 callToEnsureNotInScriptMode() // expected-error {{expressions are not allowed at the top level}}
 
-@available(OSX, introduced=10.9)
+@available(OSX, introduced: 10.9)
 var globalAvailableOn10_9: Int = 9
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 var globalAvailableOn10_51: Int = 10
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 var globalAvailableOn10_52: Int = 11
 
 // Top level should reflect the minimum deployment target.
@@ -23,7 +23,7 @@ let ignored2: Int = globalAvailableOn10_51 // expected-error {{'globalAvailableO
 let ignored3: Int = globalAvailableOn10_52 // expected-error {{'globalAvailableOn10_52' is only available on OS X 10.52 or newer}}
     // expected-note@-1 {{add @available attribute to enclosing let}}
 
-@available(OSX, introduced=10.51)
+@available(OSX, introduced: 10.51)
 func useFromOtherOn10_51() {
   // This will trigger validation of OtherIntroduced10_51 in
   // in availability_multi_other.swift
@@ -45,7 +45,7 @@ func useFromOtherOn10_51() {
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX, introduced=10.52)
+@available(OSX, introduced: 10.52)
 func useFromOtherOn10_52() {
   _ = OtherIntroduced10_52()
 

--- a/test/Sema/availability_versions_playgrounds.swift
+++ b/test/Sema/availability_versions_playgrounds.swift
@@ -7,7 +7,7 @@
 // REQUIRES: OS=macosx
 // REQUIRES: swift_interpreter
 
-@available(OSX, introduced=10.7, deprecated=10.8)
+@available(OSX, introduced: 10.7, deprecated: 10.8)
 func deprecatedOn10_8() { }
 
 func someFunction() {

--- a/test/Sema/deprecation_osx.swift
+++ b/test/Sema/deprecation_osx.swift
@@ -35,7 +35,7 @@ func useInSignature(options: NSDeprecatedOptions) { // expected-warning {{'NSDep
 
 
 class Super {
-  @available(OSX, introduced=10.9, deprecated=10.51)
+  @available(OSX, introduced: 10.9, deprecated: 10.51)
   init() { }
 }
 
@@ -48,16 +48,16 @@ class Sub : Super {
   /// cases.
 }
 
-@available(OSX, introduced=10.9, deprecated=10.51)
+@available(OSX, introduced: 10.9, deprecated: 10.51)
 func functionDeprecatedIn10_51() {
   _ = ClassDeprecatedIn10_51()
 }
 
-@available(OSX, introduced=10.9, deprecated=10.9)
+@available(OSX, introduced: 10.9, deprecated: 10.9)
 class ClassDeprecatedIn10_9 {
 }
 
-@available(OSX, introduced=10.8, deprecated=10.51)
+@available(OSX, introduced: 10.8, deprecated: 10.51)
 class ClassDeprecatedIn10_51 {
   var other10_51: ClassDeprecatedIn10_51 = ClassDeprecatedIn10_51()
 
@@ -73,7 +73,7 @@ class ClassDeprecatedIn10_51 {
 
 class ClassWithComputedPropertyDeprecatedIn10_51 {
 
-  @available(OSX, introduced=10.8, deprecated=10.51)
+  @available(OSX, introduced: 10.8, deprecated: 10.51)
   var annotatedPropertyDeprecatedIn10_51 : ClassDeprecatedIn10_51 {
     get {
       return ClassDeprecatedIn10_51()
@@ -101,7 +101,7 @@ func usesFunctionDeprecatedIn10_51() {
   _ = ClassDeprecatedIn10_51() // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 }
 
-@available(OSX, introduced=10.8, deprecated=10.51)
+@available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedUsesFunctionDeprecatedIn10_51() {
   _ = ClassDeprecatedIn10_51()
 }
@@ -109,27 +109,27 @@ func annotatedUsesFunctionDeprecatedIn10_51() {
 func hasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 }
 
-@available(OSX, introduced=10.8, deprecated=10.51)
+@available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedHasParameterDeprecatedIn10_51(p: ClassDeprecatedIn10_51) {
 }
 
 func hasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 { // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 }
 
-@available(OSX, introduced=10.8, deprecated=10.51)
+@available(OSX, introduced: 10.8, deprecated: 10.51)
 func annotatedHasReturnDeprecatedIn10_51() -> ClassDeprecatedIn10_51 {
 }
 
 var globalWithDeprecatedType : ClassDeprecatedIn10_51? = nil // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 
-@available(OSX, introduced=10.8, deprecated=10.51)
+@available(OSX, introduced: 10.8, deprecated: 10.51)
 var annotatedGlobalWithDeprecatedType : ClassDeprecatedIn10_51? = nil
 
 
 enum EnumWithDeprecatedCasePayload {
   case WithDeprecatedPayload(p: ClassDeprecatedIn10_51) // expected-warning {{ClassDeprecatedIn10_51' was deprecated in OS X 10.51}}
 
-  @available(OSX, introduced=10.8, deprecated=10.51)
+  @available(OSX, introduced: 10.8, deprecated: 10.51)
   case AnnotatedWithDeprecatedPayload(p: ClassDeprecatedIn10_51)
 }
 
@@ -137,7 +137,7 @@ extension ClassDeprecatedIn10_51 { // expected-warning {{'ClassDeprecatedIn10_51
 
 }
 
-@available(OSX, introduced=10.8, deprecated=10.51)
+@available(OSX, introduced: 10.8, deprecated: 10.51)
 extension ClassDeprecatedIn10_51 {
   func methodInExtensionOfClassDeprecatedIn10_51() {
   }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -310,7 +310,7 @@ public class FooUnavailableMembers : FooClassBase {
     public convenience init!(int i: Int32)
 
     
-    @available(*, deprecated, message="x")
+    @available(*, deprecated, message: "x")
     public func deprecated()
 
     
@@ -318,7 +318,7 @@ public class FooUnavailableMembers : FooClassBase {
     public func availabilityIntroduced()
 
     
-    @available(OSX, introduced=10.1, message="x")
+    @available(OSX, introduced: 10.1, message: "x")
     public func availabilityIntroducedMsg()
 }
 
@@ -2998,217 +2998,217 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6019,
+    key.offset: 6020,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6028,
+    key.offset: 6029,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6035,
+    key.offset: 6036,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6040,
+    key.offset: 6041,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6063,
+    key.offset: 6064,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6074,
+    key.offset: 6075,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6078,
+    key.offset: 6079,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6091,
+    key.offset: 6092,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6098,
+    key.offset: 6099,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6103,
+    key.offset: 6104,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6138,
+    key.offset: 6139,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6149,
+    key.offset: 6150,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6154,
+    key.offset: 6155,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6165,
+    key.offset: 6167,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6171,
+    key.offset: 6173,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6179,
+    key.offset: 6182,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6188,
+    key.offset: 6191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6195,
+    key.offset: 6198,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6200,
+    key.offset: 6203,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6231,
+    key.offset: 6234,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6238,
+    key.offset: 6241,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6248,
+    key.offset: 6251,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6263,
+    key.offset: 6266,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6277,
+    key.offset: 6280,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6284,
+    key.offset: 6287,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6289,
+    key.offset: 6292,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6306,
+    key.offset: 6309,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6309,
+    key.offset: 6312,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6323,
+    key.offset: 6326,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6330,
+    key.offset: 6333,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6336,
+    key.offset: 6339,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6363,
+    key.offset: 6366,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6370,
+    key.offset: 6373,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6375,
+    key.offset: 6378,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6382,
+    key.offset: 6385,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6389,
+    key.offset: 6392,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6395,
+    key.offset: 6398,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6420,
+    key.offset: 6423,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6424,
+    key.offset: 6427,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6451,
+    key.offset: 6454,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6460,
+    key.offset: 6463,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6467,
+    key.offset: 6470,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6472,
+    key.offset: 6475,
     key.length: 1
   }
 ]
@@ -3805,23 +3805,23 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6263,
+    key.offset: 6266,
     key.length: 13,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 6309,
+    key.offset: 6312,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 6420,
+    key.offset: 6423,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6424,
+    key.offset: 6427,
     key.length: 19
   }
 ]
@@ -5462,12 +5462,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooUnavailableMembers",
     key.offset: 5886,
-    key.length: 343,
+    key.length: 346,
     key.runtime_name: "_TtC4main21FooUnavailableMembers",
     key.nameoffset: 5892,
     key.namelength: 21,
     key.bodyoffset: 5930,
-    key.bodylength: 298,
+    key.bodylength: 301,
     key.inheritedtypes: [
       {
         key.name: "FooClassBase"
@@ -5510,9 +5510,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "deprecated()",
-        key.offset: 6035,
+        key.offset: 6036,
         key.length: 17,
-        key.nameoffset: 6040,
+        key.nameoffset: 6041,
         key.namelength: 12,
         key.attributes: [
           {
@@ -5524,9 +5524,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "availabilityIntroduced()",
-        key.offset: 6098,
+        key.offset: 6099,
         key.length: 29,
-        key.nameoffset: 6103,
+        key.nameoffset: 6104,
         key.namelength: 24,
         key.attributes: [
           {
@@ -5538,9 +5538,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6195,
+        key.offset: 6198,
         key.length: 32,
-        key.nameoffset: 6200,
+        key.nameoffset: 6203,
         key.namelength: 27,
         key.attributes: [
           {
@@ -5554,14 +5554,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFTypeRelease(_:)",
-    key.offset: 6284,
+    key.offset: 6287,
     key.length: 38,
-    key.nameoffset: 6289,
+    key.nameoffset: 6292,
     key.namelength: 33,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
-        key.offset: 6306,
+        key.offset: 6309,
         key.length: 15,
         key.typename: "FooCFTypeRef",
         key.nameoffset: 0,
@@ -5573,21 +5573,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6330,
+    key.offset: 6333,
     key.length: 50,
     key.runtime_name: "_TtC4main19FooOverlayClassBase",
-    key.nameoffset: 6336,
+    key.nameoffset: 6339,
     key.namelength: 19,
-    key.bodyoffset: 6357,
+    key.bodyoffset: 6360,
     key.bodylength: 22,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6370,
+        key.offset: 6373,
         key.length: 8,
-        key.nameoffset: 6375,
+        key.nameoffset: 6378,
         key.namelength: 3
       }
     ]
@@ -5596,12 +5596,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6389,
+    key.offset: 6392,
     key.length: 88,
     key.runtime_name: "_TtC4main22FooOverlayClassDerived",
-    key.nameoffset: 6395,
+    key.nameoffset: 6398,
     key.namelength: 22,
-    key.bodyoffset: 6445,
+    key.bodyoffset: 6448,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -5611,7 +5611,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6420,
+        key.offset: 6423,
         key.length: 23
       }
     ],
@@ -5620,9 +5620,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6467,
+        key.offset: 6470,
         key.length: 8,
-        key.nameoffset: 6472,
+        key.nameoffset: 6475,
         key.namelength: 3,
         key.attributes: [
           {

--- a/test/SourceKit/SourceDocInfo/cursor_stdlib.swift
+++ b/test/SourceKit/SourceDocInfo/cursor_stdlib.swift
@@ -31,7 +31,7 @@ func foo2(var a : [S1]) {
 
 // RUN: %sourcekitd-test -req=cursor -pos=8:10 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT1 %s
 // CHECK-REPLACEMENT1: <Group>Collection/Array</Group>
-// CHECK-REPLACEMENT1: <Declaration>@warn_unused_result(mutable_variant=&quot;sort&quot;) func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
+// CHECK-REPLACEMENT1: <Declaration>@warn_unused_result(mutable_variant: &quot;sort&quot;) func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
 // CHECK-REPLACEMENT1: RELATED BEGIN
 // CHECK-REPLACEMENT1: sorted(@noescape isOrderedBefore _: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
 // CHECK-REPLACEMENT1: sorted() -&gt; [Int]</RelatedName>

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -3,7 +3,7 @@
 @available(*, unavailable)
 func unavailable_func() {}
 
-@available(*, unavailable, message="message")
+@available(*, unavailable, message: "message")
 func unavailable_func_with_message() {}
 
 @available(tvOS, unavailable)
@@ -25,14 +25,14 @@ func unavailable_bad_platform() {}
 func availabilityUnknownPlatform() {}
 
 // <rdar://problem/17669805> Availability can't appear on a typealias
-@available(*, unavailable, message="oh no you don't")
+@available(*, unavailable, message: "oh no you don't")
 typealias int = Int // expected-note {{'int' has been explicitly marked unavailable here}}
 
-@available(*, unavailable, renamed="Float")
+@available(*, unavailable, renamed: "Float")
 typealias float = Float // expected-note {{'float' has been explicitly marked unavailable here}}
 
 struct MyCollection<Element> {
-  @available(*, unavailable, renamed="Element")
+  @available(*, unavailable, renamed: "Element")
   typealias T = Element // expected-note 2{{'T' has been explicitly marked unavailable here}}
 
   func foo(x: T) { } // expected-error {{'T' has been renamed to 'Element'}} {{15-16=Element}}
@@ -46,7 +46,7 @@ var x : int // expected-error {{'int' is unavailable: oh no you don't}}
 var y : float // expected-error {{'float' has been renamed to 'Float'}}{{9-14=Float}}
 
 // Encoded message
-@available(*, unavailable, message="This message has a double quote \"")
+@available(*, unavailable, message: "This message has a double quote \"")
 func unavailableWithDoubleQuoteInMessage() {} // expected-note {{'unavailableWithDoubleQuoteInMessage()' has been explicitly marked unavailable here}}
 
 func useWithEscapedMessage() {
@@ -55,17 +55,17 @@ func useWithEscapedMessage() {
 
 
 // More complicated parsing.
-@available(OSX, message="x", unavailable)
+@available(OSX, message: "x", unavailable)
 let _: Int
 
-@available(OSX, introduced=1, deprecated=2.0, obsoleted=3.0.0)
+@available(OSX, introduced: 1, deprecated: 2.0, obsoleted: 3.0.0)
 let _: Int
 
-@available(OSX, introduced=1.0.0, deprecated=2.0, obsoleted=3, unavailable, renamed="x")
+@available(OSX, introduced: 1.0.0, deprecated: 2.0, obsoleted: 3, unavailable, renamed: "x")
 let _: Int
 
 // Meaningless but accepted.
-@available(OSX, message="x")
+@available(OSX, message: "x")
 let _: Int
 
 
@@ -76,57 +76,66 @@ let _: Int
 @available(OSX,) // expected-error{{expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'}}
 let _: Int
 
-@available(OSX, message) // expected-error{{expected '=' after 'message' in 'available' attribute}}
+@available(OSX, message) // expected-error{{expected ':' after 'message' in 'available' attribute}}
 let _: Int
 
-@available(OSX, message=) // expected-error{{expected string literal in 'available' attribute}} expected-error{{'=' must have consistent whitespace on both sides}}
+@available(OSX, message=) // expected-error{{expected string literal in 'available' attribute}} expected-error{{'=' must have consistent whitespace on both sides}} expected-warning {{'=' is deprecated}}
 let _: Int
 
-@available(OSX, message=x) // expected-error{{expected string literal in 'available' attribute}}
+@available(OSX, message: ) // expected-error{{expected string literal in 'available' attribute}}
+let _: Int
+
+@available(OSX, message: x) // expected-error{{expected string literal in 'available' attribute}}
 let _: Int
 
 @available(OSX, unavailable=) // expected-error{{expected ')' in 'available' attribute}} expected-error{{'=' must have consistent whitespace on both sides}} expected-error{{expected declaration}}
 let _: Int
 
-@available(OSX, introduced) // expected-error{{expected '=' after 'introduced' in 'available' attribute}}
+@available(OSX, unavailable:) // expected-error{{expected ')' in 'available' attribute}} expected-error{{expected declaration}}
 let _: Int
 
-@available(OSX, introduced=) // expected-error{{expected version number in 'available' attribute}} expected-error{{'=' must have consistent whitespace on both sides}}
+@available(OSX, introduced) // expected-error{{expected ':' after 'introduced' in 'available' attribute}}
 let _: Int
 
-@available(OSX, introduced=x) // expected-error{{expected version number in 'available' attribute}}
+@available(OSX, introduced=) // expected-error{{expected version number in 'available' attribute}} expected-error{{'=' must have consistent whitespace on both sides}} expected-warning{{'=' is deprecated}}
 let _: Int
 
-@available(OSX, introduced=1.x) // expected-error{{expected ')' in 'available' attribute}} expected-error {{expected declaration}}
+@available(OSX, introduced: ) // expected-error{{expected version number in 'available' attribute}}
 let _: Int
 
-@available(OSX, introduced=1.0.x) // expected-error{{expected version number in 'available' attribute}}
+@available(OSX, introduced: x) // expected-error{{expected version number in 'available' attribute}}
 let _: Int
 
-@available(OSX, introduced=0x1) // expected-error{{expected version number in 'available' attribute}}
+@available(OSX, introduced: 1.x) // expected-error{{expected ')' in 'available' attribute}} expected-error {{expected declaration}}
 let _: Int
 
-@available(OSX, introduced=1.0e4) // expected-error{{expected version number in 'available' attribute}}
+@available(OSX, introduced: 1.0.x) // expected-error{{expected version number in 'available' attribute}}
 let _: Int
 
-@available(OSX, introduced=-1) // expected-error{{expected '=' after 'introduced' in 'available' attribute}} expected-error{{expected declaration}}
+@available(OSX, introduced: 0x1) // expected-error{{expected version number in 'available' attribute}}
 let _: Int
 
-@available(OSX, introduced=1.0.1e4) // expected-error{{expected version number in 'available' attribute}}
+@available(OSX, introduced: 1.0e4) // expected-error{{expected version number in 'available' attribute}}
 let _: Int
 
-@available(OSX, introduced=1.0.0x4) // expected-error{{expected version number in 'available' attribute}}
+@available(OSX, introduced: -1) // expected-error{{expected version number in 'available' attribute}} expected-error{{expected declaration}}
 let _: Int
 
-@available(*, deprecated, unavailable, message="message") // expected-error{{'available' attribute cannot be both unconditionally 'unavailable' and 'deprecated'}}
+@available(OSX, introduced: 1.0.1e4) // expected-error{{expected version number in 'available' attribute}}
+let _: Int
+
+@available(OSX, introduced: 1.0.0x4) // expected-error{{expected version number in 'available' attribute}}
+let _: Int
+
+@available(*, deprecated, unavailable, message: "message") // expected-error{{'available' attribute cannot be both unconditionally 'unavailable' and 'deprecated'}}
 struct BadUnconditionalAvailability { };
 
 // Encoding in messages
-@available(*, deprecated, message="Say \"Hi\"")
+@available(*, deprecated, message: "Say \"Hi\"")
 func deprecated_func_with_message() {}
 
 // 'PANDA FACE' (U+1F43C)
-@available(*, deprecated, message="Pandas \u{1F43C} are cute")
+@available(*, deprecated, message: "Pandas \u{1F43C} are cute")
 struct DeprecatedTypeWithMessage { }
 
 func use_deprecated_with_message() {
@@ -134,18 +143,18 @@ func use_deprecated_with_message() {
   var _: DeprecatedTypeWithMessage // expected-warning{{'DeprecatedTypeWithMessage' is deprecated: Pandas \u{1F43C} are cute}}
 }
 
-@available(*, deprecated, message="message")
+@available(*, deprecated, message: "message")
 func use_deprecated_func_with_message2() {
  deprecated_func_with_message() // no diagnostic
 }
 
-@available(*, deprecated, renamed="blarg")
+@available(*, deprecated, renamed: "blarg")
 func deprecated_func_with_renamed() {}
 
-@available(*, deprecated, message="blarg is your friend", renamed="blarg")
+@available(*, deprecated, message: "blarg is your friend", renamed: "blarg")
 func deprecated_func_with_message_renamed() {}
 
-@available(*, deprecated, renamed="wobble")
+@available(*, deprecated, renamed: "wobble")
 struct DeprecatedTypeWithRename { }
 
 func use_deprecated_with_renamed() {
@@ -191,7 +200,7 @@ func shortFormWithWildcardInMiddle() {}
 @available(iOS 8.0, OSX 10.10.3) // expected-error {{must handle potential future platforms with '*'}} {{32-32=, *}}
 func shortFormMissingWildcard() {}
 
-@availability(OSX, introduced=10.10) // expected-error {{@availability has been renamed to @available}} {{2-14=available}}
+@availability(OSX, introduced: 10.10) // expected-error {{@availability has been renamed to @available}} {{2-14=available}}
 func someFuncUsingOldAttribute() { }
 
 
@@ -201,6 +210,6 @@ func OutputStreamTest(message: String, to: inout OutputStream) {
 }
 
 // expected-note@+1{{'T' has been explicitly marked unavailable here}}
-struct UnavailableGenericParam<@available(*, unavailable, message="nope") T> {
+struct UnavailableGenericParam<@available(*, unavailable, message: "nope") T> {
   func f(t: T) { } // expected-error{{'T' is unavailable: nope}}
 }

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -parse -verify -parse-stdlib -target x86_64-apple-macosx10.10 %s
 
-@available(OSX, introduced=10.5, deprecated=10.8, obsoleted=10.9,
-              message="you don't want to do that anyway")
+@available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9,
+              message: "you don't want to do that anyway")
 func doSomething() { }
 // expected-note @-1{{'doSomething()' was obsoleted in OS X 10.9}}
 
@@ -9,14 +9,14 @@ doSomething() // expected-error{{'doSomething()' is unavailable: you don't want 
 
 
 // Preservation of major.minor.micro
-@available(OSX, introduced=10.5, deprecated=10.8, obsoleted=10.9.1)
+@available(OSX, introduced: 10.5, deprecated: 10.8, obsoleted: 10.9.1)
 func doSomethingElse() { }
 // expected-note @-1{{'doSomethingElse()' was obsoleted in OS X 10.9.1}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
 
 // Preservation of minor-only version
-@available(OSX, introduced=8.0, deprecated=8.5, obsoleted=10)
+@available(OSX, introduced: 8.0, deprecated: 8.5, obsoleted: 10)
 func doSomethingReallyOld() { }
 // expected-note @-1{{'doSomethingReallyOld()' was obsoleted in OS X 10}}
 
@@ -24,26 +24,26 @@ doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailabl
 
 // Test deprecations in 10.10 and later
 
-@available(OSX, introduced=10.5, deprecated=10.10,
-              message="Use another function")
+@available(OSX, introduced: 10.5, deprecated: 10.10,
+              message: "Use another function")
 func deprecatedFunctionWithMessage() { }
 
 deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in OS X 10.10: Use another function}}
 
 
-@available(OSX, introduced=10.5, deprecated=10.10)
+@available(OSX, introduced: 10.5, deprecated: 10.10)
 func deprecatedFunctionWithoutMessage() { }
 
 deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in OS X 10.10}}
 
-@available(OSX, introduced=10.5, deprecated=10.10,
-              message="Use BetterClass instead")
+@available(OSX, introduced: 10.5, deprecated: 10.10,
+              message: "Use BetterClass instead")
 class DeprecatedClass { }
 
 func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in OS X 10.10: Use BetterClass instead}}
 
-@available(OSX, introduced=10.5, deprecated=10.11,
-              message="Use BetterClass instead")
+@available(OSX, introduced: 10.5, deprecated: 10.11,
+              message: "Use BetterClass instead")
 class DeprecatedClassIn10_11 { }
 
 // Elements deprecated later than the minimum deployment target (which is 10.10, in this case) should not generate warnings

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -1,21 +1,21 @@
 // RUN: %swift -parse -verify -parse-stdlib -target i386-apple-tvos9.0 %s
 
-@available(tvOS, introduced=1.0, deprecated=2.0, obsoleted=9.0,
-              message="you don't want to do that anyway")
+@available(tvOS, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
+              message: "you don't want to do that anyway")
 func doSomething() { }
 // expected-note @-1{{'doSomething()' was obsoleted in tvOS 9.0}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
-@available(tvOS, introduced=1.0, deprecated=2.0, obsoleted=8.0)
+@available(tvOS, introduced: 1.0, deprecated: 2.0, obsoleted: 8.0)
 func doSomethingElse() { }
 // expected-note @-1{{'doSomethingElse()' was obsoleted in tvOS 8.0}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
 
 // Preservation of minor-only version
-@available(tvOS, introduced=1.0, deprecated=1.5, obsoleted=9)
+@available(tvOS, introduced: 1.0, deprecated: 1.5, obsoleted: 9)
 func doSomethingReallyOld() { }
 // expected-note @-1{{'doSomethingReallyOld()' was obsoleted in tvOS 9}}
 
@@ -23,26 +23,26 @@ doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailabl
 
 // Test deprecations in 9.0 and later
 
-@available(tvOS, introduced=1.1, deprecated=9.0,
-              message="Use another function")
+@available(tvOS, introduced: 1.1, deprecated: 9.0,
+              message: "Use another function")
 func deprecatedFunctionWithMessage() { }
 
 deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in tvOS 9.0: Use another function}}
 
 
-@available(tvOS, introduced=1.0, deprecated=9.0)
+@available(tvOS, introduced: 1.0, deprecated: 9.0)
 func deprecatedFunctionWithoutMessage() { }
 
 deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in tvOS 9.0}}
 
-@available(tvOS, introduced=1.0, deprecated=9.0,
-              message="Use BetterClass instead")
+@available(tvOS, introduced: 1.0, deprecated: 9.0,
+              message: "Use BetterClass instead")
 class DeprecatedClass { }
 
 func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in tvOS 9.0: Use BetterClass instead}}
 
-@available(tvOS, introduced=7.0, deprecated=10.0,
-              message="Use BetterClass instead")
+@available(tvOS, introduced: 7.0, deprecated: 10.0,
+              message: "Use BetterClass instead")
 class DeprecatedClassIn8_0 { }
 
 // Elements deprecated later than the minimum deployment target (which is 9.0, in this case) should not generate warnings
@@ -50,7 +50,7 @@ func functionWithDeprecatedLaterParameter(p: DeprecatedClassIn8_0) { }
 
 // Treat tvOS as distinct from iOS in availability queries
 
-@available(tvOS, introduced=9.2)
+@available(tvOS, introduced: 9.2)
 func functionIntroducedOntvOS9_2() { }
 
 if #available(iOS 9.3, *) {
@@ -79,10 +79,10 @@ if #available(iOS 9.2, tvOS 8.0, *) { // expected-warning {{unnecessary check fo
 @available(iOS, unavailable)
 func swiftOriginatedFunctionUnavailableOnIOS() { }
 
-@available(iOS, introduced=6.0, deprecated=9.0)
+@available(iOS, introduced: 6.0, deprecated: 9.0)
 func swiftOriginatedFunctionDeprecatedOnIOS() { }
 
-@available(iOS, introduced=10.0)
+@available(iOS, introduced: 10.0)
 func swiftOriginatedFunctionPotentiallyUnavailableOnIOS() { }
 
 func useSwiftOriginatedFunctions() {

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -1,21 +1,21 @@
 // RUN: %swift -parse -verify -parse-stdlib -target i386-apple-watchos2.0 %s
 
-@available(watchOS, introduced=1.0, deprecated=1.5, obsoleted=2.0,
-              message="you don't want to do that anyway")
+@available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2.0,
+              message: "you don't want to do that anyway")
 func doSomething() { }
 // expected-note @-1{{'doSomething()' was obsoleted in watchOS 2.0}}
 
 doSomething() // expected-error{{'doSomething()' is unavailable: you don't want to do that anyway}}
 
 // Preservation of major.minor.micro
-@available(watchOS, introduced=1.0, deprecated=1.5, obsoleted=1.5.3)
+@available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 1.5.3)
 func doSomethingElse() { }
 // expected-note @-1{{'doSomethingElse()' was obsoleted in watchOS 1.5.3}}
 
 doSomethingElse() // expected-error{{'doSomethingElse()' is unavailable}}
 
 // Preservation of minor-only version
-@available(watchOS, introduced=1.0, deprecated=1.5, obsoleted=2)
+@available(watchOS, introduced: 1.0, deprecated: 1.5, obsoleted: 2)
 func doSomethingReallyOld() { }
 // expected-note @-1{{'doSomethingReallyOld()' was obsoleted in watchOS 2}}
 
@@ -23,26 +23,26 @@ doSomethingReallyOld() // expected-error{{'doSomethingReallyOld()' is unavailabl
 
 // Test deprecations in 2.0 and later
 
-@available(watchOS, introduced=1.1, deprecated=2.0,
-              message="Use another function")
+@available(watchOS, introduced: 1.1, deprecated: 2.0,
+              message: "Use another function")
 func deprecatedFunctionWithMessage() { }
 
 deprecatedFunctionWithMessage() // expected-warning{{'deprecatedFunctionWithMessage()' was deprecated in watchOS 2.0: Use another function}}
 
 
-@available(watchOS, introduced=1.0, deprecated=2.0)
+@available(watchOS, introduced: 1.0, deprecated: 2.0)
 func deprecatedFunctionWithoutMessage() { }
 
 deprecatedFunctionWithoutMessage() // expected-warning{{'deprecatedFunctionWithoutMessage()' was deprecated in watchOS 2.0}}
 
-@available(watchOS, introduced=1.0, deprecated=2.0,
-              message="Use BetterClass instead")
+@available(watchOS, introduced: 1.0, deprecated: 2.0,
+              message: "Use BetterClass instead")
 class DeprecatedClass { }
 
 func functionWithDeprecatedParameter(p: DeprecatedClass) { } // expected-warning{{'DeprecatedClass' was deprecated in watchOS 2.0: Use BetterClass instead}}
 
-@available(watchOS, introduced=2.0, deprecated=4.0,
-              message="Use BetterClass instead")
+@available(watchOS, introduced: 2.0, deprecated: 4.0,
+              message: "Use BetterClass instead")
 class DeprecatedClassIn3_0 { }
 
 // Elements deprecated later than the minimum deployment target (which is 2.0, in this case) should not generate warnings
@@ -50,7 +50,7 @@ func functionWithDeprecatedLaterParameter(p: DeprecatedClassIn3_0) { }
 
 // Treat watchOS as distinct from iOS in availability queries
 
-@available(watchOS, introduced=2.2)
+@available(watchOS, introduced: 2.2)
 func functionIntroducedOnwatchOS2_2() { }
 
 if #available(iOS 9.3, *) {
@@ -79,10 +79,10 @@ if #available(iOS 9.2, watchOS 1.0, *) { // expected-warning {{unnecessary check
 @available(iOS, unavailable)
 func swiftOriginatedFunctionUnavailableOnIOS() { }
 
-@available(iOS, introduced=6.0, deprecated=9.0)
+@available(iOS, introduced: 6.0, deprecated: 9.0)
 func swiftOriginatedFunctionDeprecatedOnIOS() { }
 
-@available(iOS, introduced=10.0)
+@available(iOS, introduced: 10.0)
 func swiftOriginatedFunctionPotentiallyUnavailableOnIOS() { }
 
 func useSwiftOriginatedFunctions() {

--- a/test/attr/attr_swift3_migration.swift
+++ b/test/attr/attr_swift3_migration.swift
@@ -1,23 +1,23 @@
 // RUN: %target-parse-verify-swift
 
-@swift3_migration(renamed="g0(a:b:c:)", message="it's good for you")
+@swift3_migration(renamed: "g0(a:b:c:)", message: "it's good for you")
 func f0(x: Int, y: Int, z: Int) { }
 
-@swift3_migration(renamed="Y0")
+@swift3_migration(renamed: "Y0")
 struct X0 { }
 
 
 
 // Parsing diagnostics
 
-@swift3_migration(renamed) // expected-error{{expected '=' following 'renamed' argument of 'swift3_migration'}}
+@swift3_migration(renamed) // expected-error{{expected ':' following 'renamed' argument of 'swift3_migration'}}
 func bad0() { }
 
-@swift3_migration(renamed=blah) // expected-error{{expected string literal for 'renamed' argument of 'swift3_migration'}}
+@swift3_migration(renamed: blah) // expected-error{{expected string literal for 'renamed' argument of 'swift3_migration'}}
 func bad1() { }
 
-@swift3_migration(unknown="foo") // expected-warning{{expected 'renamed' or 'message' in 'swift3_migration' attribute}}
+@swift3_migration(unknown: "foo") // expected-warning{{expected 'renamed' or 'message' in 'swift3_migration' attribute}}
 func bad2() { }
 
-@swift3_migration(renamed="wibble wonka(") // expected-error{{ill-formed Swift name 'wibble wonka('}}
+@swift3_migration(renamed: "wibble wonka(") // expected-error{{ill-formed Swift name 'wibble wonka('}}
 func bad3() { }

--- a/test/attr/attr_warn_unused_result.swift
+++ b/test/attr/attr_warn_unused_result.swift
@@ -25,7 +25,7 @@ class C1 {
   @warn_unused_result
   func f1() { }
 
-  @warn_unused_result(message="huzzah")
+  @warn_unused_result(message: "huzzah")
   static func f2() { }
 }
 
@@ -52,12 +52,12 @@ func testInitsPositive() {
 // ---------------------------------------------------------------------------
 
 struct Mutating1 {
-  @warn_unused_result(mutable_variant="fooInPlace")
+  @warn_unused_result(mutable_variant: "fooInPlace")
   func foo() -> Mutating1 { return self }
 
   mutating func fooInPlace() { }
 
-  @warn_unused_result(message="zug zug", mutable_variant="barInPlace")
+  @warn_unused_result(message: "zug zug", mutable_variant: "barInPlace")
   func bar(x: Int, y: Int) -> Mutating1 { return self }
 
   mutating func barInPlace(x: Int, y: Int) { }
@@ -78,22 +78,22 @@ func testMutating1(m1: Mutating1, m2: Mutating1) {
 // ---------------------------------------------------------------------------
 struct BadAttributes1 {
   @warn_unused_result(blarg) func f1() { } // expected-warning{{unknown parameter 'blarg' in 'warn_unused_result' attribute}}
-  @warn_unused_result(wibble="foo") func f2() { } // expected-warning{{unknown parameter 'wibble' in 'warn_unused_result' attribute}}
-  @warn_unused_result(message) func f3() { } // expected-error{{expected '=' following 'message' parameter}}
-  @warn_unused_result(message=) func f4() { } // expected-error{{'=' must have consistent whitespace on both sides}}
-  // expected-error@-1{{expected a string following '=' for 'message' parameter}}
-  @warn_unused_result(message=blah) func f5() { } // expected-error{{expected a string following '=' for 'message' parameter}}
+  @warn_unused_result(wibble:"foo") func f2() { } // expected-warning{{unknown parameter 'wibble' in 'warn_unused_result' attribute}}
+  @warn_unused_result(message) func f3() { } // expected-error{{expected ':' following 'message' parameter}}
+  @warn_unused_result(message=) func f4() { } // expected-error{{'=' must have consistent whitespace on both sides}} // expected-warning{{'=' is deprecated}}
+  // expected-error@-1{{expected a string following ':' for 'message' parameter}}
+  @warn_unused_result(message: blah) func f5() { } // expected-error{{expected a string following ':' for 'message' parameter}}
 
-  @warn_unused_result(mutable_variant="oops") static func f6() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a non-instance method}}
-  @warn_unused_result(mutable_variant="oops") init() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a non-function}}
-  @warn_unused_result(mutable_variant="oops") mutating func f7() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a mutating method}}
+  @warn_unused_result(mutable_variant: "oops") static func f6() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a non-instance method}}
+  @warn_unused_result(mutable_variant: "oops") init() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a non-function}}
+  @warn_unused_result(mutable_variant: "oops") mutating func f7() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a mutating method}}
 }
 
 class BadAttributes2 {
-  @warn_unused_result(mutable_variant="oops") func f1() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a method of a class}}
+  @warn_unused_result(mutable_variant: "oops") func f1() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a method of a class}}
 }
 
-@warn_unused_result(mutable_variant="oops") func badMutableVariant() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a non-method}}
+@warn_unused_result(mutable_variant: "oops") func badMutableVariant() { } // expected-error{{'mutable_variant' parameter of 'warn_unused_result' attribute does not make sense on a non-method}}
 
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
1. Implement [SE-0040](https://github.com/apple/swift-evolution/blob/master/proposals/0040-attributecolons.md). Replace '=' with ':' before a attribute argument. The changes include parser (warning + fixit) and ASTPrinter.
2. Update tests accordingly.
3. Apply new syntax from the proposal to stdlib.

~~Note: at the time this PR is submitted, SE-0040 is still under review. I'm leaving this here _just in case this wild proposal gets accepted_.~~ SE-0040 has been approved.

![giphy-1](https://cloud.githubusercontent.com/assets/75067/13523532/e6be4024-e1aa-11e5-93e6-b8d58384042b.gif)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
