### PR TITLE
[Swift 2.2] typo correction

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -783,7 +783,7 @@ public func indices<
 /// A generator that adapts a collection `C` and any sequence of
 /// its `Index` type to present the collection's elements in a
 /// permuted order.
-@available(*, deprecated, message="PermitationGenerator will be removed in Swift 3")
+@available(*, deprecated, message="PermutationGenerator will be removed in Swift 3")
 @swift3_migration(message="Removed in Swift 3")
 public struct PermutationGenerator<
   C: CollectionType, Indices: SequenceType


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Typo correction in a Swift 2.2 deprecation warning: `Permitation` instead of `Permutation`.

<!-- Description about pull request. -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
