### PR TITLE
[Python] Fix blind "except:" statements

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -128,7 +128,7 @@ def log_results(log_directory, driver, formatted_output, swift_repo=None):
     """
     try:
         branch = get_current_git_branch(swift_repo)
-    except:
+    except (OSError, subprocess.CalledProcessError):
         branch = None
     timestamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
     if branch:
@@ -138,7 +138,7 @@ def log_results(log_directory, driver, formatted_output, swift_repo=None):
     driver_name = os.path.basename(driver)
     try:
         os.makedirs(output_directory)
-    except:
+    except OSError:
         pass
     log_file = os.path.join(output_directory,
                             driver_name + '-' + timestamp + '.log')

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -77,7 +77,7 @@ class LeaksRunnerBenchmarkDriver(perf_test_driver.BenchmarkDriver):
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             p.wait()
             error_out = p.stderr.readlines()
-        except:
+        except OSError:
             print("Child Process Failed! (%s,%s)" % (data['path'], data['test_name']))
             return LeaksRunnerResult(test_name, True)
 
@@ -94,7 +94,7 @@ class LeaksRunnerBenchmarkDriver(perf_test_driver.BenchmarkDriver):
                 d['objc_count'] -= FUNC_TO_GLOBAL_COUNTS[data['test_name']]['objc_count']
 
             return LeaksRunnerResult(test_name, (d['objc_count'] + d['swift_count']) > 0)
-        except:
+        except (KeyError, ValueError):
             print "Failed parse output! (%s,%s)" % (data['path'], data['test_name'])
             return LeaksRunnerResult(test_name, True)
 

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -38,7 +38,7 @@ PrintAllScores = 0
 def parse_int(word):
     try:
         return int(word)
-    except:
+    except ValueError:
         raise Exception("Expected integer value, not " + word)
 
 def get_scores(fname):

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -47,7 +47,7 @@ class CachedProperty(object):
         self.wrapped = wrapped
         try:
             self.__doc__ = wrapped.__doc__
-        except:
+        except AttributeError:
             pass
 
     def __get__(self, instance, instance_type=None):

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -64,7 +64,7 @@ def submit_results_to_server(results_data, submit_url):
     # The result is expected to be a JSON object.
     try:
         return json.loads(result_data)
-    except:
+    except ValueError:
         import traceback
         print("Unable to load result, not a valid JSON object.")
         print()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This commit makes sure that all Python code in the repo specifies which exceptions to catch when using `except:`.

Regressions can be catched using `flake8-blind-except` going forward.

<!-- Description about pull request. -->
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
