### PR TITLE
Specialize

### DIFF
--- a/docs/Generics.rst
+++ b/docs/Generics.rst
@@ -713,6 +713,35 @@ the virtual dispatch, inline calls when appropriate, and eliminate the overhead
 of the generic system. Such optimizations can be performed based on heuristics,
 user direction, or profile-guided optimization.
 
+An internal @_specialize function attribute allows developers to force
+full specialization by listing concrete type names corresponding to the
+function's generic signature. A function's generic signature is a
+concatenation of its generic context and the function's own generic
+type parameters.::
+
+  struct S<T> {
+    var x: T
+    @_specialize(Int, Float)
+    mutating func exchangeSecond<U>(u: U, _ t: T) -> (U, T) {
+      x = t
+      return (u, x)
+    }
+  }
+
+  // Substitutes: <T, U> with <Int, Float> producing:
+  // S<Int>::exchangeSecond<Float>(u: Float, t: Int) -> (Float, Int)
+
+@_specialize currently acts as a hint to the optimizer, which
+generates type checks and code to dispatch to the specialized routine
+without affecting the signature of the generic function. The
+intention is to support efforts at evaluating the performance of
+specialized code. The performance impact is not guaranteed and is
+likely to change with the optimizer. This attribute should only be
+used in conjunction with rigorous performance analysis. Eventually,
+a similar attribute could be defined in the language, allowing it to be
+exposed as part of a function's API. That would allow direct dispatch
+to specialized code without type checks, even across modules.
+
 Existential Types and Generics
 ------------------------------
 

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -164,6 +164,10 @@ SIMPLE_DECL_ATTR(nonobjc, NonObjC,
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
                  OnVar | OnClass | OnStruct | OnEnum | UserInaccessible, 31)
 
+DECL_ATTR(_specialize, Specialize,
+          OnConstructor | OnFunc | AllowMultipleAttributes | LongAttribute
+          | UserInaccessible, 32)
+
 // Non-serialized attributes.
 
 SIMPLE_DECL_ATTR(mutating, Mutating, OnFunc | DeclModifier | NotSerialized,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -23,6 +23,7 @@
 #include "swift/Basic/Range.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/AttrKind.h"
+#include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/Ownership.h"
 #include "swift/AST/PlatformKind.h"
@@ -38,6 +39,7 @@ class ASTContext;
 struct PrintOptions;
 class Decl;
 class ClassDecl;
+struct TypeLoc;
 
 class InfixData {
   unsigned Precedence : 8;
@@ -1133,6 +1135,36 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Swift3Migration;
+  }
+};
+
+/// The @_specialize attribute, which forces specialization on the specified
+/// type list.
+class SpecializeAttr : public DeclAttribute {
+  unsigned numTypes;
+  ConcreteDeclRef specializedDecl;
+
+  TypeLoc *getTypeLocData() {
+    return reinterpret_cast<TypeLoc *>(this + 1);
+  }
+
+  SpecializeAttr(SourceLoc atLoc, SourceRange Range,
+                 ArrayRef<TypeLoc> typeLocs);
+
+public:
+  static SpecializeAttr *create(ASTContext &Ctx, SourceLoc atLoc,
+                                SourceRange Range, ArrayRef<TypeLoc> typeLocs);
+
+  ArrayRef<TypeLoc> getTypeLocs() const;
+
+  MutableArrayRef<TypeLoc> getTypeLocs();
+
+  ConcreteDeclRef getConcreteDecl() const { return specializedDecl; }
+
+  void setConcreteDecl(ConcreteDeclRef ref) { specializedDecl = ref; }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Specialize;
   }
 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1976,6 +1976,8 @@ ERROR(generic_type_requires_arguments,none,
       "reference to generic type %0 requires arguments in <...>", (Type))
 NOTE(generic_type_declared_here,none,
      "generic type %0 declared here", (Identifier))
+ERROR(cannot_partially_specialize_generic_function,none,
+     "cannot partially specialize a generic function", ())
 
 // Ambiguities
 ERROR(ambiguous_decl_ref,none,

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -37,6 +37,24 @@ enum IsTransparent_t { IsNotTransparent, IsTransparent };
 enum Inline_t { InlineDefault, NoInline, AlwaysInline };
 enum IsThunk_t { IsNotThunk, IsThunk, IsReabstractionThunk };
 
+class SILSpecializeAttr final :
+    private llvm::TrailingObjects<SILSpecializeAttr, Substitution> {
+  friend TrailingObjects;
+
+  unsigned numSubs;
+  
+  SILSpecializeAttr(ArrayRef<Substitution> subs);
+
+public:
+  static SILSpecializeAttr *create(SILModule &M, ArrayRef<Substitution> subs);
+
+  ArrayRef<Substitution> getSubstitutions() const {
+    return { getTrailingObjects<Substitution>(), numSubs };
+  }
+  
+  void print(llvm::raw_ostream &OS) const;
+};
+
 /// SILFunction - A function body that has been lowered to SIL. This consists of
 /// zero or more SIL SILBasicBlock objects that contain the SILInstruction
 /// objects making up the function.
@@ -139,6 +157,9 @@ private:
   /// TODO: Why is this using a std::string? Why don't we use uniqued
   /// StringRefs?
   llvm::SmallVector<std::string, 1> SemanticsAttrSet;
+
+  /// The function's remaining set of specialize attributes.
+  std::vector<SILSpecializeAttr*> SpecializeAttrSet;
 
   /// The function's effects attribute.
   EffectsKind EffectsKindAttr;
@@ -382,6 +403,18 @@ public:
     auto Iter =
         std::remove(SemanticsAttrSet.begin(), SemanticsAttrSet.end(), Ref);
     SemanticsAttrSet.erase(Iter);
+  }
+
+  /// \returns the range of specialize attributes.
+  ArrayRef<SILSpecializeAttr*> getSpecializeAttrs() const {
+    return SpecializeAttrSet;
+  }
+
+  /// Removes all specialize attributes from this function.
+  void clearSpecializeAttrs() { SpecializeAttrSet.clear(); }
+
+  void addSpecializeAttr(SILSpecializeAttr *attr) {
+    SpecializeAttrSet.push_back(attr);
   }
 
   /// \returns True if the function is optimizable (i.e. not marked as no-opt),

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -88,6 +88,8 @@ PASS(DiagnoseUnreachable, "diagnose-unreachable",
      "Diagnose Unreachable Code")
 PASS(DiagnosticConstantPropagation, "diagnostic-constant-propagation",
      "Propagate constants and emit diagnostics")
+PASS(EagerSpecializer, "eager-specializer",
+     "Specialize speculatively and insert dispatch guarded by type checks")
 PASS(EarlyCodeMotion, "early-codemotion",
      "Code motion without release hoisting")
 PASS(EarlyInliner, "early-inline",

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -40,24 +40,25 @@ public:
   GenericCloner(SILFunction *F,
                 const ReabstractionInfo &ReInfo,
                 TypeSubstitutionMap &ContextSubs,
+                ArrayRef<Substitution> ParamSubs,
                 StringRef NewName,
-                ArrayRef<Substitution> ApplySubs,
                 CloneCollector::CallbackType Callback)
   : TypeSubstCloner(*initCloned(F, ReInfo, NewName), *F, ContextSubs,
-                    ApplySubs), ReInfo(ReInfo), Callback(Callback) {
+                    ParamSubs), ReInfo(ReInfo), Callback(Callback) {
     assert(F->getDebugScope()->Parent != getCloned()->getDebugScope()->Parent);
   }
   /// Clone and remap the types in \p F according to the substitution
   /// list in \p Subs. Parameters are re-abstracted (changed from indirect to
   /// direct) according to \p ReInfo.
-  static SILFunction *cloneFunction(SILFunction *F,
-                                    const ReabstractionInfo &ReInfo,
-                                    TypeSubstitutionMap &ContextSubs,
-                                    StringRef NewName, ApplySite Caller,
-                            CloneCollector::CallbackType Callback =nullptr) {
+  static SILFunction *
+  cloneFunction(SILFunction *F,
+                const ReabstractionInfo &ReInfo,
+                TypeSubstitutionMap &ContextSubs,
+                ArrayRef<Substitution> ParamSubs,
+                StringRef NewName,
+                CloneCollector::CallbackType Callback =nullptr) {
     // Clone and specialize the function.
-    GenericCloner SC(F, ReInfo, ContextSubs, NewName,
-                     Caller.getSubstitutions(), Callback);
+    GenericCloner SC(F, ReInfo, ContextSubs, ParamSubs, NewName, Callback);
     SC.populateCloned();
     SC.cleanUp(SC.getCloned());
     return SC.getCloned();

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -22,11 +22,23 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Utils/Local.h"
-#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 namespace swift {
+
+/// Tries to specialize an \p Apply of a generic function. It can be a full
+/// apply site or a partial apply.
+/// Replaced and now dead instructions are returned in \p DeadApplies.
+/// New created functions, like the specialized callee and thunks, are returned
+/// in \p NewFunctions.
+///
+/// This is the top-level entry point for specializing an existing call site.
+void trySpecializeApplyOfGeneric(
+  ApplySite Apply,
+  llvm::SmallVectorImpl<SILInstruction *> &DeadApplies,
+  llvm::SmallVectorImpl<SILFunction *> &NewFunctions);
 
 /// Helper class to describe re-abstraction of function parameters done during
 /// specialization.
@@ -34,12 +46,27 @@ namespace swift {
 /// Specifically, it contains information which parameters and returns are
 /// changed from indirect values to direct values.
 class ReabstractionInfo {
+  /// A 1-bit means that this parameter/return value is converted from indirect
+  /// to direct.
+  llvm::SmallBitVector Conversions;
+
+  /// The first NumResults bits in Conversions refer to indirect out-parameters.
+  unsigned NumResults;
+
+  /// The function type after applying the substitutions of the original
+  /// apply site.
+  CanSILFunctionType SubstitutedType;
+
+  /// The function type after applying the re-abstractions on the
+  /// SubstitutedType.
+  CanSILFunctionType SpecializedType;
+
 public:
-  /// Constructs the ReabstractionInfo for an apply site \p AI calling the
-  /// generic function \p Orig.
+  /// Constructs the ReabstractionInfo for generic function \p Orig with
+  /// substitutions \p ParamSubs.
   /// If specialization is not possible getSpecializedType() will return an
   /// invalid type.
-  ReabstractionInfo(SILFunction *Orig, ApplySite AI);
+  ReabstractionInfo(SILFunction *Orig, ArrayRef<Substitution> ParamSubs);
 
   /// Does the \p ArgIdx refer to an indirect out-parameter?
   bool isResultIndex(unsigned ArgIdx) const {
@@ -88,8 +115,8 @@ public:
     return Conversions.size() - numArgs;
   }
 
-  /// Get the function type after applying the substitutions of the original
-  /// apply site.
+  /// Get the function type after applying the substitutions to the original
+  /// generic function.
   CanSILFunctionType getSubstitutedType() const { return SubstitutedType; }
 
   /// Get the function type after applying the re-abstractions on the
@@ -101,33 +128,49 @@ public:
   /// SubstFTy by applying the re-abstractions.
   CanSILFunctionType createSpecializedType(CanSILFunctionType SubstFTy,
                                            SILModule &M) const;
-private:
-  /// A 1-bit means that this parameter/return value is converted from indirect
-  /// to direct.
-  llvm::BitVector Conversions;
-
-  /// The first NumResults bits in Conversions refer to indirect out-parameters.
-  unsigned NumResults;
-
-  /// The function type after applying the substitutions of the original
-  /// apply site.
-  CanSILFunctionType SubstitutedType;
-
-  /// The function type after applying the re-abstractions on the
-  /// SubstitutedType.
-  CanSILFunctionType SpecializedType;
 };
 
-/// Tries to specialize an \p Apply of a generic function. It can be a full
-/// apply site or a partial apply.
-/// Replaced and now dead instructions are returned in \p DeadApplies.
-/// New created functions, like the specialized callee and thunks, are returned
-/// in \p NewFunctions.
-void trySpecializeApplyOfGeneric(ApplySite Apply,
-                        llvm::SmallVectorImpl<SILInstruction *> &DeadApplies,
-                        llvm::SmallVectorImpl<SILFunction *> &NewFunctions);
+/// Helper class for specializing a generic function given a list of
+/// substitutions.
+class GenericFuncSpecializer {
+  SILModule &M;
+  SILFunction *GenericFunc;
+  ArrayRef<Substitution> ParamSubs;
+  const ReabstractionInfo &ReInfo;
 
-/// Checks if a given mangled name could be a name of a whitelisted specialization.
+  TypeSubstitutionMap ContextSubs;
+  std::string ClonedName;
+public:
+  GenericFuncSpecializer(SILFunction *GenericFunc,
+                         ArrayRef<Substitution> ParamSubs,
+                         const ReabstractionInfo &ReInfo);
+
+  /// If we already have this specialization, reuse it.
+  SILFunction *lookupSpecialization();
+
+  /// Return a newly created specialized function.
+  SILFunction *tryCreateSpecialization();
+  
+  /// Try to specialize GenericFunc given a list of ParamSubs.
+  /// Returns either a new or existing specialized function, or nullptr.
+  SILFunction *trySpecialization() {
+    if (!ReInfo.getSpecializedType())
+      return nullptr;
+
+    SILFunction *SpecializedF = lookupSpecialization();
+    if (!SpecializedF)
+      SpecializedF = tryCreateSpecialization();
+
+    return SpecializedF;
+  }
+};
+
+// =============================================================================
+// Prespecialized symbol lookup.
+// =============================================================================
+
+/// Checks if a given mangled name could be a name of a whitelisted
+/// specialization.
 bool isWhitelistedSpecialization(StringRef SpecName);
 
 /// Create a new apply based on an old one, but with a different
@@ -135,7 +178,11 @@ bool isWhitelistedSpecialization(StringRef SpecName);
 ApplySite replaceWithSpecializedFunction(ApplySite AI, SILFunction *NewF,
                                          const ReabstractionInfo &ReInfo);
 
-SILFunction *getExistingSpecialization(SILModule &M, StringRef FunctionName);
+/// Returns a SILFunction for the symbol specified by FunctioName if it is
+/// visible to the current SILModule. This is used to link call sites to
+/// externally defined specialization and should only be used when the function
+/// body is not required for further optimization or inlining (-Onone).
+SILFunction *lookupPrespecializedSymbol(SILModule &M, StringRef FunctionName);
 
 } // end namespace swift
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -53,8 +53,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-/// describe what change you made.
-const uint16_t VERSION_MINOR = 243; // Last change: re-number SIL stuff
+const uint16_t VERSION_MINOR = 244; // Last change: @_specialize attribute
 
 using DeclID = PointerEmbeddedInt<unsigned, 31>;
 using DeclIDField = BCFixed<31>;
@@ -1378,6 +1377,11 @@ namespace decls_block {
     BCVBR<6>,  // index at the end of the message,
     BCBlob     // blob contains the message and mutating-version
                // strings, separated by the prior index
+  >;
+
+  using SpecializeDeclAttrLayout = BCRecordLayout<
+    Specialize_DECL_ATTR,
+    BCArray<TypeIDField> // concrete types
   >;
 
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) \

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -442,11 +442,21 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options) 
     break;
   }
 
-  default:
-    llvm_unreachable("handled before this switch");
+  case DAK_Specialize: {
+    Printer << "@" << getAttrName() << "(";
+    auto *attr = cast<SpecializeAttr>(this);
+    interleave(attr->getTypeLocs(),
+               [&](TypeLoc tyLoc){ tyLoc.getType().print(Printer, Options); },
+               [&]{ Printer << ", "; });
+    Printer << ")";
+    break;
+  }
 
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
+
+  default:
+    llvm_unreachable("handled before this switch");
   }
 
   return true;
@@ -552,6 +562,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "swift3_migration";
   case DAK_WarnUnusedResult:
     return "warn_unused_result";
+  case DAK_Specialize:
+    return "_specialize";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -722,4 +734,26 @@ const AvailableAttr *AvailableAttr::isUnavailable(const Decl *D) {
   return D->getAttrs().getUnavailable(ctx);
 }
 
+SpecializeAttr::SpecializeAttr(SourceLoc atLoc, SourceRange range,
+                               ArrayRef<TypeLoc> typeLocs)
+    : DeclAttribute(DAK_Specialize, atLoc, range, /*Implicit=*/false),
+      numTypes(typeLocs.size())
+{
+  std::copy(typeLocs.begin(), typeLocs.end(), getTypeLocData());
+}
 
+ArrayRef<TypeLoc> SpecializeAttr::getTypeLocs() const {
+  return const_cast<SpecializeAttr*>(this)->getTypeLocs();
+}
+
+MutableArrayRef<TypeLoc> SpecializeAttr::getTypeLocs() {
+  return { this->getTypeLocData(), numTypes };
+}
+
+SpecializeAttr *SpecializeAttr::create(ASTContext &Ctx, SourceLoc atLoc,
+                                       SourceRange range,
+                                       ArrayRef<TypeLoc> typeLocs) {
+  unsigned size = sizeof(SpecializeAttr) + (typeLocs.size() * sizeof(TypeLoc));
+  void *mem = Ctx.Allocate(size, alignof(SpecializeAttr));
+  return new (mem) SpecializeAttr(atLoc, range, typeLocs);
+}

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -25,6 +25,19 @@
 using namespace swift;
 using namespace Lowering;
 
+SILSpecializeAttr::SILSpecializeAttr(ArrayRef<Substitution> subs)
+  : numSubs(subs.size()) {
+  std::copy(subs.begin(), subs.end(), getTrailingObjects<Substitution>());
+}
+
+SILSpecializeAttr *SILSpecializeAttr::create(SILModule &M,
+                                             ArrayRef<Substitution> subs) {
+  unsigned size =
+    sizeof(SILSpecializeAttr) + (subs.size() * sizeof(Substitution));
+  void *buf = M.allocate(size, alignof(SILSpecializeAttr));
+  return ::new (buf) SILSpecializeAttr(subs);
+}
+
 SILFunction *SILFunction::create(SILModule &M, SILLinkage linkage,
                                  StringRef name,
                                  CanSILFunctionType loweredType,

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -360,8 +360,15 @@ SILFunction *SILModule::getOrCreateFunction(SILLocation loc,
       F->setForeignBody(HasForeignBody);
 
     auto Attrs = constant.getDecl()->getAttrs();
-    for (auto A : Attrs.getAttributes<SemanticsAttr, false /*AllowInvalid*/>())
+    for (auto *A : Attrs.getAttributes<SemanticsAttr, false /*AllowInvalid*/>())
       F->addSemanticsAttr(cast<SemanticsAttr>(A)->Value);
+
+    for (auto *A :
+           Attrs.getAttributes<SpecializeAttr, false /*AllowInvalid*/>()) {
+      auto *SA = cast<SpecializeAttr>(A);
+      auto subs = SA->getConcreteDecl().getSubstitutions();
+      F->addSpecializeAttr(SILSpecializeAttr::create(*this, subs));
+    }
   }
 
   F->setDeclContext(constant.hasDecl() ? constant.getDecl() : nullptr);

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -841,7 +841,7 @@ public:
                [&] { *this << ", "; });
     *this << '>';
   }
-  
+
   void visitApplyInst(ApplyInst *AI) {
     *this << "apply ";
     if (AI->isNonThrowing())
@@ -1716,6 +1716,9 @@ void SILFunction::print(llvm::raw_ostream &OS,
   for (auto &Attr : getSemanticsAttrs())
     OS << "[_semantics \"" << Attr << "\"] ";
 
+  for (auto *Attr : getSpecializeAttrs()) {
+    OS << "[_specialize "; Attr->print(OS); OS << "] ";
+  }
   printName(OS);
   OS << " : $";
   
@@ -2205,4 +2208,8 @@ void SILDebugScope::dump(SourceManager &SM, llvm::raw_ostream &OS,
     OS.indent(Indent + 2);
   }
   OS << "}\n";
+}
+
+void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
+  SILPrinter(OS).printSubstitutions(getSubstitutions());
 }

--- a/lib/SILOptimizer/IPO/CMakeLists.txt
+++ b/lib/SILOptimizer/IPO/CMakeLists.txt
@@ -3,6 +3,7 @@ set(IPO_SOURCES
   IPO/CapturePropagation.cpp
   IPO/ClosureSpecializer.cpp
   IPO/DeadFunctionElimination.cpp
+  IPO/EagerSpecializer.cpp
   IPO/ExternalDefsToDecls.cpp
   IPO/FunctionSignatureOpts.cpp
   IPO/GlobalOpt.cpp

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -1,0 +1,502 @@
+//===------- EagerSpecializer.cpp - Performs Eager Specialization ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Eager Specializer
+/// -----------------
+///
+/// This transform specializes functions that are annotated with the
+/// @_specialize(<type list>) attribute. A function may be annotated with
+/// multiple @_specialize attributes, each with a list of concrete types.  For
+/// each @_specialize attribute, this transform clones the annotated generic
+/// function, creating a new function signature by substituting the concrete
+/// types specified in the attribute into the function's generic
+/// signature. Dispatch to each specialized function is implemented by inserting
+/// call at the beginning of the original generic function guarded by a type
+/// check.
+///
+/// TODO: We have not determined whether to support inexact type checks. It
+/// will be a tradeoff between utility of the attribute vs. cost of the check.
+
+#define DEBUG_TYPE "eager-specializer"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Generics.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+using llvm::dbgs;
+
+// Temporary flag.
+llvm::cl::opt<bool> EagerSpecializeFlag(
+    "enable-eager-specializer", llvm::cl::init(true),
+    llvm::cl::desc("Run the eager-specializer pass."));
+
+/// Returns true if the given return or throw block can be used as a merge point
+/// for new return or error values.
+static bool isTrivialReturnBlock(SILBasicBlock *RetBB) {
+  auto *RetInst = RetBB->getTerminator();
+  assert(isa<ReturnInst>(RetInst) || isa<ThrowInst>(RetInst) &&
+         "expected a properly terminated return or throw block");
+
+  auto RetOperand = RetInst->getOperand(0);
+
+  // Allow:
+  //   % = tuple ()
+  //   return % : $()
+  if (RetOperand->getType().isVoid()) {
+    auto *TupleI = dyn_cast<TupleInst>(RetBB->begin());
+    if (!TupleI || !TupleI->getType().isVoid())
+      return false;
+
+    if (&*std::next(RetBB->begin()) != RetInst)
+      return false;
+
+    return RetOperand == TupleI;
+  }
+  // Allow:
+  //   bb(% : $T)
+  //   return % : $T
+  if (&*RetBB->begin() != RetInst)
+    return false;
+
+  if (RetBB->bbarg_size() != 1)
+    return false;
+
+  return (RetOperand == RetBB->getBBArg(0));
+}
+
+/// Adds a CFG edge from the unterminated NewRetBB to a merged "return" or
+/// "throw" block. If the return block is not already a canonical merged return
+/// block, then split it. If the return type is not Void, add a BBArg that
+/// propagates NewRetVal to the return instruction.
+static void addReturnValueImpl(SILBasicBlock *RetBB, SILBasicBlock *NewRetBB,
+                               SILValue NewRetVal) {
+  auto *F = NewRetBB->getParent();
+
+  SILBuilder Builder(*F);
+  Builder.setCurrentDebugScope(F->getDebugScope());
+  SILLocation Loc = F->getLocation();
+  
+  auto *RetInst = RetBB->getTerminator();
+  assert(isa<ReturnInst>(RetInst) || isa<ThrowInst>(RetInst) &&
+         "expected a properly terminated return or throw block");
+  assert(RetInst->getOperand(0)->getType() == NewRetVal->getType() &&
+         "Mistmatched return type");
+  SILBasicBlock *MergedBB = RetBB;
+
+  // Split the return block if it is nontrivial.
+  if (!isTrivialReturnBlock(RetBB)) {
+    if (NewRetVal->getType().isVoid()) {
+      // Canonicalize Void return type into something that isTrivialReturnBlock
+      // expects.
+      auto *TupleI = cast<SILInstruction>(RetInst->getOperand(0));
+      if (TupleI->hasOneUse()) {
+        TupleI->removeFromParent();
+        RetBB->insert(RetInst, TupleI);
+      } else {
+        TupleI = TupleI->clone(RetInst);
+        RetInst->setOperand(0, TupleI);
+      }
+      MergedBB = RetBB->splitBasicBlock(TupleI->getIterator());
+      Builder.setInsertionPoint(RetBB);
+      Builder.createBranch(Loc, MergedBB);
+    } else {
+      // Forward the existing return argument to a new BBArg.
+      MergedBB = RetBB->splitBasicBlock(RetInst->getIterator());
+      SILValue OldRetVal = RetInst->getOperand(0);
+      RetInst->setOperand(0, MergedBB->createBBArg(OldRetVal->getType()));
+      Builder.setInsertionPoint(RetBB);
+      Builder.createBranch(Loc, MergedBB, {OldRetVal});
+    }
+  }
+  // Create a CFG edge from NewRetBB to MergedBB.
+  Builder.setInsertionPoint(NewRetBB);
+  ArrayRef<SILValue> BBArgs;
+  if (!NewRetVal->getType().isVoid())
+    BBArgs = {NewRetVal};
+  Builder.createBranch(Loc, MergedBB, BBArgs);
+}
+
+/// Adds a CFG edge from the unterminated NewRetBB to a merged "return" block.
+static void addReturnValue(SILBasicBlock *NewRetBB, SILValue NewRetVal) {
+  auto *RetBB = &*NewRetBB->getParent()->findReturnBB();
+  addReturnValueImpl(RetBB, NewRetBB, NewRetVal);
+}
+
+/// Adds a CFG edge from the unterminated NewThrowBB to a merged "throw" block.
+static void addThrowValue(SILBasicBlock *NewThrowBB, SILValue NewErrorVal) {
+  auto *ThrowBB = &*NewThrowBB->getParent()->findThrowBB();
+  addReturnValueImpl(ThrowBB, NewThrowBB, NewErrorVal);
+}
+
+/// Emits a call to a throwing function as defined by FuncRef, and passes the
+/// specified Args. Uses the provided Builder to insert a try_apply at the given
+/// SILLocation and generates control flow to handle the rethrow.
+///
+/// TODO: Move this to Utils.
+static SILValue
+emitApplyWithRethrow(SILBuilder &Builder,
+                     SILLocation Loc,
+                     SILValue FuncRef,
+                     CanSILFunctionType CanSILFuncTy,
+                     ArrayRef<SILValue> CallArgs,
+                     void (*EmitCleanup)(SILBuilder&, SILLocation)) {
+
+  auto &F = Builder.getFunction();
+  SILBasicBlock *ErrorBB = F.createBasicBlock();
+  SILBasicBlock *NormalBB = F.createBasicBlock();
+  Builder.createTryApply(Loc,
+                         FuncRef,
+                         SILType::getPrimitiveObjectType(CanSILFuncTy),
+                         ArrayRef<Substitution>(),
+                         CallArgs,
+                         NormalBB,
+                         ErrorBB);
+  {
+    // Emit the rethrow logic.
+    Builder.emitBlock(ErrorBB);
+    SILValue Error =
+      ErrorBB->createBBArg(CanSILFuncTy->getErrorResult().getSILType());
+
+    Builder.createBuiltin(Loc,
+                          Builder.getASTContext().getIdentifier("willThrow"),
+                          Builder.getModule().Types.getEmptyTupleType(),
+                          ArrayRef<Substitution>(),
+                          {Error});
+
+    EmitCleanup(Builder, Loc);
+    addThrowValue(ErrorBB, Error);
+  }
+  // Advance Builder to the fall-thru path and return a SILArgument holding the
+  // result value.
+  Builder.clearInsertionPoint();
+  Builder.emitBlock(NormalBB);
+  return Builder.getInsertionBB()->createBBArg(CanSILFuncTy->getSILResult());
+}
+
+/// Emits code to invoke the specified nonpolymorphic CalleeFunc using the
+/// provided SILBuilder.
+/// 
+/// TODO: Move this to Utils.
+static SILValue
+emitInvocation(SILBuilder &Builder, SILLocation Loc,
+               SILFunction *CalleeFunc,
+               ArrayRef<SILValue> CallArgs,
+               void (*EmitCleanup)(SILBuilder&, SILLocation)) {
+
+  auto *FuncRefInst = Builder.createFunctionRef(Loc, CalleeFunc);
+  auto CanSILFuncTy = CalleeFunc->getLoweredFunctionType();
+  assert(!CanSILFuncTy->isPolymorphic());
+
+  if (!CanSILFuncTy->hasErrorResult()) {
+    assert(!CanSILFuncTy->isPolymorphic());
+    return Builder.createApply(CalleeFunc->getLocation(), FuncRefInst, CallArgs,
+                               false);
+  }
+  return emitApplyWithRethrow(Builder, CalleeFunc->getLocation(), FuncRefInst,
+                              CanSILFuncTy, CallArgs, EmitCleanup);
+}
+
+/// Returns the thick metatype for the given SILType.
+/// e.g. $*T -> $@thick T.Type
+static SILType getThickMetatypeType(CanType Ty) {
+  auto SwiftTy = CanMetatypeType::get(Ty, MetatypeRepresentation::Thick);
+  return SILType::getPrimitiveObjectType(SwiftTy);
+}
+
+namespace {
+/// Helper class for emitting code to dispatch to a specialized function.
+class EagerDispatch {
+  SILFunction *GenericFunc;
+  const SILSpecializeAttr &SA;
+  const ReabstractionInfo &ReInfo;
+
+  SILBuilder Builder;
+  SILLocation Loc;
+
+public:
+  // Instantiate a SILBuilder for inserting instructions at the top of the
+  // original generic function.
+  EagerDispatch(SILFunction *GenericFunc, const SILSpecializeAttr &SA,
+                const ReabstractionInfo &ReInfo)
+    : GenericFunc(GenericFunc), SA(SA), ReInfo(ReInfo), Builder(*GenericFunc),
+      Loc(GenericFunc->getLocation()) {
+
+    Builder.setCurrentDebugScope(GenericFunc->getDebugScope());
+  }
+  
+  void emitDispatchTo(SILFunction *NewFunc);
+
+protected:
+  void emitTypeCheck(SILBasicBlock *FailedTypeCheckBB,
+                     SubstitutableType *ParamTy, Type SubTy);
+
+  SILValue emitArgumentCast(SILArgument *OrigArg, unsigned Idx);
+  
+  SILValue emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs);
+};
+}
+
+/// Inserts type checks in the original generic function for dispatching to the
+/// given specialized function. Converts call arguments. Emits an invocation of
+/// the specialized function. Handle the return value.
+void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
+
+  // 1. Emit a cascading sequence of type checks blocks.
+
+  // First split the entry BB, moving all instructions to the FailedTypeCheckBB.
+  auto &EntryBB = GenericFunc->front();
+  SILBasicBlock *FailedTypeCheckBB = EntryBB.splitBasicBlock(EntryBB.begin());
+  Builder.setInsertionPoint(&EntryBB, EntryBB.begin());
+
+  // Iterate over all dependent types in the generic signature, which will match
+  // the specialized attribute's substitution list. Visit only
+  // SubstitutableTypes, skipping DependentTypes.
+  auto GenericSig =
+    GenericFunc->getLoweredFunctionType()->getGenericSignature();
+  auto SubIt = SA.getSubstitutions().begin();
+  auto SubEnd = SA.getSubstitutions().end();
+  for (auto DepTy : GenericSig->getAllDependentTypes()) {
+    assert(SubIt != SubEnd && "Not enough substitutions.");
+    
+    if (auto ParamTy = DepTy->getAs<SubstitutableType>())
+      emitTypeCheck(FailedTypeCheckBB, ParamTy, SubIt->getReplacement());
+    ++SubIt;
+  }
+  assert(SubIt == SubEnd && "Too many substitutions.");
+
+  // 2. Convert call arguments, casting and adjusting for calling convention.
+
+  SmallVector<SILValue, 8> CallArgs;
+  SILValue StoreResultTo = emitArgumentConversion(CallArgs);
+
+  // 3. Emit an invocation of the specialized function.
+
+  // Emit any rethrow with no cleanup since all args have been forwarded and
+  // nothing has been locally allocated or copied.
+  auto NoCleanup = [](SILBuilder&, SILLocation){};
+  SILValue Result = emitInvocation(Builder, Loc, NewFunc, CallArgs, NoCleanup);
+
+  // 4. Handle the return value.
+
+  auto VoidTy = Builder.getModule().Types.getEmptyTupleType();
+  if (StoreResultTo) {
+    // Store the direct result to the original result address.
+    Builder.createStore(Loc, Result, StoreResultTo);
+    // And return Void.
+    Result = Builder.createTuple(Loc, VoidTy, { });
+  }
+  // Ensure that void return types original from a tuple instruction.
+  else if (Result->getType().isVoid())
+    Result = Builder.createTuple(Loc, VoidTy, { });
+
+  // Function marked as @NoReturn must be followed by 'unreachable'.
+  if (NewFunc->getLoweredFunctionType()->isNoReturn())
+    Builder.createUnreachable(Loc);
+  else {
+    auto GenResultTy = GenericFunc->mapTypeIntoContext(
+      GenericFunc->getLoweredFunctionType()->getSILResult());
+    auto CastResult = Builder.createUncheckedBitCast(Loc, Result, GenResultTy);
+    addReturnValue(Builder.getInsertionBB(), CastResult);
+  }
+}
+
+// Emits a type check in the current block.
+// Advances the builder to the successful type check's block.
+// 
+// Precondition: Builder's current insertion block is not terminated.
+//
+// Postcondition: Builder's insertion block is a new block that defines the
+// specialized call argument and has not been terminated.
+//
+// The type check is emitted in the current block as: 
+// metatype $@thick T.Type
+// %a = unchecked_bitwise_cast % to $Builtin.Int64
+// metatype $@thick <Specialized>.Type
+// %b = unchecked_bitwise_cast % to $Builtin.Int64
+// builtin "cmp_eq_Int64"(%a : $Builtin.Int64, %b : $Builtin.Int64)
+//   : $Builtin.Int1
+// cond_br %
+void EagerDispatch::
+emitTypeCheck(SILBasicBlock *FailedTypeCheckBB, SubstitutableType *ParamTy,
+              Type SubTy) {
+  // Instantiate a thick metatype for T.Type
+  auto ContextTy = GenericFunc->mapTypeIntoContext(ParamTy);
+  auto GenericMT = Builder.createMetatype(
+    Loc, getThickMetatypeType(ContextTy->getCanonicalType()));
+
+  // Instantiate a thick metatype for <Specialized>.Type
+  auto SpecializedMT = Builder.createMetatype(
+    Loc, getThickMetatypeType(SubTy->getCanonicalType()));
+
+  auto &Ctx = Builder.getASTContext();
+  auto WordTy = SILType::getBuiltinWordType(Ctx);
+  auto GenericMTVal =
+    Builder.createUncheckedBitwiseCast(Loc, GenericMT, WordTy);
+  auto SpecializedMTVal =
+    Builder.createUncheckedBitwiseCast(Loc, SpecializedMT, WordTy);
+
+  auto Cmp =
+    Builder.createBuiltinBinaryFunction(Loc, "cmp_eq", WordTy,
+                                        SILType::getBuiltinIntegerType(1, Ctx),
+                                        {GenericMTVal, SpecializedMTVal});
+
+  auto *SuccessBB = Builder.getFunction().createBasicBlock();
+  Builder.createCondBranch(Loc, Cmp, SuccessBB, FailedTypeCheckBB);
+  Builder.emitBlock(SuccessBB);
+}
+
+/// Cast a generic argument to its specialized type.
+SILValue EagerDispatch::emitArgumentCast(SILArgument *OrigArg, unsigned Idx) {
+
+  auto CastTy = ReInfo.getSubstitutedType()->getSILArgumentType(Idx);
+  assert(CastTy.isAddress() ==
+         (OrigArg->isIndirectResult()
+          || OrigArg->getKnownParameterInfo().isIndirect()) && "bad arg type");
+
+  if (CastTy.isAddress())
+    return Builder.createUncheckedAddrCast(Loc, OrigArg, CastTy);
+
+  return Builder.createUncheckedBitCast(Loc, OrigArg, CastTy);
+}
+
+/// Converts each generic function argument into a SILValue that can be passed
+/// to the specialized call by emiting a cast followed by a load.
+///
+/// Populates the CallArgs with the converted arguments.
+///
+/// Returns the SILValue to store the result into if the specialized function
+/// has a direct result.
+SILValue EagerDispatch::
+emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
+  auto OrigArgs = GenericFunc->getArguments();
+  assert(OrigArgs.size() == ReInfo.getNumArguments() && "signature mismatch");
+  
+  CallArgs.reserve(OrigArgs.size());
+  SILValue StoreResultTo;
+  for (auto *OrigArg : OrigArgs) {
+    unsigned Idx = OrigArg->getIndex();
+
+    auto CastArg = emitArgumentCast(OrigArg, Idx);
+    DEBUG(dbgs() << "  Cast generic arg: "; CastArg->print(dbgs()));
+
+    if (ReInfo.isArgConverted(OrigArg->getIndex())) {
+      if (ReInfo.isResultIndex(Idx)) {
+        // The result is converted from indirect to direct. We need to insert
+        // a store later.
+        assert(!StoreResultTo);
+        StoreResultTo = CastArg;
+      } else {
+        // An argument is converted from indirect to direct. Instead of the
+        // address we pass the loaded value.
+        SILValue Val = Builder.createLoad(Loc, CastArg);
+        CallArgs.push_back(Val);
+      }
+    } else {
+      CallArgs.push_back(CastArg);
+    }
+  }
+  return StoreResultTo;
+}
+
+namespace {
+// FIXME: This should be a function transform that pushes cloned functions on
+// the pass manager worklist.
+class EagerSpecializerTransform : public SILModuleTransform {
+public:
+  EagerSpecializerTransform() {}
+
+  void run() override;
+
+  StringRef getName() override { return "Eager Specializer"; }
+};
+}
+
+/// Specializes a generic function for a concrete type list.
+static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
+                                    const SILSpecializeAttr &SA,
+                                    const ReabstractionInfo &ReInfo) {
+  DEBUG(dbgs() << "Specializing " << GenericFunc->getName() << "\n");
+
+  DEBUG(auto FT = GenericFunc->getLoweredFunctionType();
+        dbgs() << "  Generic Sig:";
+        dbgs().indent(2); FT->getGenericSignature()->print(dbgs());
+        dbgs() << "\n  Substituting: <";
+        auto depTypes = FT->getGenericSignature()->getAllDependentTypes();
+        interleave(depTypes.begin(), depTypes.end(),
+                   [&](Type t){
+                     GenericFunc->mapTypeIntoContext(t).print(dbgs()); },
+                   []{ dbgs() << ", "; });
+        dbgs() << "> with ";
+        SA.print(dbgs()); dbgs() << "\n");
+  
+  // Create a specialized function.
+  GenericFuncSpecializer
+        FuncSpecializer(GenericFunc, SA.getSubstitutions(), ReInfo);
+
+  SILFunction *NewFunc = FuncSpecializer.trySpecialization();
+  if (!NewFunc)
+    DEBUG(dbgs() << "  Failed. Cannot specialize function.\n");
+
+  return NewFunc;
+}
+
+/// Run the pass.
+void EagerSpecializerTransform::run() {
+  if (!EagerSpecializeFlag)
+    return;
+  
+  // Process functions in any order.
+  bool Changed = false;
+  for (auto &F : *getModule()) {
+    if (!F.shouldOptimize()) {
+      DEBUG(dbgs() << "  Cannot specialize function " << F.getName()
+            << " marked to be excluded from optimizations.\n");
+      continue;
+    }
+    // Only specialize functions in their home module.
+    if (F.isExternalDeclaration() || F.isAvailableExternally())
+      continue;
+
+    // Create a specialized function with ReabstractionInfo for each attribute.
+    SmallVector<SILFunction*, 8> SpecializedFuncs;
+    SmallVector<ReabstractionInfo, 4> ReInfoVec;
+    ReInfoVec.reserve(F.getSpecializeAttrs().size());
+
+    for (auto *SA : F.getSpecializeAttrs()) {
+      ReInfoVec.emplace_back(&F, SA->getSubstitutions());
+      auto *NewFunc = eagerSpecialize(&F, *SA, ReInfoVec.back());
+      SpecializedFuncs.push_back(NewFunc);
+    }
+
+    // Emit a type check and dispatch to each specialized function.
+    for_each3(F.getSpecializeAttrs(), SpecializedFuncs, ReInfoVec,
+             [&](const SILSpecializeAttr *SA, SILFunction *NewFunc,
+                 const ReabstractionInfo &ReInfo) {
+      if (NewFunc) {
+        Changed = true;
+        EagerDispatch(&F, *SA, ReInfo).emitDispatchTo(NewFunc);
+      }
+    });
+    // As specializations are created, the attributes should be removed.
+    F.clearSpecializeAttrs();
+  }
+  // Invalidate everything since we delete calls as well as add new
+  // calls and branches.
+  if (Changed) {
+    invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+  }
+}
+
+SILTransform *swift::createEagerSpecializer() {
+  return new EagerSpecializerTransform();
+}

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -274,6 +274,8 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
 
   // Run an iteration of the high-level SSA passes.
   PM.setStageName("HighLevel+EarlyLoopOpt");
+  // FIXME: update this to be a function pass.
+  PM.addEagerSpecializer();
   AddSSAPasses(PM, OptimizationLevelKind::HighLevel);
   AddHighLevelLoopOptPasses(PM);
   PM.runOneIteration();

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -19,27 +19,40 @@
 
 using namespace swift;
 
-ReabstractionInfo::ReabstractionInfo(SILFunction *Orig, ApplySite AI) {
-  SILModule &M = Orig->getModule();
-  Module *SM = M.getSwiftModule();
+// =============================================================================
+// ReabstractionInfo
+// =============================================================================
+
+// Initialize SpecializedType iff the specialization is allowed.
+ReabstractionInfo::ReabstractionInfo(SILFunction *OrigF,
+                                     ArrayRef<Substitution> ParamSubs) {
+  if (!OrigF->shouldOptimize()) {
+    DEBUG(llvm::dbgs() << "    Cannot specialize function " << OrigF->getName()
+                       << " marked to be excluded from optimizations.\n");
+    return;
+  }
 
   TypeSubstitutionMap InterfaceSubs;
-  TypeSubstitutionMap ContextSubs;
-
-  if (Orig->getLoweredFunctionType()->getGenericSignature())
-    InterfaceSubs = Orig->getLoweredFunctionType()->getGenericSignature()
-      ->getSubstitutionMap(AI.getSubstitutions());
+  if (OrigF->getLoweredFunctionType()->getGenericSignature())
+    InterfaceSubs = OrigF->getLoweredFunctionType()->getGenericSignature()
+      ->getSubstitutionMap(ParamSubs);
 
   // We do not support partial specialization.
-  if (hasUnboundGenericTypes(InterfaceSubs))
+  if (hasUnboundGenericTypes(InterfaceSubs)) {
+    DEBUG(llvm::dbgs() <<
+          "    Cannot specialize with unbound interface substitutions.\n");
     return;
-  if (hasDynamicSelfTypes(InterfaceSubs))
+  }
+  if (hasDynamicSelfTypes(InterfaceSubs)) {
+    DEBUG(llvm::dbgs() << "    Cannot specialize with dynamic self.\n");
     return;
+  }
+  SILModule &M = OrigF->getModule();
+  Module *SM = M.getSwiftModule();
 
-  SubstitutedType =
-    SILType::substFuncType(M, SM, InterfaceSubs,
-                           Orig->getLoweredFunctionType(),
-                           /*dropGenerics = */ true);
+  SubstitutedType = SILType::substFuncType(M, SM, InterfaceSubs,
+                                           OrigF->getLoweredFunctionType(),
+                                           /*dropGenerics = */ true);
 
   NumResults = SubstitutedType->getNumIndirectResults();
   Conversions.resize(NumResults + SubstitutedType->getParameters().size());
@@ -70,6 +83,8 @@ ReabstractionInfo::ReabstractionInfo(SILFunction *Orig, ApplySite AI) {
   SpecializedType = createSpecializedType(SubstitutedType, M);
 }
 
+// Convert the substituted function type into a specialized function type based
+// on the ReabstractionInfo.
 CanSILFunctionType ReabstractionInfo::
 createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
   llvm::SmallVector<SILResultInfo, 8> SpecializedResults;
@@ -116,6 +131,71 @@ createSpecializedType(CanSILFunctionType SubstFTy, SILModule &M) const {
                          SpecializedResults, SubstFTy->getOptionalErrorResult(),
                          M.getASTContext());
 }
+
+// =============================================================================
+// GenericFuncSpecializer
+// =============================================================================
+
+GenericFuncSpecializer::GenericFuncSpecializer(SILFunction *GenericFunc,
+                                               ArrayRef<Substitution> ParamSubs,
+                                               const ReabstractionInfo &ReInfo)
+    : M(GenericFunc->getModule()),
+      GenericFunc(GenericFunc),
+      ParamSubs(ParamSubs),
+      ReInfo(ReInfo) {
+
+  assert(GenericFunc->isDefinition() && "Expected definition to specialize!");
+
+  if (GenericFunc->getContextGenericParams())
+    ContextSubs = GenericFunc->getContextGenericParams()
+      ->getSubstitutionMap(ParamSubs);
+
+  Mangle::Mangler Mangler;
+  GenericSpecializationMangler GenericMangler(Mangler, GenericFunc,
+                                                ParamSubs);
+  GenericMangler.mangle();
+  ClonedName = Mangler.finalize();
+
+  DEBUG(llvm::dbgs() << "    Specialized function " << ClonedName << '\n');
+}
+
+// Return an existing specialization if one exists.
+SILFunction *GenericFuncSpecializer::lookupSpecialization() {
+  if (SILFunction *SpecializedF = M.lookUpFunction(ClonedName)) {
+    assert(ReInfo.getSpecializedType()
+           == SpecializedF->getLoweredFunctionType() &&
+           "Previously specialized function does not match expected type.");
+    return SpecializedF;
+  }
+  return nullptr;
+}
+
+// Forward decl for prespecialization support.
+static bool linkSpecialization(SILModule &M, SILFunction *F);
+
+// Create a new specialized function if possible, and cache it.
+SILFunction *GenericFuncSpecializer::tryCreateSpecialization() {
+  // Do not create any new specializations at Onone.
+  if (M.getOptions().Optimization <= SILOptions::SILOptMode::None)
+    return nullptr;
+
+  DEBUG(
+    if (M.getOptions().Optimization <= SILOptions::SILOptMode::Debug) {
+      llvm::dbgs() << "Creating a specialization: " << ClonedName << "\n"; });
+
+  // Create a new function.
+  SILFunction * SpecializedF =
+    GenericCloner::cloneFunction(GenericFunc, ReInfo, ContextSubs, ParamSubs,
+                                 ClonedName);
+
+  // Check if this specialization should be linked for prespecialization.
+  linkSpecialization(M, SpecializedF);
+  return SpecializedF;
+}
+
+// =============================================================================
+// Apply substitution
+// =============================================================================
 
 /// Fix the case where a void function returns the result of an apply, which is
 /// also a call of a void-returning function.
@@ -209,154 +289,6 @@ replaceWithSpecializedFunction(ApplySite AI, SILFunction *NewF,
   SILBuilderWithScope Builder(AI.getInstruction());
   FunctionRefInst *FRI = Builder.createFunctionRef(AI.getLoc(), NewF);
   return replaceWithSpecializedCallee(AI, FRI, Builder, ReInfo);
-}
-
-/// Check of a given name could be a name of a white-listed
-/// specialization.
-bool swift::isWhitelistedSpecialization(StringRef SpecName) {
-  // The whitelist of classes and functions from the stdlib,
-  // whose specializations we want to preserve.
-  ArrayRef<StringRef> Whitelist = {
-      "Array",
-      "_ArrayBuffer",
-      "_ContiguousArrayBuffer",
-      "Range",
-      "RangeIterator",
-      "_allocateUninitializedArray",
-      "UTF8",
-      "UTF16",
-      "String",
-      "_StringBuffer",
-      "_toStringReadOnlyPrintable",
-  };
-
-  // TODO: Once there is an efficient API to check if
-  // a given symbol is a specialization of a specific type,
-  // use it instead. Doing demangling just for this check
-  // is just wasteful.
-  auto DemangledNameString =
-     swift::Demangle::demangleSymbolAsString(SpecName);
-
-  StringRef DemangledName = DemangledNameString;
-
-  auto pos = DemangledName.find("generic ", 0);
-  if (pos == StringRef::npos)
-    return false;
-
-  // Create "of Swift"
-  llvm::SmallString<64> OfString;
-  llvm::raw_svector_ostream buffer(OfString);
-  buffer << "of ";
-  buffer << STDLIB_NAME <<'.';
-
-  StringRef OfStr = buffer.str();
-
-  pos = DemangledName.find(OfStr, pos);
-
-  if (pos == StringRef::npos)
-    return false;
-
-  pos += OfStr.size();
-
-  for(auto Name: Whitelist) {
-    auto pos1 = DemangledName.find(Name, pos);
-    if (pos1 == pos && !isalpha(DemangledName[pos1+Name.size()])) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/// Cache a specialization.
-/// For now, it is performed only for specializations in the
-/// standard library. But in the future, one could think of
-/// maintaining a cache of optimized specializations.
-///
-/// Mark specializations as public, so that they can be used
-/// by user applications. These specializations are supposed to be
-/// used only by -Onone compiled code. They should be never inlined.
-static bool cacheSpecialization(SILModule &M, SILFunction *F) {
-  // Do not remove functions from the white-list. Keep them around.
-  // Change their linkage to public, so that other applications can refer to it.
-
-  if (M.getOptions().Optimization >= SILOptions::SILOptMode::Optimize &&
-      F->getLinkage() != SILLinkage::Public &&
-      F->getModule().getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT) {
-    if (F->getLinkage() != SILLinkage::Public &&
-        isWhitelistedSpecialization(F->getName())) {
-
-      DEBUG(
-        auto DemangledNameString =
-          swift::Demangle::demangleSymbolAsString(F->getName());
-        StringRef DemangledName = DemangledNameString;
-        llvm::dbgs() << "Keep specialization: " << DemangledName << " : "
-                     << F->getName() << "\n");
-      // Make it public, so that others can refer to it.
-      //
-      // NOTE: This function may refer to non-public symbols, which may lead to
-      // problems, if you ever try to inline this function. Therefore, these
-      // specializations should only be used to refer to them, but should never
-      // be inlined!  The general rule could be: Never inline specializations
-      // from stdlib!
-      //
-      // NOTE: Making these specializations public at this point breaks
-      // some optimizations. Therefore, just mark the function.
-      // DeadFunctionElimination pass will check if the function is marked
-      // and preserve it if required.
-      F->setKeepAsPublic(true);
-      return true;
-    }
-  }
-  return false;
-}
-
-/// Try to look up an existing specialization in the specialization cache.
-/// If it is found, it tries to link this specialization.
-///
-/// For now, it performs a lookup only in the standard library.
-/// But in the future, one could think of maintaining a cache
-/// of optimized specializations.
-static SILFunction *lookupExistingSpecialization(SILModule &M,
-                                                 StringRef FunctionName) {
-  // Try to link existing specialization only in -Onone mode.
-  // All other compilation modes perform specialization themselves.
-  // TODO: Cache optimized specializations and perform lookup here?
-  // Only check that this function exists, but don't read
-  // its body. It can save some compile-time.
-  if (isWhitelistedSpecialization(FunctionName))
-    return M.hasFunction(FunctionName, SILLinkage::PublicExternal);
-
-  return nullptr;
-}
-
-SILFunction *swift::getExistingSpecialization(SILModule &M,
-                                              StringRef FunctionName) {
-  // First check if the module contains a required specialization already.
-  auto *Specialization = M.lookUpFunction(FunctionName);
-  if (Specialization)
-    return Specialization;
-
-  // Then check if the required specialization can be found elsewhere.
-  Specialization = lookupExistingSpecialization(M, FunctionName);
-  if (!Specialization)
-    return nullptr;
-
-  assert(hasPublicVisibility(Specialization->getLinkage()) &&
-         "Pre-specializations should have public visibility");
-
-  Specialization->setLinkage(SILLinkage::PublicExternal);
-
-  assert(Specialization->isExternalDeclaration()  &&
-         "Specialization should be a public external declaration");
-
-  DEBUG(llvm::dbgs() << "Found existing specialization for: " << FunctionName
-                     << '\n';
-        llvm::dbgs() << swift::Demangle::demangleSymbolAsString(
-                            Specialization->getName())
-                     << "\n\n");
-
-  return Specialization;
 }
 
 /// Create a re-abstraction thunk for a partial_apply.
@@ -459,22 +391,13 @@ void swift::trySpecializeApplyOfGeneric(ApplySite Apply,
   assert(Apply.hasSubstitutions() && "Expected an apply with substitutions!");
 
   auto *F = cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunction();
-  assert(F->isDefinition() && "Expected definition to specialize!");
-
-  if (!F->shouldOptimize()) {
-    DEBUG(llvm::dbgs() << "    Cannot specialize function " << F->getName()
-                       << " marked to be excluded from optimizations.\n");
-    return;
-  }
 
   DEBUG(llvm::dbgs() << "  ApplyInst: " << *Apply.getInstruction());
 
-  ReabstractionInfo ReInfo(F, Apply);
-  if (!ReInfo.getSpecializedType()) {
-    DEBUG(llvm::dbgs() <<
-          "    Cannot specialize with interface subs or dynamic self.\n");
+  ReabstractionInfo ReInfo(F, Apply.getSubstitutions());
+  if (!ReInfo.getSpecializedType())
     return;
-  }
+
   SILModule &M = Apply.getInstruction()->getModule();
 
   bool needAdaptUsers = false;
@@ -513,47 +436,22 @@ void swift::trySpecializeApplyOfGeneric(ApplySite Apply,
     }
   }
 
-  TypeSubstitutionMap ContextSubs;
-
-  if (F->getContextGenericParams())
-    ContextSubs = F->getContextGenericParams()
-      ->getSubstitutionMap(Apply.getSubstitutions());
-
-  std::string ClonedName;
-  {
-    ArrayRef<Substitution> Subs = Apply.getSubstitutions();
-    Mangle::Mangler M;
-    GenericSpecializationMangler Mangler(M, F, Subs);
-    Mangler.mangle();
-    ClonedName = M.finalize();
-  }
-  DEBUG(llvm::dbgs() << "    Specialized function " << ClonedName << '\n');
-
-  // If we already have this specialization, reuse it.
-  SILFunction *SpecializedF = M.lookUpFunction(ClonedName);
-
+  GenericFuncSpecializer FuncSpecializer(F, Apply.getSubstitutions(), ReInfo);
+  SILFunction *SpecializedF = FuncSpecializer.lookupSpecialization();
   if (SpecializedF) {
-    assert(ReInfo.getSpecializedType() == SpecializedF->getLoweredFunctionType() &&
+    assert(ReInfo.getSpecializedType()
+           == SpecializedF->getLoweredFunctionType() &&
            "Previously specialized function does not match expected type.");
   } else {
-
-    // Do not create any new specializations at Onone.
-    if (M.getOptions().Optimization <= SILOptions::SILOptMode::None)
+    SpecializedF = FuncSpecializer.tryCreateSpecialization();
+    if (!SpecializedF)
       return;
 
-    DEBUG(
-      if (M.getOptions().Optimization <= SILOptions::SILOptMode::Debug) {
-        llvm::dbgs() << "Creating a specialization: " << ClonedName << "\n"; });
-
-    // Create a new function.
-    SpecializedF = GenericCloner::cloneFunction(F, ReInfo, ContextSubs,
-                                                   ClonedName, Apply);
-
-    // Check if this specialization should be cached.
-    cacheSpecialization(M, SpecializedF);
     NewFunctions.push_back(SpecializedF);
   }
+
   DeadApplies.push_back(Apply.getInstruction());
+
   if (replacePartialApplyWithoutReabstraction) {
     // There are some unknown users of the partial_apply. Therefore we need a
     // thunk which converts from the re-abstracted function back to the
@@ -600,3 +498,160 @@ void swift::trySpecializeApplyOfGeneric(ApplySite Apply,
     }
   }
 }
+
+// =============================================================================
+// Prespecialized symbol lookup.
+//
+// This uses the SIL linker to checks for the does not load the body of the pres
+// =============================================================================
+
+/// Link a specialization for generating prespecialized code.
+/// 
+/// For now, it is performed only for specializations in the
+/// standard library. But in the future, one could think of
+/// maintaining a cache of optimized specializations.
+///
+/// Mark specializations as public, so that they can be used by user
+/// applications. These specializations are generated during -O compilation of
+/// the library, but only used only by client code compiled at -Onone. They
+/// should be never inlined.
+static bool linkSpecialization(SILModule &M, SILFunction *F) {
+  // Do not remove functions from the white-list. Keep them around.
+  // Change their linkage to public, so that other applications can refer to it.
+
+  if (M.getOptions().Optimization >= SILOptions::SILOptMode::Optimize &&
+      F->getLinkage() != SILLinkage::Public &&
+      F->getModule().getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT) {
+    if (F->getLinkage() != SILLinkage::Public &&
+        isWhitelistedSpecialization(F->getName())) {
+
+      DEBUG(
+        auto DemangledNameString =
+          swift::Demangle::demangleSymbolAsString(F->getName());
+        StringRef DemangledName = DemangledNameString;
+        llvm::dbgs() << "Keep specialization: " << DemangledName << " : "
+                     << F->getName() << "\n");
+      // Make it public, so that others can refer to it.
+      //
+      // NOTE: This function may refer to non-public symbols, which may lead to
+      // problems, if you ever try to inline this function. Therefore, these
+      // specializations should only be used to refer to them, but should never
+      // be inlined!  The general rule could be: Never inline specializations
+      // from stdlib!
+      //
+      // NOTE: Making these specializations public at this point breaks
+      // some optimizations. Therefore, just mark the function.
+      // DeadFunctionElimination pass will check if the function is marked
+      // and preserve it if required.
+      F->setKeepAsPublic(true);
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Check of a given name could be a name of a white-listed
+/// specialization.
+bool swift::isWhitelistedSpecialization(StringRef SpecName) {
+  // The whitelist of classes and functions from the stdlib,
+  // whose specializations we want to preserve.
+  ArrayRef<StringRef> Whitelist = {
+      "Array",
+      "_ArrayBuffer",
+      "_ContiguousArrayBuffer",
+      "Range",
+      "RangeIterator",
+      "_allocateUninitializedArray",
+      "UTF8",
+      "UTF16",
+      "String",
+      "_StringBuffer",
+      "_toStringReadOnlyPrintable",
+  };
+
+  // TODO: Once there is an efficient API to check if
+  // a given symbol is a specialization of a specific type,
+  // use it instead. Doing demangling just for this check
+  // is just wasteful.
+  auto DemangledNameString =
+     swift::Demangle::demangleSymbolAsString(SpecName);
+
+  StringRef DemangledName = DemangledNameString;
+
+  auto pos = DemangledName.find("generic ", 0);
+  if (pos == StringRef::npos)
+    return false;
+
+  // Create "of Swift"
+  llvm::SmallString<64> OfString;
+  llvm::raw_svector_ostream buffer(OfString);
+  buffer << "of ";
+  buffer << STDLIB_NAME <<'.';
+
+  StringRef OfStr = buffer.str();
+
+  pos = DemangledName.find(OfStr, pos);
+
+  if (pos == StringRef::npos)
+    return false;
+
+  pos += OfStr.size();
+
+  for(auto Name: Whitelist) {
+    auto pos1 = DemangledName.find(Name, pos);
+    if (pos1 == pos && !isalpha(DemangledName[pos1+Name.size()])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/// Try to look up an existing specialization in the specialization cache.
+/// If it is found, it tries to link this specialization.
+///
+/// For now, it performs a lookup only in the standard library.
+/// But in the future, one could think of maintaining a cache
+/// of optimized specializations.
+static SILFunction *lookupExistingSpecialization(SILModule &M,
+                                                 StringRef FunctionName) {
+  // Try to link existing specialization only in -Onone mode.
+  // All other compilation modes perform specialization themselves.
+  // TODO: Cache optimized specializations and perform lookup here?
+  // Only check that this function exists, but don't read
+  // its body. It can save some compile-time.
+  if (isWhitelistedSpecialization(FunctionName))
+    return M.hasFunction(FunctionName, SILLinkage::PublicExternal);
+
+  return nullptr;
+}
+
+SILFunction *swift::lookupPrespecializedSymbol(SILModule &M,
+                                               StringRef FunctionName) {
+  // First check if the module contains a required specialization already.
+  auto *Specialization = M.lookUpFunction(FunctionName);
+  if (Specialization)
+    return Specialization;
+
+  // Then check if the required specialization can be found elsewhere.
+  Specialization = lookupExistingSpecialization(M, FunctionName);
+  if (!Specialization)
+    return nullptr;
+
+  assert(hasPublicVisibility(Specialization->getLinkage()) &&
+         "Pre-specializations should have public visibility");
+
+  Specialization->setLinkage(SILLinkage::PublicExternal);
+
+  assert(Specialization->isExternalDeclaration()  &&
+         "Specialization should be a public external declaration");
+
+  DEBUG(llvm::dbgs() << "Found existing specialization for: " << FunctionName
+                     << '\n';
+        llvm::dbgs() << swift::Demangle::demangleSymbolAsString(
+                            Specialization->getName())
+                     << "\n\n");
+
+  return Specialization;
+}
+

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -18,6 +18,7 @@
 #include "MiscDiagnostics.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/NameLookup.h"
+#include "swift/AST/Types.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/ClangImporter/ClangModule.h" // FIXME: SDK overlay semantics
 
@@ -71,6 +72,7 @@ public:
   IGNORED_ATTR(RequiresStoredPropertyInits)
   IGNORED_ATTR(Rethrows)
   IGNORED_ATTR(Semantics)
+  IGNORED_ATTR(Specialize)
   IGNORED_ATTR(Swift3Migration)
   IGNORED_ATTR(SwiftNativeObjCRuntimeBase)
   IGNORED_ATTR(SynthesizedProtocol)
@@ -685,6 +687,7 @@ public:
   void visitPrefixAttr(PrefixAttr *attr) { checkOperatorAttribute(attr); }
 
   void visitWarnUnusedResultAttr(WarnUnusedResultAttr *attr);
+  void visitSpecializeAttr(SpecializeAttr *attr);
 };
 } // end anonymous namespace
 
@@ -1370,6 +1373,136 @@ void AttributeChecker::visitWarnUnusedResultAttr(WarnUnusedResultAttr *attr) {
       return;      
     }
   }
+}
+
+/// Check that the @_specialize type list has the correct number of entries.
+/// Resolve each type in the list to a concrete type.
+/// Create a Substitution list mapping each nested archetype to a concrete
+/// type, and resolve conformances for each generic parameter requirement.
+/// Store the Substitution list in a ConcreteDeclRef attached to the attribute.
+void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
+  DeclContext *DC = D->getDeclContext();
+  auto *FD = cast<AbstractFunctionDecl>(D);
+  auto *genericSig = FD->getGenericSignature();
+
+  unsigned numTypes = genericSig->getGenericParams().size();
+  if (numTypes != attr->getTypeLocs().size()) {
+    TC.diagnose(attr->getLocation(), diag::type_parameter_count_mismatch,
+                FD->getName(), numTypes, attr->getTypeLocs().size(),
+                numTypes > attr->getTypeLocs().size());
+    return;
+  }
+  // Initialize each TypeLoc in this attribute with a concrete type,
+  // and populate a substitution map from GenericTypeParamType to concrete Type.
+  TypeSubstitutionMap subMap;
+  for (unsigned paramIdx = 0; paramIdx < numTypes; ++paramIdx) {
+
+    auto *genericTypeParamTy = genericSig->getGenericParams()[paramIdx];
+    auto &tl = attr->getTypeLocs()[paramIdx];
+
+    auto ty = TC.resolveType(tl.getTypeRepr(), DC, None);
+    if (ty && !ty->is<ErrorType>()) {
+      if (ty->getCanonicalType()->hasArchetype()) {
+        TC.diagnose(attr->getLocation(),
+                    diag::cannot_partially_specialize_generic_function);
+        return;
+      }
+      tl.setType(ty, /*validated=*/true);
+      subMap[genericTypeParamTy->getCanonicalType().getPointer()] = ty;
+    }
+  }
+  // Build a list of Substitutions.
+  //
+  // This walks the generic signature's requirements, similar to
+  // Solution::computeSubstitutions but with several differences:
+  // - It does not operate within the type constraint system.
+  // - This is the first point at which diagnostics must be emitted for
+  //   bad conformances. Self and super requirements must also be
+  //   checked and diagnosed.
+  // - This does not make use of Archetypes since it is directly substituting
+  //   in place of GenericTypeParams.
+  SmallVector<Substitution, 4> substitutions;
+  auto currentModule = FD->getParentModule();
+  Type currentFromTy;
+  Type currentReplacement;
+  SmallVector<ProtocolConformanceRef, 4> currentConformances;
+  for (const auto &req : genericSig->getRequirements()) {
+
+    switch (req.getKind()) {
+    case RequirementKind::WitnessMarker:
+      // Flush the current conformances.
+      if (currentFromTy) {
+        substitutions.push_back({
+          currentReplacement,
+          DC->getASTContext().AllocateCopy(currentConformances)
+        });
+        currentConformances.clear();
+      }
+      // Each witness marker starts a new substitution.
+      currentFromTy = req.getFirstType();
+      currentReplacement = currentFromTy.subst(currentModule, subMap, None);
+      break;
+
+    case RequirementKind::Conformance: {
+      assert(currentFromTy->getCanonicalType()
+             == req.getFirstType()->getCanonicalType() && "bad WitnessMarker");
+      // Get the conformance and record it.
+      auto protoType = req.getSecondType()->castTo<ProtocolType>();
+      ProtocolConformance *conformance = nullptr;
+      bool conforms =
+        TC.conformsToProtocol(currentReplacement,
+                              protoType->getDecl(),
+                              DC,
+                              (ConformanceCheckFlags::InExpression|
+                               ConformanceCheckFlags::Used),
+                              &conformance);
+      if (!conforms || !conformance) {
+        TC.diagnose(attr->getLocation(),
+                    diag::cannot_convert_argument_value_protocol,
+                    currentReplacement, protoType);
+        // leaks prior conformances
+        return;
+      }
+      currentConformances.push_back(
+        ProtocolConformanceRef(protoType->getDecl(), conformance));
+      break;
+    }
+    case RequirementKind::Superclass: {
+      // Superclass requirements aren't recorded in substitutions.
+      auto firstTy = req.getFirstType().subst(currentModule, subMap, None);
+      auto superTy = req.getSecondType().subst(currentModule, subMap, None);
+      if (!TC.isSubtypeOf(firstTy, superTy, DC)) {
+        TC.diagnose(attr->getLocation(), diag::type_does_not_inherit,
+                    FD->getType(), firstTy, superTy);
+      }
+      break;
+    }
+    case RequirementKind::SameType: {
+      // Same-type requirements are type checked but not recorded in
+      // substitutions.
+      auto firstTy = req.getFirstType().subst(currentModule, subMap, None);
+      auto sameTy = req.getSecondType().subst(currentModule, subMap, None);
+      if (!firstTy->isEqual(sameTy)) {
+        TC.diagnose(attr->getLocation(), diag::types_not_equal, FD->getType(),
+                    firstTy, sameTy);
+
+        return;
+      }
+      break;
+    }
+    }
+  }
+  // Flush the final conformances.
+  if (currentFromTy) {
+    substitutions.push_back({
+      currentReplacement,
+      DC->getASTContext().AllocateCopy(currentConformances),
+    });
+    currentConformances.clear();
+  }
+  // Package the Substitution list in the SpecializeAttr's ConcreteDeclRef.
+  attr->setConcreteDecl(
+    ConcreteDeclRef(DC->getASTContext(), FD, substitutions));
 }
 
 void TypeChecker::checkDeclAttributes(Decl *D) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5103,6 +5103,7 @@ public:
     UNINTERESTING_ATTR(UnsafeNoObjCTaggedPointer)
     UNINTERESTING_ATTR(SwiftNativeObjCRuntimeBase)
     UNINTERESTING_ATTR(ShowInInterface)
+    UNINTERESTING_ATTR(Specialize)
 
     // These can't appear on overridable declarations.
     UNINTERESTING_ATTR(AutoClosure)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2095,6 +2095,20 @@ Decl *ModuleFile::getDecl(DeclID DID, Optional<DeclContext *> ForcedContext) {
         break;
       }
 
+      case decls_block::Specialize_DECL_ATTR: {
+        ArrayRef<uint64_t> rawTypeIDs;
+        serialization::decls_block::SpecializeDeclAttrLayout::readRecord(
+          scratch, rawTypeIDs);
+
+        SmallVector<TypeLoc, 8> typeLocs;
+        for (auto tid : rawTypeIDs)
+          typeLocs.push_back(TypeLoc::withoutLoc(getType(tid)));
+
+        Attr = SpecializeAttr::create(ctx, SourceLoc(), SourceRange(),
+                                      typeLocs);
+        break;
+      }
+
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...) \
       case decls_block::CLASS##_DECL_ATTR: { \
         bool isImplicit; \

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -378,12 +378,12 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
 
   TypeID funcTyID;
   unsigned rawLinkage, isTransparent, isFragile, isThunk, isGlobal,
-           inlineStrategy, effect;
+    inlineStrategy, effect, numSpecAttrs;
   ArrayRef<uint64_t> SemanticsIDs;
   // TODO: read fragile
   SILFunctionLayout::readRecord(scratch, rawLinkage, isTransparent, isFragile,
                                 isThunk, isGlobal, inlineStrategy, effect,
-                                funcTyID, SemanticsIDs);
+                                numSpecAttrs, funcTyID, SemanticsIDs);
 
   if (funcTyID == 0) {
     DEBUG(llvm::dbgs() << "SILFunction typeID is 0.\n");
@@ -455,6 +455,28 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
     fn->setDebugScope(DS);
   }
 
+  // Read and instantiate the specialize attributes.
+  while (numSpecAttrs--) {
+    auto next = SILCursor.advance(AF_DontPopBlockAtEnd);
+    assert(next.Kind == llvm::BitstreamEntry::Record);
+
+    scratch.clear();
+    kind = SILCursor.readRecord(next.ID, scratch);
+    assert(kind == SIL_SPECIALIZE_ATTR && "Missing specialization attribute");
+    
+    unsigned NumSubstitutions;
+    SILSpecializeAttrLayout::readRecord(scratch, NumSubstitutions);
+
+    // Read the substitution list and construct a SILSpecializeAttr.
+    SmallVector<Substitution, 4> Substitutions;
+    while (NumSubstitutions--) {
+      auto sub = MF->maybeReadSubstitution(SILCursor);
+      assert(sub.hasValue() && "Missing substitution?");
+      Substitutions.push_back(*sub);
+    }
+    fn->addSpecializeAttr(SILSpecializeAttr::create(SILMod, Substitutions));
+  }
+
   GenericParamList *contextParams = nullptr;
   if (!declarationOnly) {
     // We need to construct a linked list of GenericParamList. The outermost
@@ -500,13 +522,13 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
   }
 
   NumDeserializedFunc++;
-  scratch.clear();
 
   assert(!(fn->getContextGenericParams() && !fn->empty())
          && "function already has context generic params?!");
   if (contextParams)
     fn->setContextGenericParams(contextParams);
 
+  scratch.clear();
   kind = SILCursor.readRecord(entry.ID, scratch);
 
   SILBasicBlock *CurrentBB = nullptr;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -142,6 +142,7 @@ namespace sil_block {
     SIL_DEFAULT_WITNESS_TABLE_NO_ENTRY,
     SIL_GENERIC_OUTER_PARAMS,
     SIL_INST_WITNESS_METHOD,
+    SIL_SPECIALIZE_ATTR,
 
     // We also share these layouts from the decls block. Their enumerators must
     // not overlap with ours.
@@ -245,9 +246,17 @@ namespace sil_block {
                      BCFixed<1>, // global_init
                      BCFixed<2>, // inlineStrategy
                      BCFixed<2>, // side effect info.
+                     BCFixed<2>, // number of specialize attributes
                      TypeIDField,
                      BCArray<IdentifierIDField> // Semantics Attribute
+                     // followed by specialize attributes
                      // followed by generic param list, if any
+                     >;
+
+  using SILSpecializeAttrLayout =
+      BCRecordLayout<SIL_SPECIALIZE_ATTR,
+                     BCFixed<5> // number of substitutions
+                     // followed by bound generic substitutions
                      >;
 
   // Has an optional argument list where each argument is a typed valueref.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -272,15 +272,25 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     Linkage = addExternalToLinkage(Linkage);
   }
 
+  unsigned numSpecAttrs = NoBody ? 0 : F.getSpecializeAttrs().size();
   SILFunctionLayout::emitRecord(
       Out, ScratchRecord, abbrCode, toStableSILLinkage(Linkage),
       (unsigned)F.isTransparent(), (unsigned)F.isFragile(),
       (unsigned)F.isThunk(), (unsigned)F.isGlobalInit(),
-      (unsigned)F.getInlineStrategy(), (unsigned)F.getEffectsKind(), FnID,
-      SemanticsIDs);
+      (unsigned)F.getInlineStrategy(), (unsigned)F.getEffectsKind(),
+      (unsigned)numSpecAttrs, FnID, SemanticsIDs);
 
   if (NoBody)
     return;
+
+  for (auto *SA : F.getSpecializeAttrs()) {
+    unsigned specAttrAbbrCode = SILAbbrCodes[SILSpecializeAttrLayout::Code];
+
+    auto subs = SA->getSubstitutions();
+    SILSpecializeAttrLayout::emitRecord(
+      Out, ScratchRecord, specAttrAbbrCode, (unsigned)subs.size());
+    S.writeSubstitutions(subs, SILAbbrCodes);
+  }
 
   // Write the body's context archetypes, unless we don't actually have a body.
   if (!F.isExternalDeclaration()) {
@@ -1702,6 +1712,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
 
   registerSILAbbr<SILInstCastLayout>();
   registerSILAbbr<SILInstWitnessMethodLayout>();
+  registerSILAbbr<SILSpecializeAttrLayout>();
 
   // Register the abbreviation codes so these layouts can exist in both
   // decl blocks and sil blocks.

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-silgen -emit-verbose-sil %s | FileCheck %s
+
+// CHECK-LABEL: @_specialize(Int, Float)
+// CHECK-NEXT: func specializeThis<T, U>(t: T, u: U)
+@_specialize(Int, Float)
+func specializeThis<T, U>(t: T, u: U) {}
+
+public protocol PP {
+  associatedtype PElt
+}
+public protocol QQ {
+  associatedtype QElt
+}
+
+public struct RR : PP {
+  public typealias PElt = Float
+}
+public struct SS : QQ {
+  public typealias QElt = Int
+}
+
+public struct GG<T : PP> {}
+
+// CHECK-LABEL: public class CC<T : PP> {
+// CHECK-NEXT: @_specialize(RR, SS)
+// CHECK-NEXT: @inline(never) public func foo<U : QQ>(u: U, g: GG<T>) -> (U, GG<T>)
+public class CC<T : PP> {
+  @inline(never)
+  @_specialize(RR, SS)
+  public func foo<U : QQ>(u: U, g: GG<T>) -> (U, GG<T>) {
+    return (u, g)
+  }
+}
+
+// CHECK-LABEL: sil hidden [_specialize <Int, Float>] @_TF15specialize_attr14specializeThisu0_rFTx1uq__T_ : $@convention(thin) <T, U> (@in T, @in U) -> () {
+
+// CHECK-LABEL: sil [noinline] [_specialize <RR, Float, SS, Int>] @_TFC15specialize_attr2CC3foouRd__S_2QQrfTqd__1gGVS_2GGx__Tqd__GS2_x__ : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -1,0 +1,371 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s | FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol AnElt {
+}
+
+public protocol HasElt {
+  associatedtype Elt
+  init(e: Elt)
+}
+
+struct X : AnElt {
+  @sil_stored var i: Int { get set }
+  init(i: Int)
+}
+
+struct S : HasElt {
+  typealias Elt = X
+  @sil_stored var e: X { get set }
+  init(e: Elt)
+}
+
+public struct G<Container : HasElt> {
+  public func getContainer(e: Container.Elt) -> Container
+  init()
+}
+
+// CHECK: @_specialize(S)
+// CHECK: public func getGenericContainer<T where T : HasElt, T.Elt : AnElt>(g: G<T>, e: T.Elt) -> T
+@_specialize(S)
+public func getGenericContainer<T where T : HasElt, T.Elt : AnElt>(g: G<T>, e: T.Elt) -> T
+
+enum ArithmeticError : ErrorProtocol {
+  case DivByZero
+  var hashValue: Int { get }
+  var _code: Int { get }
+}
+
+// CHECK: @_specialize(Int)
+// CHECK: public func divideNum<T : SignedInteger>(num: T, den: T) throws -> T
+@_specialize(Int)
+public func divideNum<T : SignedInteger>(num: T, den: T) throws -> T
+
+@inline(never) @_semantics("optimize.sil.never") func foo<T>(t: T) -> Int64
+
+// CHECK: @_specialize(Int64)
+// CHECK: @_specialize(Float)
+// CHECK: public func voidReturn<T>(t: T)
+@_specialize(Int64)
+@_specialize(Float)
+public func voidReturn<T>(t: T)
+
+// CHECK: @_specialize(Int64)
+// CHECK: @_specialize(Float)
+// CHECK: public func nonvoidReturn<T>(t: T) -> Int64
+@_specialize(Int64)
+@_specialize(Float)
+public func nonvoidReturn<T>(t: T) -> Int64
+
+// --- test: protocol conformance, substitution for dependent types
+// non-layout dependent generic arguments, emitUncheckedBitCast (non
+// address-type)
+
+sil_scope 19 { parent @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0 }
+sil_scope 20 { parent 19 }
+
+// Helper
+//
+// G.getContainer(A.Elt) -> A
+sil @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <Container where Container : HasElt> (@in Container.Elt, G<Container>) -> @out Container {
+bb0(%0 : $*Container, %1 : $*Container.Elt, %2 : $G<Container>):
+  %4 = witness_method $Container, #HasElt.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20 // user: %6
+  %5 = metatype $@thick Container.Type, scope 20 // user: %6
+  %6 = apply %4<Container, Container.Elt>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @thick τ_0_0.Type) -> @out τ_0_0, scope 20
+  %7 = tuple (), scope 20 // user: %8
+  return %7 : $(), scope 20 // id: %8
+}
+
+sil_scope 5 { parent @_TF16eager_specialize19getGenericContaineruRxS_6HasEltwx3EltS_5AnEltrFTGVS_1Gx_1ewxS1__x : $@convention(thin) <τ_0_0 where τ_0_0 : HasElt, τ_0_0.Elt : AnElt> (G<τ_0_0>, @in τ_0_0.Elt) -> @out τ_0_0 }
+sil_scope 6 { parent 5 }
+
+// getGenericContainer<A where ...> (G<A>, e : A.Elt) -> A
+sil [_specialize <S, X>] @_TF16eager_specialize19getGenericContaineruRxS_6HasEltwx3EltS_5AnEltrFTGVS_1Gx_1ewxS1__x : $@convention(thin) <T where T : HasElt, T.Elt : AnElt> (G<T>, @in T.Elt) -> @out T {
+bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
+  // function_ref G.getContainer(A.Elt) -> A
+  %5 = function_ref @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6 // user: %6
+  %6 = apply %5<T, T.Elt>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0, scope 6
+  %7 = tuple (), scope 6 // user: %8
+  return %7 : $(), scope 6 // id: %8
+}
+
+// Specialization getGenericContainer<S, X>
+//
+// CHECK-LABEL: sil shared @_TTSg5V4main1SS0_S_6HasEltS__VS_1XS2_S_5AnEltS____TF16eager_specialize19getGenericContaineruRxS_6HasEltwx3EltS_5AnEltrFTGVS_1Gx_1ewxS1__x : $@convention(thin) (G<S>, X) -> S {
+// CHECK: bb0(%0 : $G<S>, %1 : $X):
+// CHECK:   return %{{.*}} : $S
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+//
+// CHECK-LABEL: sil @_TF16eager_specialize19getGenericContaineruRxS_6HasEltwx3EltS_5AnEltrFTGVS_1Gx_1ewxS1__x : $@convention(thin) <T where T : HasElt, T.Elt : AnElt> (G<T>, @in T.Elt) -> @out T {
+// CHECK: bb0(%0 : $*T, %1 : $G<T>, %2 : $*T.Elt):
+// CHECK:   %3 = metatype $@thick T.Type
+// CHECK:   %4 = metatype $@thick S.Type
+// CHECK:   %5 = unchecked_bitwise_cast %3 : $@thick T.Type to $Builtin.Word
+// CHECK:   %6 = unchecked_bitwise_cast %4 : $@thick S.Type to $Builtin.Word
+// CHECK:   %7 = builtin "cmp_eq_Word"(%5 : $Builtin.Word, %6 : $Builtin.Word) : $Builtin.Int1
+// CHECK:   cond_br %7, bb3, bb1
+
+// CHECK: bb1:                                              // Preds: bb0
+// CHECK:   %9 = function_ref @_TFV16eager_specialize1G12getContainerfwx3Eltx : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
+// CHECK:   %10 = apply %9<T, T.Elt>(%0, %2, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, G<τ_0_0>) -> @out τ_0_0
+// CHECK:   br bb2
+
+// CHECK: bb2:                                              // Preds: bb1 bb3
+// CHECK:   %12 = tuple ()
+// CHECK:   return %12 : $()
+
+// CHECK: bb3:                                              // Preds: bb0
+// CHECK:   %14 = unchecked_addr_cast %0 : $*T to $*S
+// CHECK:   %15 = unchecked_trivial_bit_cast %1 : $G<T> to $G<S>
+// CHECK:   %16 = unchecked_addr_cast %2 : $*T.Elt to $*X
+// CHECK:   %17 = load %16 : $*X
+  // function_ref specialized getGenericContainer<A where ...> (G<A>, e : A.Elt) -> A
+// CHECK:   %18 = function_ref @_TTSg5V4main1SS0_S_6HasEltS__VS_1XS2_S_5AnEltS____TF16eager_specialize19getGenericContaineruRxS_6HasEltwx3EltS_5AnEltrFTGVS_1Gx_1ewxS1__x : $@convention(thin) (G<S>, X) -> S
+// CHECK:   %19 = apply %18(%15, %17) : $@convention(thin) (G<S>, X) -> S
+// CHECK:   store %19 to %14 : $*S
+// CHECK:   %21 = tuple ()
+// CHECK:   %22 = unchecked_trivial_bit_cast %21 : $() to $()
+// CHECK:   br bb2
+
+sil_scope 9 { parent @_TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) <τ_0_0 where τ_0_0 : SignedInteger, τ_0_0.Distance : _SignedInteger, τ_0_0.Distance.IntegerLiteralType : _BuiltinIntegerLiteralConvertible, τ_0_0.IntegerLiteralType : _BuiltinIntegerLiteralConvertible, τ_0_0.Stride : SignedNumber, τ_0_0.Stride.IntegerLiteralType : _BuiltinIntegerLiteralConvertible> (@in τ_0_0, @in τ_0_0) -> (@out τ_0_0, @error ErrorProtocol) }
+sil_scope 10 { parent 9 }
+sil_scope 11 { parent 10 }
+
+// --- test: rethrow
+
+sil_scope 181 {  parent @_TZFsoi2neuRxs9EquatablerFTxx_Sb : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool }
+
+// Helper
+//
+// static != infix<A where ...> (A, A) -> Bool
+sil public_external [fragile] @_TZFsoi2neuRxs9EquatablerFTxx_Sb : $@convention(thin) <T where T : Equatable> (@in T, @in T) -> Bool {
+// %0                                             // users: %2, %6
+// %1                                             // users: %3, %6
+bb0(%0 : $*T, %1 : $*T):
+  %4 = witness_method $T, #Equatable."=="!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool, scope 181 // user: %6
+  %5 = metatype $@thick T.Type, scope 181         // user: %6
+  %6 = apply %4<T>(%0, %1, %5) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool, scope 181 // user: %7
+  %7 = struct_extract %6 : $Bool, #Bool._value, scope 181 // user: %9
+  %8 = integer_literal $Builtin.Int1, -1, scope 181 // user: %9
+  %9 = builtin "xor_Int1"(%7 : $Builtin.Int1, %8 : $Builtin.Int1) : $Builtin.Int1, scope 181 // user: %10
+  %10 = struct $Bool (%9 : $Builtin.Int1), scope 181 // user: %11
+  return %10 : $Bool, scope 181                   // id: %11
+}
+
+// divideNum<A where ...> (A, den : A) throws -> A
+sil [_specialize <Int, Int, Int, Int, Int, Int, Int>] @_TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) <T where T : SignedInteger, T.Distance : _SignedInteger, T.Distance.IntegerLiteralType : _BuiltinIntegerLiteralConvertible, T.IntegerLiteralType : _BuiltinIntegerLiteralConvertible, T.Stride : SignedNumber, T.Stride.IntegerLiteralType : _BuiltinIntegerLiteralConvertible> (@in T, @in T) -> (@out T, @error ErrorProtocol) {
+// %0                                             // user: %19
+// %1                                             // users: %3, %19, %23
+// %2                                             // users: %4, %7, %19, %22
+bb0(%0 : $*T, %1 : $*T, %2 : $*T):
+  // function_ref static != infix<A where ...> (A, A) -> Bool
+  %5 = function_ref @_TZFsoi2neuRxs9EquatablerFTxx_Sb : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool, scope 10 // user: %13
+  %6 = alloc_stack $T, scope 10 // users: %7, %13, %16
+  copy_addr %2 to [initialization] %6 : $*T, scope 10 // id: %7
+  %8 = witness_method $T, #_BuiltinIntegerLiteralConvertible.init!allocator.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : _BuiltinIntegerLiteralConvertible> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0, scope 10 // user: %12
+  %9 = metatype $@thick T.Type, scope 10 // users: %12, %19
+  %10 = integer_literal $Builtin.Int2048, 0, scope 10 // user: %12
+  %11 = alloc_stack $T, scope 10 // users: %12, %13, %15
+  %12 = apply %8<T>(%11, %10, %9) : $@convention(witness_method) <τ_0_0 where τ_0_0 : _BuiltinIntegerLiteralConvertible> (Builtin.Int2048, @thick τ_0_0.Type) -> @out τ_0_0, scope 10
+  %13 = apply %5<T>(%6, %11) : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool, scope 10 // user: %14
+  %14 = struct_extract %13 : $Bool, #Bool._value, scope 10 // user: %17
+  dealloc_stack %11 : $*T, scope 10 // id: %15
+  dealloc_stack %6 : $*T, scope 10 // id: %16
+  cond_br %14, bb2, bb1, scope 10 // id: %17
+
+bb1:                                              // Preds: bb0
+  destroy_addr %2 : $*T, scope 10 // id: %22
+  destroy_addr %1 : $*T, scope 10 // id: %23
+  %24 = alloc_existential_box $ErrorProtocol, $ArithmeticError, scope 11 // users: %25, %28
+  %25 = project_existential_box $ArithmeticError in %24 : $ErrorProtocol, scope 11 // user: %27
+  %26 = enum $ArithmeticError, #ArithmeticError.DivByZero!enumelt, scope 11 // user: %27
+  store %26 to %25 : $*ArithmeticError, scope 11 // id: %27
+  throw %24 : $ErrorProtocol, scope 10 // id: %28
+
+bb2:                                              // Preds: bb0
+  %18 = witness_method $T, #IntegerArithmetic."/"!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0, scope 10 // user: %19
+  %19 = apply %18<T>(%0, %1, %2, %9) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0, scope 10
+  %20 = tuple (), scope 10 // user: %21
+  return %20 : $(), scope 10 // id: %21
+}
+
+// specialized divideNum<A where ...> (A, den : A) throws -> A
+// CHECK-LABEL: sil shared @_TTSg5SiSis13SignedIntegers_SiSis14_SignedIntegers_SiSis33_BuiltinIntegerLiteralConvertibles_SiSiS1_s_SiSis12SignedNumbers_SiSiS1_s_Si___TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) (Int, Int) -> (Int, @error ErrorProtocol) {
+// CHECK: bb0(%0 : $Int, %1 : $Int):
+// CHECK: return %{{.*}}
+// CHECK: throw %{{.*}}
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+// 
+// CHECK-LABEL: sil @_TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) <T where T : SignedInteger, T.Distance : _SignedInteger, T.Distance.IntegerLiteralType : _BuiltinIntegerLiteralConvertible, T.IntegerLiteralType : _BuiltinIntegerLiteralConvertible, T.Stride : SignedNumber, T.Stride.IntegerLiteralType : _BuiltinIntegerLiteralConvertible> (@in T, @in T) -> (@out T, @error ErrorProtocol) {
+// CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T):
+// CHECK:   %3 = metatype $@thick T.Type
+// CHECK:   %4 = metatype $@thick Int.Type
+// CHECK:   %5 = unchecked_bitwise_cast %3 : $@thick T.Type to $Builtin.Word
+// CHECK:   %6 = unchecked_bitwise_cast %4 : $@thick Int.Type to $Builtin.Word
+// CHECK:   %7 = builtin "cmp_eq_Word"(%5 : $Builtin.Word, %6 : $Builtin.Word) : $Builtin.Int1
+// CHECK:   cond_br %7, bb6, bb1
+
+// CHECK: bb1:                                              // Preds: bb0
+// CHECK:   // function_ref static != infix<A where ...> (A, A) -> Bool
+// CHECK:   cond_br %{{.*}}, bb4, bb2
+
+// CHECK: bb2:                                              // Preds: bb1
+// CHECK:   br bb3(%{{.*}} : $ErrorProtocol)
+
+// CHECK: bb3(%{{.*}} : $ErrorProtocol):                        // Preds: bb2 bb7
+// CHECK:   throw %{{.*}} : $ErrorProtocol
+
+// CHECK: bb4:                                              // Preds: bb1
+// CHECK:   %{{.*}} = witness_method $T, #IntegerArithmetic."/"!1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   apply %{{.*}}<T>({{.*}}) : $@convention(witness_method) <τ_0_0 where τ_0_0 : IntegerArithmetic> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+// CHECK:   br bb5
+
+// CHECK: bb5:                                              // Preds: bb4 bb8
+// CHECK:   %{{.*}} = tuple ()
+// CHECK:   return %{{.*}} : $()
+
+// CHECK: bb6:                                              // Preds: bb0
+// CHECK:   %{{.*}} = unchecked_addr_cast %0 : $*T to $*Int
+// CHECK:   %{{.*}} = unchecked_addr_cast %1 : $*T to $*Int
+// CHECK:   %{{.*}} = load %{{.*}} : $*Int
+// CHECK:   %{{.*}} = unchecked_addr_cast %2 : $*T to $*Int
+// CHECK:   %{{.*}} = load %{{.*}} : $*Int
+// CHECK:   // function_ref specialized divideNum<A where ...> (A, den : A) throws -> A
+// CHECK:   %{{.*}} = function_ref @_TTSg5SiSis13SignedIntegers_SiSis14_SignedIntegers_SiSis33_BuiltinIntegerLiteralConvertibles_SiSiS1_s_SiSis12SignedNumbers_SiSiS1_s_Si___TF16eager_specialize9divideNumuRxs13SignedIntegerrFzTx3denx_x : $@convention(thin) (Int, Int) -> (Int, @error ErrorProtocol)
+// CHECK:   try_apply %{{.*}}(%{{.*}}, %{{.*}}) : $@convention(thin) (Int, Int) -> (Int, @error ErrorProtocol), normal bb8, error bb7
+
+// CHECK: bb7(%{{.*}} : $ErrorProtocol):                        // Preds: bb6
+// CHECK:   %{{.*}} = builtin "willThrow"(%{{.*}} : $ErrorProtocol) : $()
+// CHECK:   br bb3(%{{.*}} : $ErrorProtocol)
+
+// CHECK: bb8(%{{.*}} : $Int):                                  // Preds: bb6
+// CHECK:   store %{{.*}} to %{{.*}} : $*Int
+// CHECK:   %{{.*}} = tuple ()
+// CHECK:   %{{.*}} = unchecked_trivial_bit_cast %{{.*}} : $() to $()
+// CHECK:   br bb5
+
+// --- test: multiple void and non-void return values
+
+sil_scope 7 { parent @_TF16eager_specialize3foourFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
+sil_scope 8 { parent 7 }
+
+// foo<A> (A) -> Int64
+sil hidden [noinline] [_semantics "optimize.sil.never"] @_TF16eager_specialize3foourFxVs5Int64 : $@convention(thin) <T> (@in T) -> Int64 {
+// %0                                             // users: %1, %4
+bb0(%0 : $*T):
+  %2 = integer_literal $Builtin.Int64, 3, scope 8 // user: %3
+  %3 = struct $Int64 (%2 : $Builtin.Int64), scope 8 // user: %5
+  destroy_addr %0 : $*T, scope 8 // id: %4
+  return %3 : $Int64, scope 8 // id: %5
+}
+
+sil_scope 1 { parent @_TF16eager_specialize10voidReturnurFxT_ : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () }
+sil_scope 2 { parent 1 }
+
+// voidReturn<A> (A) -> ()
+sil [_specialize <Float>] [_specialize <Int64>] @_TF16eager_specialize10voidReturnurFxT_ : $@convention(thin) <T> (@in T) -> () {
+bb0(%0 : $*T):
+  // function_ref foo<A> (A) -> Int64
+  %2 = function_ref @_TF16eager_specialize3foourFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 2 // user: %3
+  %3 = apply %2<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 2
+  %4 = tuple (), scope 2 // user: %5
+  return %4 : $(), scope 2 // id: %5
+}
+
+// CHECK-LABEL: // specialized voidReturn<A> (A) -> ()
+// CHECK: sil shared @_TTSg5Sf___TF16eager_specialize10voidReturnurFxT_ : $@convention(thin) (Float) -> () {
+// %0                                             // user: %2
+// CHECK: bb0(%0 : $Float):
+// CHECK:   return %5 : $()
+
+// CHECK-LABEL: // specialized voidReturn<A> (A) -> ()
+// CHECK: sil shared @_TTSg5Vs5Int64___TF16eager_specialize10voidReturnurFxT_ : $@convention(thin) (Int64) -> () {
+// CHECK: bb0(%0 : $Int64):
+// CHECK:   return %5 : $()
+
+// Generic with specialized dispatch. No more [specialize] attribute.
+//
+// CHECK-LABEL: // voidReturn<A> (A) -> ()
+// CHECK: sil @_TF16eager_specialize10voidReturnurFxT_ : $@convention(thin) <T> (@in T) -> () {
+// CHECK: bb0(%0 : $*T):
+// CHECK:  builtin "cmp_eq_Word"
+// CHECK:   cond_br %5, bb5, bb1
+
+// CHECK: bb1:                                              // Preds: bb0
+// CHECK:   builtin "cmp_eq_Word"
+// CHECK:   cond_br %11, bb4, bb2
+
+// CHECK: bb2:                                              // Preds: bb1
+// CHECK:   function_ref @_TF16eager_specialize3foourFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+// CHECK:   apply %13<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+// CHECK:   br bb3
+
+// CHECK: bb3:                                              // Preds: bb2 bb4 bb5
+// CHECK:   tuple ()
+// CHECK:   return
+
+// CHECK: bb4:                                              // Preds: bb1
+// CHECK:   function_ref @_TTSg5Sf___TF16eager_specialize10voidReturnurFxT_ : $@convention(thin) (Float) -> ()
+// CHECK:   br bb3
+
+// CHECK: bb5:                                              // Preds: bb0
+// CHECK:   br bb3
+
+sil_scope 3 { parent @_TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
+sil_scope 4 { parent 3 }
+
+// nonvoidReturn<A> (A) -> Int64
+sil [_specialize <Float>] [_specialize <Int64>] @_TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) <T> (@in T) -> Int64 {
+// %0                                             // users: %1, %3
+bb0(%0 : $*T):
+  // function_ref foo<A> (A) -> Int64
+  %2 = function_ref @_TF16eager_specialize3foourFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 4 // user: %3
+  %3 = apply %2<T>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64, scope 4 // user: %4
+  return %3 : $Int64, scope 4 // id: %4
+}
+
+// CHECK-LABEL: // specialized nonvoidReturn<A> (A) -> Int64
+// CHECK: sil shared @_TTSg5Sf___TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) (Float) -> Int64 {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   return %4 : $Int64
+
+// CHECK-LABEL: // specialized nonvoidReturn<A> (A) -> Int64
+// CHECK: sil shared @_TTSg5Vs5Int64___TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) (Int64) -> Int64 {
+// CHECK: bb0(%0 : $Int64):
+// CHECK:   return %4 : $Int64
+
+sil_scope 35 { loc "/s/s/swift/test/SILOptimizer/eager_specialize.sil":190:22 parent @_TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
+sil_scope 36 {  parent @_TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64 }
+sil_scope 37 {  parent 36 }
+
+// CHECK-LABEL: // nonvoidReturn<A> (A) -> Int64
+// CHECK: sil @_TF16eager_specialize13nonvoidReturnurFxVs5Int64 : $@convention(thin) <T> (@in T) -> Int64 {
+// CHECK: bb0(%0 : $*T):
+// CHECK:   builtin "cmp_eq_Word"
+// CHECK:   cond_br %{{.*}}, bb5, bb1
+
+// CHECK: bb1:                                              // Preds: bb0
+// CHECK:   builtin "cmp_eq_Word"
+// CHECK:   cond_br %{{.*}}, bb4, bb2
+
+// CHECK: bb2:                                              // Preds: bb1
+// CHECK:   // function_ref foo<A> (A) -> Int64
+// CHECK:   function_ref @_TF16eager_specialize3foourFxVs5Int64 : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int64
+// CHECK:   apply %13<T>
+// CHECK:   br bb3(%{{.*}} : $Int64)
+
+// CHECK: bb3(%{{.*}} : $Int64):                                  // Preds: bb2 bb4 bb5
+// CHECK:   return %{{.*}} : $Int64
+
+// CHECK: bb4:                                              // Preds: bb1
+// CHECK:   br bb3(%{{.*}} : $Int64)
+
+// CHECK: bb5:                                              // Preds: bb0
+// CHECK:   br bb3(%{{.*}} : $Int64)

--- a/test/Serialization/semantics.swift
+++ b/test/Serialization/semantics.swift
@@ -1,8 +1,0 @@
-// RUN: rm -rf %t
-// RUN: mkdir %t
-// RUN: %target-swift-frontend %s -emit-module -parse-as-library -o %t
-// RUN: %target-sil-opt -enable-sil-verify-all %t/semantics.swiftmodule -o - | FileCheck %s
-
-//CHECK: @_semantics("crazy") func foo()
-@_semantics("crazy") func foo() -> Int  { return 5}
-

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -1,0 +1,57 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %target-swift-frontend -emit-module -parse-as-library -sil-serialize-all -o %t %s
+// RUN: llvm-bcanalyzer %t/serialize_attr.swiftmodule | FileCheck %s -check-prefix=BCANALYZER
+// RUN: %target-sil-opt -enable-sil-verify-all %t/serialize_attr.swiftmodule | FileCheck %s
+
+// BCANALYZER-NOT: UnknownCode
+
+// @_semantics
+// -----------------------------------------------------------------------------
+
+//CHECK-DAG: @_semantics("crazy") func foo()
+@_semantics("crazy") func foo() -> Int  { return 5}
+
+// @_specialize
+// -----------------------------------------------------------------------------
+
+// These lines should be contiguous.
+// CHECK-DAG: @_specialize(Int, Float)
+// CHECK-DAG: func specializeThis<T, U>(t: T, u: U)
+@_specialize(Int, Float)
+func specializeThis<T, U>(t: T, u: U) {}
+
+protocol PP {
+  associatedtype PElt
+}
+protocol QQ {
+  associatedtype QElt
+}
+
+struct RR : PP {
+  typealias PElt = Float
+}
+struct SS : QQ {
+  typealias QElt = Int
+}
+
+struct GG<T : PP> {}
+
+// These three lines should be contiguous, however, there is no way to
+// sequence FileCheck directives while using CHECK-DAG as the outer
+// label, and the declaration order is unpredictable.
+//
+// CHECK-DAG: class CC<T : PP> {
+// CHECK-DAG: @_specialize(RR, SS)
+// CHECK-DAG: @inline(never) func foo<U : QQ>(u: U, g: GG<T>) -> (U, GG<T>)
+class CC<T : PP> {
+  @inline(never)
+  @_specialize(RR, SS)
+  func foo<U : QQ>(u: U, g: GG<T>) -> (U, GG<T>) {
+    return (u, g)
+  }
+}
+
+// CHECK-DAG: sil hidden [fragile] [_specialize <Int, Float>] @_TF14serialize_attr14specializeThisu0_rFTx1uq__T_ : $@convention(thin) <T, U> (@in T, @in U) -> () {
+
+// CHECK-DAG: sil hidden [fragile] [noinline] [_specialize <RR, Float, SS, Int>] @_TFC14serialize_attr2CC3foouRd__S_2QQrfTqd__1gGVS_2GGx__Tqd__GS2_x__ : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -1,0 +1,77 @@
+// RUN: %target-parse-verify-swift
+// RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module | FileCheck %s
+
+struct S<T> {}
+
+// Specialize freestanding functions with the correct number of concrete types.
+// ----------------------------------------------------------------------------
+
+// CHECK: @_specialize(Int)
+@_specialize(Int)
+// CHECK: @_specialize(S<Int>)
+@_specialize(S<Int>)
+@_specialize(Int, Int) // expected-error{{generic type 'oneGenericParam' specialized with too many type parameters (got 2, but expected 1)}},
+@_specialize(T) // expected-error{{use of undeclared type 'T'}}
+public func oneGenericParam<T>(t: T) -> T {
+  return t
+}
+
+// CHECK: @_specialize(Int, Int)
+@_specialize(Int, Int)
+@_specialize(Int) // expected-error{{generic type 'twoGenericParams' specialized with too few type parameters (got 1, but expected 2)}},
+public func twoGenericParams<T, U>(t: T, u: U) -> (T, U) {
+  return (t, u)
+}
+
+// Specialize contextual types.
+// ----------------------------
+
+class G<T> {
+  // CHECK: @_specialize(Int)
+  @_specialize(Int)
+  @_specialize(T) // expected-error{{cannot partially specialize a generic function}}
+  @_specialize(S<T>) // expected-error{{cannot partially specialize a generic function}}
+  @_specialize(Int, Int) // expected-error{{generic type 'noGenericParams' specialized with too many type parameters (got 2, but expected 1)}}
+  func noGenericParams() {}
+
+  // CHECK: @_specialize(Int, Float)
+  @_specialize(Int, Float)
+  // CHECK: @_specialize(Int, S<Int>)
+  @_specialize(Int, S<Int>)
+  @_specialize(Int) // expected-error{{generic type 'oneGenericParam' specialized with too few type parameters (got 1, but expected 2)}},
+  func oneGenericParam<U>(t: T, u: U) -> (U, T) {
+    return (u, t)
+  }
+}
+
+// Specialize with requirements.
+// -----------------------------
+
+protocol Thing {}
+
+struct AThing : Thing {}
+
+// CHECK: @_specialize(AThing)
+@_specialize(AThing)
+@_specialize(Int) // expected-error{{argument type 'Int' does not conform to expected type 'Thing'}}
+func oneRequirement<T : Thing>(t: T) {}
+
+protocol HasElt {
+  associatedtype Element
+}
+struct IntElement : HasElt {
+  typealias Element = Int
+}
+struct FloatElement : HasElt {
+  typealias Element = Float
+}
+@_specialize(FloatElement)
+@_specialize(IntElement) // expected-error{{'<T : HasElt where T.Element == Float> (T) -> ()' (aka '<T : HasElt where T.Element == Float> T -> ()') requires the types 'Element' (aka 'Int') and 'Float' be equivalent}}
+func sameTypeRequirement<T : HasElt where T.Element == Float>(t: T) {}
+
+class Base {}
+class Sub : Base {}
+class NonSub {}
+@_specialize(Sub)
+@_specialize(NonSub) // expected-error{{'<T : Base> (T) -> ()' (aka '<T : Base> T -> ()') requires that 'NonSub' inherit from 'Base'}}
+func superTypeRequirement<T : Base>(t: T) {}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### Introduces an @_specialize(...) function attribute.

<!-- Description about pull request. -->

An internal @_specialize function attribute allows developers to force
full specialization by listing concrete type names corresponding to the
function's generic signature. A function's generic signature is a
concatenation of its generic context and the function's own generic
type parameters.

```
  struct S<T> {
    var x: T
    @_specialize(Int, Float)
    mutating func exchangeSecond<U>(u: U, _ t: T) -> (U, T) {
      x = t
      return (u, x)
    }
  }

  // Substitutes: <T, U> with <Int, Float> producing:
  // S<Int>::exchangeSecond<Float>(u: Float, t: Int) -> (Float, Int)

```

@_specialize currently acts as a hint to the optimizer, which
generates type checks and code to dispatch to the specialized routine
without affecting the signature of the generic function. The
intention is to support efforts at evaluating the performance of
specialized code. The performance impact is not guaranteed and is
likely to change with the optimizer. This attribute should only be
used in conjunction with rigorous performance analysis. Eventually,
a similar attribute could be defined in the language, allowing it to be
exposed as part of a function's API. That would allow direct dispatch
to specialized code without type checks, even across modules.

In the future, we can build on this work in several ways:
- cross module dispatch directly to specialized code
- dynamic dispatch directly to specialized code
- automated specialization based on broader hints
- partial specialization
- and so on...

<!-- This selection should only be completed by Swift admin -->

@swift-ci Please test
