### PR TITLE
Refactor DemanglePrinter to eliminate the possibility of storing a da…

### DIFF
--- a/include/swift/Basic/Demangle.h
+++ b/include/swift/Basic/Demangle.h
@@ -370,8 +370,7 @@ struct NodeFactory {
   /// A class for printing to a std::string.
 class DemanglerPrinter {
 public:
-  DemanglerPrinter(std::string &out) : Stream(out) {}
-  DemanglerPrinter(std::string &&out) : Stream(out) {}
+  DemanglerPrinter() = default;
 
   DemanglerPrinter &operator<<(llvm::StringRef Value) & {
     Stream.append(Value.data(), Value.size());
@@ -405,7 +404,7 @@ public:
   std::string &&str() && { return std::move(Stream); }
   
 private:
-  std::string &Stream;
+  std::string Stream;
 };
 
 /// Is a character considered a digit by the demangling grammar?

--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -153,15 +153,14 @@ static Node::Kind nominalTypeMarkerToNodeKind(char c) {
 
 static std::string archetypeName(Node::IndexType index,
                                  Node::IndexType depth) {
-  std::string str;
-  DemanglerPrinter name(str);
+  DemanglerPrinter name;
   do {
     name << (char)('A' + (index % 26));
     index /= 26;
   } while (index);
   if (depth != 0)
     name << depth;
-  return str;
+  return std::move(name).str();
 }
 
 namespace {
@@ -1369,12 +1368,11 @@ private:
   }
 
   NodePointer getDependentGenericParamType(unsigned depth, unsigned index) {
-    std::string Name;
-    DemanglerPrinter PrintName(Name);
+    DemanglerPrinter PrintName;
     PrintName << archetypeName(index, depth);
 
     auto paramTy = NodeFactory::create(Node::Kind::DependentGenericParamType,
-                                       std::move(Name));
+                                       std::move(PrintName).str());
     paramTy->addChild(NodeFactory::create(Node::Kind::Index, depth));
     paramTy->addChild(NodeFactory::create(Node::Kind::Index, index));
 
@@ -1773,7 +1771,7 @@ private:
         if (demangleBuiltinSize(size)) {
           return NodeFactory::create(
               Node::Kind::BuiltinTypeName,
-              (DemanglerPrinter("") << "Builtin.Float" << size).str());
+              std::move(DemanglerPrinter() << "Builtin.Float" << size).str());
         }
       }
       if (c == 'i') {
@@ -1781,7 +1779,7 @@ private:
         if (demangleBuiltinSize(size)) {
           return NodeFactory::create(
               Node::Kind::BuiltinTypeName,
-              (DemanglerPrinter("") << "Builtin.Int" << size).str());
+              (DemanglerPrinter() << "Builtin.Int" << size).str());
         }
       }
       if (c == 'v') {
@@ -1795,7 +1793,7 @@ private:
               return nullptr;
             return NodeFactory::create(
                 Node::Kind::BuiltinTypeName,
-                (DemanglerPrinter("") << "Builtin.Vec" << elts << "xInt" << size)
+                (DemanglerPrinter() << "Builtin.Vec" << elts << "xInt" << size)
                     .str());
           }
           if (Mangled.nextIf('f')) {
@@ -1804,13 +1802,13 @@ private:
               return nullptr;
             return NodeFactory::create(
                 Node::Kind::BuiltinTypeName,
-                (DemanglerPrinter("") << "Builtin.Vec" << elts << "xFloat"
+                (DemanglerPrinter() << "Builtin.Vec" << elts << "xFloat"
                                     << size).str());
           }
           if (Mangled.nextIf('p'))
             return NodeFactory::create(
                 Node::Kind::BuiltinTypeName,
-                (DemanglerPrinter("") << "Builtin.Vec" << elts << "xRawPointer")
+                (DemanglerPrinter() << "Builtin.Vec" << elts << "xRawPointer")
                     .str());
         }
       }
@@ -2248,16 +2246,15 @@ swift::Demangle::demangleTypeAsNode(const char *MangledName,
 namespace {
 class NodePrinter {
 private:
-  std::string Str;
   DemanglerPrinter Printer;
   DemangleOptions Options;
   
 public:
-  NodePrinter(DemangleOptions options) : Printer(Str), Options(options) {}
+  NodePrinter(DemangleOptions options) : Options(options) {}
   
   std::string printRoot(NodePointer root) {
     print(root);
-    return Str;
+    return std::move(Printer).str();
   }
 
 private:  
@@ -2884,13 +2881,12 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
   case Node::Kind::ExplicitClosure:
   case Node::Kind::ImplicitClosure: {
     auto index = pointer->getChild(1)->getIndex();
-    std::string name;
-    DemanglerPrinter printName(name);
+    DemanglerPrinter printName;
     printName << '(';
     if (pointer->getKind() == Node::Kind::ImplicitClosure)
       printName << "implicit ";
     printName << "closure #" << (index + 1) << ")";
-    printEntity(false, false, name);
+    printEntity(false, false, std::move(printName).str());
     return;
   }
   case Node::Kind::Global:
@@ -2905,10 +2901,9 @@ void NodePrinter::print(NodePointer pointer, bool asContext, bool suppressType) 
     return;
   case Node::Kind::DefaultArgumentInitializer: {
     auto index = pointer->getChild(1);
-    std::string str;
-    DemanglerPrinter strPrinter(str);
+    DemanglerPrinter strPrinter;
     strPrinter << "(default argument " << index->getIndex() << ")";
-    printEntity(false, false, str);
+    printEntity(false, false, std::move(strPrinter).str());
     return;
   }
   case Node::Kind::DeclContext:

--- a/lib/Basic/Remangle.cpp
+++ b/lib/Basic/Remangle.cpp
@@ -122,9 +122,10 @@ static void mangleIdentifier(StringRef ident, OperatorKind operatorKind,
 void Demangle::mangleIdentifier(const char *data, size_t length,
                                 OperatorKind operatorKind,
                                 std::string &out, bool usePunycode) {
-  DemanglerPrinter printer(out);
-  return ::mangleIdentifier(StringRef(data, length), operatorKind,
-                            usePunycode, printer);
+  DemanglerPrinter printer;
+  ::mangleIdentifier(StringRef(data, length), operatorKind,
+                     usePunycode, printer);
+  out = std::move(printer).str();
 }
 
 namespace {
@@ -1610,8 +1611,7 @@ void Remangler::mangleTypeList(Node *node) {
 std::string Demangle::mangleNode(const NodePointer &node) {
   if (!node) return "";
 
-  std::string str;
-  DemanglerPrinter printer(str);
+  DemanglerPrinter printer;
   Remangler(printer).mangle(node.get());
-  return str;
+  return std::move(printer).str();
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Refactor DemanglePrinter to eliminate the possibility of storing a dangling reference.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Before the refactor, a dangling reference to a string may be stored in a DemanglePrinter in at least the following cases:
1) If an lvalue DemanglePrinter is initialized with an rvalue string:
DemanglePrinter printer("abc");
2) If an lvalue DemanglePrinter is initialized with an lvalue string which doesn't live as long as the printer:
unique_ptr<DemanglePrinter> printer;
{
  std::string s = "abc";
  printer = make_unique<DemanglePrinter>(s);
}
// Reference stored in printer is dangling

In addition, in all existing cases in the code where an lvalue DemanglePrinter is used, an empty string is initialized just before it, which isn't DRY, and is related to the previous problem - the coder shouldn't be expected to maintain the lifetime of a string separate from the DemanglePrinter which references it.

In addition, before the refactor, in any in-line use of DemanglePrinter it is constructed with an empty string parameter (in which to construct the string), but this doesn't look very clean.

The refactor solves the above issues by maintaining its own string as a member, while still enabling the original intent of being able to use DemanglePrinter both as an lvalue constructively before getting its value, and in-line as an rvalue.
