### PR TITLE
[swiftc] Add test case for crash triggered in swift::ModuleDecl::lookupPrefixOperator(…)

### DIFF
--- a/validation-test/compiler_crashers/28266-swift-moduledecl-lookupprefixoperator.swift
+++ b/validation-test/compiler_crashers/28266-swift-moduledecl-lookupprefixoperator.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+struct B<w{
+class d:A
+class A protocol c{
+typealias e:d
+typealias e:AnyObject


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
6  swift           0x000000000310ab3d llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  swift           0x000000000106f570 swift::ModuleDecl::lookupPrefixOperator(swift::Identifier, swift::SourceLoc) + 0
9  swift           0x0000000000f66048 swift::ArchetypeBuilder::PotentialArchetype::addConformance(swift::ProtocolDecl*, swift::RequirementSource const&, swift::ArchetypeBuilder&) + 296
10 swift           0x0000000000f69a16 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 118
13 swift           0x0000000000f6b9ff swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
14 swift           0x0000000000f697ea swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
15 swift           0x0000000000f69b77 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 471
18 swift           0x0000000000f6b9ff swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
19 swift           0x0000000000f697ea swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
20 swift           0x0000000000f6961c swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 172
21 swift           0x0000000000e7d3f7 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 375
22 swift           0x0000000000e7eb07 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
23 swift           0x0000000000e7eea6 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
24 swift           0x0000000000e41f31 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1601
29 swift           0x0000000000e47556 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000e6a8e2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1026
31 swift           0x0000000000cbcedf swift::CompilerInstance::performSema() + 3087
33 swift           0x000000000078b6ff frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
34 swift           0x00000000007861c5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28266-swift-moduledecl-lookupprefixoperator.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28266-swift-moduledecl-lookupprefixoperator-bacf6e.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28266-swift-moduledecl-lookupprefixoperator.swift:9:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
