### PR TITLE
<rdar://problem/24814424> Add unit tests for the error handling suppo…

### DIFF
--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -3,11 +3,9 @@
 
 // REQUIRES: objc_interop
 
-// Currently it fails because a dylib cannot be found.
-// TODO: Re-enable this test when rdar://problem/24222804 is fixed
 // REQUIRES: OS=macosx
 
-// watchOS 2.0 does not have a public XCTest module.
+// watchOS 2.0 does not have an XCTest module.
 // XFAIL: OS=watchos
 
 import StdlibUnittest
@@ -36,7 +34,7 @@ XCTestTestSuite.test("exceptions") {
     }
   }
 
-  let testCase = ExceptionTestCase(selector: "test_raises")
+  let testCase = ExceptionTestCase(selector: #selector(ExceptionTestCase.test_raises))
   testCase.runTest()
   let testRun = testCase.testRun!
 
@@ -61,7 +59,7 @@ XCTestTestSuite.test("XCTAssertEqual/Array<T>") {
     }
   }
 
-  let passingTestCase = AssertEqualArrayTestCase(selector: "test_whenArraysAreEqual_passes")
+  let passingTestCase = AssertEqualArrayTestCase(selector: #selector(AssertEqualArrayTestCase.test_whenArraysAreEqual_passes))
   passingTestCase.runTest()
   let passingTestRun = passingTestCase.testRun!
   expectEqual(1, passingTestRun.testCaseCount)
@@ -71,7 +69,7 @@ XCTestTestSuite.test("XCTAssertEqual/Array<T>") {
   expectEqual(0, passingTestRun.totalFailureCount)
   expectTrue(passingTestRun.hasSucceeded)
 
-  let failingTestCase = AssertEqualArrayTestCase(selector: "test_whenArraysAreNotEqual_fails")
+  let failingTestCase = AssertEqualArrayTestCase(selector: #selector(AssertEqualArrayTestCase.test_whenArraysAreNotEqual_fails))
   failingTestCase.runTest()
   let failingTestRun = failingTestCase.testRun!
   expectEqual(1, failingTestRun.testCaseCount)
@@ -95,7 +93,7 @@ XCTestTestSuite.test("XCTAssertEqual/Dictionary<T, U>") {
     }
   }
 
-  let passingTestCase = AssertEqualDictionaryTestCase(selector: "test_whenDictionariesAreEqual_passes")
+  let passingTestCase = AssertEqualDictionaryTestCase(selector: #selector(AssertEqualDictionaryTestCase.test_whenDictionariesAreEqual_passes))
   passingTestCase.runTest()
   let passingTestRun = passingTestCase.testRun!
   expectEqual(1, passingTestRun.testCaseCount)
@@ -105,7 +103,7 @@ XCTestTestSuite.test("XCTAssertEqual/Dictionary<T, U>") {
   expectEqual(0, passingTestRun.totalFailureCount)
   expectTrue(passingTestRun.hasSucceeded)
 
-  let failingTestCase = AssertEqualDictionaryTestCase(selector: "test_whenDictionariesAreNotEqual_fails")
+  let failingTestCase = AssertEqualDictionaryTestCase(selector: #selector(AssertEqualDictionaryTestCase.test_whenDictionariesAreNotEqual_fails))
   failingTestCase.runTest()
   let failingTestRun = failingTestCase.testRun!
   expectEqual(1, failingTestRun.testCaseCount)
@@ -114,6 +112,169 @@ XCTestTestSuite.test("XCTAssertEqual/Dictionary<T, U>") {
   expectEqual(0, failingTestRun.unexpectedExceptionCount)
   expectEqual(1, failingTestRun.totalFailureCount)
   expectFalse(failingTestRun.hasSucceeded)
+}
+
+XCTestTestSuite.test("XCTAssertThrowsError") {
+    class ErrorTestCase: XCTestCase {
+        var doThrow = true
+        var errorCode = 42
+        
+        dynamic func throwSomething() throws {
+            if doThrow {
+                throw NSError(domain: "MyDomain", code: errorCode, userInfo: nil)
+            }
+        }
+
+        dynamic func test_throws() {
+            XCTAssertThrowsError(try throwSomething()) {
+                error in
+                let nserror = error as NSError
+                XCTAssertEqual(nserror.domain, "MyDomain")
+                XCTAssertEqual(nserror.code, 42)
+            }
+        }
+    }
+    
+    // Try success case
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_throws))
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(0, testRun.failureCount)
+        expectEqual(0, testRun.unexpectedExceptionCount)
+        expectEqual(0, testRun.totalFailureCount)
+        expectTrue(testRun.hasSucceeded)
+    }
+
+    // Now try when it does not throw
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_throws))
+        testCase.doThrow = false
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(1, testRun.failureCount)
+        expectEqual(0, testRun.unexpectedExceptionCount)
+        expectEqual(1, testRun.totalFailureCount)
+        expectFalse(testRun.hasSucceeded)
+    }
+
+    
+    // Now try when it throws the wrong thing
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_throws))
+        testCase.errorCode = 23
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(1, testRun.failureCount)
+        expectEqual(0, testRun.unexpectedExceptionCount)
+        expectEqual(1, testRun.totalFailureCount)
+        expectFalse(testRun.hasSucceeded)
+    }
+
+}
+
+XCTestTestSuite.test("XCTAsserts with throwing expressions") {
+    class ErrorTestCase: XCTestCase {
+        var doThrow = true
+        var errorCode = 42
+        
+        dynamic func throwSomething() throws -> String {
+            if doThrow {
+                throw NSError(domain: "MyDomain", code: errorCode, userInfo: nil)
+            }
+            return "Hello"
+        }
+        
+        dynamic func test_withThrowing() {
+            XCTAssertEqual(try throwSomething(), "Hello")
+        }
+    }
+    
+    // Try success case
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
+        testCase.doThrow = false
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(0, testRun.failureCount)
+        expectEqual(0, testRun.unexpectedExceptionCount)
+        expectEqual(0, testRun.totalFailureCount)
+        expectTrue(testRun.hasSucceeded)
+    }
+    
+    // Now try when the expression throws
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(0, testRun.failureCount)
+        expectEqual(1, testRun.unexpectedExceptionCount)
+        expectEqual(1, testRun.totalFailureCount)
+        expectFalse(testRun.hasSucceeded)
+    }
+    
+}
+
+XCTestTestSuite.test("Test methods that wind up throwing") {
+    class ErrorTestCase: XCTestCase {
+        var doThrow = true
+        var errorCode = 42
+        
+        dynamic func throwSomething() throws {
+            if doThrow {
+                throw NSError(domain: "MyDomain", code: errorCode, userInfo: nil)
+            }
+        }
+        
+        dynamic func test_withThrowing() throws {
+            try throwSomething()
+        }
+    }
+    
+    // Try success case
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
+        testCase.doThrow = false
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(0, testRun.failureCount)
+        expectEqual(0, testRun.unexpectedExceptionCount)
+        expectEqual(0, testRun.totalFailureCount)
+        expectTrue(testRun.hasSucceeded)
+    }
+    
+    // Now try when the expression throws
+    do {
+        let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
+        testCase.runTest()
+        let testRun = testCase.testRun!
+        
+        expectEqual(1, testRun.testCaseCount)
+        expectEqual(1, testRun.executionCount)
+        expectEqual(0, testRun.failureCount)
+        expectEqual(1, testRun.unexpectedExceptionCount)
+        expectEqual(1, testRun.totalFailureCount)
+        expectFalse(testRun.hasSucceeded)
+    }
+    
 }
 
 runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This pull request adds some tests for the new functionality added recently to allow XCTest to work with swift error handling. There are three main functional additions to the overlay in support of error handling. 
- XCTAssertThrowsError() was added to allow explicit testing of APIs expected to throw.
- The other XCTAssert...() functions were changed to allow their expressions to throw. If an expression to one of these other expressions does throw, it is treated as an unexpected test failure. (This just allows reducing the boilerplate when testing APIs that can throw but are not expected to.)
- Test methods themselves are allowed to be declared as throwing. Errors thrown from a test method are also treated as an unexpected test failure. (This is also in service of reducing boilerplate.)

The tests added cover all three of these use cases.
#### Resolved bug number:

rdar://problem/24814424 Add unit tests for the error handling support in the XCTest swift overlay

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
