### PR TITLE
Runtime: avoid forward declaring public interfaces

### DIFF
--- a/include/swift/Runtime/ObjCBridge.h
+++ b/include/swift/Runtime/ObjCBridge.h
@@ -33,6 +33,7 @@ struct HeapObject;
 
 #if SWIFT_OBJC_INTEROP
 #include <objc/objc.h>
+#include <objc/runtime.h>
 
 // Redeclare APIs from the Objective-C runtime.
 // These functions are not available through public headers, but are guaranteed
@@ -44,10 +45,8 @@ extern "C" id _objc_rootAutorelease(id);
 extern "C" void objc_moveWeak(id*, id*);
 extern "C" void objc_copyWeak(id*, id*);
 extern "C" id objc_initWeak(id*, id);
-extern "C" id objc_storeWeak(id*, id);
 extern "C" void objc_destroyWeak(id*);
 extern "C" id objc_loadWeakRetained(id*);
-extern "C" Class object_setClass(id, Class);
 
 // Description of an Objective-C image.
 // __DATA,__objc_imageinfo stores one of these.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Use the "objc/runtime.h" header rather than re-declaring interfaces from the
ObjC runtime.  NFC.
