### PR TITLE
[Python] Make slice tests output identical to pre-cleanup outputs

### DIFF
--- a/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
+++ b/validation-test/stdlib/Slice/Inputs/GenerateSliceTests.py
@@ -24,7 +24,8 @@ for traversal, base_kind, mutable in itertools.product(traversal_options,
             testFilename = Wrapper + '_Of_' + Base + '_' + name + '.swift'
             with open(testFilename + '.gyb', 'w') as testFile:
                 testFile.write("""
-//// Automatically Generated From GenerateSliceTests.py
+//// Automatically Generated From \
+validation-test/stdlib/Inputs/GenerateSliceTests.py
 //////// Do Not Edit Directly!
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Make slice tests output identical to pre-cleanup outputs (prior to PR #1613).

In order to avoid introducing unnecessary diffs in `swift/validation-test/stdlib/Slice`.

<!-- Description about pull request. -->
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
