### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::resolveIdentifierType(…)

### DIFF
--- a/validation-test/compiler_crashers/28280-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers/28280-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+enum T{class B{struct S<T where f:T>:A
+let f:S<T>


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/include/swift/AST/DiagnosticEngine.h:610: swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose(swift::SourceLoc, Diag<ArgTypes...>, typename detail::PassArgument<ArgTypes>::type...) [ArgTypes = <swift::Identifier>]: Assertion `!ActiveDiagnostic && "Already have an active diagnostic"' failed.
12 swift           0x0000000000ebe50e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
14 swift           0x0000000000ebf424 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
15 swift           0x0000000000ebe40a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
16 swift           0x0000000000f763cf swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 159
17 swift           0x0000000000f53a5d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
18 swift           0x0000000000e50a39 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
19 swift           0x00000000010bb6f3 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 2435
20 swift           0x00000000010bae68 swift::ConformanceLookupTable::updateLookupTable(swift::NominalTypeDecl*, swift::ConformanceLookupTable::ConformanceStage, swift::LazyResolver*) + 248
21 swift           0x00000000010be272 swift::ConformanceLookupTable::lookupConformance(swift::ModuleDecl*, swift::NominalTypeDecl*, swift::ProtocolDecl*, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ProtocolConformance*>&) + 50
22 swift           0x0000000001085a51 swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl*, swift::LazyResolver*) + 1137
23 swift           0x0000000000e9b40a swift::TypeChecker::conformsToProtocol(swift::Type, swift::ProtocolDecl*, swift::DeclContext*, swift::OptionSet<swift::ConformanceCheckFlags, unsigned int>, swift::ProtocolConformance**, swift::SourceLoc) + 106
27 swift           0x0000000000e5f312 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1442
32 swift           0x0000000000e59776 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000e7caaa swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1146
34 swift           0x0000000000ccd3cf swift::CompilerInstance::performSema() + 3087
36 swift           0x000000000078e10c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
37 swift           0x0000000000788b85 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28280-swift-typechecker-resolveidentifiertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28280-swift-typechecker-resolveidentifiertype-6143c3.o
1.  While type-checking 'T' at validation-test/compiler_crashers/28280-swift-typechecker-resolveidentifiertype.swift:10:1
2.  While resolving type A at [validation-test/compiler_crashers/28280-swift-typechecker-resolveidentifiertype.swift:10:38 - line:10:38] RangeText="A"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
