### PR TITLE
stdlib: tweak import declarations

### DIFF
--- a/stdlib/public/SDK/Darwin/Misc.mm
+++ b/stdlib/public/SDK/Darwin/Misc.mm
@@ -13,6 +13,9 @@
 #include <fcntl.h>
 #include <semaphore.h>
 
+#define _REENTRANT
+#include <math.h>
+
 extern "C" int 
 _swift_Darwin_open(const char *path, int oflag, mode_t mode) {
   return open(path, oflag, mode);
@@ -42,3 +45,17 @@ _swift_Darwin_fcntlPtr(int fd, int cmd, void* ptr) {
   return fcntl(fd, cmd, ptr);
 }
 
+extern "C" float
+_swift_Darwin_lgammaf_r(float x, int *psigngam) {
+  return lgammaf_r(x, psigngam);
+}
+
+extern "C" double
+_swift_Darwin_lgamma_r(double x, int *psigngam) {
+  return lgamma_r(x, psigngam);
+}
+
+extern "C" long double
+_swift_Darwin_lgammal_r(long double x, int *psigngam) {
+  return lgammal_r(x, psigngam);
+}

--- a/stdlib/public/SDK/Darwin/tgmath.swift.gyb
+++ b/stdlib/public/SDK/Darwin/tgmath.swift.gyb
@@ -259,9 +259,10 @@ public func scalbn(x: ${T}, _ n: Int) -> ${T} {
 % for T, CT, f in AllFloatTypes():
 % # The real lgamma_r is not imported because it hides behind macro _REENTRANT.
 @warn_unused_result
-@_silgen_name("lgamma${f}_r") 
+@_silgen_name("_swift_Darwin_lgamma${f}_r")
 func _swift_Darwin_lgamma${f}_r(_: ${CT},
                                 _: UnsafeMutablePointer<CInt>) -> ${CT}
+
 @_transparent
 @warn_unused_result
 public func lgamma(x: ${T}) -> (${T}, Int) {

--- a/stdlib/public/SDK/ObjectiveC/CMakeLists.txt
+++ b/stdlib/public/SDK/ObjectiveC/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_swift_library(swiftObjectiveC IS_SDK_OVERLAY
+  ObjectiveC.mm
   ObjectiveC.swift
   SWIFT_MODULE_DEPENDS Darwin)
 

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.mm
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.mm
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <objc/objc-api.h>
+
+OBJC_EXPORT
+void *objc_autoreleasePoolPush(void);
+
+OBJC_EXPORT
+void objc_autoreleasePoolPop(void *);
+
+extern "C" void *_swift_objc_autoreleasePoolPush(void) {
+  return objc_autoreleasePoolPush();
+}
+
+extern "C" void _swift_objc_autoreleasePoolPop(void *context) {
+  return objc_autoreleasePoolPop(context);
+}
+

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -196,10 +196,10 @@ typealias Zone = NSZone
 //===----------------------------------------------------------------------===//
 
 @warn_unused_result
-@_silgen_name("objc_autoreleasePoolPush")
+@_silgen_name("_swift_objc_autoreleasePoolPush")
 func __pushAutoreleasePool() -> OpaquePointer
 
-@_silgen_name("objc_autoreleasePoolPop")
+@_silgen_name("_swift_objc_autoreleasePoolPop")
 func __popAutoreleasePool(pool: OpaquePointer)
 
 public func autoreleasepool(@noescape code: () -> Void) {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Ensure that the functions which are declared with @_silgen_name for importing
from external libraries are described with the correct linkage.  If the declared
functions are marked with internal or no linkage, the declaration for the import
will be given internal linkage.  However, this is incorrect if the definition is
not part of the image.

The remaining uses were filtered on the assumption that the swift standard
library is statically linked and provides the definitions for those symbols and
thus will be part of the image.

This was noticed by manual inspection of the IR generated.
