### PR TITLE
[Python] Remove unused variable last_line_content in viewcfg

### DIFF
--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -52,7 +52,6 @@ class Block(object):
     def __init__(self, name, preds):
         self.name = name
         self.content = None
-        self.last_line_content = None
         self.preds = []
         self.succs = None
         self.last_line = None


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Remove unused variable `last_line_content` in `viewcfg`.

Prior to this commit:

```
$ git grep last_line_content | wc -l
1
```

After this commit:

```
$ git grep last_line_content | wc -l
0
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
