### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::getGenericSignature(…)

### DIFF
--- a/validation-test/compiler_crashers/28278-swift-archetypebuilder-getgenericsignature.swift
+++ b/validation-test/compiler_crashers/28278-swift-archetypebuilder-getgenericsignature.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol b{func^enum S<B{extension{enum A{protocol e:a{func^


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2223: void collectRequirements(swift::ArchetypeBuilder &, ArrayRef<swift::GenericTypeParamType *>, SmallVectorImpl<swift::Requirement> &): Assertion `pa && "Missing potential archetype for generic parameter"' failed.
8  swift           0x0000000000f7a3b8 swift::ArchetypeBuilder::getGenericSignature(llvm::ArrayRef<swift::GenericTypeParamType*>) + 1576
9  swift           0x0000000000e8b2d1 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 321
10 swift           0x0000000000e8b5b6 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
11 swift           0x0000000000e4e7bc swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1596
12 swift           0x0000000000e4e251 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 209
15 swift           0x0000000001086632 swift::namelookup::lookupInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::DeclName, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1122
16 swift           0x000000000108d95a swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 3978
17 swift           0x0000000000e8d79b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
20 swift           0x0000000000e972f0 swift::TypeChecker::inferDefaultWitnesses(swift::ProtocolDecl*) + 288
21 swift           0x0000000000e77628 swift::finishTypeChecking(swift::SourceFile&) + 504
22 swift           0x0000000000cc880a swift::CompilerInstance::performSema() + 3514
24 swift           0x000000000078d3ac frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
25 swift           0x0000000000787e25 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28278-swift-archetypebuilder-getgenericsignature.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28278-swift-archetypebuilder-getgenericsignature-ed4694.o
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
