### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::validateDecl(…)

### DIFF
--- a/validation-test/compiler_crashers/28263-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers/28263-swift-typechecker-validatedecl.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+
+protocol e{func^
+protocol P{
+extension{
+class A{
+protocol c:e
+protocol P{
+typealias e:c{
+}func^


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckDecl.cpp:6379: void swift::TypeChecker::validateDecl(swift::ValueDecl *, bool): Assertion `gp->getOuterParameters() == proto->getDeclContext()->getGenericParamsOfContext()' failed.
8  swift           0x0000000000e417fe swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 7134
9  swift           0x000000000107b82c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 3612
10 swift           0x0000000001079ef0 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2384
11 swift           0x0000000000e7f38b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
14 swift           0x0000000000eaa10e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift           0x0000000000eab024 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
17 swift           0x0000000000eaa00a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
18 swift           0x0000000000f623af swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 159
19 swift           0x0000000000f40d3d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
20 swift           0x0000000000e3c9f9 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
21 swift           0x0000000000e4015b swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1339
22 swift           0x0000000000e3fcf1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 209
25 swift           0x0000000001073202 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
26 swift           0x000000000107a52a swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3978
27 swift           0x0000000000e7f38b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
30 swift           0x0000000000e88c60 swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*) + 288
31 swift           0x0000000000e69318 swift::finishTypeChecking(swift::SourceFile&) + 536
32 swift           0x0000000000cbb88a swift::CompilerInstance::performSema() + 3514
34 swift           0x000000000078ad8b frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2523
35 swift           0x0000000000785835 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28263-swift-typechecker-validatedecl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28263-swift-typechecker-validatedecl-5db636.o
1.  While resolving type c at [validation-test/compiler_crashers/28263-swift-typechecker-validatedecl.swift:14:13 - line:14:13] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
