### PR TITLE
make @IBAction imply @objc

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2241,7 +2241,8 @@ public:
   /// In that case it was inferred by the type checker and set with a call to
   /// markAsObjC().
   bool isObjC() const {
-    return getAttrs().hasAttribute<ObjCAttr>();
+    return getAttrs().hasAttribute<ObjCAttr>() ||
+      getAttrs().hasAttribute<IBActionAttr>();
   }
 
   void setIsObjC(bool Value);

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -547,7 +547,7 @@ class d0170_TestAvailability {
 // PASS_COMMON-LABEL: {{^}}@objc class d0180_TestIBAttrs {{{$}}
 
   @IBAction func anAction(_: AnyObject) {}
-// PASS_COMMON-NEXT: {{^}}  @IBAction @objc func anAction(_: AnyObject){{$}}
+// PASS_COMMON-NEXT: {{^}}  @IBAction func anAction(_: AnyObject){{$}}
 
   @IBDesignable
   class ADesignableClass {}

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -101,3 +101,10 @@ protocol CP2 : class { }
 
   init() { }
 }
+
+
+import ObjectiveC
+class Y: NSObject {
+    @IBAction private func foo(sender: AnyObject?) {}
+}
+let yFoo = #selector(Y.foo)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This patch makes @IBAction imply @objc so that the following would compile:

``` swift
class X: NSObject {
  @IBAction private func foo(sender: AnyObject?) {}
}
let xFoo = #selector(X.foo) // doesn't require '@objc' anymore.
```

This might be small enough to qualify as a bug fix. But if any reviewer thinks it needs to go through swift-evolution, I'll write a draft.
#### Resolved bug number: ([SR-1059](https://bugs.swift.org/browse/SR-1059))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
