### PR TITLE
[Sema] SR-317: Allow rethrowing functions to take an optional function parameter

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1237,7 +1237,7 @@ void AttributeChecker::visitRethrowsAttr(RethrowsAttr *attr) {
   auto fn = cast<AbstractFunctionDecl>(D);
   for (auto paramList : fn->getParameterLists()) {
     for (auto param : *paramList)
-      if (hasThrowingFunctionParameter(param->getType()->getCanonicalType()))
+      if (hasThrowingFunctionParameter(param->getType()->lookThroughAllAnyOptionalTypes()->getCanonicalType()))
         return;
   }
 

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -136,6 +136,16 @@ public:
   static AbstractFunction decomposeFunction(Expr *fn) {
     assert(fn->getValueProvidingExpr() == fn);
 
+    // Look through Optional unwraps
+    while (true) {
+      if (auto conversion = dyn_cast<ForceValueExpr>(fn)) {
+        fn = conversion->getSubExpr()->getValueProvidingExpr();
+      } else if (auto conversion = dyn_cast<BindOptionalExpr>(fn)) {
+        fn = conversion->getSubExpr()->getValueProvidingExpr();
+      } else {
+        break;
+      }
+    }
     // Look through function conversions.
     while (auto conversion = dyn_cast<FunctionConversionExpr>(fn)) {
       fn = conversion->getSubExpr()->getValueProvidingExpr();
@@ -480,7 +490,7 @@ private:
 
   Classification classifyThrowingParameterBody(ParamDecl *param,
                                                PotentialReason reason) {
-    assert(param->getType()->castTo<AnyFunctionType>()->throws());
+    assert(param->getType()->lookThroughAllAnyOptionalTypes()->castTo<AnyFunctionType>()->throws());
 
     // If we're currently doing rethrows-checking on the body of the
     // function which declares the parameter, it's rethrowing-only.
@@ -660,7 +670,7 @@ private:
 
     // Otherwise, if the original parameter type was not a throwing
     // function type, it does not contribute to 'rethrows'.
-    auto paramFnType = paramType->getAs<AnyFunctionType>();
+    auto paramFnType = paramType->lookThroughAllAnyOptionalTypes()->getAs<AnyFunctionType>();
     if (!paramFnType || !paramFnType->throws())
       return Classification();
 

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -313,6 +313,35 @@ func testGenericMethodCallACHandled<P: MyProto>(s: P) throws {
   try P.static_callAC(raise())
 }
 
+/** Optional closure parameters */
+
+func testForceUnwrappedOptionalFunctionParameter(f: (() throws -> Void)?) rethrows {
+  try f!()
+}
+
+func testBindOptionalFunctionParameter(f: (() throws -> Void)?) rethrows {
+  try f?()
+}
+
+func testImplicitlyUnwrappedFunctionParameter(f: (() throws -> Void)!) rethrows {
+  if f != nil {
+    try f()
+  }
+}
+
+func throwingFunc() throws {}
+
+func nonThrowingFunc() {}
+
+try testBindOptionalFunctionParameter(throwingFunc)
+testBindOptionalFunctionParameter(nonThrowingFunc)
+testBindOptionalFunctionParameter(nil)
+
+try testImplicitlyUnwrappedFunctionParameter(throwingFunc)
+testImplicitlyUnwrappedFunctionParameter(nonThrowingFunc)
+testImplicitlyUnwrappedFunctionParameter(nil)
+
+
 /** Miscellaneous bugs **/
 
 // rdar://problem/21967164 - Non-throwing closures are incorrectly marked as throwing in rethrow contexts


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Added the ability to declare rethrowing functions with optional function parameters, e.g.

```
func g(f: (() throws -> Void)?) rethrows {
  try f?()
}
```
#### Resolved bug number: ([SR-317](https://bugs.swift.org/browse/SR-317))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
