### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::isInstanceMember()

### DIFF
--- a/validation-test/compiler_crashers/28274-swift-valuedecl-isinstancemember.swift
+++ b/validation-test/compiler_crashers/28274-swift-valuedecl-isinstancemember.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+struct S:P{var f:a
+var _=f
+struct a{}
+}
+{
+}protocol P{protocol a:var f:a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
4  swift           0x0000000001040c01 swift::ValueDecl::isInstanceMember() const + 1
10 swift           0x0000000000e8d9fc swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) + 652
11 swift           0x000000000108c18b swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const + 171
13 swift           0x0000000000e84684 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 404
14 swift           0x0000000000e309e6 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 102
16 swift           0x0000000000fe1b03 swift::Expr::walk(swift::ASTWalker&) + 19
17 swift           0x0000000000e31fdd swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 125
18 swift           0x0000000000e38720 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
19 swift           0x0000000000e398e2 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 162
20 swift           0x0000000000e39abb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
25 swift           0x0000000000e4a8b6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
26 swift           0x0000000000e6dc92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1026
27 swift           0x0000000000cbefbf swift::CompilerInstance::performSema() + 3087
29 swift           0x000000000078bb5f frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
30 swift           0x0000000000786625 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28274-swift-valuedecl-isinstancemember.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28274-swift-valuedecl-isinstancemember-23334f.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28274-swift-valuedecl-isinstancemember.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28274-swift-valuedecl-isinstancemember.swift:10:7 - line:10:7] RangeText="f"
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
