### PR TITLE
Added missing 'const' to iterator comp. operators

### DIFF
--- a/include/swift/Basic/ArrayRefView.h
+++ b/include/swift/Basic/ArrayRefView.h
@@ -44,8 +44,8 @@ public:
     Projected operator*() const { return Project(*Ptr); }
     iterator &operator++() { Ptr++; return *this; }
     iterator operator++(int) { return iterator(Ptr++); }
-    bool operator==(iterator rhs) { return Ptr == rhs.Ptr; }
-    bool operator!=(iterator rhs) { return Ptr != rhs.Ptr; }
+    bool operator==(iterator rhs) const { return Ptr == rhs.Ptr; }
+    bool operator!=(iterator rhs) const { return Ptr != rhs.Ptr; }
 
     iterator &operator+=(difference_type i) {
       Ptr += i;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Added missing 'const' to iterator comp. operators

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
