### PR TITLE
[Python] Fix bug: Config.free() does not take any arguments

### DIFF
--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -101,7 +101,7 @@ class Object(object):
     def __repr__(self):
         ptr = conf.lib.sourcekitd_request_description_copy(self)
         s = string_at(ptr)
-        conf.free(ptr)
+        conf.free()
         return s
 
 
@@ -126,7 +126,7 @@ class Response(object):
     def __repr__(self):
         ptr = conf.lib.sourcekitd_response_description_copy(self)
         s = string_at(ptr)
-        conf.free(ptr)
+        conf.free()
         return s
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix bug: `Config.free()` does not take any arguments.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
