### PR TITLE
[AST/Sema] Don't crash when referencing enum case in where-clause

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5270,7 +5270,9 @@ public:
         static_cast<unsigned>(ElementRecursiveness::NotRecursive);
   }
 
-  void computeType();
+  /// \returns false if there was an error during the computation rendering the
+  /// EnumElementDecl invalid, true otherwise.
+  bool computeType();
 
   bool hasArgumentType() const { return !ArgumentType.getType().isNull(); }
   Type getArgumentType() const { return ArgumentType.getType(); }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4309,7 +4309,7 @@ SourceRange EnumElementDecl::getSourceRange() const {
   return {getStartLoc(), getNameLoc()};
 }
 
-void EnumElementDecl::computeType() {
+bool EnumElementDecl::computeType() {
   EnumDecl *ED = getParentEnum();
 
   Type resultTy = ED->getDeclaredTypeInContext();
@@ -4326,6 +4326,7 @@ void EnumElementDecl::computeType() {
     resultTy = FunctionType::get(argTy, resultTy);
 
   setType(resultTy);
+  return true;
 }
 
 Type EnumElementDecl::getArgumentInterfaceType() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4311,8 +4311,13 @@ SourceRange EnumElementDecl::getSourceRange() const {
 
 bool EnumElementDecl::computeType() {
   EnumDecl *ED = getParentEnum();
-
   Type resultTy = ED->getDeclaredTypeInContext();
+
+  if (resultTy->is<ErrorType>()) {
+    setType(resultTy);
+    return false;
+  }
+
   Type argTy = MetatypeType::get(resultTy);
 
   // The type of the enum element is either (T) -> T or (T) -> ArgType -> T.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5543,11 +5543,14 @@ public:
       EED->setRecursiveness(ElementRecursiveness::NotRecursive);
     }
 
-    // Now that we have an argument type we can set the element's declared
-    // type.
-    if (!EED->hasType())
-      EED->computeType();
-    EED->setIsBeingTypeChecked(false);
+    {
+      defer { EED->setIsBeingTypeChecked(false); };
+
+      // Now that we have an argument type we can set the element's declared
+      // type.
+      if (!EED->hasType() && !EED->computeType())
+        return;
+    }
 
     // Test for type parameters, as opposed to a generic decl context, in
     // case the enclosing enum type was illegally declared inside of a generic

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -334,3 +334,5 @@ struct UnsolvableInheritance1<T : T.A> {}
 struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 // expected-error@-1 {{inheritance from non-protocol, non-class type 'U.A'}}
 // expected-error@-2 {{inheritance from non-protocol, non-class type 'T.A'}}
+
+enum X7<T where X7.X : G> { case X } // expected-error{{'X' is not a member type of 'X7<T>'}}

--- a/validation-test/compiler_crashers_fixed/28224-swift-genericfunctiontype-get.swift
+++ b/validation-test/compiler_crashers_fixed/28224-swift-genericfunctiontype-get.swift
@@ -5,6 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 {enum S<T where S.c:A{case c


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Before, something like this crashed:

``` swift
protocol P {}
enum E<T where E.C : P> { case C }
```

The compiler tried to compute the interface type of the `C` case, but failed because `E` had no generic signature set. Now it bails out before trying to do this, producing the correct error message about `C` being no member type of `E`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
