### PR TITLE
[let-properties-opt] Re-factor and simplify the code. 

### DIFF
--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -11,12 +11,18 @@
 //===----------------------------------------------------------------------===//
 // Promote values of non-static let properties initialized by means
 // of constant values of simple types into their uses.
+//
+// For any given non-static let property this optimization is only possible
+// if this pass can prove that it has analyzed all assignments of an initial
+// value to this property and all those assignments assign the same value
+// to this property.
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "let-properties-opt"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/SILLinkage.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/Local.h"
@@ -58,6 +64,9 @@ class LetPropertiesOpt {
   llvm::MapVector<NominalTypeDecl *, Properties> NominalTypeLetProperties;
   // Set of properties whose initializer functions were processed already.
   llvm::SmallPtrSet<VarDecl *, 16> ProcessedPropertyInitializers;
+  // Set of properties which already fulfill all conditions, except
+  // the available of constant, statically known initializer.
+  llvm::SmallPtrSet<VarDecl *, 16> PotentialConstantLetProperty;
 
 public:
   LetPropertiesOpt(SILModule *M): Module(M) {}
@@ -70,8 +79,6 @@ protected:
   void collectStructPropertiesAccess(StructInst *SI, bool NonRemovable);
   void optimizeLetPropertyAccess(VarDecl *SILG,
                                  SmallVectorImpl<SILInstruction *> &Init);
-  bool getInitializer(NominalTypeDecl *NTD, VarDecl *Property,
-                      SmallVectorImpl<SILInstruction *> &Init);
   bool analyzeInitValue(SILInstruction *I, VarDecl *Prop);
 };
 
@@ -120,6 +127,17 @@ class InstructionsCloner : public SILClonerWithScopes<InstructionsCloner> {
 
 } // namespace
 
+#ifndef NDEBUG
+// For debugging only.
+static raw_ostream &operator<<(raw_ostream &OS, const VarDecl &decl) {
+  auto *Ty = dyn_cast<NominalTypeDecl>(decl.getDeclContext());
+  if (Ty)
+    OS << Ty->getName() << "::";
+  OS << decl.getName();
+  return OS;
+}
+#endif
+
 /// Optimize access to the let property, which is known
 /// to have a constant value. Replace all loads from the
 /// property by its constant value.
@@ -129,12 +147,14 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
   if (SkipProcessing.count(Property))
     return;
 
+  if (Init.empty())
+    return;
+
   auto *Ty = dyn_cast<NominalTypeDecl>(Property->getDeclContext());
   if (SkipTypeProcessing.count(Ty))
     return;
 
-  DEBUG(llvm::dbgs() << "Replacing access to property '"
-                     << Ty->getName() << "::" << Property->getName()
+  DEBUG(llvm::dbgs() << "Replacing access to property '" << *Property
                      << "' by its constant initializer\n");
 
   auto PropertyAccess = Property->getEffectiveAccess();
@@ -150,8 +170,7 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
           PropertyAccess == Accessibility::Internal) &&
           Module->isWholeModule())) {
     CanRemove = true;
-    DEBUG(llvm::dbgs() << "Storage for property '"
-                       << Ty->getName() << "::" << Property->getName()
+    DEBUG(llvm::dbgs() << "Storage for property '" << *Property
                        << "' can be eliminated\n");
   }
 
@@ -159,6 +178,7 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
     CanRemove = false;
 
   if (!AccessMap.count(Property)) {
+    DEBUG(llvm::dbgs() << "Property '" << *Property << "' is never read\n");
     if (CanRemove) {
       // TODO: Remove the let property, because it is never accessed.
     }
@@ -199,6 +219,9 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
       Cloner.clone();
       SILInstruction *I = &*std::prev(Load->getIterator());
       Load->replaceAllUsesWith(I);
+      DEBUG(llvm::dbgs() << "Access to " << *Property << " was replaced:\n";
+            I->dumpInContext());
+
       Load->eraseFromParent();
       ++NumReplaced;
       HasChanged = true;
@@ -224,9 +247,8 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
     }
   }
 
-  DEBUG(llvm::dbgs() << "Access to "
-                     << Ty->getName() << "::" << Property->getName()
-                     << " was replaced " << NumReplaced << " time(s)\n");
+  DEBUG(llvm::dbgs() << "Access to " << *Property << " was replaced "
+                     << NumReplaced << " time(s)\n");
 
   if (CanRemove) {
     // TODO: Remove the let property, because it is never accessed.
@@ -254,175 +276,88 @@ static bool compareInsnSequences(SmallVectorImpl<SILInstruction *> &LHS,
   return true;
 }
 
-/// Find a set of instructions computing the constant value
-/// initializing a given property.
-SILValue findStoredValue(SILFunction *Init, VarDecl *Property,
-                         SmallVectorImpl<SILInstruction *> &Insns) {
-  SILValue ResultValue;
-  for (auto &BB : *Init) {
-    for (auto &I : BB) {
-      if (auto *RI = dyn_cast<ReturnInst>(&I)) {
-        if (auto *SI = dyn_cast<StructInst>(RI->getOperand())) {
-          auto Value = SI->getFieldValue(Property);
-          SmallVector<SILInstruction *, 8> ReverseInsns;
-          if (!analyzeStaticInitializer(Value, ReverseInsns))
-            return SILValue();
-          // Produce a correct order of instructions.
-          while (!ReverseInsns.empty()) {
-            Insns.push_back(ReverseInsns.pop_back_val());
-          }
-          return Value;
-        }
-      }
-
-      if (auto *SI = dyn_cast<StoreInst>(&I)) {
-        auto Dest = SI->getDest();
-
-        auto REAI = dyn_cast<RefElementAddrInst>(Dest);
-        if (!REAI || REAI->getField() != Property)
-            continue;
-        // Bail, if it is not the only assignment to the
-        // required property.
-        if (ResultValue)
-          return SILValue();
-        auto Value = SI->getSrc();
-        SmallVector<SILInstruction *, 8> ReverseInsns;
-        if (!analyzeStaticInitializer(Value, ReverseInsns))
-          return SILValue();
-        // Produce a correct order of instructions.
-        while (!ReverseInsns.empty()) {
-          Insns.push_back(ReverseInsns.pop_back_val());
-        }
-        ResultValue = Value;
-      }
-    }
+/// Check if a given let property can be assigned externally.
+static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
+  Accessibility accessibility = Property->getEffectiveAccess();
+  SILLinkage linkage;
+  switch (accessibility) {
+  case Accessibility::Private:
+    linkage = SILLinkage::Private;
+    DEBUG(llvm::dbgs() << "Property " << *Property << " has private access\n");
+    break;
+  case Accessibility::Internal:
+    linkage = SILLinkage::Hidden;
+    DEBUG(llvm::dbgs() << "Property " << *Property << " has internal access\n");
+    break;
+  case Accessibility::Public:
+    linkage = SILLinkage::Public;
+    DEBUG(llvm::dbgs() << "Property " << *Property << " has public access\n");
+    break;
   }
 
-  return ResultValue;
-}
+  DEBUG(llvm::dbgs() << "Module of " << *Property << " WMO mode is: " << Module->isWholeModule() << "\n");
 
-// Find a statically known constant init value stored by the
-// instruction into a property.
-SILValue findStoredValue(SILInstruction *I, VarDecl *Property,
-                         SmallVectorImpl<SILInstruction *> &Insns) {
-  SILValue ResultValue;
+  if (isPossiblyUsedExternally(linkage, Module->isWholeModule())) {
+    // If at least one of the properties of the enclosing type cannot be
+    // used externally, then no intializer can be implemented externally as
+    // it wouldn't be able to intialize such a property.
+    // More over, for classes, only the class itself can intialize its
+    // let properties. Subclasses and extensions cannot do it.
+    // For structs, external extensions may initialize let properties. But to do
+    // that they need to be able to initialize all properties, i.e. all
+    // properties should be accessible by the extension.
 
-  if (auto *SI = dyn_cast<StructInst>(I)) {
-    auto Value = SI->getFieldValue(Property);
-    SmallVector<SILInstruction *, 8> ReverseInsns;
-    if (!analyzeStaticInitializer(Value, ReverseInsns))
-      return SILValue();
-    // Produce a correct order of instructions.
-    while (!ReverseInsns.empty()) {
-      Insns.push_back(ReverseInsns.pop_back_val());
-    }
-    return Value;
-  }
+    auto *Ty = dyn_cast<NominalTypeDecl>(Property->getDeclContext());
 
-  if (auto *SI = dyn_cast<StoreInst>(I)) {
-    auto Dest = SI->getDest();
-
-    // Is it a store to a required property?
-    if (auto *REAI = dyn_cast<RefElementAddrInst>(Dest))
-      if (REAI->getField() != Property)
-        return SILValue();
-
-    if (auto *SEAI = dyn_cast<StructElementAddrInst>(Dest))
-      if (SEAI->getField() != Property)
-        return SILValue();
-
-    // Bail, if it is not the only assignment to the
-    // required property.
-    if (ResultValue)
-      return SILValue();
-
-    auto Value = SI->getSrc();
-    SmallVector<SILInstruction *, 8> ReverseInsns;
-    if (!analyzeStaticInitializer(Value, ReverseInsns))
-      return SILValue();
-    // Produce a correct order of instructions.
-    while (!ReverseInsns.empty()) {
-      Insns.push_back(ReverseInsns.pop_back_val());
-    }
-    ResultValue = Value;
-  }
-
-  return ResultValue;
-}
-
-/// Try to find a sequence of instructions which initializes
-/// a given property \p Property with a constant value.
-/// If all initializers of a type enclosing this property
-/// initialize it with the same constant value, then this
-/// functions returns true and copies this sequence of
-/// instructions into \p Insns.
-/// Otherwise, false is returned, indicating a failure.
-bool
-LetPropertiesOpt::getInitializer(NominalTypeDecl *NTD, VarDecl *Property,
-                                 SmallVectorImpl<SILInstruction *> &Insns) {
-  // Iterate over all initializers of this struct and check
-  // if a given property is initialized in the same way.
-
-  // Analyze initializers only once.
-  if (ProcessedPropertyInitializers.count(Property))
-    return !Insns.empty();
-  ProcessedPropertyInitializers.insert(Property);
-
-  SmallVector<SmallVector<SILInstruction *, 8>, 4> ConstrPropertyInit;
-
-  SILFunction *Init = nullptr;
-
-  SILDeclRef::Kind InitializerKind = isa<StructDecl>(NTD) ?
-                                       SILDeclRef::Kind::Allocator:
-                                       SILDeclRef::Kind::Initializer;
-
-  for (auto *Member: NTD->getMembers()) {
-    if (auto *FD = dyn_cast<ConstructorDecl>(Member)) {
-        // Find the SIL body of this initializer.
-        auto SDR = SILDeclRef(FD, InitializerKind);
-        Init = Module->lookUpFunction(SDR);
-        if (!Init)
-          continue;
-        // Analyze the body of the constructor.
-        SmallVector<SILInstruction *, 8> Insns;
-        if (!findStoredValue(Init, Property, Insns))
-          return false;
-        // Remember the set of instructions initializing
-        // this Property inside this constructor.
-        DEBUG(llvm::dbgs() << "Found initializer insns: \n";
-              for (auto I: Insns) {
-                I->dump();
-              });
-        ConstrPropertyInit.push_back(Insns);
-    }
-  }
-
-  // Check that all collected instruction sequences are equivalent.
-  for(int i = 1, e = ConstrPropertyInit.size(); i < e; i++) {
-    if (!compareInsnSequences(ConstrPropertyInit[i-1], ConstrPropertyInit[i])) {
-      DEBUG(llvm::dbgs() << "Not all initializers are the same for '"
-                         << Property->getNameStr() << "'\n");
+    // Initializer for a let propety of a class cannot exist externally.
+    // It cannot be defined by an extension or a derived class.
+    if (isa<ClassDecl>(Ty))
       return false;
+
+    // Check if there are any private properties or any internal properties and
+    // it is a whole module compilation. In this case, no external initializer
+    // may exist.
+    for (auto SP : Ty->getStoredProperties()) {
+      auto storedPropertyAccessibility = SP->getEffectiveAccess();
+      if (storedPropertyAccessibility == Accessibility::Private ||
+          (storedPropertyAccessibility == Accessibility::Internal &&
+           Module->isWholeModule())) {
+       DEBUG(llvm::dbgs() << "Property " << *Property
+                       << " cannot be set externally\n");
+       return false;
+      }
     }
+
+    DEBUG(llvm::dbgs() << "Property " << *Property
+                       << " can be used externally\n");
+    return true;
   }
 
-  if (ConstrPropertyInit.empty())
-    return false;
-
-  // If we have seen an initialization of this property elsewhere outside of
-  // initializers, check that initializers produce the same value.
-  if (!Insns.empty() && !compareInsnSequences(Insns, ConstrPropertyInit[0])) {
-    DEBUG(llvm::dbgs() << "Not all initializers are the same for '"
-                       << Property->getNameStr() << "'\n");
-    return false;
-  }
-
-  DEBUG(llvm::dbgs() << "All initializers are the same for '"
-                     << Property->getNameStr() << "' so far\n");
-  Insns = ConstrPropertyInit[0];
-
-  return true;
+  return false;
 }
+
+// Checks if a given property may have any unknown uses which cannot
+// be analyzed by this pass.
+static bool mayHaveUnknownUses(VarDecl *Property, SILModule *Module) {
+  if (Property->getDeclContext()->getParentModule() !=
+      Module->getAssociatedContext()->getParentModule()) {
+    DEBUG(llvm::dbgs() << "Property " << *Property
+                       << " is defined in a different module\n");
+    // We don't see the bodies of initializers from a different module
+    // unless all of them are fragile.
+    // TODO: Support fragile initializers.
+    return true;
+  }
+
+  // If let properties can be assigned externally, we don't know
+  // the values they may get.
+  if (isAssignableExternally(Property, Module)) {
+    return true;
+  }
+
+  return false;
+}
+
 
 /// Check if a given property is a non-static let property
 /// with known constant value.
@@ -435,49 +370,71 @@ bool LetPropertiesOpt::isConstantLetProperty(VarDecl *Property) {
   if (SkipProcessing.count(Property))
     return false;
 
+  // If these checks were performed already, no need to
+  // repeat them.
+  if (PotentialConstantLetProperty.count(Property))
+    return true;
+
+  // Check the visibility of this property. If its visibility
+  // implies that this optimization pass cannot analyze all uses,
+  // don't process it.
+  if (mayHaveUnknownUses(Property, Module)) {
+    DEBUG(llvm::dbgs() << "Property '" << *Property
+                       << "' may have unknwon uses\n");
+    SkipProcessing.insert(Property);
+    return false;
+  }
+
+  DEBUG(llvm::dbgs() << "Property '" << *Property
+                      << "' has no unknwon uses\n");
+
   // Only properties of simple types can be optimized.
   if(!isSimpleType(Module->Types.getLoweredType(Property->getType()), *Module)) {
+     DEBUG(llvm::dbgs() << "Property '" << *Property
+                       << "' is not of trivial type\n");
     SkipProcessing.insert(Property);
     return false;
   }
 
-  auto Ty = dyn_cast<NominalTypeDecl>(Property->getDeclContext());
-
-  bool Init = false;
-
-  if (Ty && !SkipTypeProcessing.count(Ty)) {
-    if (StructDecl *SD = dyn_cast<StructDecl>(Ty)) {
-      Init = getInitializer(SD, Property, InitMap[Property]);
-    }
-
-    if (auto *CD = dyn_cast<ClassDecl>(Ty)) {
-      Init = getInitializer(CD, Property, InitMap[Property]);
-    }
-  }
-
-  if (!Init) {
-    // Remember that this property does not have a constant initializer.
-    SkipProcessing.insert(Property);
-    return false;
-  }
+  PotentialConstantLetProperty.insert(Property);
 
   return true;
 }
 
 // Analyze the init value being stored by the instruction into a property.
 bool
-LetPropertiesOpt::analyzeInitValue(SILInstruction *I, VarDecl *Prop) {
+LetPropertiesOpt::analyzeInitValue(SILInstruction *I, VarDecl *Property) {
   SmallVector<SILInstruction *, 8> Insns;
-  if (!findStoredValue(I, Prop, Insns)) {
-    // The value of a property is not a statically known constant init.
-    return false;
+  SmallVector<SILInstruction *, 8> ReverseInsns;
+  SILValue ValueOfProperty;
+  if (auto SI = dyn_cast<StructInst>(I)) {
+    ValueOfProperty = SI->getFieldValue(Property);
+  } else if (auto SI = dyn_cast<StoreInst>(I)) {
+    auto Dest = SI->getDest();
+
+    assert(((isa<RefElementAddrInst>(Dest) &&
+             cast<RefElementAddrInst>(Dest)->getField() == Property) ||
+            (isa<StructElementAddrInst>(Dest) &&
+             cast<StructElementAddrInst>(Dest)->getField() == Property)) &&
+           "Store instruction should store into a proper let property");
+    ValueOfProperty = SI->getSrc();
   }
-  auto &InitInsns = InitMap[Prop];
+
+  // Bail if a value of a property is not a statically known constant init.
+  if (!analyzeStaticInitializer(ValueOfProperty, ReverseInsns))
+    return false;
+
+  // Produce a correct order of instructions.
+  while (!ReverseInsns.empty()) {
+    Insns.push_back(ReverseInsns.pop_back_val());
+  }
+
+  auto &InitInsns = InitMap[Property];
   if (!InitInsns.empty() && !compareInsnSequences(InitInsns, Insns)) {
     // The found init value is different from the already seen init value.
     return false;
   } else {
-    DEBUG(llvm::dbgs() << "The value of property '" << Prop->getName()
+    DEBUG(llvm::dbgs() << "The value of property '" << *Property
                        << "' is statically known so far\n");
     // Remember the statically known value.
     InitInsns = Insns;
@@ -529,16 +486,34 @@ void LetPropertiesOpt::collectStructPropertiesAccess(StructInst *SI,
     if (SkipProcessing.count(Prop))
       continue;
     SILValue PropValue = SI->getOperandForField(Prop)->get();
-    DEBUG(llvm::dbgs() << "Check the value of property '" << Prop->getName()
+    DEBUG(llvm::dbgs() << "Check the value of property '" << *Prop
                        << "' :" << PropValue << "\n");
     if (!analyzeInitValue(SI, Prop)) {
       SkipProcessing.insert(Prop);
-      DEBUG(llvm::dbgs() << "The value of a let property '"
-                         << structDecl->getName() << "::" << Prop->getName()
+      DEBUG(llvm::dbgs() << "The value of a let propertiy '" << *Prop
                          << "' is not statically known\n");
     }
   }
 }
+
+/// Check if I is a sequence of projections followed by a load.
+/// Since it is supposed to be a load from a let property with
+/// statically known constant intializer, only struct_element_addr
+/// and tuple_element_addr projections are considered.
+static bool isValidPropertyLoad(SILInstruction *I) {
+  if (isa<LoadInst>(I))
+    return true;
+
+  if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I)) {
+    for (auto Use : getNonDebugUses(I))
+      if (!isValidPropertyLoad(Use->getUser()))
+        return false;
+    return true;
+  }
+
+  return false;
+}
+
 
 /// Remember where this property is accessed.
 void LetPropertiesOpt::collectPropertyAccess(SILInstruction *I,
@@ -547,25 +522,31 @@ void LetPropertiesOpt::collectPropertyAccess(SILInstruction *I,
   if (!isConstantLetProperty(Property))
     return;
 
-  DEBUG(llvm::dbgs()
-            << "Collecting property access for property '"
-            << dyn_cast<NominalTypeDecl>(Property->getDeclContext())->getName()
-            << "::" << Property->getName() << "':\n";
+  DEBUG(llvm::dbgs() << "Collecting propery access for property '" << *Property
+                     << "':\n";
         llvm::dbgs() << "The instructions are:\n"; I->dumpInContext());
 
   if (isa<RefElementAddrInst>(I) || isa<StructElementAddrInst>(I)) {
     // Check if there is a store to this property.
-    for (auto UI = I->use_begin(), E = I->use_end(); UI != E;) {
-      auto *User = UI->getUser();
-      ++UI;
-      if (!isa<StoreInst>(User))
+    for (auto Use : getNonDebugUses(I)) {
+      auto *User = Use->getUser();
+
+      if (auto *SI = dyn_cast<StoreInst>(User)) {
+        // There is a store into this property.
+        // Analyze the assigned value and check if it is a constant
+        // statically known initializer.
+        if (SI->getDest() != I || !analyzeInitValue(SI, Property)) {
+          SkipProcessing.insert(Property);
+          return;
+        }
         continue;
-      auto *SI = cast<StoreInst>(User);
-      if (SI->getDest() != I)
-        continue;
-      // There is a store into this property.
-      // Analyze the assigned value.
-      if(!analyzeInitValue(SI, Property)) {
+      }
+
+      // Follow the chain of pojections and check if it ends up with a load.
+      // If this is not the case, it is potentially a store into sub-property
+      // of a property.
+      // We cannot handle such cases yet, so bail.
+      if (!isValidPropertyLoad(User)) {
         SkipProcessing.insert(Property);
         return;
       }

--- a/test/SILOptimizer/let_propagation.swift
+++ b/test/SILOptimizer/let_propagation.swift
@@ -174,12 +174,12 @@ public func testUseGlobalLet() -> Int32 {
 */
 
 struct A1 {
-  let x: Int32
+  private let x: Int32
   
   // Propagate the value of the initializer into all instructions
   // that use it, which in turn would allow for better constant
   // propagation.
-  let y: Int32 = 100
+  private let y: Int32 = 100
   
   init(v: Int32) {
     if v > 0 {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Further improvements of let-properties-opt pass.
#### Resolved bug number: ([SR-1026](https://bugs.swift.org/browse/SR-1026))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ness.

Based on the review of my previous commit, I did some re-factorings.
The code is now simpler and handles more cases. More tests were added.

The overall idea of this rewrite is that the pass basically tries to check if it can
see all possible writes (i.e. initializations) into a given let property. Only if it can be proven
that the pass sees all possible writes and all those initializations are producing
the same constant, statically known value, the pass propagates this constant value
into uses of a property.

SR-1026 and rdar://25303106
