### PR TITLE
[let-properies-opt] Fix a bug which where a let property was wrongly …

### DIFF
--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -98,6 +98,31 @@ public class Foo2 {
   }
 }
 
+public class C {}
+
+struct Boo3 {
+  //public 
+  let Prop0: Int32
+  let Prop1: Int32
+  private let Prop2: Int32
+  internal let Prop3: Int32
+
+  @inline(__always)
+  init(_ f1: C, _ f2: C) {
+    self.Prop0 = 0
+    self.Prop1 = 1
+    self.Prop2 = 2
+    self.Prop3 = 3
+  }
+
+  init(_ v: C) {
+    self.Prop0 = 10
+    self.Prop1 = 11
+    self.Prop2 = 12
+    self.Prop3 = 13
+  }
+}
+
 // Check that Foo1.Prop1 is not constant-folded, because its value is unknown, since it is initialized differently
 // by Foo1 initializers.
 
@@ -193,4 +218,36 @@ public func testStructPublicLet(b: Boo) -> Int32 {
 // CHECK: return
 public func testClassLet2(f: Foo2) -> Int32 {
   return f.x + f.x
+}
+
+// Check that the sum of properties is not folded into a constant.
+// CHECK-WMO-LABEL: sil hidden [noinline] @_TF19let_properties_opts27testStructWithMultipleInitsFTVS_4Boo3S0__Vs5Int32 : $@convention(thin) (Boo3, Boo3) -> Int32
+// CHECK-WMO: bb0
+// No constant folding should have been performed.
+// CHECK-WMO-NOT: integer_literal $Builtin.Int32, 92
+// CHECK-WMO: struct_extract
+// CHECK-WMO: }
+@inline(never)
+func testStructWithMultipleInits( _ boos1: Boo3, _ boos2: Boo3) -> Int32 {
+  let count1 =  boos1.Prop0 + boos1.Prop1 + boos1.Prop2 + boos1.Prop3
+  let count2 =  boos2.Prop0 + boos2.Prop1 + boos2.Prop2 + boos2.Prop3
+  return count1 + count2
+}
+
+public func testStructWithMultipleInitsAndInlinedInitializer() {
+  let things = [C()]
+  // This line results in inlinig of the initializer Boo3(C, C) and later
+  // removal of this initializer by the dead function elimination pass.
+  // As a result, only one initializer, Boo3(C) is seen by the Let Properties Propagation
+  // pass. This pass may think that there is only one intializer and take the
+  // values of let properties assigned there as constants and try to propagate
+  // those values into uses. But this is wrong! The pass should be clever enough
+  // to detect all stores to the let properties, including those outside of
+  // initializers, e.g. inside inlined initializers. And if it detects all such
+  // stores it should understand that values of let properties in Boo3 are not
+  // statically known constant initializers with the same value and thus
+  // cannot be propagated.
+  let boos1 = things.map { Boo3($0, C()) }
+  let boos2 = things.map(Boo3.init)
+  print(testStructWithMultipleInits(boos1[0], boos2[0]))
 }

--- a/test/SILOptimizer/let_properties_opts_runtime.swift
+++ b/test/SILOptimizer/let_properties_opts_runtime.swift
@@ -1,6 +1,8 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift -O  %s -o %t/a.out
 // RUN: %target-run %t/a.out | FileCheck %s -check-prefix=CHECK-OUTPUT
+// RUN: %target-build-swift -O -wmo %s -o %t/a.out
+// RUN: %target-run %t/a.out | FileCheck %s -check-prefix=CHECK-OUTPUT
 // REQUIRES: executable_test
 
 // Check that in optimized builds the compiler generates correct code for
@@ -48,3 +50,59 @@ print(testClassLet(Foo1(1)))
 // CHECK-OUTPUT: 400
 print(testClassLet(Foo1(10)))
 
+public class C {}
+
+struct Boo3 {
+  //public 
+  let Prop0: Int32
+  let Prop1: Int32
+  private let Prop2: Int32
+  internal let Prop3: Int32
+
+  @inline(__always)
+  init(_ f1: C, _ f2: C) {
+    self.Prop0 = 0
+    self.Prop1 = 1
+    self.Prop2 = 2
+    self.Prop3 = 3
+  }
+
+  init(_ v: C) {
+    self.Prop0 = 10
+    self.Prop1 = 11
+    self.Prop2 = 12
+    self.Prop3 = 13
+  }
+}
+
+// Check that the sum of properties is not folded into a constant.
+@inline(never)
+func testStructWithMultipleInits( _ boos1: Boo3, _ boos2: Boo3) -> Int32 {
+  // count1 = 0 + 1 + 2 + 3 = 6
+  // count2 = 10 + 11 + 12 + 13 = 46
+  // count1 + count2 = 6 + 46 = 52
+  let count1 =  boos1.Prop0 + boos1.Prop1 + boos1.Prop2 + boos1.Prop3
+  let count2 =  boos2.Prop0 + boos2.Prop1 + boos2.Prop2 + boos2.Prop3
+  return count1 + count2
+}
+
+public func testStructWithMultipleInitsAndInlinedInitializer() {
+  let things = [C()]
+  // This line results in inlinig of the initializer Boo3(C, C) and later
+  // removal of this initializer by the dead function elimination pass.
+  // As a result, only one initializer, Boo3(C) is seen by the Let Properties Propagation
+  // pass. This pass may think that there is only one intializer and take the
+  // values of let properties assigned there as constants and try to propagate
+  // those values into uses. But this is wrong! The pass should be clever enough
+  // to detect all stores to the let properties, including those outside of
+  // initializers, e.g. inside inlined initializers. And if it detects all such
+  // stores it should understand that values of let properties in Boo3 are not
+  // statically known constant initializers with the same value and thus
+  // cannot be propagated.
+  let boos1 = things.map { Boo3($0, C()) }
+  let boos2 = things.map(Boo3.init)
+  // CHECK-OUTPUT: 52
+  print(testStructWithMultipleInits(boos1[0], boos2[0]))
+}
+
+testStructWithMultipleInitsAndInlinedInitializer()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fix a bug in let-properties-opt reported in SR-1026 and rdar://25303106
#### Resolved bug number: ([SR-1026](https://bugs.swift.org/browse/SR-1026))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…considered to have a constant value.

The optimization pass was inspecting only init methods to determine if a given let property is defined
in the same way by all initializers. But this is not enough in certain cases, e.g. when some of the
initializers were inlined into the application code and the body of the inlined SIL function representing
such an initializer was removed afterwards by the dead function elimination pass. In such situations,
the Let Properties Optimization pass was assuming that there is only one initializer and considered the
constant let property value defined there as the only possible value of this let property. Therefore it
propagated it into let-property uses, which resulted in an incorrect code.

The right thing to do is to analyze all assignments to a given let property whether they are inside initializer
SIL functions or not. This makes sure that all possible values of a let property are analyzed and compared.
The propagation of a constant let property value can only happen if all found possible values are all the same.

Fixes SR-1026 and rdar://25303106
