### PR TITLE
Add constexpr version of maximum

### DIFF
--- a/include/swift/Basic/Algorithm.h
+++ b/include/swift/Basic/Algorithm.h
@@ -24,6 +24,12 @@ namespace swift {
   constexpr const T& min(const T &a, const T &b) {
     return !(b < a) ? a : b;
   }
+  
+  /// Returns the maximum of `a` and `b`, or `a` if they are equivalent.
+  template <typename T>
+  constexpr const T& max(const T &a, const T &b) {
+    return (a < b) ? b : a;
+  }
 } // end namespace swift
 
 #endif /* SWIFT_BASIC_ALGORITHM_H */


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Add the constexpr version of max which is only available in std since c++14.
Besides being a logical addition next to the already implemented constexpr version of min, there are actually other files, even in Swift/Basic itself, which re-implement this functionality, such as PrefixMap.h. Once this is implemented here, the functionality can be re-used in those other locations, instead of re-implemented each time.
