### PR TITLE
Swift 3 indexing model flatten

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -93,7 +93,7 @@ public struct Character :
     _precondition(
       s._core.count != 0, "Can't form a Character from an empty String")
     _precondition(
-      s.characters.next(s.startIndex) == s.endIndex,
+      s.next(s.startIndex) == s.endIndex,
       "Can't form a Character from a String containing more than one extended grapheme cluster")
 
     let (count, initialUTF8) = s._core._encodeSomeUTF8(from: 0)
@@ -290,8 +290,7 @@ extension String {
         UTF8.self, input: smallUTF8)
     case let .large(value):
       let buf = String(_StringCore(_StringBuffer(value)))
-      let startIndex = buf.startIndex
-      self = buf[startIndex..<buf.characters.next(startIndex)]
+      self = buf[buf.startIndex..<buf.next(buf.startIndex)]
     }
   }
 }

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -113,7 +113,7 @@ extension LazySequenceProtocol
 }
 
 %{
-def baseCollectionForTraversal(traversal):
+def collectionForTraversal(traversal):
     if traversal == 'Forward':
         return 'Collection'
     if traversal == 'Bidirectional':
@@ -144,7 +144,7 @@ def indexConfromsToForTraversal(traversal):
 %   Index = Collection + 'Index'
 /// A position in a `${Collection}`.
 public struct ${Index}<
-  BaseElements : ${baseCollectionForTraversal(traversal)}
+  BaseElements : ${collectionForTraversal(traversal)}
   where
   ${constraints % {'Base': 'BaseElements.'}}
 > : ${indexConfromsToForTraversal(traversal)} {
@@ -196,6 +196,8 @@ public struct ${Index}<
 
   /// Construct the `startIndex` for a flattened view of `base`.
   internal init(_startIndexOfFlattened base: BaseElements) {
+    fatalError("FIXME: swift-3-indexing-model")
+    /*
     for outer in base.indices {
       let innerCollection = base[outer]
       if !innerCollection.isEmpty {
@@ -207,6 +209,7 @@ public struct ${Index}<
       }
     }
     self = ${Index}(_endIndexOfFlattened: base)
+    */
   }
 
   /// Construct the `endIndex` for a flattened view of `base`.
@@ -273,10 +276,10 @@ public func < <BaseElements> (
 ///
 /// - See also: `FlattenSequence`
 public struct ${Collection}<
-  Base : ${baseCollectionForTraversal(traversal)}
+  Base : ${collectionForTraversal(traversal)}
   where
   ${constraints % {'Base': 'Base.'}}
-> : ${baseCollectionForTraversal(traversal)} {
+> : ${collectionForTraversal(traversal)} {
   /// A type that represents a valid position in the collection.
   ///
   /// Valid indices consist of the position of every element and a
@@ -373,7 +376,7 @@ public struct ${Collection}<
   internal var _base: Base
 }
 
-extension ${baseCollectionForTraversal(traversal)}
+extension ${collectionForTraversal(traversal)}
   where ${constraints % {'Base': ''}} {
   /// A concatenation of the elements of `self`.
   @warn_unused_result


### PR DESCRIPTION
@gribozavr since you are making such quick progress and I have to head out for while I decided to deliver the last of my outstanding changes that don't conflict with yours.

Note flatten still has this issue which I think pops up in other code that uses flatten.

```
swift/stdlib/public/core/Flatten.swift.gyb:394:43: error: type 'Self.Elements' does not conform to protocol 'BidirectionalCollection'
  public func flatten() -> LazyCollection<FlattenBidirectionalCollection<Elements>> {
```
