### PR TITLE
[build-presets] Foundation built based on platform

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -262,8 +262,9 @@ skip-test-watchos
 # build for iOS/tvOS.
 mixin-preset=buildbot_incremental_base
 
-# Build Foundation, then build and test XCTest.
-foundation
+# Build and test XCTest. On Linux, the build script is aware of the dependency
+# on Foundation, so that is built as well. On OS X, Foundation is built as part
+# of the XCTest Xcode project.
 xctest
 
 dash-dash


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Yet another attempt at getting the XCTest build preset to work on both Linux and OS X.

Previously, the XCTest CI preset would attempt to build corelibs-foundation on OS X. corelibs-foundation is not meant to be built via the build-script on OS X, so this would cause issues.

Remove the explicit `--foundation` option, and instead leave it up to the build-script to determine whether to build corelibs-foundation when building XCTest.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
