### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintGraphNode::getMemberType(…)

### DIFF
--- a/validation-test/compiler_crashers/28260-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers/28260-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend %s -parse
+
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Test case found by fuzzing
+
+protocol A{func<
+typealias f:A
+protocol A{
+class a
+typealias f:a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A crash with stack trace:

```
6  swift           0x0000000000f56566 swift::constraints::ConstraintGraphNode::getMemberType(swift::Identifier, std::function<swift::TypeVariableType* ()>) + 182
7  swift           0x0000000000f5712a swift::constraints::ConstraintGraph::getMemberType(swift::TypeVariableType*, swift::Identifier, std::function<swift::TypeVariableType* ()>) + 154
9  swift           0x000000000109068d swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 45
10 swift           0x0000000000ec5ae6 swift::constraints::ConstraintSystem::openGeneric(swift::DeclContext*, llvm::ArrayRef<swift::GenericTypeParamType*>, llvm::ArrayRef<swift::Requirement>, bool, unsigned int, swift::constraints::ConstraintLocatorBuilder, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >&) + 1110
12 swift           0x000000000109068d swift::Type::transform(std::function<swift::Type (swift::Type)> const&) const + 45
13 swift           0x0000000000ec64fa swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, bool, bool, swift::constraints::ConstraintLocatorBuilder, swift::DeclRefExpr const*, llvm::DenseMap<swift::CanType, swift::TypeVariableType*, llvm::DenseMapInfo<swift::CanType>, llvm::detail::DenseMapPair<swift::CanType, swift::TypeVariableType*> >*) + 778
18 swift           0x0000000000e869a0 swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*) + 288
19 swift           0x0000000000e67048 swift::finishTypeChecking(swift::SourceFile&) + 536
20 swift           0x0000000000cb63aa swift::CompilerInstance::performSema() + 3514
22 swift           0x000000000078a58b frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2523
23 swift           0x0000000000785035 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28260-swift-constraints-constraintgraphnode-getmembertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28260-swift-constraints-constraintgraphnode-getmembertype-a2bfc8.o
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
