### PR TITLE
[Python] Fix AttributeError: CalledProcessError.strerror does not exist

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -78,12 +78,9 @@ def check_call(args, print_command=False, verbose=False):
     try:
         return subprocess.check_call(args)
     except subprocess.CalledProcessError as e:
-        if verbose:
-            print_with_argv0(e.strerror)
-        else:
-            print_with_argv0(
-                "command terminated with a non-zero exit status " +
-                str(e.returncode) + ", aborting")
+        print_with_argv0(
+            "command terminated with a non-zero exit status " +
+            str(e.returncode) + ", aborting")
         sys.stdout.flush()
         sys.exit(1)
     except OSError as e:
@@ -99,12 +96,9 @@ def check_output(args, print_command=False, verbose=False):
     try:
         return subprocess.check_output(args)
     except subprocess.CalledProcessError as e:
-        if verbose:
-            print_with_argv0(e.strerror)
-        else:
-            print_with_argv0(
-                "command terminated with a non-zero exit status " +
-                str(e.returncode) + ", aborting")
+        print_with_argv0(
+            "command terminated with a non-zero exit status " +
+            str(e.returncode) + ", aborting")
         sys.stdout.flush()
         sys.exit(1)
     except OSError as e:


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix `AttributeError`: `CalledProcessError.strerror` does not exist, see [`CalledProcessError` documentation](https://docs.python.org/2/library/subprocess.html#subprocess.CalledProcessError).
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
