### PR TITLE
[build-presets] No need to disable crash reporter (NFC)

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -41,7 +41,6 @@ build-swift-stdlib-unittest-extra
 
 compiler-vendor=apple
 
-darwin-crash-reporter-client=0
 install-swift
 
 # Path to the root of the installation filesystem.
@@ -415,9 +414,6 @@ build-swift-stdlib-unittest-extra
 
 # Set the vendor to apple
 compiler-vendor=apple
-
-# Disable crash reporter. This will improve build time even more.
-darwin-crash-reporter-client=0
 
 # Make sure our stdlib is RA.
 swift-stdlib-build-type=RelWithDebInfo


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The `--darwin-crash-reporter-client` is not enabled unless explicitly passed in to the build scripts. This is not done by the Python build script nor any of the presets, so there's no need to explicitly disable it.

This is a re-submission of https://github.com/apple/swift/pull/1746, which I accidentally pushed as a branch on the main apple/swift repository. This pull request correctly originates from my fork of Swift.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
