### PR TITLE
[Python] Remove unused function nthroot. Use sys.exit(…) instead of exit(…)

### DIFF
--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -255,12 +255,12 @@ def main():
                 write_to_file(args.output, html_data)
             else:
                 print("Error: missing --output flag.")
-                exit(1)
+                sys.exit(1)
         elif args.format.lower() == "markdown" and args.output:
             write_to_file(args.output, markdown_data)
         elif args.format.lower() != "markdown":
             print("{0} is unknown format.".format(args.format))
-            exit(1)
+            sys.exit(1)
 
 
 def convert_to_html(ratio_list, old_results, new_results, delta_list,
@@ -342,15 +342,6 @@ def sort_ratio_list(ratio_list, changes_only=False):
 
     return (complete_perf_list, increased_perf_list,
             decreased_perf_list, sorted_normal_perf_list)
-
-
-def nthroot(y, n):
-    x, xp = 1, -1
-    while abs(x - xp) > 1:
-            xp, x = x, x - x/n + y/(n * x**(n-1))
-    while x**n > y:
-            x -= 1
-    return x
 
 
 def max_width(items, title, key_len=False):


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Python cleanups:
- Remove unused function `nthroot`
- Use `sys.exit(…)` instead of `exit(…)`
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…xit(…).
