### PR TITLE
Canonicalize swift header files headers and footers

### DIFF
--- a/include/swift/Basic/Algorithm.h
+++ b/include/swift/Basic/Algorithm.h
@@ -26,4 +26,4 @@ namespace swift {
   }
 } // end namespace swift
 
-#endif /* SWIFT_BASIC_ALGORITHM_H */
+#endif // SWIFT_BASIC_ALGORITHM_H

--- a/include/swift/Basic/ArrayRefView.h
+++ b/include/swift/Basic/ArrayRefView.h
@@ -100,6 +100,6 @@ public:
   }
 };
 
-} // namespace swift
+} // end namespace swift
 
-#endif /* SWIFT_BASIC_ARRAYREFVIEW_H */
+#endif // SWIFT_BASIC_ARRAYREFVIEW_H

--- a/include/swift/Basic/AssertImplements.h
+++ b/include/swift/Basic/AssertImplements.h
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_BASIC_ASSERT_IMPLEMENTS_H
-#define SWIFT_BASIC_ASSERT_IMPLEMENTS_H
+#ifndef SWIFT_BASIC_ASSERTIMPLEMENTS_H
+#define SWIFT_BASIC_ASSERTIMPLEMENTS_H
 
 #include <type_traits>
 
@@ -61,4 +61,4 @@ namespace swift {
 
 } // end namespace swift
 
-#endif // SWIFT_BASIC_ASSERT_IMPLEMENTS_H
+#endif // SWIFT_BASIC_ASSERTIMPLEMENTS_H

--- a/include/swift/Basic/Cache.h
+++ b/include/swift/Basic/Cache.h
@@ -226,7 +226,7 @@ struct CacheValueInfo<llvm::IntrusiveRefCntPtr<T>>{
   }
 };
 
-} // namespace sys
-} // namespace swift
+} // end namespace sys
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_CACHE_H

--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -674,4 +674,4 @@ private:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_CLUSTEREDBITVECTOR_H

--- a/include/swift/Basic/Defer.h
+++ b/include/swift/Basic/Defer.h
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __SWIFT_DEFER_H
-#define __SWIFT_DEFER_H
+#ifndef SWIFT_BASIC_DEFER_H
+#define SWIFT_BASIC_DEFER_H
 
 #include <type_traits>
 
@@ -39,7 +39,7 @@ namespace swift {
       return DoAtScopeExit<typename std::decay<F>::type>(fn);
     }
   }
-}
+} // end namespace swift
 
 
 #define DEFER_CONCAT_IMPL(x, y) x##y
@@ -57,5 +57,5 @@ namespace swift {
 ///   };
 ///
 #define defer defer_impl
-#endif
 
+#endif // SWIFT_BASIC_DEFER_H

--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -419,5 +419,4 @@ static inline bool isDigit(int c) {
 } // end namespace Demangle
 } // end namespace swift
 
-#endif
-
+#endif // SWIFT_BASIC_DEMANGLE_H

--- a/include/swift/Basic/DemangleWrappers.h
+++ b/include/swift/Basic/DemangleWrappers.h
@@ -16,8 +16,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_BASIC_DEMANGLE_WRAPPERS_H
-#define SWIFT_BASIC_DEMANGLE_WRAPPERS_H
+#ifndef SWIFT_BASIC_DEMANGLEWRAPPERS_H
+#define SWIFT_BASIC_DEMANGLEWRAPPERS_H
 
 #include "swift/Basic/Demangle.h"
 #include "swift/Basic/LLVM.h"
@@ -57,5 +57,4 @@ demangleTypeAsString(StringRef MangledTypeName,
 } // end namespace demangle_wrappers
 } // end namespace swift
 
-#endif // LLVM_SWIFT_BASIC_DEMANGLE_WRAPPERS_H
-
+#endif // SWIFT_BASIC_DEMANGLEWRAPPERS_H

--- a/include/swift/Basic/DiagnosticConsumer.h
+++ b/include/swift/Basic/DiagnosticConsumer.h
@@ -16,8 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_BASIC_DIAGNOSTIC_CONSUMER_H
-#define SWIFT_BASIC_DIAGNOSTIC_CONSUMER_H
+#ifndef SWIFT_BASIC_DIAGNOSTICCONSUMER_H
+#define SWIFT_BASIC_DIAGNOSTICCONSUMER_H
 
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/Support/SourceMgr.h"
@@ -103,6 +103,6 @@ public:
                         const DiagnosticInfo &Info) override;
 };
   
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_DIAGNOSTICCONSUMER_H

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -43,6 +43,6 @@ public:
   bool WarningsAsErrors = false;
 };
 
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_DIAGNOSTICOPTIONS_H

--- a/include/swift/Basic/DiverseList.h
+++ b/include/swift/Basic/DiverseList.h
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_IRGEN_DIVERSELIST_H
-#define SWIFT_IRGEN_DIVERSELIST_H
+#ifndef SWIFT_BASIC_DIVERSELIST_H
+#define SWIFT_BASIC_DIVERSELIST_H
 
 #include <cassert>
 #include <cstring>
@@ -285,4 +285,4 @@ public:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_DIVERSELIST_H

--- a/include/swift/Basic/DiverseStack.h
+++ b/include/swift/Basic/DiverseStack.h
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_IRGEN_DIVERSESTACK_H
-#define SWIFT_IRGEN_DIVERSESTACK_H
+#ifndef SWIFT_BASIC_DIVERSESTACK_H
+#define SWIFT_BASIC_DIVERSESTACK_H
 
 #include "swift/Basic/Malloc.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
@@ -380,4 +380,4 @@ namespace llvm {
   };
 }
 
-#endif
+#endif // SWIFT_BASIC_DIVERSESTACK_H

--- a/include/swift/Basic/Dwarf.h
+++ b/include/swift/Basic/Dwarf.h
@@ -28,6 +28,6 @@ namespace swift {
   static const char MachOASTSectionName[] = "__ast";
   static const char ELFASTSectionName[] = ".swift_ast";
   static const char COFFASTSectionName[] = "swiftast";
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_DWARF_H

--- a/include/swift/Basic/EditorPlaceholder.h
+++ b/include/swift/Basic/EditorPlaceholder.h
@@ -46,7 +46,6 @@ struct EditorPlaceholderData {
 Optional<EditorPlaceholderData>
   parseEditorPlaceholder(StringRef PlaceholderText);
 
-} // namespace swift
+} // end namespace swift
 
-#endif // LLVM_SWIFT_BASIC_EDITORPLACEHOLDER_H
-
+#endif // SWIFT_BASIC_EDITORPLACEHOLDER_H

--- a/include/swift/Basic/EncodedSequence.h
+++ b/include/swift/Basic/EncodedSequence.h
@@ -371,4 +371,4 @@ public:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_ENCODEDSEQUENCE_H

--- a/include/swift/Basic/Fallthrough.h
+++ b/include/swift/Basic/Fallthrough.h
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __SWIFT_FALLTHROUGH_H__
-#define __SWIFT_FALLTHROUGH_H__
+#ifndef SWIFT_BASIC_FALLTHROUGH_H
+#define SWIFT_BASIC_FALLTHROUGH_H
 
 #ifndef __has_attribute
 # define __has_attribute(x) 0
@@ -36,4 +36,4 @@
 # define SWIFT_FALLTHROUGH
 #endif
 
-#endif
+#endif // SWIFT_BASIC_FALLTHROUGH_H

--- a/include/swift/Basic/FileSystem.h
+++ b/include/swift/Basic/FileSystem.h
@@ -24,6 +24,6 @@ namespace swift {
   /// the file at \p source will still be present at \p source.
   std::error_code moveFileIfDifferent(const llvm::Twine &source,
                                       const llvm::Twine &destination);
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_FILESYSTEM_H

--- a/include/swift/Basic/FlaggedPointer.h
+++ b/include/swift/Basic/FlaggedPointer.h
@@ -14,8 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-#ifndef SWIFT_RUNTIME_FLAGGEDPOINTER_H
-#define SWIFT_RUNTIME_FLAGGEDPOINTER_H
+#ifndef SWIFT_BASIC_FLAGGEDPOINTER_H
+#define SWIFT_BASIC_FLAGGEDPOINTER_H
 
 #include <cassert>
 
@@ -148,7 +148,7 @@ public:
   }
 };
 
-};
+} // end namespace swift
 
 // Teach SmallPtrSet that FlaggedPointer is "basically a pointer".
 template <typename PointerTy, unsigned BitPosition, typename PtrTraits>
@@ -175,4 +175,4 @@ public:
   };
 };
 
-#endif
+#endif // SWIFT_BASIC_FLAGGEDPOINTER_H

--- a/include/swift/Basic/ImmutablePointerSet.h
+++ b/include/swift/Basic/ImmutablePointerSet.h
@@ -349,4 +349,4 @@ ImmutablePointerSet<T> ImmutablePointerSetFactory<T>::EmptyPtrSet =
 
 } // end swift namespace
 
-#endif
+#endif // SWIFT_BASIC_IMMUTABLEPOINTERSET_H

--- a/include/swift/Basic/JSONSerialization.h
+++ b/include/swift/Basic/JSONSerialization.h
@@ -626,4 +626,4 @@ operator<<(Output &yout, T &seq) {
 } // end namespace json
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_JSONSERIALIZATION_H

--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_AST_LLVM_H
-#define SWIFT_AST_LLVM_H
+#ifndef SWIFT_BASIC_LLVM_H
+#define SWIFT_BASIC_LLVM_H
 
 // Do not proliferate #includes here, require clients to #include their
 // dependencies.
@@ -79,4 +79,4 @@ namespace swift {
   using llvm::NoneType;
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_LLVM_H

--- a/include/swift/Basic/LLVMInitialize.h
+++ b/include/swift/Basic/LLVMInitialize.h
@@ -40,4 +40,4 @@
   llvm::InitializeAllDisassemblers(); \
   llvm::InitializeAllTargetInfos();
 
-#endif
+#endif // SWIFT_BASIC_LLVMINITIALIZE_H

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_LANGOPTIONS_H
-#define SWIFT_LANGOPTIONS_H
+#ifndef SWIFT_BASIC_LANGOPTIONS_H
+#define SWIFT_BASIC_LANGOPTIONS_H
 
 #include "swift/Basic/LLVM.h"
 #include "clang/Basic/VersionTuple.h"
@@ -245,7 +245,6 @@ namespace swift {
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
   };
-}
+} // end namespace swift
 
-#endif // SWIFT_LANGOPTIONS_H
-
+#endif // SWIFT_BASIC_LANGOPTIONS_H

--- a/include/swift/Basic/Lazy.h
+++ b/include/swift/Basic/Lazy.h
@@ -79,7 +79,7 @@ template <typename T> inline T &Lazy<T>::get(void (*initCallback)(void*)) {
   return unsafeGetAlreadyInitialized();
 }
 
-} // namespace swift
+} // end namespace swift
 
 #define SWIFT_LAZY_CONSTANT(INITIAL_VALUE) \
   ([]{ \

--- a/include/swift/Basic/NullablePtr.h
+++ b/include/swift/Basic/NullablePtr.h
@@ -64,4 +64,4 @@ public:
   
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_NULLABLEPTR_H

--- a/include/swift/Basic/OptionSet.h
+++ b/include/swift/Basic/OptionSet.h
@@ -131,6 +131,6 @@ private:
                 "operator| should produce an OptionSet");
 };
 
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_OPTIONSET_H

--- a/include/swift/Basic/OptionalEnum.h
+++ b/include/swift/Basic/OptionalEnum.h
@@ -83,6 +83,6 @@ namespace swift {
       return (intptr_t)Storage;
     }
   };
-}
+} // end namespace swift
   
-#endif
+#endif // SWIFT_BASIC_OPTIONALENUM_H

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -57,7 +57,7 @@ namespace swift {
 
   /// Returns the platform Kind for Darwin triples.
   DarwinPlatformKind getDarwinPlatformKind(const llvm::Triple &triple);
-}
+} // end namespace swift
 
 #endif // SWIFT_BASIC_PLATFORM_H
 

--- a/include/swift/Basic/PointerIntEnum.h
+++ b/include/swift/Basic/PointerIntEnum.h
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef SWIFT_BASIC_POINTERINTENUM_H
+#define SWIFT_BASIC_POINTERINTENUM_H
+
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/PointerLikeTypeTraits.h"
@@ -223,3 +226,5 @@ public:
 };
 
 } // end swift namespace
+
+#endif // SWIFT_BASIC_POINTERINTENUM_H

--- a/include/swift/Basic/PrefixMap.h
+++ b/include/swift/Basic/PrefixMap.h
@@ -679,4 +679,4 @@ public:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_PREFIXMAP_H

--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -31,6 +31,6 @@ public:
   void print(llvm::raw_ostream &OS) const override;
 };
 
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_PRETTYSTACKTRACE_H

--- a/include/swift/Basic/PrimitiveParsing.h
+++ b/include/swift/Basic/PrimitiveParsing.h
@@ -42,7 +42,7 @@ static inline void splitIntoLines(StringRef Text,
   trimLeadingWhitespaceFromLines(Text, 0, Lines);
 }
 
-} // namespace swift
+} // end namespace swift
 
-#endif // LLVM_SWIFT_BASIC_PRIMITIVEPARSING_H
+#endif // SWIFT_BASIC_PRIMITIVEPARSING_H
 

--- a/include/swift/Basic/Program.h
+++ b/include/swift/Basic/Program.h
@@ -35,4 +35,4 @@ int ExecuteInPlace(const char *Program, const char **args,
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_PROGRAM_H

--- a/include/swift/Basic/Punycode.h
+++ b/include/swift/Basic/Punycode.h
@@ -52,5 +52,5 @@ bool decodePunycodeUTF8(StringRef InputPunycode, std::string &OutUTF8);
 } // end namespace Punycode
 } // end namespace swift
 
-#endif // LLVM_SWIFT_BASIC_PUNYCODE_H
+#endif // SWIFT_BASIC_PUNYCODE_H
 

--- a/include/swift/Basic/QuotedString.h
+++ b/include/swift/Basic/QuotedString.h
@@ -41,6 +41,6 @@ namespace swift {
       return out;
     }
   };
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_QUOTEDSTRING_H

--- a/include/swift/Basic/Range.h
+++ b/include/swift/Basic/Range.h
@@ -295,6 +295,6 @@ inline auto count_if(const Range &R, Predicate &&P)
   return std::count_if(R.begin(), R.end(), std::forward<Predicate>(P));
 }
 
-} // namespace swift
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_RANGE_H

--- a/include/swift/Basic/RelativePointer.h
+++ b/include/swift/Basic/RelativePointer.h
@@ -327,6 +327,6 @@ using FarRelativeIndirectablePointer =
 template<typename T, bool Nullable = false>
 using FarRelativeDirectPointer = RelativeDirectPointer<T, Nullable, intptr_t>;
 
-}
+} // end namespace swift
 
 #endif // SWIFT_BASIC_RELATIVEPOINTER_H

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -693,4 +693,4 @@ inline bool is_sorted_and_uniqued(const Container &C) {
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_INTERLEAVE_H

--- a/include/swift/Basic/Sanitizers.h
+++ b/include/swift/Basic/Sanitizers.h
@@ -20,5 +20,6 @@ enum class SanitizerKind : unsigned {
   Address,
 };
 
-}
+} // end namespace swift
+
 #endif // SWIFT_BASIC_SANITIZERS_H

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -14,8 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SOURCELOC_H
-#define SWIFT_SOURCELOC_H
+#ifndef SWIFT_BASIC_SOURCELOC_H
+#define SWIFT_BASIC_SOURCELOC_H
 
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
@@ -202,4 +202,4 @@ public:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_SOURCELOC_H

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SOURCEMANAGER_H
-#define SWIFT_SOURCEMANAGER_H
+#ifndef SWIFT_BASIC_SOURCEMANAGER_H
+#define SWIFT_BASIC_SOURCEMANAGER_H
 
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/Optional.h"
@@ -231,7 +231,7 @@ private:
   }
 };
 
-} // namespace swift
+} // end namespace swift
 
-#endif // LLVM_SWIFT_SOURCEMANAGER_H
+#endif // SWIFT_BASIC_SOURCEMANAGER_H
 

--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -458,6 +458,7 @@ bool omitNeedlessWords(StringRef &baseName,
                        bool isProperty,
                        const InheritedNameSet *allPropertyNames,
                        StringScratchSpace &scratch);
-}
 
-#endif // LLVM_SWIFT_BASIC_STRINGEXTRAS_HPP
+} // end namespace swift
+
+#endif // SWIFT_BASIC_STRINGEXTRAS_H

--- a/include/swift/Basic/SuccessorMap.h
+++ b/include/swift/Basic/SuccessorMap.h
@@ -457,4 +457,4 @@ private:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_SUCCESSORMAP_H

--- a/include/swift/Basic/TaskQueue.h
+++ b/include/swift/Basic/TaskQueue.h
@@ -179,4 +179,4 @@ public:
 } // end namespace sys
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_TASKQUEUE_H

--- a/include/swift/Basic/ThreadSafeRefCounted.h
+++ b/include/swift/Basic/ThreadSafeRefCounted.h
@@ -71,6 +71,6 @@ public:
   }
 };
 
-} // end namespace swift.
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_THREADSAFEREFCOUNTED_H

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -45,6 +45,6 @@ namespace swift {
       CompilationTimersEnabled = State::Enabled;
     }
   };
-}
+} // end namespace swift
 
 #endif // SWIFT_BASIC_TIMER_H

--- a/include/swift/Basic/TreeScopedHashTable.h
+++ b/include/swift/Basic/TreeScopedHashTable.h
@@ -400,4 +400,4 @@ TreeScopedHashTableScopeImpl<K, V, Allocator>::~TreeScopedHashTableScopeImpl() {
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_TREESCOPEDHASHTABLE_H

--- a/include/swift/Basic/UUID.h
+++ b/include/swift/Basic/UUID.h
@@ -115,6 +115,6 @@ namespace llvm {
       return a == b;
     }
   };
-}
+} // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_UUID_H

--- a/include/swift/Basic/Unicode.h
+++ b/include/swift/Basic/Unicode.h
@@ -83,8 +83,7 @@ unsigned extractFirstUnicodeScalar(StringRef S);
 /// Returns the number of code units in UTF16 representation
 uint64_t getUTF16Length(StringRef Str);
 
-} // namespace unicode
-} // namespace swift
+} // end namespace unicode
+} // end namespace swift
 
-#endif
-
+#endif // SWIFT_BASIC_UNICODE_H

--- a/include/swift/Basic/ValueEnumerator.h
+++ b/include/swift/Basic/ValueEnumerator.h
@@ -55,4 +55,4 @@ public:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_VALUEENUMERATOR_H

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -126,4 +126,4 @@ std::string getSwiftFullVersion();
 } // end namespace version
 } // end namespace swift
 
-#endif
+#endif // SWIFT_BASIC_VERSION_H

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_BASIC_TYPE_TRAITS_H
-#define SWIFT_BASIC_TYPE_TRAITS_H
+#ifndef SWIFT_BASIC_TYPETRAITS_H
+#define SWIFT_BASIC_TYPETRAITS_H
 
 #include <type_traits>
 
@@ -63,11 +63,10 @@ struct IsTriviallyDestructible {
 #endif
 };
 
-} // namespace swift
+} // end namespace swift
 
 #ifdef SWIFT_DEFINED_HAS_FEATURE
 #undef __has_feature
 #endif
 
-#endif // SWIFT_BASIC_TYPE_TRAITS_H
-
+#endif // SWIFT_BASIC_TYPETRAITS_H


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- Added missing ifdef guard in PointerIntEnum header
- Consistent naming convention for ifdef guards
- Consistent 'end namespace swift'
- Consistent single EOL at end of header files
