### PR TITLE
[docs] Recommend using utils/build-script to test

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -36,8 +36,24 @@ The LLVM lit-based testsuite
 Running the LLVM lit-based testsuite
 ------------------------------------
 
-You can run Swift tests using the ``build-script``, or, alternatively, using
-these targets in the build directory:
+It is recommended that you run the Swift test suites via ``utils/build-script``.
+For day-to-day work on the Swift compiler, using ``utils/build-script --test``
+should be sufficient.  The buildbot runs validation tests, so if those are
+accidentally broken, it should not go unnoticed.
+
+Before committing a large change to a compiler (especially a language change),
+or API changes to the standard library, it is recommended to run validation
+test suite, via ``utils/build-script --validation-test``.
+
+Although it is not recommended for day-to-day contributions, it is also
+technically possible to execute the tests directly via CMake. For example, if you have
+built Swift products at the directory ``build/Ninja-ReleaseAssert/swift-macosx-x86_64``,
+you may run the entire test suite directly using the following command::
+
+  cmake --build build/Ninja-ReleaseAssert/swift-macosx-x86_64 -- check-swift-macosx-x86_64
+
+Note that ``check-swift`` is suffixed with a target operating system and architecture.
+Besides ``check-swift``, other targets are also available. Here's the full list:
 
 * ``check-swift``
 
@@ -50,14 +66,6 @@ these targets in the build directory:
 * ``check-swift-all``
 
   Runs all tests.
-
-For day-to-day work on the Swift compiler, using ``check-swift`` should be
-sufficient.  The buildbot runs validation tests, so if those are accidentally
-broken, it should not go unnoticed.
-
-Before committing a large change to a compiler (especially a language change),
-or API changes to the standard library, it is recommended to run validation
-test suite.
 
 For every target above, there are variants for different optimizations:
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Contributors likely won't need to invoke CMake directly in order to run the test suite. As such, the current testing documentation is a little misleading: it jumps into a detailed explanation of the `check-swift` family of targets, even though those are abstracted away via the build script. For example, I remember when I first read this document, I spent 20 minutes searching in vain for a build executable named `check-swift`.

Instead, change the wording to make it clear that `utils/build-script` is the best way to run the tests. For those interested in **how** the tests are executed, show an example of a CMake command that runs them.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
