### PR TITLE
[Parse] Fix lookup of foo(_:bar:) expressions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -367,8 +367,8 @@ ERROR(expr_selector_module_missing,none,
       "import the 'ObjectiveC' module to use '#selector'", ())
 ERROR(expr_selector_no_declaration,none,
       "argument of '#selector' does not refer to an initializer or method", ())
-ERROR(expr_selector_property,none,
-      "argument of '#selector' cannot refer to a property", ())
+ERROR(expr_selector_var,none,
+      "argument of '#selector' cannot refer to a %select{property|parameter|variable}0", (int))
 ERROR(expr_selector_not_method_or_init,none,
       "argument of '#selector' does not refer to a method or initializer", ())
 ERROR(expr_selector_not_objc,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -541,7 +541,7 @@ public:
     getScopeInfo().addToScope(D, *this);
   }
 
-  ValueDecl *lookupInScope(Identifier Name) {
+  ValueDecl *lookupInScope(DeclName Name) {
     return getScopeInfo().lookupValueName(Name);
   }
 

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -35,7 +35,7 @@ class ScopeInfo {
 public:
   typedef std::pair<unsigned, ValueDecl*> ValueScopeEntry;
   
-  typedef TreeScopedHashTable<Identifier, ValueScopeEntry> ScopedHTTy;
+  typedef TreeScopedHashTable<DeclName, ValueScopeEntry> ScopedHTTy;
   typedef ScopedHTTy::ScopeTy ScopedHTScopeTy;
   typedef ScopedHTTy::DetachedScopeTy ScopedHTDetachedScopeTy;
 
@@ -46,7 +46,7 @@ private:
   unsigned ResolvableDepth = 0;
 
 public:
-  ValueDecl *lookupValueName(Identifier Name);
+  ValueDecl *lookupValueName(DeclName Name);
 
   Scope *getCurrentScope() const { return CurScope; }
 
@@ -158,7 +158,7 @@ public:
   }
 };
 
-inline ValueDecl *ScopeInfo::lookupValueName(Identifier Name) {
+inline ValueDecl *ScopeInfo::lookupValueName(DeclName Name) {
   // FIXME: this check can go away when SIL parser parses everything in
   // a toplevel scope.
   if (!CurScope)

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1587,7 +1587,7 @@ Expr *Parser::parseExprIdentifier() {
     hasGenericArgumentList = !args.empty();
   }
   
-  ValueDecl *D = lookupInScope(name.getBaseName());
+  ValueDecl *D = lookupInScope(name);
   // FIXME: We want this to work: "var x = { x() }", but for now it's better
   // to disallow it than to crash.
   if (D) {

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -112,7 +112,7 @@ void ScopeInfo::addToScope(ValueDecl *D, Parser &TheParser) {
 
   // If we have a shadowed variable definition, check to see if we have a
   // redefinition: two definitions in the same scope with the same name.
-  ScopedHTTy::iterator EntryI = HT.begin(CurScope->HTScope, D->getName());
+  ScopedHTTy::iterator EntryI = HT.begin(CurScope->HTScope, D->getFullName());
 
   // A redefinition is a hit in the scoped table at the same depth.
   if (EntryI != HT.end() && EntryI->first == CurScope->getDepth()) {
@@ -135,6 +135,6 @@ void ScopeInfo::addToScope(ValueDecl *D, Parser &TheParser) {
   }
 
   HT.insertIntoScope(CurScope->HTScope,
-                     D->getName(),
+                     D->getFullName(),
                      std::make_pair(CurScope->getDepth(), D));
 }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3342,11 +3342,20 @@ namespace {
       // complain.
       auto func = dyn_cast<AbstractFunctionDecl>(foundDecl);
       if (!func) {
-        tc.diagnose(E->getLoc(),
-                    isa<VarDecl>(foundDecl)
-                      ? diag::expr_selector_property
-                      : diag::expr_selector_not_method_or_init)
-          .highlight(subExpr->getSourceRange());
+        Optional<InFlightDiagnostic> diag;
+        if (auto VD = dyn_cast<VarDecl>(foundDecl)) {
+          diag.emplace(tc.diagnose(E->getLoc(), diag::expr_selector_var,
+                                   isa<ParamDecl>(VD)
+                                   ? 1
+                                   : VD->getDeclContext()->isTypeContext()
+                                     ? 0
+                                     : 2));
+        } else {
+          diag.emplace(tc.diagnose(E->getLoc(),
+                                   diag::expr_selector_not_method_or_init));
+        }
+        diag->highlight(subExpr->getSourceRange());
+        diag.reset();
         tc.diagnose(foundDecl, diag::decl_declared_here,
                     foundDecl->getFullName());
         return E;

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -26,6 +26,14 @@ class C1 {
     _ = testUnqualifiedSelector // suppress unused warning
   }
 
+  @objc func testParam(testParam: A) { // expected-note{{'testParam' declared here}}
+    _ = #selector(testParam) // expected-error{{argument of '#selector' cannot refer to a parameter}}
+  }
+
+  @objc func testVariable() {
+    let testVariable = 1 // expected-note{{'testVariable' declared here}}
+    _ = #selector(testVariable) // expected-error{{argument of '#selector' cannot refer to a variable}}
+  }
 }
 
 @objc protocol P1 {

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -18,6 +18,14 @@ class C1 {
   @objc var a: A = A() // expected-note{{'a' declared here}}
 
   @objc func getC1() -> AnyObject { return self }
+
+  @objc func testUnqualifiedSelector(a: A, b: B) {
+    _ = #selector(testUnqualifiedSelector(_:b:))
+    let testUnqualifiedSelector = 1
+    _ = #selector(testUnqualifiedSelector(_:b:))
+    _ = testUnqualifiedSelector // suppress unused warning
+  }
+
 }
 
 @objc protocol P1 {


### PR DESCRIPTION
#### What's in this pull request?

This fixes an issue where `foo(_:bar:)` expressions were resolving to a local variable or parameter `foo` instead of resolving to the correct `foo(_:bar:)` function. The problem is that `Scope` was only storing `Identifier`s and so only the base name was being used for lookup. I switched `Scope` to storing `DeclName`s instead, and it seems to work. However, I'm not particularly familiar with this code, so I don't know if there's any drawbacks to this approach.

This PR also improves the diagnostics for `#selector()` expressions to properly refer to variables and parameters instead of always calling them properties.
#### Resolved bug number: ([SR-880](https://bugs.swift.org/browse/SR-880))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
