### PR TITLE
[swiftc] Add test case for crash triggered in swift::Expr::walk(…)

### DIFF
--- a/validation-test/compiler_crashers/28269-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28269-swift-expr-walk.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A.struct B<f func a<T:A{class A{var t:B=


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/CSApply.cpp:147: swift::Type swift::constraints::Solution::computeSubstitutions(swift::Type, swift::DeclContext *, swift::Type, swift::constraints::ConstraintLocator *, SmallVectorImpl<swift::Substitution> &) const: Assertion `(conforms || firstArchetype->getIsRecursive() || isOpenedAnyObject(replacement) || replacement->is<GenericTypeParamType>()) && "Constraint system missed a conformance?"' failed.
12 swift           0x0000000000fde105 swift::Expr::walk(swift::ASTWalker&) + 69
13 swift           0x0000000000ed2786 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
14 swift           0x0000000000e3548a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
16 swift           0x0000000000eec723 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 179
17 swift           0x0000000000ef11b0 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
18 swift           0x0000000000e2ef33 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 787
19 swift           0x0000000000e353e0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
23 swift           0x0000000000ea5a5a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
24 swift           0x0000000000ea58be swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
25 swift           0x0000000000ea6458 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
27 swift           0x0000000000e6a9f4 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
28 swift           0x0000000000cbcedf swift::CompilerInstance::performSema() + 3087
30 swift           0x000000000078b6ff frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
31 swift           0x00000000007861c5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28269-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28269-swift-expr-walk-5303a6.o
1.  While type-checking getter for t at validation-test/compiler_crashers/28269-swift-expr-walk.swift:10:46
2.  While type-checking expression at [<invalid loc> - <invalid loc>]
3.  While type-checking expression at [<invalid loc> - <invalid loc>]
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
