### PR TITLE
[swiftc] Add test case for crash triggered in swift::Expr::walk(…)

### DIFF
--- a/validation-test/compiler_crashers/28272-swift-expr-walk.swift
+++ b/validation-test/compiler_crashers/28272-swift-expr-walk.swift
@@ -7,7 +7,4 @@
 
 // RUN: not --crash %target-swift-frontend %s -parse
 // REQUIRES: asserts
-func b{{
-protocol P{func b
-func b<T where T=e
-typealias e
+.A[


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/Optional.h:138: T &&llvm::Optional<swift::constraints::SelectedOverload>::operator*() && [T = swift::constraints::SelectedOverload]: Assertion `hasVal' failed.
11 swift           0x0000000000fdfea5 swift::Expr::walk(swift::ASTWalker&) + 69
12 swift           0x0000000000ed3e26 swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 502
13 swift           0x0000000000e36d5a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
16 swift           0x0000000000ef093b swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 10971
17 swift           0x0000000000ef29a0 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
18 swift           0x0000000000e30803 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 787
19 swift           0x0000000000e36cb0 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
21 swift           0x0000000000ea8986 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
22 swift           0x0000000000e6c27d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1149
23 swift           0x0000000000cbdccf swift::CompilerInstance::performSema() + 3087
25 swift           0x000000000078b89f frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
26 swift           0x0000000000786365 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28272-swift-expr-walk.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28272-swift-expr-walk-29a7d7.o
1.  While type-checking expression at [validation-test/compiler_crashers/28272-swift-expr-walk.swift:6:1 - line:6:3] RangeText=".A["
2.  While type-checking expression at [validation-test/compiler_crashers/28272-swift-expr-walk.swift:6:1 - line:6:3] RangeText=".A["
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
