### PR TITLE
[NFC][test] Remove "upload stdlib" CMake variable

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,11 +174,6 @@ if(PYTHONINTERP_FOUND)
 
         set(lit_command ${PYTHON_EXECUTABLE} "${LIT}" ${LIT_ARGS})
 
-        set(command_upload_stdlib)
-        if("${SDK}" STREQUAL "IOS" OR "${SDK}" STREQUAL "TVOS" OR "${SDK}" STREQUAL "WATCHOS")
-          # These are supported testing SDKs.
-        endif()
-
         set(test_dependencies)
         get_test_dependencies("${SDK}" test_dependencies)
         list(APPEND test_dependencies
@@ -222,7 +217,6 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         add_custom_target("check-swift${test_mode_target_suffix}${VARIANT_SUFFIX}"
-            ${command_upload_stdlib}
             ${command_clean_test_results_dir}
             ${command_profdata_merge_start}
             COMMAND ${lit_command} "${test_bin_dir}"
@@ -232,7 +226,6 @@ if(PYTHONINTERP_FOUND)
             ${cmake_3_2_USES_TERMINAL})
 
         add_custom_target("check-swift-validation${test_mode_target_suffix}${VARIANT_SUFFIX}"
-            ${command_upload_stdlib}
             ${command_clean_test_results_dir}
             ${command_profdata_merge_start}
             COMMAND ${lit_command} "${validation_test_bin_dir}"
@@ -242,7 +235,6 @@ if(PYTHONINTERP_FOUND)
             ${cmake_3_2_USES_TERMINAL})
 
         add_custom_target("check-swift-all${test_mode_target_suffix}${VARIANT_SUFFIX}"
-            ${command_upload_stdlib}
             ${command_clean_test_results_dir}
             ${command_profdata_merge_start}
             COMMAND ${lit_command} "${validation_test_bin_dir}" "${test_bin_dir}"


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

All uses of this variable were added in 4ac9c8080, but it appears to have been unused since its addition. Remove it to simplify the test CMake targets.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
