### PR TITLE
Ensure we generate unique trap locations.

### DIFF
--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -1,15 +1,22 @@
-// RUN: %target-swift-frontend -primary-file %s -g -emit-ir  | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -g -S  | FileCheck %s --check-prefix=CHECK-%target-cpu
 
 import Builtin
 import Swift
 
 // Make sure we emit two traps.
 
-// CHECK-LABEL: define {{.*}} @test_cond_fail({{.*}}) {{.*}} {
-// CHECK:  call void @llvm.trap()
-// CHECK:  call void @llvm.trap()
-// CHECK: }
-
+// CHECK-LABEL:  _test_cond_fail:
+// CHECK:        .cfi_startproc
+// CHECK-x86_64: ud2
+// CHECK-i386:   ud2
+// CHECK-arm64:  brk
+// CHECK-armv7:  trap
+// CHECK-NOT:    .cfi_endproc
+// CHECK-x86_64: ud2
+// CHECK-i386:   ud2
+// CHECK-arm64:  brk
+// CHECK-armv7:  trap
+// CHECK:        .cfi_endproc
 sil hidden @test_cond_fail : $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %2 = integer_literal $Builtin.Int32, 1
@@ -20,8 +27,9 @@ bb0(%0 : $Int32):
   %7 = tuple_extract %5 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %7 : $Builtin.Int1
   %8 = builtin "sadd_with_overflow_Int32"(%6 : $Builtin.Int32, %2 : $Builtin.Int32, %4 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
-  %9 = tuple_extract %5 : $(Builtin.Int32, Builtin.Int1), 1
-  cond_fail %9 : $Builtin.Int1
-  %10 = struct $Int32 (%6 : $Builtin.Int32)
-  return %10 : $Int32
+  %9 = tuple_extract %8 : $(Builtin.Int32, Builtin.Int1), 0
+  %10 = tuple_extract %8 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %10 : $Builtin.Int1
+  %11 = struct $Int32 (%9 : $Builtin.Int32)
+  return %11 : $Int32
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Ensure that we generate unique trap blocks to aid in post-mortem debugging.

<!-- Description about pull request. -->

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

In 2e3c0b6, code was added to emit unique trap blocks for each
cond_fail, in order to make post-mortem debugging simpler (e.g. stack
traces have correct line/column information for the trapping location,
and it's easy to trace back to the specific jump that reaches the trap).

We didn't, however, do anything to ensure that LLVM wouldn't merge these
back together again. This is an attempt to do exactly that, after seeing
BranchFolding in the code generator merging traps into a single block.

The idea here is to emit empty inline asm strings marked as
side-effecting, and taking a unique integer argument. These come before
the trap call, so they should block any valid attempt at merging the
blocks back together.

rdar://problem/25216969
