### PR TITLE
[crashers] Add license header: Apache License v2.0 with Runtime Library Exception

### DIFF
--- a/validation-test/compiler_crashers/24245-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers/24245-swift-constraints-constraintsystem-solve.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
 

--- a/validation-test/compiler_crashers/24245-swift-constraints-constraintsystem-solve.swift
+++ b/validation-test/compiler_crashers/24245-swift-constraints-constraintsystem-solve.swift
@@ -1,8 +1,7 @@
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/robrix (Rob Rix)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/19924870
 
 func unit<T>(x: T) -> T? {

--- a/validation-test/compiler_crashers/26813-generic-enum-tuple-optional-payload.swift
+++ b/validation-test/compiler_crashers/26813-generic-enum-tuple-optional-payload.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not --crash %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/austinzheng (Austin Zheng)

--- a/validation-test/compiler_crashers/26813-generic-enum-tuple-optional-payload.swift
+++ b/validation-test/compiler_crashers/26813-generic-enum-tuple-optional-payload.swift
@@ -1,7 +1,6 @@
 // RUN: not --crash %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/austinzheng (Austin Zheng)
+// Issue found by https://github.com/austinzheng (Austin Zheng)
 
 enum A<T> {
     case Just(T)

--- a/validation-test/compiler_crashers_fixed/00006-swift-mangle-mangler-manglecontext.swift
+++ b/validation-test/compiler_crashers_fixed/00006-swift-mangle-mangler-manglecontext.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -parse -verify
 
 // Issue found by https://github.com/AlexDenisov (Alexey Denisov)

--- a/validation-test/compiler_crashers_fixed/00006-swift-mangle-mangler-manglecontext.swift
+++ b/validation-test/compiler_crashers_fixed/00006-swift-mangle-mangler-manglecontext.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -parse -verify
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/AlexDenisov (Alexey Denisov)
+// Issue found by https://github.com/AlexDenisov (Alexey Denisov)
 
 func i(c: () -> ()) {
 }

--- a/validation-test/compiler_crashers_fixed/00012-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00012-emitdirecttypemetadataref.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // Issue found by https://github.com/robrix (Rob Rix)

--- a/validation-test/compiler_crashers_fixed/00012-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00012-emitdirecttypemetadataref.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/17822208
 // https://twitter.com/rob_rix/status/493199478879682561
 

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -parse -verify
 
 // Issue found by https://github.com/jvasileff (John Vasileff)

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -parse -verify
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/jvasileff (John Vasileff)
+// Issue found by https://github.com/jvasileff (John Vasileff)
 // This bug is NOT triggered when compiling with -O.
 
 func f<T : Boolean>(b: T) {

--- a/validation-test/compiler_crashers_fixed/00018-swift-irgen-emitpolymorphicarguments.swift
+++ b/validation-test/compiler_crashers_fixed/00018-swift-irgen-emitpolymorphicarguments.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -parse -verify
 
 // Issue found by https://github.com/owensd (David Owens II)

--- a/validation-test/compiler_crashers_fixed/00018-swift-irgen-emitpolymorphicarguments.swift
+++ b/validation-test/compiler_crashers_fixed/00018-swift-irgen-emitpolymorphicarguments.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -parse -verify
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/owensd (David Owens II)
+// Issue found by https://github.com/owensd (David Owens II)
 
 func a<T>() { // expected-error {{generic parameter 'T' is not used in function signature}}
     enum b { // expected-error {{type 'b' nested in generic function 'a' is not allowed}}

--- a/validation-test/compiler_crashers_fixed/00024-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00024-emitdirecttypemetadataref.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // Issue found by https://github.com/robrix (Rob Rix)

--- a/validation-test/compiler_crashers_fixed/00024-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00024-emitdirecttypemetadataref.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/17662010
 // https://twitter.com/rob_rix/status/488692270908973058
 

--- a/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/17501507
 // https://twitter.com/rob_rix/status/483456023773315073
 

--- a/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00025-no-stacktrace.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // Issue found by https://github.com/robrix (Rob Rix)

--- a/validation-test/compiler_crashers_fixed/00029-class-with-anyobject-type-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/00029-class-with-anyobject-type-constraint.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
-// Test case submitted to project by https://github.com/jansabbe (Jan Sabbe)
+// Issue found by https://github.com/jansabbe (Jan Sabbe)
 
 class A<B : Collection where B : AnyObject> {
 }

--- a/validation-test/compiler_crashers_fixed/00029-class-with-anyobject-type-constraint.swift
+++ b/validation-test/compiler_crashers_fixed/00029-class-with-anyobject-type-constraint.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // Issue found by https://github.com/jansabbe (Jan Sabbe)

--- a/validation-test/compiler_crashers_fixed/00036-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00036-szone-malloc-should-clear.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // Issue found by https://github.com/tenderlove (Aaron Patterson)

--- a/validation-test/compiler_crashers_fixed/00036-szone-malloc-should-clear.swift
+++ b/validation-test/compiler_crashers_fixed/00036-szone-malloc-should-clear.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Issue found by https://github.com/tenderlove (Aaron Patterson)
 // https://gist.github.com/tenderlove/66ff6ae1feed92ac37f2
 
 func a(x: Any, _ y: Any) -> (((Any, Any) -> Any) -> Any) {

--- a/validation-test/compiler_crashers_fixed/00043-substdependenttypes.swift
+++ b/validation-test/compiler_crashers_fixed/00043-substdependenttypes.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/jvasileff (John Vasileff)
+// Issue found by https://github.com/jvasileff (John Vasileff)
 
 protocol A {
     typealias B

--- a/validation-test/compiler_crashers_fixed/00043-substdependenttypes.swift
+++ b/validation-test/compiler_crashers_fixed/00043-substdependenttypes.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/jvasileff (John Vasileff)

--- a/validation-test/compiler_crashers_fixed/00047-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00047-emitdirecttypemetadataref.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // Issue found by https://github.com/robrix (Rob Rix)

--- a/validation-test/compiler_crashers_fixed/00047-emitdirecttypemetadataref.swift
+++ b/validation-test/compiler_crashers_fixed/00047-emitdirecttypemetadataref.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/18248167
 // https://twitter.com/rob_rix/status/507976289564000258
 

--- a/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -emit-sil
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/rnapier (Rob Napier)
+// Issue found by https://github.com/rnapier (Rob Napier)
 
 var f = 1
 var e: Int -> Int = {

--- a/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
+++ b/validation-test/compiler_crashers_fixed/00049-swift-nominaltypedecl-getmembers.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -emit-sil
 
 // Issue found by https://github.com/rnapier (Rob Napier)

--- a/validation-test/compiler_crashers_fixed/00051-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00051-resolvetypedecl.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/rnapier (Rob Napier)

--- a/validation-test/compiler_crashers_fixed/00051-resolvetypedecl.swift
+++ b/validation-test/compiler_crashers_fixed/00051-resolvetypedecl.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/rnapier (Rob Napier)
+// Issue found by https://github.com/rnapier (Rob Napier)
 
 func b(c) -> <d>(() -> d) {
 }

--- a/validation-test/compiler_crashers_fixed/00052-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00052-no-stacktrace.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s
 
 // Issue found by https://github.com/robrix (Rob Rix)

--- a/validation-test/compiler_crashers_fixed/00052-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/00052-no-stacktrace.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/practicalswift (practicalswift)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/18332184
 // https://twitter.com/rob_rix/status/510875744667701248
 

--- a/validation-test/compiler_crashers_fixed/00239-swiftdeclconverter-importconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/00239-swiftdeclconverter-importconstructor.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/fluidsonic (Marc Knaup)

--- a/validation-test/compiler_crashers_fixed/00239-swiftdeclconverter-importconstructor.swift
+++ b/validation-test/compiler_crashers_fixed/00239-swiftdeclconverter-importconstructor.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 import Foundation
 extension NSSet {

--- a/validation-test/compiler_crashers_fixed/00240-argemitter-emitexpanded.swift
+++ b/validation-test/compiler_crashers_fixed/00240-argemitter-emitexpanded.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-silgen
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 class A {
     private let a = [B<(AnyObject, AnyObject) -> Void>]()

--- a/validation-test/compiler_crashers_fixed/00240-argemitter-emitexpanded.swift
+++ b/validation-test/compiler_crashers_fixed/00240-argemitter-emitexpanded.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-silgen
 
 // Issue found by https://github.com/fluidsonic (Marc Knaup)

--- a/validation-test/compiler_crashers_fixed/00241-swift-lowering-typeconverter-getconstantinfo.swift
+++ b/validation-test/compiler_crashers_fixed/00241-swift-lowering-typeconverter-getconstantinfo.swift
@@ -2,8 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 import Foundation
 extension NSSet {

--- a/validation-test/compiler_crashers_fixed/00241-swift-lowering-typeconverter-getconstantinfo.swift
+++ b/validation-test/compiler_crashers_fixed/00241-swift-lowering-typeconverter-getconstantinfo.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -parse
 
 // REQUIRES: objc_interop

--- a/validation-test/compiler_crashers_fixed/00242-swift-lowering-silgenfunction-emitclosurevalue.swift
+++ b/validation-test/compiler_crashers_fixed/00242-swift-lowering-silgenfunction-emitclosurevalue.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -parse -verify
 
 // Issue found by https://github.com/fluidsonic (Marc Knaup)

--- a/validation-test/compiler_crashers_fixed/00242-swift-lowering-silgenfunction-emitclosurevalue.swift
+++ b/validation-test/compiler_crashers_fixed/00242-swift-lowering-silgenfunction-emitclosurevalue.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -parse -verify
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 class A {
     class func a() -> String {

--- a/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
+++ b/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 class A {
     class func a() -> Self {

--- a/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
+++ b/validation-test/compiler_crashers_fixed/00272-llvm-irbuilder-createcall.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/fluidsonic (Marc Knaup)

--- a/validation-test/compiler_crashers_fixed/01340-llvm-getelementptrinst-getindexedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01340-llvm-getelementptrinst-getindexedtype.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // REQUIRES: objc_interop

--- a/validation-test/compiler_crashers_fixed/01340-llvm-getelementptrinst-getindexedtype.swift
+++ b/validation-test/compiler_crashers_fixed/01340-llvm-getelementptrinst-getindexedtype.swift
@@ -2,8 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 import Foundation
 class X {

--- a/validation-test/compiler_crashers_fixed/01341-broken-function-found-compilation-aborted.swift
+++ b/validation-test/compiler_crashers_fixed/01341-broken-function-found-compilation-aborted.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-silgen
 
 // Issue found by https://github.com/fluidsonic (Marc Knaup)

--- a/validation-test/compiler_crashers_fixed/01341-broken-function-found-compilation-aborted.swift
+++ b/validation-test/compiler_crashers_fixed/01341-broken-function-found-compilation-aborted.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-silgen
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/fluidsonic (Marc Knaup)
+// Issue found by https://github.com/fluidsonic (Marc Knaup)
 
 class A {
     var a: () {

--- a/validation-test/compiler_crashers_fixed/01647-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01647-no-stacktrace.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-silgen
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/radex
+// Issue found by https://github.com/radex
 // rdar://18851497
 
 struct A {

--- a/validation-test/compiler_crashers_fixed/01647-no-stacktrace.swift
+++ b/validation-test/compiler_crashers_fixed/01647-no-stacktrace.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-silgen
 
 // Issue found by https://github.com/radex

--- a/validation-test/compiler_crashers_fixed/02257-swift-any-from-nsmutablearray.swift
+++ b/validation-test/compiler_crashers_fixed/02257-swift-any-from-nsmutablearray.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: %target-swift-frontend %s -emit-ir
 
 // REQUIRES: objc_interop

--- a/validation-test/compiler_crashers_fixed/02257-swift-any-from-nsmutablearray.swift
+++ b/validation-test/compiler_crashers_fixed/02257-swift-any-from-nsmutablearray.swift
@@ -2,8 +2,7 @@
 
 // REQUIRES: objc_interop
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/mattdaw (Matt Daw)
+// Issue found by https://github.com/mattdaw (Matt Daw)
 
 import Foundation
 var a: NSMutableArray = [""]

--- a/validation-test/compiler_crashers_fixed/22725-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/22725-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/robrix (Rob Rix)

--- a/validation-test/compiler_crashers_fixed/22725-swift-constraints-constraintsystem-solvesimplified.swift
+++ b/validation-test/compiler_crashers_fixed/22725-swift-constraints-constraintsystem-solvesimplified.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/robrix (Rob Rix)
+// Issue found by https://github.com/robrix (Rob Rix)
 // http://www.openradar.me/19343997
 
 func b<T>(String -> (T, String)?

--- a/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/zneak (zneak)

--- a/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
+++ b/validation-test/compiler_crashers_fixed/24879-getmemberforbasetype.swift
@@ -1,11 +1,10 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case submitted to project by https://github.com/zneak (zneak)
+// Issue found by https://github.com/zneak (zneak)
 
 protocol A { typealias B }
 class C : A { typealias B = Int }
 
 func crash<D: C>() -> Bool {
-	let a: D.B? = nil
+  let a: D.B? = nil
 }

--- a/validation-test/compiler_crashers_fixed/28182-anonymous-namespace-favorcalloverloads.swift
+++ b/validation-test/compiler_crashers_fixed/28182-anonymous-namespace-favorcalloverloads.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/jtbandes (Jacob Bandes-Storch)
+// Issue found by https://github.com/jtbandes (Jacob Bandes-Storch)
 // <rdar://23719809>
 
 func~=switch 0{case 0

--- a/validation-test/compiler_crashers_fixed/28182-anonymous-namespace-favorcalloverloads.swift
+++ b/validation-test/compiler_crashers_fixed/28182-anonymous-namespace-favorcalloverloads.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/jtbandes (Jacob Bandes-Storch)

--- a/validation-test/compiler_crashers_fixed/28183-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/28183-swift-typebase-isequal.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/jtbandes (Jacob Bandes-Storch)
+// Issue found by https://github.com/jtbandes (Jacob Bandes-Storch)
 // <rdar://23720006>
 
 func~=(()->(}switch 0{case 0

--- a/validation-test/compiler_crashers_fixed/28183-swift-typebase-isequal.swift
+++ b/validation-test/compiler_crashers_fixed/28183-swift-typebase-isequal.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/jtbandes (Jacob Bandes-Storch)

--- a/validation-test/compiler_crashers_fixed/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,8 +1,7 @@
 // RUN: not %target-swift-frontend %s -parse
 // REQUIRES: objc_interop
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/benshan (Ben Shanfelder)
+// Issue found by https://github.com/benshan (Ben Shanfelder)
 
 import Foundation
 

--- a/validation-test/compiler_crashers_fixed/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/validation-test/compiler_crashers_fixed/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 // REQUIRES: objc_interop
 

--- a/validation-test/compiler_crashers_fixed/28185-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/28185-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 
 // Issue found by https://github.com/benshan (Ben Shanfelder)

--- a/validation-test/compiler_crashers_fixed/28185-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/28185-llvm-foldingset-swift-genericfunctiontype-nodeequals.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -parse
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/benshan (Ben Shanfelder)
+// Issue found by https://github.com/benshan (Ben Shanfelder)
 
 import Cocoa
 

--- a/validation-test/compiler_crashers_fixed/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
+++ b/validation-test/compiler_crashers_fixed/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
@@ -1,8 +1,7 @@
 // RUN: not %target-swift-frontend %s -parse
 // REQUIRES: objc_interop
 
-// Distributed under the terms of the MIT license
-// Test case found by https://github.com/PartiallyFinite (Greg Omelaenko)
+// Issue found by https://github.com/PartiallyFinite (Greg Omelaenko)
 
 import Foundation
 

--- a/validation-test/compiler_crashers_fixed/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
+++ b/validation-test/compiler_crashers_fixed/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
@@ -1,3 +1,11 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
 // RUN: not %target-swift-frontend %s -parse
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This is a follow-up to PR #1649.

Add license header: Apache License v2.0 with Runtime Library Exception.

Approvals given in #1649.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
