### PR TITLE
Consistently name stacks as 'stack' instead of 'queue'

### DIFF
--- a/include/swift/Basic/PrefixMap.h
+++ b/include/swift/Basic/PrefixMap.h
@@ -308,16 +308,16 @@ private:
   static void deleteTree(Node *root) {
     if (!root) return;
 
-    SmallVector<Node *, 8> queue; // actually a stack
-    auto enqueueChildrenAndDelete = [&](Node *node) {
-      if (node->Left) queue.push_back(node->Left);
-      if (node->Right) queue.push_back(node->Right);
-      if (node->Further) queue.push_back(node->Further);
+    SmallVector<Node *, 8> stack;
+    auto pushChildrenAndDelete = [&](Node *node) {
+      if (node->Left) stack.push_back(node->Left);
+      if (node->Right) stack.push_back(node->Right);
+      if (node->Further) stack.push_back(node->Further);
       delete node;
     };
-    enqueueChildrenAndDelete(root);
-    while (!queue.empty()) {
-      enqueueChildrenAndDelete(queue.pop_back_val());
+    pushChildrenAndDelete(root);
+    while (!stack.empty()) {
+      pushChildrenAndDelete(stack.pop_back_val());
     }
   }
 
@@ -325,18 +325,18 @@ private:
   static Node *cloneTree(Node *root) {
     if (!root) return nullptr;
 
-    SmallVector<Node **, 8> queue; // actually a stack.
-    auto copyAndEnqueueChildren = [&](Node **ptr) {
+    SmallVector<Node **, 8> stack;
+    auto copyAndPushChildren = [&](Node **ptr) {
       assert(*ptr);
       Node *copy = new Node(**ptr);
       *ptr = copy;
-      if (copy->Left) queue.push_back(&copy->Left);
-      if (copy->Right) queue.push_back(&copy->Right);
-      if (copy->Further) queue.push_back(&copy->Further);
+      if (copy->Left) stack.push_back(&copy->Left);
+      if (copy->Right) stack.push_back(&copy->Right);
+      if (copy->Further) stack.push_back(&copy->Further);
     };
     copyAndEnqueueChildren(&root);
-    while (!queue.empty()) {
-      copyAndEnqueueChildren(queue.pop_back_val());
+    while (!stack.empty()) {
+      copyAndEnqueueChildren(stack.pop_back_val());
     }
     return root;
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Currently some stacks are named 'stack' and some are named 'queue' with a comment saying 'actually a stack'. Just call these a 'stack' as well.
