### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeBase::getSuperclass(…)

### DIFF
--- a/validation-test/compiler_crashers/28275-swift-typebase-getsuperclass.swift
+++ b/validation-test/compiler_crashers/28275-swift-typebase-getsuperclass.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol e{func^class r{extension{enum S<h{class a:a{protocol d{func^


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:237: typename cast_retty<X, Y *>::ret_type llvm::cast(Y *) [X = swift::BoundGenericType, Y = swift::TypeBase]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
8  swift           0x000000000109c869 swift::TypeBase::getSuperclass(swift::LazyResolver*) + 857
9  swift           0x0000000000e547ad swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) + 109
10 swift           0x0000000000e538f9 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1417
11 swift           0x0000000000e466cd swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 6077
12 swift           0x0000000000e4830f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 527
13 swift           0x0000000000e481d1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 209
14 swift           0x0000000000e481d1 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 209
17 swift           0x000000000107f0d2 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
18 swift           0x00000000010863fa swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3978
19 swift           0x0000000000e879bb swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
22 swift           0x0000000000e91380 swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*) + 288
23 swift           0x0000000000e717a8 swift::finishTypeChecking(swift::SourceFile&) + 536
24 swift           0x0000000000cc27ea swift::CompilerInstance::performSema() + 3514
26 swift           0x000000000078c25c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
27 swift           0x0000000000786d25 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28275-swift-typebase-getsuperclass.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28275-swift-typebase-getsuperclass-4e8e8d.o
1.  While defining default constructor for 'a' at validation-test/compiler_crashers/28275-swift-typebase-getsuperclass.swift:10:44
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
