### PR TITLE
Use a stack allocated _NSContiguousString for hashing and comparison

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -314,6 +314,11 @@ extension String {
 public func _stdlib_compareNSStringDeterministicUnicodeCollation(
   lhs: AnyObject, _ rhs: AnyObject
 ) -> Int32
+
+@_silgen_name("swift_stdlib_compareNSStringDeterministicUnicodeCollationPtr")
+public func _stdlib_compareNSStringDeterministicUnicodeCollationPointer(
+  lhs: OpaquePointer, _ rhs: OpaquePointer
+) -> Int32
 #endif
 
 extension String : Equatable {
@@ -372,6 +377,15 @@ extension String {
     // Note: this operation should be consistent with equality comparison of
     // Character.
 #if _runtime(_ObjC)
+    if self._core.hasContiguousStorage && rhs._core.hasContiguousStorage {
+      let lhsStr = _NSContiguousString(self._core)
+      let rhsStr = _NSContiguousString(rhs._core)
+      let res = lhsStr._unsafeWithNotEscapedSelfPointerPair(rhsStr) {
+        return Int(
+            _stdlib_compareNSStringDeterministicUnicodeCollationPointer($0, $1))
+      }
+      return res
+    }
     return Int(_stdlib_compareNSStringDeterministicUnicodeCollation(
       _bridgeToObjectiveCImpl(), rhs._bridgeToObjectiveCImpl()))
 #else
@@ -445,12 +459,12 @@ extension String {
 
 #if _runtime(_ObjC)
 @warn_unused_result
-@_silgen_name("swift_stdlib_NSStringNFDHashValue")
-func _stdlib_NSStringNFDHashValue(str: AnyObject) -> Int
+@_silgen_name("swift_stdlib_NSStringHashValue")
+func _stdlib_NSStringHashValue(str: AnyObject, _ isASCII: Bool) -> Int
 
 @warn_unused_result
-@_silgen_name("swift_stdlib_NSStringASCIIHashValue")
-func _stdlib_NSStringASCIIHashValue(str: AnyObject) -> Int
+@_silgen_name("swift_stdlib_NSStringHashValuePointer")
+func _stdlib_NSStringHashValuePointer(str: OpaquePointer, _ isASCII: Bool) -> Int
 #endif
 
 extension String : Hashable {
@@ -470,16 +484,18 @@ extension String : Hashable {
 #else
     let hashOffset = Int(bitPattern: 0x429b_1266_88dd_cc21)
 #endif
-    // FIXME(performance): constructing a temporary NSString is extremely
-    // wasteful and inefficient.
-    let cocoaString = unsafeBitCast(
-      self._bridgeToObjectiveCImpl(), to: _NSStringCore.self)
-
-    // If we have an ASCII string, we do not need to normalize.
-    if self._core.isASCII {
-      return hashOffset ^ _stdlib_NSStringASCIIHashValue(cocoaString)
+    // If we have a contigous string then we can use the stack optimization.
+    let core = self._core
+    let isASCII = core.isASCII
+    if core.hasContiguousStorage {
+      let stackAllocated = _NSContiguousString(core)
+      return hashOffset ^ stackAllocated._unsafeWithNotEscapedSelfPointer {
+        return _stdlib_NSStringHashValuePointer($0, isASCII )
+      }
     } else {
-      return hashOffset ^ _stdlib_NSStringNFDHashValue(cocoaString)
+      let cocoaString = unsafeBitCast(
+        self._bridgeToObjectiveCImpl(), to: _NSStringCore.self)
+      return hashOffset ^ _stdlib_NSStringHashValue(cocoaString, isASCII)
     }
 #else
     if self._core.isASCII {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -269,6 +269,39 @@ public final class _NSContiguousString : _SwiftNativeNSString {
     return self
   }
 
+  /// The caller of this function guarantees that the closure 'body' does not
+  /// escape the object referenced by the opaque pointer passed to it or
+  /// anything transitively reachable form this object. Doing so
+  /// will result in undefined behavior.
+  @_semantics("self_no_escaping_closure")
+  func _unsafeWithNotEscapedSelfPointer<Result>(
+    @noescape body: (OpaquePointer) throws -> Result
+  ) rethrows -> Result {
+    let selfAsPointer = unsafeBitCast(self, to: OpaquePointer.self)
+    defer {
+      _fixLifetime(self)
+    }
+    return try body(selfAsPointer)
+  }
+
+  /// The caller of this function guarantees that the closure 'body' does not
+  /// escape either object referenced by the opaque pointer pair passed to it or
+  /// transitively reachable objects. Doing so will result in undefined
+  /// behavior.
+  @_semantics("pair_no_escaping_closure")
+  func _unsafeWithNotEscapedSelfPointerPair<Result>(
+    rhs: _NSContiguousString,
+    @noescape body: (OpaquePointer, OpaquePointer) throws -> Result
+  ) rethrows -> Result {
+    let selfAsPointer = unsafeBitCast(self, to: OpaquePointer.self)
+    let rhsAsPointer = unsafeBitCast(rhs, to: OpaquePointer.self)
+    defer {
+      _fixLifetime(self)
+      _fixLifetime(rhs)
+    }
+    return try body(selfAsPointer, rhsAsPointer)
+  }
+
   public let _core: _StringCore
 }
 

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -117,21 +117,36 @@ extern "C" int32_t swift_stdlib_compareNSStringDeterministicUnicodeCollation(
 }
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
+extern "C" int32_t
+swift_stdlib_compareNSStringDeterministicUnicodeCollationPtr(void *Lhs,
+                                                             void *Rhs) {
+  NSString *lhs = (NSString *)Lhs;
+  NSString *rhs = (NSString *)Rhs;
+
+  // 'kCFCompareNonliteral' actually means "normalize to NFD".
+  int Result = CFStringCompare((__bridge CFStringRef)lhs,
+                               (__bridge CFStringRef)rhs, kCFCompareNonliteral);
+  return Result;
+}
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" size_t
-swift_stdlib_NSStringNFDHashValue(NSString *NS_RELEASES_ARGUMENT str) {
-  size_t Result = str.decomposedStringWithCanonicalMapping.hash;
+swift_stdlib_NSStringHashValue(NSString *NS_RELEASES_ARGUMENT str,
+                               bool isASCII) {
+  size_t Result =
+      isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
+
   swift_unknownRelease(str);
   return Result;
 }
 
-// For strings we know only have ASCII
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" size_t
-swift_stdlib_NSStringASCIIHashValue(NSString *NS_RELEASES_ARGUMENT str) {
-  size_t Result = str.hash;
-  swift_unknownRelease(str);
-  return Result;
+swift_stdlib_NSStringHashValuePointer(void *opaque, bool isASCII) {
+  NSString *str = (NSString *)opaque;
+  return isASCII ? str.hash : str.decomposedStringWithCanonicalMapping.hash;
 }
+
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,

--- a/test/1_stdlib/RuntimeObjC.swift
+++ b/test/1_stdlib/RuntimeObjC.swift
@@ -543,22 +543,12 @@ RuntimeFoundationWrappers.test(
   expectEqual(0, nsStringCanaryCount)
 }
 
-RuntimeFoundationWrappers.test("_stdlib_NSStringNFDHashValue/NoLeak") {
+RuntimeFoundationWrappers.test("_stdlib_NSStringHashValue/NoLeak") {
   nsStringCanaryCount = 0
   autoreleasepool {
     let a = NSStringCanary()
     expectEqual(1, nsStringCanaryCount)
-    _stdlib_NSStringNFDHashValue(a)
-  }
-  expectEqual(0, nsStringCanaryCount)
-}
-
-RuntimeFoundationWrappers.test("_stdlib_NSStringASCIIHashValue/NoLeak") {
-  nsStringCanaryCount = 0
-  autoreleasepool {
-    let a = NSStringCanary()
-    expectEqual(1, nsStringCanaryCount)
-    _stdlib_NSStringASCIIHashValue(a)
+    _stdlib_NSStringHashValue(a, true)
   }
   expectEqual(0, nsStringCanaryCount)
 }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1214,3 +1214,38 @@ sil [_semantics "array.get_element_address"] @get_element_address : $@convention
 sil [_semantics "array.get_count"] @get_count : $@convention(method) (@guaranteed Array<X>) -> Int32
 sil [_semantics "array.get_capacity"] @get_capacity : $@convention(method) (@guaranteed Array<X>) -> Int32
 
+sil [_semantics "pair_no_escaping_closure"] @unsafeWithNotEscapedSelfPointerPair : $@convention(method) (@owned X, @owned @callee_owned (X, X) -> (@out X, @error ErrorType), @guaranteed X) -> (@out X, @error ErrorType)
+sil [_semantics "self_no_escaping_closure"] @unsafeWithNotEscapedSelfPointer: $@convention(method) (@owned @callee_owned (X, X) -> (@out X, @error ErrorType), @guaranteed X) -> (@out X, @error ErrorType)
+
+// CHECK-LABEL: CG of semantics_pair_no_escaping_closure
+// CHECK-NEXT:   Arg %0 Esc: A, Succ:
+// CHECK-NEXT:   Arg %1 Esc: A, Succ:
+// CHECK-NEXT:   Arg %2 Esc: G, Succ: (%2.1)
+// CHECK-NEXT:   Con %2.1 Esc: G, Succ:
+// CHECK-NEXT:   Val %4 Esc: %5, Succ:
+// CHECK-NEXT: End
+sil @semantics_pair_no_escaping_closure : $@convention(thin) (@owned X, @guaranteed X, @owned @callee_owned (X, X) -> (@out X, @error ErrorType)) -> () {
+bb(%0 : $X, %1 : $X, %2: $@callee_owned (X, X) -> (@out X, @error ErrorType)):
+  %3 = function_ref @unsafeWithNotEscapedSelfPointerPair : $@convention(method) (@owned X, @owned @callee_owned (X, X) -> (@out X, @error ErrorType), @guaranteed X) -> (@out X, @error ErrorType)
+  %4 = alloc_stack $X
+  %6 = apply [nothrow] %3(%4, %0, %2, %1) : $@convention(method) (@owned X, @owned @callee_owned (X, X) -> (@out X, @error ErrorType), @guaranteed X) -> (@out X, @error ErrorType)
+  dealloc_stack %4 : $*X
+  %7 = tuple()
+	return %7 : $()
+}
+
+// CHECK-LABEL: CG of semantics_self_no_escaping_closure
+// CHECK-NEXT:   Arg %0 Esc: A, Succ:
+// CHECK-NEXT:   Arg %1 Esc: G, Succ: (%1.1)
+// CHECK-NEXT:   Con %1.1 Esc: G, Succ:
+// CHECK-NEXT:   Val %3 Esc: %4, Succ:
+// CHECK-NEXT: End
+sil @semantics_self_no_escaping_closure : $@convention(thin) (@guaranteed X, @owned @callee_owned (X, X) -> (@out X, @error ErrorType)) -> () {
+bb(%0 : $X, %1: $@callee_owned (X, X) -> (@out X, @error ErrorType)):
+  %2 = function_ref @unsafeWithNotEscapedSelfPointer : $@convention(method) (@owned @callee_owned (X, X) -> (@out X, @error ErrorType), @guaranteed X) -> (@out X, @error ErrorType)
+  %3 = alloc_stack $X
+  %6 = apply [nothrow] %2(%3, %1, %0) : $@convention(method) (@owned @callee_owned (X, X) -> (@out X, @error ErrorType), @guaranteed X) -> (@out X, @error ErrorType)
+  dealloc_stack %3 : $*X
+  %7 = tuple()
+	return %7 : $()
+}


### PR DESCRIPTION
#### What's in this pull request?

Make String's comparison and hash function faster on platforms that use objc interopt.

During String's hashValue and comparison function we create a
_NSContiguousString instance to call Foundation's hash/compare function. This is
expensive because we have allocate and deallocate a short lived object on the
heap (and deallocation for Swift objects is expensive).  Instead, allocate this
object on the stack in the runtime.

Tested by existing String tests.

We should see some nice performance improvements for string comparison and
dictionary benchmarks.

Here is what I measured at -O on my machine

Name                          Speedup
Dictionary                      2.16x
Dictionary2                     1.47x
Dictionary2OfObjects            1.21x
Dictionary3                     1.55x
Dictionary3OfObjects            1.44x
DictionaryOfObjects             1.42x
SuperChars                      1.66x

rdar://22173647
