### PR TITLE
[arc] guaranteed parameters are always known safe BU.

### DIFF
--- a/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransitionVisitors.cpp
@@ -80,6 +80,15 @@ BottomUpDataflowRCStateVisitor<ARCState>::visitStrongDecrement(ValueBase *V) {
     }
   }
 
+  // A guaranteed function argument is guaranteed to outlive the function we are
+  // processing. So bottom up for such a parameter, we are always known safe.
+  if (auto *Arg = dyn_cast<SILArgument>(Op)) {
+    if (Arg->isFunctionArg() &&
+        Arg->hasConvention(SILArgumentConvention::Direct_Guaranteed)) {
+      State.updateKnownSafe(true);
+    }
+  }
+
   DEBUG(llvm::dbgs() << "    REF COUNT DECREMENT! Known Safe: "
                      << (State.isKnownSafe() ? "yes" : "no") << "\n");
 

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -2116,3 +2116,18 @@ bb2:
   %5 = tuple()
   return %5 : $()
 }
+
+// CHECK-LABEL: sil @guaranteed_always_known_safe_bu : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK: strong_retain
+// CHECK-NOT: strong_retain
+// CHECK-NOT: strong_release
+sil @guaranteed_always_known_safe_bu : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  strong_retain %0 : $Builtin.NativeObject
+  %1 = function_ref @use : $@convention(thin) (Builtin.NativeObject) -> ()
+  apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
+  apply %1(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
+  strong_release %0 : $Builtin.NativeObject
+  return undef : $()
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The reason why this is true is that we know that a guaranteed parameter must out
live the current function. That means that no releases on that guaranteed
parameter can be "last" releases.

rdar://25091228

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
