### PR TITLE
[Runtime] Use OBJC_EXPORT for compatibility

### DIFF
--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -34,19 +34,20 @@ struct HeapObject;
 #if SWIFT_OBJC_INTEROP
 #include <objc/objc.h>
 #include <objc/runtime.h>
+#include <objc/objc-api.h>
 
 // Redeclare APIs from the Objective-C runtime.
 // These functions are not available through public headers, but are guaranteed
 // to exist on OS X >= 10.9 and iOS >= 7.0.
 
-extern "C" id objc_retain(id);
-extern "C" void objc_release(id);
-extern "C" id _objc_rootAutorelease(id);
-extern "C" void objc_moveWeak(id*, id*);
-extern "C" void objc_copyWeak(id*, id*);
-extern "C" id objc_initWeak(id*, id);
-extern "C" void objc_destroyWeak(id*);
-extern "C" id objc_loadWeakRetained(id*);
+OBJC_EXPORT id objc_retain(id);
+OBJC_EXPORT void objc_release(id);
+OBJC_EXPORT id _objc_rootAutorelease(id);
+OBJC_EXPORT void objc_moveWeak(id*, id*);
+OBJC_EXPORT void objc_copyWeak(id*, id*);
+OBJC_EXPORT id objc_initWeak(id*, id);
+OBJC_EXPORT void objc_destroyWeak(id*);
+OBJC_EXPORT id objc_loadWeakRetained(id*);
 
 // Description of an Objective-C image.
 // __DATA,__objc_imageinfo stores one of these.

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -47,7 +47,7 @@
 using namespace swift;
 
 #if SWIFT_HAS_ISA_MASKING
-extern "C" __attribute__((weak_import))
+OBJC_EXPORT __attribute__((weak_import))
 const uintptr_t objc_debug_isa_class_mask;
 
 static uintptr_t computeISAMask() {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

ObjC APIs are declared in objc4 as OBJC_EXPORT, but in swift they were just extern "C". This change fixes them to match the objc4 declaration.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

objc uses OBJC_EXPORT when defining these symbols, the declarations should match
