### PR TITLE
Add ifPresent function to Optional

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -45,6 +45,11 @@ public enum Optional<Wrapped> : NilLiteralConvertible {
     }
   }
 
+  /// If `self == nil`, does nothing. Otherwise, run `f(self!)`.
+  public func ifPresent(@noescape f: (Wrapped) throws -> Void) rethrows {
+    _ = try map(f)
+  }
+
   /// Create an instance initialized with `nil`.
   @_transparent
   public init(nilLiteral: ()) {

--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -332,4 +332,19 @@ OptionalTests.test("unsafelyUnwrapped") {
   empty.unsafelyUnwrapped
 }
 
+OptionalTests.test("ifPresent") {
+  var result: String? = nil
+  var input: String? = nil
+  func f(value: String) {
+    result = value
+  }
+
+  input.ifPresent(f)
+  expectTrue(result == nil)
+
+  input = "passed"
+  input.ifPresent(f)
+  expectOptionalEqual("passed", result)
+}
+
 runAllTests()

--- a/test/IDE/complete_generic_optional.swift
+++ b/test/IDE/complete_generic_optional.swift
@@ -11,6 +11,6 @@ struct Foo<T> {
 // SR-642 Code completion does not instantiate generic arguments of a type wrapped in an optional
 let x: Foo<Bar>? = Foo<Bar>()
 x.#^FOO_OPTIONAL_1^#
-// FOO_OPTIONAL_1: Begin completions, 5 items
+// FOO_OPTIONAL_1: Begin completions, 6 items
 // FOO_OPTIONAL_1-DAG: Decl[InstanceMethod]/CurrNominal/Erase[1]: ?.myFunction({#(foobar): Bar#})[#Void#]; name=myFunction(foobar: Bar)
 // FOO_OPTIONAL_1: End completions


### PR DESCRIPTION
#### What's in this pull request?

An `ifPresent` function has been added to `Optional`. This function is much like the `map` function except that the passed in function always returns `Void`. Almost the same can be done with the `map` function, however the `map` function gives a compiler warning if it's result is unused. Also a `map` function can be ambiguous when there are multiple functions with the same name. The `ifPresent` will always pick the right function; i.e. the one returning `Void` and therefore is not ambiguous .

The `ifPresent` function is like the `map` function very powerful. Some examples of its usage:

```
let mapView: MKMapView = ... // some map view
let annotation: MKAnnotation? = ... // some optional annotation
annotation.ifPresent(mapView.addAnnotation)
```

I also wrote a [Blog Post](https://swiftforward.wordpress.com/2015/12/04/add-ifpresent-to-swift-optionals/) about this topic in which I present it as an extension of `Optional`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
