### PR TITLE
[Darwin] Get rid of trampoline hack for lgamma function.

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -13,7 +13,9 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
       POSIXError.swift
       MachError.swift)
   set(swift_platform_flags
-      SWIFT_COMPILE_FLAGS -Xfrontend -disable-objc-attr-requires-foundation-module
+      SWIFT_COMPILE_FLAGS
+          -Xfrontend -disable-objc-attr-requires-foundation-module
+          -Xcc -D_REENTRANT # Required to unveil lgamma_r used in tgmath.
       API_NOTES_NON_OVERLAY)
 else()
   set(swift_platform_name swiftGlibc)

--- a/stdlib/public/Platform/Misc.c
+++ b/stdlib/public/Platform/Misc.c
@@ -44,26 +44,6 @@ _swift_Platform_fcntlPtr(int fd, int cmd, void* ptr) {
   return fcntl(fd, cmd, ptr);
 }
 
-#if defined(__APPLE__)
-#define _REENTRANT
-#include <math.h>
-
-extern float
-_swift_Darwin_lgammaf_r(float x, int *psigngam) {
-  return lgammaf_r(x, psigngam);
-}
-
-extern double
-_swift_Darwin_lgamma_r(double x, int *psigngam) {
-  return lgamma_r(x, psigngam);
-}
-
-extern long double
-_swift_Darwin_lgammal_r(long double x, int *psigngam) {
-  return lgammal_r(x, psigngam);
-}
-#endif
-
 #if defined(__FreeBSD__)
 extern char **
 _swift_FreeBSD_getEnv() {

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -282,7 +282,6 @@ public func scalbn(x: ${T}, _ n: Int) -> ${T} {
 
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
-#if os(Linux) || os(FreeBSD)
 @_transparent
 @warn_unused_result
 public func lgamma(x: ${T}) -> (${T}, Int) {
@@ -290,25 +289,6 @@ public func lgamma(x: ${T}) -> (${T}, Int) {
   let value = lgamma${f}_r(${CT}(x), &sign)
   return (${T}(value), Int(sign))
 }
-#else
-% # On Darwin platform,
-% # The real lgamma_r is not imported because it hides behind macro _REENTRANT.
-@warn_unused_result
-@_silgen_name("_swift_Darwin_lgamma${f}_r")
-func _swift_Darwin_lgamma${f}_r(_: ${CT},
-                                _: UnsafeMutablePointer<CInt>) -> ${CT}
-
-@_transparent
-@warn_unused_result
-public func lgamma(x: ${T}) -> (${T}, Int) {
-  var sign = CInt(0)
-  let value = withUnsafeMutablePointer(&sign) { 
-    (signp: UnsafeMutablePointer<CInt>) -> ${CT} in
-    return _swift_Darwin_lgamma${f}_r(${CT}(x), signp)
-  }
-  return (${T}(value), Int(sign))
-}
-#endif
 
 % end
 


### PR DESCRIPTION
#### What's in this pull request?

Since swiftc pass-through `-Xcc` arguments to ClangImporter,
we can unveil `lgamma_r` with `-Xcc -D_REENTRANT`.
#### Resolved bug number: N/A

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
