### PR TITLE
clone dependent submodules using --recursive

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -74,10 +74,11 @@ def obtain_additional_swift_sources(
                 else:
                     remote = "https://github.com/" + repo + '.git'
                 if skip_history:
-                    check_call(['git', 'clone', '--depth', '1', remote,
-                                dir_name])
+                    check_call(['git', 'clone', '--recursive', '--depth', '1',
+                                remote, dir_name])
                 else:
-                    check_call(['git', 'clone', remote, dir_name])
+                    check_call(['git', 'clone', '--recursive', remote,
+                                dir_name])
                 if branch:
                     src_path = SWIFT_SOURCE_ROOT + "/" + dir_name + "/" + ".git"
                     check_call(['git', '--git-dir', src_path, '--work-tree',


### PR DESCRIPTION
Running `utils/update-checkout --clone` does a checkout of the sources for the other projects. However, swift-corelibs-libdispatch includes libpwq (pthread worker queue) as a submodule dependency, which isn't checked out by the current script.

Adding the `--recursive` flag to the `git clone` commands pulls down the submodule dependency as well.

Note that swift-corelibs-libdispatch is the only project with a submodule, so there shouldn't be any side effects on the other projects.
