### PR TITLE
Change all remaining tests to use associatedtype instead of typealias in protocols

### DIFF
--- a/test/1_stdlib/BridgeStorage.swift.gyb
+++ b/test/1_stdlib/BridgeStorage.swift.gyb
@@ -28,8 +28,8 @@ import Swift
 import SwiftShims
 
 protocol BridgeStorage {
-  typealias Native : AnyObject
-  typealias ObjC : AnyObject
+  associatedtype Native : AnyObject
+  associatedtype ObjC : AnyObject
 
   init(native: Native, bits: Int)
   init(native: Native)

--- a/test/1_stdlib/TypeName.swift
+++ b/test/1_stdlib/TypeName.swift
@@ -8,9 +8,9 @@ enum E {}
 protocol P {}
 protocol P2 {}
 protocol AssociatedTypes {
-  typealias A
-  typealias B
-  typealias C
+  associatedtype A
+  associatedtype B
+  associatedtype C
 }
 
 class Model : AssociatedTypes {

--- a/test/DebugInfo/archetype.swift
+++ b/test/DebugInfo/archetype.swift
@@ -5,7 +5,7 @@ protocol IntegerArithmetic {
 }
 
 protocol RandomAccessIndex : IntegerArithmetic {
-  typealias Distance : IntegerArithmetic
+  associatedtype Distance : IntegerArithmetic
   static func uncheckedSubtract(lhs: Self, rhs: Self) -> (Distance, Bool)
 }
 

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -56,13 +56,13 @@ func foo(n : Float) -> Int {
 }
 
 // CHECK-LABEL: protocol <Protocol>Prot</Protocol> {
-// CHECK-NEXT:   typealias <AssociatedType>Blarg</AssociatedType>
+// CHECK-NEXT:   associatedtype <AssociatedType>Blarg</AssociatedType>
 // CHECK-NEXT:   func <Func>protMeth</Func>(<Param>x</Param>: <iStruct@>Int</iStruct>)
 // CHECK-NEXT:   var <Var>protocolProperty1</Var>: <iStruct@>Int</iStruct> { get }
 // CHECK-NEXT:   var <Var>protocolProperty2</Var>: <iStruct@>Int</iStruct> { get set }
 // CHECK-NEXT: }
 protocol Prot {
-  typealias Blarg
+  associatedtype Blarg
   func protMeth(x: Int)
   var protocolProperty1: Int { get }
   var protocolProperty2: Int { get set }
@@ -81,7 +81,7 @@ class SubCls : MyCls, Prot {
   var protocolProperty2 = 0
 }
 
-// CHECK: func <Func>genFn</Func><<GenericTypeParam>T</GenericTypeParam> : <Protocol@64:10>Prot</Protocol> where <GenericTypeParam@85:12>T</GenericTypeParam>.<AssociatedType@65:13>Blarg</AssociatedType> : <Protocol@71:10>Prot2</Protocol>>(<Param>p</Param> : <GenericTypeParam@85:12>T</GenericTypeParam>) -> <iStruct@>Int</iStruct> {}{{$}}
+// CHECK: func <Func>genFn</Func><<GenericTypeParam>T</GenericTypeParam> : <Protocol@64:10>Prot</Protocol> where <GenericTypeParam@85:12>T</GenericTypeParam>.<AssociatedType@65:18>Blarg</AssociatedType> : <Protocol@71:10>Prot2</Protocol>>(<Param>p</Param> : <GenericTypeParam@85:12>T</GenericTypeParam>) -> <iStruct@>Int</iStruct> {}{{$}}
 func genFn<T : Prot where T.Blarg : Prot2>(p : T) -> Int {}
 
 func test(x: Int) {

--- a/test/IDE/comment_attach.swift
+++ b/test/IDE/comment_attach.swift
@@ -184,7 +184,7 @@ class decl_class_1 {
 /// decl_protocol_1 Aaa.
 protocol decl_protocol_1 {
   /// NestedTypealias Aaa.
-  typealias NestedTypealias
+  associatedtype NestedTypealias
 
   /// instanceFunc1 Aaa.
   func instanceFunc1()
@@ -293,7 +293,7 @@ func unterminatedBlockDocComment() {}
 // CHECK-NEXT: comment_attach.swift:177:15: EnumElement/decl_enum_1.Case5 RawComment=[/// Case4 Case5 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:181:7: Class/decl_class_1 RawComment=[/// decl_class_1 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:185:10: Protocol/decl_protocol_1 RawComment=[/// decl_protocol_1 Aaa.\n]
-// CHECK-NEXT: comment_attach.swift:187:13: AssociatedType/decl_protocol_1.NestedTypealias RawComment=[/// NestedTypealias Aaa.\n]
+// CHECK-NEXT: comment_attach.swift:187:18: AssociatedType/decl_protocol_1.NestedTypealias RawComment=[/// NestedTypealias Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:190:8: Func/decl_protocol_1.instanceFunc1 RawComment=[/// instanceFunc1 Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:193:7: Var/decl_protocol_1.propertyWithGet RawComment=[/// propertyWithGet Aaa.\n]
 // CHECK-NEXT: comment_attach.swift:193:30: Func/decl_protocol_1.<getter for decl_protocol_1.propertyWithGet> RawComment=none

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -167,7 +167,7 @@ func testArchetypeReplacement3 (a : [Int]) {
 
 
 protocol P2 {
-  typealias MyElement
+  associatedtype MyElement
 }
 
 extension P2 {

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -100,7 +100,7 @@ func testPostfix8(x: S) {
 // POSTFIX_8-NOT: ***
 
 protocol P {
-  typealias T
+  associatedtype T
   func foo() -> T
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1583,7 +1583,7 @@ func testGenericConforming3<T: P3>(x: T) {
 
 struct OnlyMe {}
 protocol P4 {
-  typealias T
+  associatedtype T
 }
 extension P4 where Self.T : P1 {
   final func extP4WhenP1() {}
@@ -1724,7 +1724,7 @@ extension P4 where Self.T == WillConformP1 {
 // PROTOCOL_EXT_P4_T_DOT_1: End completions
 
 protocol PWithT {
-  typealias T
+  associatedtype T
   func foo(x: T) -> T
 }
 
@@ -1745,7 +1745,7 @@ func testUnusableProtExt(x: PWithT) {
 // PROTOCOL_EXT_UNUSABLE_EXISTENTIAL: End completions
 
 protocol dedupP {
-  typealias T
+  associatedtype T
   func foo() -> T
   var bar: T {get}
   subscript(x: T) -> T {get}

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -7,7 +7,7 @@ protocol P {}
 protocol Q {}
 
 protocol Assocked {
-  typealias Assoc : P, Q
+  associatedtype Assoc : P, Q
 }
 
 struct Universal : P, Q {}
@@ -124,7 +124,7 @@ struct Computed<T, U> : Assocked {
 
 struct PBox<T: P> {}
 protocol HasSimpleAssoc {
-  typealias Assoc
+  associatedtype Assoc
 }
 protocol DerivedFromSimpleAssoc : HasSimpleAssoc {}
 
@@ -163,7 +163,7 @@ struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
 
 
 protocol HasAssocked {
-  typealias Contents : Assocked
+  associatedtype Contents : Assocked
 }
 struct FulfilledFromAssociatedType<T : HasAssocked> : HasSimpleAssoc {
   typealias Assoc = PBox<T.Contents.Assoc>

--- a/test/IRGen/dependent_reabstraction.swift
+++ b/test/IRGen/dependent_reabstraction.swift
@@ -3,7 +3,7 @@
 func markUsed<T>(t: T) {}
 
 protocol A {
-  typealias B
+  associatedtype B
   func b(_: B)
 }
 

--- a/test/IRGen/infinite_archetype.swift
+++ b/test/IRGen/infinite_archetype.swift
@@ -3,7 +3,7 @@
 // REQUIRES: CPU=i386_or_x86_64
 
 protocol Fooable {
-  typealias Foo
+  associatedtype Foo
 }
 
 // CHECK: define hidden void @_TF18infinite_archetype3foo{{.*}}(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.Fooable)

--- a/test/IRGen/partial_apply_generic.swift
+++ b/test/IRGen/partial_apply_generic.swift
@@ -16,7 +16,7 @@ func ~> <Target, Args, Result> (
 }
 
 protocol Runcible {
-  typealias Element
+  associatedtype Element
 }
 
 struct Mince {}

--- a/test/IRGen/protocol_extensions_constrain.swift
+++ b/test/IRGen/protocol_extensions_constrain.swift
@@ -7,7 +7,7 @@ public protocol P1 {
 }
 
 public protocol P2 {
-  typealias Index : P1
+  associatedtype Index : P1
 
   var startIndex: Index {get}
 }

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -6,7 +6,7 @@ public struct DefaultFoo<T> {
 }
 
 public protocol P {
-  typealias Foo
+  associatedtype Foo
 }
 
 public extension P where Foo == DefaultFoo<Self> {

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -12,7 +12,7 @@ import sil_witness_tables_external_conformance
 protocol A {}
 
 protocol P {
-  typealias Assoc: A
+  associatedtype Assoc: A
 
   static func staticMethod()
   func instanceMethod()

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -3,14 +3,14 @@
 protocol A {}
 
 protocol B {
-  typealias AA: A
+  associatedtype AA: A
   func foo()
 }
 
 @objc protocol O {}
 
 protocol C {
-  typealias OO: O
+  associatedtype OO: O
   func foo()
 }
 

--- a/test/Interpreter/dependent_reabstraction.swift
+++ b/test/Interpreter/dependent_reabstraction.swift
@@ -2,7 +2,7 @@
 // REQUIRES: executable_test
 
 protocol A {
-  typealias B
+  associatedtype B
   func b(_: B)
 }
 

--- a/test/Interpreter/function_metatypes.swift
+++ b/test/Interpreter/function_metatypes.swift
@@ -2,7 +2,7 @@
 // REQUIRES: executable_test
 
 protocol ProtocolHasInOut {
-  typealias Input
+  associatedtype Input
   typealias Mutator = (inout Input) -> ()
   var f: Mutator { get }
 }

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -67,8 +67,10 @@ internal func _splitRandomAccessIndexRange<Index : RandomAccessIndex>(
 /// Using a builder can be more efficient than creating an empty collection
 /// instance and adding elements one by one.
 public protocol CollectionBuilder {
-  typealias Destination : Collection
-  typealias Element = Destination.Iterator.Element
+  associatedtype Destination : Collection
+    
+  // FIXME: should really be a typealias once that is supported
+  associatedtype Element = Destination.Iterator.Element
 
   init()
 
@@ -118,7 +120,7 @@ public protocol CollectionBuilder {
 }
 
 public protocol BuildableCollectionProtocol : Collection {
-  typealias Builder : CollectionBuilder
+  associatedtype Builder : CollectionBuilder
 }
 
 extension Array : SplittableCollection {
@@ -518,7 +520,7 @@ final class _ForkJoinWorkerThread {
 }
 
 internal protocol _Future {
-  typealias Result
+  associatedtype Result
 
   /// Establishes a happens-before relation between completing the future and
   /// the call to wait().
@@ -827,8 +829,8 @@ final public class ForkJoinPool {
 //===----------------------------------------------------------------------===//
 
 internal protocol _CollectionTransformerStepProtocol /*: class*/ {
-  typealias PipelineInputElement
-  typealias OutputElement
+  associatedtype PipelineInputElement
+  associatedtype OutputElement
 
   func transform<
     InputCollection : Collection,
@@ -1070,7 +1072,7 @@ struct _ElementCollectorOneToMaybeOne<
 }
 
 protocol _ElementCollector {
-  typealias Element
+  associatedtype Element
 
   mutating func sizeHint(approximateSize: Int)
 

--- a/test/Prototypes/FloatingPoint.swift
+++ b/test/Prototypes/FloatingPoint.swift
@@ -36,7 +36,7 @@ public protocol FloatingPoint : Comparable, SignedNumber,
 FloatLiteralConvertible {
   
   /// An unsigned integer type large enough to hold the significand field.
-  typealias SignificandBits: FloatingPointRepresentation
+  associatedtype SignificandBits: FloatingPointRepresentation
   
   /// Positive infinity.
   ///
@@ -841,7 +841,7 @@ extension BinaryFloatingPoint {
 public protocol FloatingPointInterchange: FloatingPoint {
   
   /// An unsigned integer type used to represent floating-point encodings.
-  typealias BitPattern: FloatingPointRepresentation
+  associatedtype BitPattern: FloatingPointRepresentation
   
   /// Interpret `encoding` as a little-endian encoding of `Self`.
   init(littleEndian encoding: BitPattern)

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -187,7 +187,7 @@ public protocol IntegerType
   // possible, and we really need to factor IntegerType differently
   // than it currently is so we can remove the constraints on
   // AbsoluteValue in the multiprecision multiplication routines.
-  typealias AbsoluteValue : Comparable, ArithmeticType, 
+  associatedtype AbsoluteValue : Comparable, ArithmeticType,
     IntegerLiteralConvertible, CustomStringConvertible 
 
   var absoluteValue: AbsoluteValue { get }
@@ -649,7 +649,7 @@ public func &${x.operator} <T: FixedWidthIntegerType>(lhs: T, rhs: T) -> T {
 //===--- UnsignedIntegerType ----------------------------------------------===//
 //===----------------------------------------------------------------------===//
 public protocol UnsignedIntegerType : IntegerType {
-  typealias AbsoluteValue : IntegerType  
+  associatedtype AbsoluteValue : IntegerType
 }
 
 extension UnsignedIntegerType {
@@ -731,7 +731,7 @@ extension UnsignedIntegerType where Self : FixedWidthIntegerType {
 //===----------------------------------------------------------------------===//
 
 public protocol SignedIntegerType : IntegerType {
-  typealias AbsoluteValue : IntegerType
+  associatedtype AbsoluteValue : IntegerType
 }
 
 extension SignedIntegerType {

--- a/test/Prototypes/TextFormatting.swift
+++ b/test/Prototypes/TextFormatting.swift
@@ -35,7 +35,7 @@ protocol XStreamable {
 /// declare conformance: simply give the type a debugFormat().
 protocol XDebugPrintable {
 
-  typealias DebugRepresentation : XStreamable // = String
+  associatedtype DebugRepresentation : XStreamable // = String
 
   /// \brief Produce a textual representation for the REPL and
   /// Debugger.
@@ -89,7 +89,7 @@ func ~> <T:XDebugPrintable> (x: T, _: __PrintedFormat) -> T.DebugRepresentation 
 /// to do is declare conformance to XPrintable, and there's nothing to
 /// implement.
 protocol XPrintable: XDebugPrintable {
-  typealias PrintRepresentation: XStreamable = DebugRepresentation
+  associatedtype PrintRepresentation: XStreamable = DebugRepresentation
 
   /// \brief produce a "pretty" textual representation that can be
   /// distinct from the debug format.  For example,

--- a/test/SIL/Parser/generic_signature_with_depth.swift
+++ b/test/SIL/Parser/generic_signature_with_depth.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend %s -emit-silgen | %target-sil-opt | FileCheck %s
 
 protocol mmGeneratorType {
-  typealias Element
+  associatedtype Element
 }
 
 protocol mmSequenceType {
-  typealias Generator : mmGeneratorType
+  associatedtype Generator : mmGeneratorType
 }
 
 protocol mmCollectionType : mmSequenceType {

--- a/test/SIL/Parser/generics.sil
+++ b/test/SIL/Parser/generics.sil
@@ -91,7 +91,7 @@ sil [transparent] @_TTRXFo_iBi32__dT__XFo_dBi32__dT__ : $@convention(thin) (Buil
 
 protocol FooProtoHelper {}
 protocol FooProto {
-  typealias Assoc : FooProtoHelper
+  associatedtype Assoc : FooProtoHelper
   var value: Assoc { get }
 }
 

--- a/test/SIL/Parser/where.swift
+++ b/test/SIL/Parser/where.swift
@@ -2,7 +2,7 @@
 
 import Swift
 protocol P {
-  typealias CodeUnit
+  associatedtype CodeUnit
   mutating func decode<
     G : IteratorProtocol where G.Element == CodeUnit
   >(next: inout G) -> Int

--- a/test/SIL/Parser/where_clause.sil
+++ b/test/SIL/Parser/where_clause.sil
@@ -4,8 +4,8 @@
 // Make sure we can parse where clause with conformance & same-type requirements.
 
 protocol Runcible {
-  typealias Mince
-  typealias Quince
+  associatedtype Mince
+  associatedtype Quince
 }
 
 struct Spoon<T: Runcible> {}

--- a/test/SIL/Parser/witness_specialize.sil
+++ b/test/SIL/Parser/witness_specialize.sil
@@ -11,7 +11,7 @@ struct GenericAssocType<T> : AssocReqt {
 }
 
 protocol AssocTypeWithReqt {
-  typealias AssocType : AssocReqt
+  associatedtype AssocType : AssocReqt
 }
 
 struct ConformsWithDependentAssocType2<DD> : AssocTypeWithReqt {

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -31,8 +31,8 @@ sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
 }
 
 protocol AnyProtocol {
-  typealias AssocType
-  typealias AssocWithReqt : AssocReqt
+  associatedtype AssocType
+  associatedtype AssocWithReqt : AssocReqt
   func assocTypesMethod(x: AssocType, y: AssocWithReqt)
   static func staticMethod(x: Self)
 }

--- a/test/SIL/Serialization/Inputs/def_generic_marker.swift
+++ b/test/SIL/Serialization/Inputs/def_generic_marker.swift
@@ -1,9 +1,9 @@
 public protocol mmGeneratorType {
-  typealias Element
+  associatedtype Element
 }
 
 public protocol mmSequenceType {
-  typealias Generator : mmGeneratorType
+  associatedtype Generator : mmGeneratorType
 }
 
 public protocol mmCollectionType : mmSequenceType {

--- a/test/SIL/Serialization/witness_tables.sil
+++ b/test/SIL/Serialization/witness_tables.sil
@@ -31,8 +31,8 @@ sil_witness_table ConformingAssoc: AssocReqt module witness_tables {
 }
 
 protocol AnyProtocol {
-  typealias AssocType
-  typealias AssocWithReqt : AssocReqt
+  associatedtype AssocType
+  associatedtype AssocWithReqt : AssocReqt
   func assocTypesMethod(x: AssocType, y: AssocWithReqt)
   static func staticMethod(x: Self)
 }

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -51,7 +51,7 @@ func useEmAll(model: CCMagnetismModel) {
 
 // Ensure that accessors are emitted for fields used as protocol witnesses.
 protocol Impedance {
-  typealias Component
+  associatedtype Component
   var real: Component { get }
   var imag: Component { get }
 }

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
 
 protocol P {
-  typealias A
+  associatedtype A
 
   func f(x: A)
 }

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -284,7 +284,7 @@ func interpolated_string(x: Int, y: String) -> String {
 }
 
 protocol Runcible {
-  typealias U
+  associatedtype U
   var free:Int { get }
   var associated:U { get }
 

--- a/test/SILGen/generic_signatures.swift
+++ b/test/SILGen/generic_signatures.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend -emit-silgen -parse-stdlib %s
 
 protocol P {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 protocol Q {
-  typealias Assoc1
-  typealias Assoc2
+  associatedtype Assoc1
+  associatedtype Assoc2
 }
 
 struct G<T> {}
@@ -50,11 +50,11 @@ struct Foo<V> {
 // member of a dependent member that substitutes to a type parameter.
 // <rdar://problem/16257259>
 protocol Fooable {
-  typealias Foo
+  associatedtype Foo
 }
 
 protocol Barrable {
-  typealias Bar: Fooable
+  associatedtype Bar: Fooable
 
   func bar(_: Bar) -> Bar.Foo
 }

--- a/test/SILGen/interface_type_mangling.swift
+++ b/test/SILGen/interface_type_mangling.swift
@@ -1,19 +1,19 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle %s -emit-silgen | FileCheck %s
 
 protocol P {
-  typealias Assoc1
-  typealias Assoc2
+  associatedtype Assoc1
+  associatedtype Assoc2
 }
 protocol PP: P {}
 protocol PQ: P {
-  typealias Assoc1: A
+  associatedtype Assoc1: A
 }
 protocol Q {
-  typealias Assoc0: A
+  associatedtype Assoc0: A
 }
 
 protocol A {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 class Base: Q, A {
@@ -186,7 +186,7 @@ func m2<T: A, U: A where U.Assoc == Y, T.Assoc == X>(x: T, y: U) {}
 func m3<T, U where T: A, U: A, U.Assoc == Y, T.Assoc == X>(x: T, y: U) {}
 
 protocol GenericWitnessTest {
-  typealias Tee
+  associatedtype Tee
 
   func closureInGenericContext<X>(b: X)
   var closureInGenericPropertyContext: Tee { get }

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -126,7 +126,7 @@ func autoClosureOverloadCalls() {
 protocol AssocReqt {}
 
 protocol HasAssocType {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 // CHECK-LABEL: sil hidden @_TF8mangling4fooAuRxS_12HasAssocTyperFxT_ : $@convention(thin) <T where T : HasAssocType> (@in T) -> ()

--- a/test/SILGen/mangling_generic_extensions.swift
+++ b/test/SILGen/mangling_generic_extensions.swift
@@ -4,8 +4,8 @@ struct Foo<T> {
 }
 
 protocol Runcible {
-  typealias Spoon
-  typealias Hat
+  associatedtype Spoon
+  associatedtype Hat
 }
 
 extension Foo {

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -114,7 +114,7 @@ class MyClass {}
 // When simply assigning to a property, reabstract the r-value and assign
 // to the base instead of materializing and then assigning.
 protocol Factory {
-  typealias Product
+  associatedtype Product
   var builder : () -> Product { get set }
 }
 func setBuilder<F: Factory where F.Product == MyClass>(factory: inout F) {

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -793,7 +793,7 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
 // ----------------------------------------------------------------------------
 
 protocol P2 {
-  typealias A
+  associatedtype A
   func f1(a: A)
   func f2(a: A)
   var x: A { get }

--- a/test/SILGen/result_abstraction.swift
+++ b/test/SILGen/result_abstraction.swift
@@ -4,7 +4,7 @@ struct S {}
 struct R {}
 
 protocol ReturnsMetatype {
-  typealias Assoc
+  associatedtype Assoc
   mutating
   func getAssocMetatype() -> Assoc.Type
 }
@@ -19,8 +19,8 @@ struct ConformsToReturnsMetatype : ReturnsMetatype {
 }
 
 protocol ReturnsFunction {
-  typealias Arg
-  typealias Result
+  associatedtype Arg
+  associatedtype Result
   func getFunc() -> Arg -> Result
 }
 
@@ -33,7 +33,7 @@ struct ConformsToReturnsFunction : ReturnsFunction {
 }
 
 protocol ReturnsAssoc {
-  typealias Assoc
+  associatedtype Assoc
   mutating
   func getAssoc() -> Assoc
 }

--- a/test/SILGen/same_type_abstraction.swift
+++ b/test/SILGen/same_type_abstraction.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
 
 protocol Associated {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 struct Abstracted<T: Associated, U: Associated> {

--- a/test/SILGen/vtable_thunks_reabstraction_final.swift
+++ b/test/SILGen/vtable_thunks_reabstraction_final.swift
@@ -5,7 +5,7 @@ protocol Fooable {
 }
 
 protocol Barrable {
-  typealias Bar
+  associatedtype Bar
   func foo(x: Bar) -> Bar?
 }
 

--- a/test/SILGen/witness_same_type.swift
+++ b/test/SILGen/witness_same_type.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
 
 protocol Fooable {
-  typealias Bar
+  associatedtype Bar
 
   func foo<T: Fooable where T.Bar == Self.Bar>(x x: T) -> Self.Bar
 }

--- a/test/SILGen/witness_tables.swift
+++ b/test/SILGen/witness_tables.swift
@@ -23,8 +23,8 @@ protocol ArchetypeReqt {
 }
 
 protocol AnyProtocol {
-  typealias AssocType
-  typealias AssocWithReqt: AssocReqt
+  associatedtype AssocType
+  associatedtype AssocWithReqt: AssocReqt
 
   func method(x x: Arg, y: Self)
   func generic<A: ArchetypeReqt>(x x: A, y: Self)
@@ -37,8 +37,8 @@ protocol AnyProtocol {
 }
 
 protocol ClassProtocol : class {
-  typealias AssocType
-  typealias AssocWithReqt: AssocReqt
+  associatedtype AssocType
+  associatedtype AssocWithReqt: AssocReqt
 
   func method(x x: Arg, y: Self)
   func generic<B: ArchetypeReqt>(x x: B, y: Self)
@@ -475,7 +475,7 @@ struct GenericAssocType<T> : AssocReqt {
 }
 
 protocol AssocTypeWithReqt {
-  typealias AssocType : AssocReqt
+  associatedtype AssocType : AssocReqt
 }
 
 struct ConformsWithDependentAssocType1<CC: AssocReqt> : AssocTypeWithReqt {
@@ -508,7 +508,7 @@ class ConformsInheritedFromObjC : InheritedFromObjC {
 // TABLE-NEXT:  }
 
 protocol ObjCAssoc {
-  typealias AssocType : ObjCProtocol
+  associatedtype AssocType : ObjCProtocol
 }
 
 struct HasObjCAssoc : ObjCAssoc {

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -87,7 +87,7 @@ protocol X {
 protocol Y {}
 
 protocol WithAssoc {
-  typealias AssocType
+  associatedtype AssocType
   func useAssocType(x x: AssocType) -> Self
 }
 
@@ -422,12 +422,12 @@ final class IUOFailableClassModel: NonFailableClassRefinement, IUOFailableClassR
 }
 
 protocol HasAssoc {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 protocol GenericParameterNameCollisionProtocol {
   func foo<T>(x: T)
-  typealias Assoc2
+  associatedtype Assoc2
   func bar<T>(x: T -> Assoc2)
 }
 

--- a/test/SILGen/witnesses_canonical.swift
+++ b/test/SILGen/witnesses_canonical.swift
@@ -20,7 +20,7 @@ extension _CDT {
 }
 
 public protocol CT : ST, _CDT {
-  typealias _SS : ST, _CDT
+  associatedtype _SS : ST, _CDT
 
   subscript(_bounds: Int) -> _SS { get }
 }
@@ -34,15 +34,15 @@ public protocol P1 { }
 public protocol P2 { }
 
 public protocol Q1 {
-  typealias Assoc : P1
+  associatedtype Assoc : P1
 }
 
 public protocol Q2 {
-  typealias Assoc : P2
+  associatedtype Assoc : P2
 }
 
 public protocol Q3 : Q1, Q2 {
-  typealias Assoc
+  associatedtype Assoc
 }
 
 struct XP : P1, P2 { }

--- a/test/SILGen/writeback.swift
+++ b/test/SILGen/writeback.swift
@@ -118,13 +118,13 @@ funge(x: &addressOnly)
 // <rdar://problem/16525257> 
 
 protocol Runcible {
-  typealias Frob: Frobable
+  associatedtype Frob: Frobable
 
   var frob: Frob { get set }
 }
 
 protocol Frobable {
-  typealias Anse
+  associatedtype Anse
   
   var anse: Anse { get set }
 }

--- a/test/SILOptimizer/devirt_dependent_types.swift
+++ b/test/SILOptimizer/devirt_dependent_types.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -O %s | FileCheck %s
 
 protocol Bar {
-  typealias Element
+  associatedtype Element
 }
 
 class FooImplBase<OutputElement> {

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -8,7 +8,7 @@
 // rdar://19912272
 
 protocol P {
-   typealias Node
+   associatedtype Node
 }
 
 class C<T:P> {

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2117,7 +2117,7 @@ protocol AnForwardIndexType {
 }
 
 protocol AnIndexable {
-  typealias Index = AnForwardIndexType
+  associatedtype Index = AnForwardIndexType
 }
 
 struct GenContainer2<T : AnIndexable> {

--- a/test/SILOptimizer/specialize_anyobject.swift
+++ b/test/SILOptimizer/specialize_anyobject.swift
@@ -2,7 +2,7 @@
 
 // rdar://problem/20338028
 protocol PA: class { }
-protocol PB { typealias B: PA }
+protocol PB { associatedtype B: PA }
 
 class CA: PA { }
 class CB: PB { typealias B = CA }

--- a/test/SILOptimizer/specialize_apply_conf.swift
+++ b/test/SILOptimizer/specialize_apply_conf.swift
@@ -4,7 +4,7 @@
 // is fixed then we should convert this test to a SIL test.
 
 protocol Pingable {
-  typealias Tp
+  associatedtype Tp
   func ping(x x : Tp) -> Tp
 
 }

--- a/test/Sema/Inputs/diag_values_of_module_type_foo.swift
+++ b/test/Sema/Inputs/diag_values_of_module_type_foo.swift
@@ -13,7 +13,7 @@ public enum SomeEnum {
   case Foo
 }
 public protocol SomeProtocol {
-  typealias Foo
+  associatedtype Foo
 }
 public protocol SomeExistential {
 }

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -1244,8 +1244,8 @@ sil_witness_table ConformingAssoc: AssocReqt module def_basic {
 }
 
 protocol AnyProtocol {
-  typealias AssocType
-  typealias AssocWithReqt : AssocReqt
+  associatedtype AssocType
+  associatedtype AssocWithReqt : AssocReqt
   func assocTypesMethod(x: AssocType, y: AssocWithReqt)
   static func staticMethod(x: Self)
 }

--- a/test/Serialization/Inputs/def_class.swift
+++ b/test/Serialization/Inputs/def_class.swift
@@ -76,8 +76,8 @@ public typealias Cacheable = protocol<Resettable, Computable>
 public protocol SpecialResettable : Resettable, Computable {}
 
 public protocol PairLike {
-  typealias FirstType
-  typealias SecondType
+  associatedtype FirstType
+  associatedtype SecondType
   func getFirst() -> FirstType
   func getSecond() -> SecondType
 }

--- a/test/Serialization/Inputs/def_func.swift
+++ b/test/Serialization/Inputs/def_func.swift
@@ -37,7 +37,7 @@ public func different2<T where T : Equatable>(a a: T, b: T) -> Bool {
 public func selectorFunc1(a a: Int, b x: Int) {}
 
 public protocol Wrapped {
-  typealias Value : Equatable
+  associatedtype Value : Equatable
   
   //var value : Value
   func getValue() -> Value

--- a/test/Serialization/Inputs/def_struct.swift
+++ b/test/Serialization/Inputs/def_struct.swift
@@ -70,7 +70,7 @@ public typealias Cacheable = protocol<Resettable, Computable>
 public protocol SpecialResettable : Resettable, Computable {}
 
 public protocol HasAssociatedType {
-  typealias ComputableType : Computable
+  associatedtype ComputableType : Computable
 }
 
 public struct ComputableWrapper<T : Computable> : HasAssociatedType {
@@ -79,7 +79,7 @@ public struct ComputableWrapper<T : Computable> : HasAssociatedType {
 }
 
 public protocol AnotherAssociated {
-  typealias ResettableType : Resettable
+  associatedtype ResettableType : Resettable
 }
 
 public struct ResettableWrapper<T : Resettable> : AnotherAssociated {

--- a/test/Serialization/Inputs/has_generic_witness.swift
+++ b/test/Serialization/Inputs/has_generic_witness.swift
@@ -30,7 +30,7 @@ public struct BarStruct : Barrable {
 
 
 public protocol HasAssociatedType {
-  typealias Foo : Fooable
+  associatedtype Foo : Fooable
 }
 
 public protocol Bassable {
@@ -51,7 +51,7 @@ public struct BasStruct : Bassable {
 prefix operator ~~~ {}
 
 public protocol _CyclicAssociated {
-  typealias Assoc = CyclicImpl
+  associatedtype Assoc = CyclicImpl
 }
 
 public protocol CyclicAssociated : _CyclicAssociated {

--- a/test/multifile/synthesized-accessors/one-module-imported/library.swift
+++ b/test/multifile/synthesized-accessors/one-module-imported/library.swift
@@ -3,7 +3,7 @@
 import CoreGraphics
 
 protocol OtherPoint {
-  typealias FloatType
+  associatedtype FloatType
 
   var x: FloatType { get set }
   var y: FloatType { get set }

--- a/test/multifile/synthesized-accessors/one-module-imported/main.swift
+++ b/test/multifile/synthesized-accessors/one-module-imported/main.swift
@@ -9,7 +9,7 @@
 import CoreGraphics
 
 protocol MyPoint {
-  typealias FloatType
+  associatedtype FloatType
 
   var x: FloatType { get set }
   var y: FloatType { get set }

--- a/test/multifile/synthesized-accessors/two-modules-imported/library.swift
+++ b/test/multifile/synthesized-accessors/two-modules-imported/library.swift
@@ -3,7 +3,7 @@
 import CoreGraphics
 
 public protocol OtherPoint {
-  typealias FloatType
+  associatedtype FloatType
 
   var x: FloatType { get set }
   var y: FloatType { get set }

--- a/test/multifile/synthesized-accessors/two-modules-imported/main.swift
+++ b/test/multifile/synthesized-accessors/two-modules-imported/main.swift
@@ -9,7 +9,7 @@
 import CoreGraphics
 
 protocol MyPoint {
-  typealias FloatType
+  associatedtype FloatType
 
   var x: FloatType { get set }
   var y: FloatType { get set }

--- a/validation-test/IDE/crashers/010-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/IDE/crashers/010-swift-archetypebuilder-addrequirement.swift
@@ -3,5 +3,5 @@
 #^A^#{"
 protocol c{
 func a
-typealias b:c
-typealias e:c
+associatedtype b:c
+associatedtype e:c

--- a/validation-test/IDE/crashers/021-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/IDE/crashers/021-swift-typechecker-resolveidentifiertype.swift
@@ -1,2 +1,2 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-{class T{protocol b{#^A^#typealias b:B<T>struct B<b
+{class T{protocol b{#^A^#associatedtype b:B<T>struct B<b

--- a/validation-test/IDE/crashers/022-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/IDE/crashers/022-swift-typechecker-applygenericarguments.swift
@@ -6,4 +6,4 @@ protocol P{
 class B<T
 {struct c{
 #^A^#
-protocol b{typealias e:B<T>
+protocol b{associatedtype e:B<T>

--- a/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,4 +1,4 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
 protocol c{func a:P
 protocol P{#^A^#func a:b
-typealias b:a
+associatedtype b:a

--- a/validation-test/IDE/crashers/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/IDE/crashers/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,5 +1,5 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
 protocol A{protocol A{
-typealias e:a
+associatedtype e:a
 func a<T:e
 enum b{func a{#^A^#

--- a/validation-test/compiler_crashers/24394-swift-typevariabletype-implementation-getrepresentative.swift
+++ b/validation-test/compiler_crashers/24394-swift-typevariabletype-implementation-getrepresentative.swift
@@ -6,6 +6,6 @@
 
 // Crash type: memory error ("Invalid read of size 8")
 [Void{}}struct A
-protocol A{typealias b:A func b
+protocol A{associatedtype b:A func b
 class A<S:e
-typealias e
+associatedtype e

--- a/validation-test/compiler_crashers/27156-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers/27156-swift-typechecker-applygenericarguments.swift
@@ -6,4 +6,4 @@
 
 struct B<T{protocol A{
 class B<T
-typealias e:B<T>
+associatedtype e:B<T>

--- a/validation-test/compiler_crashers/27636-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers/27636-swift-typechecker-resolvetypeincontext.swift
@@ -8,5 +8,5 @@
 
 enum A
 protocol A{
-typealias f:a
+associatedtype f:a
 func a<T where f:d

--- a/validation-test/compiler_crashers/27832-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers/27832-swift-typechecker-resolvetypeincontext.swift
@@ -8,5 +8,5 @@
 
 enum A
 protocol A{
-typealias f:a
+associatedtype f:a
 func a<T where f:d

--- a/validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers/28201-swift-typechecker-resolvetypewitness.swift
@@ -4,4 +4,4 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-{class A:a protocol a{typealias e:A}class A:A.e
+{class A:a protocol a{associatedtype e:A}class A:A.e

--- a/validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers/28202-swift-typechecker-applygenericarguments.swift
@@ -5,4 +5,4 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-class B<T{func a{{func g:A}protocol A{typealias e=c<T>struct c<a]typealias d:e
+class B<T{func a{{func g:A}protocol A{associatedtype e=c<T>struct c<a]associatedtype d:e

--- a/validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers/28225-swift-typechecker-checkconformance.swift
@@ -4,5 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-func e{enum k:A}protocol A{typealias B:A
-typealias n
+func e{enum k:A}protocol A{associatedtype B:A
+associatedtype n

--- a/validation-test/compiler_crashers/28226-swift-iterativetypechecker-processinheritedprotocols.swift
+++ b/validation-test/compiler_crashers/28226-swift-iterativetypechecker-processinheritedprotocols.swift
@@ -5,5 +5,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol A{typealias e:A protocol A:a
+protocol A{associatedtype e:A protocol A:a
 protocol a:c}struct c<I:A

--- a/validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/compiler_crashers/28228-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -7,5 +7,5 @@
 // Test case found by fuzzing
 
 struct g
-struct c{}protocol c{typealias e:d
+struct c{}protocol c{associatedtype e:d
 class d<T where g:e.T

--- a/validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers/28229-swift-valuedecl-getinterfacetype.swift
@@ -5,4 +5,4 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol c{typealias e:a:protocol a{typealias a}func b:e.c
+protocol c{associatedtype e:a:protocol a{associatedtype a}func b:e.c

--- a/validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers/28233-swift-typebase-getmembersubstitutions.swift
@@ -5,4 +5,4 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-protocol A{class A}protocol a:A{protocol P{typealias e:A}}a
+protocol A{class A}protocol a:A{protocol P{associatedtype e:A}}a

--- a/validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
+++ b/validation-test/compiler_crashers/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
@@ -4,5 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-struct c:protocol A{typealias f{}func g:B
+struct c:protocol A{associatedtype f{}func g:B
 class B<T where f.h:b,f=c

--- a/validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift
+++ b/validation-test/compiler_crashers/28240-swift-archetypebuilder-addrequirement.swift
@@ -5,4 +5,4 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-struct B<g:a{}protocol a{typealias e:a{}typealias f:a
+struct B<g:a{}protocol a{associatedtype e:a{}associatedtype f:a

--- a/validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift
+++ b/validation-test/compiler_crashers/28248-swift-dynamicselftype-get.swift
@@ -4,5 +4,5 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-if{func b:a protocol a{{}typealias d:d
+if{func b:a protocol a{{}associatedtype d:d
 func b->Self

--- a/validation-test/compiler_crashers/28257-swift-typechecker-resolvetypewitness.swift
+++ b/validation-test/compiler_crashers/28257-swift-typechecker-resolvetypewitness.swift
@@ -7,8 +7,8 @@
 protocol A{
 class A:a{
 }
-typealias e:a
+associatedtype e:a
 protocol a{
-typealias r
+associatedtype r
 }
-typealias e:A
+associatedtype e:A

--- a/validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
+++ b/validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
@@ -5,4 +5,4 @@
 // Test case submitted to project by https://github.com/practicalswift (practicalswift)
 // Test case found by fuzzing
 
-func<{struct c<T{enum S<T{struct A:a protocol a{typealias e}struct S<T:A.e
+func<{struct c<T{enum S<T{struct A:a protocol a{associatedtype e}struct S<T:A.e

--- a/validation-test/compiler_crashers_2_fixed/0008-rdar18796397.swift
+++ b/validation-test/compiler_crashers_2_fixed/0008-rdar18796397.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -o /dev/null
 public protocol OurProtocol {
 
-  typealias T
+  associatedtype T
   var myVar: T? {get set}
   var validator: (Int) -> (T) { get set }
 }

--- a/validation-test/compiler_crashers_2_fixed/0012-rdar20270240.swift
+++ b/validation-test/compiler_crashers_2_fixed/0012-rdar20270240.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend %s -emit-silgen
 
 protocol FooProtocol {
-  typealias Element
+  associatedtype Element
 }
 
 protocol Bar {
-  typealias Foo : FooProtocol
+  associatedtype Foo : FooProtocol
   typealias Element = Foo.Element
 
   mutating func extend<

--- a/validation-test/compiler_crashers_2_fixed/0013-rdar19519590.swift
+++ b/validation-test/compiler_crashers_2_fixed/0013-rdar19519590.swift
@@ -1,9 +1,11 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
 protocol SourceTargetTransformable {
-    typealias Source
-    typealias Target
-    typealias Transformer = Source -> Target
+    associatedtype Source
+    associatedtype Target
+  
+    // FIXME: should really be a typealias once we support that
+    associatedtype Transformer = Source -> Target
 }
 
 

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -42,13 +42,13 @@ public class TypeIndexed<Value> : Resettable {
 //===----------------------------------------------------------------------===//
 
 public protocol Wrapper {
-  typealias Base
+  associatedtype Base
   init(_: Base)
   var base: Base {get set}
 }
 
 public protocol LoggingType : Wrapper {
-  typealias Log : AnyObject
+  associatedtype Log : AnyObject
 }
 
 extension LoggingType {
@@ -104,9 +104,9 @@ public class SequenceLog {
 }
 
 public protocol LoggingSequenceType  : Sequence, LoggingType {
-  typealias Base : Sequence
-  typealias Log : AnyObject = SequenceLog
-  typealias Iterator : IteratorProtocol = LoggingIterator<Base.Iterator>
+  associatedtype Base : Sequence
+  associatedtype Log : AnyObject = SequenceLog
+  associatedtype Iterator : IteratorProtocol = LoggingIterator<Base.Iterator>
 }
 
 extension LoggingSequenceType {
@@ -201,8 +201,8 @@ public class CollectionLog : SequenceLog {
 }
 
 public protocol LoggingCollectionType : LoggingSequenceType, Collection {
-  typealias Base : Collection
-  typealias Index : ForwardIndex = Base.Index
+  associatedtype Base : Collection
+  associatedtype Index : ForwardIndex = Base.Index
 }
 
 extension LoggingCollectionType

--- a/validation-test/compiler_crashers_2_fixed/0026-rdar21382194.swift
+++ b/validation-test/compiler_crashers_2_fixed/0026-rdar21382194.swift
@@ -17,14 +17,14 @@ extension Float : ApproximateReal {}
 // Abstraction of a mathematical vector
 protocol Vector {
   init()
-  typealias Element : ApproximateReal
+  associatedtype Element : ApproximateReal
   func dotProduct(Self) -> Element
 
 
   // Extras
   var count: Int {get}
   subscript(Int) -> Element {get set}
-  typealias Tail
+  associatedtype Tail
 }
 
 struct EmptyVector<T: ApproximateReal> : Vector {

--- a/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
@@ -6,7 +6,7 @@
 // https://twitter.com/rob_rix/status/483456023773315073
 
 protocol A {
-    typealias B
+    associatedtype B
     func b(_: B)
 }
 struct X<Y> : A {

--- a/validation-test/compiler_crashers_fixed/00031-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00031-no-stacktrace.swift
@@ -11,7 +11,7 @@ protocol b : a {
 protocol c : a {
 }
 protocol d {
-    typealias e = a
+    associatedtype e = a
 }
 struct e : d {
     typealias e = b

--- a/validation-test/compiler_crashers_fixed/00033-error.swift
+++ b/validation-test/compiler_crashers_fixed/00033-error.swift
@@ -5,5 +5,5 @@
 struct d<f : e, g: e where g.h == f.h> {
 }
 protocol e {
-    typealias h
+    associatedtype h
 }

--- a/validation-test/compiler_crashers_fixed/00041-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00041-szone-malloc-should-clear.swift
@@ -5,14 +5,14 @@
 // http://www.openradar.me/18176436
 
 protocol A {
-    typealias E
+    associatedtype E
 }
 struct B<T : A> {
     let h: T
     let i: T.E
 }
 protocol C {
-    typealias F
+    associatedtype F
     func g<T where T.E == F>(f: B<T>)
 }
 struct D : C {

--- a/validation-test/stdlib/MicroStdlib.swift
+++ b/validation-test/stdlib/MicroStdlib.swift
@@ -28,12 +28,12 @@ public protocol _BuiltinFloatLiteralConvertible {
 }
 
 public protocol IntegerLiteralConvertible {
-  typealias IntegerLiteralType : _BuiltinIntegerLiteralConvertible
+  associatedtype IntegerLiteralType : _BuiltinIntegerLiteralConvertible
   init(integerLiteral value: IntegerLiteralType)
 }
 
 public protocol FloatLiteralConvertible {
-  typealias FloatLiteralType : _BuiltinFloatLiteralConvertible
+  associatedtype FloatLiteralType : _BuiltinFloatLiteralConvertible
   init(floatLiteral value: FloatLiteralType)
 }
 

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -18,8 +18,8 @@ import Foundation
 @_silgen_name("random") func random() -> UInt32
 @_silgen_name("srandomdev") func srandomdev()
 
-protocol TestableUnicodeCodec : UnicodeCodec {
-  typealias CodeUnit : Integer
+protocol TestableUnicodeCodec : UnicodeCodecType {
+  associatedtype CodeUnit : Integer
   static func encodingId() -> NSStringEncoding
   static func name() -> NSString
 }


### PR DESCRIPTION
Split parsing for typealias & associatedtype, allow typealias in protocol, but not as a constraint in generics.

First step in getting real type aliases in protocols is to finish smoking out the ones that ought to be associated types. Cleaned up parsing of the two, including dropping a now unneeded ParseDeclOptions flag, made typealias in a protocol an error for the moment, and then converted all the places in the tests that didn’t care about it being a deprecation warning before but do care now.

Then made typealias in a protocol actually valid, which works great except that you can't use them in where clauses in generics. So added new diagnosis if you attempt to use a protocol’s typealias in a where clause, suggesting an associatedtype instead.
