### PR TITLE
WIP (no merge) New indexing model: updated String.UnicodeScalarIndex

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -78,7 +78,10 @@ extension String {
   /// representation.
   @warn_unused_result
   func _index(utf16Index: Int) -> Index {
-    return Index(_base: String.UnicodeScalarView.Index(utf16Index, _core))
+    return Index(
+      _base: String.UnicodeScalarView.Index(utf16Index),
+      _view: unicodeScalars
+    )
   }
 
   /// Return a `Range<Index>` corresponding to the given `NSRange` of

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -928,26 +928,26 @@ extension String {
 extension String {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf8Index: String.UTF8Index
   ) -> String.Index? {
-    return characters.index(equivalentTo: utf8Index)
+    return characters._index(equivalentTo: utf8Index)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf16Index: String.UTF16Index
   ) -> String.Index? {
-    return characters.index(equivalentTo: utf16Index)
+    return characters._index(equivalentTo: utf16Index)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> String.Index? {
-    return characters.index(equivalentTo: unicodeScalarIndex)
+    return characters._index(equivalentTo: unicodeScalarIndex)
   }
 }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -925,91 +925,57 @@ extension String {
 }
 
 // Index conversions
-extension String.Index {
-  /// Construct the position in `characters` that corresponds exactly to
-  /// `unicodeScalarIndex`. If no such position exists, the result is `nil`.
-  ///
-  /// - Precondition: `unicodeScalarIndex` is an element of
-  ///   `characters.unicodeScalars.indices`.
-  public init?(
-    _ unicodeScalarIndex: String.UnicodeScalarIndex,
-    within characters: String
-  ) {
-    if !unicodeScalarIndex._isOnGraphemeClusterBoundary {
+extension String {
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func convert(
+    index index: String.UTF8Index,
+    from view: String.UTF8View
+  ) -> String.Index? {
+    fatalError("FIXME: swift-3-indexing-model: implement")
+
+    // FIXME: swift-3-indexing-model: rework the following
+//    if let me = utf8Index.samePosition(
+//      in: characters.unicodeScalars
+//      )?.samePosition(in: characters) {
+//        self = me
+//    }
+//    else {
+//      return nil
+//    }
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func convert(
+    index index: String.UTF16Index,
+    from view: String.UTF16View
+  ) -> String.Index? {
+    fatalError("FIXME: swift-3-indexing-model: implement")
+
+    // FIXME: swift-3-indexing-model: rework the following
+//    if let me = utf16Index.samePosition(
+//      in: characters.unicodeScalars
+//      )?.samePosition(in: characters) {
+//        self = me
+//    }
+//    else {
+//      return nil
+//    }
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func convert(
+    index index: String.UnicodeScalarIndex,
+    from view: String.UnicodeScalarView
+  ) -> String.Index? {
+    // FIXME: swift-3-indexing-model: verify cores match?
+    // FIXME: swift-3-indexing-model: range check?
+    if !view._isOnGraphemeClusterBoundary(index) {
       return nil
     }
-    self.init(_base: unicodeScalarIndex)
-  }
-
-  /// Construct the position in `characters` that corresponds exactly to
-  /// `utf16Index`. If no such position exists, the result is `nil`.
-  ///
-  /// - Precondition: `utf16Index` is an element of
-  ///   `characters.utf16.indices`.
-  public init?(
-    _ utf16Index: String.UTF16Index,
-    within characters: String
-  ) {
-    if let me = utf16Index.samePosition(
-      in: characters.unicodeScalars
-    )?.samePosition(in: characters) {
-      self = me
-    }
-    else {
-      return nil
-    }
-  }
-
-  /// Construct the position in `characters` that corresponds exactly to
-  /// `utf8Index`. If no such position exists, the result is `nil`.
-  ///
-  /// - Precondition: `utf8Index` is an element of
-  ///   `characters.utf8.indices`.
-  public init?(
-    _ utf8Index: String.UTF8Index,
-    within characters: String
-  ) {
-    if let me = utf8Index.samePosition(
-      in: characters.unicodeScalars
-    )?.samePosition(in: characters) {
-      self = me
-    }
-    else {
-      return nil
-    }
-  }
-
-  /// Returns the position in `utf8` that corresponds exactly
-  /// to `self`.
-  ///
-  /// - Precondition: `self` is an element of `String(utf8).indices`.
-  @warn_unused_result
-  public func samePosition(
-    in utf8: String.UTF8View
-  ) -> String.UTF8View.Index {
-    return String.UTF8View.Index(self, within: utf8)
-  }
-
-  /// Returns the position in `utf16` that corresponds exactly
-  /// to `self`.
-  ///
-  /// - Precondition: `self` is an element of `String(utf16).indices`.
-  @warn_unused_result
-  public func samePosition(
-    in utf16: String.UTF16View
-  ) -> String.UTF16View.Index {
-    return String.UTF16View.Index(self, within: utf16)
-  }
-
-  /// Returns the position in `unicodeScalars` that corresponds exactly
-  /// to `self`.
-  ///
-  /// - Precondition: `self` is an element of `String(unicodeScalars).indices`.
-  @warn_unused_result
-  public func samePosition(
-    in unicodeScalars: String.UnicodeScalarView
-  ) -> String.UnicodeScalarView.Index {
-    return String.UnicodeScalarView.Index(self, within: unicodeScalars)
+    Index(_base: index)
   }
 }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -928,54 +928,26 @@ extension String {
 extension String {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UTF8Index,
-    from view: String.UTF8View
+  public func index(
+    equivalentTo utf8Index: String.UTF8Index
   ) -> String.Index? {
-    fatalError("FIXME: swift-3-indexing-model: implement")
-
-    // FIXME: swift-3-indexing-model: rework the following
-//    if let me = utf8Index.samePosition(
-//      in: characters.unicodeScalars
-//      )?.samePosition(in: characters) {
-//        self = me
-//    }
-//    else {
-//      return nil
-//    }
+    return characters.index(equivalentTo: utf8Index)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UTF16Index,
-    from view: String.UTF16View
+  public func index(
+    equivalentTo utf16Index: String.UTF16Index
   ) -> String.Index? {
-    fatalError("FIXME: swift-3-indexing-model: implement")
-
-    // FIXME: swift-3-indexing-model: rework the following
-//    if let me = utf16Index.samePosition(
-//      in: characters.unicodeScalars
-//      )?.samePosition(in: characters) {
-//        self = me
-//    }
-//    else {
-//      return nil
-//    }
+    return characters.index(equivalentTo: utf16Index)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UnicodeScalarIndex,
-    from view: String.UnicodeScalarView
+  public func index(
+    equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> String.Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
-    // FIXME: swift-3-indexing-model: range check?
-    if !view._isOnGraphemeClusterBoundary(index) {
-      return nil
-    }
-    Index(_base: index)
+    return characters.index(equivalentTo: unicodeScalarIndex)
   }
 }
 

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -284,7 +284,7 @@ extension String.CharacterView {
 extension String.CharacterView {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf8Index: String.UTF8Index
   ) -> Index? {
     fatalError("FIXME: swift-3-indexing-model: implement")
@@ -303,7 +303,7 @@ extension String.CharacterView {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf16Index: String.UTF16Index
   ) -> Index? {
     fatalError("FIXME: swift-3-indexing-model: implement")
@@ -322,7 +322,7 @@ extension String.CharacterView {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> Index? {
     fatalError("FIXME: swift-3-indexing-model: implement")

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -280,6 +280,63 @@ extension String.CharacterView {
   }
 }
 
+// Index conversions
+extension String.CharacterView {
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func index(
+    equivalentTo utf8Index: String.UTF8Index
+  ) -> Index? {
+    fatalError("FIXME: swift-3-indexing-model: implement")
+    
+    // FIXME: swift-3-indexing-model: range check?
+    // FIXME: swift-3-indexing-model: rework the following, does it need other?
+//    if let me = utf8Index.samePosition(
+//      in: characters.unicodeScalars
+//      )?.samePosition(in: characters) {
+//        self = me
+//    }
+//    else {
+//      return nil
+//    }
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func index(
+    equivalentTo utf16Index: String.UTF16Index
+  ) -> Index? {
+    fatalError("FIXME: swift-3-indexing-model: implement")
+
+    // FIXME: swift-3-indexing-model: range check?
+    // FIXME: swift-3-indexing-model: rework the following, does it need other?
+//    if let me = utf16Index.samePosition(
+//      in: characters.unicodeScalars
+//      )?.samePosition(in: characters) {
+//        self = me
+//    }
+//    else {
+//      return nil
+//    }
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func index(
+    equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
+  ) -> Index? {
+    fatalError("FIXME: swift-3-indexing-model: implement")
+
+    // FIXME: swift-3-indexing-model: range check?
+    // FIXME: swift-3-indexing-model: rework the following, does it need other?
+//    if !view._isOnGraphemeClusterBoundary(index) {
+//      return nil
+//    }
+//    let countUTF16 = view._measureExtendedGraphemeClusterForward(from: _base)
+//    return Index(_base: index, _countUTF16: countUTF16)
+  }
+}
+
 extension String.CharacterView {
   @available(*, unavailable, renamed: "replaceSubrange")
   public mutating func replaceRange<

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -136,7 +136,7 @@ extension String {
     for i in rng.indices {
       if rng[i] == delim {
         return (String(rng[rng.startIndex..<i]), 
-                String(rng[i.successor()..<rng.endIndex]), 
+                String(rng[rng.next(i)..<rng.endIndex]),
                 true)
       }
     }
@@ -155,7 +155,7 @@ extension String {
       if predicate(rng[i]) {
         return (String(rng[rng.startIndex..<i]),
                 rng[i], 
-                String(rng[i.successor()..<rng.endIndex]), 
+                String(rng[rng.next(i)..<rng.endIndex]), 
                 true)
       }
     }

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -199,8 +199,8 @@ extension String {
     let startUTF16 = UTF16Index(_offset: utf16._offset)
     let endUTF16 = UTF16Index(_offset: utf16._offset + utf16._length)
 
-    if let start = wholeString.convert(index: startUTF16, from: utf16),
-       let end = wholeString.convert(index: endUTF16, from: utf16) {
+    if let start = wholeString.index(equivalentTo: startUTF16),
+       let end = wholeString.index(equivalentTo: endUTF16) {
       self = wholeString[start..<end]
       return
     }
@@ -231,48 +231,36 @@ public func < (
 extension String.UTF16View {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UTF8Index,
-    from view: String.UTF8View
+  public func index(
+    equivalentTo utf8Index: String.UTF8Index
   ) -> String.UTF16Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
+    _precondition(
+      utf8Index._coreIndex >= 0 && utf8Index._coreIndex <= _core.endIndex,
+      "Invalid String.UTF8Index for this UTF-16 view")
 
-    fatalError("FIXME: swift-3-indexing-model: implement")
-
-    // FIXME: swift-3-indexing-model: rework the following
-//    let core = utf16._core
-//
-//    _precondition(
-//      utf8Index._coreIndex >= 0 && utf8Index._coreIndex <= core.endIndex,
-//      "Invalid String.UTF8Index for this UTF-16 view")
-//
-//    // Detect positions that have no corresponding index.
-//    if !utf8Index._isOnUnicodeScalarBoundary {
-//      return nil
-//    }
-//    _offset = utf8Index._coreIndex
+    // Detect positions that have no corresponding index.
+    if !utf8Index._isOnUnicodeScalarBoundary {
+      return nil
+    }
+    return Index(_offset: utf8Index._coreIndex)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UnicodeScalarIndex,
-    from view: String.UnicodeScalarView
+  public func index(
+    equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> String.UTF16Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
     // FIXME: swift-3-indexing-model: range check?
     return Index(_offset: unicodeScalarIndex._position)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.Index,
-    from view: String
+  public func index(
+    equivalentTo stringIndex: String.Index
   ) -> String.UTF16Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
     // FIXME: swift-3-indexing-model: range check?
-    return Index(_offset: characterIndex._utf16Index)
+    return Index(_offset: stringIndex._utf16Index)
   }
 }
 

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -196,15 +196,13 @@ extension String {
   public init?(_ utf16: UTF16View) {
     let wholeString = String(utf16._core)
 
-    if let start = UTF16Index(
-      _offset: utf16._offset
-    ).samePosition(in: wholeString) {
-      if let end = UTF16Index(
-        _offset: utf16._offset + utf16._length
-      ).samePosition(in: wholeString) {
-        self = wholeString[start..<end]
-        return
-      }
+    let startUTF16 = UTF16Index(_offset: utf16._offset)
+    let endUTF16 = UTF16Index(_offset: utf16._offset + utf16._length)
+
+    if let start = wholeString.convert(index: startUTF16, from: utf16),
+       let end = wholeString.convert(index: endUTF16, from: utf16) {
+      self = wholeString[start..<end]
+      return
     }
     return nil
   }
@@ -230,81 +228,51 @@ public func < (
 }
 
 // Index conversions
-extension String.UTF16View.Index {
-  /// Construct the position in `utf16` that corresponds exactly to
-  /// `utf8Index`. If no such position exists, the result is `nil`.
-  ///
-  /// - Precondition: `utf8Index` is an element of
-  ///   `String(utf16)!.utf8.indices`.
-  public init?(
-    _ utf8Index: String.UTF8Index, within utf16: String.UTF16View
-  ) {
-    let core = utf16._core
-
-    _precondition(
-      utf8Index._coreIndex >= 0 && utf8Index._coreIndex <= core.endIndex,
-      "Invalid String.UTF8Index for this UTF-16 view")
-
-    // Detect positions that have no corresponding index.
-    if !utf8Index._isOnUnicodeScalarBoundary {
-      return nil
-    }
-    _offset = utf8Index._coreIndex
-  }
-
-  /// Construct the position in `utf16` that corresponds exactly to
-  /// `unicodeScalarIndex`.
-  ///
-  /// - Precondition: `unicodeScalarIndex` is an element of
-  ///   `String(utf16)!.unicodeScalars.indices`.
-  public init(
-    _ unicodeScalarIndex: String.UnicodeScalarIndex,
-    within utf16: String.UTF16View) {
-    _offset = unicodeScalarIndex._position
-  }
-
-  /// Construct the position in `utf16` that corresponds exactly to
-  /// `characterIndex`.
-  ///
-  /// - Precondition: `characterIndex` is an element of
-  ///   `String(utf16)!.indices`.
-  public init(_ characterIndex: String.Index, within utf16: String.UTF16View) {
-    _offset = characterIndex._utf16Index
-  }
-
-  /// Returns the position in `utf8` that corresponds exactly
-  /// to `self`, or if no such position exists, `nil`.
-  ///
-  /// - Precondition: `self` is an element of
-  ///   `String(utf8)!.utf16.indices`.
+extension String.UTF16View {
+  // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func samePosition(
-    in utf8: String.UTF8View
-  ) -> String.UTF8View.Index? {
-    return String.UTF8View.Index(self, within: utf8)
+  public func convert(
+    index index: String.UTF8Index,
+    from view: String.UTF8View
+  ) -> String.UTF16Index? {
+    // FIXME: swift-3-indexing-model: verify cores match?
+
+    fatalError("FIXME: swift-3-indexing-model: implement")
+
+    // FIXME: swift-3-indexing-model: rework the following
+//    let core = utf16._core
+//
+//    _precondition(
+//      utf8Index._coreIndex >= 0 && utf8Index._coreIndex <= core.endIndex,
+//      "Invalid String.UTF8Index for this UTF-16 view")
+//
+//    // Detect positions that have no corresponding index.
+//    if !utf8Index._isOnUnicodeScalarBoundary {
+//      return nil
+//    }
+//    _offset = utf8Index._coreIndex
   }
 
-  /// Returns the position in `unicodeScalars` that corresponds exactly
-  /// to `self`, or if no such position exists, `nil`.
-  ///
-  /// - Precondition: `self` is an element of
-  ///   `String(unicodeScalars).utf16.indices`.
+  // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func samePosition(
-    in unicodeScalars: String.UnicodeScalarView
-  ) -> String.UnicodeScalarIndex? {
-    return String.UnicodeScalarIndex(self, within: unicodeScalars)
+  public func convert(
+    index index: String.UnicodeScalarIndex,
+    from view: String.UnicodeScalarView
+  ) -> String.UTF16Index? {
+    // FIXME: swift-3-indexing-model: verify cores match?
+    // FIXME: swift-3-indexing-model: range check?
+    return Index(_offset: unicodeScalarIndex._position)
   }
 
-  /// Returns the position in `characters` that corresponds exactly
-  /// to `self`, or if no such position exists, `nil`.
-  ///
-  /// - Precondition: `self` is an element of `characters.utf16.indices`.
+  // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func samePosition(
-    in characters: String
-  ) -> String.Index? {
-    return String.Index(self, within: characters)
+  public func convert(
+    index index: String.Index,
+    from view: String
+  ) -> String.UTF16Index? {
+    // FIXME: swift-3-indexing-model: verify cores match?
+    // FIXME: swift-3-indexing-model: range check?
+    return Index(_offset: characterIndex._utf16Index)
   }
 }
 

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -199,8 +199,8 @@ extension String {
     let startUTF16 = UTF16Index(_offset: utf16._offset)
     let endUTF16 = UTF16Index(_offset: utf16._offset + utf16._length)
 
-    if let start = wholeString.index(equivalentTo: startUTF16),
-       let end = wholeString.index(equivalentTo: endUTF16) {
+    if let start = wholeString._index(equivalentTo: startUTF16),
+       let end = wholeString._index(equivalentTo: endUTF16) {
       self = wholeString[start..<end]
       return
     }
@@ -231,7 +231,7 @@ public func < (
 extension String.UTF16View {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf8Index: String.UTF8Index
   ) -> String.UTF16Index? {
     _precondition(
@@ -247,7 +247,7 @@ extension String.UTF16View {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> String.UTF16Index? {
     // FIXME: swift-3-indexing-model: range check?
@@ -256,7 +256,7 @@ extension String.UTF16View {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo stringIndex: String.Index
   ) -> String.UTF16Index? {
     // FIXME: swift-3-indexing-model: range check?

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -290,8 +290,8 @@ extension String {
   public init?(_ utf8: UTF8View) {
     let wholeString = String(utf8._core)
 
-    if let start = wholeString.convert(index: utf8.startIndex, from: utf8),
-       let end = wholeString.convert(index: utf8.endIndex, from: utf8) {
+    if let start = wholeString.index(equivalentTo: utf8.startIndex),
+       let end = wholeString.index(equivalentTo: utf8.endIndex) {
       self = wholeString[start..<end]
       return
     }
@@ -356,61 +356,52 @@ public func < (
 extension String.UTF8View {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UTF16Index,
-    from view: String.UTF16View
+  public func index(
+    equivalentTo utf16Index: String.UTF16Index
   ) -> String.UTF8Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
-
-    // FIXME: swift-3-indexing-model: just use supplied view, assuming cores match?
     let utf16 = String.UTF16View(_core)
 
-    if index != utf16.startIndex && index != utf16.endIndex {
+    if utf16Index != utf16.startIndex && utf16Index != utf16.endIndex {
       _precondition(
-        index >= utf16.startIndex && index <= utf16.endIndex,
-        "Invalid String.UTF16Index for this UTF-8 view"
-      )
+        utf16Index >= utf16.startIndex && utf16Index <= utf16.endIndex,
+        "Invalid String.UTF16Index for this UTF-8 view")
 
       // Detect positions that have no corresponding index.  Note that
       // we have to check before and after, because an unpaired
       // surrogate will be decoded as a single replacement character,
       // thus making the corresponding position valid in UTF8.
-      if UTF16.isTrailSurrogate(utf16[index])
-      && UTF16.isLeadSurrogate(utf16[utf16.previous(index)]) {
+      if UTF16.isTrailSurrogate(utf16[utf16Index])
+      && UTF16.isLeadSurrogate(utf16[utf16.previous(utf16Index)]) {
           return nil
       }
     }
 
-    return Index(_core, _utf16Offset: index._offset)
+    return Index(_core, _utf16Offset: utf16Index._offset)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UnicodeScalarIndex,
-    from view: String.UnicodeScalarView
+  public func index(
+    equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> String.UTF8Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
     // FIXME: swift-3-indexing-model: range check?
-    return Index(_core, _utf16Offset: index._position)
+    return Index(_core, _utf16Offset: unicodeScalarIndex._position)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.Index,
-    from view: String
+  public func index(
+    equivalentTo stringIndex: String.Index
   ) -> String.UTF8Index? {
-    // FIXME: swift-3-indexing-model: verify cores match?
     // FIXME: swift-3-indexing-model: range check?
-    return Index(_core, _utf16Offset: index._base._position)
+    return Index(_core, _utf16Offset: stringIndex._base._position)
   }
 }
 
 extension String.UTF8View.Index {
   internal init(_ core: _StringCore, _utf16Offset: Int) {
-      let (_, buffer) = core._encodeSomeUTF8(from: _utf16Offset)
-      self.init(core, _utf16Offset, buffer)
+    let (_, buffer) = core._encodeSomeUTF8(from: _utf16Offset)
+    self.init(core, _utf16Offset, buffer)
   }
 }
 

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -290,8 +290,8 @@ extension String {
   public init?(_ utf8: UTF8View) {
     let wholeString = String(utf8._core)
 
-    if let start = wholeString.index(equivalentTo: utf8.startIndex),
-       let end = wholeString.index(equivalentTo: utf8.endIndex) {
+    if let start = wholeString._index(equivalentTo: utf8.startIndex),
+       let end = wholeString._index(equivalentTo: utf8.endIndex) {
       self = wholeString[start..<end]
       return
     }
@@ -356,7 +356,7 @@ public func < (
 extension String.UTF8View {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf16Index: String.UTF16Index
   ) -> String.UTF8Index? {
     let utf16 = String.UTF16View(_core)
@@ -381,7 +381,7 @@ extension String.UTF8View {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo unicodeScalarIndex: String.UnicodeScalarIndex
   ) -> String.UTF8Index? {
     // FIXME: swift-3-indexing-model: range check?
@@ -390,7 +390,7 @@ extension String.UTF8View {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo stringIndex: String.Index
   ) -> String.UTF8Index? {
     // FIXME: swift-3-indexing-model: range check?

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -281,64 +281,53 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
 extension String.UnicodeScalarView {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UTF8Index,
-    from view: String.UTF8View
+  public func index(
+    equivalentTo utf8Index: String.UTF8Index
   ) -> String.UnicodeScalarIndex? {
-    // FIXME: swift-3-indexing-model: verify cores match?
-
     _precondition(
-      index._coreIndex >= 0 && index._coreIndex <= _core.endIndex,
-      "Invalid String.UTF8Index for this UnicodeScalar view"
-    )
+      utf8Index._coreIndex >= 0 && utf8Index._coreIndex <= _core.endIndex,
+      "Invalid String.UTF8Index for this UnicodeScalar view")
 
     // Detect positions that have no corresponding index.
-    if !index._isOnUnicodeScalarBoundary {
+    if !utf8Index._isOnUnicodeScalarBoundary {
       return nil
     }
 
-    return Index(index._coreIndex)
+    return Index(utf8Index._coreIndex)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.UTF16Index,
-    from view: String.UTF16View // needed?
+  public func index(
+    equivalentTo utf16Index: String.UTF16Index
   ) -> String.UnicodeScalarIndex? {
-    // FIXME: swift-3-indexing-model: verify cores match?
-
-    // FIXME: swift-3-indexing-model: just use supplied view, assuming cores match?
     let utf16 = String.UTF16View(_core)
 
-    if index != utf16.startIndex && index != utf16.endIndex {
+    if utf16Index != utf16.startIndex && utf16Index != utf16.endIndex {
       _precondition(
-        index >= utf16.startIndex && index <= utf16.endIndex,
-        "Invalid String.UTF16Index for this UnicodeScalar view"
-      )
+        utf16Index >= utf16.startIndex && utf16Index <= utf16.endIndex,
+        "Invalid String.UTF16Index for this UnicodeScalar view")
 
       // Detect positions that have no corresponding index.  Note that
       // we have to check before and after, because an unpaired
       // surrogate will be decoded as a single replacement character,
       // thus making the corresponding position valid.
-      if UTF16.isTrailSurrogate(utf16[index])
-      && UTF16.isLeadSurrogate(utf16[utf16.previous(index)]) {
-          return nil
+      if UTF16.isTrailSurrogate(utf16[utf16Index])
+      && UTF16.isLeadSurrogate(utf16[utf16.previous(utf16Index)]) {
+        return nil
       }
     }
 
-    return Index(index._offset)
+    return Index(utf16Index._offset)
   }
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func convert(
-    index index: String.Index,
-    from view: String
+  public func index(
+    equivalentTo stringIndex: String.Index
   ) -> String.UnicodeScalarIndex? {
-    // FIXME: swift-3-indexing-model: verify cores match?
     // FIXME: swift-3-indexing-model: range check?
-    return Index(index._base._position)
+    return Index(stringIndex._base._position)
   }
 }
 
@@ -350,7 +339,7 @@ extension String.UnicodeScalarView {
   internal func _measureExtendedGraphemeClusterForward(
     from start: Index
   ) -> Int {
-    var end = self.endIndex
+    let end = self.endIndex
     if start == end {
       return 0
     }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -56,57 +56,17 @@ extension String {
 
     /// A position in a `String.UnicodeScalarView`.
     public struct Index : Comparable {
-      public init(_ _position: Int, _ _core: _StringCore) {
+      public init(_ _position: Int) {
         self._position = _position
-        self._core = _core
-      }
-
-      /// Returns the next consecutive value after `self`.
-      ///
-      /// - Precondition: The next value is representable.
-      @warn_unused_result
-      public func successor() -> Index {
-        // FIXME: swift-3-indexing-model: remove `successor()`.
-        var scratch = _ScratchIterator(_core, _position)
-        var decoder = UTF16()
-        let (_, length) = decoder._decodeOne(&scratch)
-        return Index(_position + length, _core)
-      }
-
-      /// Returns the previous consecutive value before `self`.
-      ///
-      /// - Precondition: The previous value is representable.
-      @warn_unused_result
-      public func predecessor() -> Index {
-        // FIXME: swift-3-indexing-model: remove `predecessor()`.
-        var i = _position-1
-        let codeUnit = _core[i]
-        if _slowPath((codeUnit >> 10) == 0b1101_11) {
-          if i != 0 && (_core[i - 1] >> 10) == 0b1101_10 {
-            i -= 1
-          }
-        }
-        return Index(i, _core)
-      }
-
-      /// The end index that for this view.
-      internal var _viewStartIndex: Index {
-        return Index(_core.startIndex, _core)
-      }
-
-      /// The end index that for this view.
-      internal var _viewEndIndex: Index {
-        return Index(_core.endIndex, _core)
       }
 
       internal var _position: Int
-      internal var _core: _StringCore
     }
 
     /// The position of the first `UnicodeScalar` if the `String` is
     /// non-empty; identical to `endIndex` otherwise.
     public var startIndex: Index {
-      return Index(_core.startIndex, _core)
+      return Index(_core.startIndex)
     }
 
     /// The "past the end" position.
@@ -115,21 +75,30 @@ extension String {
     /// reachable from `startIndex` by zero or more applications of
     /// `successor()`.
     public var endIndex: Index {
-      return Index(_core.endIndex, _core)
+      return Index(_core.endIndex)
     }
 
     // TODO: swift-3-indexing-model - add docs
     @warn_unused_result
     public func next(i: Index) -> Index {
-      // FIXME: swift-3-indexing-model: move `successor()` implementation here.
-      return i.successor()
+      // FIXME: swift-3-indexing-model: range checks?
+      var scratch = _ScratchIterator(_core, i._position)
+      var decoder = UTF16()
+      let (_, length) = decoder._decodeOne(&scratch)
+      return Index(i._position + length)
     }
 
     // TODO: swift-3-indexing-model - add docs
     @warn_unused_result
     public func previous(i: Index) -> Index {
-      // FIXME: swift-3-indexing-model: move `predecessor()` implementation here.
-      return i.predecessor()
+      // FIXME: swift-3-indexing-model: range checks?
+      var position = i._position-1
+      if _slowPath((_core[position] >> 10) == 0b1101_11) {
+        if position != 0 && (_core[position - 1] >> 10) == 0b1101_10 {
+          position -= 1
+        }
+      }
+      return Index(position)
     }
 
     /// Access the element at `position`.
@@ -212,6 +181,7 @@ extension String {
           return UnicodeScalar(0xfffd)
         }
       }
+
       internal var _decoder: UTF16 = UTF16()
       internal let _baseSet: Bool
       internal let _ascii: Bool
@@ -308,123 +278,178 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
 }
 
 // Index conversions
-extension String.UnicodeScalarIndex {
-  /// Construct the position in `unicodeScalars` that corresponds exactly to
-  /// `utf16Index`. If no such position exists, the result is `nil`.
-  ///
-  /// - Precondition: `utf16Index` is an element of
-  ///   `String(unicodeScalars).utf16.indices`.
-  public init?(
-    _ utf16Index: String.UTF16Index,
-    within unicodeScalars: String.UnicodeScalarView
-  ) {
-    let utf16 = String.UTF16View(unicodeScalars._core)
+extension String.UnicodeScalarView {
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func convert(
+    index index: String.UTF8Index,
+    from view: String.UTF8View
+  ) -> String.UnicodeScalarIndex? {
+    // FIXME: swift-3-indexing-model: verify cores match?
 
-    if utf16Index != utf16.startIndex
-    && utf16Index != utf16.endIndex {
+    _precondition(
+      index._coreIndex >= 0 && index._coreIndex <= _core.endIndex,
+      "Invalid String.UTF8Index for this UnicodeScalar view"
+    )
+
+    // Detect positions that have no corresponding index.
+    if !index._isOnUnicodeScalarBoundary {
+      return nil
+    }
+
+    return Index(index._coreIndex)
+  }
+
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func convert(
+    index index: String.UTF16Index,
+    from view: String.UTF16View // needed?
+  ) -> String.UnicodeScalarIndex? {
+    // FIXME: swift-3-indexing-model: verify cores match?
+
+    // FIXME: swift-3-indexing-model: just use supplied view, assuming cores match?
+    let utf16 = String.UTF16View(_core)
+
+    if index != utf16.startIndex && index != utf16.endIndex {
       _precondition(
-        utf16Index >= utf16.startIndex
-        && utf16Index <= utf16.endIndex,
-        "Invalid String.UTF16Index for this UnicodeScalar view")
+        index >= utf16.startIndex && index <= utf16.endIndex,
+        "Invalid String.UTF16Index for this UnicodeScalar view"
+      )
 
       // Detect positions that have no corresponding index.  Note that
       // we have to check before and after, because an unpaired
       // surrogate will be decoded as a single replacement character,
       // thus making the corresponding position valid.
-      if UTF16.isTrailSurrogate(utf16[utf16Index])
-        && UTF16.isLeadSurrogate(utf16[utf16.previous(utf16Index)]) {
-        return nil
+      if UTF16.isTrailSurrogate(utf16[index])
+      && UTF16.isLeadSurrogate(utf16[utf16.previous(index)]) {
+          return nil
       }
     }
-    self.init(utf16Index._offset, unicodeScalars._core)
+
+    return Index(index._offset)
   }
 
-  /// Construct the position in `unicodeScalars` that corresponds exactly to
-  /// `utf8Index`. If no such position exists, the result is `nil`.
-  ///
-  /// - Precondition: `utf8Index` is an element of
-  ///   `String(unicodeScalars).utf8.indices`.
-  public init?(
-    _ utf8Index: String.UTF8Index,
-    within unicodeScalars: String.UnicodeScalarView
-  ) {
-    let core = unicodeScalars._core
+  // TODO: swift-3-indexing-model - add docs
+  @warn_unused_result
+  public func convert(
+    index index: String.Index,
+    from view: String
+  ) -> String.UnicodeScalarIndex? {
+    // FIXME: swift-3-indexing-model: verify cores match?
+    // FIXME: swift-3-indexing-model: range check?
+    return Index(index._base._position)
+  }
+}
 
-    _precondition(
-      utf8Index._coreIndex >= 0 && utf8Index._coreIndex <= core.endIndex,
-      "Invalid String.UTF8Index for this UnicodeScalar view")
-
-    // Detect positions that have no corresponding index.
-    if !utf8Index._isOnUnicodeScalarBoundary {
-      return nil
+extension String.UnicodeScalarView {
+  /// Returns the length of the first extended grapheme cluster in UTF-16
+  /// code units.
+  @warn_unused_result
+  @inline(never)
+  internal func _measureExtendedGraphemeClusterForward(
+    from start: Index
+  ) -> Int {
+    var end = self.endIndex
+    if start == end {
+      return 0
     }
-    self.init(utf8Index._coreIndex, core)
+
+    let clusterBreakProperty = _UnicodeGraphemeClusterBreakPropertyTrie()
+    let clusterSegmenter = _UnicodeExtendedGraphemeClusterSegmenter()
+    var index = start
+
+    var gcb0 = clusterBreakProperty.getPropertyRawValue(
+      self[index].value
+    )
+
+    _nextInPlace(&index)
+
+    while index != end {
+      // FIXME(performance): consider removing this "fast path".  A branch
+      // that is hard to predict could be worse for performance than a few
+      // loads from cache to fetch the property 'gcb1'.
+      if clusterSegmenter.isBoundaryAfter(gcb0) {
+        break
+      }
+      let gcb1 = clusterBreakProperty.getPropertyRawValue(
+        self[index].value
+      )
+      if clusterSegmenter.isBoundary(gcb0, gcb1) {
+        break
+      }
+      gcb0 = gcb1
+      _nextInPlace(&index)
+    }
+
+    return index._position - start._position
   }
 
-  /// Construct the position in `unicodeScalars` that corresponds
-  /// exactly to `characterIndex`.
-  ///
-  /// - Precondition: `characterIndex` is an element of
-  ///   `String(unicodeScalars).indices`.
-  public init(
-    _ characterIndex: String.Index,
-    within unicodeScalars: String.UnicodeScalarView
-  ) {
-    self.init(characterIndex._base._position, unicodeScalars._core)
-  }
-
-  /// Returns the position in `utf8` that corresponds exactly
-  /// to `self`.
-  ///
-  /// - Precondition: `self` is an element of `String(utf8)!.indices`.
+  /// Returns the length of the previous extended grapheme cluster in UTF-16
+  /// code units.
   @warn_unused_result
-  public func samePosition(in utf8: String.UTF8View) -> String.UTF8View.Index {
-    return String.UTF8View.Index(self, within: utf8)
+  @inline(never)
+  internal func _measureExtendedGraphemeClusterBackward(
+    from end: Index
+  ) -> Int {
+    let start = self.startIndex
+    if start == end {
+      return 0
+    }
+
+    let clusterBreakProperty = _UnicodeGraphemeClusterBreakPropertyTrie()
+    let clusterSegmenter = _UnicodeExtendedGraphemeClusterSegmenter()
+    var index = end
+
+    _previousInPlace(&index)
+    var gcb0 = clusterBreakProperty.getPropertyRawValue(
+      self[index].value
+    )
+
+    while index != start {
+      _previousInPlace(&index)
+      let gcb1 = clusterBreakProperty.getPropertyRawValue(
+        self[index].value
+      )
+      if clusterSegmenter.isBoundary(gcb1, gcb0) {
+        break
+      }
+      gcb0 = gcb1
+    }
+
+    return end._position - index._position
   }
 
-  /// Returns the position in `utf16` that corresponds exactly
-  /// to `self`.
-  ///
-  /// - Precondition: `self` is an element of `String(utf16)!.indices`.
-  @warn_unused_result
-  public func samePosition(
-    in utf16: String.UTF16View
-  ) -> String.UTF16View.Index {
-    return String.UTF16View.Index(self, within: utf16)
-  }
+  internal func _isOnGraphemeClusterBoundary(
+    index: String.UnicodeScalarIndex
+  ) -> Bool {
+    fatalError("FIXME: swift-3-indexing-model: implement")
 
-  /// Returns the position in `characters` that corresponds exactly
-  /// to `self`, or if no such position exists, `nil`.
-  ///
-  /// - Precondition: `self` is an element of
-  ///   `characters.unicodeScalars.indices`.
-  @warn_unused_result
-  public func samePosition(in characters: String) -> String.Index? {
-    return String.Index(self, within: characters)
-  }
-
-  internal var _isOnGraphemeClusterBoundary: Bool {
+    // FIXME: swift-3-indexing-model: rework the following to work
+    //        against the supplied index
+    /*
     let scalars = String.UnicodeScalarView(_core)
     if self == scalars.startIndex || self == scalars.endIndex {
-      return true
+    return true
     }
     let precedingScalar = scalars[self.predecessor()]
 
     let graphemeClusterBreakProperty =
-      _UnicodeGraphemeClusterBreakPropertyTrie()
+    _UnicodeGraphemeClusterBreakPropertyTrie()
     let segmenter = _UnicodeExtendedGraphemeClusterSegmenter()
 
     let gcb0 = graphemeClusterBreakProperty.getPropertyRawValue(
-      precedingScalar.value)
+    precedingScalar.value)
 
     if segmenter.isBoundaryAfter(gcb0) {
-      return true
+    return true
     }
 
     let gcb1 = graphemeClusterBreakProperty.getPropertyRawValue(
-      scalars[self].value)
+    scalars[self].value)
 
     return segmenter.isBoundary(gcb0, gcb1)
+    */
   }
 }
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -281,7 +281,7 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
 extension String.UnicodeScalarView {
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf8Index: String.UTF8Index
   ) -> String.UnicodeScalarIndex? {
     _precondition(
@@ -298,7 +298,7 @@ extension String.UnicodeScalarView {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo utf16Index: String.UTF16Index
   ) -> String.UnicodeScalarIndex? {
     let utf16 = String.UTF16View(_core)
@@ -323,7 +323,7 @@ extension String.UnicodeScalarView {
 
   // TODO: swift-3-indexing-model - add docs
   @warn_unused_result
-  public func index(
+  public func _index(
     equivalentTo stringIndex: String.Index
   ) -> String.UnicodeScalarIndex? {
     // FIXME: swift-3-indexing-model: range check?


### PR DESCRIPTION
@gribozavr @austinzheng 

In support of removing lingering uses of successor and predecessor I took a first pass at modifying String.UnicodeScalarIndex to the new model and updating affected code. I also attempted to lay a possible code structure for things that existed in an index and that now should exist at the view level.

Note this PR builds on #1653 so ignore the changes coming from those commits (will disappear if and when that other PR is merged).

We still need to rework UTF8View.Index and CharacterView.Index and related code. Also a handful of things need to be implement (fatalError("FIXME: swift-3-indexing-model: implement")) across the String cluster of structs.

---
- converted String.UnicodeScalarIndex to a simple Int based index
- removed samePosition and conversion initializers from all String
  Indexes
- added convert(index: String.XxxIndex, from: String.XxxxView) ->
  String.YyyyIndex to replace samePosition functionality
- moved UnicodeScalarView related measurement / boundary into
  UnicodeScalarView and out of indexes
- …more to go with the remaining String indexes
