### PR TITLE
Enable SIL verification with the sil-opt driver.

### DIFF
--- a/test/SILOptimizer/devirt_static_witness_method.sil
+++ b/test/SILOptimizer/devirt_static_witness_method.sil
@@ -18,7 +18,7 @@ struct S<T> : CanAdd {
 func +<T>(lhs: S<T>, rhs: S<T>) -> S<T>
 
 
-sil hidden [transparent] [thunk] @operator_plus_static_non_generic_witness_for_S : $@convention(thin) <T where T : CanAdd> (@in S<T>, @in S<T>, @thick S<T>.Type) -> @out S<T> {
+sil hidden [transparent] [thunk] @operator_plus_static_non_generic_witness_for_S : $@convention(witness_method) <T where T : CanAdd> (@in S<T>, @in S<T>, @thick S<T>.Type) -> @out S<T> {
 bb0(%0 : $*S<T>, %1 : $*S<T>, %2 : $*S<T>, %3 : $@thick S<T>.Type) :
   %17 = tuple ()
   return %17 : $()

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -167,6 +167,9 @@ static void runCommandLineSelectedPasses(SILModule *Module) {
     PM.addPass(Pass);
   }
   PM.run();
+
+  if (Module->getOptions().VerifyAll)
+    Module->verify();
 }
 
 // This function isn't referenced outside its translation unit, but it

--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -13,7 +13,8 @@ for id in $(seq 0 $process_id_max); do
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
 // REQUIRES: long_test
 __EOF__
 

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_11.sil
+++ b/validation-test/SIL/parse_stdlib_11.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
 // REQUIRES: long_test

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -5,5 +5,6 @@
 
 // RUN: rm -f %t.*
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
-// RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
+// FIXME: Add -enable-sil-verify-all after fixing rdar://26530182 -enable-sil-verify-all fails with stdlib.
+// RUN: %target-sil-opt %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
 // REQUIRES: long_test


### PR DESCRIPTION
Enable SIL verification with the sil-opt driver.

```
This was obviously intended given that the driver enables the
corresponding compiler option by default, and most SIL tests
explicitly call for it.

Enabling verification does not increase the run time of the
swift-check target.
```
