### PR TITLE
[build_support] Added -sparse option for llvm-profdata if supported

### DIFF
--- a/utils/profdata_merge/process.py
+++ b/utils/profdata_merge/process.py
@@ -14,9 +14,23 @@
 import logging
 import os
 import pipes
-import subprocess
+import sys
 
 from multiprocessing import Process
+
+
+# hack to import SwiftBuildSupport and swift_build_support
+parent_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+sys.path.append(parent_dir)
+support_dir = os.path.join(parent_dir, 'swift_build_support')
+sys.path.append(support_dir)
+from swift_build_support import xcrun  # noqa (E402)
+from SwiftBuildSupport import check_output, check_call  # noqa (E402)
+
+# FIXME: This doesn't work on non-Darwin platforms.
+LLVM_PROFDATA_PATH = xcrun.find('default', 'llvm-profdata')
+_profdata_help = check_output([LLVM_PROFDATA_PATH, 'merge', '-help'])
+LLVM_PROFDATA_SUPPORTS_SPARSE = 'sparse' in _profdata_help
 
 
 class ProfdataMergerProcess(Process):
@@ -45,13 +59,13 @@ class ProfdataMergerProcess(Process):
         if os.path.exists(self.profdata_path):
             os.rename(self.profdata_path, self.profdata_tmp_path)
             self.filename_buffer.append(self.profdata_tmp_path)
-        cleaned_files = ' '.join(pipes.quote(f) for f in self.filename_buffer)
-        # FIXME: This doesn't necessarily always line up with the version
-        #        of clang++ used to build the binaries.
-        llvm_cmd = ("xcrun llvm-profdata merge -o %s %s"
-                    % (self.profdata_path, cleaned_files))
+        cleaned_files = [pipes.quote(f) for f in self.filename_buffer]
+        llvm_cmd = [LLVM_PROFDATA_PATH, "merge", "-o", self.profdata_path]
+        if LLVM_PROFDATA_SUPPORTS_SPARSE:
+            llvm_cmd.append("-sparse")
+        llvm_cmd += cleaned_files
         self.report(llvm_cmd)
-        ret = subprocess.call(llvm_cmd, shell=True)
+        ret = check_call(llvm_cmd)
         if ret != 0:
             self.report("llvm profdata command failed -- Exited with code %d"
                         % ret, level=logging.ERROR)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Adds the `-sparse` option to invocations of `llvm-profdata` if it's supported.
Abstracts out the lookup for `llvm-profdata` such that it can be replaced if/when #1586 is merged.

<!-- Description about pull request. -->
#### Resolved bug number: [rdar://problem/25072811](rdar://problem/25072811)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
