### PR TITLE
A few final replacements of typealias with associatedtype.

### DIFF
--- a/validation-test/compiler_crashers/28260-swift-constraints-constraintgraphnode-getmembertype.swift
+++ b/validation-test/compiler_crashers/28260-swift-constraints-constraintgraphnode-getmembertype.swift
@@ -5,7 +5,7 @@
 // Test case found by fuzzing
 
 protocol A{func<
-typealias f:A
+associatedtype f:A
 protocol A{
 class a
-typealias f:a
+associatedtype f:a

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -18,7 +18,7 @@ import Foundation
 @_silgen_name("random") func random() -> UInt32
 @_silgen_name("srandomdev") func srandomdev()
 
-protocol TestableUnicodeCodec : UnicodeCodecType {
+protocol TestableUnicodeCodec : UnicodeCodec {
   associatedtype CodeUnit : Integer
   static func encodingId() -> NSStringEncoding
   static func name() -> NSString


### PR DESCRIPTION
Mismerge during my last commit made for a couple of leftovers that I didn't discover until now.
