### PR TITLE
SR-946 - Unify mutexes in the Swift runtime

### DIFF
--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -1,0 +1,295 @@
+//===--- Mutex.h - Lockables ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Mutex, Condition, and Scoped lock abstactions for use in Swift runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_MUTEX_H
+#define SWIFT_RUNTIME_MUTEX_H
+
+namespace swift {
+
+/// A Condition that works with Mutex to allow – as an example – multi-threaded
+/// producers and consumers to signal each other in a safe way.
+class Condition {
+  friend class MutexImplementation;
+
+public:
+  explicit Condition();
+  ~Condition();
+
+public:
+  /// Notifies one waiter (if any exists) that the condition has been met.
+  ///
+  /// Note: To avoid missed notification it is best hold the related mutex
+  //        lock when calling notifyOne.
+  void notifyOne() const;
+
+  /// Notifies all waiters (if any exists) that the condition has been met.
+  ///
+  /// Note: To avoid missed notification it is best hold the related mutex
+  //        lock when calling notifyAll.
+  void notifyAll() const;
+
+protected:
+  void* Data;
+};
+
+/// Internal (private) implementation of mutex functionality.
+/// Use Mutex or RecursiveMutex instead (see below).
+class MutexImplementation {
+  friend class Mutex;
+
+public:
+  MutexImplementation() = delete;
+  ~MutexImplementation();
+
+protected:
+  explicit MutexImplementation(bool checked);
+
+public:
+  void lock() const;
+  void unlock() const;
+  bool try_lock() const;
+
+public:
+  void wait(const Condition& condition) const;
+
+private:
+  void* Data;
+};
+
+/// Internal (private) implementation of scoped locking functionality.
+/// Use ScopedLock instead (see below).
+class ScopedLockImplementation {
+  friend class Mutex;
+
+public:
+  ScopedLockImplementation() = delete;
+  ~ScopedLockImplementation() {
+    Impl.unlock();
+  }
+
+protected:
+  ScopedLockImplementation(const MutexImplementation& impl) : Impl(impl) {
+    Impl.lock();
+  }
+
+public:
+  void wait(const Condition& condition) const {
+    Impl.wait(condition);
+  }
+
+private:
+  const MutexImplementation& Impl;
+};
+
+/// Internal (private) implementation of scoped unlocking functionality.
+/// Use ScopedUnlock instead (see below).
+class ScopedUnlockImplementation {
+  friend class Mutex;
+
+public:
+  ScopedUnlockImplementation() = delete;
+  ~ScopedUnlockImplementation() {
+    Impl.lock();
+  }
+
+protected:
+  ScopedUnlockImplementation(const MutexImplementation& impl) : Impl(impl) {
+    Impl.unlock();
+  }
+
+private:
+  const MutexImplementation& Impl;
+};
+
+/// A Mutex object that supports `BasicLockable` and `Lockable` C++ concepts.
+/// See http://en.cppreference.com/w/cpp/concept/BasicLockable
+/// See http://en.cppreference.com/w/cpp/concept/Lockable
+///
+/// This is NOT a recursive mutex.
+class Mutex {
+  friend class ScopedLock;
+  friend class ScopedUnlock;
+
+public:
+  /// Constructs a non-recursive mutex.
+  ///
+  /// If `checked` is true the mutex will attempt to check for misuse and
+  /// fatalError when detected. If `checked` is false (the default) the
+  /// mutex will make little to no effort to check for misuse (e.g. efficient).
+  explicit Mutex(bool checked = false) : Impl(checked) {}
+
+public:
+  /// The method lock() has the following properties:
+  /// - Behaves as an atomic operation.
+  /// - Blocks the calling thread until exclusive ownership of the mutex
+  ///   can be obtained.
+  /// - Prior m.unlock() operations on the same mutex synchronize-with
+  ///   this lock operation.
+  /// - The behavior is undefined if the calling thread already owns
+  ///   the mutex (likely a deadlock).
+  /// - Does not throw exceptions but will halt on error (fatalError).
+  void lock() const {
+    Impl.lock();
+  }
+
+  /// The method unlock() has the following properties:
+  /// - Behaves as an atomic operation.
+  /// - Releases the calling thread's ownership of the mutex and
+  ///   synchronizes-with the subsequent successful lock operations on
+  ///   the same object.
+  /// - The behavior is undefined if the calling thread does not own
+  ///   the mutex.
+  /// - Does not throw exceptions but will halt on error (fatalError).
+  void unlock() const {
+    Impl.unlock();
+  }
+
+  /// The method lock() has the following properties:
+  /// - Behaves as an atomic operation.
+  /// - Attempts to obtain exclusive ownership of the mutex for the calling
+  ///   thread without blocking. If ownership is not obtained, returns
+  ///   immediately. The function is allowed to spuriously fail and return
+  ///   even if the mutex is not currently owned by another thread.
+  /// - If try_lock() succeeds, prior unlock() operations on the same object
+  ///   synchronize-with this operation. lock() does not synchronize with a
+  ///   failed try_lock()
+  /// - The behavior is undefined if the calling thread already owns
+  ///   the mutex (likely a deadlock)?
+  /// - Does not throw exceptions but will halt on error (fatalError).
+  bool try_lock() const {
+    return Impl.try_lock();
+  }
+
+public:
+  /// Releases lock, waits on supplied condition, and relocks before returning.
+  ///
+  /// Precondition: Mutex locked by this thread, undefined otherwise.
+  void wait(const Condition& condition) const {
+    Impl.wait(condition);
+  }
+
+public:
+  /// Acquires lock before calling the supplied critical section and release
+  /// lock on return from critical section.
+  ///
+  /// For example the following mutates value while holding the mutex lock.
+  ///
+  ///   mutex.lock([&value] { value++; });
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  template<typename CriticalSection>
+  void lock(CriticalSection criticalSection) const {
+    ScopedLockImplementation guard(Impl);
+    criticalSection();
+  }
+
+  /// Acquires lock before calling the supplied critical section. If critical
+  /// section returns `true` then it will wait on the supplied condition and
+  /// call critical section again when wait returns (again holding the lock).
+  /// If critical section returns `false` it will no longer wait, it will
+  /// release the lock and return (e.g. lockOrWait returns).
+  ///
+  /// For example the following will loop waiting on condition until
+  /// `value > 0`. It will then "consume" that value and stop looping.
+  /// ...all while being correctly protected by mutex.
+  ///
+  ///   mutex.lockOrWait(condition, [&value] {
+  ///     if (value > 0) {
+  ///       value--;
+  ///       return false;
+  ///     }
+  ///    return true;
+  ///   });
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  template<typename CriticalSection>
+  void lockOrWait(const Condition& condition,
+                  CriticalSection criticalSection) const {
+    ScopedLockImplementation guard(Impl);
+    while ( criticalSection() ) {
+      Impl.wait(condition);
+    }
+  }
+
+  /// Acquires lock before calling the supplied critical section and on return
+  /// from critical section it notifies one waiter of supplied condition and
+  /// then releases the lock.
+  ///
+  /// For example the following mutates value while holding the mutex lock and
+  /// then notifies one condition waiter about this change.
+  ///
+  ///   mutex.lockAndNotifyOne([&value] { value++; });
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  template<typename CriticalSection>
+  void lockAndNotifyOne(const Condition& condition,
+                        CriticalSection criticalSection) const {
+    ScopedLockImplementation guard(Impl);
+    criticalSection();
+    condition.notifyOne();
+  }
+
+  /// Acquires lock before calling the supplied critical section and on return
+  /// from critical section it notifies all waiters of supplied condition and
+  /// then releases the lock.
+  ///
+  /// For example the following mutates value while holding the mutex lock and
+  /// then notifies all condition waiters about this change.
+  ///
+  ///   mutex.lockAndNotifyAll([&value] { value++; });
+  ///
+  /// Precondition: Mutex unlocked by this thread, undefined otherwise.
+  template<typename CriticalSection>
+  void lockAndNotifyAll(const Condition& condition,
+                        CriticalSection criticalSection) const {
+    ScopedLockImplementation guard(Impl);
+    criticalSection();
+    condition.notifyAll();
+  }
+
+protected:
+  MutexImplementation Impl;
+};
+
+/// A stack based object that locks the supplied mutex on construction
+/// and unlock it on destruction.
+///
+/// Precondition: Mutex unlocked by this thread, undefined otherwise.
+class ScopedLock : ScopedLockImplementation {
+public:
+  ScopedLock(Mutex& mutex) : ScopedLockImplementation(mutex.Impl) {}
+
+public:
+  /// Releases lock, waits on supplied condition, and relocks before returning.
+  ///
+  /// Precondition: Mutex locked by this thread, undefined otherwise.
+  void wait(const Condition& condition) const {
+    ScopedLockImplementation::wait(condition);
+  }
+};
+
+/// A stack based object that unlocks the supplied mutex on construction
+/// and relocks it on destruction.
+///
+/// Precondition: Mutex locked by this thread, undefined otherwise.
+class ScopedUnlock : ScopedUnlockImplementation {
+public:
+  ScopedUnlock(Mutex& mutex) : ScopedUnlockImplementation(mutex.Impl) {}
+};
+
+}
+
+#endif

--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -42,7 +42,7 @@ public:
   void notifyAll() const;
 
 protected:
-  void* Data;
+  void *Data;
 };
 
 /// Internal (private) implementation of mutex functionality.
@@ -63,10 +63,10 @@ public:
   bool try_lock() const;
 
 public:
-  void wait(const Condition& condition) const;
+  void wait(const Condition &condition) const;
 
 private:
-  void* Data;
+  void *Data;
 };
 
 /// Internal (private) implementation of scoped locking functionality.
@@ -80,18 +80,23 @@ public:
     Impl.unlock();
   }
 
+  ScopedLockImplementation
+    &operator=(const ScopedLockImplementation &) = delete;
+  ScopedLockImplementation
+    &operator=(ScopedLockImplementation &&) = delete;
+
 protected:
   ScopedLockImplementation(const MutexImplementation& impl) : Impl(impl) {
     Impl.lock();
   }
 
 public:
-  void wait(const Condition& condition) const {
+  void wait(const Condition &condition) const {
     Impl.wait(condition);
   }
 
 private:
-  const MutexImplementation& Impl;
+  const MutexImplementation &Impl;
 };
 
 /// Internal (private) implementation of scoped unlocking functionality.
@@ -105,13 +110,18 @@ public:
     Impl.lock();
   }
 
+  ScopedUnlockImplementation
+    &operator=(const ScopedUnlockImplementation &) = delete;
+  ScopedUnlockImplementation
+    &operator=(ScopedUnlockImplementation &&) = delete;
+
 protected:
-  ScopedUnlockImplementation(const MutexImplementation& impl) : Impl(impl) {
+  ScopedUnlockImplementation(const MutexImplementation &impl) : Impl(impl) {
     Impl.unlock();
   }
 
 private:
-  const MutexImplementation& Impl;
+  const MutexImplementation &Impl;
 };
 
 /// A Mutex object that supports `BasicLockable` and `Lockable` C++ concepts.
@@ -177,7 +187,7 @@ public:
   /// Releases lock, waits on supplied condition, and relocks before returning.
   ///
   /// Precondition: Mutex locked by this thread, undefined otherwise.
-  void wait(const Condition& condition) const {
+  void wait(const Condition &condition) const {
     Impl.wait(condition);
   }
 
@@ -216,7 +226,7 @@ public:
   ///
   /// Precondition: Mutex unlocked by this thread, undefined otherwise.
   template<typename CriticalSection>
-  void lockOrWait(const Condition& condition,
+  void lockOrWait(const Condition &condition,
                   CriticalSection criticalSection) const {
     ScopedLockImplementation guard(Impl);
     while ( criticalSection() ) {
@@ -235,7 +245,7 @@ public:
   ///
   /// Precondition: Mutex unlocked by this thread, undefined otherwise.
   template<typename CriticalSection>
-  void lockAndNotifyOne(const Condition& condition,
+  void lockAndNotifyOne(const Condition &condition,
                         CriticalSection criticalSection) const {
     ScopedLockImplementation guard(Impl);
     criticalSection();
@@ -253,7 +263,7 @@ public:
   ///
   /// Precondition: Mutex unlocked by this thread, undefined otherwise.
   template<typename CriticalSection>
-  void lockAndNotifyAll(const Condition& condition,
+  void lockAndNotifyAll(const Condition &condition,
                         CriticalSection criticalSection) const {
     ScopedLockImplementation guard(Impl);
     criticalSection();
@@ -270,13 +280,17 @@ protected:
 /// Precondition: Mutex unlocked by this thread, undefined otherwise.
 class ScopedLock : ScopedLockImplementation {
 public:
-  ScopedLock(Mutex& mutex) : ScopedLockImplementation(mutex.Impl) {}
+  explicit ScopedLock(const Mutex &mutex)
+    : ScopedLockImplementation(mutex.Impl) {}
+
+  ScopedLock &operator=(const ScopedLock &) = delete;
+  ScopedLock &operator=(ScopedLock &&) = delete;
 
 public:
   /// Releases lock, waits on supplied condition, and relocks before returning.
   ///
   /// Precondition: Mutex locked by this thread, undefined otherwise.
-  void wait(const Condition& condition) const {
+  void wait(const Condition &condition) const {
     ScopedLockImplementation::wait(condition);
   }
 };
@@ -287,7 +301,11 @@ public:
 /// Precondition: Mutex locked by this thread, undefined otherwise.
 class ScopedUnlock : ScopedUnlockImplementation {
 public:
-  ScopedUnlock(Mutex& mutex) : ScopedUnlockImplementation(mutex.Impl) {}
+  explicit ScopedUnlock(const Mutex &mutex)
+    : ScopedUnlockImplementation(mutex.Impl) {}
+  
+  ScopedUnlock &operator=(const ScopedUnlock &) = delete;
+  ScopedUnlock &operator=(ScopedUnlock &&) = delete;
 };
 
 }

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -45,6 +45,7 @@ set(swift_runtime_sources
     KnownMetadata.cpp
     Metadata.cpp
     MetadataLookup.cpp
+    Mutex.cpp
     Once.cpp
     ProtocolConformance.cpp
     Reflection.cpp

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -32,8 +32,11 @@
 #include "stddef.h"
 
 #include <cstring>
-#include <mutex>
 #include <type_traits>
+
+// FIXME: SR-946 - we ideally want to switch off of using pthread_rwlock
+//                 directly and instead expand Mutex.h to support rwlocks.
+#include <mutex>
 
 // FIXME: Clang defines max_align_t in stddef.h since 3.6.
 // Remove this hack when we don't care about older Clangs on all platforms.

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -165,6 +165,9 @@ struct crashreporter_annotations_t gCRAnnotations
 static void
 reportOnCrash(uint32_t flags, const char *message)
 {
+  // FIXME: SR-946 - we can't yet switch the following to use swift::Mutex
+  //                 since swift::Mutex uses fatalError and we could end
+  //                 up back here again ...and again ...and again
   static pthread_mutex_t crashlogLock = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&crashlogLock);
   

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -21,6 +21,7 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Mutex.h"
 #include "swift/Strings.h"
 #include "MetadataCache.h"
 #include <algorithm>
@@ -28,7 +29,6 @@
 #include <new>
 #include <cctype>
 #include <sys/mman.h>
-#include <pthread.h>
 #include <unistd.h>
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
@@ -2344,12 +2344,8 @@ struct llvm::DenseMapInfo<GlobalString> {
 // StringMap because we don't need to actually copy the string.
 namespace {
 struct ForeignTypeState {
-  pthread_mutex_t Lock;
+  Mutex Lock;
   llvm::DenseMap<GlobalString, const ForeignTypeMetadata *> Types;
-  
-  ForeignTypeState() {
-    pthread_mutex_init(&Lock, nullptr);
-  }
 };
 }
 
@@ -2364,7 +2360,8 @@ swift::swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique) {
 
   // Okay, insert a new row.
   auto &Foreign = ForeignTypes.get();
-  pthread_mutex_lock(&Foreign.Lock);
+  ScopedLock guard(Foreign.Lock);
+  
   auto insertResult = Foreign.Types.insert({GlobalString(nonUnique->getName()),
                                             nonUnique});
   auto uniqueMetadata = insertResult.first->second;
@@ -2382,7 +2379,7 @@ swift::swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique) {
   // it will be possible for code to fast-path through this function
   // too soon.
   nonUnique->setCachedUniqueMetadata(uniqueMetadata);
-  pthread_mutex_unlock(&Foreign.Lock);
+
   return uniqueMetadata;
 }
 

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -16,7 +16,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/Metadata.h"
-#include <mutex>
+#include "swift/Runtime/Mutex.h"
 #include <condition_variable>
 #include <thread>
 
@@ -253,8 +253,8 @@ template <class ValueTy> class MetadataCache {
   const ValueTy *Head;
 
   struct ConcurrencyControl {
-    std::mutex Lock;
-    std::condition_variable Queue;
+    Mutex Lock;
+    Condition Queue;
   };
   std::unique_ptr<ConcurrencyControl> Concurrency;
 
@@ -303,17 +303,19 @@ public:
     if (!insertResult.second) {
 
       // If the entry is already initialized, great.
-      if (auto value = entry->getValue())
+      auto value = entry->getValue();
+      if (value) {
         return value;
+      }
 
       // Otherwise, we have to grab the lock and wait for the value to
       // appear there.  Note that we have to check again immediately
       // after acquiring the lock to prevent a race.
       auto concurrency = Concurrency.get();
-      std::unique_lock<std::mutex> guard(concurrency->Lock);
-      while (true) {
-        if (auto value = entry->getValue())
-          return value;
+      concurrency->Lock.lockOrWait(concurrency->Queue, [&value, &entry, this] {
+        if ((value = entry->getValue())) {
+          return false; // found a value, done waiting
+        }
 
         // As a QoI safe-guard against the simplest form of cyclic
         // dependency, check whether this thread is the one responsible
@@ -325,8 +327,10 @@ public:
           abort();
         }
 
-        concurrency->Queue.wait(guard);
-      }
+        return true; // don't have a value, continue waiting
+      });
+
+      return value;
     }
 
     // Otherwise, we created the entry and are responsible for
@@ -343,12 +347,10 @@ public:
 #endif
 
     // Acquire the lock, set the value, and notify any waiters.
-    {
-      auto concurrency = Concurrency.get();
-      std::unique_lock<std::mutex> guard(concurrency->Lock);
+    auto concurrency = Concurrency.get();
+    concurrency->Lock.lockAndNotifyAll(concurrency->Queue, [&entry, &value] {
       entry->setValue(value);
-      concurrency->Queue.notify_all();
-    }
+    });
 
     return value;
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -19,6 +19,7 @@
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Mutex.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/PointerIntPair.h"
@@ -34,7 +35,6 @@
 #endif
 
 #include <dlfcn.h>
-#include <mutex>
 
 using namespace swift;
 using namespace Demangle;
@@ -107,11 +107,10 @@ static void _addImageTypeMetadataRecordsBlock(const uint8_t *records,
 struct TypeMetadataState {
   ConcurrentMap<TypeMetadataCacheEntry> Cache;
   std::vector<TypeMetadataSection> SectionsToScan;
-  pthread_mutex_t SectionsToScanLock;
+  Mutex SectionsToScanLock;
 
   TypeMetadataState() {
     SectionsToScan.reserve(16);
-    pthread_mutex_init(&SectionsToScanLock, nullptr);
 #if defined(__APPLE__) && defined(__MACH__)
     _initializeCallbacksToInspectDylib();
 #else
@@ -120,6 +119,7 @@ struct TypeMetadataState {
       SWIFT_TYPE_METADATA_SECTION);
 #endif
   }
+
 };
 
 static Lazy<TypeMetadataState> TypeMetadataRecords;
@@ -128,9 +128,8 @@ static void
 _registerTypeMetadataRecords(TypeMetadataState &T,
                              const TypeMetadataRecord *begin,
                              const TypeMetadataRecord *end) {
-  pthread_mutex_lock(&T.SectionsToScanLock);
+  ScopedLock guard(T.SectionsToScanLock);
   T.SectionsToScan.push_back(TypeMetadataSection{begin, end});
-  pthread_mutex_unlock(&T.SectionsToScanLock);
 }
 
 static void _addImageTypeMetadataRecordsBlock(const uint8_t *records,
@@ -265,9 +264,9 @@ _typeByMangledName(const llvm::StringRef typeName) {
     return Value->getMetadata();
 
   // Check type metadata records
-  pthread_mutex_lock(&T.SectionsToScanLock);
-  foundMetadata = _searchTypeMetadataRecords(T, typeName);
-  pthread_mutex_unlock(&T.SectionsToScanLock);
+  T.SectionsToScanLock.lock([&] {
+    foundMetadata = _searchTypeMetadataRecords(T, typeName);
+  });
 
   // Check protocol conformances table. Note that this has no support for
   // resolving generic types yet.

--- a/stdlib/public/runtime/Mutex.cpp
+++ b/stdlib/public/runtime/Mutex.cpp
@@ -1,0 +1,139 @@
+//===--- Mutex.cpp - Lockables --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Mutex, Condition, and Scoped lock abstactions for use in Swift runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Mutex.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "swift/Runtime/Debug.h"
+
+using namespace swift;
+
+#define reportError(PThreadFunction) \
+{ \
+  int errorcode = PThreadFunction; \
+  if (errorcode != 0) { \
+    fatalError(/* flags = */ 0, \
+               "[%p] '%s' failed with error '%s'(%d)\n", \
+               this, #PThreadFunction, errorName(errorcode), errorcode); \
+  } \
+}
+
+#define returnOrReportError(PThreadFunction, allowEBUSY) \
+{ \
+  int errorcode = PThreadFunction; \
+  if (errorcode == 0 || (allowEBUSY && errorcode == EBUSY)) { \
+    return errorcode != EBUSY; \
+  } \
+  fatalError(/* flags = */ 0, \
+    "[%p] '%s' failed with error '%s'(%d)\n", \
+    this, #PThreadFunction, errorName(errorcode), errorcode); \
+}
+
+static const char* errorName(int errorcode) {
+  switch (errorcode) {
+    case EINVAL:
+      return "EINVAL";
+    case EPERM:
+      return "EPERM";
+    case EDEADLK:
+      return "EDEADLK";
+    case ENOMEM:
+      return "ENOMEM";
+    case EAGAIN:
+      return "EAGAIN";
+    case EBUSY:
+      return "EBUSY";
+    default:
+      return "<unknown>";
+  }
+}
+
+Condition::Condition() : Data(nullptr) {
+  pthread_cond_t* cond =
+    static_cast<pthread_cond_t*>(malloc(sizeof(pthread_cond_t)));
+
+  if (cond == nullptr) {
+    fatalError(/* flags = */ 0, "pthread condition could not be allocated\n");
+  }
+
+  reportError( pthread_cond_init(cond, nullptr) );
+  Data = cond;
+}
+
+Condition::~Condition() {
+  pthread_cond_t* cond = static_cast<pthread_cond_t*>(Data);
+  reportError( pthread_cond_destroy(cond) );
+  free(cond);
+}
+
+void Condition::notifyOne() const {
+  pthread_cond_t* cond = static_cast<pthread_cond_t*>(Data);
+  reportError( pthread_cond_signal(cond) );
+}
+
+void Condition::notifyAll() const {
+  pthread_cond_t* cond = static_cast<pthread_cond_t*>(Data);
+  reportError( pthread_cond_broadcast(cond) );
+}
+
+MutexImplementation::MutexImplementation( bool checked ) : Data(nullptr) {
+
+  int kind =
+    ( checked ? PTHREAD_MUTEX_ERRORCHECK : PTHREAD_MUTEX_NORMAL );
+
+  pthread_mutexattr_t attr;
+  pthread_mutex_t* mutex =
+    static_cast<pthread_mutex_t*>(malloc(sizeof(pthread_mutex_t)));
+
+  if (mutex == nullptr) {
+    fatalError(/* flags = */ 0, "pthread mutex could not be allocated\n");
+  }
+
+  reportError( pthread_mutexattr_init(&attr) );
+  reportError( pthread_mutexattr_settype(&attr, kind) );
+  reportError( pthread_mutex_init(mutex, &attr) );
+  reportError( pthread_mutexattr_destroy(&attr) );
+  Data = mutex;
+}
+
+MutexImplementation::~MutexImplementation() {
+  pthread_mutex_t* mutex = static_cast<pthread_mutex_t*>(Data);
+  reportError( pthread_mutex_destroy(mutex) );
+  free(mutex);
+}
+
+void MutexImplementation::lock() const {
+  pthread_mutex_t* mutex = static_cast<pthread_mutex_t*>(Data);
+  reportError( pthread_mutex_lock(mutex) );
+}
+
+void MutexImplementation::unlock() const {
+  pthread_mutex_t* mutex = static_cast<pthread_mutex_t*>(Data);
+  reportError( pthread_mutex_unlock(mutex) );
+}
+
+bool MutexImplementation::try_lock() const {
+  pthread_mutex_t* mutex = static_cast<pthread_mutex_t*>(Data);
+  returnOrReportError( pthread_mutex_trylock(mutex), /* allowEBUSY = */ true );
+}
+
+void MutexImplementation::wait(const Condition& condition) const {
+  pthread_mutex_t* mutex = static_cast<pthread_mutex_t*>(Data);
+  pthread_cond_t* cond = static_cast<pthread_cond_t*>(condition.Data);
+  reportError( pthread_cond_wait(cond, mutex) );
+}

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -18,6 +18,7 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Mutex.h"
 #include "Private.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
@@ -29,7 +30,6 @@
 #endif
 
 #include <dlfcn.h>
-#include <mutex>
 
 using namespace swift;
 
@@ -242,11 +242,10 @@ static void _addImageProtocolConformancesBlock(const uint8_t *conformances,
 struct ConformanceState {
   ConcurrentMap<ConformanceCacheEntry> Cache;
   std::vector<ConformanceSection> SectionsToScan;
-  pthread_mutex_t SectionsToScanLock;
+  Mutex SectionsToScanLock;
   
   ConformanceState() {
     SectionsToScan.reserve(16);
-    pthread_mutex_init(&SectionsToScanLock, nullptr);
 #if defined(__APPLE__) && defined(__MACH__)
     _initializeCallbacksToInspectDylib();
 #else
@@ -291,9 +290,8 @@ static void
 _registerProtocolConformances(ConformanceState &C,
                               const ProtocolConformanceRecord *begin,
                               const ProtocolConformanceRecord *end) {
-  pthread_mutex_lock(&C.SectionsToScanLock);
+  ScopedLock guard(C.SectionsToScanLock);
   C.SectionsToScan.push_back(ConformanceSection{begin, end});
-  pthread_mutex_unlock(&C.SectionsToScanLock);
 }
 
 static void _addImageProtocolConformancesBlock(const uint8_t *conformances,
@@ -565,7 +563,7 @@ recur:
   unsigned failedGeneration = ConformanceCacheGeneration;
 
   // If we didn't have an up-to-date cache entry, scan the conformance records.
-  pthread_mutex_lock(&C.SectionsToScanLock);
+  C.SectionsToScanLock.lock();
 
   // If we have no new information to pull in (and nobody else pulled in
   // new information while we waited on the lock), we're done.
@@ -573,7 +571,7 @@ recur:
     if (failedGeneration != ConformanceCacheGeneration) {
       // Someone else pulled in new conformances while we were waiting.
       // Start over with our newly-populated cache.
-      pthread_mutex_unlock(&C.SectionsToScanLock);
+      C.SectionsToScanLock.unlock();
       type = origType;
       goto recur;
     }
@@ -582,7 +580,7 @@ recur:
     // Save the failure for this type-protocol pair in the cache.
     C.cacheFailure(type, protocol);
 
-    pthread_mutex_unlock(&C.SectionsToScanLock);
+    C.SectionsToScanLock.unlock();
     return nullptr;
   }
 
@@ -643,7 +641,7 @@ recur:
   }
   ++ConformanceCacheGeneration;
 
-  pthread_mutex_unlock(&C.SectionsToScanLock);
+  C.SectionsToScanLock.unlock();
   // Start over with our newly-populated cache.
   type = origType;
   goto recur;
@@ -654,7 +652,7 @@ swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
   auto &C = Conformances.get();
   const Metadata *foundMetadata = nullptr;
 
-  pthread_mutex_lock(&C.SectionsToScanLock);
+  ScopedLock guard(C.SectionsToScanLock);
 
   unsigned sectionIdx = 0;
   unsigned endSectionIdx = C.SectionsToScan.size();
@@ -673,8 +671,6 @@ swift::_searchConformancesByMangledTypeName(const llvm::StringRef typeName) {
     if (foundMetadata != nullptr)
       break;
   }
-
-  pthread_mutex_unlock(&C.SectionsToScanLock);
 
   return foundMetadata;
 }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -37,7 +37,6 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <mutex>
 #include <unordered_map>
 #if SWIFT_OBJC_INTEROP
 # import <CoreFoundation/CFBase.h> // for CFTypeID

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -20,6 +20,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 
   add_swift_unittest(SwiftRuntimeTests
     Metadata.cpp
+    Mutex.cpp
     Enum.cpp
     Refcounting.cpp
     ${PLATFORM_SOURCES}

--- a/unittests/runtime/Mutex.cpp
+++ b/unittests/runtime/Mutex.cpp
@@ -1,0 +1,339 @@
+//===--- Mutex.cpp - Mutex tests ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Mutex.h"
+#include "gtest/gtest.h"
+#include <thread>
+
+using namespace swift;
+
+TEST(MutexTest, BasicLockable) {
+  Mutex mutex(/* checked = */ true);
+
+  int count = 0;
+  mutex.lock();
+  count++;
+  mutex.unlock();
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST(MutexTest, Lockable) {
+  Mutex mutex(/* checked = */ true);
+
+  int count = 0;
+  ASSERT_TRUE(mutex.try_lock());
+  count++;
+  mutex.unlock();
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST(MutexTest, ScopedLock) {
+  Mutex mutex(/* checked = */ true);
+
+  int count = 0;
+  {
+    ScopedLock guard(mutex);
+    count++;
+  }
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST(MutexTest, ScopedUnlock) {
+  Mutex mutex(/* checked = */ true);
+  mutex.lock();
+
+  int count = 0;
+  {
+    ScopedUnlock unguard(mutex);
+    count++;
+  }
+
+  mutex.unlock();
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST(MutexTest, ScopedUnlockNestedUnderScopedLock) {
+  Mutex mutex(/* checked = */ true);
+
+  int count = 0;
+  {
+    ScopedLock guard(mutex);
+    {
+      ScopedUnlock unguard(mutex);
+      count++;
+    }
+  }
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST(MutexTest, CriticalSection) {
+  Mutex mutex(/* checked = */ true);
+
+  int count = 0;
+  mutex.lock([&] {
+    count++;
+  });
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST(MutexTest, ScopedUnlockNestedCriticalSection) {
+  Mutex mutex(/* checked = */ true);
+
+  int count = 0;
+  mutex.lock([&] {
+    {
+      ScopedUnlock unguard(mutex);
+      count++;
+    }
+  });
+
+  ASSERT_EQ(count, 1);
+}
+
+template<typename ThreadBody>
+void threadedExecute(int threadCount,
+                     const Mutex& mutex,
+                     ThreadBody threadBody) {
+
+  std::vector<std::thread> threads;
+
+  // Block the threads we are about to create.
+  mutex.lock();
+
+  for(int i = 0; i < 5; ++i){
+    threads.push_back(std::thread([&]{
+      threadBody();
+    }));
+  }
+
+  // Allow our threads to fight for the lock.
+  mutex.unlock();
+
+  // Wait until all of our threads have finished.
+  for(auto& thread : threads){
+    thread.join();
+  }
+}
+
+TEST(MutexTest, BasicLockableThreaded) {
+  Mutex mutex(/* checked = */ true);
+  int count = 0;
+
+  threadedExecute(5, mutex, [&]{
+    for (int j = 0; j < 10; ++j) {
+      mutex.lock();
+      count++;
+      mutex.unlock();
+    }
+  });
+
+  ASSERT_EQ(count, 50);
+}
+
+TEST(MutexTest, LockableThreaded) {
+  Mutex mutex(/* checked = */ true);
+  int count = 0;
+
+  threadedExecute(5, mutex, [&]{
+    for (int j = 0; j < 10; ++j) {
+      if (mutex.try_lock()) {
+        count++;
+        mutex.unlock();
+      } else {
+        j--;
+      }
+    }
+  });
+
+  ASSERT_EQ(count, 50);
+}
+
+TEST(MutexTest, ScopedLockThreaded) {
+  Mutex mutex(/* checked = */ true);
+  int count = 0;
+
+  threadedExecute(5, mutex, [&]{
+    for (int j = 0; j < 10; ++j) {
+      ScopedLock guard(mutex);
+      count++;
+    }
+  });
+
+  ASSERT_EQ(count, 50);
+}
+
+TEST(MutexTest, ScopedUnlockNestedUnderScopedLockThreaded) {
+  Mutex mutex(/* checked = */ true);
+  int count = 0;
+  int badCount = 0;
+
+  threadedExecute(5, mutex, [&]{
+    for (int j = 0; j < 10; ++j) {
+      ScopedLock guard(mutex);
+      {
+        ScopedUnlock unguard(mutex);
+        badCount++;
+      }
+      count++;
+    }
+  });
+
+  ASSERT_EQ(count, 50);
+}
+
+TEST(MutexTest, CriticalSectionThreaded) {
+  Mutex mutex(/* checked = */ true);
+  int count = 0;
+
+  threadedExecute(5, mutex, [&]{
+    for (int j = 0; j < 10; ++j) {
+      mutex.lock([&] {
+        count++;
+      });
+    }
+  });
+
+  ASSERT_EQ(count, 50);
+}
+
+static bool trace = false;
+
+template<typename ConsumerBody, typename ProducerBody>
+void threadedExecute(const Mutex& mutex,
+                     const Condition& condition,
+                     bool& done,
+                     ConsumerBody consumerBody,
+                     ProducerBody producerBody) {
+
+  std::vector<std::thread> producers;
+  std::vector<std::thread> consumers;
+
+  // Block the threads we are about to create.
+  mutex.lock();
+
+  for(int i = 1; i <= 5; ++i){
+    consumers.push_back(std::thread([&, i]{
+      consumerBody(i);
+      if (trace) printf("### Consumer[%d] thread exiting.\n", i);
+    }));
+  }
+
+  for(int i = 1; i <= 3; ++i){
+    producers.push_back(std::thread([&, i]{
+      producerBody(i);
+      if (trace) printf("### Producer[%d] thread exiting.\n", i);
+    }));
+  }
+
+  // Allow our threads to fight for the lock.
+  mutex.unlock();
+
+  // Wait until all of our producer threads have finished.
+  for (auto& thread : producers){
+    thread.join();
+  }
+
+  // Inform consumers that producers are done.
+  mutex.lockAndNotifyAll(condition, [&] {
+    if (trace) printf("### Informing consumers we are done.\n");
+    done = true;
+    condition.notifyAll();
+  });
+
+  // Wait for consumers to finish.
+  for (auto& thread : consumers){
+    thread.join();
+  }
+}
+
+TEST(MutexTest, ConditionThreaded) {
+  Mutex mutex(/* checked = */ true);
+  Condition condition;
+
+  bool done = false;
+  int count = 200;
+
+  threadedExecute(mutex, condition, done,
+    [&] (int index) {
+      ScopedLock guard(mutex);
+      while(true) {
+        if (count - index >= 50) {
+          count -= index;
+          mutex.unlock(); mutex.lock(); // Only to give others a chance
+          if (trace) printf("Consumer[%d] count-%d = %d\n", index, index, count);
+          continue; // keep trying to consume before waiting again.
+        } else if (done && count == 50) {
+          if (trace) printf("Consumer[%d] count == %d and done!\n", index, count);
+          break;
+        }
+        guard.wait(condition);
+      }
+    },
+    [&] (int index) {
+      for (int j = 0; j < 10; j++) {
+        mutex.lock();
+        count += index;
+        if (trace) printf("Producer[%d] count+%d = %d\n",
+               index, index, count);
+        condition.notifyOne();
+        mutex.unlock();
+      }
+      if (trace) printf("Producer[%d] done!\n", index);
+    }
+  );
+
+  ASSERT_EQ(count, 50);
+}
+
+TEST(MutexTest, ConditionLockOrWaitLockAndNotifyThreaded) {
+  Mutex mutex(/* checked = */ true);
+  Condition condition;
+
+  bool done = false;
+  int count = 200;
+
+  threadedExecute(mutex, condition, done,
+    [&] (int index) {
+      mutex.lockOrWait(condition, [&, index] {
+        while(true) {
+          if (count - index >= 50) {
+            count -= index;
+            mutex.unlock(); mutex.lock(); // Only to give others a chance.
+            if (trace) printf("Consumer[%d] count-%d = %d\n", index, index, count);
+            continue; // keep trying to consume before waiting again.
+          } else if (done && count == 50) {
+            if (trace) printf("Consumer[%d] count == %d and done!\n", index, count);
+            return false;
+          }
+          return true;
+        }
+      });
+    },
+    [&] (int index) {
+      for (int j = 0; j < 10; j++) {
+        mutex.lockAndNotifyOne(condition,  [&, index] {
+          count += index;
+          if (trace) printf("Producer[%d] count+%d = %d\n", index, index, count);
+        });
+      }
+      if (trace) printf("Producer[%d] done!\n", index);
+    }
+  );
+
+  ASSERT_EQ(count, 50);
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

The changes in this pull request addresses SR-946 by adding swift::Mutex, swift:Condition, swift::ScopedLock, and swift::ScopedUnlock to the swift runtime. Existing swift runtime code was converted over to use these new classes and off of pthread_mutex directly and/or std::mutex.

Note two locations in the runtime continue to use pthread_mutex and pthread_rwlock (comments added to affected source code). Those will be corrected in a later pull request / SR as needed.
#### Resolved bug number: ([SR-946](https://bugs.swift.org/browse/SR-946))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
