### PR TITLE
Remove escaped spaces from the MutableCollectionType’s partition method

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -99,9 +99,9 @@ partitionDocComment = """\
   /// Re-order the given `range` of elements in `self` and return
   /// a pivot index *p*.
   ///
-  /// - Postcondition: For all *i* in `range.startIndex..<`\ *p*, and *j*
-  ///   in *p*\ `..<range.endIndex`, `less(self[`\ *i*\ `],
-  ///   self[`\ *j*\ `]) && !less(self[`\ *j*\ `], self[`\ *p*\ `])`.
+  /// - Postcondition: For all *i* in `range.startIndex..<`*p*, and *j*
+  ///   in *p*`..<range.endIndex`, `less(self[`*i*`],
+  ///   self[`*j*`]) && !less(self[`*j*`], self[`*p*`])`.
   ///   Only returns `range.endIndex` when `self` is empty."""
 
 orderingRequirementForPredicate = """\


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Spaces should not be backslash-escaped per the [CMark spec](http://spec.commonmark.org/0.23/#example-277).  Even though they are not allowed, backslash-spaces are used in the MutableCollectionType documentation:

```
/// Re-order the given `range` of elements in `self` and return 
/// a pivot index *p*.
///
/// - Postcondition: For all *i* in `range.startIndex..<`\ *p*, and *j*    
///   in *p*\ `..<range.endIndex`, `less(self[`\ *i*\ `], ...
```

Consequently, the documentation gets rendered with backslashes as shown in the screenshot below:

**BEFORE:**
![screen shot 2016-03-23 at 11 18 13 am](https://cloud.githubusercontent.com/assets/5067214/13992184/18e4817e-f0e9-11e5-969d-48d48f67f4d2.png)
[CMark Renderer](http://spec.commonmark.org/dingus/?text=Re-order%20the%20given%20%60range%60%20of%20elements%20in%20%60self%60%20and%20return%0Aa%20pivot%20index%20*p*.%0A%0A-%20Postcondition%3A%20For%20all%20*i*%20in%20%60range.startIndex..%3C%60%5C%20*p*%2C%20and%20*j*%0Ain%20*p*%5C%20%60..%3Crange.endIndex%60%2C%20%60less%28self%5B%60%5C%20*i*%5C%20%60%5D%2C%0Aself%5B%60%5C%20*j*%5C%20%60%5D%29%20%26%26%20!less%28self%5B%60%5C%20*j*%5C%20%60%5D%2C%20self%5B%60%5C%20*p*%5C%20%60%5D%29%60.%0AOnly%20returns%20%60range.endIndex%60%20when%20%60self%60%20is%20empty.%22%22%22)

Removing escaped spaces fixes the encoding issues specified in [SR-1034](https://bugs.swift.org/browse/SR-1034) and the documentation now renders as:

**AFTER:**
![screen shot 2016-03-23 at 11 18 55 am](https://cloud.githubusercontent.com/assets/5067214/13992203/2bc484ec-f0e9-11e5-9c42-643b205f661b.png)
[CMark Renderer](http://spec.commonmark.org/dingus/?text=%0ARe-order%20the%20given%20%60range%60%20of%20elements%20in%20%60self%60%20and%20return%0Aa%20pivot%20index%20*p*.%0A%0A-%20Postcondition%3A%20For%20all%20*i*%20in%20%60range.startIndex..%3C%60*p*%2C%20and%20*j*%0Ain%20*p*%60..%3Crange.endIndex%60%2C%20%60less%28self%5B%60*i*%60%5D%2C%0Aself%5B%60*j*%60%5D%29%20%26%26%20!less%28self%5B%60*j*%60%5D%2C%20self%5B%60*p*%60%5D%29%60.%0AOnly%20returns%20%60range.endIndex%60%20when%20%60self%60%20is%20empty)

This also brings the documentation in line with similar looking comments in Sort.swift.gyb (`swift/stdlib/public/core/Sort.swift.gyb`) which also do not escape spaces.
#### Resolved bug number: ([SR-1034](https://bugs.swift.org/browse/SR-1034))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

documentation.
