### PR TITLE
[build-script] XCTest xcodebuild uses SWIFT_EXEC

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1900,19 +1900,20 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 continue
                 ;;
             xctest)
+                SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
                 XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                     set -x
                     xcodebuild \
                         -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
                         -scheme SwiftXCTest \
+                        SWIFT_EXEC="${SWIFTC_BIN}" \
                         SKIP_INSTALL=NO \
                         DEPLOYMENT_LOCATION=YES \
                         DSTROOT="${XCTEST_BUILD_DIR}" \
                         INSTALL_PATH="/"
                     { set +x; } 2>/dev/null
                 else
-                    SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
                     FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
                     set -x
                     # FIXME: Use XCTEST_BUILD_TYPE (which is never properly
@@ -2168,14 +2169,15 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                     continue
                 fi
                 echo "--- Running tests for ${product} ---"
+                SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                     set -x
                     xcodebuild \
                         -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
-                        -scheme SwiftXCTestFunctionalTests
+                        -scheme SwiftXCTestFunctionalTests \
+                        SWIFT_EXEC="${SWIFTC_BIN}"
                     { set +x; } 2>/dev/null
                 else
-                    SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
                     FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
                     XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
                     set -x


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Because the `xcodebuild` invocation used to compile swift-corelibs-xctest on OS X uses a toolchain that is usually out of date, it often fails (for example, when building the newly migrated Swift 3 code).

Pass the path to the freshly built `swiftc` to `xcodebuild` in order to use the latest Swift compiler. This should allow the swift-corelibs-xctest OS X CI to pass.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
