### PR TITLE
[Parser] Cleans up parsing of function parameter attributes

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -148,9 +148,6 @@ WARNING(lex_editor_placeholder_in_playground,none,
 
 NOTE(note_in_decl_extension,none,
      "in %select{declaration|extension}0 of %1", (bool, Identifier))
-WARNING(inout_as_attr_deprecated,none,
-        "'inout' before a parameter name is deprecated, place it before the parameter type instead",
-        ())
 WARNING(line_directive_style_deprecated,none,
         "#line directive is deprecated, please use #sourceLocation instead",
         ())
@@ -692,12 +689,15 @@ ERROR(multiple_parameter_ellipsis,none,
       "only a single variadic parameter '...' is permitted", ())
 ERROR(parameter_vararg_default,none,
       "variadic parameter cannot have a default value", ())
-ERROR(parameter_inout_var_let,none,
+ERROR(inout_as_attr_disallowed,none,
+      "'inout' before a parameter name is not allowed, place it before the parameter type instead",
+      ())
+ERROR(parameter_inout_var_let_repeated,none,
       "parameter may not have multiple 'inout', 'var', or 'let' specifiers",
       ())
+ERROR(parameter_let_as_attr,none,
+      "'let' as a parameter attribute is not allowed", ())
 
-ERROR(var_parameter_not_allowed,none,
-        "parameters may not have the 'var' specifier", ())
 
 ERROR(expected_behavior_name,none,
       "expected behavior name after '[' in property declaration", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -778,6 +778,9 @@ ERROR(inout_cant_be_variadic,none,
       "inout arguments cannot be variadic", ())
 ERROR(inout_only_parameter,none,
       "'inout' is only valid in parameter lists", ())
+ERROR(var_parameter_not_allowed,none,
+      "parameters may not have the 'var' specifier", ())
+
 
 ERROR(mutating_invalid_global_scope,none,
       "'mutating' is only valid on methods", ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -933,7 +933,6 @@ public:
     DeclAttributes Attrs;
 
     /// The location of the 'let', 'var', or 'inout' keyword, if present.
-    ///
     SourceLoc LetVarInOutLoc;
 
     enum SpecifierKindTy {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -186,27 +186,31 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         status |= makeParserCodeCompletionStatus();
       }
     }
+    
     // ('inout' | 'let' | 'var')?
-    if (Tok.is(tok::kw_inout)) {
-      param.LetVarInOutLoc = consumeToken();
-      param.SpecifierKind = ParsedParameter::InOut;
-    } else if (Tok.is(tok::kw_let)) {
-      param.LetVarInOutLoc = consumeToken();
-      param.SpecifierKind = ParsedParameter::Let;
-    } else if (Tok.is(tok::kw_var)) {
-      diagnose(Tok.getLoc(), diag::var_parameter_not_allowed)
+    bool hasSpecifier = false;
+    while (Tok.isAny(tok::kw_inout, tok::kw_let, tok::kw_var)) {
+      if (!hasSpecifier) {
+        if (Tok.is(tok::kw_let)) {
+          diagnose(Tok, diag::parameter_let_as_attr)
+          .fixItRemove(Tok.getLoc());
+          param.isInvalid = true;
+        } else {
+          // We handle the var error in sema for a better fixit and inout is
+          // handled later in this function for better fixits.
+          param.SpecifierKind = Tok.is(tok::kw_inout) ? ParsedParameter::InOut :
+                                                        ParsedParameter::Var;
+        }
+        param.LetVarInOutLoc = consumeToken();
+        hasSpecifier = true;
+      } else {
+        // Redundant specifiers are fairly common, recognize, reject, and recover
+        // from this gracefully.
+        diagnose(Tok, diag::parameter_inout_var_let_repeated)
         .fixItRemove(Tok.getLoc());
-      param.LetVarInOutLoc = consumeToken();
-      param.SpecifierKind = ParsedParameter::Var;
-    }
-
-    // Redundant specifiers are fairly common, recognize, reject, and recover
-    // from this gracefully.
-    if (Tok.isAny(tok::kw_inout, tok::kw_let, tok::kw_var)) {
-      diagnose(Tok, diag::parameter_inout_var_let)
-        .fixItRemove(Tok.getLoc());
-      consumeToken();
-      param.isInvalid = true;
+        consumeToken();
+        param.isInvalid = true;
+      }
     }
 
     if (startsParameterName(*this, isClosure)) {
@@ -248,20 +252,28 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
         bool hasDeprecatedInOut =
           param.SpecifierKind == ParsedParameter::InOut;
-
-        if (Tok.is(tok::kw_inout)) {
-          param.LetVarInOutLoc = consumeToken();
-          param.SpecifierKind = ParsedParameter::InOut;
-          if (hasDeprecatedInOut) {
-            diagnose(param.LetVarInOutLoc, diag::inout_as_attr_deprecated)
-              .fixItRemove(param.LetVarInOutLoc);
+        bool hasValidInOut = false;
+        
+        while (Tok.is(tok::kw_inout)) {
+          hasValidInOut = true;
+          if (hasSpecifier) {
+            diagnose(Tok.getLoc(), diag::parameter_inout_var_let_repeated)
+            .fixItRemove(param.LetVarInOutLoc);
+            consumeToken(tok::kw_inout);
+            param.isInvalid = true;
+          } else {
+            hasSpecifier = true;
+            param.LetVarInOutLoc = consumeToken(tok::kw_inout);
+            param.SpecifierKind = ParsedParameter::InOut;
           }
-        } else if (hasDeprecatedInOut) {
-          diagnose(param.LetVarInOutLoc, diag::inout_as_attr_deprecated)
-            .fixItRemove(param.LetVarInOutLoc)
-            .fixItInsert(postColonLoc, "inout ");
         }
-
+        if (!hasValidInOut && hasDeprecatedInOut) {
+          diagnose(Tok.getLoc(), diag::inout_as_attr_disallowed)
+          .fixItRemove(param.LetVarInOutLoc)
+          .fixItInsert(postColonLoc, "inout ");
+          param.isInvalid = true;
+        }
+        
         auto type = parseType(diag::expected_parameter_type);
         status |= type;
         param.Type = type.getPtrOrNull();

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -711,6 +711,73 @@ static bool validateTypedPattern(TypeChecker &TC, DeclContext *DC,
   return hadError;
 }
 
+static void diagnoseAndMigrateVarParameterToBody(ParamDecl *decl,
+                                                 AbstractFunctionDecl *func,
+                                                 TypeChecker &TC) {
+  if (!func || !func->hasBody()) {
+    // If there is no function body, just suggest removal.
+    TC.diagnose(decl->getLetVarInOutLoc(),
+                diag::var_parameter_not_allowed)
+      .fixItRemove(decl->getLetVarInOutLoc());
+    return;
+  }
+  // Insert the shadow copy. The computations that follow attempt to
+  // 'best guess' the indentation and new lines so that the user
+  // doesn't have to add any whitespace.
+  auto declBody = func->getBody();
+  
+  auto &SM = TC.Context.SourceMgr;
+  
+  SourceLoc insertionStartLoc;
+  std::string start;
+  std::string end;
+  
+  auto lBraceLine = SM.getLineNumber(declBody->getLBraceLoc());
+  auto rBraceLine = SM.getLineNumber(declBody->getRBraceLoc());
+
+  if (!declBody->getNumElements()) {
+    
+    // Empty function body.
+    insertionStartLoc = declBody->getRBraceLoc();
+    
+    if (lBraceLine == rBraceLine) {
+      // Same line braces, means we probably have something
+      // like {} as the func body. Insert directly into body with spaces.
+      start = " ";
+      end = " ";
+    } else {
+      // Different line braces, so use RBrace's indentation.
+      end = "\n" + Lexer::getIndentationForLine(SM, declBody->
+                                                getRBraceLoc()).str();
+      start = "    "; // Guess 4 spaces as extra indentation.
+    }
+  } else {
+    auto firstLine = declBody->getElement(0);
+    insertionStartLoc = firstLine.getStartLoc();
+    if (lBraceLine == SM.getLineNumber(firstLine.getStartLoc())) {
+      // Function on same line, insert with semi-colon. Not ideal but
+      // better than weird space alignment.
+      start = "";
+      end = "; ";
+    } else {
+      start = "";
+      end = "\n" + Lexer::getIndentationForLine(SM, firstLine.
+                                                getStartLoc()).str();
+    }
+  }
+  if (insertionStartLoc.isInvalid()) {
+    TC.diagnose(decl->getLetVarInOutLoc(),
+                diag::var_parameter_not_allowed)
+    .fixItRemove(decl->getLetVarInOutLoc());
+    return;
+  }
+  auto parameterName = decl->getNameStr().str();
+  TC.diagnose(decl->getLetVarInOutLoc(),
+              diag::var_parameter_not_allowed)
+  .fixItRemove(decl->getLetVarInOutLoc())
+  .fixItInsert(insertionStartLoc, start + "var " + parameterName + " = " +
+               parameterName + end);
+}
 
 static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
                                   TypeResolutionOptions options,
@@ -735,6 +802,15 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
       }
     }
     decl->getTypeLoc().setType(Ty);
+  }
+  // If the param is not a 'let' and it is not an 'inout'.
+  // It must be a 'var'. Provide helpful diagnostics like a shadow copy
+  // in the function body to fix the 'var' attribute.
+  if (!decl->isLet() && !Ty->is<InOutType>()) {
+    auto func = dyn_cast_or_null<AbstractFunctionDecl>(DC);
+    diagnoseAndMigrateVarParameterToBody(decl, func, TC);
+    decl->setInvalid();
+    hadError = true;
   }
 
   if (hadError)

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -103,7 +103,7 @@ func testLValue(c: C) {
 
 
 // <rdar://problem/21444509> Crash in TypeChecker::coercePatternToType
-func invalidPatternCrash(let k : Int) {
+func invalidPatternCrash(k : Int) {
   switch k {
   case (k, cph_: k) as UInt8:  // expected-error {{tuple pattern cannot match values of the non-tuple type 'UInt8'}} expected-warning {{cast from 'Int' to unrelated type 'UInt8' always fails}}
     break

--- a/test/FixCode/fixits-apply-all.swift
+++ b/test/FixCode/fixits-apply-all.swift
@@ -7,3 +7,13 @@
 func ftest1() {
   let myvar = 0
 }
+
+func foo() -> Int {
+  do {
+  } catch var err {
+    goo(err)
+  }
+}
+func goo(e: ErrorProtocol) {
+	
+}

--- a/test/FixCode/fixits-apply-all.swift.result
+++ b/test/FixCode/fixits-apply-all.swift.result
@@ -7,3 +7,13 @@
 func ftest1() {
   _ = 0
 }
+
+func foo() -> Int {
+  do {
+  } catch let err {
+    goo(err)
+  }
+}
+func goo(e: ErrorProtocol) {
+	
+}

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -31,14 +31,25 @@ func supported() -> MyMask {
   return Int(MyMask.Bingo.rawValue)
 }
 
-func foo() -> Int {
-  do {
-  } catch var err {
-    goo(err)
+func goo(var e : ErrorProtocol) {
+}
+func goo2(var e: ErrorProtocol) {}
+func goo3(var e: Int) { e = 3 }
+protocol A {
+  func bar(var s: Int)
+}
+extension A {
+  func bar(var s: Int) {
+    s += 5
   }
 }
 
-func goo(var e : ErrorProtocol) {}
+func baz(var x: Int) {
+  x += 10
+}
+func foo(let y: String, inout x: Int) {
+  
+}
 
 struct Test1 : OptionSet {
   init(rawValue: Int) {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -31,14 +31,28 @@ func supported() -> MyMask {
   return MyMask.Bingo
 }
 
-func foo() -> Int {
-  do {
-  } catch let err {
-    goo(err)
+func goo(e : ErrorProtocol) {
+    var e = e
+}
+func goo2(e: ErrorProtocol) { var e = e }
+func goo3(e: Int) { var e = e; e = 3 }
+protocol A {
+  func bar(s: Int)
+}
+extension A {
+  func bar(s: Int) {
+    var s = s
+    s += 5
   }
 }
 
-func goo(e : ErrorProtocol) {}
+func baz(x: Int) {
+  var x = x
+  x += 10
+}
+func foo(y: String, x: inout Int) {
+  
+}
 
 struct Test1 : OptionSet {
   init(rawValue: Int) {}

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -229,7 +229,7 @@ func testPostfixOperator1(x: Int) {
 // POSTFIX_RVALUE_INT-NOT: ++
 // POSTFIX_RVALUE_INT-NOT: --
 
-func testPostfixOperator2(var x: Int) {
+func testPostfixOperator2(x: inout Int) {
   x#^POSTFIX_INT_2^#
 }
 // POSTFIX_LVALUE_INT: Decl[PostfixOperatorFunction]/OtherModule[Swift]: ++[#Int#]; name=
@@ -253,7 +253,7 @@ func testInfixOperator1(x: Int) {
 // INFIX_INT: End completions
 // NEGATIVE_INFIX_INT-NOT: &&
 // NEGATIVE_INFIX_INT-NOT: +=
-func testInfixOperator2(var x: Int) {
+func testInfixOperator2(x: inout Int) {
   x#^INFIX_INT_2^#
 }
 // INFIX_LVALUE_INT: Begin completions

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -66,7 +66,7 @@ func testPostfix1(x: S) {
 }
 // POSTFIX_1-NOT: ++
 
-func testPostfix2(var x: S) {
+func testPostfix2(x: inout S) {
   x#^POSTFIX_2^#
 }
 // POSTFIX_2: Begin completions
@@ -130,7 +130,7 @@ func testPostfix10<G: P where G.T : Fooable>(x: G) {
 }
 // POSTFIX_10: Decl[PostfixOperatorFunction]/CurrModule: ***[#G.T#]
 
-func testPostfixSpace(var x: S) {
+func testPostfixSpace(x: inout S) {
   x #^S_POSTFIX_SPACE^#
 }
 // S_POSTFIX_SPACE: Decl[PostfixOperatorFunction]/CurrModule/Erase[1]:  ++[#S#]
@@ -167,7 +167,7 @@ func testInfix1(x: S2) {
 // NEGATIVE_S2_INFIX-NOT: ~>
 // NEGATIVE_S2_INFIX-NOT: = {#
 
-func testInfix2(var x: S2) {
+func testInfix2(x: inout S2) {
   x#^INFIX_2^#
 }
 // S2_INFIX_LVALUE: Begin completions
@@ -296,7 +296,7 @@ func testSpace(x: S2) {
 // S2_INFIX_SPACE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']+ {#S2#}[#S2#]
 // S2_INFIX_SPACE: End completions
 
-func testExtInfix1(var x: S2) {
+func testExtInfix1(x: inout S2) {
   x + S2() + x + S2() + x + S2() + x#^EXT_INFIX_1^#
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -587,7 +587,7 @@ func testCurriedFunc() {
 // CF4-NEXT: End completions
 }
 
-func testImplicitlyCurriedFunc(var fs: FooStruct) {
+func testImplicitlyCurriedFunc(fs: inout FooStruct) {
   FooStruct.instanceFunc0(&fs)#^IMPLICITLY_CURRIED_FUNC_0^#
 // IMPLICITLY_CURRIED_FUNC_0: Begin completions
 // IMPLICITLY_CURRIED_FUNC_0-NEXT: Pattern/ExprSpecific: ()[#Void#]{{; name=.+$}}
@@ -832,12 +832,12 @@ func testInsideFunctionCall7() {
 // INSIDE_FUNCTION_CALL_7: End completions
 }
 
-func testInsideFunctionCall8(var x: FooStruct) {
+func testInsideFunctionCall8(x: inout FooStruct) {
   x.instanceFunc0(#^INSIDE_FUNCTION_CALL_8^#)
 // Since we already have '()', there is no pattern to complete.
 // INSIDE_FUNCTION_CALL_8-NOT: Pattern/{{.*}}:
 }
-func testInsideFunctionCall9(var x: FooStruct) {
+func testInsideFunctionCall9(x: inout FooStruct) {
   x.instanceFunc1(#^INSIDE_FUNCTION_CALL_9^#)
 // Annotated ')'
 // INSIDE_FUNCTION_CALL_9: Begin completions
@@ -845,7 +845,7 @@ func testInsideFunctionCall9(var x: FooStruct) {
 // INSIDE_FUNCTION_CALL_9-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_9: End completions
 }
-func testInsideFunctionCall10(var x: FooStruct) {
+func testInsideFunctionCall10(x: inout FooStruct) {
   x.instanceFunc2(#^INSIDE_FUNCTION_CALL_10^#)
 // Annotated ')'
 // INSIDE_FUNCTION_CALL_10: Begin completions
@@ -853,11 +853,11 @@ func testInsideFunctionCall10(var x: FooStruct) {
 // INSIDE_FUNCTION_CALL_10-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_10: End completions
 }
-func testInsideFunctionCall11(var x: FooStruct) {
+func testInsideFunctionCall11(x: inout FooStruct) {
   x.instanceFunc2(#^INSIDE_FUNCTION_CALL_11^#,
 // INSIDE_FUNCTION_CALL_11-NOT: Pattern/{{.*}}:{{.*}}({{.*}}{#Int#}
 }
-func testInsideFunctionCall12(var x: FooStruct) {
+func testInsideFunctionCall12(x: inout FooStruct) {
   x.instanceFunc2(#^INSIDE_FUNCTION_CALL_12^#<#placeholder#>
 // INSIDE_FUNCTION_CALL_12-NOT: Pattern/{{.*}}:{{.*}}({{.*}}{#Int#}
 }
@@ -1186,7 +1186,7 @@ func testFuncParenPattern2(fpp: FuncParenPattern) {
 // FUNC_PAREN_PATTERN_2-NEXT: End completions
 }
 
-func testFuncParenPattern3(var fpp: FuncParenPattern) {
+func testFuncParenPattern3(fpp: inout FuncParenPattern) {
   fpp.instanceFunc#^FUNC_PAREN_PATTERN_3^#
 // FUNC_PAREN_PATTERN_3: Begin completions
 // FUNC_PAREN_PATTERN_3-NEXT: Pattern/ExprSpecific: ({#Int#})[#Void#]{{; name=.+$}}

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -126,7 +126,7 @@ struct d0100_FooStruct {
   func instanceFunc2(a: Int, b: inout Double) {}
 // PASS_COMMON-NEXT: {{^}}  func instanceFunc2(a: Int, b: inout Double){{$}}
 
-  func instanceFunc3(a: Int, let b: Double) { var a = a; a = 1; _ = a }
+  func instanceFunc3(a: Int, b: Double) { var a = a; a = 1; _ = a }
 // PASS_COMMON-NEXT: {{^}}  func instanceFunc3(a: Int, b: Double){{$}}
 
   func instanceFuncWithDefaultArg1(a: Int = 0) {}

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -38,7 +38,7 @@ func dup<T>(x: T) -> (T, T) { var x = x; return (x,x) }
 struct S {}
 
 
-func callDup(let s: S) { _ = dup(s) }
+func callDup(s: S) { _ = dup(s) }
 // CHECK-LABEL: define hidden void @_TF14generic_tuples7callDupFVS_1ST_()
 // CHECK-NEXT: entry:
 // CHECK-NEXT: call void @_TF14generic_tuples3dupurFxTxx_({{.*}} undef, {{.*}} undef, %swift.type* {{.*}} @_TMfV14generic_tuples1S, {{.*}})
@@ -46,7 +46,7 @@ func callDup(let s: S) { _ = dup(s) }
 
 class C {}
 
-func dupC<T : C>(let x: T) -> (T, T) { return (x, x) }
+func dupC<T : C>(x: T) -> (T, T) { return (x, x) }
 // CHECK-LABEL: define hidden { %C14generic_tuples1C*, %C14generic_tuples1C* } @_TF14generic_tuples4dupCuRxCS_1CrFxTxx_(%C14generic_tuples1C*, %swift.type* %T)
 // CHECK-NEXT: entry:
 // CHECK:      [[REF:%.*]] = bitcast %C14generic_tuples1C* %0 to %swift.refcounted*
@@ -55,7 +55,7 @@ func dupC<T : C>(let x: T) -> (T, T) { return (x, x) }
 // CHECK-NEXT: [[TUP2:%.*]] = insertvalue { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUP1:%.*]], %C14generic_tuples1C* %0, 1
 // CHECK-NEXT: ret { %C14generic_tuples1C*, %C14generic_tuples1C* } [[TUP2]]
 
-func callDupC(let c: C) { _ = dupC(c) }
+func callDupC(c: C) { _ = dupC(c) }
 // CHECK-LABEL: define hidden void @_TF14generic_tuples8callDupCFCS_1CT_(%C14generic_tuples1C*)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[REF:%.*]] = bitcast %C14generic_tuples1C* %0 to %swift.refcounted*

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -9,9 +9,9 @@ func foo(a: Int) {
 
 // rdar://15946844
 func test1(inout var x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
-// expected-warning @-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}
 func test2(inout let x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{18-22=}}
-// expected-warning @-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{12-17=}} {{26-26=inout }}
 
 func test3() {
   undeclared_func( // expected-error {{use of unresolved identifier 'undeclared_func'}} expected-note {{to match this opening '('}} expected-error {{expected ',' separator}} {{19-19=,}}
@@ -66,3 +66,26 @@ func g573() { f573(Starfish(), Salmon()) }
 
 func SR698(a: Int, b: Int) {}
 SR698(1, b: 2,) // expected-error {{unexpected ',' separator}}
+
+//SR-979 - Two inout crash compiler
+func SR979a(a : inout inout Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
+func SR979b(inout inout b: Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{19-25=}}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{13-18=}} {{28-28=inout }}
+func SR979c(let a: inout Int) {}	 // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-16=}} 
+// expected-error @-1 {{'let' as a parameter attribute is not allowed}} {{13-16=}}
+func SR979d(let let a: Int) {}  // expected-error {{'let' as a parameter attribute is not allowed}} {{13-16=}} 
+// expected-error @-1 {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-21=}}
+func SR979e(inout x: inout String) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{13-18=}}
+func SR979f(var inout x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
+// expected-error @-1 {{parameters may not have the 'var' specifier}} {{13-16=}}{{3-3=var x = x\n  }} 
+  x += 10
+}
+func SR979h(let inout x : Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
+// expected-error @-1 {{'let' as a parameter attribute is not allowed}}
+class VarTester {
+  init(var a: Int, var b: Int) {} // expected-error {{parameters may not have the 'var' specifier}} {{8-11=}} {{33-33= var a = a }}
+  // expected-error @-1 {{parameters may not have the 'var' specifier}} {{20-24=}} {{33-33= var b = b }}
+    func x(var b: Int) { //expected-error {{parameters may not have the 'var' specifier}} {{12-15=}} {{9-9=var b = b\n        }}
+        b += 10
+    }
+}

--- a/test/SIL/Parser/polymorphic_function.sil
+++ b/test/SIL/Parser/polymorphic_function.sil
@@ -8,7 +8,7 @@ public protocol mmOutputStreamType {
 }
 
 public protocol mmStreamable {
-  func writeTo<Target : mmOutputStreamType>(inout target: Target)
+  func writeTo<Target : mmOutputStreamType>(target: inout Target)
 }
 
 // CHECK-LABEL: sil @test : $@convention(thin) () -> () {

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -11,7 +11,7 @@ protocol Unloadable {
 }
 
 // CHECK-LABEL: sil hidden @_TF18address_only_types21address_only_argument
-func address_only_argument(let x: Unloadable) {
+func address_only_argument(x: Unloadable) {
   // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
   // CHECK: debug_value_addr [[XARG]]
   // CHECK-NEXT: destroy_addr [[XARG]]
@@ -28,7 +28,7 @@ func address_only_ignored_argument(_: Unloadable) {
 }
 
 // CHECK-LABEL: sil hidden @_TF18address_only_types19address_only_return
-func address_only_return(let x: Unloadable, let y: Int) -> Unloadable {
+func address_only_return(x: Unloadable, y: Int) -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable, [[XARG:%[0-9]+]] : $*Unloadable, [[YARG:%[0-9]+]] : $Builtin.Int64):
   // CHECK-NEXT: debug_value_addr [[XARG]] : $*Unloadable, let, name "x"
   // CHECK-NEXT: debug_value [[YARG]] : $Builtin.Int64, let, name "y"
@@ -44,7 +44,7 @@ func address_only_missing_return() -> Unloadable {
 }
 
 // CHECK-LABEL: sil hidden @_TF18address_only_types39address_only_conditional_missing_return
-func address_only_conditional_missing_return(let x: Unloadable) -> Unloadable {
+func address_only_conditional_missing_return(x: Unloadable) -> Unloadable {
   // CHECK: bb0({{%.*}} : $*Unloadable, {{%.*}} : $*Unloadable):
   // CHECK:   switch_enum {{%.*}}, case #Bool.true_!enumelt: [[TRUE:bb[0-9]+]], case #Bool.false_!enumelt: [[FALSE:bb[0-9]+]]
   switch Bool.true_ {
@@ -112,7 +112,7 @@ func address_only_call_1_ignore_return() {
 }
 
 // CHECK-LABEL: sil hidden @_TF18address_only_types19address_only_call_2
-func address_only_call_2(let x: Unloadable) {
+func address_only_call_2(x: Unloadable) {
   // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
   // CHECK: debug_value_addr [[XARG]] : $*Unloadable
   some_address_only_function_2(x)
@@ -203,7 +203,7 @@ func address_only_assignment_from_temp_to_property() {
 }
 
 // CHECK-LABEL: sil hidden @_TF18address_only_types43address_only_assignment_from_lv_to_property
-func address_only_assignment_from_lv_to_property(let v: Unloadable) {
+func address_only_assignment_from_lv_to_property(v: Unloadable) {
   // CHECK: bb0([[VARG:%[0-9]+]] : $*Unloadable):
   // CHECK: debug_value_addr [[VARG]] : $*Unloadable
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $Unloadable

--- a/test/SILGen/generic_tuples.swift
+++ b/test/SILGen/generic_tuples.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen -parse-as-library %s | FileCheck %s
 
 
-func dup<T>(let x: T) -> (T, T) { return (x,x) }
+func dup<T>(x: T) -> (T, T) { return (x,x) }
 // CHECK-LABEL:      sil hidden @_TF14generic_tuples3dup
 // CHECK:      ([[RESULT_0:%.*]] : $*T, [[RESULT_1:%.*]] : $*T, [[XVAR:%.*]] : $*T):
 // CHECK-NEXT: debug_value_addr [[XVAR]] : $*T, let, name "x"

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -30,7 +30,7 @@ struct B : AddressOnly {}
 func consumeAddressOnly(_: AddressOnly) {}
 
 // CHECK: sil hidden @_TF7if_expr19addr_only_ternary_1
-func addr_only_ternary_1(let x: Bool) -> AddressOnly {
+func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK: bb0([[RET:%.*]] : $*AddressOnly, {{.*}}):
   // CHECK: [[a:%[0-9]+]] = alloc_box $AddressOnly, var, name "a"
   // CHECK: [[PBa:%.*]] = project_box [[a]]

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -5,7 +5,7 @@ func takeClosure(a : () -> Int) {}
 // Let decls don't get boxes for trivial types.
 //
 // CHECK-LABEL: sil hidden @{{.*}}test1
-func test1(let a : Int) -> Int {
+func test1(a : Int) -> Int {
   // CHECK-NOT: alloc_box
   // CHECK-NOT: alloc_stack
 
@@ -204,7 +204,7 @@ func produceNMSubscriptableRValue() -> NonMutableSubscriptable {}
 // CHECK: [[GETFN:%[0-9]+]] = function_ref @_TFV9let_decls23NonMutableSubscriptableg9subscript
 // CHECK-NEXT: [[RES2:%[0-9]+]] = apply [[GETFN]](%0, [[RES]])
 // CHECK-NEXT: return [[RES2]]
-func test_nm_subscript_get(let a : Int) -> Int {
+func test_nm_subscript_get(a : Int) -> Int {
   return produceNMSubscriptableRValue()[a]
 }
 
@@ -214,7 +214,7 @@ func test_nm_subscript_get(let a : Int) -> Int {
 // CHECK-NEXT: [[RES:%[0-9]+]] = apply [[FR1]]()
 // CHECK: [[SETFN:%[0-9]+]] = function_ref @_TFV9let_decls23NonMutableSubscriptables9subscript
 // CHECK-NEXT: [[RES2:%[0-9]+]] = apply [[SETFN]](%0, %0, [[RES]])
-func test_nm_subscript_set(let a : Int) {
+func test_nm_subscript_set(a : Int) {
   produceNMSubscriptableRValue()[a] = a
 }
 
@@ -229,7 +229,7 @@ struct WeirdPropertyTest {
 }
 
 // CHECK-LABEL: sil hidden @{{.*}}test_weird_property
-func test_weird_property(v : WeirdPropertyTest, let i : Int) -> Int {
+func test_weird_property(v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
   // CHECK: [[VBOX:%[0-9]+]] = alloc_box $WeirdPropertyTest
   // CHECK: [[PB:%.*]] = project_box [[VBOX]]
@@ -255,7 +255,7 @@ func test_weird_property(v : WeirdPropertyTest, let i : Int) -> Int {
 // CHECK-NEXT: copy_addr [take] %1 to [initialization] %0 : $*T
 // CHECK-NEXT: %4 = tuple ()
 // CHECK-NEXT: return %4
-func generic_identity<T>(let a : T) -> T {
+func generic_identity<T>(a : T) -> T {
   // Should be a single copy_addr, with no temporary.
   return a
 }
@@ -282,7 +282,7 @@ protocol SimpleProtocol {
 
 // CHECK-LABEL: sil hidden @{{.*}}testLetProtocolBases
 // CHECK: bb0(%0 : $*SimpleProtocol):
-func testLetProtocolBases(let p : SimpleProtocol) {
+func testLetProtocolBases(p : SimpleProtocol) {
   // CHECK-NEXT: debug_value_addr
   // CHECK-NEXT: open_existential_addr
   // CHECK-NEXT: witness_method
@@ -301,7 +301,7 @@ func testLetProtocolBases(let p : SimpleProtocol) {
 
 // CHECK-LABEL: sil hidden @{{.*}}testLetArchetypeBases
 // CHECK: bb0(%0 : $*T):
-func testLetArchetypeBases<T : SimpleProtocol>(let p : T) {
+func testLetArchetypeBases<T : SimpleProtocol>(p : T) {
   // CHECK-NEXT: debug_value_addr
   // CHECK-NEXT: witness_method $T
   // CHECK-NEXT: apply
@@ -319,7 +319,7 @@ func testLetArchetypeBases<T : SimpleProtocol>(let p : T) {
 // CHECK: bb0(%0 : $Int, %1 : $*SimpleProtocol):
 // CHECK-NEXT: debug_value %0 : $Int, let, name "a"
 // CHECK-NEXT: debug_value_addr %1 : $*SimpleProtocol, let, name "b"
-func testDebugValue(let a : Int, let b : SimpleProtocol) -> Int {
+func testDebugValue(a : Int, b : SimpleProtocol) -> Int {
 
   // CHECK-NEXT: debug_value %0 : $Int, let, name "x"
   let x = a
@@ -335,7 +335,7 @@ func testDebugValue(let a : Int, let b : SimpleProtocol) -> Int {
 
 
 // CHECK-LABEL: sil hidden @{{.*}}testAddressOnlyTupleArgument
-func testAddressOnlyTupleArgument(let bounds: (start: SimpleProtocol, pastEnd: Int)) {
+func testAddressOnlyTupleArgument(bounds: (start: SimpleProtocol, pastEnd: Int)) {
 // CHECK:       bb0(%0 : $*SimpleProtocol, %1 : $Int):
 // CHECK-NEXT:    %2 = alloc_stack $(start: SimpleProtocol, pastEnd: Int), let, name "bounds"
 // CHECK-NEXT:    %3 = tuple_element_addr %2 : $*(start: SimpleProtocol, pastEnd: Int), 0
@@ -348,7 +348,7 @@ func testAddressOnlyTupleArgument(let bounds: (start: SimpleProtocol, pastEnd: I
 }
 
 
-func address_only_let_closure<T>(let x:T) -> T {
+func address_only_let_closure<T>(x:T) -> T {
   return { { x }() }()
 }
 
@@ -360,13 +360,13 @@ struct GenericFunctionStruct<T, U> {
 // CHECK-LABEL: sil hidden @{{.*}}member_ref_abstraction_change
 // CHECK: function_ref reabstraction thunk helper
 // CHECK: return
-func member_ref_abstraction_change(let x: GenericFunctionStruct<Int, Int>) -> Int -> Int {
+func member_ref_abstraction_change(x: GenericFunctionStruct<Int, Int>) -> Int -> Int {
   return x.f
 }
 
 // CHECK-LABEL: sil hidden @{{.*}}call_auto_closure
 // CHECK: apply %0()
-func call_auto_closure(@autoclosure let x: () -> Bool) -> Bool {
+func call_auto_closure(@autoclosure x: () -> Bool) -> Bool {
   return x()  // Calls of autoclosures should be marked transparent.
 }
 

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -111,7 +111,7 @@ func test9(g: Gizmo) -> Gizmo {
 }
 
 // CHECK-LABEL: sil hidden @_TF26objc_ownership_conventions6test10
-func test10(let g: Gizmo) -> AnyClass {
+func test10(g: Gizmo) -> AnyClass {
   // CHECK: bb0([[G:%[0-9]+]] : $Gizmo):
   // CHECK:      strong_retain [[G]]
   // CHECK-NEXT: [[NS_G:%[0-9]+]] = upcast [[G:%[0-9]+]] : $Gizmo to $NSObject
@@ -131,7 +131,7 @@ func test10(let g: Gizmo) -> AnyClass {
 }
 
 // CHECK-LABEL: sil hidden @_TF26objc_ownership_conventions6test11
-func test11(let g: Gizmo) -> AnyClass {
+func test11(g: Gizmo) -> AnyClass {
   // CHECK: bb0([[G:%[0-9]+]] : $Gizmo):
   // CHECK: strong_retain [[G]]
   // CHECK: [[NS_G:%[0-9]+]] = upcast [[G:%[0-9]+]] : $Gizmo to $NSObject

--- a/test/SILGen/property_behavior.swift
+++ b/test/SILGen/property_behavior.swift
@@ -37,7 +37,7 @@ class C1<T> {
 
 var zero: Int { get { } }
 
-func exerciseBehavior<T>(inout _ sx: S1<T>, inout _ sy: S1<Int>,
+func exerciseBehavior<T>(_ sx: inout S1<T>, _ sy: inout S1<Int>,
                          _ cx: C1<T>, _ cy: C1<Int>,
                          _ z: T) {
   /* FIXME
@@ -101,7 +101,7 @@ class C2<T> {
   var instance: T __behavior withStorage
 }
 
-func exerciseStorage<T>(inout _ sx: S2<T>, inout _ sy: S2<Int>,
+func exerciseStorage<T>(_ sx: inout S2<T>, _ sy: inout S2<Int>,
                         _ cx: C2<T>, _ cy: C2<Int>,
                         _ z: T) {
   _ = sx.instance
@@ -141,7 +141,7 @@ class C3<T> {
   var instance: T __behavior withInit { any() }
 }
 
-func exerciseStorage<T>(inout _ sx: S3<T>, inout _ sy: S3<Int>,
+func exerciseStorage<T>(_ sx: inout S3<T>, _ sy: inout S3<Int>,
                         _ cx: C3<T>, _ cy: C3<Int>,
                         _ z: T) {
   _ = sx.instance

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -431,7 +431,7 @@ class D2 : D1 {}
 class E : C {}
 
 // CHECK-LABEL: sil hidden @_TF6switch16test_isa_class_1FT1xCS_1B_T_
-func test_isa_class_1(let x x: B) {
+func test_isa_class_1(x x: B) {
   // CHECK: strong_retain %0
   switch x {
   // CHECK:   checked_cast_br [[X:%.*]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -37,7 +37,7 @@ _ = AddressOnly(x: C(), p: X())
 // CHECK: }
 
 // CHECK-LABEL:    sil hidden @_TF7unowned5test0FT1cCS_1C_T_ : $@convention(thin) (@owned C) -> () {
-func test0(let c c: C) {
+func test0(c c: C) {
 // CHECK:    bb0(%0 : $C):
 
   var a: A

--- a/test/SILOptimizer/bridging_checked_cast.sil
+++ b/test/SILOptimizer/bridging_checked_cast.sil
@@ -16,9 +16,9 @@ struct Butt: _ObjectiveCBridgeable {
   static func _isBridgedToObjectiveC() -> Bool
   func _bridgeToObjectiveC() -> NSCloud
   static func _forceBridgeFromObjectiveC(source: NSCloud,
-                                         inout result: Butt?)
+                                         result: inout Butt?)
   static func _conditionallyBridgeFromObjectiveC(source: NSCloud,
-                                         inout result: Butt?) -> Bool
+                                         result: inout Butt?) -> Bool
 }
 
 sil @checked_cast_object_to_value : $@convention(thin) () -> () {

--- a/test/SILOptimizer/sil_combine_objc_bridge.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge.sil
@@ -28,13 +28,13 @@ struct AnArray<T> : _ObjectiveCBridgeable {
   }
   static func _forceBridgeFromObjectiveC(
     x: AnNSArray,
-    inout result: AnArray?
+    result: inout AnArray?
   ) {
     _preconditionFailure("implement")
   }
   static func _conditionallyBridgeFromObjectiveC(
     x: AnNSArray,
-    inout result: AnArray?
+    result: inout AnArray?
   ) -> Bool {
     _preconditionFailure("implement")
   }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -222,11 +222,10 @@ func test_mutability() {
 
 func test_arguments(a : Int,
                     b : Int,
-                    let c : Int) {
+                    let c : Int) { // expected-error {{'let' as a parameter attribute is not allowed}} {{21-25=}}
   var b = b
   a = 1  // expected-error {{cannot assign to value: 'a' is a 'let' constant}}
   b = 2  // ok.
-  c = 3  // expected-error {{cannot assign to value: 'c' is a 'let' constant}}
   _ = b
 }
 
@@ -323,7 +322,7 @@ protocol SubscriptNoGetter {
   subscript (i: Int) -> Int { get }
 }
 
-func testSubscriptNoGetter(let iis: SubscriptNoGetter) {
+func testSubscriptNoGetter(let iis: SubscriptNoGetter) { // expected-error {{'let' as a parameter attribute is not allowed}}{{28-31=}}
   var _: Int = iis[17]
 }
 
@@ -336,16 +335,22 @@ func testSelectorStyleArguments1(x: Int, bar y: Int) {
   _ = y
 }
 
-func testSelectorStyleArguments2(let x: Int,
-                                 let bar y: Int) {
+func testSelectorStyleArguments2(let x: Int, // expected-error {{'let' as a parameter attribute is not allowed}}{{34-37=}}
+                                 let bar y: Int) { // expected-error {{'let' as a parameter attribute is not allowed}}{{34-38=}}
+                                 
+  
+}
+func testSelectorStyleArguments3(x: Int, bar y: Int) {
   ++x  // expected-error {{cannot pass immutable value to mutating operator: 'x' is a 'let' constant}}
   ++y  // expected-error {{cannot pass immutable value to mutating operator: 'y' is a 'let' constant}}
 }
 
 func invalid_inout(inout var x : Int) { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{26-30=}}
-// expected-warning@-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{20-25=}}{{34-34=inout }}
 }
-
+func invalid_var(var x: Int) { // expected-error {{parameters may not have the 'var' specifier}}{{18-21=}} {{1-1=    var x = x\n}}
+  
+}
 
 
 func updateInt(x : inout Int) {}
@@ -444,7 +449,8 @@ struct StructWithDelegatingInit {
   init() { self.init(x: 0); self.x = 22 } // expected-error {{cannot assign to property: 'x' is a 'let' constant}}
 }
 
-func test_recovery_missing_name_2(let: Int) {} // expected-error 2{{expected ',' separator}} {{38-38=,}} expected-error 2 {{expected parameter name followed by ':'}}
+func test_recovery_missing_name_2(let: Int) {} // expected-error {{'let' as a parameter attribute is not allowed}}{{35-38=}} 
+// expected-error @-1 2{{expected ',' separator}} {{38-38=,}} expected-error @-1 2 {{expected parameter name followed by ':'}}
 
 // <rdar://problem/16792027> compiler infinite loops on a really really mutating function
 struct F { // expected-note 2 {{in declaration of 'F'}}

--- a/test/SourceKit/CodeComplete/complete_operators.swift
+++ b/test/SourceKit/CodeComplete/complete_operators.swift
@@ -11,7 +11,7 @@ postfix func ++(x: inout MyInt) -> MyInt { return x }
 func !=(x: MyInt, y: MyInt) -> Bool { return true }
 
 let xxxx = 1
-func test1(var x: MyInt) {
+func test1(x: inout MyInt) {
   x#^INT_OPERATORS^#
 }
 // CHECK: .
@@ -20,7 +20,7 @@ func test1(var x: MyInt) {
 // CHECK: ++
 // CHECK: =
 
-func test2(var x: MyInt) {
+func test2(x: inout MyInt) {
   #^INT_OPERATORS_INNER,x^#
 }
 // INNER: x.

--- a/test/SourceKit/CodeComplete/complete_structure.swift
+++ b/test/SourceKit/CodeComplete/complete_structure.swift
@@ -110,7 +110,7 @@ func test8() {
 // FIXME: should the ( go inside the name here?
 // S1_INNER_0: {name:S1}(
 
-func test9(var x: Int) {
+func test9(x: inout Int) {
   #^INT_INNER_0,x^#
 }
 // INT_INNER_0: {name:x+}

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -25,7 +25,7 @@ let testLetString = "testString"
 
 func testLetParam(arg1 : Int) {
 }
-func testVarParam(var arg1 : Int) {
+func testInoutParam(arg1 : inout Int) {
 }
 
 func testDefaultParam(arg1: Int = 0) {
@@ -292,9 +292,9 @@ typealias MyVoid = ()
 // CHECK11: <decl.var.parameter><syntaxtype.keyword>let</syntaxtype.keyword> <decl.var.parameter.name>arg1</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>
 
 // RUN: %sourcekitd-test -req=cursor -pos=28:24 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK12 %s
-// CHECK12: source.lang.swift.decl.var.parameter (28:23-28:27)
-// CHECK12: <Declaration>var arg1: <Type usr="s:Si">Int</Type></Declaration>
-// CHECK12: <decl.var.parameter><syntaxtype.keyword>var</syntaxtype.keyword> <decl.var.parameter.name>arg1</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>
+// CHECK12: source.lang.swift.decl.var.parameter (28:21-28:25)
+// CHECK12: <Declaration>var arg1: inout <Type usr="s:Si">Int</Type></Declaration>
+// CHECK12: <decl.var.parameter><syntaxtype.keyword>var</syntaxtype.keyword> <decl.var.parameter.name>arg1</decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.keyword>inout</syntaxtype.keyword> <ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>
 
 // RUN: %sourcekitd-test -req=cursor -pos=31:7 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK13 %s
 // CHECK13: source.lang.swift.decl.function.free (31:6-31:37)

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -4,14 +4,14 @@ var x = NSUTF8StringEncoding
 
 var d : AnyIterator<Int>
 
-func foo1(var a : [Int]) {
+func foo1(a : inout [Int]) {
   a = a.sorted()
   a.append(1)
 }
 
 struct S1 {}
 
-func foo2(var a : [S1]) {
+func foo2(a : inout [S1]) {
   a = a.sorted(isOrderedBefore: { (a, b) -> Bool in
     return false
   })
@@ -62,9 +62,6 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-MODULE-GROUP1-DAG: Collection
 // CHECK-MODULE-GROUP1-DAG: Collection/Array
 // CHECK-MODULE-GROUP1: MODULE GROUPS END
-
-// RUN: %sourcekitd-test -req=cursor -pos=7:21 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-INT1 %s
-// CHECK-INT1: s:Si
 
 // RUN: %sourcekitd-test -req=cursor -pos=22:17 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-FLOAT1 %s
 // CHECK-FLOAT1: s:Sf

--- a/test/SourceKit/Indexing/index.swift
+++ b/test/SourceKit/Indexing/index.swift
@@ -33,7 +33,7 @@ protocol Prot {
   func protMeth(a: Prot)
 }
 
-func foo(a: CC, var b: E) {
+func foo(a: CC, b: inout E) {
   globV = 0
   a + a.instV
   a.meth()

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -246,7 +246,7 @@
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "foo(_:b:)",
-      key.usr: "s:F5index3fooFTCS_2CC1bOS_1E_T_",
+      key.usr: "s:F5index3fooFTCS_2CC1bROS_1E_T_",
       key.line: 36,
       key.column: 6,
       key.entities: [
@@ -262,7 +262,7 @@
           key.name: "E",
           key.usr: "s:O5index1E",
           key.line: 36,
-          key.column: 24
+          key.column: 26
         },
         {
           key.kind: source.lang.swift.ref.var.global,

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift
@@ -1,6 +1,6 @@
 import swift_mod_syn
 
-func f(var s : [Int]) {
+func f(s : inout [Int]) {
   s.sort()
 }
 

--- a/test/attr/attr_inout.swift
+++ b/test/attr/attr_inout.swift
@@ -10,4 +10,4 @@ enum inout_carrier {
   case carry(inout Int) // expected-error {{'inout' is only valid in parameter lists}}
 }
 
-func deprecated(inout x: Int) {} // expected-warning {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+func deprecated(inout x: Int) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -144,13 +144,12 @@ class H : G {
 
   func oneA(_: AnyObject) {}
   func oneB(x x: AnyObject) {}
-  func oneC(var x x: AnyObject) {} // expected-error {{parameters may not have the 'var' specifier}} expected-warning {{parameter 'x' was never mutated; consider changing to 'let' constant}}
-  func oneD(x: AnyObject) {}
+  func oneC(x: AnyObject) {}
 
   func manyA(_: AnyObject, _: AnyObject) {}
   func manyB(a: AnyObject, b: AnyObject) {}
-  func manyC(var a: AnyObject,  // expected-error {{parameters may not have the 'var' specifier}} expected-warning {{parameter 'a' was never mutated; consider changing to 'let' constant}}
-             var b: AnyObject) {} // expected-error {{parameters may not have the 'var' specifier}} expected-warning {{parameter 'b' was never mutated; consider changing to 'let' constant}}
+  func manyC(var a: AnyObject,  // expected-error {{parameters may not have the 'var' specifier}} {{14-17=}}
+             var b: AnyObject) {} // expected-error {{parameters may not have the 'var' specifier}} {{14-18=}}
 
   func result() -> AnyObject? { return nil }
   func both(x: AnyObject) -> AnyObject? { return x }
@@ -167,10 +166,7 @@ class IUOTestSubclass : IUOTestBaseClass {
   override func oneB(x x: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
   // expected-note@-1 {{remove '!' to make the parameter required}} {{36-37=}}
   // expected-note@-2 {{add parentheses to silence this warning}} {{27-27=(}} {{37-37=)}}
-  override func oneC(var x x: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}} expected-warning {{parameter 'x' was never mutated; consider changing to 'let' constant}} expected-error {{parameters may not have the 'var' specifier}}
-  // expected-note@-1 {{remove '!' to make the parameter required}} {{40-41=}}
-  // expected-note@-2 {{add parentheses to silence this warning}} {{31-31=(}} {{41-41=)}}
-  override func oneD(x: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
+  override func oneC(x: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
   // expected-note@-1 {{remove '!' to make the parameter required}} {{34-35=}}
   // expected-note@-2 {{add parentheses to silence this warning}} {{25-25=(}} {{35-35=)}}
 
@@ -179,9 +175,6 @@ class IUOTestSubclass : IUOTestBaseClass {
   // expected-note@-2 2 {{add parentheses to silence this warning}}
   override func manyB(a: AnyObject!, b: AnyObject!) {} // expected-warning 2 {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
   // expected-note@-1 2 {{remove '!' to make the parameter required}} 
-  // expected-note@-2 2 {{add parentheses to silence this warning}}
-  override func manyC(var a: AnyObject!, var b: AnyObject!) {} // expected-warning 2 {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}} expected-warning {{parameter 'a' was never mutated; consider changing to 'let' constant}} expected-warning {{parameter 'b' was never mutated; consider changing to 'let' constant}} expected-error {{parameters may not have the 'var' specifier}} expected-error {{parameters may not have the 'var' specifier}}
-  // expected-note@-1 2 {{remove '!' to make the parameter required}}
   // expected-note@-2 2 {{add parentheses to silence this warning}}
 
   override func result() -> AnyObject! { return nil } // expected-warning {{overriding instance method optional result type 'AnyObject?' with implicitly unwrapped optional type 'AnyObject!'}}
@@ -206,21 +199,20 @@ class IUOTestSubclass2 : IUOTestBaseClass {
   override func oneA(x: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
   // expected-note@-1 {{remove '!' to make the parameter required}} {{34-35=}}
   // expected-note@-2 {{add parentheses to silence this warning}} {{25-25=(}} {{35-35=)}}
-  override func oneB(var x x: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}} expected-warning {{parameter 'x' was never mutated; consider changing to 'let' constant}} expected-error {{parameters may not have the 'var' specifier}}
-  // expected-note@-1 {{remove '!' to make the parameter required}} {{40-41=}}
-  // expected-note@-2 {{add parentheses to silence this warning}} {{31-31=(}} {{41-41=)}}
-  override func oneD(_: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
+
+  override func oneB(x x: ImplicitlyUnwrappedOptional<AnyObject>) {}  // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'ImplicitlyUnwrappedOptional<AnyObject>'}}
+  // expected-note@-1 {{add parentheses to silence this warning}} {{27-27=(}} {{65-65=)}}
+
+  override func oneC(_: AnyObject!) {} // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject!'}}
   // expected-note@-1 {{remove '!' to make the parameter required}} {{34-35=}}
   // expected-note@-2 {{add parentheses to silence this warning}} {{25-25=(}} {{35-35=)}}
-
-  override func oneC(x x: ImplicitlyUnwrappedOptional<AnyObject>) {}  // expected-warning {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'ImplicitlyUnwrappedOptional<AnyObject>'}}
-  // expected-note@-1 {{add parentheses to silence this warning}} {{27-27=(}} {{65-65=)}}
+  
 }
 
 class IUOTestSubclassOkay : IUOTestBaseClass {
   override func oneA(_: AnyObject?) {}
   override func oneB(x x: (AnyObject!)) {}
-  override func oneC(x x: AnyObject) {}
+  override func oneC(x: AnyObject) {}
 
   override func result() -> (AnyObject!) { return nil }
 }

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -121,7 +121,7 @@ func testObjCMethodCurry(a : ClassWithObjCMethod) -> (Int) -> () {
 
 // We used to crash on this.
 func rdar16786220(inout let c: Int) -> () { // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{25-29=}}
-// expected-warning@-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}{{19-24=}}{{32-32=inout }}
 
   c = 42
 }
@@ -137,7 +137,7 @@ func !!!<T>(lhs: UnsafePointer<T>, rhs: UnsafePointer<T>) -> Bool { return false
 
 // <rdar://problem/16786168> Functions currently permit 'var inout' parameters
 func var_inout_error(inout var x : Int) {} // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{28-32=}}
-// expected-warning@-1 {{'inout' before a parameter name is deprecated, place it before the parameter type instead}}
+// expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{22-27=}}{{36-36=inout }}
 
 // Unnamed parameters require the name "_":
 func unnamed(Int) { } // expected-error{{unnamed parameters must be written with the empty name '_'}}{{14-14=_: }}

--- a/validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift
+++ b/validation-test/compiler_crashers/28252-swift-constraints-constraintsystem-assignfixedtype.swift
@@ -9,7 +9,7 @@
 // REQUIRES: asserts
 public protocol P {}
 public func foo<T, TargetStream : P>(
-  value: T, inout _ target: TargetStream
+  value: T, _ target: inout TargetStream
 ) {
   fatalError()
 }


### PR DESCRIPTION
#### What's in this pull request?

This pull request cleans up parsing of parameter attributes by parsing the inout, let and var tokens better. It cleans up the implementation to work better with SE-0003 by giving better fix-its and diagnostics for var as parameter attributes. It implements SE-0053 to disallow `let` as an attribute. It provides better fixits for `inout` that are either duplicated or misplaced to better implement SE-0031. 
#### Resolved bug number:
- [SR-979](https://bugs.swift.org/browse/SR-979)
- [SR-1020](https://bugs.swift.org/browse/SR-1020)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
