### PR TITLE
Replace XFAIL with Requires for ArrayBridge

### DIFF
--- a/test/1_stdlib/ArrayBridge.swift
+++ b/test/1_stdlib/ArrayBridge.swift
@@ -19,8 +19,7 @@
 // RUN: %target-run %t/ArrayBridge > %t.txt
 // RUN: FileCheck %s < %t.txt
 // REQUIRES: executable_test
-
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import Foundation
 import ArrayBridgeObjC


### PR DESCRIPTION
All code in ArrayBridge requires objc interop, so this is why it fails
on Linux, I think.
