### PR TITLE
[gardening] Remove double new lines from stdlib files

### DIFF
--- a/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
+++ b/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
@@ -183,4 +183,3 @@ public func ⊉ <
   >(lhs: Set<T>, rhs: S) -> Bool {
   return !lhs.isSupersetOf(rhs)
 }
-

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -1244,4 +1244,3 @@ self.test("\(testNamePrefix).suffix/semantics") {
 //===----------------------------------------------------------------------===//
   } // addRandomAccessCollectionTests
 }
-

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -1286,4 +1286,3 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
     // No extra checks for collections with random access traversal so far.
   } // addRandomAccessRangeReplaceableCollectionTests
 }
-

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -348,4 +348,3 @@ extension TestSuite {
     // No tests yet.
   } // addRandomAccessRangeReplaceableCollectionTests
 }
-

--- a/stdlib/private/StdlibCollectionUnittest/StdlibCollectionUnittest.swift
+++ b/stdlib/private/StdlibCollectionUnittest/StdlibCollectionUnittest.swift
@@ -19,4 +19,3 @@ import SwiftPrivate
 #if _runtime(_ObjC)
 import ObjectiveC
 #endif
-

--- a/stdlib/private/StdlibUnittest/Statistics.swift
+++ b/stdlib/private/StdlibUnittest/Statistics.swift
@@ -47,5 +47,3 @@ public func chiSquaredUniform2(
   }
   return true
 }
-
-

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -177,4 +177,3 @@ public func forAllPermutations<S : SequenceType>(
     return ()
   }
 }
-

--- a/stdlib/private/StdlibUnittest/TypeIndexed.swift
+++ b/stdlib/private/StdlibUnittest/TypeIndexed.swift
@@ -109,4 +109,3 @@ public func expectEqual<V: Comparable>(
     actual.byType,
     message(), stackTrace: stackTrace) { $0 <=> $1 }
 }
-

--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -73,4 +73,3 @@ public func autoreleasepoolIfUnoptimizedReturnAutoreleased(
   body()
 #endif
 }
-

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -128,4 +128,3 @@ public struct _FDOutputStream : OutputStreamType {
     isClosed = true
   }
 }
-

--- a/stdlib/private/SwiftPrivate/PRNG.swift
+++ b/stdlib/private/SwiftPrivate/PRNG.swift
@@ -61,4 +61,3 @@ public func pickRandom<
   let i = Int(rand32(exclusiveUpperBound: numericCast(c.count)))
   return c[c.startIndex.advancedBy(numericCast(i))]
 }
-

--- a/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
+++ b/stdlib/private/SwiftPrivate/ShardedAtomicCounter.swift
@@ -80,4 +80,3 @@ public struct _stdlib_ShardedAtomicCounter {
     }
   }
 }
-

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -95,4 +95,3 @@ public func withArrayOfCStrings<R>(
     return body(cStrings)
   }
 }
-

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -127,4 +127,3 @@ public func WEXITSTATUS(status: CInt) -> CInt {
 public func WTERMSIG(status: CInt) -> CInt {
   return _WSTATUS(status)
 }
-

--- a/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
@@ -129,4 +129,3 @@ public func _stdlib_pthread_barrier_wait(
     return _stdlib_PTHREAD_BARRIER_SERIAL_THREAD
   }
 }
-

--- a/stdlib/public/core/ArrayBody.swift
+++ b/stdlib/public/core/ArrayBody.swift
@@ -81,4 +81,3 @@ internal struct _ArrayBody {
     }
   }
 }
-

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -99,4 +99,3 @@ public prefix func !(a: Bool) -> Bool {
 public func ==(lhs: Bool, rhs: Bool) -> Bool {
   return Bool(Builtin.cmp_eq_Int1(lhs._value, rhs._value))
 }
-

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -193,4 +193,3 @@ add_swift_library(swiftCore SHARED IS_STDLIB IS_STDLIB_CORE
   PRIVATE_LINK_LIBRARIES ${swift_core_private_link_libraries}
   FRAMEWORK_DEPENDS ${swift_core_framework_depends}
   INSTALL_IN_COMPONENT stdlib)
-

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -826,4 +826,3 @@ public func suffix<
 
 @available(*, unavailable, renamed="CollectionType")
 public struct Sliceable {}
-

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -300,4 +300,3 @@ ${orderingRequirementForPredicate}
     }
   }
 }
-

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -76,4 +76,3 @@ public struct EmptyCollection<Element> : CollectionType {
     return 0
   }
 }
-

--- a/stdlib/public/core/Existential.swift
+++ b/stdlib/public/core/Existential.swift
@@ -63,4 +63,3 @@ internal struct _CollectionOf<
 
 @available(*, unavailable, message="SinkOf has been removed. Use (T) -> () closures directly instead.")
 public struct SinkOf<T> {}
-

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -79,4 +79,3 @@ extension ${Self} {
 % end
 
 % end
-

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -182,4 +182,3 @@ func _squeezeHashValue(hashValue: Int, _ resultRange: Range<UInt>) -> UInt {
   }
   return resultRange.startIndex + (mixedHashValue % resultCardinality)
 }
-

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -230,4 +230,3 @@ func == <Value, Element> (
   rhs: _HeapBuffer<Value, Element>) -> Bool {
   return lhs._nativeObject == rhs._nativeObject
 }
-

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -65,4 +65,3 @@ public func readLine(stripNewline stripNewline: Bool = true) -> String? {
   _swift_stdlib_free(linePtr)
   return result
 }
-

--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -141,4 +141,3 @@ extension ${Self} {
 }
 
 % end
-

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -184,4 +184,3 @@ public func join<
 ) -> C {
   fatalError("unavailable function can't be called")
 }
-

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -211,4 +211,3 @@ extension LazySequenceType {
 public func lazy<Base : SequenceType>(s: Base) -> LazySequence<Base> {
   fatalError("unavailable")
 }
-

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -819,4 +819,3 @@ extension Mirror : CustomReflectable {
 
 @available(*, unavailable, renamed="PlaygroundQuickLook")
 public typealias QuickLookObject = PlaygroundQuickLook
-

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -164,4 +164,3 @@ func _floorLog2(x: Int64) -> Int {
   // overflow.
   return 63 &- Int(_countLeadingZeros(x))
 }
-

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -437,4 +437,3 @@ internal struct _TeeStream<
   mutating func _lock() { left._lock(); right._lock() }
   mutating func _unlock() { left._unlock(); right._unlock() }
 }
-

--- a/stdlib/public/core/Process.swift
+++ b/stdlib/public/core/Process.swift
@@ -72,4 +72,3 @@ func _didEnterMain(
   Process._argc = CInt(argc)
   Process._unsafeArgv = UnsafeMutablePointer(argv)
 }
-

--- a/stdlib/public/core/REPL.swift
+++ b/stdlib/public/core/REPL.swift
@@ -23,4 +23,3 @@ public // COMPILER_INTRINSIC
 func _replDebugPrintln<T>(value: T) {
   debugPrint(value)
 }
-

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -234,4 +234,3 @@ public func ~= <I : ForwardIndexType where I : Comparable> (
 ) -> Bool {
   return pattern.contains(value)
 }
-

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -532,4 +532,3 @@ struct _MetatypeMirror : _MirrorType {
 public func reflect<T>(x: T) -> _MirrorType {
   fatalError("unavailable function can't be called")
 }
-

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -56,4 +56,3 @@ public struct Repeat<Element> : CollectionType {
   /// The value of every element in this collection.
   public let repeatedValue: Element
 }
-

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -647,4 +647,3 @@ public struct GeneratorSequence<
 
   internal var _base: Base
 }
-

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -420,4 +420,3 @@ extension SequenceType {
     return result
   }
 }
-

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -125,4 +125,3 @@ public struct MutableSlice<Base : MutableIndexable> : MutableCollectionType {
   internal var _startIndex: Index
   internal var _endIndex: Index
 }
-

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -988,4 +988,3 @@ extension String.Index {
     return String.UnicodeScalarView.Index(self, within: unicodeScalars)
   }
 }
-

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -309,4 +309,3 @@ extension String.CharacterView {
       String(_core).unicodeScalars[unicodeScalarRange]._core)
   }
 }
-

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -108,4 +108,3 @@ ${stringSubscriptComment}
     fatalError("unavailable function can't be called")
   }
 }
-

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -955,4 +955,3 @@ extension UTF16 {
     return (count, isAscii)
   }
 }
-

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -330,4 +330,3 @@ func _ascii16(c: UnicodeScalar) -> UTF16.CodeUnit {
   _sanityCheck(c.value >= 0 && c.value <= 0x7F, "not ASCII")
   return UTF16.CodeUnit(c.value)
 }
-

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -501,4 +501,3 @@ public struct RawByte {
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:
-

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -433,4 +433,3 @@ final public class VaListBuilder {
 }
 
 #endif
-

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -102,4 +102,3 @@ public struct ZipGenerator2<
 public struct Zip2<
   Sequence1 : SequenceType, Sequence2 : SequenceType
 > {}
-


### PR DESCRIPTION
I spotted a double newline at the end of a file whilst browsing the source, so I fixed all similar occurences
