### PR TITLE
[SR-938][AST/Sema] Typealias in protocol extension, spurious conformance failure fixes

### DIFF
--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -477,9 +477,10 @@ auto ArchetypeBuilder::PotentialArchetype::getNestedType(
           continue;
 
         auto type = alias->getUnderlyingType();
+        SmallVector<Identifier, 4> identifiers;
+        
         if (auto archetype = type->getAs<ArchetypeType>()) {
           auto containingProtocol = cast<ProtocolDecl>(alias->getParent());
-          SmallVector<Identifier, 4> identifiers;
           
           // Go up archetype parents until we find our containing protocol.
           while (archetype->getSelfProtocol() != containingProtocol) {
@@ -490,19 +491,32 @@ auto ArchetypeBuilder::PotentialArchetype::getNestedType(
           }
           if (!archetype)
             continue;
-          
+        } else if (auto dependent = type->getAs<DependentMemberType>()) {
+          do {
+            identifiers.push_back(dependent->getName());
+            dependent = dependent->getBase()->getAs<DependentMemberType>();
+          } while (dependent);
+        }
+        
+        if (identifiers.size()) {
           // Go down our PAs until we find the referenced PA.
           auto existingPA = this;
           while(identifiers.size()) {
-            existingPA = existingPA->getNestedType(identifiers.back(), builder);
-            existingPA = existingPA->getRepresentative();
-            if (existingPA == this)
-              break;
+            auto identifier = identifiers.back();
+            // If we end up looking for ourselves, don't recurse.
+            if (existingPA == this && identifier == nestedName) {
+              existingPA = pa;
+            } else {
+              existingPA = existingPA->getNestedType(identifier, builder);
+              existingPA = existingPA->getRepresentative();
+            }
             identifiers.pop_back();
           }
-          pa->Representative = existingPA;
-          RequirementSource source(RequirementSource::Inferred, SourceLoc());
-          pa->SameTypeSource = source;
+          if (pa != existingPA) {
+            pa->Representative = existingPA;
+            RequirementSource source(RequirementSource::Inferred, SourceLoc());
+            pa->SameTypeSource = source;
+          }
         } else if (type->hasArchetype()) {
           // This is a complex type involving other associatedtypes, we'll fail
           // to resolve and get a special diagnosis in finalize.
@@ -518,24 +532,28 @@ auto ArchetypeBuilder::PotentialArchetype::getNestedType(
       RequirementSource source(RequirementSource::Inferred, SourceLoc());
       if (!nested.empty()) {
         auto existing = nested.front();
-        if (auto alias = existing->getTypeAliasDecl()) {
+        if (existing->getTypeAliasDecl() && !pa->getTypeAliasDecl()) {
           // If we found a typealias first, and now have an associatedtype
           // with the same name, it was a Swift 2 style declaration of the
           // type an inherited associatedtype should be bound to. In such a
           // case we want to make sure the associatedtype is frontmost to
           // generate generics/witness lists correctly, and the alias
           // will be unused/useless for generic constraining anyway.
-          alias->setInvalid();
-          nested.clear();
+          for (auto existing : nested) {
+            existing->Representative = pa;
+            existing->Representative->EquivalenceClass.push_back(existing);
+            existing->SameTypeSource = source;
+          }
+          nested.insert(nested.begin(), pa);
+          NestedTypes[nestedName] = nested;
         } else {
           pa->Representative = existing->getRepresentative();
           pa->Representative->EquivalenceClass.push_back(pa);
           pa->SameTypeSource = source;
+          nested.push_back(pa);
         }
-      }
-
-      // Add this resolved nested type.
-      nested.push_back(pa);
+      } else
+        nested.push_back(pa);
 
       // If there's a superclass constraint that conforms to the protocol,
       // add the appropriate same-type relationship.
@@ -662,8 +680,11 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
       (void) resolver;
 
       // Resolve the member type.
-      auto depMemberType = getDependentType(builder, false)
-        ->castTo<DependentMemberType>();
+      auto type = getDependentType(builder, false);
+      if (type->is<ErrorType>())
+        return NestedType::forConcreteType(type);
+
+      auto depMemberType = type->castTo<DependentMemberType>();
       Type memberType = depMemberType->substBaseType(
                           &mod,
                           parent->ArchetypeOrConcreteType.getAsConcreteType(),

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -121,7 +121,7 @@ Type PartialGenericTypeToArchetypeResolver::resolveSelfAssociatedType(
        AssociatedTypeDecl *assocType) {
   // We don't have enough information to find the associated type.
   // FIXME: Nonsense, but we shouldn't need this code anyway.
-  return DependentMemberType::get(selfTy, assocType->getName(), TC.Context);
+  return DependentMemberType::get(selfTy, assocType, TC.Context);
 }
 
 Type
@@ -177,9 +177,6 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   // If the nested type comes from a type alias, use either the alias's
   // concrete type, or resolve its components down to another dependent member.
   if (auto alias = nestedPA->getTypeAliasDecl()) {
-    if (nestedPA->isConcreteType())
-      return nestedPA->getConcreteType();
-
     return TC.substMemberTypeWithBase(DC->getParentModule(), alias,
                                       baseTy, true);
   }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -160,6 +160,9 @@ namespace {
         if (auto assocType = dyn_cast<AssociatedTypeDecl>(found)) {
           witness = conformance->getTypeWitnessSubstAndDecl(assocType, &TC)
             .second;
+        } else if (isa<TypeAliasDecl>(found)) {
+          // No witness for typealiases.
+          return;
         } else {
           witness = conformance->getWitness(found, &TC).getDecl();
         }
@@ -356,6 +359,13 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
         inferredAssociatedTypes.push_back(assocType);
         continue;
       }
+    }
+
+    // Ignore typealiases found in protocol members.
+    if (auto alias = dyn_cast<TypeAliasDecl>(typeDecl)) {
+      auto aliasParent = alias->getParent();
+      if (aliasParent != dc && isa<ProtocolDecl>(aliasParent))
+        continue;
     }
 
     // Substitute the base into the member's type.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3597,6 +3597,9 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
   if (auto *FD = dyn_cast<FuncDecl>(requirement))
     if (FD->isAccessor())
       return;
+  // If this is a typealias, it does not need a witness check.
+  if (isa<TypeAliasDecl>(requirement))
+    return;
 
   // Resolve all associated types before trying to resolve this witness.
   resolveTypeWitnesses();

--- a/validation-test/compiler_crashers_2_fixed/0041-walkToDeclPost-crash.swift
+++ b/validation-test/compiler_crashers_2_fixed/0041-walkToDeclPost-crash.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 
 extension Collection {
     func f() -> [Generator.Element] {

--- a/validation-test/compiler_crashers_fixed/28277-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers_fixed/28277-swift-archetypebuilder-getgenericsignature.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
 {
 protocol A{


### PR DESCRIPTION
Don’t try to find a conformation witness for typealias declarations in protocols.

Don’t lookup type aliases as members with the  NL_ProtocolMembers flag, because it keeps us from having aliases and associated types with the same name in two conformances to the same nominal, which the stdlib really wants to have. Added test of that.

Fixed a bug with same type constraint between an alias and a concrete type - just a bad assumption on my part. Added test for that.

Made archetype builder more resilient in constructing PA trees: it will work correctly now if the alias destination is a dependent member type instead of an archetype type. It also handles the case of finding multiple aliases with the same name along with an associatedtype with that name, fixing up all the representative ptrs.

There’s one bug I’m aware of remaining, I’m being bit by the FIXME on TypeCheckGeneric.cpp:123 where validating an alias is causing one of the intermediate dependent members along its path to be created without an associated type decl ptr.
