### PR TITLE
[Python] Use consistent import ordering

### DIFF
--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -12,10 +12,10 @@
 #
 # ===----------------------------------------------------------------------===//
 
-import os
-import sys
-import subprocess
 import argparse
+import os
+import subprocess
+import sys
 
 DRIVER_LIBRARY_PATH = "@PATH_TO_DRIVER_LIBRARY@"
 sys.path.append(DRIVER_LIBRARY_PATH)

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -13,17 +13,17 @@
 #
 # ===----------------------------------------------------------------------===//
 
-import subprocess
-import sys
+import argparse
+import datetime
+import glob
+import json
 import os
 import re
-import json
-import urllib2
-import urllib
-import datetime
-import argparse
+import subprocess
+import sys
 import time
-import glob
+import urllib
+import urllib2
 
 DRIVER_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -13,8 +13,8 @@
 # ===----------------------------------------------------------------------===//
 
 import os
-import sys
 import subprocess
+import sys
 
 sys.path.append("@PATH_TO_DRIVER_LIBRARY@")
 

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -12,10 +12,10 @@
 #
 # ===----------------------------------------------------------------------===//
 
-import os
-import sys
 import json
+import os
 import subprocess
+import sys
 
 sys.path.append("@PATH_TO_DRIVER_LIBRARY@")
 

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -18,8 +18,8 @@
 # repeat.sh 3 mypatch/bin/Benchmark_Driver run -o -O > mypatch.O.times
 # compare_perf_tests.py tot.O.times mypatch.O.times | sort -t, -n -k 6 | column -s, -t
 
-import sys
 import re
+import sys
 
 VERBOSE = 0
 

--- a/benchmark/scripts/generate_harness/generate_harness.py
+++ b/benchmark/scripts/generate_harness/generate_harness.py
@@ -14,10 +14,11 @@
 
 # Generate CMakeLists.txt and utils/main.swift from templates.
 
-import jinja2
-import os
 import glob
+import os
 import re
+
+import jinja2
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 perf_dir = os.path.realpath(os.path.join(script_dir, '../..'))

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -12,10 +12,10 @@
 #
 # ===----------------------------------------------------------------------===//
 
-import os
-import subprocess
 import multiprocessing
+import os
 import re
+import subprocess
 
 class Result(object):
     def __init__(self, name, status, output, xfail_list):

--- a/benchmark/utils/convertToJSON.py
+++ b/benchmark/utils/convertToJSON.py
@@ -57,9 +57,10 @@
 #     ]
 # }
 
-import sys
 import json
 import re
+import sys
+
 # Parse lines like this
 # #,TEST,SAMPLES,MIN(ms),MAX(ms),MEAN(ms),SD(ms),MEDIAN(ms)
 SCORERE = re.compile(r"(\d+),[ \t]*(\w+),[ \t]*([\d.]+),[ \t]*([\d.]+)")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -265,7 +265,7 @@ todo_include_todos = True
 #
 
 # Pull in the Swift lexers
-from os.path import dirname, abspath, join as join_paths
+from os.path import abspath, dirname, join as join_paths
 sys.path = [
     join_paths(dirname(dirname(abspath(__file__))), 'utils', 'pygments')
 ] + sys.path

--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -8,8 +8,8 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-import re
 import codecs
+import re
 
 class UnicodeProperty(object):
     """Abstract base class for Unicode properties."""

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -11,10 +11,10 @@
 
 from __future__ import print_function
 
-import json
 import argparse
-import sys
+import json
 import os
+import sys
 
 def find_remap_files(path):
     for root, dirs, files in os.walk(path):

--- a/utils/build-script
+++ b/utils/build-script
@@ -28,22 +28,23 @@ from SwiftBuildSupport import (
     HOME,
     SWIFT_BUILD_ROOT,
     SWIFT_SOURCE_ROOT,
+    WorkingDirectory,
     check_call,
     get_all_preset_names,
     get_preset_options,
     print_with_argv0,
     quote_shell_command,
-    WorkingDirectory,
 )
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
+
 import swift_build_support.clang
 import swift_build_support.cmake
 import swift_build_support.debug
+from swift_build_support.migration import migrate_impl_args
 import swift_build_support.ninja
 import swift_build_support.tar
 import swift_build_support.targets
-from swift_build_support.migration import migrate_impl_args
 
 
 # Main entry point for the preset mode.

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -10,10 +10,11 @@
 
 from __future__ import print_function
 
-import re
-import os
-import subprocess
 import collections
+import os
+import re
+import subprocess
+
 from operator import itemgetter
 
 prefixes = {

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -12,10 +12,10 @@
 from __future__ import print_function
 
 import argparse
-import sys
-import os
-import glob
 import collections
+import glob
+import os
+import sys
 
 from cmpcodesize.compare import \
     compare_function_sizes, compare_sizes_of_file, list_function_sizes, read_sizes

--- a/utils/cmpcodesize/setup.py
+++ b/utils/cmpcodesize/setup.py
@@ -9,9 +9,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import os
-import setuptools
 
 import cmpcodesize
+
+import setuptools
 
 # setuptools expects to be invoked from within the directory of setup.py,
 # but it is nice to allow `python path/to/setup.py install` to work

--- a/utils/create-filecheck-test.py
+++ b/utils/create-filecheck-test.py
@@ -5,10 +5,10 @@
 # the amount of time required for creating complicated FileCheck
 # Tests.
 
-import sys
 import argparse
-import textwrap
 import re
+import sys
+import textwrap
 
 parser = argparse.ArgumentParser(description=textwrap.dedent("""
 Takes an input SIL fragment and changes all SSA variables into FileCheck

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -4,15 +4,16 @@
 
 from __future__ import print_function
 
+import os
 import re
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-import tokenize
 import textwrap
+import tokenize
+
 from bisect import bisect
-import os
 
 def get_line_starts(s):
     """Return a list containing the start index of each line in s.

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -16,10 +16,10 @@
 #
 # ----------------------------------------------------------------------------
 
-import sys
-import re
 import bisect
+import re
 import subprocess
+import sys
 
 line_pattern = re.compile(r'^// ###setline ([0-9]+) "([^"]+)"\s*')
 

--- a/utils/pass-pipeline/scripts/pipeline_generator.py
+++ b/utils/pass-pipeline/scripts/pipeline_generator.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import argparse
 import json
+import os
+import sys
 import textwrap
 
 # Append the src dir
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
 import pass_pipeline_library
+
 import passes
 
 normal_pipeline = list(pass_pipeline_library.normal_passpipelines())

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import subprocess
 import argparse
+import os
+import subprocess
+import sys
 import textwrap
 
 # Append the src dir

--- a/utils/pass-pipeline/src/pass_pipeline_library.py
+++ b/utils/pass-pipeline/src/pass_pipeline_library.py
@@ -1,5 +1,6 @@
 
 import pass_pipeline as ppipe
+
 import passes as p
 
 def diagnostic_passlist():

--- a/utils/profdata_merge/config.py
+++ b/utils/profdata_merge/config.py
@@ -11,8 +11,8 @@
 # This file contains the data structure that transforms arguments into usable
 # values
 
-import tempfile
 import os
+import tempfile
 
 
 class Config():

--- a/utils/profdata_merge/main.py
+++ b/utils/profdata_merge/main.py
@@ -16,10 +16,11 @@
 # This file invokes the runner after parsing arguments.
 
 from __future__ import print_function
-import sys
+
 import argparse
-import tempfile
 import logging
+import sys
+import tempfile
 
 import runner
 

--- a/utils/profdata_merge/process.py
+++ b/utils/profdata_merge/process.py
@@ -11,11 +11,12 @@
 # This file contains the worker processes that watch a file queue for files and
 # merge profile data in parallel.
 
-from multiprocessing import Process
-import pipes
-import os
-import subprocess
 import logging
+import os
+import pipes
+import subprocess
+
+from multiprocessing import Process
 
 
 class ProfdataMergerProcess(Process):

--- a/utils/profdata_merge/runner.py
+++ b/utils/profdata_merge/runner.py
@@ -10,17 +10,21 @@
 
 # This file contains the main subroutines that invoke or stop the merge worker.
 
-import shutil
+import logging
 import os
+import shutil
 import socket
 import sys
-import logging
 
 from multiprocessing import JoinableQueue
-from process import ProfdataMergerProcess
-from server import ProfdataServer
-from main import SERVER_ADDRESS, TESTS_FINISHED_SENTINEL
+
 from config import Config
+
+from main import SERVER_ADDRESS, TESTS_FINISHED_SENTINEL
+
+from process import ProfdataMergerProcess
+
+from server import ProfdataServer
 
 
 def run_server(config):

--- a/utils/profdata_merge/server.py
+++ b/utils/profdata_merge/server.py
@@ -12,8 +12,8 @@
 # the merge worker processes.
 
 import SocketServer
-import thread
 import logging
+import thread
 
 from main import SERVER_ADDRESS, TESTS_FINISHED_SENTINEL
 

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -25,10 +25,10 @@
 
 from __future__ import print_function
 
+import cgi
+import os
 import re
 import sys
-import os
-import cgi
 
 # Open 'stdlib.swift' in this directory if no path specified.
 args = list(sys.argv) + [os.path.join(os.path.dirname(__file__), 'stdlib.swift')]

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -3,9 +3,9 @@
 from __future__ import print_function
 
 import argparse
-import os.path
 import filecmp
 import os
+import os.path
 import shutil
 
 from SwiftBuildSupport import check_call

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -4,9 +4,9 @@
 # where some compiler crashers have been fixed, and move them into the
 # "fixed" testsuite, removing the "--crash" in the process.
 
+import os
 import re
 import sys
-import os
 
 def execute_cmd(cmd):
     print(cmd)

--- a/utils/rth
+++ b/utils/rth
@@ -9,13 +9,13 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-import sys
-import subprocess
 import argparse
-import shutil
 import os
-import shlex
 import pipes
+import shlex
+import shutil
+import subprocess
+import sys
 
 VERBOSE = True
 

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -15,10 +15,10 @@ import argparse
 import glob
 import multiprocessing
 import os
+import pipes
 import subprocess
 import sys
 import tempfile
-import pipes
 
 def get_verify_toolchain_modules_commands(toolchain_dir, sil_opt):
     if sil_opt is None:

--- a/utils/split_file.py
+++ b/utils/split_file.py
@@ -9,10 +9,10 @@ every time an annotation of the form "// BEGIN file1.swift" is encountered. If
 current directory.
 """
 
-import os
-import sys
-import re
 import getopt
+import os
+import re
+import sys
 
 def usage():
     sys.stderr.write(__doc__.strip() + "\n")

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -22,11 +22,11 @@
 from __future__ import print_function
 
 import argparse
+import multiprocessing
 import os
 import re
-import sys
 import subprocess
-import multiprocessing
+import sys
 
 DEFAULT_TARGET_BASED_ON_SDK = {
     'macosx': 'x86_64-apple-macosx10.11',

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -34,12 +34,12 @@
 
 from __future__ import print_function
 
-import subprocess
-import re
-import os
-import sys
 import argparse
 import math
+import os
+import re
+import subprocess
+import sys
 
 
 # Calculate the population standard deviation

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -29,9 +29,9 @@
 from __future__ import print_function
 
 import re
+import subprocess
 import sys
 import tempfile
-import subprocess
 
 def help():
   print("""\


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Use consistent import ordering in Python code.

Ordering used:
1. standard library imports
2. third party imports
3. local package imports

Each group is individually sorted.

This corresponds to the ordering currently in use in the project. Luckily it corresponds to the ordering used by `flake8-import-order` as well.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
