### PR TITLE
[Python] Remove file level Python linting bypass ("# flake8: noqa") from GenerateSliceTests.py

### DIFF
--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# flake8: noqa
 
 import itertools
 
@@ -17,19 +16,23 @@ for traversal, base_kind, mutable in itertools.product(traversal_options,
                 ('FullWidth', '[]', '[]'),
                 ('WithPrefix', '[-9999, -9998, -9997]', '[]'),
                 ('WithSuffix', '[]', '[ -9999, -9998, -9997]'),
-                ('WithPrefixAndSuffix', '[-9999, -9998, -9997, -9996, -9995]', '[-9994, -9993, -9992]')
+                ('WithPrefixAndSuffix', '[-9999, -9998, -9997, -9996, -9995]',
+                 '[-9994, -9993, -9992]')
         ]:
-            Base = '%s%s%sCollection' % (base_kind, traversal, 'Mutable' if mutable else '')
+            Base = '%s%s%sCollection' % (
+                base_kind, traversal, 'Mutable' if mutable else '')
             testFilename = Wrapper + '_Of_' + Base + '_' + name + '.swift'
             with open(testFilename + '.gyb', 'w') as testFile:
                 testFile.write("""
-//// Automatically Generated From validation-test/stdlib/Inputs/GenerateSliceTests.py
+//// Automatically Generated From GenerateSliceTests.py
 //////// Do Not Edit Directly!
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
 // RUN: %S/../../../utils/gyb %s -o %t/{testFilename} -D test_path="%S"
-// RUN: %S/../../../utils/line-directive %t/{testFilename} -- %target-build-swift %t/{testFilename} -o %t/{testFilename}.a.out
-// RUN: %S/../../../utils/line-directive %t/{testFilename} -- %target-run %t/{testFilename}.a.out
+// RUN: %S/../../../utils/line-directive %t/{testFilename} -- \
+%target-build-swift %t/{testFilename} -o %t/{testFilename}.a.out
+// RUN: %S/../../../utils/line-directive %t/{testFilename} -- \
+%target-run %t/{testFilename}.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix linting issues in `GenerateSliceTests.py` and remove file level Python linting bypass (`# flake8: noqa`).

Thanks to @rintaro who suggested the fix.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
