### PR TITLE
[build-presets] Remove explicit =1 for impl params

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -29,20 +29,20 @@ validation-test
 
 dash-dash
 
-verbose-build=1
+verbose-build
 build-ninja
 
 swift-sdks=OSX;IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR
 
 # Build static standard library because it is used
 # to build external projects.
-build-swift-static-stdlib=1
-build-swift-stdlib-unittest-extra=1
+build-swift-static-stdlib
+build-swift-stdlib-unittest-extra
 
 compiler-vendor=apple
 
 darwin-crash-reporter-client=0
-install-swift=1
+install-swift
 
 # Path to the root of the installation filesystem.
 install-destdir=%(install_destdir)s
@@ -116,7 +116,7 @@ dash-dash
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=false
-build-serialized-stdlib-unittest=1
+build-serialized-stdlib-unittest
 
 
 [preset: mixin_buildbot_tools_RA_stdlib_DA]
@@ -181,8 +181,8 @@ dash-dash
 skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
-swift-enable-lto=1
-llvm-enable-lto=1
+swift-enable-lto
+llvm-enable-lto
 
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes
@@ -198,13 +198,13 @@ dash-dash
 # in the build-script and build-presets.ini.
 reconfigure
 
-verbose-build=1
+verbose-build
 build-ninja
 
 # Don't build static standard library to speed up the build.
 build-swift-static-stdlib=0
 
-build-swift-stdlib-unittest-extra=1
+build-swift-stdlib-unittest-extra
 
 compiler-vendor=apple
 
@@ -402,7 +402,7 @@ dash-dash
 reconfigure
 
 # We want to always perform a verbose build
-verbose-build=1
+verbose-build
 
 # Build ninja while we are at it
 build-ninja
@@ -411,7 +411,7 @@ build-ninja
 build-swift-static-stdlib=0
 
 # We need to build the unittest extras so we can test
-build-swift-stdlib-unittest-extra=1
+build-swift-stdlib-unittest-extra
 
 # Set the vendor to apple
 compiler-vendor=apple
@@ -435,7 +435,7 @@ swift-primary-variant-sdk=OSX
 swift-primary-variant-arch=x86_64
 
 # Don't build the benchmarks
-skip-build-benchmarks=1
+skip-build-benchmarks
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
@@ -443,7 +443,7 @@ build-subdir=buildbot_incremental
 
 dash-dash
 
-swift-enable-lto=1
+swift-enable-lto
 
 
 #===------------------------------------------------------------------------===#
@@ -469,12 +469,12 @@ dash-dash
 # in the build-script and build-presets.ini.
 reconfigure
 
-verbose-build=1
+verbose-build
 build-ninja
 
 # Don't build static standard library to speed up the build.
 build-swift-static-stdlib=0
-build-swift-stdlib-unittest-extra=1
+build-swift-stdlib-unittest-extra
 
 skip-build-ios
 skip-test-ios
@@ -514,13 +514,13 @@ skip-test-osx
 # Always reconfigure so we pick up changes in the build-script and
 # build-presets.ini.
 reconfigure
-verbose-build=1
+verbose-build
 build-ninja
 # Don't build static standard library to speed up the build.
 build-swift-static-stdlib=0
-build-swift-stdlib-unittest-extra=1
+build-swift-stdlib-unittest-extra
 compiler-vendor=apple
-swift-runtime-enable-leak-checker=1
+swift-runtime-enable-leak-checker
 
 [preset: buildbot_incremental_leaks,tools=RA,stdlib=R]
 mixin-preset=buildbot_incremental_leaks
@@ -579,13 +579,13 @@ install-swiftpm
 install-xctest
 install-prefix=/usr
 swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license
-build-swift-static-stdlib=1
-build-swift-stdlib-unittest-extra=1
-skip-test-lldb=1
+build-swift-static-stdlib
+build-swift-stdlib-unittest-extra
+skip-test-lldb
 
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
-test-installable-package=1
+test-installable-package
 
 # Path to the root of the installation filesystem.
 install-destdir=%(install_destdir)s
@@ -637,13 +637,13 @@ install-swiftpm
 install-xctest
 install-prefix=/usr
 swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;dev
-build-swift-static-stdlib=1
-skip-test-lldb=1
+build-swift-static-stdlib
+skip-test-lldb
 
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-package-tests repo is checked out
 # FIXME: Disabled until a home for the swift-snapshot-tests can be found.
-#test-installable-package=1
+#test-installable-package
 
 # Path to the root of the installation filesystem.
 install-destdir=%(install_destdir)s
@@ -672,21 +672,21 @@ dash-dash
 
 lldb-no-debugserver
 lldb-build-type=Release
-verbose-build=1
+verbose-build
 build-ninja
-build-swift-static-stdlib=1
-build-swift-stdlib-unittest-extra=1
+build-swift-static-stdlib
+build-swift-stdlib-unittest-extra
 compiler-vendor=apple
 swift-sdks=OSX;IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR
 
-install-swift=1
-install-lldb=1
-install-llbuild=1
-install-swiftpm=1
+install-swift
+install-lldb
+install-llbuild
+install-swiftpm
 
 install-destdir=%(install_destdir)s
 
-darwin-install-extract-symbols=1
+darwin-install-extract-symbols
 
 # Path where debug symbols will be installed.
 install-symroot=%(install_symroot)s
@@ -697,7 +697,7 @@ install-prefix=%(install_toolchain_dir)s/usr
 
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
-test-installable-package=1
+test-installable-package
 
 # If someone uses this for incremental builds, force reconfiguration.
 reconfigure
@@ -755,7 +755,7 @@ darwin-toolchain-alias=%(darwin_toolchain_alias)s
 
 [preset: LLDB_Nested]
 dash-dash
-skip-build-benchmarks=1
+skip-build-benchmarks
 install-destdir=%(swift_install_destdir)s
 
 [preset: LLDB_Swift_DebugAssert]


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The `utils/build-script-impl` shellscript takes arguments in the form of `--foo=bar` or `--baz`. In the second form, the argument is automatically interpreted as `--baz=1`. There is no need to manually specify `=1`, so remove it from the build presets.

There is another reason to do this: the argument parser used by the Python `utils/build-script` is not as loose as the shellscript's. For a boolean switch such as `--baz`, the argument parser throws an exception if given a numerical value such as `--baz=1`. Therefore attempts to migrate certain parameters from the shellscript to the Python build script will encounter trouble when dealing with these explicit `--baz=1` parameters in the build presets.

This commit does not touch any of the `--foo=0` parameters. Although they should be removed, it's trickier due to the inheritance of the build presets, and so I will do so in a later commit.
#### ~~Resolved~~ Related bug number: ([SR-237](https://bugs.swift.org/browse/SR-237))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
