### PR TITLE
fix tests for FileCheck behaviour (DAG edition)

### DIFF
--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -208,20 +208,24 @@ class C3 {
 // OVERLOAD2-NEXT: End completions
 
 // OVERLOAD3: Begin completions
+// OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal:      C1I[#C1#]; name=C1I
+// OVERLOAD3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C2I[#C2#]; name=C2I
 // OVERLOAD3-DAG: Decl[Class]/CurrModule/TypeRelation[Identical]: C2[#C2#]
-// OVERLOAD3-DAG-NOT: Decl[Class]{{.*}} C1
-// OVERLOAD3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
-// OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal:      C1I[#C1#]; name=C1I
 // OVERLOAD3: End completions
+
+// FIXME: This should be a negative test case
+// NEGATIVE_OVERLOAD_3-NOT: Decl[Class]{{.*}} C1
 
 // OVERLOAD4: Begin completions
 // OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
+// OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
 // OVERLOAD4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // OVERLOAD4-DAG: Decl[Class]/CurrModule/TypeRelation[Identical]: C1[#C1#]
-// OVERLOAD4-DAG-NOT: Decl[Class]{{.*}} C2
-// OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
 // OVERLOAD4: End completions
+
+// FIXME: This should be a negative test case
+// NEGATIVE_OVERLOAD4-NOT: Decl[Class]{{.*}} C2
 
 class C4 {
   func f1(G : Gen) {

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -8,8 +8,15 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_5 | FileCheck %s -check-prefix=DEFAULT_ARGS_5
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_6 | FileCheck %s -check-prefix=DEFAULT_ARGS_6
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_7 | FileCheck %s -check-prefix=DEFAULT_ARGS_7
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_8 | FileCheck %s -check-prefix=DEFAULT_ARGS_8
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_9 | FileCheck %s -check-prefix=DEFAULT_ARGS_9
+//
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_8 > %t
+// RUN: FileCheck %s -check-prefix=DEFAULT_ARGS_8 < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_DEFAULT_ARGS_8 < %t
+//
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_9 > %t
+// RUN: FileCheck %s -check-prefix=DEFAULT_ARGS_9 < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_DEFAULT_ARGS_9 < %t
+//
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_1 | FileCheck %s -check-prefix=DEFAULT_ARG_INIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_2 | FileCheck %s -check-prefix=DEFAULT_ARG_INIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_3 | FileCheck %s -check-prefix=DEFAULT_ARG_INIT
@@ -111,19 +118,19 @@ func testDefaultArgs8(x: C1) {
 // DEFAULT_ARGS_8: Begin completions
 // DEFAULT_ARGS_8-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgs1()[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_8-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgs1({#a: Int#})[#Void#]{{; name=.+$}}
-// DEFAULT_ARGS_8-DAG-NOT: methodWithDefaultArgsInSub1()
 // DEFAULT_ARGS_8-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgsInSub1({#(a): Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_8: End completions
+// NEGATIVE_DEFAULT_ARGS_8-NOT: methodWithDefaultArgsInSub1()
 
 func testDefaultArgs9(x: C2) {
   x.#^DEFAULT_ARGS_9^#
 }
 // DEFAULT_ARGS_9: Begin completions
-// DEFAULT_ARGS_9-DAG-NOT: methodWithDefaultArgs1()
 // DEFAULT_ARGS_9-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgs1({#a: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_9-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgsInSub1()[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_9-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgsInSub1({#(a): Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_9: End completions
+// NEGATIVE_DEFAULT_ARGS_9-NOT: methodWithDefaultArgs1()
 
 let globalVar = 1
 func testDefaultArgInit1(x = #^DEFAULT_ARG_INIT_1^#) { }

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -108,7 +108,6 @@ protocol Bar { func bar() }
 // DL_INSTANCE_NO_DOT-DAG: Decl[InstanceVar]/OtherModule[swift_ide_test]:      .nested1_Property1[#Int?#]{{; name=.+$}}
 // DL_INSTANCE_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .nested2_ObjcInstanceFunc1!()[#Void#]{{; name=.+$}}
 // DL_INSTANCE_NO_DOT-DAG: Decl[InstanceVar]/OtherModule[swift_ide_test]:      .nested2_Property[#Int?#]{{; name=.+$}}
-// DL_INSTANCE_NO_DOT-DAG-NOT:.objectAtIndexedSubscript
 // DL_INSTANCE_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .returnsObjcClass!({#(i): Int#})[#TopLevelObjcClass#]{{; name=.+$}}
 // DL_INSTANCE_NO_DOT-DAG: Decl[InstanceMethod]/OtherModule[swift_ide_test]:   .topLevelClass_ObjcInstanceFunc1!()[#Void#]{{; name=.+$}}
 // DL_INSTANCE_NO_DOT-DAG: Decl[InstanceVar]/OtherModule[swift_ide_test]:      .topLevelClass_ObjcProperty1[#Int?#]{{; name=.+$}}
@@ -127,6 +126,7 @@ protocol Bar { func bar() }
 // DL_INSTANCE_NO_DOT-DAG: Decl[Subscript]/OtherModule[baz_clang_module]:      [{#Int32#}][#AnyObject!?#]{{; name=.+$}}
 // DL_INSTANCE_NO_DOT-DAG: Decl[Subscript]/OtherModule[baz_clang_module]:      [{#AnyObject!#}][#AnyObject!?#]{{; name=.+$}}
 // DL_INSTANCE_NO_DOT: End completions
+// GLOBAL_NEGATIVE-NOT:.objectAtIndexedSubscript
 
 // DL_INSTANCE_DOT: Begin completions
 // DL_INSTANCE_DOT-DAG: Decl[InstanceMethod]/OtherModule[bar_swift_module]: bar_ImportedObjcClass_InstanceFunc1!()[#Void#]{{; name=.+$}}

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -8,16 +8,19 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PRIVATE_NOMINAL_MEMBERS_2B > %t.members2a.txt
 // RUN: FileCheck %s -check-prefix=PRIVATE_NOMINAL_MEMBERS_2 < %t.members2a.txt
+// RUN: FileCheck %s -check-prefix=NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2 < %t.members2a.txt
 // FIXME: filter?
 // RUN-disabled: FileCheck %s -check-prefix=NO_STDLIB_PRIVATE < %t.members2a.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PRIVATE_NOMINAL_MEMBERS_2B > %t.members2b.txt
 // RUN: FileCheck %s -check-prefix=PRIVATE_NOMINAL_MEMBERS_2 < %t.members2b.txt
+// RUN: FileCheck %s -check-prefix=NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2 < %t.members2b.txt
 // FIXME: filter?
 // RUN-disabled: FileCheck %s -check-prefix=NO_STDLIB_PRIVATE < %t.members2b.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PRIVATE_NOMINAL_MEMBERS_3 > %t.members3.txt
 // RUN: FileCheck %s -check-prefix=PRIVATE_NOMINAL_MEMBERS_3 < %t.members3.txt
+// RUN: FileCheck %s -check-prefix=NEGATIVE_PRIVATE_NOMINAL_MEMBERS_3 < %t.members3.txt
 // FIXME: filter?
 // RUN-disabled: FileCheck %s -check-prefix=NO_STDLIB_PRIVATE < %t.members3.txt
 
@@ -55,7 +58,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POSTFIX_INT_2 | FileCheck %s -check-prefix=POSTFIX_LVALUE_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POSTFIX_OPTIONAL_1 | FileCheck %s -check-prefix=POSTFIX_OPTIONAL
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_INT_1 | FileCheck %s -check-prefix=INFIX_INT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_INT_1 > %t
+// RUN: FileCheck %s -check-prefix=INFIX_INT < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_INFIX_INT < %t
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_INT_2 | FileCheck %s -check-prefix=INFIX_LVALUE_INT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_STRING_1 | FileCheck %s -check-prefix=INFIX_STRING
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INFIX_EXT_STRING_1 | FileCheck %s -check-prefix=INFIX_EXT_STRING
@@ -91,8 +97,8 @@ func protocolExtCollection1b(a: Collection) {
 
 // PRIVATE_NOMINAL_MEMBERS_2: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_2-DAG: map({#(transform): (Self.Iterator.Element) throws -> T##(Self.Iterator.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_2-DAG-NOT: Decl{{.*}}: last
 // PRIVATE_NOMINAL_MEMBERS_2: End completions
+// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2-NOT: Decl{{.*}}: last
 
 func protocolExtCollection2<C : Collection where C.Index : BidirectionalIndex>(a: C) {
   a.#^PRIVATE_NOMINAL_MEMBERS_3^#
@@ -101,9 +107,9 @@ func protocolExtCollection2<C : Collection where C.Index : BidirectionalIndex>(a
 // PRIVATE_NOMINAL_MEMBERS_3: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceMethod]/Super:         map({#(transform): (C.Iterator.Element) throws -> T##(C.Iterator.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceVar]/Super:            last[#C.Iterator.Element?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_3-DAG-NOT: Decl{{.*}}:         index({#({{.*}}): Self.Iterator.Element
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: index({#where: (C.Iterator.Element) throws -> Bool##(C.Iterator.Element) throws -> Bool#})[' rethrows'][#C.Index?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_3: End completions
+// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_3-NOT: Decl{{.*}}:         index({#({{.*}}): Self.Iterator.Element
 
 func protocolExtArray<T : Equatable>(a: [T]) {
   a.#^PRIVATE_NOMINAL_MEMBERS_4^#
@@ -244,9 +250,9 @@ func testInfixOperator1(x: Int) {
 // INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  << {#Int#}[#Int#]
 // INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  < {#Int#}[#Bool#]
 // INFIX_INT-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  == {#Int#}[#Bool#]
-// INFIX_INT-DAG-NOT: &&
-// INFIX_INT-DAG-NOT: +=
 // INFIX_INT: End completions
+// NEGATIVE_INFIX_INT-NOT: &&
+// NEGATIVE_INFIX_INT-NOT: +=
 func testInfixOperator2(var x: Int) {
   x#^INFIX_INT_2^#
 }

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -22,7 +22,9 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=MODULE_QUALIFIED_5 | FileCheck %s -check-prefix=ERROR_COMMON
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=POSTFIX_OPERATOR_1 | FileCheck %s -check-prefix=POSTFIX_OPERATOR_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=POSTFIX_OPERATOR_1 > %t.compl.txt
+// RUN: FileCheck %s -check-prefix=POSTFIX_OPERATOR_1 < %t.compl.txt
+// RUN: FileCheck %s -check-prefix=NEGATIVE_POSTFIX_OPERATOR_1 < %t.compl.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -code-completion-token=TOP_LEVEL_1 > %t.compl.txt
 // RUN: FileCheck %s -check-prefix=TOP_LEVEL_1 < %t.compl.txt
@@ -88,8 +90,8 @@ func testPostfixOperator1(x: Int) {
 // POSTFIX_OPERATOR_1: Begin completions
 // POSTFIX_OPERATOR_1-DAG: Decl[PostfixOperatorFunction]/OtherModule[foo_swift_module]: =>[#Int#]
 // POSTFIX_OPERATOR_1-DAG: Decl[InfixOperatorFunction]/OtherModule[foo_swift_module]:  %%% {#Int#}[#Int#]
-// POSTFIX_OPERATOR_1-DAG-NOT: =->
 // POSTFIX_OPERATOR_1: End completions
+// NEGATIVE_POSTFIX_OPERATOR_1-NOT: =->
 
 #^TOP_LEVEL_1^#
 // TOP_LEVEL_1: Begin completions

--- a/test/IDE/complete_init.swift
+++ b/test/IDE/complete_init.swift
@@ -1,12 +1,16 @@
 // RUN: sed -n -e '1,/NO_ERRORS_UP_TO_HERE$/ p' %s > %t_no_errors.swift
 // RUN: %target-swift-frontend -parse -verify %t_no_errors.swift
 
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=TOP_LEVEL_0 | FileCheck %s -check-prefix=TOP_LEVEL_0
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=TOP_LEVEL_0 > %t
+// RUN: FileCheck %s -check-prefix=TOP_LEVEL_0 < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_TOP_LEVEL_0 < %t
+
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=TOP_LEVEL_1 > %t.generic
 // RUN: FileCheck %s -check-prefix=TOP_LEVEL_0 < %t.generic
 // RUN: FileCheck %s -check-prefix=GENERIC_PARAM_0 < %t.generic
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=K_QUALIFIED_0 | FileCheck %s -check-prefix=K_QUALIFIED_0
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=L_QUALIFIED_0 | FileCheck %s -check-prefix=L_QUALIFIED_0
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=L_QUALIFIED_0 | FileCheck %s -check-prefix=NEGATIVE_L_QUALIFIED_0
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=INSIDE_L_0 | FileCheck %s -check-prefix=INSIDE_L_0
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-complete-inits-in-postfix-expr -code-completion-token=INSIDE_M_0 | FileCheck %s -check-prefix=INSIDE_M_0
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=ALIAS_CONSTRUCTOR_0 | FileCheck %s -check-prefix=ALIAS_CONSTRUCTOR_0
@@ -75,7 +79,6 @@ func testTopLevel() {
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    C({#y: A#})[#C#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    D()[#D#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    E({#x: A#})[#E#]{{; name=.+}}
-// TOP_LEVEL_0-DAG-NOT: Decl[Constructor]/CurrModule:    E()
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    F({#x: A#})[#F#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    F()[#F#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    G({#x: A#})[#Self#]{{; name=.+}}
@@ -84,6 +87,7 @@ func testTopLevel() {
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    I({#y: A#})[#Self#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    J()[#A#]{{; name=.+}}
 // TOP_LEVEL_0: End completions
+// NEGATIVE_TOP_LEVEL_0-NOT: Decl[Constructor]/CurrModule:    E()
 
 func testQualified0() {
   K.#^K_QUALIFIED_0^#
@@ -98,8 +102,8 @@ func testQualified1() {
 }
 // L_QUALIFIED_0: Begin completions
 // L_QUALIFIED_0-DAG: Decl[Constructor]/CurrNominal:    Y({#x: A#})[#L<τ_0_0>.Type#]{{; name=.+}}
-// L_QUALIFIED_0-DAG-NOT: X({#x: A#})
 // L_QUALIFIED_0: End completions
+// NEGATIVE_L_QUALIFIED_0-NOT: X({#x: A#})
 
 func testGenericParam<T: I, U: G>() {
   #^TOP_LEVEL_1^#
@@ -108,7 +112,7 @@ func testGenericParam<T: I, U: G>() {
 // GENERIC_PARAM_0-DAG: Decl[Constructor]/Local:    T({#x: A#})[#Self#]{{; name=.+}}
 // GENERIC_PARAM_0-DAG: Decl[Constructor]/Local:    T({#y: A#})[#Self#]{{; name=.+}}
 // GENERIC_PARAM_0-DAG: Decl[Constructor]/Local:    U({#x: A#})[#Self#]{{; name=.+}}
-// GENERIC_PARAM_0-DAG-NOT: Decl[Constructor]/Local:    U({#y
+// GENERIC_PARAM_0-NOT: Decl[Constructor]/Local:    U({#y
 // GENERIC_PARAM_0: End completions
 
 extension L {

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -1,5 +1,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_1 | FileCheck %s -check-prefix=POSTFIX_1
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_2 | FileCheck %s -check-prefix=POSTFIX_2
+
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_2 > %t
+// RUN: FileCheck %s -check-prefix=POSTFIX_2 < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_POSTFIX_2 < %t
+
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_3 | FileCheck %s -check-prefix=POSTFIX_3
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_4 | FileCheck %s -check-prefix=POSTFIX_4
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_5 | FileCheck %s -check-prefix=POSTFIX_5
@@ -9,13 +13,24 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_9 | FileCheck %s -check-prefix=POSTFIX_9
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=POSTFIX_10 | FileCheck %s -check-prefix=POSTFIX_10
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=S_POSTFIX_SPACE | FileCheck %s -check-prefix=S_POSTFIX_SPACE
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_1 | FileCheck %s -check-prefix=S2_INFIX
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_2 | FileCheck %s -check-prefix=S2_INFIX_LVALUE
+
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_1 > %t
+// RUN: FileCheck %s -check-prefix=S2_INFIX < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_S2_INFIX < %t
+
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_2 > %t
+// RUN: FileCheck %s -check-prefix=S2_INFIX_LVALUE < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_S2_INFIX_LVALUE < %t
+
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_3 | FileCheck %s -check-prefix=S2_INFIX_LVALUE
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_4 | FileCheck %s -check-prefix=S2_INFIX
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_5 | FileCheck %s -check-prefix=S2_INFIX
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_6 | FileCheck %s -check-prefix=S2_INFIX
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_7 | FileCheck %s -check-prefix=S2_INFIX_OPTIONAL
+
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_7 > %t
+// RUN: FileCheck %s -check-prefix=S2_INFIX_OPTIONAL < %t
+// RUN: FileCheck %s -check-prefix=NEGATIVE_S2_INFIX_OPTIONAL < %t
+
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_8 | FileCheck %s -check-prefix=S3_INFIX_OPTIONAL
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_9 | FileCheck %s -check-prefix=FOOABLE_INFIX
 // RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=INFIX_10 | FileCheck %s -check-prefix=FOOABLE_INFIX
@@ -55,8 +70,8 @@ func testPostfix2(var x: S) {
 }
 // POSTFIX_2: Begin completions
 // POSTFIX_2-DAG: Decl[PostfixOperatorFunction]/CurrModule:  ++[#S#]
-// POSTFIX_2-DAG-NOT: --
 // POSTFIX_2: End completions
+// NEGATIVE_POSTFIX_2-NOT: --
 
 
 postfix operator +- {}
@@ -141,15 +156,15 @@ func testInfix1(x: S2) {
 // S2_INFIX: Begin completions
 // FIXME: rdar://problem/22997089 - should be CurrModule
 // S2_INFIX-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:   + {#S2#}[#S2#]
-// S2_INFIX-DAG: Decl[InfixOperatorFunction]/CurrModule:   ** {#Int#}[#S2#]
-// S2_INFIX-DAG-NOT: **=
-// S2_INFIX-DAG-NOT: +=
-// S2_INFIX-DAG-NOT: *
-// S2_INFIX-DAG-NOT: ??
-// S2_INFIX-DAG-NOT: ~=
-// S2_INFIX-DAG-NOT: ~>
-// S2_INFIX-DAG-NOT: = {#
+// S2_INFIX-DAG: Decl[InfixOperatorFunction]/CurrModule:   ** {#Int#}[#S2#]; name=**
 // S2_INFIX: End completions
+// NEGATIVE_S2_INFIX-NOT: **=
+// NEGATIVE_S2_INFIX-NOT: +=
+// NEGATIVE_S2_INFIX-NOT: \* {#Int#}
+// NEGATIVE_S2_INFIX-NOT: ??
+// NEGATIVE_S2_INFIX-NOT: ~=
+// NEGATIVE_S2_INFIX-NOT: ~>
+// NEGATIVE_S2_INFIX-NOT: = {#
 
 func testInfix2(var x: S2) {
   x#^INFIX_2^#
@@ -160,12 +175,12 @@ func testInfix2(var x: S2) {
 // S2_INFIX_LVALUE-DAG: Decl[InfixOperatorFunction]/CurrModule:   ** {#Int#}[#S2#]
 // S2_INFIX_LVALUE-DAG: Decl[InfixOperatorFunction]/CurrModule:   **= {#Int#}[#Void#]
 // S2_INFIX_LVALUE-DAG: Pattern/None:                             = {#S2#}[#Void#]
-// S2_INFIX_LVALUE-DAG-NOT: +=
-// S2_INFIX_LVALUE-DAG-NOT: *
-// S2_INFIX_LVALUE-DAG-NOT: ??
-// S2_INFIX_LVALUE-DAG-NOT: ~=
-// S2_INFIX_LVALUE-DAG-NOT: ~>
 // S2_INFIX_LVALUE: End completions
+// NEGATIVE_S2_INFIX_LVALUE-NOT: +=
+// NEGATIVE_S2_INFIX_LVALUE-NOT: \* {#Int#}
+// NEGATIVE_S2_INFIX_LVALUE-NOT: ??
+// NEGATIVE_S2_INFIX_LVALUE-NOT: ~=
+// NEGATIVE_S2_INFIX_LVALUE-NOT: ~>
 
 func testInfix3(x: inout S2) {
   x#^INFIX_3^#
@@ -187,14 +202,14 @@ func testInfix7(x: S2?) {
   x#^INFIX_7^#
 }
 // S2_INFIX_OPTIONAL: Begin completions
-// S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  ?? {#S2#}[#S2#]
-// S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  == {#{{.*}}#}[#Bool#]
-// S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  != {#{{.*}}#}[#Bool#]
-// The equality operators don't come from equatable.
-// S2_INFIX_OPTIONAL-DAG-NOT: == {#S2
 // FIXME: rdar://problem/22996887 - shouldn't complete with optional LHS
 // S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/CurrModule:   ** {#Int#}[#S2#]
+// S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  != {#{{.*}}#}[#Bool#]
+// S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  == {#{{.*}}#}[#Bool#]
+// S2_INFIX_OPTIONAL-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]:  ?? {#S2#}[#S2#]; name=?? S2
 // S2_INFIX_OPTIONAL: End completions
+// The equality operators don't come from equatable.
+// NEGATIVE_S2_INFIX_OPTIONAL-NOT: == {#S2
 
 struct S3: Equatable {}
 func ==(x: S3, y: S3) -> Bool { return true }

--- a/test/SourceKit/CodeComplete/complete_underscores.swift
+++ b/test/SourceKit/CodeComplete/complete_underscores.swift
@@ -40,8 +40,6 @@ func test001() {
 // TOP_LEVEL_0-DAG: Baz
 // TOP_LEVEL_0-DAG: quux
 // TOP_LEVEL_0-DAG: _quux
-// TOP_LEVEL_0-DAG-NOT: _internalTopLevelFunc()
-// TOP_LEVEL_0-DAG-NOT: _InternalStruct
 // TOP_LEVEL_0: ]
 // TOP_LEVEL_0-LABEL: Results for filterText: _ [
 // TOP_LEVEL_0-DAG: _Bar
@@ -49,6 +47,11 @@ func test001() {
 // TOP_LEVEL_0-DAG: _internalTopLevelFunc()
 // TOP_LEVEL_0-DAG: _InternalStruct
 // TOP_LEVEL_0: ]
+// RUN: %complete-test %s -hide-none -tok=TOP_LEVEL_0  -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=NEGATIVE_TOP_LEVEL_0
+// NEGATIVE_TOP_LEVEL_0-LABEL: Results for filterText: [
+// NEGATIVE_TOP_LEVEL_0-NOT: _internalTopLevelFunc()
+// NEGATIVE_TOP_LEVEL_0-NOT: _InternalStruct
+// NEGATIVE_TOP_LEVEL_0: ]
 
 func test002(x: Foo) {
   x.#^FOO_QUALIFIED_0,,^#
@@ -69,15 +72,18 @@ func test003(x: _Bar) {
 // BAR_QUALIFIED_0-DAG:   bar()
 // BAR_QUALIFIED_0-DAG:   _bar()
 // BAR_QUALIFIED_0-DAG:   foo()
-// BAR_QUALIFIED_0-DAG-NOT:   _foo()
 // BAR_QUALIFIED_0-DAG:   extFoo()
-// BAR_QUALIFIED_0-DAG-NOT:   _extFoo()
 // BAR_QUALIFIED_0: ]
 // BAR_QUALIFIED_0: Results for filterText: _ [
 // BAR_QUALIFIED_0-DAG:   _bar()
 // BAR_QUALIFIED_0-DAG:   _foo()
 // BAR_QUALIFIED_0-DAG:   _extFoo()
 // BAR_QUALIFIED_0: ]
+// RUN: %complete-test %s -tok=BAR_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=NEGATIVE_BAR_QUALIFIED_0
+// NEGATIVE_BAR_QUALIFIED_0: Results for filterText: [
+// NEGATIVE_BAR_QUALIFIED_0-NOT:   _foo()
+// NEGATIVE_BAR_QUALIFIED_0-NOT:   _extFoo()
+// NEGATIVE_BAR_QUALIFIED_0: ]
 
 func test004(x: Baz) {
   x.#^BAZ_QUALIFIED_0,,^#
@@ -94,8 +100,11 @@ func test005(x: SBaz) {
 // RUN: %complete-test %s -tok=BAZ_QUALIFIED_1  -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=BAZ_QUALIFIED_1
 // BAZ_QUALIFIED_1: Results for filterText: [
 // BAZ_QUALIFIED_1-DAG:   baz()
-// BAZ_QUALIFIED_1-DAG-NOT:   _baz()
 // BAZ_QUALIFIED_1: ]
+// RUN: %complete-test %s -tok=BAZ_QUALIFIED_1  -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=NEGATIVE_BAZ_QUALIFIED_1
+// NEGATIVE_BAZ_QUALIFIED_1: Results for filterText: [
+// NEGATIVE_BAZ_QUALIFIED_1-NOT:   _baz()
+// NEGATIVE_BAZ_QUALIFIED_1: ]
 
 func test006() {
   Norf.#^NORF_QUALIFIED_0,,^#


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

FileCheck does not support the combination negation.  These tests were incorrect
and silently passing rather than checking what they intended.
