### PR TITLE
[gardening] Fix recently introduced typos: "peoperty" → "property" and "specifiedso" → "specified so"

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2170,7 +2170,8 @@ ParserStatus Parser::parseDecl(SmallVectorImpl<Decl*> &Entries,
       Status = makeParserCodeCompletionStatus();
       if (CodeCompletion) {
         // If we need to complete an override, collect the keywords already
-        // specifiedso that we do not duplicate them in code completion strings.
+        // specified so that we do not duplicate them in code completion
+        // strings.
         SmallVector<StringRef, 3> Keywords;
         switch (OrigTok.getKind()) {
         case tok::kw_func:

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -749,7 +749,7 @@ extension Collection {
     fatalError("unavailable function can't be called")
   }
 
-  @available(*, unavailable, message: "Removed in Swift 3. Please use underestimatedCount peoperty.")
+  @available(*, unavailable, message: "Removed in Swift 3. Please use underestimatedCount property.")
   public func underestimateCount() -> Int {
     fatalError("unavailable function can't be called")
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix recently introduced typos: "peoperty" → "property" and "specifiedso" → "specified so"
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
