### PR TITLE
[Python] Fix two pylint warnings in swift-bench.py

### DIFF
--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -352,12 +352,15 @@ class Test(object):
         self.processed_source = processed_source
         self.binary = binary
         self.status = ""
+        self.results = None
+        self.output = None
 
     def do_print(self):
         print("NAME: %s" % self.name)
         print("SOURCE: %s" % self.source)
         if self.status == "":
-            self.results.do_print()
+            if self.results is not None:
+                self.results.do_print()
         else:
             print("STATUS: %s" % self.status)
             print("OUTPUT:")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix two `pylint` warnings in `swift-bench.py`.

Prior to this commit:

```
$ pylint utils/swift-bench.py 2>&1 | grep '(no-member)'
E:360,12: Instance of 'Test' has no 'results' member (no-member)
E:364,18: Instance of 'Test' has no 'output' member (no-member)
$
```

After this commit:

```
$ pylint utils/swift-bench.py 2>&1 | grep '(no-member)'
$
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
