### PR TITLE
Fix for SR-912: Runtime exception casting an Any nil to an Optional.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -2062,6 +2062,13 @@ bool swift::swift_dynamicCast(OpaqueValue *dest,
   switch (targetType->getKind()) {
   // Handle wrapping an Optional target.
   case MetadataKind::Optional: {
+    // If the source is an existential, attempt to cast it first without
+    // unwrapping the target. This handles an optional source wrapped within an
+    // existential that Optional conforms to (Any).
+    if (auto srcExistentialType = dyn_cast<ExistentialTypeMetadata>(srcType)) {
+      return _dynamicCastFromExistential(dest, src, srcExistentialType,
+                                         targetType, flags);
+    }
     // Recursively cast into the layout compatible payload area.
     const Metadata *payloadType =
       cast<EnumMetadata>(targetType)->getGenericArgs()[0];

--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -202,6 +202,9 @@ func canGenericCast<T, U>(a: T, _ ty : U.Type) -> Bool {
   return anyToAnyOrNil(a, ty) != nil
 }
 
+protocol TestExistential {}
+extension Int : TestExistential {}
+
 OptionalTests.test("Casting Optional") {
   let x = C()
   let sx: C? = x
@@ -235,12 +238,25 @@ OptionalTests.test("Casting Optional") {
     _ = anyToAny(Optional(t), CustomDebugStringConvertible.self)
   }
   expectTrue(deinitRan)
+
+  // Test for SR-912: Runtime exception casting an Any nil to an Optional.
+  let oi: Int? = nil
+  expectTrue(anyToAny(oi as Any, Optional<Int>.self) == nil)
+  // For good measure test an existential that Optional does not conform to.
+  expectTrue(anyToAny(3 as TestExistential, Optional<Int>.self) == 3)
+  // And a type that is not convertible to its target.
+  anyToAny(nx as Any, Optional<Int>.self)
 }
 
 OptionalTests.test("Casting Optional Traps") {
   let nx: C? = nil
   expectCrashLater()
   _blackHole(anyToAny(nx, Int.self))
+}
+OptionalTests.test("Casting Optional Any Traps") {
+  let nx: X? = X()
+  expectCrashLater()
+  _blackHole(anyToAny(nx as Any, Optional<Int>.self))
 }
 
 class TestNoString {}


### PR DESCRIPTION
This is a simple runtime fix for the following case:

func cast<U>(t: Any) -> U {
  return t as! U
}
cast(nil as Int?) as Int?
