### PR TITLE
Remove extra spaces in empty-body ctors

### DIFF
--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -87,7 +87,7 @@ public:
   SourceLoc Start, End;
 
   SourceRange() {}
-  SourceRange(SourceLoc Loc) : Start(Loc), End(Loc) { }
+  SourceRange(SourceLoc Loc) : Start(Loc), End(Loc) {}
   SourceRange(SourceLoc Start, SourceLoc End) : Start(Start), End(End) {
     assert(Start.isValid() == End.isValid() &&
            "Start and end should either both be valid or both be invalid!");
@@ -122,7 +122,7 @@ public:
   CharSourceRange() {}
 
   CharSourceRange(SourceLoc Start, unsigned ByteLength)
-    : Start(Start), ByteLength(ByteLength) { }
+    : Start(Start), ByteLength(ByteLength) {}
 
   /// \brief Constructs a character range which starts and ends at the
   /// specified character locations.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Currently some empty-body ctors in the file have a space, some don't. Canonized it.
