### PR TITLE
[Coverage] Make getEquivalentPGOLinkage exhaustive (NFC)

### DIFF
--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -637,11 +637,18 @@ static void walkForProfiling(AbstractFunctionDecl *Root, ASTWalker &Walker) {
 
 static llvm::GlobalValue::LinkageTypes
 getEquivalentPGOLinkage(FormalLinkage Linkage) {
-  return (Linkage == FormalLinkage::HiddenUnique ||
-          Linkage == FormalLinkage::HiddenNonUnique ||
-          Linkage == FormalLinkage::Private)
-             ? llvm::GlobalValue::PrivateLinkage
-             : llvm::GlobalValue::ExternalLinkage;
+  switch (Linkage) {
+  case FormalLinkage::Top:
+  case FormalLinkage::PublicUnique:
+  case FormalLinkage::PublicNonUnique:
+    return llvm::GlobalValue::ExternalLinkage;
+
+  case FormalLinkage::Bottom:
+  case FormalLinkage::HiddenUnique:
+  case FormalLinkage::HiddenNonUnique:
+  case FormalLinkage::Private:
+    return llvm::GlobalValue::PrivateLinkage;
+  }
 }
 
 void SILGenProfiling::assignRegionCounters(AbstractFunctionDecl *Root) {

--- a/lib/SILGen/SILGenProfiling.cpp
+++ b/lib/SILGen/SILGenProfiling.cpp
@@ -638,12 +638,10 @@ static void walkForProfiling(AbstractFunctionDecl *Root, ASTWalker &Walker) {
 static llvm::GlobalValue::LinkageTypes
 getEquivalentPGOLinkage(FormalLinkage Linkage) {
   switch (Linkage) {
-  case FormalLinkage::Top:
   case FormalLinkage::PublicUnique:
   case FormalLinkage::PublicNonUnique:
     return llvm::GlobalValue::ExternalLinkage;
 
-  case FormalLinkage::Bottom:
   case FormalLinkage::HiddenUnique:
   case FormalLinkage::HiddenNonUnique:
   case FormalLinkage::Private:


### PR DESCRIPTION
#### What's in this pull request?

Use a switch so things don't silently break when new linkage types are ever introduced.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
