### PR TITLE
Count countif range adaptors

### DIFF
--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -270,8 +270,8 @@ template <class T> EnumeratorRange<T> enumerate(T Begin, T End) {
 
 /// An adaptor of std::none_of for ranges.
 template <class Range, class Predicate>
-inline bool none_of(const Range &R, Predicate P) {
-  return std::none_of(R.begin(), R.end(), P);
+inline bool none_of(const Range &R, Predicate &&P) {
+  return std::none_of(R.begin(), R.end(), std::forward<Predicate>(P));
 }
 
 /// An adaptor of std::count for ranges.
@@ -290,9 +290,9 @@ inline auto count(const Range &R, Value V)
 /// We use std::result_of on Range::begin since llvm::iterator_range does not
 /// have a public typedef set to what is the underlying iterator.
 template <class Range, class Predicate>
-inline auto count_if(const Range &R, Predicate P)
+inline auto count_if(const Range &R, Predicate &&P)
   -> typename std::iterator_traits<decltype(R.begin())>::difference_type {
-  return std::count_if(R.begin(), R.end(), P);
+  return std::count_if(R.begin(), R.end(), std::forward<Predicate>(P));
 }
 
 } // namespace swift

--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -274,6 +274,17 @@ inline bool none_of(const Range &R, Predicate P) {
   return std::none_of(R.begin(), R.end(), P);
 }
 
+/// An adaptor of std::count for ranges.
+///
+/// We use std::result_of on Range::begin since llvm::iterator_range does not
+/// have a public typedef set to what is the underlying iterator.
+//typename std::iterator_traits<decltype(&Range::begin())>::difference_type
+template <class Range, class Value>
+inline auto count(const Range &R, Value V)
+  -> typename std::iterator_traits<decltype(R.begin())>::difference_type {
+  return std::count(R.begin(), R.end(), V);
+}
+
 /// An adaptor of std::count_if for ranges.
 ///
 /// We use std::result_of on Range::begin since llvm::iterator_range does not

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -366,7 +366,7 @@ public:
 
   /// \returns True if the function has the semantics flag \p Value;
   bool hasSemanticsAttr(StringRef Value) const {
-    return std::count(SemanticsAttrSet.begin(), SemanticsAttrSet.end(), Value);
+    return count(SemanticsAttrSet, Value);
   }
 
   /// Add the given semantics attribute to the attr list set.

--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -247,13 +247,13 @@ public:
   void recompute();
 
   bool isSingleReleaseMatchedToArgument(SILInstruction *Inst) {
-    auto Pred = [&Inst](std::pair<SILArgument *,
-                                  ReleaseList> &P) -> bool {
+    auto Pred = [&Inst](const std::pair<SILArgument *,
+                                        ReleaseList> &P) -> bool {
       if (P.second.size() > 1)
         return false;
       return *P.second.begin() == Inst;
     };
-    return std::count_if(ArgInstMap.begin(), ArgInstMap.end(), Pred);
+    return count_if(ArgInstMap, Pred);
   }
 
   using iterator = decltype(ArgInstMap)::iterator;

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -607,7 +607,7 @@ private:
 
   void addPred(LoopRegion *LNR) {
     assert(!isFunction() && "Functions cannot have predecessors");
-    if (std::count(pred_begin(), pred_end(), LNR->getID()))
+    if (count(getPreds(), LNR->getID()))
       return;
     Preds.push_back(LNR->ID);
   }
@@ -620,7 +620,7 @@ private:
   void replacePred(unsigned OldPredID, unsigned NewPredID) {
     // Check if we already have NewPred in our list. If so, we just delete
     // OldPredID.
-    if (std::count(Preds.begin(), Preds.end(), NewPredID)) {
+    if (count(Preds, NewPredID)) {
       // If this becomes a performance issue due to copying/moving/etc (which it
       // most likely will not), just use the marked dead model like successor
       // does.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1583,11 +1583,12 @@ SourceFile::getDiscriminatorForPrivateValue(const ValueDecl *D) const {
 
   StringRef name = getFilename();
   if (name.empty()) {
-    assert(1 == std::count_if(getParentModule()->getFiles().begin(),
-                              getParentModule()->getFiles().end(),
-                              [](const FileUnit *FU) -> bool {
-      return isa<SourceFile>(FU) && cast<SourceFile>(FU)->getFilename().empty();
-    }) && "can't promise uniqueness if multiple source files are nameless");
+    assert(1 == count_if(getParentModule()->getFiles(),
+                         [](const FileUnit *FU) -> bool {
+                           return isa<SourceFile>(FU) &&
+                                  cast<SourceFile>(FU)->getFilename().empty();
+                         }) &&
+           "can't promise uniqueness if multiple source files are nameless");
 
     // We still need a discriminator, so keep going.
   }

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -534,8 +534,7 @@ PromotedParamCloner::initCloned(SILFunction *Orig,
   SILFunctionType *OrigFTI = Orig->getLoweredFunctionType();
   unsigned Index = OrigFTI->getNumIndirectResults();
   for (auto &param : OrigFTI->getParameters()) {
-    if (std::count(PromotedParamIndices.begin(), PromotedParamIndices.end(),
-                   Index)) {
+    if (count(PromotedParamIndices, Index)) {
       auto paramTy = param.getType()->castTo<SILBoxType>()
         ->getBoxedAddressType();
       auto promotedParam = SILParameterInfo(paramTy.getSwiftRValueType(),
@@ -588,8 +587,7 @@ PromotedParamCloner::populateCloned() {
   unsigned ArgNo = 0;
   auto I = OrigEntryBB->bbarg_begin(), E = OrigEntryBB->bbarg_end();
   while (I != E) {
-    if (std::count(PromotedParamIndices.begin(),
-                   PromotedParamIndices.end(), ArgNo)) {
+    if (count(PromotedParamIndices, ArgNo)) {
       // Create a new argument with the promoted type.
       auto promotedTy = (*I)->getType().castTo<SILBoxType>()
         ->getBoxedAddressType();
@@ -694,8 +692,7 @@ specializePartialApply(PartialApplyInst *PartialApply,
   // Promote the arguments that need promotion.
   for (auto &O : PartialApply->getArgumentOperands()) {
     auto ParamIndex = getParameterIndexForOperand(&O);
-    if (!std::count(PromotedParamIndices.begin(), PromotedParamIndices.end(),
-                    ParamIndex)) {
+    if (!count(PromotedParamIndices, ParamIndex)) {
       Args.push_back(O.get());
       continue;
     }

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2411,10 +2411,9 @@ bool ArgumentSplitter::createNewArguments() {
 
   // We do not want to split arguments that have less than 2 non-trivial
   // projections.
-  if (std::count_if(Projections.begin(), Projections.end(),
-                    [&](const Projection &P) {
-                      return !P.getType(Ty, Mod).isTrivial(Mod);
-                    }) < 2)
+  if (count_if(Projections, [&](const Projection &P) {
+        return !P.getType(Ty, Mod).isTrivial(Mod);
+      }) < 2)
     return false;
 
   // We subtract one since this will be the number of the first new argument

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -57,7 +57,7 @@ static Optional<Type> checkTypeOfBinding(ConstraintSystem &cs,
   // If the type references the type variable, don't permit the binding.
   SmallVector<TypeVariableType *, 4> referencedTypeVars;
   type->getTypeVariables(referencedTypeVars);
-  if (std::count(referencedTypeVars.begin(), referencedTypeVars.end(), typeVar))
+  if (count(referencedTypeVars, typeVar))
     return None;
 
   // If the type is a type variable itself, don't permit the binding.

--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -253,11 +253,10 @@ bool CtorTesterSet::hasLiveTesters() const {
 }
 
 bool CtorTesterSet::numLiveTesters() const {
-  return std::count_if(Constructed.begin(), Constructed.end(),
-                       [](CtorTester *T) -> bool {
-                         assert(T);
-                         return !T->isIgnorableTester();
-                       });
+  return count_if(Constructed, [](CtorTester *T) -> bool {
+    assert(T);
+    return !T->isIgnorableTester();
+  });
 }
 
 void CtorTesterSet::clearTesters() {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The first commit adds a range adaptor for std::count and changes APIs that use std::count on ranges to just use the range adaptor instead. The second commit changes some uses of std::count_if on ranges to just use the already provided range adaptor.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
