### PR TITLE
Implement a function signature cloner and rewriter.

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -772,6 +772,8 @@ public:
   NullablePtr<SILInstruction> createProjection(SILBuilder &B, SILLocation Loc,
                                                SILValue Arg) const;
 
+  std::string getNameEncoding(const ProjectionTree &PT) const;
+
   SILInstruction *
   createAggregate(SILBuilder &B, SILLocation Loc,
                   ArrayRef<SILValue> Args) const;
@@ -845,6 +847,9 @@ public:
   /// Compute liveness and use information in this projection tree using Base.
   /// All debug instructions (debug_value, debug_value_addr) are ignored.
   void computeUsesAndLiveness(SILValue Base);
+
+  /// Return a name encoding of the projection tree.
+  std::string getNameEncoding() const; 
 
   /// Initialize an empty projection tree with an existing, computed projection
   /// tree.

--- a/include/swift/SILOptimizer/Analysis/FunctionSignatureAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/FunctionSignatureAnalysis.h
@@ -174,6 +174,12 @@ struct ResultDescriptor {
 };
 
 class FunctionSignatureInfo {
+  /// Have the signature be computed for this function.
+  bool SignatureComputed;
+
+  /// Should we optimize the signature for this function.
+  bool SignatureOptimize;
+
   /// Function currently analyzing.
   SILFunction *F;
 
@@ -204,9 +210,10 @@ class FunctionSignatureInfo {
 
 
 public:
-  FunctionSignatureInfo(SILFunction *F, llvm::BumpPtrAllocator &BPA, AliasAnalysis *AA,
-                        RCIdentityFunctionInfo *RCFI) :
-  F(F), Allocator(BPA), AA(AA), RCFI(RCFI), MayBindDynamicSelf(computeMayBindDynamicSelf(F)) {}
+  FunctionSignatureInfo(SILFunction *F, llvm::BumpPtrAllocator &BPA,
+                        AliasAnalysis *AA, RCIdentityFunctionInfo *RCFI) :
+  SignatureComputed(false), SignatureOptimize(false), F(F), Allocator(BPA),
+  AA(AA), RCFI(RCFI), MayBindDynamicSelf(computeMayBindDynamicSelf(F)) {}
 
   bool analyze();
   bool analyzeParameters();

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -104,6 +104,10 @@ PASS(FunctionOrderPrinter, "function-order-printer",
      "Print function orderings for test purposes")
 PASS(FunctionSignatureOpts, "function-signature-opts",
      "Optimize Function Signatures")
+PASS(FunctionSignatureOptCloner, "function-signature-opt-cloner",
+     "Create function with optimized signatures")
+PASS(FunctionSignatureOptRewriter, "function-signature-opt-rewriter",
+     "Optimize Function Signatures by rewriting callsites")
 PASS(ARCSequenceOpts, "arc-sequence-opts",
      "Optimize sequences of retain/release opts by removing redundant inner "
      "retain/release sequences")

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -1,0 +1,45 @@
+//===--- FunctionSignatureOptUtils.h ----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_FUNCTIONSIGOPTUTILS_H
+#define SWIFT_SIL_FUNCTIONSIGOPTUTILS_H
+
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILDebugScope.h"
+#include "swift/SILOptimizer/Analysis/FunctionSignatureAnalysis.h"
+
+namespace swift {
+
+bool canSpecializeFunction(SILFunction *F);
+
+void 
+addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
+                                      SILLocation Loc,
+                                      OperandValueArrayRef Parameters,
+                                      ArrayRef<ArgumentDescriptor> &ArgDescs);
+
+void
+addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
+                                      SILLocation Loc,
+                                      ArrayRef<SILArgument*> Parameters,
+                                      ArrayRef<ArgumentDescriptor> &ArgDescs);
+void
+addRetainsForConvertedDirectResults(SILBuilder &Builder,
+                                    SILLocation Loc,
+                                    SILValue ReturnValue,
+                                    SILInstruction *AI,
+                                    ArrayRef<ResultDescriptor> DirectResults);
+
+} // end namespace swift
+
+#endif

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -875,6 +875,19 @@ createProjection(SILBuilder &B, SILLocation Loc, SILValue Arg) const {
   return Proj->createProjection(B, Loc, Arg);
 }
 
+std::string
+ProjectionTreeNode::getNameEncoding(const ProjectionTree &PT) const {
+  std::string Encoding;
+  const ProjectionTreeNode *Node = this;
+  while(Node) {
+    if (Node->isRoot())
+      break;
+    Encoding += std::to_string(Node->Proj->getIndex());
+    Node = Node->getParent(PT);
+  }
+  return Encoding;
+}
+
 void
 ProjectionTreeNode::
 processUsersOfValue(ProjectionTree &Tree,
@@ -1180,6 +1193,15 @@ ProjectionTree::initializeWithExistingTree(const ProjectionTree &PT) {
   for (const auto &N : PT.ProjectionTreeNodes) {
     ProjectionTreeNodes.push_back(new (Allocator) ProjectionTreeNode(*N));
   }
+}
+
+std::string ProjectionTree::getNameEncoding() const {
+  std::string Encoding;
+  for (unsigned index : LiveLeafIndices) {
+    const ProjectionTreeNode *Node = ProjectionTreeNodes[index];
+    Encoding += Node->getNameEncoding(*this);
+  }
+  return Encoding;
 }
 
 SILValue

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -197,6 +197,7 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
   // current function (after optimizing any new callees).
   PM.addDevirtualizer();
   PM.addGenericSpecializer();
+
   switch (OpLevel) {
     case OptimizationLevelKind::HighLevel:
       // Does not inline functions with defined semantics.
@@ -245,6 +246,7 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
     PM.addLateCodeMotion();
   else
     PM.addEarlyCodeMotion();
+
   PM.addARCSequenceOpts();
   PM.addRemovePins();
 }
@@ -327,8 +329,6 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   // We do this late since it is a pass like the inline caches that we only want
   // to run once very late. Make sure to run at least one round of the ARC
   // optimizer after this.
-  PM.addFunctionSignatureOpts();
-
   PM.runOneIteration();
   PM.resetAndRemoveTransformations();
 
@@ -338,11 +338,20 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
 
   PM.setStageName("LowLevel");
 
+  // Rewrite to get the benefit of release devirtualizer.
+  // Also, Make sure the run the rewriter to create the optimized functions before
+  // the cloner on the current function is run !.
+  PM.addFunctionSignatureOptRewriter();
+
   // Should be after FunctionSignatureOpts and before the last inliner.
   PM.addReleaseDevirtualizer();
 
   AddSSAPasses(PM, OptimizationLevelKind::LowLevel);
   PM.addDeadStoreElimination();
+
+  // We've done a lot of optimizations on this function, attempt to FSO.
+  PM.addFunctionSignatureOptCloner();
+
   PM.runOneIteration();
   PM.resetAndRemoveTransformations();
 

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -8,6 +8,8 @@ set(TRANSFORMS_SOURCES
   Transforms/DeadObjectElimination.cpp
   Transforms/DeadStoreElimination.cpp
   Transforms/Devirtualizer.cpp
+  Transforms/FunctionSignatureOptCloner.cpp
+  Transforms/FunctionSignatureOptRewriter.cpp
   Transforms/GenericSpecializer.cpp
   Transforms/MergeCondFail.cpp
   Transforms/RedundantLoadElimination.cpp

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOptCloner.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOptCloner.cpp
@@ -1,0 +1,584 @@
+//===--- FunctionSignatureOptCloner.cpp - Optimizes function signatures ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-function-signature-opt-cloner"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/CallerAnalysis.h"
+#include "swift/SILOptimizer/Analysis/FunctionSignatureAnalysis.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SIL/Projection.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILCloner.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+STATISTIC(NumFunctionSignaturesOptimized, "Total func sig optimized");
+STATISTIC(NumDeadArgsEliminated, "Total dead args eliminated");
+STATISTIC(NumOwnedConvertedToGuaranteed, "Total owned args -> guaranteed args");
+STATISTIC(NumOwnedConvertedToNotOwnedResult, "Total owned result -> not owned result");
+STATISTIC(NumSROAArguments, "Total SROA arguments optimized");
+
+
+/// Creates a decrement on \p Ptr at insertion point \p InsertPt that creates a
+/// strong_release if \p Ptr has reference semantics itself or a release_value
+/// if \p Ptr is a non-trivial value without reference-semantics.
+static SILInstruction *createDecrement(SILValue Ptr, SILInstruction *InsertPt) {
+  // Setup the builder we will use to insert at our insertion point.
+  SILBuilder B(InsertPt);
+  auto Loc = RegularLocation(SourceLoc());
+
+  // If Ptr has reference semantics itself, create a strong_release.
+  if (Ptr->getType().isReferenceCounted(B.getModule()))
+    return B.createStrongRelease(Loc, Ptr);
+
+  // Otherwise create a release value.
+  return B.createReleaseValue(Loc, Ptr);
+}
+
+//===----------------------------------------------------------------------===//
+//                     Argument and Result Optimizer
+//===----------------------------------------------------------------------===//
+
+static void
+computeOptimizedInterfaceParams(const ArgumentDescriptor &AD,
+                                SmallVectorImpl<SILParameterInfo> &Out) {
+  DEBUG(llvm::dbgs() << "        Computing Interface Params\n");
+  // If we have a dead argument, bail.
+  if (AD.IsEntirelyDead) {
+    DEBUG(llvm::dbgs() << "            Dead!\n");
+    ++NumDeadArgsEliminated;
+    return;
+  }
+
+  // If we have an indirect result, bail.
+  if (AD.IsIndirectResult) {
+    DEBUG(llvm::dbgs() << "            Indirect result.\n");
+    return;
+  }
+
+  auto ParameterInfo = AD.Arg->getKnownParameterInfo();
+
+  // If this argument is live, but we cannot optimize it.
+  if (!AD.canOptimizeLiveArg()) {
+    DEBUG(llvm::dbgs() << "            Cannot optimize live arg!\n");
+    Out.push_back(ParameterInfo);
+    return;
+  }
+
+  // If we cannot explode this value, handle callee release and return.
+  if (!AD.Explode) {
+    DEBUG(llvm::dbgs() << "            ProjTree cannot explode arg.\n");
+    // If we found releases in the callee in the last BB on an @owned
+    // parameter, change the parameter to @guaranteed and continue...
+    if (!AD.CalleeRelease.empty()) {
+      DEBUG(llvm::dbgs() << "            Has callee release.\n");
+      assert(ParameterInfo.getConvention() ==
+                 ParameterConvention::Direct_Owned &&
+             "Can only transform @owned => @guaranteed in this code path");
+      SILParameterInfo NewInfo(ParameterInfo.getType(),
+                               ParameterConvention::Direct_Guaranteed);
+      Out.push_back(NewInfo);
+      ++NumOwnedConvertedToGuaranteed;
+      return;
+    }
+
+    DEBUG(llvm::dbgs() << "            Does not have callee release.\n");
+    // Otherwise just propagate through the parameter info.
+    Out.push_back(ParameterInfo);
+    return;
+  }
+
+  ++NumSROAArguments;
+  DEBUG(llvm::dbgs() << "            ProjTree can explode arg.\n");
+  // Ok, we need to use the projection tree. Iterate over the leafs of the
+  // tree...
+  llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
+  AD.ProjTree.getLeafNodes(LeafNodes);
+  DEBUG(llvm::dbgs() << "            Leafs:\n");
+  for (auto Node : LeafNodes) {
+    // Node type.
+    SILType Ty = Node->getType();
+    DEBUG(llvm::dbgs() << "                " << Ty << "\n");
+    // If Ty is trivial, just pass it directly.
+    if (Ty.isTrivial(AD.Arg->getModule())) {
+      SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+                               ParameterConvention::Direct_Unowned);
+      Out.push_back(NewInfo);
+      continue;
+    }
+
+    // If Ty is guaranteed, just pass it through.
+    ParameterConvention Conv = ParameterInfo.getConvention();
+    if (Conv == ParameterConvention::Direct_Guaranteed) {
+      assert(AD.CalleeRelease.empty() && "Guaranteed parameter should not have a "
+                                      "callee release.");
+      SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+                               ParameterConvention::Direct_Guaranteed);
+      Out.push_back(NewInfo);
+      continue;
+    }
+
+    // If Ty is not trivial and we found a callee release, pass it as
+    // guaranteed.
+    assert(ParameterInfo.getConvention() == ParameterConvention::Direct_Owned &&
+           "Can only transform @owned => @guaranteed in this code path");
+    if (!AD.CalleeRelease.empty()) {
+      SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+                               ParameterConvention::Direct_Guaranteed);
+      Out.push_back(NewInfo);
+      ++NumOwnedConvertedToGuaranteed;
+      continue;
+    }
+
+    // Otherwise, just add Ty as an @owned parameter.
+    SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+                             ParameterConvention::Direct_Owned);
+    Out.push_back(NewInfo);
+  }
+}
+
+static void
+addThunkArgs(const ArgumentDescriptor &AD, SILBuilder &Builder,
+             SILBasicBlock *BB, llvm::SmallVectorImpl<SILValue> &NewArgs) {
+  if (AD.IsEntirelyDead)
+    return;
+
+  if (!AD.Explode) {
+    NewArgs.push_back(BB->getBBArg(AD.Index));
+    return;
+  }
+
+  AD.ProjTree.createTreeFromValue(Builder, BB->getParent()->getLocation(),
+                                  BB->getBBArg(AD.Index), NewArgs);
+}
+
+static unsigned
+updateOptimizedBBArgs(const ArgumentDescriptor &AD, SILBuilder &Builder,
+                      SILBasicBlock *BB, unsigned ArgOffset) {
+  // If this argument is completely dead, delete this argument and return
+  // ArgOffset.
+  if (AD.IsEntirelyDead) {
+    // If we have a callee release and we are dead, set the callee release's
+    // operand to undef. We do not need it to have the argument anymore, but we
+    // do need the instruction to be non-null.
+    //
+    // TODO: This should not be necessary.
+    for (auto &X : AD.CalleeRelease) {
+      SILType CalleeReleaseTy = X->getOperand(0)->getType();
+      X->setOperand(
+          0, SILUndef::get(CalleeReleaseTy, Builder.getModule()));
+    }
+
+    // We should be able to recursively delete all of the remaining
+    // instructions.
+    SILArgument *Arg = BB->getBBArg(ArgOffset);
+    eraseUsesOfValue(Arg);
+    BB->eraseBBArg(ArgOffset);
+    return ArgOffset;
+  }
+
+  // If this argument is not dead and we did not perform SROA, increment the
+  // offset and return.
+  if (!AD.Explode) {
+    return ArgOffset + 1;
+  }
+
+  // Create values for the leaf types.
+  llvm::SmallVector<SILValue, 8> LeafValues;
+
+  // Create a reference to the old arg offset and increment arg offset so we can
+  // create the new arguments.
+  unsigned OldArgOffset = ArgOffset++;
+
+  // We do this in the same order as leaf types since ProjTree expects that the
+  // order of leaf values matches the order of leaf types.
+  {
+    llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
+    AD.ProjTree.getLeafNodes(LeafNodes);
+    for (auto Node : LeafNodes) {
+      LeafValues.push_back(BB->insertBBArg(
+          ArgOffset++, Node->getType(), BB->getBBArg(OldArgOffset)->getDecl()));
+    }
+  }
+
+  // We have built a projection tree and filled it with liveness information.
+  //
+  // Use this as a base to replace values in current function with their leaf
+  // values.
+  //
+  // NOTE: this also allows us to NOT modify the results of an analysis pass.
+  llvm::BumpPtrAllocator Allocator;
+  ProjectionTree PT(BB->getModule(), Allocator);
+  PT.initializeWithExistingTree(AD.ProjTree);
+
+  // Then go through the projection tree constructing aggregates and replacing
+  // uses.
+  //
+  // TODO: What is the right location to use here?
+  PT.replaceValueUsesWithLeafUses(Builder, BB->getParent()->getLocation(),
+                                  LeafValues);
+
+  // We ignored debugvalue uses when we constructed the new arguments, in order
+  // to preserve as much information as possible, we construct a new value for
+  // OrigArg from the leaf values and use that in place of the OrigArg.
+  SILValue NewOrigArgValue = PT.computeExplodedArgumentValue(Builder,
+                                           BB->getParent()->getLocation(),
+                                           LeafValues);
+
+  // Replace all uses of the original arg with the new value.
+  SILArgument *OrigArg = BB->getBBArg(OldArgOffset);
+  OrigArg->replaceAllUsesWith(NewOrigArgValue);
+
+  // Now erase the old argument since it does not have any uses. We also
+  // decrement ArgOffset since we have one less argument now.
+  BB->eraseBBArg(OldArgOffset);
+  --ArgOffset;
+
+  return ArgOffset;
+}
+
+namespace {
+
+/// A class that contains all analysis information we gather about our
+/// function. Also provides utility methods for creating the new empty function.
+class SignatureOptimizer {
+  FunctionSignatureInfo &FSI;
+
+public:
+  SignatureOptimizer() = delete;
+  SignatureOptimizer(const SignatureOptimizer &) = delete;
+  SignatureOptimizer(SignatureOptimizer &&) = delete;
+
+  SignatureOptimizer(FunctionSignatureInfo &FSI) : FSI(FSI) {}
+
+  ArrayRef<ArgumentDescriptor> getArgDescList() const {
+    return FSI.getArgDescList();
+  }
+
+  ArrayRef<ArgumentDescriptor> getArgDescList() {
+    return FSI.getArgDescList();
+  }
+
+  ArrayRef<ResultDescriptor> getResultDescList() {
+    return FSI.getResultDescList();
+  }
+
+  /// Create a new empty function with the optimized signature found by this
+  /// analysis.
+  ///
+  /// *NOTE* This occurs in the same module as F.
+  SILFunction *createEmptyFunctionWithOptimizedSig(const std::string &Name);
+
+private:
+  /// Compute the CanSILFunctionType for the optimized function.
+  CanSILFunctionType createOptimizedSILFunctionType();
+};
+
+} // end anonymous namespace
+
+CanSILFunctionType SignatureOptimizer::createOptimizedSILFunctionType() {
+  auto *F = FSI.getAnalyzedFunction();
+
+  const ASTContext &Ctx = F->getModule().getASTContext();
+  CanSILFunctionType FTy = F->getLoweredFunctionType();
+
+  // The only way that we modify the arity of function parameters is here for
+  // dead arguments. Doing anything else is unsafe since by definition non-dead
+  // arguments will have SSA uses in the function. We would need to be smarter
+  // in our moving to handle such cases.
+  llvm::SmallVector<SILParameterInfo, 8> InterfaceParams;
+  for (auto &ArgDesc : getArgDescList()) {
+    computeOptimizedInterfaceParams(ArgDesc, InterfaceParams);
+  }
+
+  // ResultDescs only covers the direct results; we currently can't ever
+  // change an indirect result.  Piece the modified direct result information
+  // back into the all-results list.
+  llvm::SmallVector<SILResultInfo, 8> InterfaceResults;
+  auto ResultDescs = getResultDescList();
+  for (SILResultInfo InterfaceResult : FTy->getAllResults()) {
+    if (InterfaceResult.isDirect()) {
+      auto &RV = ResultDescs[0];
+      ResultDescs = ResultDescs.slice(0);
+      if (!RV.CalleeRetain.empty()) {
+        InterfaceResults.push_back(SILResultInfo(InterfaceResult.getType(),
+                                                 ResultConvention::Unowned));
+        ++NumOwnedConvertedToNotOwnedResult;
+        continue;
+      }
+    }
+
+    InterfaceResults.push_back(InterfaceResult);
+  }
+
+  auto InterfaceErrorResult = FTy->getOptionalErrorResult();
+  auto ExtInfo = FTy->getExtInfo();
+
+  // Don't use a method representation if we modified self.
+  if (FSI.shouldModifySelfArgument())
+    ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
+
+  return SILFunctionType::get(FTy->getGenericSignature(), ExtInfo,
+                              FTy->getCalleeConvention(), InterfaceParams,
+                              InterfaceResults, InterfaceErrorResult, Ctx);
+}
+
+SILFunction *
+SignatureOptimizer::
+createEmptyFunctionWithOptimizedSig(const std::string &NewFName) {
+
+  auto *F = FSI.getAnalyzedFunction();
+  SILModule &M = F->getModule();
+
+  // Create the new optimized function type.
+  CanSILFunctionType NewFTy = createOptimizedSILFunctionType();
+
+  // Create the new function.
+  auto *NewF = M.getOrCreateFunction(
+      F->getLinkage(), NewFName, NewFTy, nullptr, F->getLocation(), F->isBare(),
+      F->isTransparent(), F->isFragile(), F->isThunk(), F->getClassVisibility(),
+      F->getInlineStrategy(), F->getEffectsKind(), 0, F->getDebugScope(),
+      F->getDeclContext());
+
+  NewF->setDeclCtx(F->getDeclContext());
+
+  // Array semantic clients rely on the signature being as in the original
+  // version.
+  for (auto &Attr : F->getSemanticsAttrs())
+    if (!StringRef(Attr).startswith("array."))
+      NewF->addSemanticsAttr(Attr);
+
+  return NewF;
+}
+
+static void createThunkBody(SILBasicBlock *BB, SILFunction *NewF,
+                            SignatureOptimizer &Optimizer) {
+  // TODO: What is the proper location to use here?
+  SILLocation Loc = BB->getParent()->getLocation();
+  SILBuilder Builder(BB);
+  Builder.setCurrentDebugScope(BB->getParent()->getDebugScope());
+
+  FunctionRefInst *FRI = Builder.createFunctionRef(Loc, NewF);
+
+  // Create the args for the thunk's apply, ignoring any dead arguments.
+  llvm::SmallVector<SILValue, 8> ThunkArgs;
+  ArrayRef<ArgumentDescriptor> ArgDescs = Optimizer.getArgDescList();
+  for (auto &ArgDesc : ArgDescs) {
+    addThunkArgs(ArgDesc, Builder, BB, ThunkArgs);
+  }
+
+  // We are ignoring generic functions and functions with out parameters for
+  // now.
+  SILType LoweredType = NewF->getLoweredType();
+  SILType ResultType = LoweredType.getFunctionInterfaceResultType();
+  SILValue ReturnValue;
+  auto FunctionTy = LoweredType.castTo<SILFunctionType>();
+  if (FunctionTy->hasErrorResult()) {
+    // We need a try_apply to call a function with an error result.
+    SILFunction *Thunk = BB->getParent();
+    SILBasicBlock *NormalBlock = Thunk->createBasicBlock();
+    ReturnValue = NormalBlock->createBBArg(ResultType, 0);
+    SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
+    SILType ErrorProtocol =
+        SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getType());
+    auto *ErrorArg = ErrorBlock->createBBArg(ErrorProtocol, 0);
+    Builder.createTryApply(Loc, FRI, LoweredType, ArrayRef<Substitution>(),
+                           ThunkArgs, NormalBlock, ErrorBlock);
+
+    // If we have any arguments that were consumed but are now guaranteed,
+    // insert a release_value in the error block.
+    Builder.setInsertionPoint(ErrorBlock);
+    for (auto &ArgDesc : ArgDescs) {
+      if (ArgDesc.CalleeRelease.empty())
+        continue;
+      Builder.createReleaseValue(Loc, BB->getBBArg(ArgDesc.Index));
+    }
+    Builder.createThrow(Loc, ErrorArg);
+
+    // Also insert release_value in the normal block (done below).
+    Builder.setInsertionPoint(NormalBlock);
+  } else {
+    ReturnValue =
+        Builder.createApply(Loc, FRI, LoweredType, ResultType,
+                            ArrayRef<Substitution>(), ThunkArgs, false);
+  }
+
+  // Add releases for the converted @owned to @guaranteed parameter.
+  addReleasesForConvertedOwnedParameter(Builder, Loc, BB->getBBArgs(),
+                                        ArgDescs);
+
+  // Handle @owned to @unowned return value conversion.
+  addRetainsForConvertedDirectResults(Builder, Loc, ReturnValue, nullptr,
+                                      Optimizer.getResultDescList());
+
+  // Function that are marked as @NoReturn must be followed by an 'unreachable'
+  // instruction.
+  if (NewF->getLoweredFunctionType()->isNoReturn()) {
+    Builder.createUnreachable(Loc);
+    return;
+  }
+
+  Builder.createReturn(Loc, ReturnValue);
+}
+
+static SILFunction *
+createOptimizedFunctionBody(SILFunction *F, const std::string &NewFName,
+                            SignatureOptimizer &Optimizer) {
+  // First we create an empty function (i.e. no BB) whose function signature has
+  // had its arity modified.
+  //
+  // We only do this to remove dead arguments. All other function signature
+  // optimization is done later by modifying the function signature elements
+  // themselves.
+  SILFunction *NewF = Optimizer.createEmptyFunctionWithOptimizedSig(NewFName);
+
+  // Then we transfer the body of F to NewF. At this point, the arguments of the
+  // first BB will not match.
+  NewF->spliceBody(F);
+  // Do the same with the call graph.
+
+  // Then perform any updates to the arguments of NewF.
+  SILBasicBlock *NewFEntryBB = &*NewF->begin();
+  ArrayRef<ArgumentDescriptor> ArgDescs = Optimizer.getArgDescList();
+  unsigned ArgOffset = 0;
+  SILBuilder Builder(NewFEntryBB->begin());
+  Builder.setCurrentDebugScope(NewFEntryBB->getParent()->getDebugScope());
+  for (auto &ArgDesc : ArgDescs) {
+    // We always need to reset the insertion point in case we delete the first
+    // instruction.
+    Builder.setInsertionPoint(NewFEntryBB->begin());
+    DEBUG(llvm::dbgs() << "Updating arguments at ArgOffset: " << ArgOffset
+                       << " for: " << *ArgDesc.Arg);
+    ArgOffset = updateOptimizedBBArgs(ArgDesc, Builder, NewFEntryBB, ArgOffset);
+  }
+
+  // Otherwise generate the thunk body just in case.
+  SILBasicBlock *ThunkBody = F->createBasicBlock();
+  for (auto &ArgDesc : ArgDescs) {
+    ThunkBody->createBBArg(ArgDesc.Arg->getType(), ArgDesc.Decl);
+  }
+  createThunkBody(ThunkBody, NewF, Optimizer);
+
+  F->setThunk(IsThunk);
+  assert(F->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+
+  return NewF;
+}
+
+/// Create an optimized version of the current function.
+static SILFunction* 
+createOptimizedFunction(RCIdentityFunctionInfo *RCIA,
+                        FunctionSignatureInfo *FSI,
+                        AliasAnalysis *AA, SILFunction *F) {
+  // Analyze function arguments. If there is no work to be done, exit early.
+  if (!FSI->analyze()) 
+    return nullptr;
+
+  // This is the new function name.
+  auto NewFName = FSI->getOptimizedName();
+
+  // If we already have a specialized version of this function, do not
+  // respecialize. For now just bail.
+  if (F->getModule().lookUpFunction(NewFName))
+    return nullptr;
+
+  ++NumFunctionSignaturesOptimized;
+  SignatureOptimizer Optimizer(*FSI);
+
+  // Otherwise, move F over to NewF.
+  SILFunction *NewF = createOptimizedFunctionBody(F, NewFName, Optimizer);
+
+  // And remove all Callee releases that we found and made redundant via owned
+  // to guaranteed conversion.
+  //
+  // TODO: If more stuff needs to be placed here, refactor into its own method.
+  for (auto &A : Optimizer.getArgDescList()) {
+    for (auto &X : A.CalleeRelease) 
+      X->eraseFromParent();
+    for (auto &X : A.CalleeReleaseInThrowBlock) 
+      X->eraseFromParent();
+  }
+
+  // And remove all callee retains that we found and made redundant via owned
+  // to unowned conversion.
+  for (const ResultDescriptor &RD : Optimizer.getResultDescList()) {
+    for (auto &X : RD.CalleeRetain) {
+      if (isa<StrongRetainInst>(X) || isa<RetainValueInst>(X)) {
+        X->eraseFromParent();
+        continue;
+      }
+      assert(isa<ApplyInst>(X) && "Unknown epilogue retain");
+      // Create a release to balance it out.
+      createDecrement(X, dyn_cast<ApplyInst>(X)->getParent()->getTerminator());
+    }
+  }
+  return NewF;
+}
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+namespace {
+class FunctionSignatureOptCloner : public SILFunctionTransform {
+public:
+  void run() override {
+    auto *RCIA = getAnalysis<RCIdentityAnalysis>();
+    auto *FSA = getAnalysis<FunctionSignatureAnalysis>();
+    auto *AA = PM->getAnalysis<AliasAnalysis>();
+    auto *CA = PM->getAnalysis<CallerAnalysis>();
+
+    SILFunction *F = getFunction();
+    DEBUG(llvm::dbgs() << "*** FSO on function: " << F->getName() << " ***\n");
+
+    // Don't optimize callees that should not be optimized.
+    if (!F->shouldOptimize())
+      return;
+
+    // If this function does not have a caller in the current module. We do not
+    // function signature specialize it.
+    if (!CA->hasCaller(F))
+      return;
+
+    // Check the signature of F to make sure that it is a function that we
+    // can specialize. These are conditions independent of the call graph.
+    if (!canSpecializeFunction(F))
+      return;
+
+    // Try to create an optimized function based on the signature analysis.
+    SILFunction *NewF = 
+                 createOptimizedFunction(RCIA->get(F), FSA->get(F), AA, F);
+  
+    if (NewF) { 
+      // Make sure the PM knows about this function.
+      notifyPassManagerOfFunction(NewF);
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+    }
+  }
+
+  StringRef getName() override {
+    return "Function Signature Optimization Cloner";
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createFunctionSignatureOptCloner() {
+  return new FunctionSignatureOptCloner();
+}

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOptRewriter.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOptRewriter.cpp
@@ -1,0 +1,241 @@
+//===--- FunctionSignatureOptRewriter.cpp - Rewrite function callsites ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-function-signature-opt-rewriter"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/FunctionSignatureAnalysis.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+STATISTIC(NumCallSitesOptimized, "Total call sites optimized");
+
+//===----------------------------------------------------------------------===//
+//                                Main Routine
+//===----------------------------------------------------------------------===//
+
+static void
+addCallerArgs(const ArgumentDescriptor &AD, SILBuilder &B, FullApplySite FAS,
+              llvm::SmallVectorImpl<SILValue> &NewArgs) {
+  if (AD.IsEntirelyDead)
+    return;
+
+  SILValue Arg = FAS.getArgument(AD.Index);
+  if (!AD.Explode) {
+    NewArgs.push_back(Arg);
+    return;
+  }
+
+  AD.ProjTree.createTreeFromValue(B, FAS.getLoc(), Arg, NewArgs);
+}
+
+/// This function takes in OldF and a callsite of OldF and rewrites the
+/// callsite to call the new function.
+static void
+rewriteApplyInstToCallNewFunction(FunctionSignatureInfo *FSI,
+                                  SILFunction *NewF,
+                                  const FullApplySite &FAS,
+                                  llvm::DenseSet<SILInstruction *> &DeadInsts) {
+  auto *AI = FAS.getInstruction();
+
+  SILBuilderWithScope Builder(AI);
+
+  FunctionRefInst *FRI = Builder.createFunctionRef(AI->getLoc(), NewF);
+
+  // Create the args for the new apply, ignoring any dead arguments.
+  llvm::SmallVector<SILValue, 8> NewArgs;
+  ArrayRef<ArgumentDescriptor> ArgDescs = FSI->getArgDescList();
+  for (auto &ArgDesc : ArgDescs) {
+    addCallerArgs(ArgDesc, Builder, FAS, NewArgs);
+  }
+
+  // We are ignoring generic functions and functions with out parameters for
+  // now.
+  SILType LoweredType = NewF->getLoweredType();
+  SILType ResultType = LoweredType.getFunctionInterfaceResultType();
+  SILLocation Loc = AI->getLoc();
+  SILValue ReturnValue = SILValue();
+
+  // Create the new apply.
+  if (ApplyInst *RealAI = dyn_cast<ApplyInst>(AI)) {
+    auto *NewAI = Builder.createApply(Loc, FRI, LoweredType, ResultType,
+                                      ArrayRef<Substitution>(), NewArgs,
+                                      RealAI->isNonThrowing());
+    // This is the return value.
+    ReturnValue = SILValue(NewAI);
+    // Replace all uses of the old apply with the new apply.
+    AI->replaceAllUsesWith(NewAI);
+  } else {
+    auto *TAI = cast<TryApplyInst>(AI);
+    Builder.createTryApply(Loc, FRI, LoweredType,
+                           ArrayRef<Substitution>(), NewArgs,
+                           TAI->getNormalBB(), TAI->getErrorBB());
+
+    // This is the return value.
+    ReturnValue = TAI->getNormalBB()->getBBArg(0);
+    Builder.setInsertionPoint(TAI->getErrorBB(), TAI->getErrorBB()->begin());
+    // If we have any arguments that were consumed but are now guaranteed,
+    // insert a release_value in the error block.
+    for (auto &ArgDesc : ArgDescs) {
+      if (ArgDesc.CalleeRelease.empty())
+        continue;
+      Builder.createReleaseValue(Loc, FAS.getArgument(ArgDesc.Index));
+    }
+    // Also insert release_value in the normal block (done below).
+    Builder.setInsertionPoint(TAI->getNormalBB(),
+                              TAI->getNormalBB()->begin());
+  }
+
+  // Add releases for the converted @owned to @guaranteed parameter.
+  addReleasesForConvertedOwnedParameter(Builder, Loc, FAS.getArguments(),
+                                        ArgDescs);
+
+  // If we have converted the return value from @owned to @guaranteed,
+  // insert a retain_value at the callsite.
+  addRetainsForConvertedDirectResults(Builder, Loc, ReturnValue, AI,
+                                      FSI->getResultDescList());
+
+  ++NumCallSitesOptimized;
+  // Make sure we remove this apply in the end.
+  DeadInsts.insert(AI);
+}
+
+/// Look up the optimized version of the function and rewrite the callsite.
+static bool
+optimizeCallSite(SILModule *Mod, RCIdentityFunctionInfo *RCIA,
+                 FunctionSignatureInfo *FSI, AliasAnalysis *AA, 
+                 const FullApplySite &CallSite,
+                 llvm::DenseSet<SILInstruction *> &DeadInsts) {
+  // Analyze function arguments. If there is no work to be done, exit early.
+  if (!FSI->analyze())
+    return false;
+
+  // Get the name of the optimized function.
+  auto NewFName = FSI->getOptimizedName();
+
+  // Check whether we have already created the optimized function.
+  SILFunction *NewFn = Mod->lookUpFunction(NewFName);
+  if (!NewFn)
+    return false;
+
+  // Rewrite all apply insts calling F to call NewF. Update each call site as
+  // appropriate given the form of function signature optimization performed.
+  rewriteApplyInstToCallNewFunction(FSI, NewFn, CallSite, DeadInsts);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+namespace {
+
+class FunctionSignatureOptRewriter : public SILFunctionTransform {
+public:
+  FunctionSignatureOptRewriter() {}
+
+  void run() override {
+    auto *RCIA = getAnalysis<RCIdentityAnalysis>();
+    auto *FSA = getAnalysis<FunctionSignatureAnalysis>();
+    auto *AA = PM->getAnalysis<AliasAnalysis>();
+
+    SILFunction *F = getFunction();
+    DEBUG(llvm::dbgs() << "*** FSO on function: " << F->getName() << " ***\n");
+
+    // Don't optimize function that should not be optimized.
+    if (!F->shouldOptimize())
+      return;
+
+    llvm::SmallVector<FullApplySite, 4> Sites;
+    llvm::DenseSet<SILInstruction *> DeadInsts;
+
+    bool Changed = false;
+    // Scan the whole function and search Apply sites.
+    for (auto &BB : *F) {
+      for (auto &II : BB) {
+        if (auto Apply = FullApplySite::isa(&II)) {
+           SILValue Callee = Apply.getCallee();
+
+           //  Strip ThinToThickFunctionInst.
+           if (auto TTTF = dyn_cast<ThinToThickFunctionInst>(Callee)) {
+             Callee = TTTF->getOperand();
+           }
+           // Find the target function.
+           auto *FRI = dyn_cast<FunctionRefInst>(Callee);
+           if (!FRI)
+             continue;
+           // This is a callsite we can optimize.
+           Sites.push_back(Apply);
+        }
+      }
+    }
+
+    // These are the callsites to optimize.
+    for (auto &Apply : Sites) {
+      SILValue Fn = Apply.getCallee();
+
+      //  Strip ThinToThickFunctionInst.
+      if (auto TTTF = dyn_cast<ThinToThickFunctionInst>(Fn)) {
+        Fn = TTTF->getOperand();
+      }
+
+      // Find the target function.
+      auto *FRI = dyn_cast<FunctionRefInst>(Fn);
+      if (!FRI)
+        continue;
+
+      SILFunction *Callee = FRI->getReferencedFunction();
+
+      // Check the signature of Callee to make sure that it is a function that
+      // we can specialize. These are conditions independent of the call graph.
+      // If this function cant be specialized, that means we have not created
+      // the function signature specialized version for it.
+      if (!canSpecializeFunction(Callee))
+        continue;
+
+      // We may have a specialized version of this function, try to rewrite
+      // the callsite to it.
+      Changed |= optimizeCallSite(&Callee->getModule(), RCIA->get(Callee),
+                                  FSA->get(Callee), AA, Apply, DeadInsts);
+    }
+
+    // Lastly, we have rewritten all the callsites, erase the old applys and
+    // its callee.
+    for (auto AI : DeadInsts) {
+      recursivelyDeleteTriviallyDeadInstructions(AI, true,
+                                                [](SILInstruction *) {});
+    }
+
+    // If we changed anything, invalidate the call graph.
+    if (Changed) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Calls);
+    }
+  }
+
+  StringRef getName() override {
+    return "Function Signature Optimization Rewriter";
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createFunctionSignatureOptRewriter() {
+  return new FunctionSignatureOptRewriter();
+}

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UTILS_SOURCES
   Utils/CheckedCastBrJumpThreading.cpp
   Utils/ConstantFolding.cpp
   Utils/Devirtualize.cpp
+  Utils/FunctionSignatureOptUtils.cpp
   Utils/GenericCloner.cpp
   Utils/Generics.cpp
   Utils/Local.cpp

--- a/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
@@ -1,0 +1,131 @@
+//===--- FunctionSignatureOptUtils.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+
+using namespace swift;
+
+static bool isSpecializableRepresentation(SILFunctionTypeRepresentation Rep) {
+  switch (Rep) {
+  case SILFunctionTypeRepresentation::Method:
+  case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::Thick:
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+    return true;
+  case SILFunctionTypeRepresentation::WitnessMethod:
+  case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::Block:
+    return false;
+  }
+}
+
+/// Returns true if F is a function which the pass know show to specialize
+/// function signatures for.
+bool swift::canSpecializeFunction(SILFunction *F) {
+  // Do not specialize the signature of SILFunctions that are external
+  // declarations since there is no body to optimize.
+  if (F->isExternalDeclaration())
+    return false;
+
+  // Do not specialize functions that are available externally. If an external
+  // function was able to be specialized, it would have been specialized in its
+  // own module. We will inline the original function as a thunk. The thunk will
+  // call the specialized function.
+  if (F->isAvailableExternally())
+    return false;
+
+  // Do not specialize the signature of always inline functions. We
+  // will just inline them and specialize each one of the individual
+  // functions that these sorts of functions are inlined into.
+  if (F->getInlineStrategy() == Inline_t::AlwaysInline)
+    return false;
+
+  // For now ignore generic functions to keep things simple...
+  if (F->getLoweredFunctionType()->isPolymorphic())
+    return false;
+
+  // Make sure F has a linkage that we can optimize.
+  if (!isSpecializableRepresentation(F->getRepresentation()))
+    return false;
+
+  return true;
+}
+
+void swift::
+addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
+                                      SILLocation Loc,
+                                      ArrayRef<SILArgument*> Parameters,
+                                      ArrayRef<ArgumentDescriptor> &ArgDescs) {
+  // If we have any arguments that were consumed but are now guaranteed,
+  // insert a release_value.
+  for (auto &ArgDesc : ArgDescs) {
+    if (ArgDesc.CalleeRelease.empty())
+      continue;
+    Builder.createReleaseValue(Loc, Parameters[ArgDesc.Index]);
+  }
+}
+
+void swift::
+addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
+                                      SILLocation Loc,
+                                      OperandValueArrayRef Parameters,
+                                      ArrayRef<ArgumentDescriptor> &ArgDescs) {
+  // If we have any arguments that were consumed but are now guaranteed,
+  // insert a release_value.
+  for (auto &ArgDesc : ArgDescs) {
+    // The argument is dead. Make sure we have a release to balance out
+    // the retain for creating the @owned parameter.
+    if (ArgDesc.IsEntirelyDead && 
+        ArgDesc.Arg->getKnownParameterInfo().getConvention() ==
+        ParameterConvention::Direct_Owned) {
+       Builder.createReleaseValue(Loc, Parameters[ArgDesc.Index]);
+       continue;
+    }
+    if (ArgDesc.CalleeRelease.empty())
+      continue;
+    Builder.createReleaseValue(Loc, Parameters[ArgDesc.Index]);
+  }
+}
+
+void swift::
+addRetainsForConvertedDirectResults(SILBuilder &Builder,
+                                    SILLocation Loc,
+                                    SILValue ReturnValue,
+                                    SILInstruction *AI,
+                                    ArrayRef<ResultDescriptor> DirectResults) {
+  for (auto I : indices(DirectResults)) {
+    auto &RV = DirectResults[I];
+    if (RV.CalleeRetain.empty()) continue;
+
+    bool IsSelfRecursionEpilogueRetain = false;
+    for (auto &X : RV.CalleeRetain) {
+      IsSelfRecursionEpilogueRetain |= (AI == X);
+    }
+
+    // We do not create a retain if this ApplyInst is a self-recursion.
+    if (IsSelfRecursionEpilogueRetain)
+      continue;
+
+    // Extract the return value if necessary.
+    SILValue SpecificResultValue = ReturnValue;
+    if (DirectResults.size() != 1)
+      SpecificResultValue = Builder.createTupleExtract(Loc, ReturnValue, I);
+
+    Builder.createRetainValue(Loc, SpecificResultValue);
+  }
+}

--- a/test/SILOptimizer/devirt_default_case.swift
+++ b/test/SILOptimizer/devirt_default_case.swift
@@ -108,11 +108,11 @@ class E3 :C3 {}
 func foo(a: A3) -> Int {
 // Check that call to A3.f() can be devirtualized.
 //
-// CHECK-LABEL: sil{{( hidden)?}} [noinline] @_TF19devirt_default_case3fooFCS_2A3Si
-// CHECK: function_ref @{{.*}}TFC19devirt_default_case2B31f
-// CHECK: function_ref @{{.*}}TFC19devirt_default_case2A31f
+// CHECK-NORMAL: sil{{( hidden)?}} [noinline] @_TF19devirt_default_case3fooFCS_2A3Si
+// CHECK-TESTABLE: sil{{( hidden)?}} [thunk] [noinline] @_TF19devirt_default_case3fooFCS_2A3Si
+// CHECK-NORMAL: function_ref @{{.*}}TFC19devirt_default_case2B31f
+// CHECK-NORMAL: function_ref @{{.*}}TFC19devirt_default_case2A31f
 // CHECK-NORMAL-NOT: class_method
-// CHECK-TESTABLE: class_method %0 : $A3, #A3.f!1
 // CHECK: }
   return a.f()
 }
@@ -166,7 +166,7 @@ class D6 : C6 {
 func check_static_class_devirt(c: C6) -> Int { 
 // Check that C.bar() and D.bar() are devirtualized.
 //
-// CHECK-LABEL: sil{{( hidden)?}} [noinline] @_TF19devirt_default_case25check_static_class_devirtFCS_2C6Si
+// CHECK-LABEL: sil{{( hidden)?}} [noinline] @_TTSf4g___TF19devirt_default_case25check_static_class_devirtFCS_2C6Si
 // CHECK: checked_cast_br [exact] %0 : $C6 to $C6
 // CHECK: checked_cast_br [exact] %0 : $C6 to $D6
 // CHECK: class_method

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opts %s | FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opts %s | FileCheck -check-prefix=CHECK-NEGATIVE %s
+// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opt-rewriter -function-signature-opt-cloner %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opt-rewriter -function-signature-opt-cloner %s | FileCheck -check-prefix=CHECK-NEGATIVE %s
 
 import Builtin
 import Swift
@@ -92,7 +92,7 @@ bb0(%0 : $lotsoffield):
 // Make sure argument is exploded and the baz part is not passed in as argument, as its only use
 // is a release.
 // CHECK-LABEL: sil [thunk] @dead_argument_due_to_more_than_release_user
-// CHECK: [[FN1:%.*]] = function_ref @_TTSf4gs__dead_argument_due_to_more_than_release_user : $@convention(thin) (@guaranteed baz, Int) -> (Int, Int)
+// CHECK: [[FN1:%.*]] = function_ref @_TTSf4gs__dead_argument_due_to_more_than_release_user_arg0_01 : $@convention(thin) (@guaranteed baz, Int) -> (Int, Int)
 sil @dead_argument_due_to_more_than_release_user : $@convention(thin) (@owned boo) -> (Int, Int) {
 bb0(%0 : $boo):
   %1 = struct_extract %0 : $boo, #boo.tbaz
@@ -193,7 +193,7 @@ bb3(%4 : $boo):
 
 // CHECK-LABEL: sil [thunk] @single_owned_return_value_with_interfering_release
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
-// CHECK: [[IN1:%.*]] = function_ref @_TTSf4s__single_owned_return_value_with_interfering_release
+// CHECK: [[IN1:%.*]] = function_ref @_TTSf4g_n_n___TTSf4s__single_owned_return_value_with_interfering_release_arg0_00101
 // CHECK-NOT: retain_value
 // CHECK: return
 sil @single_owned_return_value_with_interfering_release : $@convention(thin) (@owned boo) -> @owned boo {
@@ -777,9 +777,11 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-NOT: retain_value
 // CHECK: return
 
-// CHECK-LABEL: sil @_TTSf4s__single_owned_return_value_with_interfering_release : $@convention(thin) (@owned foo, @owned foo, Int) -> @owned boo {
+// CHECK-LABEL: sil [thunk] @_TTSf4s__single_owned_return_value_with_interfering_release_arg0_00101 : $@convention(thin) (@owned foo, @owned foo, Int) -> @owned boo {
 // CHECK: retain_value
 // CHECK: release_value
+
+// CHECK-LABEL: sil [thunk] @_TTSf4g_n_n___TTSf4s__single_owned_return_value_with_interfering_release_arg0_00101
 
 // CHECK-LABEL: @_TTSf4n_g_owned_to_unowned_retval_with_error_result : $@convention(thin) (@owned boo) -> (boo, @error ErrorProtocol) {
 // CHECK: bb2

--- a/test/SILOptimizer/functionsigopts_sroa.sil
+++ b/test/SILOptimizer/functionsigopts_sroa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opts %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -function-signature-opt-rewriter -function-signature-opt-cloner %s | FileCheck %s
 
 import Builtin
 
@@ -138,7 +138,7 @@ struct SingleFieldLvl3 {
 /// dead.
 // CHECK-LABEL: sil [fragile] [thunk] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_dead_root_callee : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_dead_root_callee_arg0_1 : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
 // CHECK: [[ARG:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
 // CHECK: apply [[FN]]([[ARG]])
 sil [fragile] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
@@ -149,7 +149,7 @@ bb0(%0 : $S1):
 
 // CHECK-LABEL: sil [fragile] @single_level_dead_root_caller : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_dead_root_callee : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
+// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_dead_root_callee_arg0_1 : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
 // CHECK: [[ARG:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
 // CHECK: apply [[FN]]([[ARG]])
 sil [fragile] @single_level_dead_root_caller : $@convention(thin) (S1) -> () {
@@ -162,7 +162,7 @@ bb0(%0 : $S1):
 
 // CHECK-LABEL: sil [fragile] [thunk] @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_live_root_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32
+// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_live_root_callee_arg0_01 : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32
 // CHECK: [[ARG2:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
 // CHECK: [[ARG1:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f1
 // CHECK: apply [[FN]]([[ARG1]], [[ARG2]])
@@ -176,7 +176,7 @@ bb0(%0 : $S1):
 
 // CHECK-LABEL: sil [fragile] @single_level_live_root_caller : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
-// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_live_root_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32
+// CHECK: [[FN:%[0-9]+]] = function_ref @_TTSf4s__single_level_live_root_callee_arg0_01 : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32
 // CHECK: [[ARG2:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
 // CHECK: [[ARG1:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f1
 // CHECK: apply [[FN]]([[ARG1]], [[ARG2]])
@@ -193,7 +193,7 @@ bb0(%0 : $S1):
 // everything, but we should not "reform" the aggregate.
 // CHECK-LABEL: sil [fragile] [thunk] @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[INPUT:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_all_root_fields_used_callee : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_all_root_fields_used_callee_arg0_001 : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f1
 // CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f1
@@ -211,7 +211,7 @@ bb0(%0 : $S2):
 
 // CHECK-LABEL: sil [fragile] @multiple_level_all_root_fields_used_caller : $@convention(thin) (S2) -> () {
 // CHECK: bb0([[INPUT:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_all_root_fields_used_callee : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_all_root_fields_used_callee_arg0_001 : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f1
 // CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f1
@@ -227,7 +227,7 @@ bb0(%0 : $S2):
 /// This test checks a multiple level hierarchy where the root has no fields used.
 // CHECK-LABEL: sil [fragile] [thunk] @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN:%.*]] : $S3):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_no_root_fields_have_direct_uses_callee_arg0_00010 : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S3, #S3.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S3, #S3.f1
 // CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S2, #S2.f2
@@ -247,7 +247,7 @@ bb0(%0 : $S3):
 
 // CHECK-LABEL: sil [fragile] @multiple_level_no_root_fields_have_direct_uses_caller : $@convention(thin) (S3) -> () {
 // CHECK: bb0([[IN:%.*]] : $S3):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_no_root_fields_have_direct_uses_callee_arg0_00010 : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S3, #S3.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S3, #S3.f1
 // CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S2, #S2.f2
@@ -266,7 +266,7 @@ bb0(%0 : $S3):
 // and needs to be reformed via a struct.
 // CHECK-LABEL: sil [fragile] [thunk] @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_root_must_be_reformed_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_root_must_be_reformed_callee_arg0_00101 : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S2, #S2.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S2, #S2.f1
 // CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f2
@@ -285,7 +285,7 @@ bb0(%0 : $S2):
 
 // CHECK-LABEL: sil [fragile] @multiple_level_root_must_be_reformed_caller : $@convention(thin) (S2) -> () {
 // CHECK: bb0([[IN:%.*]] : $S2):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_root_must_be_reformed_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__multiple_level_root_must_be_reformed_callee_arg0_00101 : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S2, #S2.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S2, #S2.f1
 // CHECK: [[EXT3:%.*]] = struct_extract [[EXT2]] : $S1, #S1.f2
@@ -302,7 +302,7 @@ bb0(%0 : $S2):
 // This test checks if we can handle @owned structs correctly
 // CHECK-LABEL: sil [fragile] [thunk] @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 // CHECK: bb0([[IN1:%.*]] : $S5, [[IN2:%.*]] : $S5):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4dg_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4dg_gs__owned_struct_1_callee_arg1_00111 : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S5, #S5.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN2]] : $S5, #S5.f1
 // CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
@@ -326,7 +326,7 @@ bb0(%0 : $S5, %1 : $S5):
 
 // CHECK-LABEL: sil [fragile] @owned_struct_1_caller : $@convention(thin) (S5) -> () {
 // CHECK: bb0([[IN:%.*]] : $S5):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4dg_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4dg_gs__owned_struct_1_callee_arg1_00111 : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S5, #S5.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S5, #S5.f1
 // CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
@@ -344,7 +344,7 @@ bb0(%0 : $S5):
 // This test checks if we can properly insert arguments in between dead arguments.
 // CHECK-LABEL: sil [fragile] [thunk] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $Builtin.Int256, [[IN3:%.*]] : $S5, [[IN4:%.*]] : $Builtin.Int128, [[IN5:%.*]] : $Builtin.Int128):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_d_gs_d_n__owned_struct_2_callee : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_d_gs_d_n__owned_struct_2_callee_arg2_00111 : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN3]] : $S5, #S5.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN3]] : $S5, #S5.f1
 // CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
@@ -365,7 +365,7 @@ bb0(%0 : $Builtin.Int256, %1 : $Builtin.Int256, %2 : $S5, %3 : $Builtin.Int128, 
 
 // CHECK-LABEL: sil [fragile] @owned_struct_2_caller : $@convention(thin) (Builtin.Int256, S5, Builtin.Int128) -> () {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $S5, [[IN3:%.*]] : $Builtin.Int128):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_d_gs_d_n__owned_struct_2_callee : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_d_gs_d_n__owned_struct_2_callee_arg2_00111 : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S5, #S5.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN2]] : $S5, #S5.f1
 // CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
@@ -382,7 +382,7 @@ bb0(%0 : $Builtin.Int256, %1 : $S5, %2 : $Builtin.Int128):
 /// This test makes sure that we ignore pointer arguments for now.
 // CHECK-LABEL: sil [fragile] [thunk] @ignore_ptrs_callee : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16) {
 // CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $S1, [[IN3:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_s_s__ignore_ptrs_callee : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_s_s__ignore_ptrs_callee_arg1_0_arg2_0 : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S1, #S1.f1
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN3]] : $S1, #S1.f1
 // CHECK: apply [[FN]]([[IN1]], [[EXT1]], [[EXT2]]) : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
@@ -400,7 +400,7 @@ bb0(%0 : $*S1, %1 : $S1, %2 : $S1):
 
 // CHECK-LABEL: sil [fragile] @ignore_ptrs_caller : $@convention(thin) (@in S1, S1, S1) -> () {
 // CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $S1, [[IN3:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_s_s__ignore_ptrs_callee : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4n_s_s__ignore_ptrs_callee_arg1_0_arg2_0 : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S1, #S1.f1
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN3]] : $S1, #S1.f1
 // CHECK: apply [[FN]]([[IN1]], [[EXT1]], [[EXT2]]) : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
@@ -444,7 +444,7 @@ bb0(%0 : $FakeStaticString, %1 : $FakeString, %2 : $FakeStaticString):
 // structure.
 // CHECK-LABEL: sil [fragile] [thunk] @check_out_of_order_uses_callee : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[IN:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__check_out_of_order_uses_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__check_out_of_order_uses_callee_arg0_01 : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S1, #S1.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S1, #S1.f1
 // CHECK: apply [[FN]]([[EXT2]], [[EXT1]]) : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
@@ -463,7 +463,7 @@ bb0(%0 : $S1):
 
 // CHECK-LABEL: sil [fragile] @check_out_of_order_uses_caller : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[IN:%.*]] : $S1):
-// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__check_out_of_order_uses_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
+// CHECK: [[FN:%.*]] = function_ref @_TTSf4s__check_out_of_order_uses_callee_arg0_01 : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S1, #S1.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S1, #S1.f1
 // CHECK: apply [[FN]]([[EXT2]], [[EXT1]]) : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
@@ -577,14 +577,14 @@ bb0(%0 : $SingleFieldLvl1):
 
 // Check Statements for generated code.
 
-// CHECK-LABEL: sil [fragile] @_TTSf4s__single_level_dead_root_callee : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil [fragile] @_TTSf4s__single_level_dead_root_callee_arg0_1 : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0([[IN:%.*]] : $Builtin.Int32):
 // CHECK-NEXT: [[UN:%.*]] = struct $S1 (undef : $Builtin.Int16, [[IN]] : $Builtin.Int32)
 // CHECK-NEXT: struct_extract [[UN]] : $S1, #S1.f2
 // CHECK-NEXT: return [[IN]] : $Builtin.Int32
 
 
-// CHECK-LABEL: sil [fragile] @_TTSf4s__single_level_live_root_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil [fragile] @_TTSf4s__single_level_live_root_callee_arg0_01 : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
@@ -594,7 +594,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: return [[IN2]]
 
 
-// CHECK-LABEL: sil [fragile] @_TTSf4s__multiple_level_all_root_fields_used_callee : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil [fragile] @_TTSf4s__multiple_level_all_root_fields_used_callee_arg0_001 : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int64):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S2 (%2 : $S1, [[IN2]] : $Builtin.Int64)
@@ -605,7 +605,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: return [[OUT]]
 
 
-// CHECK-LABEL: sil [fragile] @_TTSf4s__multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil [fragile] @_TTSf4s__multiple_level_no_root_fields_have_direct_uses_callee_arg0_00010 : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int64):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S2 ([[STRUCT1]] : $S1, [[IN2]] : $Builtin.Int64)
@@ -615,7 +615,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: return [[OUT]]
 
 
-// CHECK-LABEL: sil [fragile] @_TTSf4s__multiple_level_root_must_be_reformed_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil [fragile] @_TTSf4s__multiple_level_root_must_be_reformed_callee_arg0_00101 : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32, [[IN3:%.*]] : $Builtin.Int64):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S2 ([[STRUCT1]] : $S1, [[IN3]] : $Builtin.Int64)
@@ -629,7 +629,7 @@ bb0(%0 : $SingleFieldLvl1):
 
 
 
-// CHECK-LABEL: sil [fragile] @_TTSf4dg_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
+// CHECK-LABEL: sil [fragile] @_TTSf4dg_gs__owned_struct_1_callee_arg1_00111 : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 // CHECK: bb0([[IN1:%.*]] : $S4, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN1]] : $S4, [[STRUCT1]] : $S1)
@@ -639,7 +639,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: [[OUT:%.*]] = tuple ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32, [[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
 // CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 
-// CHECK-LABEL: sil [fragile] @_TTSf4n_d_gs_d_n__owned_struct_2_callee : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
+// CHECK-LABEL: sil [fragile] @_TTSf4n_d_gs_d_n__owned_struct_2_callee_arg2_00111 : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $S4, [[IN3:%.*]] : $Builtin.Int16, [[IN4:%.*]] : $Builtin.Int32, [[IN5:%.*]] : $Builtin.Int128):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, [[IN4]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN2]] : $S4, [[STRUCT1]] : $S1)
@@ -652,7 +652,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: [[OUT]] : $(Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
 
 
-// CHECK-LABEL: sil [fragile] @_TTSf4n_s_s__ignore_ptrs_callee : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16) {
+// CHECK-LABEL: sil [fragile] @_TTSf4n_s_s__ignore_ptrs_callee_arg1_0_arg2_0 : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16) {
 // CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int16):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, undef : $Builtin.Int32)
@@ -665,7 +665,7 @@ bb0(%0 : $SingleFieldLvl1):
 // CHECK: [[OUT:%.*]] = tuple ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int16)
 // CHECK: return [[OUT]] : $(Builtin.Int16, Builtin.Int16)
 
-// CHECK-LABEL: sil [fragile] @_TTSf4s__check_out_of_order_uses_callee : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> () {
+// CHECK-LABEL: sil [fragile] @_TTSf4s__check_out_of_order_uses_callee_arg0_01 : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> () {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int16, [[IN2:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT0:%.*]] = struct $S1 ([[IN1]] : $Builtin.Int16, [[IN2]] : $Builtin.Int32) 
 // CHECK: debug_value [[STRUCT0]]


### PR DESCRIPTION
This split the function signature module pass into 2 function passes.

By doing so,  this allows us to rewrite to using the FSO-optimized function prior to optimization, e.g. inlining, but allow us to do a substantial amount of optimization on the current function before attempting to do FSO on that function.

And also helps us to move to a model which module pass is NOT used unless necessary.

With this change, we should be able to place signature cloner and rewriter anywhere in the pipeline and run any # of iterations. 

Performance test suite: I do not see regression nor improvement for this change on the performance test suite.

Compilation time on StdLib:

Running Time    Self (ms)       Symbol Name
477.0ms    1.9% 14.0                 (anonymous namespace)::GenericSpecializer::run()
424.0ms    1.7% 1.0              (anonymous namespace)::StackPromotion::run()
290.0ms    1.2% 60.0                 (anonymous namespace)::SILMem2Reg::run()
275.0ms    1.1% 6.0              (anonymous namespace)::ABCOpt::run()
273.0ms    1.1% 4.0              (anonymous namespace)::SILCodeMotion::run()
151.0ms    0.6% 45.0                 (anonymous namespace)::FunctionSignatureOptRewriter::run()
144.0ms    0.6% 14.0                 (anonymous namespace)::DeadStoreElimination::run()
144.0ms    0.6% 28.0                 (anonymous namespace)::SILSROA::run()
99.0ms    0.4%  1.0              (anonymous namespace)::FunctionSignatureOptCloner::run()
96.0ms    0.4%  0.0              (anonymous namespace)::ConstantPropagation::run()
91.0ms    0.3%  33.0                 (anonymous namespace)::SILLowerAggregate::run()
