### PR TITLE
[build-script] Remove obsolete PM --build-tests

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2109,7 +2109,7 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 fi
                 echo "--- Running tests for ${product} ---"
                 set -x
-                "${swiftpm_bootstrap_command[@]}" --build-tests test
+                "${swiftpm_bootstrap_command[@]}" test
                 { set +x; } 2>/dev/null
                 # As swiftpm tests itself, we break early here.
                 continue


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The `swiftpm/Utilities/bootstrap --build-tests` parameter was deprecated in https://github.com/apple/swift-package-manager/commit/ae9121960e977066ee93c985602bb64df60db770 and is no longer used. Remove it to reduce confusion.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

/cc @mxcl 
