### PR TITLE
build: add missing dependency

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-test/CMakeLists.txt
@@ -13,7 +13,7 @@ add_sourcekit_executable(sourcekitd-test
   TestOptions.cpp
   DEPENDS ${SOURCEKITD_TEST_DEPEND}
     clangRewrite clangLex clangBasic
-  COMPONENT_DEPENDS support option
+  COMPONENT_DEPENDS core support option
 )
 
 add_dependencies(sourcekitd-test sourcekitdTestOptionsTableGen)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Add a dependency on LLVMCore to satisfy the link dependency.  Upstream changes
to the Target structure have caused a missing definition:

Undefined symbols for architecture ...:
  "llvm::DataLayout::~DataLayout()", referenced from:
      clang::TargetInfo::~TargetInfo() in libclangBasic.a(TargetInfo.cpp.o)
