### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift
@@ -1,0 +1,8 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+class A<T{init(){class S<f{func d:d typealias d:A


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:4372: void (anonymous namespace)::DeclChecker::visitFuncDecl(swift::FuncDecl *): Assertion `!FD->getType()->hasTypeParameter()' failed.
10 swift           0x0000000000e3d6d4 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 788
12 swift           0x0000000000e3d6d4 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 788
13 swift           0x00000000010778fc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 3612
14 swift           0x0000000001075fc0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
15 swift           0x0000000000e7c99b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
18 swift           0x0000000000ea745e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
20 swift           0x0000000000ea8374 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
21 swift           0x0000000000ea735a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
23 swift           0x0000000000e7910c swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
28 swift           0x0000000000e42f36 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
31 swift           0x0000000000ea178d swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 845
32 swift           0x0000000000ea1192 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
33 swift           0x0000000000ea1d38 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
35 swift           0x0000000000e662f4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
36 swift           0x0000000000cb5b9f swift::CompilerInstance::performSema() + 3087
38 swift           0x000000000078a49b frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2523
39 swift           0x0000000000784f45 main + 2837
Stack dump:
0.  Program arguments: /usr/local/bin/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28259-swift-typechecker-validatedecl-e3f732.o
1.  While type-checking 'init' at validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift:8:11
2.  While type-checking 'S' at validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift:8:18
3.  While resolving type d at [validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift:8:35 - line:8:35] RangeText="d"
4.  While type-checking 'd' at validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift:8:37
5.  While type-checking 'd' at validation-test/compiler_crashers/28259-swift-typechecker-validatedecl.swift:8:28
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
