### PR TITLE
[Python] Use new style class definitions: "class A" → "class A(object)"

### DIFF
--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -555,7 +555,7 @@ def register_functions(lib, ignore_errors):
     map(register, functionList)
 
 
-class Config:
+class Config(object):
     library_path = None
     library_file = None
     loaded = False

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -371,7 +371,7 @@ def code_starts_with_dedent_keyword(source_lines):
     return token_text in ('else', 'elif', 'except', 'finally')
 
 
-class ParseContext:
+class ParseContext(object):
     """State carried through a parse of a template"""
 
     filename = ''
@@ -539,7 +539,7 @@ class ParseContext:
         self.token_kind = None
 
 
-class ExecutionContext:
+class ExecutionContext(object):
     """State we pass around during execution of a template"""
 
     def __init__(self, line_directive='// ###setline', **local_bindings):

--- a/utils/profdata_merge/config.py
+++ b/utils/profdata_merge/config.py
@@ -15,7 +15,7 @@ import os
 import tempfile
 
 
-class Config():
+class Config(object):
     """A class to store configuration information specified by command-line
     arguments.
     """

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -47,7 +47,7 @@ def pstdev(l):
     return (sum((x - sum(l) / float(len(l))) ** 2 for x in l) / len(l)) ** 0.5
 
 
-class SwiftBenchHarness:
+class SwiftBenchHarness(object):
     sources = []
     verbose_level = 0
     compiler = ""
@@ -332,7 +332,7 @@ extern "C" int64_t opaqueGetInt64(int64_t x) { return x; }
             self.tests[t].do_print()
 
 
-class Test:
+class Test(object):
 
     def __init__(self, name, source, processed_source, binary):
         self.name = name
@@ -354,7 +354,7 @@ class Test:
         print("")
 
 
-class TestResults:
+class TestResults(object):
 
     def __init__(self, name, samples):
         self.name = name

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -45,7 +45,7 @@ Use the a unique output-suffix to open a CFG in a new window.
 """)
 
 
-class Block:
+class Block(object):
 
     current_index = 0
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Use new style class definitions: `class A` → `class A(object)`

Context: https://www.python.org/doc/newstyle/
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
