### PR TITLE
[upstream-update] update AA interface usage

### DIFF
--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -22,8 +22,7 @@ namespace swift {
   struct SwiftAAResult : llvm::AAResultBase<SwiftAAResult> {
     friend llvm::AAResultBase<SwiftAAResult>;
 
-    explicit SwiftAAResult(const llvm::TargetLibraryInfo &TLI)
-        : AAResultBase(TLI) {}
+    explicit SwiftAAResult() : AAResultBase() {}
     SwiftAAResult(SwiftAAResult &&Arg)
         : AAResultBase(std::move(Arg)) {}
 

--- a/lib/LLVMPasses/LLVMSwiftAA.cpp
+++ b/lib/LLVMPasses/LLVMSwiftAA.cpp
@@ -72,8 +72,7 @@ SwiftAAWrapperPass::SwiftAAWrapperPass() : ImmutablePass(ID) {
 }
 
 bool SwiftAAWrapperPass::doInitialization(Module &M) {
-  Result.reset(new SwiftAAResult(
-      getAnalysis<TargetLibraryInfoWrapperPass>().getTLI()));
+  Result.reset(new SwiftAAResult());
   return false;
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

SVN r262490 reformulated the Alias Analysis interfaces.  The TLI is no longer
needed to construct the AA Result.  Because the TLI was used specifically for
the base constructor, we now no longer need that option.  Simplify it according
to the new API.  NFC.
