### PR TITLE
Improve template typenames consistency

### DIFF
--- a/include/swift/Basic/BlotMapVector.h
+++ b/include/swift/Basic/BlotMapVector.h
@@ -28,18 +28,18 @@ bool compareKeyAgainstDefaultKey(const std::pair<KeyT, ValueT> &Pair) {
 /// \brief An associative container with fast insertion-order (deterministic)
 /// iteration over its elements. Plus the special blot operation.
 template <typename KeyT, typename ValueT,
-          typename MapTy = llvm::DenseMap<KeyT, size_t>,
-          typename VectorTy = std::vector<Optional<std::pair<KeyT, ValueT>>>>
+          typename MapT = llvm::DenseMap<KeyT, size_t>,
+          typename VectorT = std::vector<Optional<std::pair<KeyT, ValueT>>>>
 class BlotMapVector {
     /// Map keys to indices in Vector.
-    MapTy Map;
+    MapT Map;
 
     /// Keys and values.
-    VectorTy Vector;
+    VectorT Vector;
 
   public:
-    using iterator = typename VectorTy::iterator;
-    using const_iterator = typename VectorTy::const_iterator;
+    using iterator = typename VectorT::iterator;
+    using const_iterator = typename VectorT::const_iterator;
     using key_type = KeyT;
     using mapped_type = ValueT;
 
@@ -76,7 +76,7 @@ class BlotMapVector {
     }
 
     iterator find(const KeyT &Key) {
-      typename MapTy::iterator It = Map.find(Key);
+      typename MapT::iterator It = Map.find(Key);
       if (It == Map.end()) return Vector.end();
       auto Iter = Vector.begin() + It->second;
       if (!Iter->hasValue())
@@ -102,7 +102,7 @@ class BlotMapVector {
     /// vector, it just zeros out the key in the vector. This leaves iterators
     /// intact, but clients must be prepared for zeroed-out keys when iterating.
     void blot(const KeyT &Key) {
-      typename MapTy::iterator It = Map.find(Key);
+      typename MapT::iterator It = Map.find(Key);
       if (It == Map.end()) return;
       Vector[It->second] = None;
       Map.erase(It);


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Rename BlotMapVector's template typenames: MapTy -> MapT and VectorTy -> VectorT. This is consistent both with BlotMapVector's other template typename KeyT and ValueT, and with SmallBlotMapVector's MapT and VectorT template typenames.
