### PR TITLE
[build-script] Build Foundation before XCTest [AsyncXCTest 4/6]

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -729,6 +729,12 @@ the number of parallel build jobs to use""",
     if args.test_optimized:
         args.test = True
 
+    # XCTest has a dependency on Foundation.
+    # On OS X, Foundation is built automatically using xcodebuild.
+    # On Linux, we must build ensure that it is built manually.
+    if args.build_xctest and platform.system() != "Darwin":
+        args.build_foundation = True
+
     # --skip-test-ios is merely a shorthand for host and simulator tests.
     if args.skip_test_ios:
         args.skip_test_ios_host = True

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -947,14 +947,16 @@ fi
 if [[ ! "${SKIP_BUILD_SWIFTPM}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" swiftpm)
 fi
-if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
-     PRODUCTS=("${PRODUCTS[@]}" xctest)
-fi
 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" libdispatch)
 fi
+# XCTest has a dependency on Foundation, so Foundation must be added to the
+# list of build products first.
 if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
      PRODUCTS=("${PRODUCTS[@]}" foundation)
+fi
+if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
+     PRODUCTS=("${PRODUCTS[@]}" xctest)
 fi
 
 SWIFT_STDLIB_TARGETS=()
@@ -1343,7 +1345,8 @@ function set_swiftpm_bootstrap_command() {
     
     SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
     LLBUILD_BIN="$(build_directory_bin ${deployment_target} llbuild)/swift-build-tool"
-    if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
+    if [[ ! "${SKIP_BUILD_FOUNDATION}" && ! "${SKIP_BUILD_XCTEST}" ]] ; then
+        FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
         XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
     fi
     if [ ! -e "${LLBUILD_BIN}" ]; then
@@ -1357,8 +1360,8 @@ function set_swiftpm_bootstrap_command() {
     swiftpm_bootstrap_command=("${swiftpm_bootstrap_command[@]}" --swiftc="${SWIFTC_BIN}")
     swiftpm_bootstrap_command=("${swiftpm_bootstrap_command[@]}" --sbt="${LLBUILD_BIN}")
     swiftpm_bootstrap_command=("${swiftpm_bootstrap_command[@]}" --build="${build_dir}")
-    if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
-        swiftpm_bootstrap_command=("${swiftpm_bootstrap_command[@]}" --xctest="${XCTEST_BUILD_DIR}")
+    if [[ ! "${SKIP_BUILD_FOUNDATION}" && ! "${SKIP_BUILD_XCTEST}" ]] ; then
+        swiftpm_bootstrap_command=("${swiftpm_bootstrap_command[@]}" --foundation="${FOUNDATION_BUILD_DIR}/Foundation" --xctest="${XCTEST_BUILD_DIR}")
     fi
 }
 
@@ -1859,7 +1862,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                     set -x
                     xcodebuild \
-                        -project "${XCTEST_SOURCE_DIR}"/XCTest.xcodeproj \
+                        -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
                         -scheme SwiftXCTest \
                         SKIP_INSTALL=NO \
                         DEPLOYMENT_LOCATION=YES \
@@ -1868,12 +1871,14 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     { set +x; } 2>/dev/null
                 else
                     SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
+                    FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
                     set -x
                     # FIXME: Use XCTEST_BUILD_TYPE (which is never properly
                     #        set) to build either --debug or --release.
                     "${XCTEST_SOURCE_DIR}"/build_script.py \
                         --swiftc="${SWIFTC_BIN}" \
-                        --build-dir="${XCTEST_BUILD_DIR}"
+                        --build-dir="${XCTEST_BUILD_DIR}" \
+                        --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation"
                     { set +x; } 2>/dev/null
                 fi
 
@@ -1881,7 +1886,9 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 continue
                 ;;
             foundation)
-                # the configuration script requires knowing about XCTest's location for building and running the tests
+                # The configuration script requires knowing about XCTest's
+                # location for building and running the tests. Note that XCTest
+                # is not yet built at this point.
                 XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
                 SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
                 SWIFT_BIN="$(build_directory_bin ${deployment_target} swift)/swift"
@@ -2122,15 +2129,17 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                     set -x
                     xcodebuild \
-                        -project "${XCTEST_SOURCE_DIR}"/XCTest.xcodeproj \
+                        -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
                         -scheme SwiftXCTestFunctionalTests
                     { set +x; } 2>/dev/null
                 else
                     SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
+                    FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
                     XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
                     set -x
                     "${XCTEST_SOURCE_DIR}"/build_script.py test \
                         --swiftc="${SWIFTC_BIN}" \
+                        --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
                         "${XCTEST_BUILD_DIR}"
                     { set +x; } 2>/dev/null
                 fi


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

> This is [the fourth of six pull requests](https://github.com/apple/swift-corelibs-xctest/pull/43#issuecomment-192813377) necessary to introduce asynchronous testing to swift-corelibs-xctest.

https://github.com/apple/swift-corelibs-xctest/pull/43 introduces a dependency between XCTest and Foundation. Modify the build script in order to properly build all products:
- Build Foundation before XCTest, then link Foundation when building XCTest by using new '--foundation-build-dir' option from https://github.com/apple/swift-corelibs-xctest/pull/62.
- Link Foundation when testing SwiftPM by using new '--foundation' option from https://github.com/apple/swift-package-manager/pull/176.
- On Linux, ensure Foundation is built when XCTest is.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Confirm https://github.com/apple/swift-corelibs-xctest/pull/62 has been merged.
- [x] Confirm https://github.com/apple/swift-corelibs-xctest/pull/63 has been merged.
- [x] Confirm https://github.com/apple/swift-package-manager/pull/176 has been merged.
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
