### PR TITLE
Mark Array.withUnsafeMutableBuffer as not escaping the array storage.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -33,6 +33,7 @@ enum class ArrayCallKind {
   kGetElementAddress,
   kMakeMutable,
   kMutateUnknown,
+  kWithUnsafeMutableBufferPointer,
   // The following two semantic function kinds return the result @owned
   // instead of operating on self passed as parameter.
   kArrayInit,

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -99,6 +99,13 @@ bool swift::ArraySemanticsCall::isValidSignature() {
     }
     return true;
   }
+  case ArrayCallKind::kWithUnsafeMutableBufferPointer: {
+    if (SemanticsCall->getOrigCalleeType()->getNumIndirectResults() != 1 ||
+        SemanticsCall->getNumArguments() != 3)
+      return false;
+    auto SelfConvention = FnTy->getSelfParameter().getConvention();
+    return SelfConvention == ParameterConvention::Indirect_Inout;
+  }
   }
 
   return true;
@@ -155,6 +162,7 @@ ArrayCallKind swift::ArraySemanticsCall::getKind() const {
             .Case("array.get_element_address",
                   ArrayCallKind::kGetElementAddress)
             .Case("array.mutate_unknown", ArrayCallKind::kMutateUnknown)
+            .Case("array.withUnsafeMutableBufferPointer", ArrayCallKind::kWithUnsafeMutableBufferPointer)
             .Default(ArrayCallKind::kNone);
     if (Tmp != ArrayCallKind::kNone) {
       assert(Kind == ArrayCallKind::kNone && "Multiple array semantic "

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -486,6 +486,7 @@ static bool isNonMutatingArraySemanticCall(SILInstruction *Inst) {
     return true;
   case ArrayCallKind::kMakeMutable:
   case ArrayCallKind::kMutateUnknown:
+  case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
     return false;
@@ -819,6 +820,7 @@ static bool mayChangeArrayValueToNonUniqueState(ArraySemanticsCall &Call) {
 
   case ArrayCallKind::kNone:
   case ArrayCallKind::kMutateUnknown:
+  case ArrayCallKind::kWithUnsafeMutableBufferPointer:
   case ArrayCallKind::kArrayInit:
   case ArrayCallKind::kArrayUninitialized:
     return true;

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -866,6 +866,7 @@ extension ${Self} {
   ///   that is the target of this method) during the execution of
   ///   `body`: it may not appear to have its correct value.  Instead,
   ///   use only the `UnsafeMutableBufferPointer` argument to `body`.
+  @_semantics("array.withUnsafeMutableBufferPointer")
   public mutating func withUnsafeMutableBufferPointer<R>(
     @noescape body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
@@ -874,6 +875,13 @@ extension ${Self} {
 
     // Ensure that body can't invalidate the storage or its bounds by
     // moving self into a temporary working array.
+    // NOTE: The stack promotion optimization that keys of the
+    // "array.withUnsafeMutableBufferPointer" semantics annotation relies on the
+    // array buffer not being able to escape in the closure. It can do this
+    // because we swap the array buffer in self with an empty buffer here. Any
+    // escape via the address of self in the closure will therefore escape the
+    // empty array.
+
     var work = ${Self}()
     swap(&work, &self)
 

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1183,6 +1183,28 @@ bb0(%0 : $Array<X>):
   return %r : $()
 }
 
+// CHECK-LABEL: CG of arraysemantics_withUnsafeMutableBufferPointer
+// CHECK-NEXT:   Arg %0 Esc: A, Succ: (%0.1)
+// CHECK-NEXT:   Con %0.1 Esc: A, Succ: (%0.2)
+// CHECK-NEXT:   Con %0.2 Esc: A, Succ: (%0.3)
+// CHECK-NEXT:   Con %0.3 Esc: G, Succ:
+// CHECK-NEXT:   Arg %1 Esc: G, Succ: (%1.1)
+// CHECK-NEXT:   Con %1.1 Esc: G, Succ:
+// CHECK-NEXT:   Val %3 Esc: %4, Succ:
+// CHECK-NEXT: End
+sil @arraysemantics_withUnsafeMutableBufferPointer : $@convention(thin) (@inout Array<X>, @owned @callee_owned (@inout X) -> (@out (), @error ErrorType)) -> () {
+bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error ErrorType)):
+
+  %2 = function_ref @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout X) -> (@out (), @error ErrorType), @inout Array<X>) -> (@out (), @error ErrorType)
+  %3 = alloc_stack $()
+  %4 = apply [nothrow] %2(%3, %1, %0) : $@convention(method) (@owned @callee_owned (@inout X) -> (@out (), @error ErrorType), @inout Array<X>) -> (@out (), @error ErrorType)
+  dealloc_stack %3 : $*()
+
+  %r = tuple()
+  return %r : $()
+}
+
+sil [_semantics "array.withUnsafeMutableBufferPointer"] @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout X) -> (@out (), @error ErrorType), @inout Array<X>) -> (@out (), @error ErrorType)
 sil [_semantics "array.props.isNativeTypeChecked"] @is_native_type_checked : $@convention(method) (@guaranteed Array<X>) -> Bool
 sil [_semantics "array.check_subscript"] @check_subscript : $@convention(method) (Int32, Bool, @guaranteed Array<X>) -> ()
 sil [_semantics "array.check_index"] @check_index : $@convention(method) (Int32, @guaranteed Array<X>) -> ()

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -349,6 +349,7 @@ bb0(%0 : $Int, %1 : $Int, %2 : $Int, %3 : $Int):
 }
 
 sil [_semantics "array.uninitialized"] @init_array_with_buffer : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+sil [_semantics "array.withUnsafeMutableBufferPointer"] @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
 
 sil @swift_bufferAllocate : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
 
@@ -359,6 +360,174 @@ bb0(%0 : $Array<Int>):
   return %2 : $()                                 
 }
 
+// CHECK-LABEL: sil @promote_array_withUnsafeMutableBufferPointer_use
+// CHECK: [[ARR:%.*]] = alloc_stack $Array<Int>
+// CHECK: [[AF:%[0-9]+]] = function_ref @swift_bufferAllocateOnStack : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+// CHECK: [[B:%[0-9]+]] = apply [[AF]](
+// CHECK: [[IF:%[0-9]+]] = function_ref @init_array_with_buffer
+// CHECK: [[A:%[0-9]+]] = apply [[IF]]([[B]],
+// CHECK: [[AV:%.*]] = tuple_extract [[A]]{{.*}}, 0
+// CHECK: tuple_extract [[A]]
+// CHECK: store [[AV]] to [[ARR]]
+// CHECK: [[DF:%[0-9]+]] = function_ref @swift_bufferDeallocateFromStack : $@convention(thin) (@guaranteed AnyObject) -> ()
+// CHECK: apply [[DF]]([[B]])
+// CHECK: return
 
+sil @promote_array_withUnsafeMutableBufferPointer_use : $@convention(thin) (Int, Int, Int, Int, @owned @callee_owned (@inout Int) -> (@out (), @error ErrorType)) -> () {
+bb0(%0 : $Int, %1 : $Int, %2 : $Int, %3 : $Int, %closure: $@callee_owned (@inout Int) -> (@out (), @error ErrorType)):
 
+  %the_array = alloc_stack $Array<Int>
 
+  %4 = function_ref @swift_bufferAllocate : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+  %5 = metatype $@thick DummyArrayStorage<Int>.Type
+  %6 = init_existential_metatype %5 : $@thick DummyArrayStorage<Int>.Type, $@thick AnyObject.Type
+
+  // allocate the buffer
+  %7 = apply %4(%6, %1, %2) : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+  %8 = metatype $@thin Array<Int>.Type
+  %9 = function_ref @init_array_with_buffer : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+
+  // initialize the buffer
+  %10 = apply %9(%7, %3, %8) : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+  %11 = tuple_extract %10 : $(Array<Int>, UnsafeMutablePointer<Int>), 0
+  %12 = tuple_extract %10 : $(Array<Int>, UnsafeMutablePointer<Int>), 1
+  %13 = struct_extract %12 : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+  %14 = pointer_to_address %13 : $Builtin.RawPointer to $*Int
+
+  // store the 2 elements
+  store %0 to %14 : $*Int
+  %16 = integer_literal $Builtin.Word, 1
+  %17 = index_addr %14 : $*Int, %16 : $Builtin.Word
+  store %0 to %17 : $*Int
+
+  store %11 to %the_array : $*Array<Int>
+
+  // pass the array to a function
+  %19 = function_ref @take_array : $@convention(thin) (@owned Array<Int>) -> ()
+  %20 = apply %19(%11) : $@convention(thin) (@owned Array<Int>) -> ()
+
+  // pass the array to the withUnsafeMutableBufferPointer closure.
+  %21 = function_ref @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
+  %22 = alloc_stack $()
+  %23 = apply [nothrow]%21(%22, %closure, %the_array) : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
+  dealloc_stack %22 : $*()
+
+  dealloc_stack %the_array: $*Array<Int>
+  %24 = tuple ()
+  return %24 : $()
+}
+
+sil @array_capture_closure : $@convention(thin) (@inout Int, @owned Array<Int>) -> (@out ())
+
+// CHECK-LABEL: sil @dont_promote_array_withUnsafeMutableBufferPointer_capture
+// CHECK: [[AF:%[0-9]+]] = function_ref @swift_bufferAllocate : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+// CHECK: apply [[AF]](
+// CHECK-NOT: swift_bufferDeallocateFromStack
+// CHECK: return
+
+sil @dont_promote_array_withUnsafeMutableBufferPointer_capture : $@convention(thin) (Int, Int, Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int, %2 : $Int, %3 : $Int):
+
+  %the_array = alloc_stack $Array<Int>
+
+  %4 = function_ref @swift_bufferAllocate : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+  %5 = metatype $@thick DummyArrayStorage<Int>.Type
+  %6 = init_existential_metatype %5 : $@thick DummyArrayStorage<Int>.Type, $@thick AnyObject.Type
+
+  // allocate the buffer
+  %7 = apply %4(%6, %1, %2) : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+  %8 = metatype $@thin Array<Int>.Type
+  %9 = function_ref @init_array_with_buffer : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+
+  // initialize the buffer
+  %10 = apply %9(%7, %3, %8) : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+  %11 = tuple_extract %10 : $(Array<Int>, UnsafeMutablePointer<Int>), 0
+  %12 = tuple_extract %10 : $(Array<Int>, UnsafeMutablePointer<Int>), 1
+  %13 = struct_extract %12 : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+  %14 = pointer_to_address %13 : $Builtin.RawPointer to $*Int
+
+  // store the 2 elements
+  store %0 to %14 : $*Int
+  %16 = integer_literal $Builtin.Word, 1
+  %17 = index_addr %14 : $*Int, %16 : $Builtin.Word
+  store %0 to %17 : $*Int
+
+  store %11 to %the_array : $*Array<Int>
+
+  // pass the array to a function
+  %19 = function_ref @take_array : $@convention(thin) (@owned Array<Int>) -> ()
+  %20 = apply %19(%11) : $@convention(thin) (@owned Array<Int>) -> ()
+
+  // pass the array to the withUnsafeMutableBufferPointer closure.
+  %closure_fun = function_ref @array_capture_closure : $@convention(thin) (@inout Int, @owned Array<Int>) -> (@out ())
+  %closure = partial_apply %closure_fun(%11) : $@convention(thin) (@inout Int, @owned Array<Int>) -> (@out ())
+  %closure2 = convert_function %closure : $@callee_owned (@inout Int) -> (@out ()) to $@callee_owned (@inout Int) -> (@out (), @error ErrorType)
+  %21 = function_ref @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
+  %22 = alloc_stack $()
+  %23 = apply [nothrow]%21(%22, %closure2, %the_array) : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
+  dealloc_stack %22 : $*()
+
+  dealloc_stack %the_array: $*Array<Int>
+  %24 = tuple ()
+  return %24 : $()
+}
+
+// CHECK-LABEL: sil @promote_array_withUnsafeMutableBufferPointer_capture
+// CHECK: [[ARR:%.*]] = alloc_stack $Array<Int>
+// CHECK: [[AF:%[0-9]+]] = function_ref @swift_bufferAllocateOnStack : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+// CHECK: [[B:%[0-9]+]] = apply [[AF]](
+// CHECK: [[IF:%[0-9]+]] = function_ref @init_array_with_buffer
+// CHECK: [[A:%[0-9]+]] = apply [[IF]]([[B]],
+// CHECK: [[AV:%.*]] = tuple_extract [[A]]{{.*}}, 0
+// CHECK: tuple_extract [[A]]
+// CHECK: store [[AV]] to [[ARR]]
+// CHECK: [[DF:%[0-9]+]] = function_ref @swift_bufferDeallocateFromStack : $@convention(thin) (@guaranteed AnyObject) -> ()
+// CHECK: apply [[DF]]([[B]])
+// CHECK: return
+
+sil @promote_array_withUnsafeMutableBufferPointer_capture : $@convention(thin) (Int, Int, Int, Int, @owned Array<Int>) -> () {
+bb0(%0 : $Int, %1 : $Int, %2 : $Int, %3 : $Int, %another: $Array<Int>):
+
+  %the_array = alloc_stack $Array<Int>
+
+  %4 = function_ref @swift_bufferAllocate : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+  %5 = metatype $@thick DummyArrayStorage<Int>.Type
+  %6 = init_existential_metatype %5 : $@thick DummyArrayStorage<Int>.Type, $@thick AnyObject.Type
+
+  // allocate the buffer
+  %7 = apply %4(%6, %1, %2) : $@convention(thin) (@thick AnyObject.Type, Int, Int) -> @owned AnyObject
+  %8 = metatype $@thin Array<Int>.Type
+  %9 = function_ref @init_array_with_buffer : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+
+  // initialize the buffer
+  %10 = apply %9(%7, %3, %8) : $@convention(thin) (@owned AnyObject, Int, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
+  %11 = tuple_extract %10 : $(Array<Int>, UnsafeMutablePointer<Int>), 0
+  %12 = tuple_extract %10 : $(Array<Int>, UnsafeMutablePointer<Int>), 1
+  %13 = struct_extract %12 : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+  %14 = pointer_to_address %13 : $Builtin.RawPointer to $*Int
+
+  // store the 2 elements
+  store %0 to %14 : $*Int
+  %16 = integer_literal $Builtin.Word, 1
+  %17 = index_addr %14 : $*Int, %16 : $Builtin.Word
+  store %0 to %17 : $*Int
+
+  store %11 to %the_array : $*Array<Int>
+
+  // pass the array to a function
+  %19 = function_ref @take_array : $@convention(thin) (@owned Array<Int>) -> ()
+  %20 = apply %19(%11) : $@convention(thin) (@owned Array<Int>) -> ()
+
+  // pass the array to the withUnsafeMutableBufferPointer closure.
+  %closure_fun = function_ref @array_capture_closure : $@convention(thin) (@inout Int, @owned Array<Int>) -> (@out ())
+  %closure = partial_apply %closure_fun(%another) : $@convention(thin) (@inout Int, @owned Array<Int>) -> (@out ())
+  %closure2 = convert_function %closure : $@callee_owned (@inout Int) -> (@out ()) to $@callee_owned (@inout Int) -> (@out (), @error ErrorType)
+  %21 = function_ref @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
+  %22 = alloc_stack $()
+  %23 = apply [nothrow]%21(%22, %closure2, %the_array) : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error ErrorType), @inout Array<Int>) -> (@out (), @error ErrorType)
+  dealloc_stack %22 : $*()
+
+  dealloc_stack %the_array: $*Array<Int>
+  %24 = tuple ()
+  return %24 : $()
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Optimization to stack promote in the presence of Array.withUnsafeMutableBufferPointer {...}
#### Resolved bug number: None

---

This is safe because the closure is not allowed to capture the array according
to the documentation of 'withUnsafeMutableBuffer' and the current implementation
makes sure that any such capture would observe an empty array by swapping self
with an empty array.

Users will get "almost guaranteed" stack promotion for small arrays by writing
something like:

  func testStackAllocation(p: Proto) {
    var a = [p, p, p]
    a.withUnsafeMutableBufferPointer {
      let array = $0
      work(array)
    }
  }

It is "almost guaranteed" because we need to statically be able to tell the size
required for the array (no unspecialized generics) and the total buffer size
must not exceed 1K.
