### PR TITLE
[ClangImporter] Correctly set up inherited protocol conformances

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5299,8 +5299,10 @@ void ClangImporter::Implementation::finishPendingActions() {
 /// by filling in any missing witnesses.
 void ClangImporter::Implementation::finishProtocolConformance(
     NormalProtocolConformance *conformance) {
+  const ProtocolDecl *proto = conformance->getProtocol();
+
   // Create witnesses for requirements not already met.
-  for (auto req : conformance->getProtocol()->getMembers()) {
+  for (auto req : proto->getMembers()) {
     auto valueReq = dyn_cast<ValueDecl>(req);
     if (!valueReq)
       continue;
@@ -5327,6 +5329,34 @@ void ClangImporter::Implementation::finishProtocolConformance(
         }
       }
     }
+  }
+
+  // And make sure any inherited conformances also get completed, if necessary.
+  SmallVector<ProtocolDecl *, 8> inheritedProtos;
+  for (auto *inherited : proto->getInheritedProtocols(/*resolver=*/nullptr)) {
+    inheritedProtos.push_back(inherited);
+  }
+  // Sort for deterministic import.
+  llvm::array_pod_sort(inheritedProtos.begin(),
+                       inheritedProtos.end(),
+                       [](ProtocolDecl * const *left,
+                          ProtocolDecl * const *right) -> int {
+    // We know all Objective-C protocols have unique names.
+    auto getDeclName = [](const ProtocolDecl *proto) -> StringRef {
+      return cast<clang::ObjCProtocolDecl>(proto->getClangDecl())->getName();
+    };
+    return getDeclName(*left).compare(getDeclName(*right));
+  });
+  // Schedule any that aren't complete.
+  for (auto *inherited : inheritedProtos) {
+    Module *M = conformance->getDeclContext()->getParentModule();
+    auto inheritedConformance = M->lookupConformance(conformance->getType(),
+                                                     inherited,
+                                                     /*resolver=*/nullptr);
+    assert(inheritedConformance && inheritedConformance->isConcrete() &&
+           "inherited conformance not found");
+    conformance->setInheritedConformance(inherited,
+                                         inheritedConformance->getConcrete());
   }
 
   conformance->setState(ProtocolConformanceState::Complete);

--- a/test/ClangModules/Inputs/inherited-protocols-sil.h
+++ b/test/ClangModules/Inputs/inherited-protocols-sil.h
@@ -1,0 +1,13 @@
+@protocol BaseProto
+@end
+
+@protocol SubProto <BaseProto>
+@end
+
+@interface UnrelatedBaseClass
+@end
+
+@interface Impl : UnrelatedBaseClass <SubProto>
+- (instancetype)init;
++ (instancetype)implWithChild:(id<BaseProto>)child;
+@end

--- a/test/ClangModules/inherited-protocols-sil.swift
+++ b/test/ClangModules/inherited-protocols-sil.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -sdk "" -emit-sil %s -import-objc-header %S/Inputs/inherited-protocols-sil.h -O
+
+// REQUIRES: objc_interop
+
+// <rdar://problem/24547884> Protocol Extensions May Crash Swift Compiler when Whole-Module Optimization is Enabled
+
+extension SubProto {
+  func foo() -> Impl {
+    return Impl(child: self)
+  }
+}
+
+_ = Impl().foo()


### PR DESCRIPTION
Previously we just left them out, and then bits of the SIL optimizer would just crash when they asked about them. @DougGregor, does this look like the correct fix? @eeckstein, is there a better way to trigger specialization than this RUN line and this awkward global?

This is rdar://problem/24547884, which includes a reference to facebook/AsyncDisplayKit#1109. (As in, this should fix that issue as well. The test case in the Radar included a stripped-down client but the full AsyncDisplayKit.)
