### PR TITLE
[swiftc] Add test case for crash triggered in swift::Expr::walk(…)

### DIFF
--- a/validation-test/compiler_crashers/28265-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28265-swift-expr-walk.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class c<func a{if c == .h.c=a{


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:2314: swift::Expr *(anonymous namespace)::ExprRewriter::applyMemberRefExpr(swift::Expr *, swift::Expr *, swift::SourceLoc, swift::DeclNameLoc, bool): Assertion `resultTy->hasUnresolvedType() && "Should have a selected member if we got a type"' failed.
13 swift           0x0000000000fdccbe swift::Expr::walk(swift::ASTWalker&) + 46
14 swift           0x0000000000ed1376 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
15 swift           0x0000000000e33eca swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
18 swift           0x0000000000eeb2c9 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
19 swift           0x0000000000eefda0 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
20 swift           0x0000000000e2d973 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 787
21 swift           0x0000000000e33e20 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
22 swift           0x0000000000e35ad1 swift::TypeChecker::typeCheckCondition(swift::Expr*&, swift::DeclContext*) + 145
23 swift           0x0000000000e35c2b swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 251
27 swift           0x0000000000ea468a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
28 swift           0x0000000000ea44ee swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
29 swift           0x0000000000ea5088 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
31 swift           0x0000000000e69624 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
32 swift           0x0000000000cbc58f swift::CompilerInstance::performSema() + 3087
34 swift           0x000000000078b54f frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
35 swift           0x0000000000786015 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28265-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28265-swift-expr-walk-d333bf.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28265-swift-expr-walk.swift:10:9
2.  While type-checking expression at [validation-test/compiler_crashers/28265-swift-expr-walk.swift:10:19 - line:10:29] RangeText="c == .h.c=a"
3.  While type-checking expression at [validation-test/compiler_crashers/28265-swift-expr-walk.swift:10:19 - line:10:27] RangeText="c == .h.c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
