### PR TITLE
[stdlib] Add @noescape to output parameter of UnicodeCodecType.encode

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -286,7 +286,7 @@ extension String {
   // with unpaired surrogates
   func _encode<
     Encoding: UnicodeCodecType
-  >(encoding: Encoding.Type, output: (Encoding.CodeUnit) -> Void)
+  >(encoding: Encoding.Type, @noescape output: (Encoding.CodeUnit) -> Void)
   {
     return _core.encode(encoding, output: output)
   }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -326,7 +326,7 @@ public struct _StringCore {
   /// Write the string, in the given encoding, to output.
   func encode<
     Encoding: UnicodeCodecType
-  >(encoding: Encoding.Type, output: (Encoding.CodeUnit) -> Void)
+  >(encoding: Encoding.Type, @noescape output: (Encoding.CodeUnit) -> Void)
   {
     if _fastPath(_baseAddress != nil) {
       if _fastPath(elementWidth == 1) {

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -66,7 +66,7 @@ public protocol UnicodeCodecType {
 
   /// Encode a `UnicodeScalar` as a series of `CodeUnit`s by
   /// calling `output` on each `CodeUnit`.
-  static func encode(input: UnicodeScalar, output: (CodeUnit) -> Void)
+  static func encode(input: UnicodeScalar, @noescape output: (CodeUnit) -> Void)
 }
 
 /// A codec for [UTF-8](http://www.unicode.org/glossary/#UTF_8).
@@ -389,7 +389,7 @@ public struct UTF8 : UnicodeCodecType {
   /// calling `output` on each `CodeUnit`.
   public static func encode(
     input: UnicodeScalar,
-    output put: (CodeUnit) -> Void
+    @noescape output put: (CodeUnit) -> Void
   ) {
     var c = UInt32(input)
     var buf3 = UInt8(c & 0xFF)
@@ -558,7 +558,7 @@ public struct UTF16 : UnicodeCodecType {
   /// calling `output` on each `CodeUnit`.
   public static func encode(
     input: UnicodeScalar,
-    output put: (CodeUnit) -> Void
+    @noescape output put: (CodeUnit) -> Void
   ) {
     let scalarValue: UInt32 = UInt32(input)
 
@@ -616,7 +616,7 @@ public struct UTF32 : UnicodeCodecType {
   /// calling `output` on each `CodeUnit`.
   public static func encode(
     input: UnicodeScalar,
-    output put: (CodeUnit) -> Void
+    @noescape output put: (CodeUnit) -> Void
   ) {
     put(UInt32(input))
   }
@@ -634,7 +634,7 @@ public func transcode<
   OutputEncoding : UnicodeCodecType
   where InputEncoding.CodeUnit == Input.Element>(
   inputEncoding: InputEncoding.Type, _ outputEncoding: OutputEncoding.Type,
-  _ input: Input, _ output: (OutputEncoding.CodeUnit) -> Void,
+  _ input: Input, @noescape _ output: (OutputEncoding.CodeUnit) -> Void,
   stopOnError: Bool
 ) -> Bool {
   var input = input


### PR DESCRIPTION
#### What's in this pull request?

swift-evolution thread: http://thread.gmane.org/gmane.comp.lang.swift.evolution/8867

Add `@noescape` to  output parameter of `UnicodeCodecType.encode` and related functions.

Conformance:
- `UTF8.encode`
- `UTF16.encode`
- `UTF32.encode`

Related functions:
- `transcode`
- `String._encode`
- `_StringCore.encode`

<!--
Also, add `@noescape` to local closures passed to these functions
E.g.:

```
var result = [UTF8.CodeUnit]()
let output: @noescape (UTF8.CodeUnit) -> Void = { result.append($0) }
UTF8.encode(scalar, output: output)
```
-->

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
