### PR TITLE
[stdlib] Remove 'never-returned-nil' precondition for GeneratorType.next()

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -164,8 +164,6 @@ public struct EnumerateGenerator<
 
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.
-  ///
-  /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Element? {
     guard let b = base.next() else { return nil }
     defer { count += 1 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -98,8 +98,6 @@ public struct IndexingGenerator<Elements : Indexable>
 
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.
-  ///
-  /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Elements._Element? {
     if _position == _elements.endIndex { return nil }
     let element = _elements[_position]
@@ -773,8 +771,6 @@ public struct PermutationGenerator<
 
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.
-  ///
-  /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> Element? {
     return indices.next().map { seq[$0] }
   }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -25,8 +25,7 @@ public struct GeneratorOfOne<Element> : GeneratorType, SequenceType {
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.
+  ///   since the copy was made.
   public mutating func next() -> Element? {
     let result = elements
     elements = nil

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -22,8 +22,7 @@ public struct LazyFilterGenerator<
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.
+  ///   since the copy was made.
   public mutating func next() -> Base.Element? {
     while let n = _base.next() {
       if _predicate(n) {

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -30,8 +30,7 @@ public struct FlattenGenerator<
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.
+  ///   since the copy was made.
   public mutating func next() -> Base.Element.Generator.Element? {
     repeat {
       if _fastPath(_inner != nil) {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3963,8 +3963,6 @@ public struct ${Self}Generator<${TypeParametersDecl}> : GeneratorType {
 
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.
-  ///
-  /// - Requires: No preceding call to `self.next()` has returned `nil`.
   public mutating func next() -> ${SequenceType}? {
     if _fastPath(_guaranteedNative) {
       return _nativeNext()

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -23,8 +23,7 @@ public struct LazyMapGenerator<
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.
+  ///   since the copy was made.
   public mutating func next() -> Element? {
     return _base.next().map(_transform)
   }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -30,10 +30,7 @@ public protocol GeneratorType {
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.  Specific implementations of this protocol
-  ///   are encouraged to respond to violations of this requirement by
-  ///   calling `preconditionFailure("...")`.
+  ///   since the copy was made.
   @warn_unused_result
   mutating func next() -> Element?
 }
@@ -639,8 +636,7 @@ public struct GeneratorSequence<
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.
+  ///   since the copy was made.
   public mutating func next() -> Base.Element? {
     return _base.next()
   }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -165,9 +165,6 @@ extension String {
 
       /// Advance to the next element and return it, or `nil` if no next
       /// element exists.
-      ///
-      /// - Requires: No preceding call to `self.next()` has returned
-      ///   `nil`.
       public mutating func next() -> UnicodeScalar? {
         var result: UnicodeDecodingResult
         if _baseSet {

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -35,8 +35,7 @@ public struct Zip2Generator<
   /// element exists.
   ///
   /// - Requires: `next()` has not been applied to a copy of `self`
-  ///   since the copy was made, and no preceding call to `self.next()`
-  ///   has returned `nil`.
+  ///   since the copy was made.
   public mutating func next() -> Element? {
     // The next() function needs to track if it has reached the end. If we
     // didn't, and the first sequence is longer than the second, then when we


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Removes the following precondition from `GeneratorType.next()`:

`- Requires: No preceding call to `self.next()` has returned `nil`.`

I (re-)checked all `GeneratorType` implementations in the standard library and they all already comply.

We could add an extra sentence to clarify that `nil` should be returned indefinitely, though perhaps that is already clear from the current description:

`/// Advance to the next element and return it, or `nil` if no next element exists.`

Swift evolution thread: http://thread.gmane.org/gmane.comp.lang.swift.evolution/focus=8519
