### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::checkConformance(…)

### DIFF
--- a/validation-test/compiler_crashers/28267-swift-typechecker-checkconformance.swift
+++ b/validation-test/compiler_crashers/28267-swift-typechecker-checkconformance.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol a}struct B<T:a{{}init(){{enum S<h{case


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:147: swift::Type swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &) const: Assertion `(conforms || firstArchetype->getIsRecursive() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.
13 swift           0x0000000000e89f3d swift::TypeChecker::checkConformance(swift::NormalProtocolConformance*) + 2237
17 swift           0x0000000000e47556 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
20 swift           0x0000000000ea6d8a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
21 swift           0x0000000000ed28bc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
22 swift           0x0000000000e3548a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
25 swift           0x0000000000ea5ead swift::TypeChecker::typeCheckConstructorBodyUntil(swift::ConstructorDecl*, swift::SourceLoc) + 845
26 swift           0x0000000000ea58b2 swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 34
27 swift           0x0000000000ea6458 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
29 swift           0x0000000000e6a9f4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
30 swift           0x0000000000cbcedf swift::CompilerInstance::performSema() + 3087
32 swift           0x000000000078b6ff frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
33 swift           0x00000000007861c5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28267-swift-typechecker-checkconformance.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28267-swift-typechecker-checkconformance-1f2757.o
1.  While type-checking 'init' at validation-test/compiler_crashers/28267-swift-typechecker-checkconformance.swift:10:27
2.  While type-checking expression at [validation-test/compiler_crashers/28267-swift-typechecker-checkconformance.swift:10:34 - line:10:44] RangeText="{enum S<h{c"
3.  While type-checking 'S' at validation-test/compiler_crashers/28267-swift-typechecker-checkconformance.swift:10:35
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
