### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::getAllArchetypes()

### DIFF
--- a/validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift
+++ b/validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// See http://swift.org/LICENSE.txt for license information
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func b{{
+protocol P{func b
+func b<T where T=e
+typealias e


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/include/swift/AST/Types.h:3616: swift::ArchetypeType *swift::ArchetypeType::NestedType::castToArchetype() const: Assertion `!isConcreteType()' failed.
8  swift           0x0000000000f6cec5 swift::ArchetypeBuilder::getAllArchetypes() + 533
12 swift           0x0000000000e41db1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
16 swift           0x0000000000e475d6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 swift           0x0000000000ea6e0a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
20 swift           0x0000000000ed293c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
21 swift           0x0000000000e3550a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
24 swift           0x0000000000ea5ada swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
25 swift           0x0000000000ea593e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
26 swift           0x0000000000ea64d8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
28 swift           0x0000000000e6aa74 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1300
29 swift           0x0000000000cbcf5f swift::CompilerInstance::performSema() + 3087
31 swift           0x000000000078b6ff frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
32 swift           0x00000000007861c5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28271-swift-archetypebuilder-getallarchetypes-7ceb13.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift:6:1
2.  While type-checking expression at [validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift:6:8 - line:9:11] RangeText="{
3.  While type-checking 'P' at validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift:7:1
4.  While type-checking 'b' at validation-test/compiler_crashers/28271-swift-archetypebuilder-getallarchetypes.swift:8:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
