### PR TITLE
move copy-append before move-append overload (NFC)

### DIFF
--- a/include/swift/Basic/ClusteredBitVector.h
+++ b/include/swift/Basic/ClusteredBitVector.h
@@ -327,18 +327,6 @@ public:
   }
 
   /// Append the bits from the given vector to this one.
-  void append(ClusteredBitVector &&other) {
-    // If this vector is empty, just move the other.
-    if (empty()) {
-      *this = std::move(other);
-      return;
-    }
-
-    // Otherwise, use copy-append.
-    append(other);
-  }
-
-  /// Append the bits from the given vector to this one.
   void append(const ClusteredBitVector &other) {
     // Nothing to do if the other vector is empty.
     if (other.empty()) return;
@@ -358,6 +346,18 @@ public:
     } else {
       appendReserved(other.size(), other.getChunksPtr());
     }
+  }
+
+  /// Append the bits from the given vector to this one.
+  void append(ClusteredBitVector &&other) {
+    // If this vector is empty, just move the other.
+    if (empty()) {
+      *this = std::move(other);
+      return;
+    }
+
+    // Otherwise, use copy-append.
+    append(other);
   }
 
   /// Add the low N bits from the given value to the vector.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This is consistent with the usual convention of having copy methods before move methods (which is also used in this file in previous methods).
