### PR TITLE
[unittests] Include header for llvm::outs()

### DIFF
--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 #include <map>
 #include <set>


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

`unittests/Basic/BlotMapVectorTest.cpp` references `llvm::outs()`, which is defined in `llvm/Support/raw_ostream.h`. I believe this currently works without the import because it is transitively included via some CMake incantations and conditionals in the googletest headers invovling `GTEST_NO_LLVM_RAW_OSTREAM`. I'm not sure.

In any case, including the header is more explicit. The file uses `llvm::outs()`, so it should include the header that defines it.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
