### PR TITLE
[stdlib] Remove unavailable annotation for MutableCollection.sort()

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -319,22 +319,6 @@ extension MutableCollection
   }
 }
 
-% for Self in [ 'Sequence', 'MutableCollection' ]:
-extension ${Self} where Self.Iterator.Element : Comparable {
-  @available(*, unavailable, renamed: "sorted")
-  public func sort() -> [Iterator.Element] {
-    fatalError("unavailable function can't be called")
-  }
-
-  @available(*, unavailable, renamed: "sorted(isOrderedBefore:)")
-  public func sort(
-    @noescape isOrderedBefore: (Iterator.Element, Iterator.Element) -> Bool
-  ) -> [Iterator.Element] {
-    fatalError("unavailable function can't be called")
-  }
-}
-%end
-
 extension MutableCollection
   where
   Self.Index : RandomAccessIndex,


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This removes the `@available(*, unavailable, renamed: "....")` annotations for `MutableCollection`'s `sort()` and `sort(isOrderedBefore:)` methods. `sort()` is the new name for `sortInPlace()` and this unavailability marker is preventing calls to the new method.
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
