### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::applyUnboundGenericArguments(…)

### DIFF
--- a/validation-test/compiler_crashers/28262-swift-typechecker-applyunboundgenericarguments.swift
+++ b/validation-test/compiler_crashers/28262-swift-typechecker-applyunboundgenericarguments.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+if{enum S<T{enum S:d<T>}typealias d<T where B:T>:a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2439: swift::Type swift::TypeAliasDecl::getUnderlyingType() const: Assertion `!UnderlyingTy.getType().isNull() && "getting invalid underlying type"' failed.
8  swift           0x0000000000ea84f9 swift::TypeChecker::applyUnboundGenericArguments(swift::UnboundGenericType*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) + 1321
9  swift           0x0000000000ea7e7f swift::TypeChecker::applyGenericArguments(swift::Type, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, bool, swift::GenericTypeResolver*) + 431
13 swift           0x0000000000ea864e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
15 swift           0x0000000000ea9564 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
16 swift           0x0000000000ea854a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
17 swift           0x0000000000f6086f swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 159
18 swift           0x0000000000f3f22d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
19 swift           0x0000000000f3f3b9 swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 889
20 swift           0x0000000000e3af40 swift::TypeChecker::resolveRawType(swift::EnumDecl*) + 64
21 swift           0x00000000010848bf swift::NominalTypeDecl::prepareConformanceTable() const + 351
22 swift           0x0000000001084b7f swift::NominalTypeDecl::getImplicitProtocols(llvm::SmallVectorImpl<swift::ProtocolDecl*>&) + 15
23 swift           0x0000000000e3b52c swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 1180
24 swift           0x0000000000e3e47f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 527
29 swift           0x0000000000e43ed6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000ea3736 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
34 swift           0x0000000000e671bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1149
35 swift           0x0000000000cb9d8f swift::CompilerInstance::performSema() + 3087
37 swift           0x000000000078ab9b frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2523
38 swift           0x0000000000785645 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28262-swift-typechecker-applyunboundgenericarguments.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28262-swift-typechecker-applyunboundgenericarguments-a3dcd2.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28262-swift-typechecker-applyunboundgenericarguments.swift:8:4
2.  While resolving type d<T> at [validation-test/compiler_crashers/28262-swift-typechecker-applyunboundgenericarguments.swift:8:20 - line:8:23] RangeText="d<T>"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
