### PR TITLE
[build-presets] No need to disable static stdlib

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -201,9 +201,6 @@ reconfigure
 verbose-build=1
 build-ninja
 
-# Don't build static standard library to speed up the build.
-build-swift-static-stdlib=0
-
 build-swift-stdlib-unittest-extra=1
 
 compiler-vendor=apple
@@ -407,9 +404,6 @@ verbose-build=1
 # Build ninja while we are at it
 build-ninja
 
-# Building a static stdlib would waste time.
-build-swift-static-stdlib=0
-
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra=1
 
@@ -472,8 +466,6 @@ reconfigure
 verbose-build=1
 build-ninja
 
-# Don't build static standard library to speed up the build.
-build-swift-static-stdlib=0
 build-swift-stdlib-unittest-extra=1
 
 skip-build-ios
@@ -516,8 +508,6 @@ skip-test-osx
 reconfigure
 verbose-build=1
 build-ninja
-# Don't build static standard library to speed up the build.
-build-swift-static-stdlib=0
 build-swift-stdlib-unittest-extra=1
 compiler-vendor=apple
 swift-runtime-enable-leak-checker=1


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Static stdlib builds are disabled unless `--build-swift-static-stdlib` is explicitly passed in to the build scripts. As a result, `--build-swift-static-stdlib=0` is pointless--unless it's being used to counteract another `--build-swift-static-stdlib` being passed to the build script, but this is not the case in any of the uses in the build presets.

Remove the unnecessary parameters to make the build presets easier to understand.
#### ~~Resolved~~ Related bug number: ([SR-237](https://bugs.swift.org/browse/SR-237))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
