### PR TITLE
fix tests for FileCheck behaviour

### DIFF
--- a/test/1_stdlib/ArrayBridge.swift
+++ b/test/1_stdlib/ArrayBridge.swift
@@ -345,7 +345,7 @@ func testExplicitlyBridged() {
   let roundTripBridgedSwifts
     = Swift._forceBridgeFromObjectiveC(bridgedSwiftsAsNSArray, 
                                        [BridgedSwift].self)
-  // CHECK-NEXT-NOT: [BridgedSwift#[[id00]](42), BridgedSwift#[[id01]](17)]
+  // CHECK-NOT: [BridgedSwift#[[id00]](42), BridgedSwift#[[id01]](17)]
   // CHECK-NEXT: [BridgedSwift#[[id10:[0-9]+]](42), BridgedSwift#[[id11:[0-9]+]](17)]
   print("roundTripBridgedSwifts = \(roundTripBridgedSwifts))")
 
@@ -355,8 +355,8 @@ func testExplicitlyBridged() {
   // ...and bridge *that* back
   let bridgedBackSwifts
     = Swift._forceBridgeFromObjectiveC(cocoaBridgedSwifts, [BridgedSwift].self)
-  // CHECK-NEXT-NOT: [BridgedSwift#[[id00]](42), BridgedSwift#[[id01]](17)]
-  // CHECK-NEXT-NOT: [BridgedSwift#[[id10]](42), BridgedSwift#[[id11]](17)]
+  // CHECK-NOT: [BridgedSwift#[[id00]](42), BridgedSwift#[[id01]](17)]
+  // CHECK-NOT: [BridgedSwift#[[id10]](42), BridgedSwift#[[id11]](17)]
   // CHECK-NEXT: [BridgedSwift#{{[0-9]+}}(42), BridgedSwift#{{[0-9]+}}(17)]
   print("bridgedBackSwifts      = \(bridgedBackSwifts)")
   

--- a/test/SourceKit/Indexing/index_with_clang_module.swift
+++ b/test/SourceKit/Indexing/index_with_clang_module.swift
@@ -11,7 +11,7 @@ func foo(a: FooClassDerived) {
 // CHECK:      key.kind: source.lang.swift.import.module.clang
 // CHECK-NEXT: key.name: "Foo"
 // CHECK-NEXT: key.filepath: "{{.*[/\\]}}Foo{{.*}}.pcm"
-// CHECK-NEXT-NOT: key.hash:
+// CHECK-NOT: key.hash:
 
 // CHECK:      key.kind: source.lang.swift.ref.class
 // CHECK-NEXT: key.name: "FooClassDerived"


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

FileCheck does not support the combination negation.  These tests were incorrect
and silently passing rather than checking what they intended.  The changes in
the DAG tests are due to the fact that they ensure that the order is matched,
which the tests seem to not be interested in.
