### PR TITLE
build: install swift-autolink-extract always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ set(SWIFT_ENABLE_GOLD_LINKER FALSE CACHE BOOL
     "Enable using the gold linker when available")
 
 set(_SWIFT_KNOWN_INSTALL_COMPONENTS
-    "compiler;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;stdlib;stdlib-experimental;sdk-overlay;editor-integration;tools;testsuite-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc")
+    "autolink-driver;compiler;clang-builtin-headers;clang-resource-dir-symlink;clang-builtin-headers-in-clang-resource-dir;stdlib;stdlib-experimental;sdk-overlay;editor-integration;tools;testsuite-tools;dev;license;sourcekit-xpc-service;sourcekit-inproc")
 
 # Set the SWIFT_INSTALL_COMPONENTS variable to the default value if it is not passed in via -D
 set(SWIFT_INSTALL_COMPONENTS "${_SWIFT_KNOWN_INSTALL_COMPONENTS}" CACHE STRING
@@ -91,6 +91,7 @@ set(SWIFT_INSTALL_COMPONENTS "${_SWIFT_KNOWN_INSTALL_COMPONENTS}" CACHE STRING
 # components would approximately correspond to packages in a Debian-style Linux
 # packaging.  The following components are defined:
 #
+# * autolink-driver -- the Swift driver support tools
 # * compiler -- the Swift compiler and (on supported platforms) the REPL.
 # * clang-builtin-headers -- install a copy of Clang builtin headers under
 #   'lib/swift/clang'.  This is useful when Swift compiler is installed in

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -52,10 +52,6 @@ swift_install_in_component(compiler
 swift_install_in_component(compiler
     FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc"
     DESTINATION "bin")
-
-if(SWIFT_HOST_VARIANT STREQUAL "linux")
-# No need for this on other platforms.
-  swift_install_in_component(compiler
-      FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract"
-      DESTINATION "bin")
-endif()
+swift_install_in_component(autolink-driver
+    FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract"
+    DESTINATION "bin")

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -578,7 +578,7 @@ install-llbuild
 install-swiftpm
 install-xctest
 install-prefix=/usr
-swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;license
 build-swift-static-stdlib
 build-swift-stdlib-unittest-extra
 skip-test-lldb
@@ -636,7 +636,7 @@ install-foundation
 install-swiftpm
 install-xctest
 install-prefix=/usr
-swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;dev
+swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;dev
 build-swift-static-stdlib
 skip-test-lldb
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

swift supports cross-compilation.  The autolink extract tool is needed when
targeting non-Darwin targets even on Darwin.  Always install it.
