### PR TITLE
Allow swift to be built for iphoneos-armv7s, a variation on armv7,

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -359,6 +359,22 @@ function set_deployment_target_based_options() {
                         -DSWIFT_HOST_VARIANT_ARCH="armv7"
                     )
                     ;;
+                iphoneos-armv7s)
+                    xcrun_sdk_name="iphoneos"
+                    llvm_host_triple="armv7s-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}"
+                    llvm_target_arch="ARM"
+                    cmake_osx_deployment_target=""
+                    cmark_cmake_options=(
+                        -DCMAKE_C_FLAGS="$(cmark_c_flags ${deployment_target})"
+                        -DCMAKE_CXX_FLAGS="$(cmark_c_flags ${deployment_target})"
+                        -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
+                    )
+                    swift_cmake_options=(
+                        -DSWIFT_HOST_VARIANT="iphoneos"
+                        -DSWIFT_HOST_VARIANT_SDK="IOS"
+                        -DSWIFT_HOST_VARIANT_ARCH="armv7s"
+                    )
+                    ;;
                 iphoneos-arm64)
                     xcrun_sdk_name="iphoneos"
                     llvm_host_triple="arm64-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}"
@@ -787,7 +803,7 @@ CROSS_TOOLS_DEPLOYMENT_TARGETS=()
 for t in ${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS} ; do
     case ${t} in
         iphonesimulator-i386 | iphonesimulator-x86_64 | \
-        iphoneos-arm64 | iphoneos-armv7 | \
+        iphoneos-arm64 | iphoneos-armv7 | iphoneos-armv7s | \
         appletvos-arm64 | appletvsimulator-x86_64 | \
         watchos-armv7k | watchsimulator-i386)
             CROSS_TOOLS_DEPLOYMENT_TARGETS=(
@@ -1258,6 +1274,9 @@ function common_cross_c_flags() {
             ;;
         iphoneos-armv7)
             echo "-arch armv7 -miphoneos-version-min=${DARWIN_DEPLOYMENT_VERSION_IOS}"
+            ;;
+        iphoneos-armv7s)
+            echo "-arch armv7s -miphoneos-version-min=${DARWIN_DEPLOYMENT_VERSION_IOS}"
             ;;
         iphoneos-arm64)
             echo "-arch arm64 -miphoneos-version-min=${DARWIN_DEPLOYMENT_VERSION_IOS}"


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Allow swift to be configured for iphoneos-armv7s, similar to iphoneos-armv7.  armv7s is a variation on armv7, used in Apple A6 and later 32-bit devices.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

used with the Apple A6 and later 32-bit devices.
