### PR TITLE
Fix the cast optimizer to remove instructions after inserting unreach…

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -467,6 +467,9 @@ class CastOptimizer {
       SILBasicBlock *SuccessBB,
       SILBasicBlock *FailureBB);
 
+  void deleteInstructionsAfterUnreachable(SILInstruction *UnreachableInst,
+                                          SILInstruction *TrapInst);
+
 public:
   CastOptimizer(std::function<void (SILInstruction *I, ValueBase *V)> ReplaceInstUsesAction,
                 std::function<void (SILInstruction *)> EraseAction = [](SILInstruction*){},

--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -866,8 +866,10 @@ processFunction(SILFunction &F, bool EnableDiagnostics,
       [&](SILInstruction *I) { /* EraseAction */
         auto *TI = dyn_cast<TermInst>(I);
 
-        if (TI && TI->isBranch()) {
-          // Invalidate analysis information related to branches.
+        if (TI) {
+          // Invalidate analysis information related to branches. Replacing
+          // unconditional_check_branch type instructions by a trap will also
+          // invalidate branches/the CFG.
           InvalidateBranches = true;
         }
 

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -415,3 +415,34 @@ bb0:
   %3 = tuple ()
   return %3 : $()                             // id: %3
 }
+
+struct Value {}
+
+class AnObject {}
+
+// CHECK-LABEL: sil @replace_unconditional_check_cast_failure
+// CHECK:  bb2:
+// CHECK:  alloc_stack $AnObject
+// CHECK:  store undef to %0
+// CHECK:  dealloc_stack
+// CHECK:  builtin "int_trap"()
+// CHECK:  unreachable
+
+sil @replace_unconditional_check_cast_failure : $@convention(thin) (Builtin.Int1, @guaranteed AnObject) -> (@out Value) {
+bb0(%2 : $*Value, %0 : $Builtin.Int1, %1 : $AnObject):
+  cond_br %0, bb1, bb2
+
+bb1:
+  %3 = tuple()
+  return %3 : $()
+
+bb2:
+  %31 = alloc_stack $AnObject
+  store %1 to %31 : $*AnObject
+  strong_retain %1 : $AnObject
+  unconditional_checked_cast_addr take_always AnObject in %31 : $*AnObject to Value in %2 : $*Value
+  %32 = alloc_stack $AnObject
+  dealloc_stack %32: $*AnObject
+  dealloc_stack %31 : $*AnObject
+  br bb1
+}

--- a/test/SILOptimizer/sil_combine_uncheck.sil
+++ b/test/SILOptimizer/sil_combine_uncheck.sil
@@ -38,6 +38,7 @@ bb0(%0 : $Builtin.Int1):
 
 // CHECK-LABEL: sil @test_unconditional_checked_cast_addr_fail
 // CHECK: bb0
+// CHECK-NEXT: store undef
 // CHECK-NEXT: builtin "int_trap"
 // CHECK: unreachable
 // CHECK: }


### PR DESCRIPTION
#### What's in this pull request?

Fixes an issue that got exposed by running a custom SIL pass pipeline.
#### Resolved bug number: rdar://24761530

---

Fix the cast optimizer to remove instructions after inserting unreachable

Also insert the store and dealloc_stack instructions before the trap the cast
optimizer inserts.

rdar://24761530
