### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::diagnoseFailureForExpr(…)

### DIFF
--- a/validation-test/compiler_crashers/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,0 +1,5 @@
+// This source file is part of the Swift.org open source project
+// See http://swift.org/LICENSE.txt for license information
+
+// RUN: not --crash %target-swift-frontend %s -parse
+!(0^_{


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
6  swift           0x000000000310acdd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
12 swift           0x0000000000eec759 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
13 swift           0x0000000000ef1230 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
14 swift           0x0000000000e2efb3 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 787
15 swift           0x0000000000e35460 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
20 swift           0x0000000000eec759 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
21 swift           0x0000000000ef1230 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
22 swift           0x0000000000e2efb3 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 787
23 swift           0x0000000000e35460 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
28 swift           0x0000000000eec759 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
29 swift           0x0000000000ef1230 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
30 swift           0x0000000000e2efb3 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 787
31 swift           0x0000000000e35460 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
33 swift           0x0000000000ea6f56 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
34 swift           0x0000000000e6a9dd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1149
35 swift           0x0000000000cbcf5f swift::CompilerInstance::performSema() + 3087
37 swift           0x000000000078b6ff frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
38 swift           0x00000000007861c5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28270-swift-constraints-constraintsystem-diagnosefailureforexpr-edc728.o
1.  While type-checking expression at [validation-test/compiler_crashers/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:5:1 - line:5:6] RangeText="!(0^_{"
2.  While type-checking expression at [validation-test/compiler_crashers/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:5:3 - line:5:6] RangeText="0^_{"
3.  While type-checking expression at [validation-test/compiler_crashers/28270-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:5:5 - line:5:6] RangeText="_{"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
