### PR TITLE
[WIP] fleshing out Collection.next(Index) -> Index

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -98,7 +98,7 @@ extension BidirectionalCollection {
 extension BidirectionalCollection where Index : Strideable {
   @warn_unused_result
   public func previous(i: Index) -> Index {
-    _failEarlyRangeCheck(i, bounds:startIndex..<endIndex)
+    _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
 
     return i.advanced(by: -1)
   }

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -34,10 +34,6 @@ public protocol BidirectionalCollection : Collection {
 
 /// Default implementation for bidirectional collections.
 extension BidirectionalCollection {
-// TODO: swift-3-indexing-model - stub to allow things to compile, remove when we have real implementations
-  public func previous(i: Index) -> Index {
-    fatalError("FIXME: swift-3-indexing-model")
-  }
 
   @inline(__always)
   public func _previousInPlace(i: inout Index) {
@@ -75,27 +71,67 @@ extension BidirectionalCollection {
     return i
   }
 
-// TODO: swift-3-indexing-model - once Index is Comparable something like following is possible, right?
-  //  @warn_unused_result
-  //  public func distance(from start: Index, to end: Index) -> IndexDistance {
-  //    var start = start
-  //    var count: IndexDistance = 0
-  //
-  //    if start < end {
-  //      while start != end {
-  //        count = count + 1
-  //        _nextInPlace(&start)
-  //      }
-  //    }
-  //    else if start > end {
-  //      while start != end {
-  //        count = count - 1
-  //        _previousInPlace(&start)
-  //      }
-  //    }
-  //
-  //    return count
-  //  }
+  @warn_unused_result
+  public func distance(from start: Index, to end: Index) -> IndexDistance {
+    var start = start
+    var count: IndexDistance = 0
+
+    if start < end {
+      while start != end {
+        count += 1 as IndexDistance
+        _nextInPlace(&start)
+      }
+    }
+    else if start > end {
+      while start != end {
+        count -= 1 as IndexDistance
+        _previousInPlace(&start)
+      }
+    }
+
+    return count
+  }
+}
+
+/// Supply optimized defaults for `BidirectionalCollection` models that use
+/// some model of `Strideable` as their `Index`.
+extension BidirectionalCollection where Index : Strideable {
+  @warn_unused_result
+  public func previous(i: Index) -> Index {
+    _failEarlyRangeCheck(i, bounds:startIndex..<endIndex)
+
+    return i.advanced(by: -1)
+  }
+
+  /*
+  @warn_unused_result
+  public func advance(i: Index, by n: IndexDistance) -> Index {
+    // FIXME: swift-3-indexing-model: range check i
+
+    // FIXME: swift-3-indexing-model - error: cannot invoke 'advanced' with an argument list of type '(by: Self.IndexDistance)'
+    return i.advanced(by: n)
+  }
+
+  @warn_unused_result
+  public func advance(i: Index, by n: IndexDistance, limit: Index) -> Index {
+    // FIXME: swift-3-indexing-model: range check i
+
+    // FIXME: swift-3-indexing-model - error: cannot invoke 'advanced' with an argument list of type '(by: Self.IndexDistance)'
+    let i = i.advanced(by: n)
+    if (i >= limit) {
+      return limit
+    }
+    return i
+  }
+
+  @warn_unused_result
+  public func distance(from start: Index, to end: Index) -> IndexDistance {
+    // FIXME: swift-3-indexing-model: range check supplies start and end?
+
+    // FIXME: swift-3-indexing-model - error: cannot invoke 'distance' with an argument list of type '(to: Self.Index)'
+    return start.distance(to: end)
+  }
+  */
 }
 
 extension BidirectionalCollection where SubSequence == Self {

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -323,7 +323,7 @@ extension Collection {
   }
 
   public func _failEarlyRangeCheck(index: Index, bounds: Range<Index>) {
-    // Can't perform range checks in O(1) on non-RandomAccessCollections.
+    // FIXME: swift-3-indexing-model: range check now that indexes are Comparable.
   }
 
   public func _failEarlyRangeCheck(
@@ -332,7 +332,7 @@ extension Collection {
     boundsStart: Index,
     boundsEnd: Index
   ) {
-      // Can't perform range checks in O(1) on non-RandomAccessCollections.
+    // FIXME: swift-3-indexing-model: range check now that indexes are Comparable.
   }
 
   @warn_unused_result
@@ -347,9 +347,9 @@ extension Collection {
 
   @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
-    // TODO: swift-3-indexing-model - once Index is Comparable the following is possible, right?
-    //    _precondition(start <= end,
-    //      "Only BidirectionalCollections can have end come before start")
+    _precondition(start <= end,
+      "Only BidirectionalCollections can have end come before start")
+
     var start = start
     var count: IndexDistance = 0
     while start != end {
@@ -392,13 +392,50 @@ extension Collection {
   }
 }
 
-/// Supply a default `next()` method for `Collection` models that
-/// use some model of `Strideable` as their `Index`.
+/// Supply optimized defaults for `Collection` models that use some model 
+/// of `Strideable` as their `Index`.
 extension Collection where Index : Strideable {
   @warn_unused_result
   public func next(i: Index) -> Index {
+    _failEarlyRangeCheck(i, bounds:startIndex..<endIndex)
+
     return i.advanced(by: 1)
   }
+
+  /*
+  @warn_unused_result
+  public func advance(i: Index, by n: IndexDistance) -> Index {
+    _precondition(n >= 0,
+      "Only BidirectionalCollections can be advanced by a negative amount")
+    // FIXME: swift-3-indexing-model: range check i
+
+    // FIXME: swift-3-indexing-model - error: cannot invoke 'advanced' with an argument list of type '(by: Self.IndexDistance)'
+    return i.advanced(by: n)
+  }
+
+  @warn_unused_result
+  public func advance(i: Index, by n: IndexDistance, limit: Index) -> Index {
+    _precondition(n >= 0,
+      "Only BidirectionalCollections can be advanced by a negative amount")
+    // FIXME: swift-3-indexing-model: range check i
+
+    // FIXME: swift-3-indexing-model - error: cannot invoke 'advanced' with an argument list of type '(by: Self.IndexDistance)'
+    let i = i.advanced(by: n)
+    if (i >= limit) {
+      return limit
+    }
+    return i
+  }
+
+  @warn_unused_result
+  public func distance(from start: Index, to end: Index) -> IndexDistance {
+    _precondition(start <= end,
+      "Only BidirectionalCollections can have end come before start")
+
+    // FIXME: swift-3-indexing-model - error: cannot invoke 'distance' with an argument list of type '(to: Self.Index)'
+    return start.distance(to: end)
+  }
+  */
 }
 
 // TODO: swift-3-indexing-model - review the following
@@ -482,7 +519,6 @@ extension Collection {
   /// - Complexity: O(1) if `Index` conforms to `RandomAccessIndex`;
   ///   O(N) otherwise.
   public var count: IndexDistance {
-// FIXME: swift-3-indexing-model - Need to fix up Index.Distance to make the following happy
     return distance(from: startIndex, to: endIndex)
   }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -96,13 +96,7 @@ public protocol Indexable {
   /// range check.
   ///
   /// - Complexity: O(1).
-  func _failEarlyRangeCheck(
-    rangeStart rangeStart: Index,
-    rangeEnd: Index,
-    boundsStart: Index,
-    boundsEnd: Index)
-// TODO: swift-3-indexing-model - can we change the above to the following? (possible compiler issue)
-//  func _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>)
+  func _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>)
 
   /// Returns the next consecutive `Index` in a discrete sequence of
   /// `Index` values.
@@ -326,12 +320,7 @@ extension Collection {
     // FIXME: swift-3-indexing-model: range check now that indexes are Comparable.
   }
 
-  public func _failEarlyRangeCheck(
-    rangeStart rangeStart: Index,
-    rangeEnd: Index,
-    boundsStart: Index,
-    boundsEnd: Index
-  ) {
+  public func _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>) {
     // FIXME: swift-3-indexing-model: range check now that indexes are Comparable.
   }
 
@@ -454,11 +443,7 @@ extension Collection where Iterator == IndexingIterator<Self> {
 /// that accept the default associated `SubSequence`, `Slice<Self>`.
 extension Collection where SubSequence == Slice<Self> {
   public subscript(bounds: Range<Index>) -> Slice<Self> {
-    _failEarlyRangeCheck(
-      rangeStart: bounds.startIndex,
-      rangeEnd: bounds.endIndex,
-      boundsStart: startIndex,
-      boundsEnd: endIndex)
+    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
     return Slice(_base: self, bounds: bounds)
   }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -24,7 +24,6 @@ public protocol Indexable {
   ///
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
-// TODO: swift-3-indexing-model - Index only needs to be comparable or must be comparable..?
   associatedtype Index : Comparable
 
   /// The position of the first element in a non-empty collection.
@@ -318,11 +317,6 @@ public protocol Collection : Indexable, Sequence {
 
 /// Default implementation for forward collections.
 extension Collection {
-  // TODO: swift-3-indexing-model - stub to allow things to compile, remove when we have real implementations
-  public func next(i: Index) -> Index {
-    fatalError("FIXME: swift-3-indexing-model")
-  }
-
   @inline(__always)
   public func _nextInPlace(i: inout Index) {
     i = next(i)
@@ -395,6 +389,15 @@ extension Collection {
       _nextInPlace(&i)
     }
     return i
+  }
+}
+
+/// Supply a default `next()` method for `Collection` models that
+/// use some model of `Strideable` as their `Index`.
+extension Collection where Index : Strideable {
+  @warn_unused_result
+  public func next(i: Index) -> Index {
+    return i.advanced(by: 1)
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -431,6 +431,7 @@ extension Collection where Index : Strideable {
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     _precondition(start <= end,
       "Only BidirectionalCollections can have end come before start")
+    // FIXME: swift-3-indexing-model: range check supplied start and end?
 
     // FIXME: swift-3-indexing-model - error: cannot invoke 'distance' with an argument list of type '(to: Self.Index)'
     return start.distance(to: end)
@@ -655,11 +656,6 @@ extension Collection {
   public func prefix(through position: Index) -> SubSequence {
     return prefix(upTo: next(position))
   }
-// TODO: swift-3-indexing-model - uncomment and replace above ready
-//  @warn_unused_result
-//  public func prefix(through position: Index) -> SubSequence {
-//    return prefix(upTo: position.next())
-//  }
 
 // TODO: swift-3-indexing-model - review the following
   /// Returns the maximal `SubSequence`s of `self`, in order, that

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -54,6 +54,12 @@ public struct CollectionOfOne<Element> : Collection {
   public var endIndex: Int {
     return 1
   }
+  
+  /// Always returns `endIndex`.
+  @warn_unused_result
+  public func next(i: Int) -> Int {
+    return endIndex
+  }
 
   /// Returns an iterator over the elements of this sequence.
   ///

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -58,6 +58,7 @@ public struct CollectionOfOne<Element> : Collection {
   /// Always returns `endIndex`.
   @warn_unused_result
   public func next(i: Int) -> Int {
+    _precondition(i == startIndex)
     return endIndex
   }
 

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -51,6 +51,12 @@ public struct EmptyCollection<Element> : Collection {
     return 0
   }
 
+  /// Always returns `endIndex`.
+  @warn_unused_result
+  public func next(i: Index) -> Index {
+    return endIndex
+  }
+
   /// Returns an empty iterator.
   ///
   /// - Complexity: O(1).

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -113,6 +113,8 @@ public struct EmptyCollection<Element> :
   /// The distance between two indexes (always zero).
   @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
+    _precondition(start == 0, "From must be startIndex (or endIndex)")
+    _precondition(end == 0, "To must be endIndex (or startIndex)")
     return 0
   }
 

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -31,12 +31,16 @@ public struct EmptyIterator<Element> : IteratorProtocol, Sequence {
 }
 
 /// A collection whose element type is `Element` but that is always empty.
-public struct EmptyCollection<Element> : Collection {
+public struct EmptyCollection<Element> :
+  RandomAccessCollection
+  // FIXME: swift-3-indexing-model - conform to MutableCollection as well
+{
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
   /// "past the end" position that's not valid for use as a subscript.
   public typealias Index = Int
+  public typealias IndexDistance = Int
 
   /// Construct an instance.
   public init() {}
@@ -51,10 +55,22 @@ public struct EmptyCollection<Element> : Collection {
     return 0
   }
 
-  /// Always returns `endIndex`.
+  /// Always traps.
+  ///
+  /// EmptyCollection does not have any element indices, so it is not
+  /// possible to advance indices.
   @warn_unused_result
   public func next(i: Index) -> Index {
-    return endIndex
+    fatalError("EmptyCollection can't advance indices")
+  }
+
+  /// Always traps.
+  ///
+  /// EmptyCollection does not have any element indices, so it is not
+  /// possible to advance indices.
+  @warn_unused_result
+  public func previous(i: Index) -> Index {
+    fatalError("EmptyCollection can't advance indices")
   }
 
   /// Returns an empty iterator.
@@ -75,6 +91,32 @@ public struct EmptyCollection<Element> : Collection {
   public var count: Int {
     return 0
   }
+
+  /// Always traps.
+  ///
+  /// EmptyCollection does not have any element indices, so it is not
+  /// possible to advance indices.
+  @warn_unused_result
+  public func advance(i: Index, by n: IndexDistance) -> Index {
+    fatalError("EmptyCollection can't advance indices")
+  }
+
+  /// Always traps.
+  ///
+  /// EmptyCollection does not have any element indices, so it is not
+  /// possible to advance indices.
+  @warn_unused_result
+  public func advance(i: Index, by n: IndexDistance, limit: Index) -> Index {
+    fatalError("EmptyCollection can't advance indices")
+  }
+
+  /// The distance between two indexes (always zero).
+  @warn_unused_result
+  public func distance(from start: Index, to end: Index) -> IndexDistance {
+    return 0
+  }
+
+  // TODO: swift-3-indexing-model - fast fail any others from RandomAccessCollection (and up inheritance)?
 }
 
 @available(*, unavailable, renamed="EmptyIterator")

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -102,7 +102,7 @@ public struct LazyFilterSequence<Base : Sequence>
 public struct LazyFilterIndex<Base : Collection> : Comparable {
 
   /// The position corresponding to `self` in the underlying collection.
-  public let baseIndex: Base.Index
+  public let base: Base.Index
 }
 
 /// Returns `true` iff `lhs` is identical to `rhs`.
@@ -111,7 +111,7 @@ public func == <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
 ) -> Bool {
-  return lhs.baseIndex == rhs.baseIndex
+  return lhs.base == rhs.base
 }
 
 /// Returns `true` iff `lhs` is less than `rhs`.
@@ -120,7 +120,34 @@ public func < <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
 ) -> Bool {
-    return lhs.baseIndex < rhs.baseIndex
+    return lhs.base < rhs.base
+}
+
+/// Returns `true` iff `lhs` is less than or identical to `rhs`.
+@warn_unused_result
+public func <= <Base : Collection>(
+  lhs: LazyFilterIndex<Base>,
+  rhs: LazyFilterIndex<Base>
+  ) -> Bool {
+    return lhs.base <= rhs.base
+}
+
+/// Returns `true` iff `lhs` is greater than or identical to  `rhs`.
+@warn_unused_result
+public func >= <Base : Collection>(
+  lhs: LazyFilterIndex<Base>,
+  rhs: LazyFilterIndex<Base>
+  ) -> Bool {
+    return lhs.base >= rhs.base
+}
+
+/// Returns `true` iff `lhs` is greater than `rhs`.
+@warn_unused_result
+public func > <Base : Collection>(
+  lhs: LazyFilterIndex<Base>,
+  rhs: LazyFilterIndex<Base>
+  ) -> Bool {
+    return lhs.base > rhs.base
 }
 
 /// A lazy `Collection` wrapper that includes the elements of an
@@ -160,7 +187,7 @@ public struct LazyFilterCollection<
   /// - Complexity: O(N), where N is the ratio between unfiltered and
   ///   filtered collection counts.
   public var startIndex: Index {
-    return LazyFilterIndex(baseIndex: _filteredNext(_base.startIndex))
+    return LazyFilterIndex(base: _nextFiltered(_base.startIndex))
   }
 
   /// The collection's "past the end" position.
@@ -171,25 +198,25 @@ public struct LazyFilterCollection<
   ///
   /// - Complexity: O(1).
   public var endIndex: Index {
-    return LazyFilterIndex(baseIndex: _base.endIndex)
+    return LazyFilterIndex(base: _base.endIndex)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
   public func next(index: Index) -> Index {
-    return LazyFilterIndex(baseIndex: _filteredNext(index.baseIndex))
+    return LazyFilterIndex(base: _nextFiltered(index.base))
   }
 
   @inline(__always)
-  private func _filteredNext(baseIndex: Base.Index) -> Base.Index {
-    var baseIndex = baseIndex
-    while baseIndex != _base.endIndex {
-      if _predicate(_base[baseIndex]) {
+  internal func _nextFiltered(index: Base.Index) -> Base.Index {
+    var index = index
+    while index != _base.endIndex {
+      if _predicate(_base[index]) {
         break
       }
-      _base._nextInPlace(&baseIndex)
+      _base._nextInPlace(&index)
     }
-    return baseIndex
+    return index
   }
 
   /// Access the element at `position`.
@@ -197,7 +224,7 @@ public struct LazyFilterCollection<
   /// - Precondition: `position` is a valid position in `self` and
   /// `position != endIndex`.
   public subscript(position: Index) -> Base.Iterator.Element {
-    return _base[position.baseIndex]
+    return _base[position.base]
   }
 
   /// Returns an iterator over the elements of this sequence.

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -189,6 +189,7 @@ public struct LazyFilterCollection<
       }
       _base._nextInPlace(&baseIndex)
     }
+    return baseIndex
   }
 
   /// Access the element at `position`.

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -120,7 +120,7 @@ public func < <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
 ) -> Bool {
-    return lhs.base < rhs.base
+  return lhs.base < rhs.base
 }
 
 /// Returns `true` iff `lhs` is less than or identical to `rhs`.
@@ -128,8 +128,8 @@ public func < <Base : Collection>(
 public func <= <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base <= rhs.base
+) -> Bool {
+  return lhs.base <= rhs.base
 }
 
 /// Returns `true` iff `lhs` is greater than or identical to  `rhs`.
@@ -137,8 +137,8 @@ public func <= <Base : Collection>(
 public func >= <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base >= rhs.base
+) -> Bool {
+  return lhs.base >= rhs.base
 }
 
 /// Returns `true` iff `lhs` is greater than `rhs`.
@@ -146,8 +146,8 @@ public func >= <Base : Collection>(
 public func > <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
-  ) -> Bool {
-    return lhs.base > rhs.base
+) -> Bool {
+  return lhs.base > rhs.base
 }
 
 /// A lazy `Collection` wrapper that includes the elements of an

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -353,6 +353,12 @@ public struct Set<Element : Hashable> :
     return _variantStorage.endIndex
   }
 
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func next(i: Index) -> Index {
+    fatalError("FIXME: swift-3-indexing-model implement")
+  }
+
   // APINAMING: complexity docs are broadly missing in this file.
 
   /// Returns `true` if the set contains a member.
@@ -1033,6 +1039,12 @@ public struct Dictionary<Key : Hashable, Value> :
   ///   `NSDictionary`, O(N) otherwise.
   public var endIndex: Index {
     return _variantStorage.endIndex
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func next(i: Index) -> Index {
+    fatalError("FIXME: swift-3-indexing-model implement")
   }
 
   /// Returns the `Index` for the given key, or `nil` if the key is not

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -170,6 +170,24 @@ extension LazyCollection : Collection {
   public var first: Base.Iterator.Element? {
     return _base.first
   }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func advance(i: Index, by n: Base.IndexDistance) -> Index {
+    return _base.advance(i, by: n)
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func advance(i: Index, by n: Base.IndexDistance, limit: Index) -> Index {
+    return _base.advance(i, by: n, limit: limit)
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
+    return _base.distance(from:start, to: end)
+  }
 }
 
 /// Augment `self` with lazy methods such as `map`, `filter`, etc.

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -118,6 +118,12 @@ extension LazyCollection : Collection {
     return _base.endIndex
   }
 
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func next(i: Base.Index) -> Base.Index {
+    return _base.next(i)
+  }
+
   /// Access the element at `position`.
   ///
   /// - Precondition: `position` is a valid position in `self` and

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -81,7 +81,10 @@ public struct LazyMapCollection<Base : Collection, Element>
 
   public var startIndex: Base.Index { return _base.startIndex }
   public var endIndex: Base.Index { return _base.endIndex }
-  
+
+  @warn_unused_result
+  public func next(i: Index) -> Index { return _base.next(i) }
+
   /// Access the element at `position`.
   ///
   /// - Precondition: `position` is a valid position in `self` and

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -115,7 +115,7 @@ public struct LazyMapCollection<Base : Collection, Element>
 
   @warn_unused_result
   public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
-    return _base.distance(from:start, to: end)
+    return _base.distance(from: start, to: end)
   }
 
   /// Returns an iterator over the elements of this sequence.

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -69,6 +69,11 @@ public struct LazyMapSequence<Base : Sequence, Element>
 
 //===--- Collections ------------------------------------------------------===//
 
+// FIXME: swift-3-indexing-model - need to gyb three variants of 
+//        LazyMapCollection now, for forward, bidirectional and random access
+//        traversal, so that the mapped collection preserves the traversal of
+//        the base collection.
+
 /// A `Collection` whose elements consist of those in a `Base`
 /// `Collection` passed through a transform function returning `Element`.
 /// These elements are computed lazily, each time they're read, by
@@ -97,7 +102,21 @@ public struct LazyMapCollection<Base : Collection, Element>
   public var isEmpty: Bool { return _base.isEmpty }
 
   public var first: Element? { return _base.first.map(_transform) }
-  
+
+  @warn_unused_result
+  public func advance(i: Index, by n: Base.IndexDistance) -> Index {
+    return _base.advance(i, by: n)
+  }
+
+  @warn_unused_result
+  public func advance(i: Index, by n: Base.IndexDistance, limit: Index) -> Index {
+    return _base.advance(i, by: n, limit: limit)
+  }
+
+  @warn_unused_result
+  public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
+    return _base.distance(from:start, to: end)
+  }
 
   /// Returns an iterator over the elements of this sequence.
   ///

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -95,13 +95,7 @@ public protocol MutableIndexable {
   /// range check.
   ///
   /// - Complexity: O(1).
-  func _failEarlyRangeCheck(
-    rangeStart rangeStart: Index,
-    rangeEnd: Index,
-    boundsStart: Index,
-    boundsEnd: Index)
-  // TODO: swift-3-indexing-model - can we change the above to the following? (possible compiler issue)
-  //  func _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>)
+  func _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>)
 
   /// Returns the next consecutive `Index` in a discrete sequence of
   /// `Index` values.
@@ -179,11 +173,7 @@ extension MutableCollection {
 
   public subscript(bounds: Range<Index>) -> MutableSlice<Self> {
     get {
-      _failEarlyRangeCheck(
-        rangeStart: bounds.startIndex,
-        rangeEnd: bounds.endIndex,
-        boundsStart: startIndex,
-        boundsEnd: endIndex)
+      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
       return MutableSlice(_base: self, bounds: bounds)
     }
     set {
@@ -202,11 +192,8 @@ internal func _writeBackMutableSlice<
 >(self_: inout C, bounds: Range<C.Index>, slice: Slice_) {
   fatalError("FIXME: swift-3-indexing-model")
   /*
-  C._failEarlyRangeCheck(
-    rangeStart: bounds.startIndex,
-    rangeEnd: bounds.endIndex,
-    boundsStart: self_.startIndex,
-    boundsEnd: self_.endIndex)
+  C._failEarlyRangeCheck(bounds, self_.startIndex..<self_.endIndex)
+  
   // FIXME(performance): can we use
   // _withUnsafeMutableBufferPointerIfSupported?  Would that create inout
   // aliasing violations if the newValue points to the same buffer?

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -29,7 +29,7 @@ public protocol RandomAccessCollection : BidirectionalCollection {
 extension RandomAccessCollection {
 
   public func _failEarlyRangeCheck(index: Index, bounds: Range<Index>) {
-    fatalError("implement") // TODO: swift-3-indexing-model - implement
+    fatalError("FIXME: swift-3-indexing-model implement")
 /*
     _precondition(
       bounds.startIndex <= index,
@@ -40,12 +40,8 @@ extension RandomAccessCollection {
 */
   }
 
-  public func _failEarlyRangeCheck(
-    rangeStart rangeStart: Index,
-    rangeEnd: Index,
-    boundsStart: Index,
-    boundsEnd: Index
-  ) {
+  public func _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>) {
+    fatalError("FIXME: swift-3-indexing-model implement")
 /*
     let range = rangeStart..<rangeEnd
     let bounds = boundsStart..<boundsEnd
@@ -63,7 +59,6 @@ extension RandomAccessCollection {
       range.endIndex <= bounds.endIndex,
       "range.startIndex is out of bounds: index designates a position after bounds.endIndex")
 */
-    fatalError("implement") // TODO: swift-3-indexing-model - implement
   }
 
 // TODO: swift-3-indexing-model - implement optimized version of the following

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -68,6 +68,12 @@ public struct RangeOfStrideable<
   /// reachable from `startIndex` by zero or more applications of
   /// `successor()`.
   public var endIndex: Element
+  
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func next(i: Element) -> Element {
+    fatalError("FIXME: swift-3-indexing-model implement")
+  }
 
   @warn_unused_result
   public func _customContainsEquatableElement(element: Element) -> Bool? {

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -53,9 +53,7 @@ public struct Slice<Base : Indexable> : Collection {
   }
 
   public subscript(bounds: Range<Index>) -> Slice {
-    _failEarlyRangeCheck(
-      rangeStart: bounds.startIndex, rangeEnd: bounds.endIndex,
-      boundsStart: startIndex, boundsEnd: endIndex)
+    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
     return Slice(_base: _base, bounds: bounds)
   }
 
@@ -119,9 +117,7 @@ public struct MutableSlice<Base : MutableIndexable> : MutableCollection {
 
   public subscript(bounds: Range<Index>) -> MutableSlice {
     get {
-      _failEarlyRangeCheck(
-        rangeStart: bounds.startIndex, rangeEnd: bounds.endIndex,
-        boundsStart: startIndex, boundsEnd: endIndex)
+      _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
       return MutableSlice(_base: _base, bounds: bounds)
     }
     set {

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -231,6 +231,12 @@ extension String.CharacterView : BidirectionalCollection {
     return Index(_base: unicodeScalars.endIndex)
   }
 
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func next(i: Index) -> Index {
+    fatalError("FIXME: swift-3-indexing-model implement")
+  }
+
   /// Access the `Character` at `position`.
   ///
   /// - Precondition: `position` is a valid position in `self` and

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -237,6 +237,12 @@ extension String.CharacterView : BidirectionalCollection {
     fatalError("FIXME: swift-3-indexing-model implement")
   }
 
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func previous(i: Index) -> Index {
+    fatalError("FIXME: swift-3-indexing-model implement")
+  }
+
   /// Access the `Character` at `position`.
   ///
   /// - Precondition: `position` is a valid position in `self` and

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -42,6 +42,12 @@ extension String {
       return Index(_offset: _length)
     }
 
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func next(i: Index) -> Index {
+      return Index(_offset: i._offset.advanced(by: 1))
+    }
+
     @warn_unused_result
     func _internalIndex(at i: Int) -> Int {
       return _core.startIndex + _offset + i

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -48,6 +48,34 @@ extension String {
       return Index(_offset: i._offset.advanced(by: 1))
     }
 
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func previous(i: Index) -> Index {
+      return Index(_offset: i._offset.advanced(by: -1))
+    }
+
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func advance(i: Index, by n: Int) -> Index {
+      return Index(_offset: i._offset.advanced(by: n))
+    }
+
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func advance(i: Index, by n: Int, limit: Index) -> Index {
+      let d = i._offset.distance(to: limit._offset)
+      if d == 0 || (d > 0 ? d <= n : d >= n) {
+        return limit
+      }
+      return Index(_offset: i._offset.advanced(by: n))
+    }
+
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func distance(from start: Index, to end: Index) -> Int {
+      return start._offset.distance(to: end._offset)
+    }
+
     @warn_unused_result
     func _internalIndex(at i: Int) -> Int {
       return _core.startIndex + _offset + i

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -209,6 +209,12 @@ extension String {
       return self._endIndex
     }
 
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func next(i: Index) -> Index {
+      fatalError("FIXME: swift-3-indexing-model implement")
+    }
+
     /// Access the element at `position`.
     ///
     /// - Precondition: `position` is a valid position in `self` and

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -122,6 +122,12 @@ extension String {
       fatalError("FIXME: swift-3-indexing-model implement")
     }
 
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func previous(i: Index) -> Index {
+      fatalError("FIXME: swift-3-indexing-model implement")
+    }
+
     /// Access the element at `position`.
     ///
     /// - Precondition: `position` is a valid position in `self` and

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -116,6 +116,12 @@ extension String {
       return Index(_core.endIndex, _core)
     }
 
+    // TODO: swift-3-indexing-model - add docs
+    @warn_unused_result
+    public func next(i: Index) -> Index {
+      fatalError("FIXME: swift-3-indexing-model implement")
+    }
+
     /// Access the element at `position`.
     ///
     /// - Precondition: `position` is a valid position in `self` and


### PR DESCRIPTION
-removed fatal stub Collection.next(Index)
-added default Collection.next(Index) where Index is Strideable
-added custom next(Index) on some collections
-added fatal stub next(Index) on some collections

@gribozavr I took a stab at building Collection.next(Index) -> Index. As you can see a good number need to be implemented still (those are marked with fatalError("FIXME: swift-3-indexing-model")).
