### PR TITLE
[StdlibUnittest] Make output for expected crashes less fatalistic

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -604,8 +604,9 @@ struct _ParentProcess {
           }
           if stderrSeenCrashDelimiter {
             capturedCrashStderr.append(line)
+          } else {
+            print("err>>> \(line)")
           }
-          print("err>>> \(line)")
         }
         continue
       }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -443,6 +443,7 @@ var _allTestSuites: [TestSuite] = []
 var _testSuiteNameToIndex: [String : Int] = [:]
 
 let _stdlibUnittestStreamPrefix = "__STDLIB_UNITTEST__"
+let _crashedPrefix = "CRASHED:"
 
 @_silgen_name("swift_stdlib_installTrapInterceptor")
 func _stdlib_installTrapInterceptor()
@@ -579,7 +580,7 @@ struct _ParentProcess {
           if stdoutSeenCrashDelimiter {
             capturedCrashStdout.append(line)
           }
-          print("out>>> \(line)")
+          print("stdout>>> \(line)")
         }
         continue
       }
@@ -604,9 +605,11 @@ struct _ParentProcess {
           }
           if stderrSeenCrashDelimiter {
             capturedCrashStderr.append(line)
-          } else {
-            print("err>>> \(line)")
+            if findSubstring(line, _crashedPrefix) != nil {
+              line = "OK: saw expected \"\(line.lowercased())\""
+            }
           }
+          print("stderr>>> \(line)")
         }
         continue
       }

--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -240,17 +240,17 @@ takes precedence for files in the Swift project"
     ad-do-it))
 
 (push 'swift-stdlibunittest-possibly-expected-assertion compilation-error-regexp-alist)
-(push `(swift-stdlibunittest-possibly-expected-assertion "^\\(\\(?:out\\|err\\)>>> *\\).*\\(?:failed\\(?: at\\|.*file\\)\\|.*: file\\) \\([^,]*\\), line \\([0-9]+\\)$"
+(push `(swift-stdlibunittest-possibly-expected-assertion "^\\(\\(?:stdout\\|stderr\\)>>> *\\).*\\(?:failed\\(?: at\\|.*file\\)\\|.*: file\\) \\([^,]*\\), line \\([0-9]+\\)$"
               2 3 ,(not :column) 0)
       compilation-error-regexp-alist-alist)
 
 (push 'swift-stdlibunittest-stackframe compilation-error-regexp-alist)
-(push `(swift-stdlibunittest-stackframe "^\\(?:\\(?:out\\|err\\)>>> *\\)#[0-9]+: \\(.+\\):\\([0-9]+\\)\\(?: +.*\\)?$"
+(push `(swift-stdlibunittest-stackframe "^\\(?:\\(?:stdout\\|stderr\\)>>> *\\)#[0-9]+: \\(.+\\):\\([0-9]+\\)\\(?: +.*\\)?$"
               1 2 ,(not :column) ,(not :just-a-warning))
       compilation-error-regexp-alist-alist)
     
 (push 'swift-stdlibunittest-failure compilation-error-regexp-alist)
-(push `(swift-stdlibunittest-failure "^\\(?:out\\|err\\)>>> check failed at \\([^,]*\\), line \\([0-9]+\\)$"
+(push `(swift-stdlibunittest-failure "^\\(?:stdout\\|stderr\\)>>> check failed at \\([^,]*\\), line \\([0-9]+\\)$"
               1 2 ,(not :column) ,(not :just-a-warning))
       compilation-error-regexp-alist-alist)
 

--- a/validation-test/stdlib/StdlibUnittest.swift
+++ b/validation-test/stdlib/StdlibUnittest.swift
@@ -240,12 +240,12 @@ PassThroughStdoutStderr.test("hasNewline") {
   print("stderr third", to: &stderr)
 }
 // CHECK: [ RUN      ] PassThroughStdoutStderr.hasNewline
-// CHECK-DAG: out>>> stdout first
-// CHECK-DAG: out>>> stdout second
-// CHECK-DAG: out>>> stdout third
-// CHECK-DAG: err>>> stderr first
-// CHECK-DAG: err>>> stderr second
-// CHECK-DAG: err>>> stderr third
+// CHECK-DAG: stdout>>> stdout first
+// CHECK-DAG: stdout>>> stdout second
+// CHECK-DAG: stdout>>> stdout third
+// CHECK-DAG: stderr>>> stderr first
+// CHECK-DAG: stderr>>> stderr second
+// CHECK-DAG: stderr>>> stderr third
 // CHECK: [       OK ] PassThroughStdoutStderr.hasNewline
 
 PassThroughStdoutStderr.test("noNewline") {
@@ -259,12 +259,12 @@ PassThroughStdoutStderr.test("noNewline") {
   print("stderr third", terminator: "", to: &stderr)
 }
 // CHECK: [ RUN      ] PassThroughStdoutStderr.noNewline
-// CHECK-DAG: out>>> stdout first
-// CHECK-DAG: out>>> stdout second
-// CHECK-DAG: out>>> stdout third
-// CHECK-DAG: err>>> stderr first
-// CHECK-DAG: err>>> stderr second
-// CHECK-DAG: err>>> stderr third
+// CHECK-DAG: stdout>>> stdout first
+// CHECK-DAG: stdout>>> stdout second
+// CHECK-DAG: stdout>>> stdout third
+// CHECK-DAG: stderr>>> stderr first
+// CHECK-DAG: stderr>>> stderr second
+// CHECK-DAG: stderr>>> stderr third
 // CHECK: [       OK ] PassThroughStdoutStderr.noNewline
 // CHECK: PassThroughStdoutStderr: All tests passed
 
@@ -282,8 +282,8 @@ TestSuiteWithSetUpPasses.setUp {
   print("setUp")
 }
 // CHECK: [ RUN      ] TestSuiteWithSetUpPasses.passes
-// CHECK: out>>> setUp
-// CHECK: out>>> test body
+// CHECK: stdout>>> setUp
+// CHECK: stdout>>> test body
 // CHECK: [       OK ] TestSuiteWithSetUpPasses.passes
 // CHECK: TestSuiteWithSetUpPasses: All tests passed
 
@@ -298,9 +298,9 @@ TestSuiteWithSetUpFails.setUp {
   expectEqual(1, 2)
 }
 // CHECK: [ RUN      ] TestSuiteWithSetUpFails.fails
-// CHECK: out>>> setUp
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> test body
+// CHECK: stdout>>> setUp
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> test body
 // CHECK: [     FAIL ] TestSuiteWithSetUpFails.fails
 // CHECK: TestSuiteWithSetUpFails: Some tests failed, aborting
 
@@ -314,8 +314,8 @@ TestSuiteWithTearDownPasses.tearDown {
   print("tearDown")
 }
 // CHECK: [ RUN      ] TestSuiteWithTearDownPasses.passes
-// CHECK: out>>> test body
-// CHECK: out>>> tearDown
+// CHECK: stdout>>> test body
+// CHECK: stdout>>> tearDown
 // CHECK: [       OK ] TestSuiteWithTearDownPasses.passes
 
 var TestSuiteWithTearDownFails = TestSuite("TestSuiteWithTearDownFails")
@@ -330,9 +330,9 @@ TestSuiteWithTearDownFails.tearDown {
 }
 // CHECK: TestSuiteWithTearDownPasses: All tests passed
 // CHECK: [ RUN      ] TestSuiteWithTearDownFails.fails
-// CHECK: out>>> test body
-// CHECK: out>>> tearDown
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> test body
+// CHECK: stdout>>> tearDown
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
 // CHECK: [     FAIL ] TestSuiteWithTearDownFails.fails
 // CHECK: TestSuiteWithTearDownFails: Some tests failed, aborting
 
@@ -349,9 +349,9 @@ AssertionsTestSuite.test("expectFailure/Pass") {
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/Pass
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: 1 (of type Swift.Int)
-// CHECK: out>>> actual: 2 (of type Swift.Int)
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: 1 (of type Swift.Int)
+// CHECK: stdout>>> actual: 2 (of type Swift.Int)
 // CHECK: [       OK ] Assertions.expectFailure/Pass
 
 AssertionsTestSuite.test("expectFailure/UXPass")
@@ -363,9 +363,9 @@ AssertionsTestSuite.test("expectFailure/UXPass")
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/UXPass ({{X}}FAIL: [Custom(reason: test)])
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: 1 (of type Swift.Int)
-// CHECK: out>>> actual: 2 (of type Swift.Int)
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: 1 (of type Swift.Int)
+// CHECK: stdout>>> actual: 2 (of type Swift.Int)
 // CHECK: [   UXPASS ] Assertions.expectFailure/UXPass
 
 AssertionsTestSuite.test("expectFailure/Fail") {
@@ -374,9 +374,9 @@ AssertionsTestSuite.test("expectFailure/Fail") {
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/Fail
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: true
-// CHECK: out>>> running `body` should produce an expected failure
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: true
+// CHECK: stdout>>> running `body` should produce an expected failure
 // CHECK: [     FAIL ] Assertions.expectFailure/Fail
 
 AssertionsTestSuite.test("expectFailure/XFail")
@@ -387,9 +387,9 @@ AssertionsTestSuite.test("expectFailure/XFail")
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/XFail ({{X}}FAIL: [Custom(reason: test)])
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: true
-// CHECK: out>>> running `body` should produce an expected failure
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: true
+// CHECK: stdout>>> running `body` should produce an expected failure
 // CHECK: [    XFAIL ] Assertions.expectFailure/XFail
 
 AssertionsTestSuite.test("expectFailure/AfterFailure/Fail") {
@@ -400,12 +400,12 @@ AssertionsTestSuite.test("expectFailure/AfterFailure/Fail") {
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/AfterFailure/Fail
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: 1 (of type Swift.Int)
-// CHECK: out>>> actual: 2 (of type Swift.Int)
-// CHECK: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: 3 (of type Swift.Int)
-// CHECK: out>>> actual: 4 (of type Swift.Int)
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: 1 (of type Swift.Int)
+// CHECK: stdout>>> actual: 2 (of type Swift.Int)
+// CHECK: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: 3 (of type Swift.Int)
+// CHECK: stdout>>> actual: 4 (of type Swift.Int)
 // CHECK: [     FAIL ] Assertions.expectFailure/AfterFailure/Fail
 
 AssertionsTestSuite.test("expectFailure/AfterFailure/XFail")
@@ -418,20 +418,20 @@ AssertionsTestSuite.test("expectFailure/AfterFailure/XFail")
   }
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/AfterFailure/XFail ({{X}}FAIL: [Custom(reason: test)])
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: 1 (of type Swift.Int)
-// CHECK: out>>> actual: 2 (of type Swift.Int)
-// CHECK: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> expected: 3 (of type Swift.Int)
-// CHECK: out>>> actual: 4 (of type Swift.Int)
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: 1 (of type Swift.Int)
+// CHECK: stdout>>> actual: 2 (of type Swift.Int)
+// CHECK: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> expected: 3 (of type Swift.Int)
+// CHECK: stdout>>> actual: 4 (of type Swift.Int)
 // CHECK: [    XFAIL ] Assertions.expectFailure/AfterFailure/XFail
 
 AssertionsTestSuite.test("expectUnreachable") {
   expectUnreachable()
 }
 // CHECK: [ RUN      ] Assertions.expectUnreachable
-// CHECK-NEXT: out>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
-// CHECK: out>>> this code should not be executed
+// CHECK-NEXT: stdout>>> check failed at {{.*}}/stdlib/StdlibUnittest.swift, line
+// CHECK: stdout>>> this code should not be executed
 // CHECK: [     FAIL ] Assertions.expectUnreachable
 
 AssertionsTestSuite.test("expectCrashLater/Pass") {
@@ -440,7 +440,7 @@ AssertionsTestSuite.test("expectCrashLater/Pass") {
   _blackHole(array[0])
 }
 // CHECK: [ RUN      ] Assertions.expectCrashLater/Pass
-// CHECK: err>>> CRASHED: SIG{{.*}}
+// CHECK: stderr>>> OK: saw expected "crashed: sig{{.*}}
 // CHECK: [       OK ] Assertions.expectCrashLater/Pass
 
 AssertionsTestSuite.test("expectCrashLater/UXPass")
@@ -451,7 +451,7 @@ AssertionsTestSuite.test("expectCrashLater/UXPass")
   _blackHole(array[0])
 }
 // CHECK: [ RUN      ] Assertions.expectCrashLater/UXPass ({{X}}FAIL: [Custom(reason: test)])
-// CHECK: err>>> CRASHED: SIG{{.*}}
+// CHECK: stderr>>> OK: saw expected "crashed: sig{{.*}}
 // CHECK: [   UXPASS ] Assertions.expectCrashLater/UXPass
 
 AssertionsTestSuite.test("expectCrashLater/Fail") {
@@ -475,7 +475,7 @@ AssertionsTestSuite.test("UnexpectedCrash/RuntimeTrap") {
   _blackHole(array[0])
 }
 // CHECK: [ RUN      ] Assertions.UnexpectedCrash/RuntimeTrap
-// CHECK: err>>> CRASHED: SIG{{.*}}
+// CHECK: stderr>>> CRASHED: SIG
 // CHECK: the test crashed unexpectedly
 // CHECK: [     FAIL ] Assertions.UnexpectedCrash/RuntimeTrap
 
@@ -484,7 +484,7 @@ AssertionsTestSuite.test("UnexpectedCrash/NullPointerDereference") {
   _blackHole(ptr.pointee)
 }
 // CHECK: [ RUN      ] Assertions.UnexpectedCrash/NullPointerDereference
-// CHECK: err>>> CRASHED: SIG{{.*}}
+// CHECK: stderr>>> CRASHED: SIG
 // CHECK: the test crashed unexpectedly
 // CHECK: [     FAIL ] Assertions.UnexpectedCrash/NullPointerDereference
 
@@ -494,9 +494,9 @@ TestSuiteLifetimeTracked.test("failsIfLifetimeTrackedAreLeaked") {
   leakMe = LifetimeTracked(0)
 }
 // CHECK: [ RUN      ] TestSuiteLifetimeTracked.failsIfLifetimeTrackedAreLeaked
-// CHECK-NEXT: out>>> check failed at {{.*}}.swift, line [[@LINE-4]]
-// CHECK: out>>> expected: 0 (of type Swift.Int)
-// CHECK: out>>> actual: 1 (of type Swift.Int)
+// CHECK-NEXT: stdout>>> check failed at {{.*}}.swift, line [[@LINE-4]]
+// CHECK: stdout>>> expected: 0 (of type Swift.Int)
+// CHECK: stdout>>> actual: 1 (of type Swift.Int)
 // CHECK: [     FAIL ] TestSuiteLifetimeTracked.failsIfLifetimeTrackedAreLeaked
 
 TestSuiteLifetimeTracked.test("passesIfLifetimeTrackedAreResetAfterFailure") {}

--- a/validation-test/stdlib/StdlibUnittestCommandLine.swift
+++ b/validation-test/stdlib/StdlibUnittestCommandLine.swift
@@ -19,10 +19,10 @@ var CommandLineArguments = TestSuite("CommandLineArguments")
 CommandLineArguments.test("printCommandLineArguments") {
   debugPrint(Process.arguments)
 }
-// CHECK-EMPTY: {{^}}out>>> ["{{[^"]+}}", "--stdlib-unittest-run-child"]{{$}}
-// CHECK-1: {{^}}out>>> ["{{[^"]+}}", "--stdlib-unittest-run-child", "--abc"]{{$}}
-// CHECK-2: {{^}}out>>> ["{{[^"]+}}", "--stdlib-unittest-run-child", "--abc", "def"]{{$}}
-// CHECK-3: {{^}}out>>> ["{{[^"]+}}", "--stdlib-unittest-run-child", "a", "--bcd", "efghijk"]{{$}}
+// CHECK-EMPTY: {{^}}stdout>>> ["{{[^"]+}}", "--stdlib-unittest-run-child"]{{$}}
+// CHECK-1: {{^}}stdout>>> ["{{[^"]+}}", "--stdlib-unittest-run-child", "--abc"]{{$}}
+// CHECK-2: {{^}}stdout>>> ["{{[^"]+}}", "--stdlib-unittest-run-child", "--abc", "def"]{{$}}
+// CHECK-3: {{^}}stdout>>> ["{{[^"]+}}", "--stdlib-unittest-run-child", "a", "--bcd", "efghijk"]{{$}}
 
 runAllTests()
 

--- a/validation-test/stdlib/StdlibUnittestCrashingTests.swift
+++ b/validation-test/stdlib/StdlibUnittestCrashingTests.swift
@@ -24,48 +24,48 @@ TestSuiteCrashes.test("crashesUnexpectedly1") {
   print("crashesUnexpectedly1")
   fatalError("this should crash")
 }
-// CHECK: out>>> crashesUnexpectedly1
-// CHECK: err>>> fatal error: this should crash:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> crashesUnexpectedly1
+// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly1
 
 TestSuiteCrashes.test("passes1") {
   print("passes1")
   expectEqual(1, 1)
 }
-// CHECK: out>>> passes1
+// CHECK: stdout>>> passes1
 // CHECK: [       OK ] TestSuiteCrashes.passes1
 
 TestSuiteCrashes.test("fails1") {
   print("fails1")
   expectEqual(1, 2)
 }
-// CHECK: out>>> fails1
-// CHECK: out>>> check failed
+// CHECK: stdout>>> fails1
+// CHECK: stdout>>> check failed
 // CHECK: [     FAIL ] TestSuiteCrashes.fails1
 
 TestSuiteCrashes.test("crashesUnexpectedly2") {
   print("crashesUnexpectedly2")
   fatalError("this should crash")
 }
-// CHECK: out>>> crashesUnexpectedly2
-// CHECK: err>>> fatal error: this should crash:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> crashesUnexpectedly2
+// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> CRASHED: SIG
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesUnexpectedly2
 
 TestSuiteCrashes.test("passes2") {
   print("passes2")
   expectEqual(1, 1)
 }
-// CHECK: out>>> passes2
+// CHECK: stdout>>> passes2
 // CHECK: [       OK ] TestSuiteCrashes.passes2
 
 TestSuiteCrashes.test("fails2") {
   print("fails2")
   expectEqual(1, 2)
 }
-// CHECK: out>>> fails2
-// CHECK: out>>> check failed
+// CHECK: stdout>>> fails2
+// CHECK: stdout>>> check failed
 // CHECK: [     FAIL ] TestSuiteCrashes.fails2
 
 TestSuiteCrashes.test("crashesAsExpected1") {
@@ -73,24 +73,24 @@ TestSuiteCrashes.test("crashesAsExpected1") {
   expectCrashLater()
   fatalError("this should crash")
 }
-// CHECK: out>>> crashesAsExpected1
-// CHECK: err>>> fatal error: this should crash:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> crashesAsExpected1
+// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesAsExpected1
 
 TestSuiteCrashes.test("passes3") {
   print("passes3")
   expectEqual(1, 1)
 }
-// CHECK: out>>> passes3
+// CHECK: stdout>>> passes3
 // CHECK: [       OK ] TestSuiteCrashes.passes3
 
 TestSuiteCrashes.test("fails3") {
   print("fails3")
   expectEqual(1, 2)
 }
-// CHECK: out>>> fails3
-// CHECK: out>>> check failed
+// CHECK: stdout>>> fails3
+// CHECK: stdout>>> check failed
 // CHECK: [     FAIL ] TestSuiteCrashes.fails3
 
 TestSuiteCrashes.test("crashesUnexpectedlyXfail")
@@ -98,9 +98,9 @@ TestSuiteCrashes.test("crashesUnexpectedlyXfail")
   print("crashesUnexpectedlyXfail")
   fatalError("this should crash")
 }
-// CHECK: out>>> crashesUnexpectedlyXfail
-// CHECK: err>>> fatal error: this should crash:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> crashesUnexpectedlyXfail
+// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> CRASHED: SIG
 // CHECK: [    XFAIL ] TestSuiteCrashes.crashesUnexpectedlyXfail
 
 TestSuiteCrashes.test("crashesAsExpectedXfail")
@@ -109,9 +109,9 @@ TestSuiteCrashes.test("crashesAsExpectedXfail")
   expectCrashLater()
   fatalError("this should crash")
 }
-// CHECK: out>>> crashesAsExpectedXfail
-// CHECK: err>>> fatal error: this should crash:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> crashesAsExpectedXfail
+// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [   UXPASS ] TestSuiteCrashes.crashesAsExpectedXfail
 
 TestSuiteCrashes.test("crashesWithMessagePasses")
@@ -120,9 +120,9 @@ TestSuiteCrashes.test("crashesWithMessagePasses")
   expectCrashLater()
   fatalError("this should crash")
 }
-// CHECK: out>>> abcd
-// CHECK: err>>> fatal error: this should crash:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> abcd
+// CHECK: stderr>>> fatal error: this should crash:
+// CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesWithMessagePasses
 
 TestSuiteCrashes.test("crashesWithMessageFails")
@@ -131,9 +131,9 @@ TestSuiteCrashes.test("crashesWithMessageFails")
   expectCrashLater()
   fatalError("unexpected message")
 }
-// CHECK: out>>> this should crash
-// CHECK: err>>> fatal error: unexpected message:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> this should crash
+// CHECK: stderr>>> fatal error: unexpected message:
+// CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: did not find expected string after crash: "this should crash"
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesWithMessageFails
 
@@ -146,9 +146,9 @@ TestSuiteCrashes.test("crashesWithMultipleMessagesPasses")
   expectCrashLater()
   fatalError("this should crash and your little dog too")
 }
-// CHECK: out>>> abcd
-// CHECK: err>>> fatal error: this should crash and your little dog too:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> abcd
+// CHECK: stderr>>> fatal error: this should crash and your little dog too:
+// CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: [       OK ] TestSuiteCrashes.crashesWithMultipleMessagesPasses
 
 TestSuiteCrashes.test("crashesWithMultipleMessagesFails")
@@ -161,9 +161,9 @@ TestSuiteCrashes.test("crashesWithMultipleMessagesFails")
   expectCrashLater()
   fatalError("unexpected message and your little dog too")
 }
-// CHECK: out>>> this should crash
-// CHECK: err>>> fatal error: unexpected message and your little dog too:
-// CHECK: err>>> CRASHED: SIG
+// CHECK: stdout>>> this should crash
+// CHECK: stderr>>> fatal error: unexpected message and your little dog too:
+// CHECK: stderr>>> OK: saw expected "crashed: sig
 // CHECK: did not find expected string after crash: "this should crash"
 // CHECK: did not find expected string after crash: "big dog"
 // CHECK: [     FAIL ] TestSuiteCrashes.crashesWithMultipleMessagesFails

--- a/validation-test/stdlib/StdlibUnittestRaceTest.swift
+++ b/validation-test/stdlib/StdlibUnittestRaceTest.swift
@@ -83,9 +83,9 @@ RaceTestSuite.test("passes") {
   runRaceTest(RaceTest1.self, trials: 10)
 }
 // CHECK: [ RUN      ] Race.passes
-// CHECK: out>>> Pass: {{.*}} times
-// CHECK: out>>> Pass (2): 4 times
-// CHECK: out>>> Failure: 0 times
+// CHECK: stdout>>> Pass: {{.*}} times
+// CHECK: stdout>>> Pass (2): 4 times
+// CHECK: stdout>>> Failure: 0 times
 // CHECK: [       OK ] Race.passes
 
 RaceTestSuite.test("fails") {
@@ -95,10 +95,10 @@ RaceTestSuite.test("fails") {
 }
 // CHECK: [ RUN      ] Race.fails
 // REQUIRES: executable_test
-// CHECK: out>>> Pass: {{.*}} times
-// CHECK: out>>> Pass (2): 1 times
-// CHECK: out>>> Failure: 1 times
-// CHECK: out>>> Failure (65534): 3 times
+// CHECK: stdout>>> Pass: {{.*}} times
+// CHECK: stdout>>> Pass (2): 1 times
+// CHECK: stdout>>> Failure: 1 times
+// CHECK: stdout>>> Failure (65534): 3 times
 // CHECK: [     FAIL ] Race.fails
 // CHECK: Race: Some tests failed, aborting
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A small change that disables printing stderr for expected crashes in StdlibUnittest

For example:

``` swift
$ cat t.swift 
import StdlibUnittest

TestSuite("Foo").test("bar") {
  expectCrashLater()
  assert(false)
}
runAllTests()
```

Would print:

```
$ ./t 
[ RUN      ] Foo.bar
err>>> assertion failed: file t.swift, line 6
err>>> CRASHED: SIGILL
[       OK ] Foo.bar
```

Which is problematic, because at a glance it looks like a failure.
With this change, it prints:

```
$ ./t 
[ RUN      ] Foo.bar
[       OK ] Foo.bar
```

<!-- Description about pull request. -->
#### Resolved bug number: rdar://18081448

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
