### PR TITLE
stdlib: unhide important underscored protocols in the generated interface

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2467,7 +2467,8 @@ public:
   // Implement swift::VisibleDeclConsumer.
   void foundDecl(ValueDecl *D, DeclVisibilityKind Reason) override {
     // Hide private stdlib declarations.
-    if (D->isPrivateStdlibDecl(/*whitelistProtocols*/false))
+    if (D->isPrivateStdlibDecl(/*whitelistProtocols*/false) ||
+        D->getAttrs().hasAttribute<ShowInInterfaceAttr>())
       return;
     if (AvailableAttr::isUnavailable(D))
       return;

--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -48,6 +48,7 @@ public typealias UIntMax = ${UIntMax}
 
 /// This protocol is an implementation detail of `Integer`; do
 /// not use it directly.
+@_show_in_interface
 public protocol _Integer
   : _BuiltinIntegerLiteralConvertible,
     IntegerLiteralConvertible,
@@ -65,6 +66,7 @@ public protocol Integer : _Integer, RandomAccessIndex {
 
 /// This protocol is an implementation detail of `SignedInteger`;
 /// do not use it directly.
+@_show_in_interface
 public protocol _SignedInteger : _Integer, SignedNumber {
   /// Represent this number using Swift's widest native signed integer
   /// type.
@@ -89,6 +91,7 @@ public protocol SignedInteger : _SignedInteger, Integer {
 
 /// This protocol is an implementation detail of `UnsignedInteger`;
 /// do not use it directly.
+@_show_in_interface
 public protocol _DisallowMixedSignArithmetic : _Integer {
   // Used to create a deliberate ambiguity in cases like UInt(1) +
   // Int(1), which would otherwise compile due to the arithmetic

--- a/stdlib/public/core/Index.swift
+++ b/stdlib/public/core/Index.swift
@@ -22,6 +22,7 @@
 ///
 /// Its requirements are inherited by `ForwardIndex` and thus must
 /// be satisfied by types conforming to that protocol.
+@_show_in_interface
 public protocol _Incrementable : Equatable {
   /// Returns the next consecutive value in a discrete sequence of
   /// `Self` values.
@@ -329,6 +330,7 @@ public postfix func -- <T : BidirectionalIndex> (i: inout T) -> T {
 
 /// Used to force conformers of RandomAccessIndex to implement
 /// `advanced(by:)` methods and `distance(to:)`.
+@_show_in_interface
 public protocol _RandomAccessAmbiguity {
   associatedtype Distance : _SignedInteger = Int
 }

--- a/stdlib/public/core/IntegerArithmetic.swift.gyb
+++ b/stdlib/public/core/IntegerArithmetic.swift.gyb
@@ -29,6 +29,7 @@ integerBinaryOps = [
 ///
 /// Its requirements are inherited by `IntegerArithmetic` and thus must
 /// be satisfied by types conforming to that protocol.
+@_show_in_interface
 public protocol _IntegerArithmetic {
 % for name,_,Action,result in integerBinaryOps:
   /// ${Action} `lhs` and `rhs`, returning ${result} and a `Bool` that is

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that is just a wrapper over some base Sequence
+@_show_in_interface
 public // @testable
 protocol _SequenceWrapper {
   associatedtype Base : Sequence

--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -14,6 +14,13 @@
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=Swift -source-filename %s -print-interface -skip-underscored-stdlib-protocols > %t-prot.txt
 // RUN: FileCheck -check-prefix=CHECK-UNDERSCORED-PROT %s < %t-prot.txt
+// CHECK-UNDERSCORED-PROT: public protocol _DisallowMixedSignArithmetic
+// CHECK-UNDERSCORED-PROT: public protocol _Incrementable
+// CHECK-UNDERSCORED-PROT: public protocol _Integer
+// CHECK-UNDERSCORED-PROT: public protocol _IntegerArithmetic
+// CHECK-UNDERSCORED-PROT: public protocol _RandomAccessAmbiguity
+// CHECK-UNDERSCORED-PROT: public protocol _SequenceWrapper
+// CHECK-UNDERSCORED-PROT: public protocol _SignedInteger
 // CHECK-UNDERSCORED-PROT-NOT: protocol _
 
 // CHECK-ARGC: static var argc: CInt { get }


### PR DESCRIPTION
Some protocols are underscored, and yet they contribute important APIs to the types provided by the standard library.
