### PR TITLE
[gardening] Fix recently introduced typos: "fucntion" → "function", "functio" → "function", "mergable" → "mergeable", "mistmatched" → "mismatched"

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -72,8 +72,8 @@ public:
 
   enum class MergeGroupKind : char {
     All,
-    MergableWithTypeDef,
-    UnmergableWithTypeDef,
+    MergeableWithTypeDef,
+    UnmergeableWithTypeDef,
   };
 
   void forEachExtensionMergeGroup(MergeGroupKind Kind,

--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -121,7 +121,7 @@ namespace swift {
     /// know that this function is a dead function and going to be deleted from
     /// the module.
     virtual void invalidateForDeadFunction(SILFunction *F, InvalidationKind K) {
-      // Call the normal invaldate fucntion unless overridden by specific
+      // Call the normal invalidate function unless overridden by specific
       // analysis.
       invalidate(F, K);
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -263,14 +263,14 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       Requirements.insert({First, Second, Kind});
     }
     bool operator== (const ExtensionMergeInfo& Another) const {
-      // Trivially unmergable.
+      // Trivially unmergeable.
       if (HasDocComment || Another.HasDocComment)
         return false;
       if (InheritsCount != 0 || Another.InheritsCount != 0)
         return false;
       return Requirements == Another.Requirements;
     }
-    bool isMergableWithTypeDef() {
+    bool isMergeableWithTypeDef() {
       return !HasDocComment && InheritsCount == 0 && Requirements.empty();
     }
   };
@@ -286,11 +286,11 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     ExtensionMergeGroup(SynthesizedExtensionInfo *Info,
                         unsigned RequirementsCount,
                         unsigned InheritanceCount,
-                        bool MergableWithType) :
+                        bool MergeableWithType) :
       InheritanceCount(InheritanceCount),
       RequirementsCount(RequirementsCount),
-      Kind(MergableWithType ? MergeGroupKind::MergableWithTypeDef :
-                              MergeGroupKind::UnmergableWithTypeDef) {
+      Kind(MergeableWithType ? MergeGroupKind::MergeableWithTypeDef :
+                               MergeGroupKind::UnmergeableWithTypeDef) {
       Members.push_back(Info);
     }
 
@@ -470,7 +470,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
         Results.push_back({&ExtInfo,
                           (unsigned)MergeInfo.Requirements.size(),
                           MergeInfo.InheritsCount,
-                          MergeInfo.isMergableWithTypeDef()});
+                          MergeInfo.isMergeableWithTypeDef()});
       } else {
         Found->Members.push_back(&ExtInfo);
       }

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -437,7 +437,7 @@ void swift::ide::printSubmoduleInterface(
         pAnalyzer.reset(new SynthesizedExtensionAnalyzer(NTD, AdjustedOptions));
         AdjustedOptions.BracketOptions.shouldCloseNominal =
           !pAnalyzer->hasMergeGroup(SynthesizedExtensionAnalyzer::
-                                    MergeGroupKind::MergableWithTypeDef);
+                                    MergeGroupKind::MergeableWithTypeDef);
       }
     }
     if (D->print(Printer, AdjustedOptions)) {
@@ -482,7 +482,7 @@ void swift::ide::printSubmoduleInterface(
           if (IsTopLevelDecl) {
           // Print the part that should be merged with the type decl.
           pAnalyzer->forEachExtensionMergeGroup(
-            SynthesizedExtensionAnalyzer::MergeGroupKind::MergableWithTypeDef,
+            SynthesizedExtensionAnalyzer::MergeGroupKind::MergeableWithTypeDef,
             [&](ArrayRef<ExtensionAndIsSynthesized> Decls){
               for (auto ET : Decls) {
                 AdjustedOptions.BracketOptions.shouldOpenExtension = false;
@@ -508,10 +508,10 @@ void swift::ide::printSubmoduleInterface(
 
           // Print the rest as synthesized extensions.
           pAnalyzer->forEachExtensionMergeGroup(
-            // For top-level decls, only contraint extensions are to print;
+            // For top-level decls, only constraint extensions are to print;
             // Since the rest are merged into the main body.
             IsTopLevelDecl ?
-              SynthesizedExtensionAnalyzer::MergeGroupKind::UnmergableWithTypeDef :
+              SynthesizedExtensionAnalyzer::MergeGroupKind::UnmergeableWithTypeDef :
             // For sub-decls, all extensions should be printed.
               SynthesizedExtensionAnalyzer::MergeGroupKind::All,
             [&](ArrayRef<ExtensionAndIsSynthesized> Decls){

--- a/lib/SILOptimizer/UtilityPasses/CallerAnalysisPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/CallerAnalysisPrinter.cpp
@@ -1,4 +1,4 @@
-//===--- CallerAnalysisPrinter.cpp - Caller Analysis test  pass -----------===//
+//===--- CallerAnalysisPrinter.cpp - Caller Analysis test pass ------------===//
 //
 // This source file is part of the Swift.org open source project
 //


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix recently introduced typos: "fucntion" → "function", "functio" → "function", "mergable" → "mergeable" and "mistmatched" → "mismatched".
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
