### PR TITLE
Don't try to build compiler-rt when cross-compiling

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -483,8 +483,6 @@ function set_deployment_target_based_options() {
                     ;;
             esac
 
-	    echo "num deployment targets = ${#CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS[@]}"
-
             llvm_cmake_options=(
                 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="${cmake_osx_deployment_target}"
                 -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -488,6 +488,7 @@ function set_deployment_target_based_options() {
                 -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                 -DLLVM_HOST_TRIPLE:STRING="${llvm_host_triple}"
                 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
+                -DLLVM_BUILD_EXTERNAL_COMPILER_RT=$(true_false "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS}")
                 -DCOMPILER_RT_ENABLE_IOS:BOOL=$(false_true ${SKIP_IOS})
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -483,12 +483,14 @@ function set_deployment_target_based_options() {
                     ;;
             esac
 
+	    echo "num deployment targets = ${#CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS[@]}"
+
             llvm_cmake_options=(
                 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="${cmake_osx_deployment_target}"
                 -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                 -DLLVM_HOST_TRIPLE:STRING="${llvm_host_triple}"
                 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
-                -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL="$(true_false ${#CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS[@]})"
+                -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${#CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS[@]})"
                 -DCOMPILER_RT_ENABLE_IOS:BOOL="$(false_true ${SKIP_IOS})"
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE
@@ -810,7 +812,11 @@ function true_false() {
 }
 
 function false_true() {
-    true_false $(not "$1")
+    if [[ $(true_false "$1") = "TRUE" ]]; then
+        echo "FALSE"
+    else
+        echo "TRUE"
+    fi
 }
 
 function cmake_version() {

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -488,8 +488,8 @@ function set_deployment_target_based_options() {
                 -DCMAKE_OSX_SYSROOT:PATH="$(xcrun --sdk ${xcrun_sdk_name} --show-sdk-path)"
                 -DLLVM_HOST_TRIPLE:STRING="${llvm_host_triple}"
                 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
-                -DLLVM_BUILD_EXTERNAL_COMPILER_RT=$(true_false "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS}")
-                -DCOMPILER_RT_ENABLE_IOS:BOOL=$(false_true ${SKIP_IOS})
+                -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL="$(true_false ${#CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS[@]})"
+                -DCOMPILER_RT_ENABLE_IOS:BOOL="$(false_true ${SKIP_IOS})"
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE
             )


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This PR makes build-script skip building compiler-rt when cross-compiling.

A user has reported a build-time failure when building swift-compiler-rt along with `--cross-compile-tools-deployment-targets` set. We should have a workaround in place before investigating a longer-term fix.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
