### PR TITLE
[Swift 2.2.1][Swift runtime] Deallocation of partial class instances for Objective-C-derived classes

### DIFF
--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -45,6 +45,7 @@ extern "C" id objc_initWeak(id*, id);
 extern "C" id objc_storeWeak(id*, id);
 extern "C" void objc_destroyWeak(id*);
 extern "C" id objc_loadWeakRetained(id*);
+extern "C" Class object_setClass(id, Class);
 
 // Description of an Objective-C image.
 // __DATA,__objc_imageinfo stores one of these.

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -453,15 +453,47 @@ extern "C" void swift_deallocPartialClassInstance(HeapObject *object,
     return;
 
   // Destroy ivars
-  auto *objectMetadata = _swift_getClassOfAllocated(object);
-  while (objectMetadata != metadata) {
-    auto classMetadata = objectMetadata->getClassObject();
-    assert(classMetadata && "Not a class?");
+  auto *classMetadata = _swift_getClassOfAllocated(object)->getClassObject();
+  assert(classMetadata && "Not a class?");
+  while (classMetadata != metadata) {
+#if SWIFT_OBJC_INTEROP
+    // If we have hit a pure Objective-C class, we won't see another ivar
+    // destroyer.
+    if (classMetadata->isPureObjC()) {
+      // Set the class to the pure Objective-C superclass, so that when dealloc
+      // runs, it starts at that superclass.
+      object_setClass((id)object, (Class)classMetadata);
+
+      // Release the object.
+      objc_release((id)object);
+      return;
+    }
+#endif
+
     if (auto fn = classMetadata->getIVarDestroyer())
       fn(object);
-    objectMetadata = classMetadata->SuperClass;
-    assert(objectMetadata && "Given metatype not a superclass of object type?");
+
+    classMetadata = classMetadata->SuperClass->getClassObject();
+    assert(classMetadata && "Given metatype not a superclass of object type?");
   }
+
+#if SWIFT_OBJC_INTEROP
+  // If this class doesn't use Swift-native reference counting, use
+  // objc_release instead.
+  if (!usesNativeSwiftReferenceCounting(classMetadata)) {
+    // Find the pure Objective-C superclass.
+    while (!classMetadata->isPureObjC())
+      classMetadata = classMetadata->SuperClass->getClassObject();
+
+    // Set the class to the pure Objective-C superclass, so that when dealloc
+    // runs, it starts at that superclass.
+    object_setClass((id)object, (Class)classMetadata);
+
+    // Release the object.
+    objc_release((id)object);
+    return;
+  }
+#endif
 
   // The strong reference count should be +1 -- tear down the object
   bool shouldDeallocate = object->refCount.decrementShouldDeallocate();

--- a/test/Interpreter/SDK/objc_failable_initializers.swift
+++ b/test/Interpreter/SDK/objc_failable_initializers.swift
@@ -1,0 +1,89 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+var ObjCFailableInitTestSuite = TestSuite("ObjCFailableInit")
+
+class Canary {
+  static var count: Int = 0
+
+  init() {
+    Canary.count += 1
+  }
+
+  deinit {
+    Canary.count -= 1
+  }
+}
+
+extension NSDate {
+  convenience init?(b: Bool) {
+    guard b else { return nil }
+    self.init()
+  }
+}
+
+class MyDate : NSDate {
+  var derivedCanary = Canary()
+
+  static var count = 0
+
+  override init() {
+    MyDate.count += 1
+    super.init()
+  }
+
+  required convenience init(coder: NSCoder) {
+    fatalError("not implemented")
+  }
+
+  deinit {
+    MyDate.count -= 1
+  }
+
+  @objc convenience init?(b: Bool) {
+    guard b else { return nil }
+    self.init()
+  }
+}
+
+class MyDerivedDate : MyDate {
+  var canary = Canary()
+
+  static var derivedCount = 0
+
+  override init() {
+    MyDerivedDate.count += 1
+  }
+
+  deinit {
+    MyDerivedDate.count -= 1
+  }
+
+}
+
+func mustFail<T>(f: () -> T?) {
+  if f() != nil {
+    preconditionFailure("Didn't fail")
+  }
+}
+
+ObjCFailableInitTestSuite.test("InitFailure_Before") {
+  mustFail { NSDate(b: false) }
+  expectEqual(0, Canary.count)
+
+  mustFail { MyDate(b: false) }
+  expectEqual(0, Canary.count)
+  expectEqual(0, MyDate.count)
+
+  mustFail { MyDerivedDate(b: false) }
+  expectEqual(0, Canary.count)
+  expectEqual(0, MyDate.count)
+  expectEqual(0, MyDerivedDate.derivedCount)
+}
+
+runAllTests()
+


### PR DESCRIPTION
#### What's in this pull request?

Backport the fix for deallocation of partial class instances for Objective-C-derived classes to Swift 2.2. We had fixed this regression from Swift 2.1 on mainline, but it's causing trouble in Swift 2.2 as well.
#### Resolved bug number: ([SR-704](https://bugs.swift.org/browse/SR-704))

Teach swift_deallocPartialClassInstance how to deal with classes that
have pure Objective-C classes in their hierarchy. In such cases, we
need to make sure a few things happen:

1) We deallocate via objc_release rather than
swift_deallocClassInstance.
2) We only attempt to find an execute ivar destroyers for
Swift-defined classes in the hierarchy
3) When we hit the most-derived pure Objective-C class, make sure that we
only execute the dealloc of that class and not any of the subclasses
(which would end up trying to destroy ivars again).

Fixes rdar://problem/25023544 / SR-704.

@swift-ci Please test
