### PR TITLE
ClangImporter: provide a warning when an interface is pruned

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -64,6 +64,10 @@ WARNING(inconsistent_swift_name,none,
         (bool, StringRef, StringRef, DeclName, StringRef, DeclName,
          StringRef))
 
+WARNING(pruned_module_interface, none,
+        "interface %0 imported from module '%1' will be unavailable",
+        (DeclName, StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/test/ClangModules/Inputs/custom-modules/floats.h
+++ b/test/ClangModules/Inputs/custom-modules/floats.h
@@ -1,0 +1,3 @@
+
+long double long_double_returning_function(void);
+

--- a/test/ClangModules/Inputs/custom-modules/module.map
+++ b/test/ClangModules/Inputs/custom-modules/module.map
@@ -141,3 +141,8 @@ module MacrosRedefA {
 module MacrosRedefB {
   header "MacrosRedefB.h"
 }
+
+module floats {
+  header "floats.h"
+}
+

--- a/test/ClangModules/import-warnings.swift
+++ b/test/ClangModules/import-warnings.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify -I %S/Inputs/custom-modules %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -I %S/Inputs/custom-modules %s 2>&1 | FileCheck %s
+
+import floats
+// CHECK: interface 'long_double_returning_function()' imported from module 'floats' will be unavailable
+
+let v = long_double_returning_function()
+// expected-error@-1{{use of unresolved identifier 'long_double_returning_function'}}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Certain types in external imported modules are not mappable to swift types for
various reasons.  Enable a warning to be emitted when such a declaration is
encountered during the import of a module.
