### PR TITLE
[stdlib] Add `rethrows` to the `ObjectiveC.autoreleasepool` function

### DIFF
--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -202,10 +202,12 @@ func __pushAutoreleasePool() -> OpaquePointer
 @_silgen_name("objc_autoreleasePoolPop")
 func __popAutoreleasePool(pool: OpaquePointer)
 
-public func autoreleasepool(@noescape code: () -> Void) {
+public func autoreleasepool(@noescape code: () throws -> Void) rethrows {
   let pool = __pushAutoreleasePool()
-  code()
-  __popAutoreleasePool(pool)
+  defer {
+    __popAutoreleasePool(pool)
+  }
+  try code()
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Interpreter/SDK/autorelease.swift
+++ b/test/Interpreter/SDK/autorelease.swift
@@ -36,3 +36,32 @@ print("autorelease test end")
 // CHECK-NEXT: object died
 // CHECK-NEXT: after call to useTemp
 // CHECK-NEXT: autorelease test end
+
+// Using an @objc class to check that errors are retained across the pool
+// boundaries. A classic crash is an error created inside a pool and then
+// zombied before handling it outside the pool.
+@objc class Error: NSObject, ErrorProtocol {
+  let message:String
+  init(message:String) {
+    self.message = message
+  }
+}
+
+// Check that rethrow works.
+func requireString(string:String?) throws -> String {
+  guard let string = string else {
+    throw Error(message:"no string")
+  }
+  print("returning \"\(string)\"")
+  return string
+}
+do {
+  try autoreleasepool {
+    try requireString("ok")
+    try requireString(nil)
+  }
+} catch let err as Error {
+  print("caught \"\(err.message)\"")
+}
+// CHECK-NEXT:      returning "ok"
+// CHECK-NEXT:      caught "no string"


### PR DESCRIPTION
Adds the `rethrows` annotation to the `ObjectiveC.autoreleasepool` function, along with a test that it works.

Resolves #43454.