### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::getGenericSignature(…)

### DIFF
--- a/validation-test/compiler_crashers/28277-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers/28277-swift-archetypebuilder-getgenericsignature.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+protocol A{
+func<typealias e=b
+typealias e typealias b


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/TinyPtrVector.h:182: EltTy llvm::TinyPtrVector<swift::ArchetypeBuilder::PotentialArchetype *>::front() const [EltTy = swift::ArchetypeBuilder::PotentialArchetype *]: Assertion `!empty() && "vector empty"' failed.
10 swift           0x0000000000f78281 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 1089
11 swift           0x0000000000e885f7 swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 359
16 swift           0x0000000000e52296 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
19 swift           0x0000000000eb203a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
20 swift           0x0000000000edc00c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
21 swift           0x0000000000e401aa swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
23 swift           0x0000000000eb2186 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
24 swift           0x0000000000e755bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1117
25 swift           0x0000000000cc6e2f swift::CompilerInstance::performSema() + 3087
27 swift           0x000000000078d17c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
28 swift           0x0000000000787c45 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28277-swift-archetypebuilder-getgenericsignature.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28277-swift-archetypebuilder-getgenericsignature-82990f.o
1.  While type-checking expression at [validation-test/compiler_crashers/28277-swift-archetypebuilder-getgenericsignature.swift:10:1 - line:13:23] RangeText="{
2.  While type-checking 'A' at validation-test/compiler_crashers/28277-swift-archetypebuilder-getgenericsignature.swift:11:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
