### PR TITLE
[swiftc] Add test case for crash triggered in swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
+++ b/validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+func<{struct c<T{enum S<T{struct A:a protocol a{typealias e}struct S<T:A.e


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash with stack trace:

```
swift: /path/to/swift/lib/AST/Type.cpp:2126: TypeSubstitutionMap swift::GenericParamList::getSubstitutionMap(ArrayRef<swift::Substitution>) const: Assertion `Subs.empty() && "did not use all substitutions?!"' failed.
9  swift           0x000000000105a0ea swift::SpecializedProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 202
10 swift           0x0000000001059e02 swift::ProtocolConformance::getTypeWitnessSubstAndDecl(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 18
11 swift           0x000000000105a616 swift::ProtocolConformance::getTypeWitness(swift::AssociatedTypeDecl*, swift::LazyResolver*) const + 6
12 swift           0x0000000000e5949a swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 1066
14 swift           0x0000000000e82d7e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift           0x0000000000e83c84 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
17 swift           0x0000000000e82c7a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
18 swift           0x0000000000e1719a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5274
19 swift           0x0000000000e54775 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 357
20 swift           0x0000000000e55e97 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
21 swift           0x0000000000e56244 swift::TypeChecker::validateGenericTypeSignature(swift::NominalTypeDecl*) + 116
22 swift           0x0000000000e18fe1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 353
29 swift           0x0000000000e1e936 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
32 swift           0x0000000000e7cc4a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
33 swift           0x0000000000e7caae swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
34 swift           0x0000000000e7d648 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
36 swift           0x0000000000e41dd4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
37 swift           0x0000000000cb3b5f swift::CompilerInstance::performSema() + 3087
39 swift           0x00000000007885fb frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2523
40 swift           0x00000000007830d5 main + 2773
Stack dump:
0.  Program arguments: /usr/local/bin/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl-a81e65.o
1.  While type-checking '<' at validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift:8:1
2.  While type-checking 'c' at validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift:8:7
3.  While resolving type A.e at [validation-test/compiler_crashers/28258-swift-specializedprotocolconformance-gettypewitnesssubstanddecl.swift:8:72 - line:8:74] RangeText="A.e"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
