### PR TITLE
[loop-region] Track the backedges of all loop regions.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -131,7 +131,9 @@
 namespace swift {
 
 /// A loop region is a data structure which represents one of a basic block,
-/// loop, or function. In the case of a loop, function, it contains an internal
+/// loop, or function.
+///
+/// In the case of a loop, function, it contains an internal
 /// data structure that represents the subregions of the loop/function. This
 /// data is tail allocated so that the basic block case is not penalized by
 /// storing this unnecessary information.
@@ -319,6 +321,66 @@ public:
   };
   using subregion_reverse_iterator = std::reverse_iterator<subregion_iterator>;
 
+  /// An iterator that knows how to iterate over the backedge indices of a
+  /// region.
+  class backedge_iterator
+      : public std::iterator<std::bidirectional_iterator_tag, unsigned> {
+    friend struct SubregionData;
+    using InnerIterTy = llvm::SmallVectorImpl<unsigned>::const_iterator;
+    llvm::Optional<InnerIterTy> InnerIter;
+
+    backedge_iterator(llvm::SmallVectorImpl<unsigned>::const_iterator iter)
+        : InnerIter(iter) {}
+
+  public:
+    using value_type = unsigned;
+    using reference = unsigned;
+    using pointer = void;
+    using iterator_category = std::bidirectional_iterator_tag;
+    using difference_type = int;
+
+    /// Construct a backedge_iterator suitable for use with a basic block. It
+    /// does not contain any data and can only be compared against another
+    /// invalid iterator (for which it will return true). Any other usage
+    /// results in an unreachable being hit.
+    backedge_iterator() : InnerIter() {}
+
+    bool hasValue() const { return InnerIter.hasValue(); }
+
+    /// Return the index of the current backedge index.
+    unsigned operator*() const { return **InnerIter; }
+
+    backedge_iterator &operator++() {
+      ++(*InnerIter);
+      return *this;
+    }
+    backedge_iterator operator++(int) {
+      backedge_iterator iter = *this;
+      ++iter;
+      return iter;
+    }
+    backedge_iterator &operator--() {
+      --(*InnerIter);
+      return *this;
+    }
+    backedge_iterator operator--(int) {
+      backedge_iterator iter = *this;
+      --iter;
+      return iter;
+    }
+    bool operator==(backedge_iterator rhs) const {
+      if (InnerIter.hasValue() != rhs.InnerIter.hasValue())
+        llvm_unreachable("Comparing uncomparable iterators");
+      // Now we know that the two either both have values or both do not have
+      // values.
+      if (!InnerIter.hasValue())
+        return true;
+      return *InnerIter == *rhs.InnerIter;
+    }
+    bool operator!=(backedge_iterator rhs) const { return !(*this == rhs); }
+  };
+  using backedge_reverse_iterator = std::reverse_iterator<backedge_iterator>;
+
 private:
   /// A pointer to one of a Loop, Basic Block, or Function represented by this
   /// region.
@@ -383,6 +445,13 @@ private:
     /// used as the RPO number for the whole region.
     unsigned RPONumOfHeaderBlock;
 
+    /// The RPO number of the back edge blocks of this loop. We use a
+    /// SmallVector of size 1 since after loop canonicalization we will always
+    /// have exactly one back edge block. But we want to be correct even in a
+    /// non-canonicalized case implying that we need to be able to support
+    /// multiple backedge blocks.
+    llvm::SmallVector<unsigned, 1> BackedgeRegions;
+
     /// A list of subregion IDs of this region sorted in RPO order.
     ///
     /// This takes advantage of the fact that the ID of a basic block is the
@@ -430,6 +499,29 @@ private:
       Subloops.push_back({Header->ID, L->ID});
     }
 
+    void addBackedgeSubregion(unsigned ID) {
+      if (count(BackedgeRegions, ID))
+        return;
+      BackedgeRegions.push_back(ID);
+    }
+
+    backedge_iterator backedge_begin() const {
+      return backedge_iterator(BackedgeRegions.begin());
+    }
+    backedge_iterator backedge_end() const {
+      return backedge_iterator(BackedgeRegions.end());
+    }
+    backedge_reverse_iterator backedge_rbegin() const {
+      return backedge_reverse_iterator(backedge_begin());
+    }
+    backedge_reverse_iterator backedge_rend() const {
+      return backedge_reverse_iterator(backedge_end());
+    }
+    bool backedge_empty() const { return BackedgeRegions.empty(); }
+    unsigned backedge_size() const { return BackedgeRegions.size(); }
+
+    ArrayRef<unsigned> getBackedgeRegions() const { return BackedgeRegions; }
+
     /// Once we finish processing a loop, we sort its subregions so that they
     /// are guaranteed to be in RPO order. This works because each BB's ID is
     /// its RPO number and we represent loops by the RPO number of their
@@ -441,7 +533,6 @@ private:
     /// going to sort just to be careful while bringing this up.
     void sortSubregions() { std::sort(Subregions.begin(), Subregions.end()); }
   };
-
 public:
   ~LoopRegion();
 
@@ -476,21 +567,34 @@ public:
     return getSubregionData().end();
   }
 
-  bool subregions_empty() const { return getSubregionData().empty(); }
-  unsigned subregions_size() const { return getSubregionData().size(); }
+  bool subregions_empty() const {
+    if (isBlock())
+      return true;
+    return getSubregionData().empty();
+  }
+
+  unsigned subregions_size() const {
+    if (isBlock())
+      return 0;
+    return getSubregionData().size();
+  }
+
   subregion_reverse_iterator subregion_rbegin() const {
     if (isBlock())
       return subregion_reverse_iterator();
     return getSubregionData().rbegin();
   }
+
   subregion_reverse_iterator subregion_rend() const {
     if (isBlock())
       return subregion_reverse_iterator();
     return getSubregionData().rend();
   }
+
   llvm::iterator_range<subregion_iterator> getSubregions() const {
     return {subregion_begin(), subregion_end()};
   }
+
   llvm::iterator_range<subregion_reverse_iterator>
   getReverseSubregions() const {
     return {subregion_rbegin(), subregion_rend()};
@@ -508,6 +612,50 @@ public:
   /// representing a block.
   ArrayRef<unsigned> getExitingSubregions() const {
     return getSubregionData().ExitingSubregions;
+  }
+
+  bool isBackedgeRegion(unsigned ID) const {
+    if (isBlock())
+      return false;
+    return count(getSubregionData().getBackedgeRegions(), ID);
+  }
+
+  ArrayRef<unsigned> getBackedgeRegions() const {
+    if (isBlock())
+      return ArrayRef<unsigned>();
+    return getSubregionData().getBackedgeRegions();
+  }
+
+  Optional<unsigned> getBackedgeRegion() const {
+    if (isBlock())
+      return None;
+    auto bedge_begin = getSubregionData().backedge_begin();
+    auto bedge_end = getSubregionData().backedge_end();
+    if (bedge_begin == bedge_end)
+      return None;
+    return *bedge_begin;
+  }
+
+  using backedge_iterator = backedge_iterator;
+  backedge_iterator backedge_begin() const {
+    if (isBlock())
+      return backedge_iterator();
+    return getSubregionData().backedge_begin();
+  }
+  backedge_iterator backedge_end() const {
+    if (isBlock())
+      return backedge_iterator();
+    return getSubregionData().backedge_end();
+  }
+  bool backedge_empty() const {
+    if (isBlock())
+      return true;
+    return getSubregionData().backedge_empty();
+  }
+  unsigned backedge_size() const {
+    if (isBlock())
+      return 0;
+    return getSubregionData().backedge_size();
   }
 
   using pred_const_iterator = decltype(Preds)::const_iterator;
@@ -781,8 +929,15 @@ public:
     return IDToRegionMap[RegionID];
   }
 
-  RegionTy *getRegionForNonLocalSuccessor(const LoopRegion *Child,
+  RegionTy *getRegionForNonLocalSuccessor(const RegionTy *Child,
                                           unsigned SuccID) const;
+
+  Optional<unsigned> getGrandparentID(const RegionTy *GrandChild) {
+    if (auto ParentID = GrandChild->getParentID()) {
+      return getRegion(*ParentID)->getParentID();
+    }
+    return None;
+  }
 
   /// Look up the region associated with this block and return it. Asserts if
   /// the block does not have a region associated with it.

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -570,7 +570,7 @@ public:
 
   /// Return the ID of the parent region of this BB. Asserts if this is a
   /// function region.
-  unsigned getParentID() const { return *ParentID; }
+  Optional<unsigned> getParentID() const { return ParentID; }
 
   unsigned getRPONumber() const {
     if (isBlock())

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -493,9 +493,12 @@ rewriteLoopHeaderPredecessors(LoopTy *SubLoop, RegionTy *SubLoopRegion) {
     }
 
     DEBUG(llvm::dbgs() << "            Is in loop... Erasing...\n");
+    // Ok, we have a predecessor inside the loop. This must be a backedge.
+    //
     // We are abusing the fact that a block can only be a local successor.
     PredRegion->removeLocalSucc(SubLoopHeaderRegion->getID());
     propagateLivenessDownNonLocalSuccessorEdges(PredRegion);
+    SubLoopRegion->getSubregionData().addBackedgeSubregion(PredRegion->getID());
   }
   SubLoopHeaderRegion->Preds.clear();
 
@@ -565,6 +568,7 @@ rewriteLoopExitingBlockSuccessors(LoopTy *Loop, RegionTy *LRegion) {
     auto *ExitingSubregion = getRegion(ExitingSubregionID);
     DEBUG(llvm::dbgs() << "        Exiting Region: "
                        << ExitingSubregion->getID() << "\n");
+    bool HasBackedge = false;
 
     // For each successor region S of ER...
     for (auto SuccID : ExitingSubregion->getSuccs()) {
@@ -605,14 +609,23 @@ rewriteLoopExitingBlockSuccessors(LoopTy *Loop, RegionTy *LRegion) {
         continue;
       }
 
-      // If the edge from ER to S is a back edge, we want to clip it.
+      // If the edge from ER to S is a back edge, we want to clip it and add
+      // exiting subregion to
       DEBUG(llvm::dbgs() << "            Is a subregion and a backedge, "
             "removing.\n");
+      HasBackedge = true;
       auto Iter =
           std::remove(SuccRegion->Preds.begin(), SuccRegion->Preds.end(),
                       ExitingSubregion->getID());
       SuccRegion->Preds.erase(Iter);
     }
+
+    // If we found a backedge, add ER's ID to LRegion's Backedge list.
+    if (!HasBackedge) {
+      continue;
+    }
+
+    LRegion->getSubregionData().addBackedgeSubregion(ExitingSubregion->getID());
   }
 }
 
@@ -848,6 +861,19 @@ void LoopRegionFunctionInfo::print(raw_ostream &os) const {
         Subregion->print(os, true);
       }
     }
+    os << ")\n";
+
+    os << "    (backedge-regs";
+    if (!R->isBlock()) {
+      auto BackedgeIDs = R->getBackedgeRegions();
+      if (!BackedgeIDs.empty()) {
+        for (unsigned BackedgeID : BackedgeIDs) {
+          os << "\n        ";
+          LoopRegion *BackedgeRegion = getRegion(BackedgeID);
+          BackedgeRegion->print(os, true);
+        }
+      }
+    }
     os << "))\n";
   }
 }
@@ -890,20 +916,27 @@ struct alledge_iterator
     : std::iterator<std::forward_iterator_tag, LoopRegionWrapper> {
   LoopRegionWrapper *Wrapper;
   LoopRegion::subregion_iterator SubregionIter;
-  LoopRegion::const_succ_iterator SuccIter;
+  LoopRegion::backedge_iterator BackedgeIter;
+
+  using SuccFilterFnTy = std::function<bool (LoopRegion::SuccessorID)>;
+  using SuccIterTy =
+    OptionalTransformIterator<LoopRegion::const_succ_iterator,
+                              LoopRegion::SuccessorID::ToLiveSucc>;
+  SuccIterTy SuccIter;
 
   alledge_iterator(LoopRegionWrapper *w,
                    swift::LoopRegion::subregion_iterator subregioniter,
-                   LoopRegion::const_succ_iterator succiter)
-      : Wrapper(w), SubregionIter(subregioniter), SuccIter(succiter) {
+                   LoopRegion::const_succ_iterator succiter,
+                   LoopRegion::backedge_iterator backedgeiter)
+      : Wrapper(w), SubregionIter(subregioniter),
+        BackedgeIter(backedgeiter),
+        SuccIter(succiter, w->Region->succ_end(),
+                 LoopRegion::SuccessorID::ToLiveSucc()) {}
 
-    // Prime the successor iterator so that we skip over any initial dead
-    // successor edges.
-    //
-    // TODO: Refactor this to use a FilterRange.
-    for (auto SuccEnd = Wrapper->Region->succ_end();
-         !SuccIter->hasValue() && SuccIter != SuccEnd; ++SuccIter) {
-    }
+  // This is not efficient, but this is graphing code...
+  SuccIterTy getSuccEnd() const {
+    return SuccIterTy(Wrapper->Region->succ_end(), Wrapper->Region->succ_end(),
+                      LoopRegion::SuccessorID::ToLiveSucc());
   }
 
   bool isSubregion() const {
@@ -911,42 +944,68 @@ struct alledge_iterator
   }
 
   bool isNonLocalEdge() const {
+    // If we are not a subregion...
     if (isSubregion())
       return false;
-    return SuccIter->getValue().IsNonLocal;
+
+    // Then if succ iterator is not succ end, we are a non local edge if that
+    // value is Non Local.
+    return getSuccEnd() != SuccIter && (*SuccIter).IsNonLocal;
+  }
+
+  bool isBackEdge() const {
+    if (isSubregion())
+      return false;
+    // If our successor iterator has reached the end of the successor list.
+    return getSuccEnd() == SuccIter;
   }
 
   LoopRegionWrapper *operator*() const {
-    if (SubregionIter != Wrapper->Region->subregion_end()) {
+    // If we have a subregion... return the wrapper for it.
+    if (isSubregion()) {
       return &Wrapper->FuncInfo.Data[*SubregionIter];
     }
+
+    // If we have a backedge... return the wrapper for that.
+    if (isBackEdge()) {
+      return &Wrapper->FuncInfo.Data[*BackedgeIter];
+    }
+
     // If we have a non-local id, just return the parent region's data.
-    if ((*SuccIter)->IsNonLocal)
+    if ((*SuccIter).IsNonLocal)
       return &Wrapper->FuncInfo.Data[*(Wrapper->Region->getParentID())];
     // Otherwise return the data associated with this successor.
-    return &Wrapper->FuncInfo.Data[(*SuccIter)->ID];
+    return &Wrapper->FuncInfo.Data[(*SuccIter).ID];
   }
 
   alledge_iterator &operator++() {
-    if (SubregionIter != Wrapper->Region->subregion_end()) {
-      SubregionIter++;
-    } else {
-      // Make sure that we skip past any dead successors.
-      auto End = Wrapper->Region->succ_end();
-      do {
-        SuccIter++;
-      } while (!SuccIter->hasValue() && SuccIter != End);
+    // If we are still a subregion, increment the SubregionIter and return.
+    if (isSubregion()) {
+      ++SubregionIter;
+      return *this;
     }
+
+    // Make sure that we skip past any dead successors. If after skipping dead
+    // successors, if our SuccIter is not end, then return. We have a true
+    // successor.
+    if (SuccIter != getSuccEnd()) {
+      ++SuccIter;
+      return *this;
+    }
+
+    // Ok, now we know that we have a back edge region. Increment the backedge
+    // region.
+    ++BackedgeIter;
+
     return *this;
   }
+
   alledge_iterator operator++(int) {
-    if (SubregionIter != Wrapper->Region->subregion_end()) {
-      return alledge_iterator{Wrapper, SubregionIter++, SuccIter};
-    }
-    auto NewIter = *this;
-    ++NewIter;
-    return NewIter;
+    alledge_iterator copy = *this;
+    ++copy;
+    return copy;
   }
+
   bool operator==(alledge_iterator rhs) {
     if (Wrapper->Region != rhs.Wrapper->Region)
       return false;
@@ -954,20 +1013,24 @@ struct alledge_iterator
       return false;
     if (SuccIter != rhs.SuccIter)
       return false;
-    return true;
+    if (BackedgeIter.hasValue() != rhs.BackedgeIter.hasValue())
+      return false;
+    return BackedgeIter == rhs.BackedgeIter;
   }
+
   bool operator!=(alledge_iterator rhs) { return !(*this == rhs); }
 };
 
 } // end anonymous namespace
 
 alledge_iterator LoopRegionWrapper::begin() {
-  return alledge_iterator(this, Region->subregion_begin(),
-                          Region->succ_begin());
+  return alledge_iterator(this, Region->subregion_begin(), Region->succ_begin(),
+                          Region->backedge_begin());
 }
 
 alledge_iterator LoopRegionWrapper::end() {
-  return alledge_iterator(this, Region->subregion_end(), Region->succ_end());
+  return alledge_iterator(this, Region->subregion_end(), Region->succ_end(),
+                          Region->backedge_end());
 }
 
 namespace llvm {
@@ -1129,6 +1192,8 @@ struct DOTGraphTraits<LoopRegionFunctionInfoGrapherWrapper *>
       return "NLSuc";
     if (I.isSubregion())
       return "Sub";
+    if (I.isBackEdge())
+      return "B";
     return "LSuc";
   }
 
@@ -1141,6 +1206,8 @@ struct DOTGraphTraits<LoopRegionFunctionInfoGrapherWrapper *>
       return "color=red";
     if (EI.isNonLocalEdge())
       return "color=blue";
+    if (EI.isBackEdge())
+      return "color=darkgreen";
     return "";
   }
 
@@ -1160,9 +1227,9 @@ struct DOTGraphTraits<LoopRegionFunctionInfoGrapherWrapper *>
                                  "local edge");
     auto *ParentRegion = Node->getParent();
     auto SuccIter = ParentRegion->Region->succ_begin();
-    std::advance(SuccIter, (*I.SuccIter)->ID);
+    std::advance(SuccIter, (*I.SuccIter).ID);
     return alledge_iterator(ParentRegion, ParentRegion->Region->subregion_end(),
-                            SuccIter);
+                            SuccIter, ParentRegion->Region->backedge_begin());
   }
 };
 } // end llvm namespace

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -512,10 +512,10 @@ static void getExitingRegions(LoopRegionFunctionInfo *LRFI, SILLoop *Loop,
   // this subloop's region. That is the *true* exiting region.
   for (auto *BB : ExitingBlocks) {
     auto *Region = LRFI->getRegion(BB);
-    unsigned RegionParentID = Region->getParentID();
+    unsigned RegionParentID = *Region->getParentID();
     while (RegionParentID != LRegion->getID()) {
       Region = LRFI->getRegion(RegionParentID);
-      RegionParentID = Region->getParentID();
+      RegionParentID = *Region->getParentID();
     }
     ExitingRegions.push_back(Region->getID());
   }
@@ -745,7 +745,7 @@ getRegionForNonLocalSuccessor(const LoopRegion *Child, unsigned SuccID) const {
   LoopRegion::SuccessorID Succ = {0, 0};
 
   do {
-    Iter = getRegion(Iter->getParentID());
+    Iter = getRegion(*Iter->getParentID());
     Succ = Iter->Succs[SuccID].getValue();
     SuccID = Succ.ID;
   } while (Succ.IsNonLocal);
@@ -876,7 +876,7 @@ struct LoopRegionWrapper {
   LoopRegion *Region;
 
   LoopRegionWrapper *getParent() const {
-    unsigned ParentIndex = Region->getParentID();
+    unsigned ParentIndex = *Region->getParentID();
     return &FuncInfo.Data[ParentIndex];
   }
 
@@ -922,7 +922,7 @@ struct alledge_iterator
     }
     // If we have a non-local id, just return the parent region's data.
     if ((*SuccIter)->IsNonLocal)
-      return &Wrapper->FuncInfo.Data[Wrapper->Region->getParentID()];
+      return &Wrapper->FuncInfo.Data[*(Wrapper->Region->getParentID())];
     // Otherwise return the data associated with this successor.
     return &Wrapper->FuncInfo.Data[(*SuccIter)->ID];
   }

--- a/test/SILOptimizer/loop-region-analysis.sil
+++ b/test/SILOptimizer/loop-region-analysis.sil
@@ -36,14 +36,16 @@ sil @no_return_func : $@convention(thin) @noreturn () -> ()
 // CHECK-NEXT:         (region id:4)
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:3
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:loop ucfh:false ucft:false parent:3
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -53,6 +55,8 @@ sil @no_return_func : $@convention(thin) @noreturn () -> ()
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:1)))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:4
 // CHECK-NEXT:     (preds)
@@ -60,14 +64,16 @@ sil @no_return_func : $@convention(thin) @noreturn () -> ()
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:3
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @one_natural_self_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -96,14 +102,16 @@ bb2:
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -115,6 +123,8 @@ bb2:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:3)))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
@@ -123,7 +133,8 @@ bb2:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -131,21 +142,24 @@ bb2:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @one_natural_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -182,14 +196,16 @@ bb4:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -202,6 +218,8 @@ bb4:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
@@ -211,7 +229,8 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -219,7 +238,8 @@ bb4:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -227,7 +247,8 @@ bb4:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -235,14 +256,16 @@ bb4:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @one_natural_loop_with_diamond : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -280,14 +303,16 @@ bb5:
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:loop ucfh:true  ucft:true  parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -299,6 +324,9 @@ bb5:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:true  parent:6
 // CHECK-NEXT:     (preds
@@ -307,7 +335,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs)) 
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:true  parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -315,21 +344,24 @@ bb5:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs)) 
 // CHECK: (region id:1 kind:bb   ucfh:true  ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs)) 
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs)) 
 sil @one_natural_loop_multiple_backedges : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -352,6 +384,8 @@ bb4:
 // inner loop. The ucfh does not propagate up b/c the header of the loop is not
 // in the inner loop.
 //
+// This is an example that can not happen in sil with canonicalized loops.
+//
 // CHECK-LABEL: @inner_natural_loop_with_multiple_backedges@
 // CHECK: (region id:6 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
@@ -361,14 +395,16 @@ bb4:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:true  parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -379,6 +415,8 @@ bb4:
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:8)))
 // CHECK: (region id:8 kind:loop ucfh:true  ucft:true  parent:7
 // CHECK-NEXT:     (preds
@@ -391,6 +429,9 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:true  parent:8
 // CHECK-NEXT:     (preds
@@ -399,7 +440,8 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
@@ -407,28 +449,32 @@ bb4:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:true  ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @inner_natural_loop_with_multiple_backedges : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -468,14 +514,16 @@ bb5:
 // CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
@@ -486,7 +534,9 @@ bb5:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4)))
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
@@ -494,14 +544,16 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -512,6 +564,8 @@ bb5:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:2)))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
@@ -520,21 +574,24 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @two_separate_natural_loops : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -577,14 +634,16 @@ bb5:
 // CHECK-NEXT:         (region id:9)
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3)
@@ -596,6 +655,8 @@ bb5:
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:5)))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
@@ -604,14 +665,16 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
@@ -619,7 +682,8 @@ bb5:
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -631,6 +695,8 @@ bb5:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:2)))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
@@ -640,21 +706,24 @@ bb5:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @two_separate_natural_loops_separated_by_diamond : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -704,7 +773,8 @@ bb6:
 // CHECK-NEXT:         (region id:11)
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:10)
@@ -712,7 +782,8 @@ bb6:
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9)
@@ -724,6 +795,8 @@ bb6:
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:6)))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
@@ -732,14 +805,16 @@ bb6:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -751,6 +826,8 @@ bb6:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
@@ -760,14 +837,16 @@ bb6:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -779,6 +858,8 @@ bb6:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:2)))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
@@ -788,21 +869,24 @@ bb6:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @two_separate_natural_loops_separated_by_diamond_with_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -842,7 +926,8 @@ bb7:
 // CHECK-NEXT:         (region id:11)
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:10)
@@ -850,7 +935,8 @@ bb7:
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -861,6 +947,8 @@ bb7:
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:6)))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
@@ -869,14 +957,16 @@ bb7:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
@@ -886,6 +976,8 @@ bb7:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
@@ -893,7 +985,8 @@ bb7:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -901,7 +994,8 @@ bb7:
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -913,6 +1007,8 @@ bb7:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:2)))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
@@ -922,21 +1018,24 @@ bb7:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @three_separate_natural_loops : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -980,14 +1079,16 @@ bb7:
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -999,7 +1100,9 @@ bb7:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:3)))
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:3))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
@@ -1007,7 +1110,8 @@ bb7:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -1017,28 +1121,33 @@ bb7:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2)))
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:2))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @two_level_natural_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -1074,14 +1183,16 @@ bb4:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1094,7 +1205,9 @@ bb4:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4)))
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3)
@@ -1103,7 +1216,8 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1112,7 +1226,8 @@ bb4:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -1123,7 +1238,9 @@ bb4:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2)))
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:2))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
@@ -1131,7 +1248,7 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1139,14 +1256,15 @@ bb4:
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @two_level_natural_loop_with_diamond_and_multiple_loop_exits : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -1177,14 +1295,16 @@ bb5:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1197,7 +1317,9 @@ bb5:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4)))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
@@ -1206,7 +1328,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -1216,6 +1339,8 @@ bb5:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:3)))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
@@ -1223,7 +1348,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -1231,7 +1357,8 @@ bb5:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1239,14 +1366,16 @@ bb5:
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @three_level_natural_loop_with_inner_loop_in_diamond : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -1283,14 +1412,16 @@ bb5:
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0)
@@ -1299,7 +1430,8 @@ bb5:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1310,7 +1442,8 @@ bb5:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:true  ucft:true  parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0)
@@ -1319,7 +1452,8 @@ bb5:
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1327,7 +1461,8 @@ bb5:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @one_level_irreducible_loop : $@convention(thin) () -> () {
 bb0:
   cond_br undef, bb1, bb3
@@ -1357,14 +1492,16 @@ bb5:
 // CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1378,6 +1515,8 @@ bb5:
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:5)))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
@@ -1386,7 +1525,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1395,7 +1535,8 @@ bb5:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
@@ -1406,7 +1547,8 @@ bb5:
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1415,7 +1557,8 @@ bb5:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1423,14 +1566,16 @@ bb5:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @natural_loop_containing_irreducible_loop : $@convention(thin) () -> () {
 bb0:
   br bb6
@@ -1470,14 +1615,16 @@ bb7:
 // CHECK-NEXT:         (region id:11)
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:10))
@@ -1488,6 +1635,8 @@ bb7:
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:7)))
 // CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
@@ -1496,14 +1645,16 @@ bb7:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1517,6 +1668,8 @@ bb7:
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:5)))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
@@ -1525,7 +1678,8 @@ bb7:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1534,7 +1688,8 @@ bb7:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
@@ -1545,7 +1700,8 @@ bb7:
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1554,7 +1710,8 @@ bb7:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1562,14 +1719,16 @@ bb7:
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @two_natural_loop_one_with_irreducible_loop : $@convention(thin) () -> () {
 bb0:
   br bb6
@@ -1610,14 +1769,16 @@ bb9:
 // CHECK-NEXT:         (region id:16)
 // CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:16 kind:loop ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:13))
@@ -1628,6 +1789,8 @@ bb9:
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:10)))
 // CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
@@ -1636,14 +1799,16 @@ bb9:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1657,6 +1822,8 @@ bb9:
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:8)))
 // CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
@@ -1665,7 +1832,8 @@ bb9:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:14 kind:loop ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1678,14 +1846,17 @@ bb9:
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4)))
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:7)))
 // CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:15 kind:loop ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4))
@@ -1696,6 +1867,8 @@ bb9:
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:6)))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
@@ -1704,14 +1877,16 @@ bb9:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1719,7 +1894,8 @@ bb9:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
@@ -1730,7 +1906,8 @@ bb9:
 // CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
@@ -1739,7 +1916,8 @@ bb9:
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1747,14 +1925,16 @@ bb9:
 // CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @multiple_level_natural_loop_with_irreducible_loop_sandwich : $@convention(thin) () -> () {
 bb0:
   br bb6
@@ -1804,21 +1984,21 @@ bb12:
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1831,6 +2011,8 @@ bb12:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:2)))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
@@ -1839,7 +2021,7 @@ bb12:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1847,14 +2029,14 @@ bb12:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 sil @unreachable_bb_in_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -1882,21 +2064,21 @@ bb4:
 // CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -1910,7 +2092,9 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -1918,7 +2102,7 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -1931,6 +2115,8 @@ bb4:
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:3)))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
@@ -1939,7 +2125,7 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -1947,21 +2133,21 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 sil @unreachable_bb_in_inner_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -1995,21 +2181,21 @@ bb6:
 // CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2023,7 +2209,9 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -2031,7 +2219,7 @@ bb6:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2044,6 +2232,8 @@ bb6:
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:3)))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
@@ -2053,7 +2243,7 @@ bb6:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2061,21 +2251,21 @@ bb6:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 sil @unreachable_bb_in_inner_loop_with_multiple_edges : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2110,21 +2300,21 @@ bb6:
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2137,7 +2327,7 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2)))
+// CHECK-NEXT:         (region id:2))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2145,7 +2335,7 @@ bb6:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2153,14 +2343,14 @@ bb6:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 sil @noreturn_bb_in_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2192,21 +2382,21 @@ bb4:
 // CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:11))
@@ -2217,7 +2407,7 @@ bb4:
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:7)))
+// CHECK-NEXT:         (region id:7))
 // CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
@@ -2225,21 +2415,21 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2255,7 +2445,7 @@ bb4:
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:12)))
+// CHECK-NEXT:         (region id:12))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:12))
@@ -2263,7 +2453,7 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:12 kind:loop ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2276,7 +2466,7 @@ bb4:
 // CHECK-NEXT:         (parentindex:2))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)))
+// CHECK-NEXT:         (region id:3))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
@@ -2284,7 +2474,7 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2292,7 +2482,7 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2300,14 +2490,14 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 sil @noreturn_bb_in_three_level_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2397,14 +2587,14 @@ bb4:
 // CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:6 kind:loop ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2415,6 +2605,8 @@ bb4:
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:7)))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
@@ -2426,14 +2618,16 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2)))
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2441,21 +2635,21 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
 sil @exit_block_that_is_a_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2486,7 +2680,8 @@ bb4:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4)
@@ -2494,7 +2689,8 @@ bb4:
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:10))
@@ -2502,7 +2698,8 @@ bb4:
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:10))
@@ -2510,7 +2707,8 @@ bb4:
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:10 kind:loop ucfh:true  ucft:true  parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2524,7 +2722,10 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12)))
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12))
 // CHECK: (region id:12 kind:loop ucfh:false ucft:true  parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2535,6 +2736,8 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:6)))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:true  parent:12
 // CHECK-NEXT:     (preds
@@ -2543,14 +2746,16 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:11 kind:loop ucfh:false ucft:true  parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2561,6 +2766,8 @@ bb4:
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:3)))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:true  parent:11
 // CHECK-NEXT:     (preds
@@ -2569,14 +2776,16 @@ bb4:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:true  ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2584,14 +2793,16 @@ bb4:
 // CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @multiple_exit_blocks_that_are_loops : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2630,14 +2841,16 @@ bb8:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2652,6 +2865,8 @@ bb8:
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
@@ -2660,7 +2875,8 @@ bb8:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
@@ -2669,7 +2885,8 @@ bb8:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2678,21 +2895,24 @@ bb8:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @loop_with_multiple_early_exit : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2732,14 +2952,16 @@ bb5:
 // CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2752,13 +2974,16 @@ bb5:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:5)))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2771,6 +2996,8 @@ bb5:
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
@@ -2779,7 +3006,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2787,21 +3015,24 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:     (backedge-regs))
 sil @loop_with_one_early_exit_from_inner_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2831,14 +3062,16 @@ bb5:
 // CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
@@ -2851,7 +3084,9 @@ bb5:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:9)))
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:5)))
 // CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -2859,7 +3094,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
@@ -2874,6 +3110,8 @@ bb5:
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:4)))
 // CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
@@ -2882,7 +3120,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
@@ -2891,7 +3130,8 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
@@ -2899,21 +3139,24 @@ bb5:
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @loop_with_multiple_early_exit_from_inner_loop : $@convention(thin) () -> () {
 bb0:
   br bb1


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
We already computed this information so this is just storing information
we were already computing.

One thing to note is that in code with canonicalized loops, we will
always only have one backedge. But we would like loop region to be
correct even in the case of non-canonicalized code so we support having
multiple back edges. But since the common case is 1 backedge, we
optimize for that case.

This commit contains updated tests and also updates to the loop region graph
viewer so that it draws backedges as green arrows from the loop to its backedge
subregions. The test updates were done by examining each test case by hand.
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
