### PR TITLE
[FreeBSD] Rename .memory to .pointee in Glibc

### DIFF
--- a/stdlib/public/Glibc/Glibc.swift
+++ b/stdlib/public/Glibc/Glibc.swift
@@ -228,6 +228,6 @@ func _swift_FreeBSD_getEnv(
 ) -> UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<CChar>>>
 
 public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>> {
-  return _swift_FreeBSD_getEnv().memory
+  return _swift_FreeBSD_getEnv().pointee
 }
 #endif


### PR DESCRIPTION
#### What's in this pull request?

.memory was renamed to .pointee but one instance was missed in Glibc due to being behind #if.

This partially fixes the build for FreeBSD.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))
## 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

.memory was renamed to .pointee but one location was missed, renaming to fix the build for FreeBSD
