### PR TITLE
[gardening] Fix recently introduced comparisons to true: if (x == true) { … }

### DIFF
--- a/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
+++ b/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
@@ -382,7 +382,7 @@ func testObjectiveCBridgeFromNSSetAnyObject() {
        result = nativeSet.contains(nsString)
     }
   }
-	CheckResults(result != nil && result! == true, "Expected results did not match")
+	CheckResults(result != nil && result!, "Expected results did not match")
 }
 
 @inline(never)
@@ -403,7 +403,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectForced() {
        result = nativeSet.contains(nsString)
     }
   }
-	CheckResults(result != nil && result! == true, "Expected results did not match")
+	CheckResults(result != nil && result!, "Expected results did not match")
 }
 
 @inline(never)
@@ -446,7 +446,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToString() {
        result = nativeSet.contains(nativeString)
     }
   }
-	CheckResults(result != nil && result! == true, "Expected results did not match")
+	CheckResults(result != nil && result!, "Expected results did not match")
 }
 
 @inline(never)
@@ -468,7 +468,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToStringForced() {
        result = nativeSet.contains(nativeString)
     }
   }
-	CheckResults(result != nil && result! == true, "Expected results did not match")
+	CheckResults(result != nil && result!, "Expected results did not match")
 }
 
 @inline(never)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix recently introduced comparisons to `true`: `if (x == true) { … }`
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
