### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::resolveWitness(…)

### DIFF
--- a/validation-test/compiler_crashers/28281-swift-typechecker-resolvewitness.swift
+++ b/validation-test/compiler_crashers/28281-swift-typechecker-resolvewitness.swift
@@ -1,0 +1,18 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{protocol A{
+func b
+typealias e
+}
+struct Q<d{
+var:{struct B:A{
+typealias e:d
+var a{
+b


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckProtocol.cpp:1826: swift::Substitution getArchetypeSubstitution(swift::TypeChecker &, swift::DeclContext *, swift::ArchetypeType *, swift::Type): Assertion `!resultReplacement->isTypeParameter() && "Can't be dependent"' failed.
11 swift           0x0000000000e9ed19 swift::TypeChecker::resolveWitness(swift::NormalProtocolConformance const*, swift::ValueDecl*) + 569
12 swift           0x00000000010a2ddb swift::NormalProtocolConformance::getWitness(swift::ValueDecl*, swift::LazyResolver*) const + 171
14 swift           0x0000000000e95784 swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 404
15 swift           0x0000000000e41e46 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 102
17 swift           0x0000000000ff81f3 swift::Expr::walk(swift::ASTWalker&) + 19
18 swift           0x0000000000e4343d swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 125
19 swift           0x0000000000e49c20 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
22 swift           0x0000000000eba65a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
23 swift           0x0000000000eba4be swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
24 swift           0x0000000000ebb058 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
26 swift           0x0000000000e7f034 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1268
27 swift           0x0000000000ccf8bf swift::CompilerInstance::performSema() + 3087
29 swift           0x000000000078e52c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
30 swift           0x0000000000788fb5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28281-swift-typechecker-resolvewitness.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28281-swift-typechecker-resolvewitness-f2097b.o
1.  While type-checking getter for a at validation-test/compiler_crashers/28281-swift-typechecker-resolvewitness.swift:17:6
2.  While type-checking expression at [validation-test/compiler_crashers/28281-swift-typechecker-resolvewitness.swift:18:1 - line:18:1] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
