### PR TITLE
[stdlib] Remove what might be an unused CMake variable (RUNTIME_DEPENDENCY)

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -174,7 +174,6 @@ option(SWIFT_CHECK_ESSENTIAL_STDLIB
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_library(swift_stdlib_essential SHARED IS_STDLIB IS_STDLIB_CORE
       ${SWIFTLIB_ESSENTIAL})
-  target_link_libraries(swift_stdlib_essential ${RUNTIME_DEPENDENCY})
 endif()
 
 add_swift_library(swiftCore SHARED IS_STDLIB IS_STDLIB_CORE


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

**Warning: This PR is work in progress. This needs careful review from someone who understands the build process and CMake better than I do :-)**

Variable that _appear_ be unused:
- `RUNTIME_DEPENDENCY`

This variable appears to be unused judging from a naïve `git grep VARIABLE_NAME` scan. But perhaps it is used/set in a way that I'm missing :-)
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
