### PR TITLE
[Python] Remove unused functions in FloatingPoint.swift.gyb

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -60,14 +60,6 @@ def cFuncSuffix(bits):
     if bits == 80:
         return 'l'
 
-def llvmIntrinsicSuffix(bits):
-    if bits == 32:
-        return 'f32'
-    if bits == 64:
-        return 'f64'
-    if bits == 80:
-        return 'f80'
-
 def getInfBitPattern(bits):
     if bits == 32:
         return '0x7f800000'
@@ -82,25 +74,11 @@ def getQuietNaNBitPattern(bits):
         return '0x7ff8000000000000'
     return 'error'
 
-def getSignalingNanBitPattern(bits):
-    if bits == 32:
-        return '0x7fa00000'
-    if bits == 64:
-        return '0x7ff4000000000000'
-    return 'error'
-
 def getMinNormalBitPattern(bits):
     if bits == 32:
         return '0x00800000'
     if bits == 64:
         return '0x0010000000000000'
-    return 'error'
-
-def getExponentBitCount(bits):
-    if bits == 32:
-        return '8'
-    if bits == 64:
-        return '11'
     return 'error'
 
 def getSignificantBitCount(bits):


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Removed:
- `getExponentBitCount(bits)`
- `getSignalingNanBitPattern(bits)`
- `llvmIntrinsicSuffix(bits)`
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
