### PR TITLE
[stdlib] Add @noescape to output parameter of UnicodeCodecType.encode

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -289,7 +289,7 @@ extension String {
   // with unpaired surrogates
   func _encode<
     Encoding: UnicodeCodec
-  >(encoding: Encoding.Type, output: (Encoding.CodeUnit) -> Void)
+  >(encoding: Encoding.Type, @noescape output: (Encoding.CodeUnit) -> Void)
   {
     return _core.encode(encoding, output: output)
   }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -328,7 +328,7 @@ public struct _StringCore {
   /// Write the string, in the given encoding, to output.
   func encode<
     Encoding: UnicodeCodec
-  >(encoding: Encoding.Type, output: (Encoding.CodeUnit) -> Void)
+  >(encoding: Encoding.Type, @noescape output: (Encoding.CodeUnit) -> Void)
   {
     if _fastPath(_baseAddress != nil) {
       if _fastPath(elementWidth == 1) {

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -72,7 +72,7 @@ public protocol UnicodeCodec {
   /// calling `output` on each `CodeUnit`.
   static func encode(
     input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: (CodeUnit) -> Void
+    @noescape sendingOutputTo processCodeUnit: (CodeUnit) -> Void
   )
 }
 
@@ -396,7 +396,7 @@ public struct UTF8 : UnicodeCodec {
   /// calling `output` on each `CodeUnit`.
   public static func encode(
     input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: (CodeUnit) -> Void
+    @noescape sendingOutputTo processCodeUnit: (CodeUnit) -> Void
   ) {
     var c = UInt32(input)
     var buf3 = UInt8(c & 0xFF)
@@ -563,7 +563,7 @@ public struct UTF16 : UnicodeCodec {
   /// calling `output` on each `CodeUnit`.
   public static func encode(
     input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: (CodeUnit) -> Void
+    @noescape sendingOutputTo processCodeUnit: (CodeUnit) -> Void
   ) {
     let scalarValue: UInt32 = UInt32(input)
 
@@ -619,7 +619,7 @@ public struct UTF32 : UnicodeCodec {
   /// calling `output` on each `CodeUnit`.
   public static func encode(
     input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: (CodeUnit) -> Void
+    @noescape sendingOutputTo processCodeUnit: (CodeUnit) -> Void
   ) {
     processCodeUnit(UInt32(input))
   }
@@ -641,7 +641,7 @@ public func transcode<
   from inputEncoding: InputEncoding.Type,
   to outputEncoding: OutputEncoding.Type,
   stoppingOnError stopOnError: Bool,
-  sendingOutputTo processCodeUnit: (OutputEncoding.CodeUnit) -> Void
+  @noescape sendingOutputTo processCodeUnit: (OutputEncoding.CodeUnit) -> Void
 ) -> Bool {
   var input = input
 


### PR DESCRIPTION
Reverts apple/swift#1590

To be merged when https://bugs.swift.org/browse/SR-901 is fixed.
