### PR TITLE
[stdlib] Fix type of _swift_stdlib_HashingDetail_fixedSeedOverride

### DIFF
--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -40,7 +40,7 @@ extern "C" _SwiftEmptyArrayStorage _swiftEmptyArrayStorage = {
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
-uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride = 0;
+__swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride = 0;
 
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Changed type of _swift_stdlib_HashingDetail_fixedSeedOverride definition to __swift_uint64_t to match extern declaration in header.

<!-- Description about pull request. -->

GlobalObjects.h declares it as __swift_uint64_t, but GlobalObjects.cpp declared
it as uint64_t. The types should match exactly.

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
