### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::getInterfaceType()

### DIFF
--- a/validation-test/compiler_crashers/28264-swift-valuedecl-getinterfacetype.swift
+++ b/validation-test/compiler_crashers/28264-swift-valuedecl-getinterfacetype.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{class A{typealias B<T where B:T>:v


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
4  swift           0x000000000103cc7c swift::ValueDecl::getInterfaceType() const + 12
5  swift           0x000000000103d836 swift::TypeDecl::getDeclaredInterfaceType() const + 6
6  swift           0x0000000000e7b8a1 swift::DependentGenericTypeResolver::resolveTypeOfContext(swift::DeclContext*) + 81
7  swift           0x0000000000ea979f swift::TypeChecker::resolveTypeInContext(swift::TypeDecl*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 911
11 swift           0x0000000000eaaa1e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
13 swift           0x0000000000eab934 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
14 swift           0x0000000000eaa91a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
15 swift           0x0000000000e7c162 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 690
16 swift           0x0000000000e7d737 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
17 swift           0x0000000000e7dad6 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
18 swift           0x0000000000e40b42 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1554
23 swift           0x0000000000e46196 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 swift           0x0000000000ea59ba swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
27 swift           0x0000000000ed14ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
28 swift           0x0000000000e33eca swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
30 swift           0x0000000000ea5b06 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
31 swift           0x0000000000e6958d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1149
32 swift           0x0000000000cbc58f swift::CompilerInstance::performSema() + 3087
34 swift           0x000000000078b54f frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
35 swift           0x0000000000786015 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28264-swift-valuedecl-getinterfacetype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28264-swift-valuedecl-getinterfacetype-d01804.o
1.  While type-checking expression at [validation-test/compiler_crashers/28264-swift-valuedecl-getinterfacetype.swift:9:1 - line:9:35] RangeText="{class A{typealias B<T where B:T>:v"
2.  While type-checking 'A' at validation-test/compiler_crashers/28264-swift-valuedecl-getinterfacetype.swift:9:2
3.  While resolving type B at [validation-test/compiler_crashers/28264-swift-valuedecl-getinterfacetype.swift:9:30 - line:9:30] RangeText="B"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
