### PR TITLE
[stdlib] Fix an unused function warning on Linux

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -559,7 +559,7 @@ extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
   swift_deallocClassInstance(object, allocatedSize, allocatedAlignMask);
 }
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && defined(SWIFT_RUNTIME_CLOBBER_FREED_OBJECTS)
 static inline void memset_pattern8(void *b, const void *pattern8, size_t len) {
   char *ptr = static_cast<char *>(b);
   while (len >= 8) {


### PR DESCRIPTION
#### What's in this pull request?

Fixes a compiler warning on non Apple platforms.

```
swift/stdlib/public/runtime/HeapObject.cpp:563:20: warning: unused function 'memset_pattern8' [-Wunused-function]
static inline void memset_pattern8(void *b, const void *pattern8, size_t len) {
                   ^
```
