### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::PotentialArchetype::getNestedType(…)

### DIFF
--- a/validation-test/compiler_crashers/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift
+++ b/validation-test/compiler_crashers/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+{
+protocol A{
+typealias e
+let f
+typealias e
+typealias e=b
+typealias b


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
4  swift           0x0000000000f72f8d swift::ArchetypeBuilder::PotentialArchetype::getNestedType(swift::Identifier, swift::ArchetypeBuilder&) + 797
5  swift           0x0000000000f75bec swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 444
6  swift           0x0000000000f77fed swift::ArchetypeBuilder::addRequirement(swift::Requirement const&, swift::RequirementSource) + 317
7  swift           0x0000000000f79ce3 swift::ArchetypeBuilder::addGenericSignature(swift::GenericSignature*, bool, bool) + 515
8  swift           0x0000000000e899c7 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 55
10 swift           0x0000000000e89efc swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 124
13 swift           0x0000000000e53c86 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
14 swift           0x0000000000ec3423 swift::convertStoredVarInProtocolToComputed(swift::VarDecl*, swift::TypeChecker&) + 115
19 swift           0x0000000000e53c86 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
22 swift           0x0000000000eb3a2a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
23 swift           0x0000000000edd9fc swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
24 swift           0x0000000000e41c9a swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
26 swift           0x0000000000eb3b76 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
27 swift           0x0000000000e76fad swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1117
28 swift           0x0000000000cc865f swift::CompilerInstance::performSema() + 3087
30 swift           0x000000000078d3ac frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
31 swift           0x0000000000787e25 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28279-swift-archetypebuilder-potentialarchetype-getnestedtype-b5cbd1.o
1.  While type-checking expression at [validation-test/compiler_crashers/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift:9:1 - line:15:11] RangeText="{
2.  While type-checking 'A' at validation-test/compiler_crashers/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift:10:1
3.  While type-checking getter for f at validation-test/compiler_crashers/28279-swift-archetypebuilder-potentialarchetype-getnestedtype.swift:12:5
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
