### PR TITLE
[Python] Replace global linting excludes with local line-level excludes ("noqa")

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,4 +1,3 @@
 [flake8]
 filename = *.py,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,gyb,line-directive,ns-html2rst,recursive-lipo,rth,submit-benchmark-results,update-checkout,viewcfg
-ignore = D100,D101,D102,D103,D104,D105,E402
 max-line-length = 80

--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -21,7 +21,7 @@ DRIVER_LIBRARY_PATH = "@PATH_TO_DRIVER_LIBRARY@"
 sys.path.append(DRIVER_LIBRARY_PATH)
 DTRACE_PATH = os.path.join(DRIVER_LIBRARY_PATH, 'swift_stats.d')
 
-import perf_test_driver
+import perf_test_driver  # noqa (E402 module level import not at top of file)
 
 # Regexes for the XFAIL_LIST. Matches against '([Onone|O|Ounchecked],TestName)'
 XFAIL_LIST = [

--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -18,7 +18,7 @@ import sys
 
 sys.path.append("@PATH_TO_DRIVER_LIBRARY@")
 
-import perf_test_driver
+import perf_test_driver  # noqa (E402 module level import not at top of file)
 
 # Regexes for the XFAIL_LIST. Matches against '([Onone|O|Ounchecked],TestName)'
 XFAIL_LIST = [

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -19,7 +19,7 @@ import sys
 
 sys.path.append("@PATH_TO_DRIVER_LIBRARY@")
 
-import perf_test_driver
+import perf_test_driver  # noqa (E402 module level import not at top of file)
 
 # This is a hacked up XFAIL list. It should really be a json file, but it will
 # work for now. Add in the exact name of the pass to XFAIL.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -265,17 +265,20 @@ todo_include_todos = True
 #
 
 # Pull in the Swift lexers
-from os.path import abspath, dirname, join as join_paths
+from os.path import abspath, dirname, join as join_paths  # noqa (E402)
 sys.path = [
     join_paths(dirname(dirname(abspath(__file__))), 'utils', 'pygments')
 ] + sys.path
 
-import swift as swift_pygments_lexers
+import swift as swift_pygments_lexers  # noqa (E402 module level import not at top of file)
 
 sys.path.pop(0)
 
-# Monkeypatch pygments.lexers.get_lexer_by_name to return our lexers
-from pygments.lexers import get_lexer_by_name as original_get_lexer_by_name
+# Monkeypatch pygments.lexers.get_lexer_by_name to return our lexers. The
+# ordering required to allow for monkeypatching causes the warning
+# "I100 Import statements are in the wrong order." when linting using
+# flake8-import-order. "noqa" is used to suppress this warning.
+from pygments.lexers import get_lexer_by_name as original_get_lexer_by_name  # noqa (E402)
 
 
 def swift_get_lexer_by_name(_alias, *args, **kw):
@@ -286,5 +289,5 @@ def swift_get_lexer_by_name(_alias, *args, **kw):
     else:
         return original_get_lexer_by_name(_alias, *args, **kw)
 
-import pygments.lexers
+import pygments.lexers  # noqa (I100 Import statements are in the wrong order.)
 pygments.lexers.get_lexer_by_name = swift_get_lexer_by_name

--- a/utils/build-script
+++ b/utils/build-script
@@ -21,7 +21,8 @@ import textwrap
 
 # FIXME: Instead of modifying the system path in order to enable imports from
 #        other directories, all Python modules related to the build script
-#        should be moved to the `swift_build_support` module.
+#        should be moved to the `swift_build_support` module. Remove "noqa"
+#        markers when this is fixed.
 #        For additional information, see: https://bugs.swift.org/browse/SR-237.
 sys.path.append(os.path.dirname(__file__))
 from SwiftBuildSupport import (
@@ -34,17 +35,17 @@ from SwiftBuildSupport import (
     get_preset_options,
     print_with_argv0,
     quote_shell_command,
-)
+)  # noqa (E402 module level import not at top of file)
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 
-import swift_build_support.clang
-import swift_build_support.cmake
-import swift_build_support.debug
-from swift_build_support.migration import migrate_impl_args
-import swift_build_support.ninja
-import swift_build_support.tar
-import swift_build_support.targets
+import swift_build_support.clang    # noqa (E402 module level import not at top of file)
+import swift_build_support.cmake    # noqa (E402)
+import swift_build_support.debug    # noqa (E402)
+from swift_build_support.migration import migrate_impl_args  # noqa (E402)
+import swift_build_support.ninja    # noqa (E402)
+import swift_build_support.tar      # noqa (E402)
+import swift_build_support.targets  # noqa (E402)
 
 
 # Main entry point for the preset mode.

--- a/utils/pass-pipeline/scripts/pipeline_generator.py
+++ b/utils/pass-pipeline/scripts/pipeline_generator.py
@@ -10,9 +10,9 @@ import textwrap
 sys.path.append(os.path.join(os.path.dirname(
     os.path.dirname(os.path.abspath(__file__))), 'src'))
 
-import pass_pipeline_library
+import pass_pipeline_library  # noqa (E402 module level import not at top of file)
 
-import passes
+import passes                 # noqa (E402)
 
 normal_pipeline = list(pass_pipeline_library.normal_passpipelines())
 pass_pipelines = [x.identifier for x in normal_pipeline]

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -10,7 +10,7 @@ import textwrap
 sys.path.append(os.path.join(os.path.dirname(
     os.path.dirname(os.path.abspath(__file__))), 'src'))
 
-import passes
+import passes  # noqa (E402 module level import not at top of file)
 
 # TODO: This should not be hard coded.
 PIPELINES = ["PreSpecialize", "HighLevel", "EarlyLoopOpt",

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -22,7 +22,7 @@ from SwiftBuildSupport import (
     WorkingDirectory,
     check_call,
     check_output,
-)
+)  # noqa (E402 module level import not at top of file)
 
 REPOSITORIES = {
     'llvm': 'apple/swift-llvm',


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Replace the project global linting rule excludes (as defined in `.pep8`) with fine-grained `# noqa` annotations.

By using `noqa` annotations the excludes are made on a per line basis instead of globally.

These annotations are used where we make deliberate deviations from the standard linting rules.

To lint the Python code in the project:

```
  $ flake8
```

To install `flake8`:

```
  $ pip install flake8
```

See https://flake8.readthedocs.org/en/latest/ for details.

To enable checking of the PEP-8 naming conventions, install the optional extension `pep8-naming`:

```
  $ pip install pep8-naming
```

To enable checking of blind `except:` statements, install the optional extension `flake8-blind-except`:

```
  $ pip install flake8-blind-except
```

To enable checking of import statement order, install the optional extension `flake8-import-order`:

```
  $ pip install flake8-import-order
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
