### PR TITLE
IRGen: Add missing forwarding stub in FixedEnumImplStrategy.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -4855,6 +4855,10 @@ namespace {
     const override {
       return Strategy.getFixedExtraInhabitantValue(IGM, bits, index);
     }
+    
+    APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
+      return Strategy.getFixedExtraInhabitantMask(IGM);
+    }
   };
 
   /// TypeInfo for loadable enum types.

--- a/test/IRGen/enum_switch_singleton_enum_in_optional.sil
+++ b/test/IRGen/enum_switch_singleton_enum_in_optional.sil
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+sil_stage canonical
+
+enum Optional<T> { case Some(T), None }
+
+class AClass {
+}
+
+protocol  AProto {
+}
+
+enum AnEnum {
+    case ACase(a: AClass, b: AProto)
+}
+
+// CHECK-LABEL: define {{.*}} @switch_singleton_enum_in_optional
+// CHECK:         [[CAST:%.*]] = bitcast {{.*}} %0 to { [[WORD:i[0-9]+]], [[WORD]], [[WORD]], [[WORD]], [[WORD]], [[WORD]] }*
+// CHECK:         [[GEP:%.*]] = getelementptr {{.*}} %1, i32 0, i32 0
+// CHECK:         [[FIRSTWORD:%.*]] = load [[WORD]], [[WORD]]* [[GEP]]
+// CHECK:         [[TEST:%.*]] = icmp eq [[WORD]] [[FIRSTWORD]], 0
+// CHECK:         br i1 [[TEST]]
+sil public @switch_singleton_enum_in_optional :
+    $@convention(thin) (@in Optional<AnEnum>) -> () {
+entry(%a : $*Optional<AnEnum>):
+  switch_enum_addr %a : $*Optional<AnEnum>,
+    case #Optional.Some!enumelt.1: some,
+    case #Optional.None!enumelt: none
+some:
+  unreachable
+none:
+  unreachable
+}
+
+sil_vtable AClass {}


### PR DESCRIPTION
Without this, fixed-sized, address-only enums failed to correctly delegate their `getFixedExtraInhabitantMask` implementation to the enum layout strategy, causing a miscompile where switches would test undefined bits of the enum payload. Fixes rdar://problem/24885747.
