### PR TITLE
SE-0055: Making pointer nullability explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 Swift 3.0
 -------
 
+* As part of the changes for SE-0055 (see below), the *pointee* types of
+  imported pointers (e.g. the `id` in `id *`) are no longer assumed to always
+  be `_Nullable` even if annotated otherwise. However, an implicit or explicit
+  annotation of `_Null_unspecified` on a pointee type is still imported as
+  `Optional`.
+
+* [SE-0055](https://github.com/apple/swift-evolution/blob/master/proposals/0055-optional-unsafe-pointers.md):
+  The types `UnsafePointer`, `UnsafeMutablePointer`,
+  `AutoreleasingUnsafeMutablePointer`, `OpaquePointer`, `Selector`, and `Zone`
+  (formerly `NSZone`) now represent non-nullable pointers, i.e. pointers that
+  are never `nil`. A nullable pointer is now represented using `Optional`, e.g.
+  `UnsafePointer<Int>?` For types imported from C, non-object pointers (such as
+  `int *`) now have their nullability taken into account.
+
+  One possible area of difficulty is passing a nullable pointer to a function
+  that uses C variadics. Swift will not permit this directly, so as a
+  workaround please use the following idiom to pass it as a pointer-sized
+  integer value instead:
+
+  ```swift
+  unsafeBitCast(nullablePointer, to: Int.self)
+  ```
+
 * [SE-0046] (https://github.com/apple/swift-evolution/blob/master/proposals/0046-first-label.md) Function parameters now have consistent labelling across all function parameters. With this update the first parameter declarations will now match the existing behavior of the second and later parameters. This change makes the language simpler. 
 
     Functions that were written and called as follows 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -907,6 +907,9 @@ extern "C" const ValueWitnessTable _TWVXwGSqBo_; // weak Builtin.NativeObject?
 SWIFT_RUNTIME_EXPORT
 extern "C" const ExtraInhabitantsValueWitnessTable _TWVBb; // Builtin.BridgeObject
 
+SWIFT_RUNTIME_EXPORT
+extern "C" const ExtraInhabitantsValueWitnessTable _TWVBp; // Builtin.RawPointer
+
 #if SWIFT_OBJC_INTEROP
 // The ObjC-pointer table can be used for arbitrary ObjC pointer types.
 SWIFT_RUNTIME_EXPORT
@@ -1287,6 +1290,8 @@ SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBo;        // Builtin.NativeObject
 SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBb;        // Builtin.BridgeObject
+SWIFT_RUNTIME_EXPORT
+extern "C" const FullOpaqueMetadata _TMBp;        // Builtin.RawPointer
 SWIFT_RUNTIME_EXPORT
 extern "C" const FullOpaqueMetadata _TMBB;        // Builtin.UnsafeValueBuffer
 #if SWIFT_OBJC_INTEROP

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3620,7 +3620,7 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
 
     // Pre-populate the foreign-representable cache with known types.
     if (auto stdlib = getStdlibModule()) {
-      addTrivial(getIdentifier("OpaquePointer"), stdlib);
+      addTrivial(getIdentifier("OpaquePointer"), stdlib, true);
 
       // Builtin types
       // FIXME: Layering violation to use the ClangImporter's define.
@@ -3636,13 +3636,13 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
     }
 
     if (auto objectiveC = getLoadedModule(Id_ObjectiveC)) {
-      addTrivial(Id_Selector, objectiveC);
+      addTrivial(Id_Selector, objectiveC, true);
 
       // Note: ObjCBool is odd because it's bridged to Bool in APIs,
       // but can also be trivially bridged.
       addTrivial(getIdentifier("ObjCBool"), objectiveC);
 
-      addTrivial(getSwiftId(KnownFoundationEntity::NSZone), objectiveC);
+      addTrivial(getSwiftId(KnownFoundationEntity::NSZone), objectiveC, true);
     }
 
     if (auto coreGraphics = getLoadedModule(getIdentifier("CoreGraphics"))) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2116,10 +2116,6 @@ getForeignRepresentable(Type type, ForeignLanguage language, DeclContext *dc) {
   // Pointers may be representable in ObjC.
   PointerTypeKind pointerKind;
   if (auto pointerElt = type->getAnyPointerElementType(pointerKind)) {
-    // FIXME: Optionality should be embedded in the pointer types.
-    if (wasOptional)
-      return failure();
-
     switch (pointerKind) {
     case PTK_UnsafeMutablePointer:
     case PTK_UnsafePointer:

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -150,17 +150,16 @@ namespace {
   getOptionalType(Type payloadType,
                   ImportTypeKind kind,
                   OptionalTypeKind OptKind = OTK_ImplicitlyUnwrappedOptional) {
-    // Import pointee types as true Optional.
-    if (kind == ImportTypeKind::Pointee)
-      return OptionalType::get(payloadType);
-
     switch (OptKind) {
-      case OTK_ImplicitlyUnwrappedOptional:
-        return ImplicitlyUnwrappedOptionalType::get(payloadType);
-      case OTK_None:
-        return payloadType;
-      case OTK_Optional:
+    case OTK_None:
+      return payloadType;
+    case OTK_Optional:
+      return OptionalType::get(payloadType);
+    case OTK_ImplicitlyUnwrappedOptional:
+      // Import pointee types as true Optional.
+      if (kind == ImportTypeKind::Pointee)
         return OptionalType::get(payloadType);
+      return ImplicitlyUnwrappedOptionalType::get(payloadType);
     }
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3309,6 +3309,7 @@ public:
     // If the expected type is ObjectiveC.Selector, add #selector.
     if (Ctx.LangOpts.EnableObjCInterop) {
       for (auto T : ExpectedTypes) {
+        T = T->lookThroughAllAnyOptionalTypes();
         if (auto structDecl = T->getStructOrBoundGenericStruct()) {
           if (structDecl->getName() == Ctx.Id_Selector &&
               structDecl->getParentModule()->getName() == Ctx.Id_ObjectiveC) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1765,7 +1765,8 @@ namespace {
       if (t == C.TheEmptyTupleType
           || t == C.TheNativeObjectType
           || t == C.TheUnknownObjectType
-          || t == C.TheBridgeObjectType)
+          || t == C.TheBridgeObjectType
+          || t == C.TheRawPointerType)
         return true;
       if (auto intTy = dyn_cast<BuiltinIntegerType>(t)) {
         auto width = intTy->getWidth();

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -411,7 +411,53 @@ namespace {
                       Alignment align)
       : PODSingleScalarTypeInfo(storage, size, std::move(spareBits), align) {}
   };
-  
+
+  /// A TypeInfo implementation for bare non-null pointers (like `void *`).
+  class RawPointerTypeInfo final :
+    public PODSingleScalarTypeInfo<RawPointerTypeInfo, LoadableTypeInfo> {
+  public:
+    RawPointerTypeInfo(llvm::Type *storage, Size size, Alignment align)
+      : PODSingleScalarTypeInfo(
+          storage, size,
+          SpareBitVector::getConstant(size.getValueInBits(), false),
+          align) {}
+
+    bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
+      return true;
+    }
+
+    unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
+      return 1;
+    }
+
+    APInt getFixedExtraInhabitantValue(IRGenModule &IGM, unsigned bits,
+                                       unsigned index) const override {
+      assert(index == 0);
+      return APInt(bits, 0);
+    }
+
+    llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
+                                         Address src,
+                                         SILType T) const override {
+      // Copied from BridgeObjectTypeInfo.
+      src = IGF.Builder.CreateBitCast(src, IGF.IGM.IntPtrTy->getPointerTo());
+      auto val = IGF.Builder.CreateLoad(src);
+      auto zero = llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0);
+      auto isNonzero = IGF.Builder.CreateICmpNE(val, zero);
+      // We either have extra inhabitant 0 or no extra inhabitant (-1).
+      // Conveniently, this is just a sext i1 -> i32 away.
+      return IGF.Builder.CreateSExt(isNonzero, IGF.IGM.Int32Ty);
+    }
+
+    void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
+                              Address dest, SILType T) const override {
+      // Copied from BridgeObjectTypeInfo.
+      // There's only one extra inhabitant, 0.
+      dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.IntPtrTy->getPointerTo());
+      IGF.Builder.CreateStore(llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0),dest);
+    }
+  };
+
   /// A TypeInfo implementation for opaque storage. Swift will preserve any
   /// data stored into this arbitrarily sized and aligned field, but doesn't
   /// know anything about the data.
@@ -718,6 +764,20 @@ const LoadableTypeInfo &TypeConverter::getBridgeObjectTypeInfo() {
   BridgeObjectTI->NextConverted = FirstType;
   FirstType = BridgeObjectTI;
   return *BridgeObjectTI;
+}
+
+const LoadableTypeInfo &IRGenModule::getRawPointerTypeInfo() {
+  return Types.getRawPointerTypeInfo();
+}
+
+const LoadableTypeInfo &TypeConverter::getRawPointerTypeInfo() {
+  if (RawPointerTI) return *RawPointerTI;
+  RawPointerTI = new RawPointerTypeInfo(IGM.Int8PtrTy,
+                                        IGM.getPointerSize(),
+                                        IGM.getPointerAlignment());
+  RawPointerTI->NextConverted = FirstType;
+  FirstType = RawPointerTI;
+  return *RawPointerTI;
 }
 
 const LoadableTypeInfo &TypeConverter::getEmptyTypeInfo() {
@@ -1263,6 +1323,7 @@ TypeCacheEntry TypeConverter::convertType(CanType ty) {
                            getFixedBufferSize(IGM),
                            getFixedBufferAlignment(IGM));
   case TypeKind::BuiltinRawPointer:
+    return &getRawPointerTypeInfo();
   case TypeKind::BuiltinFloat:
   case TypeKind::BuiltinInteger:
   case TypeKind::BuiltinVector: {

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -86,6 +86,7 @@ private:
   const LoadableTypeInfo *NativeObjectTI = nullptr;
   const LoadableTypeInfo *UnknownObjectTI = nullptr;
   const LoadableTypeInfo *BridgeObjectTI = nullptr;
+  const LoadableTypeInfo *RawPointerTI = nullptr;
   const LoadableTypeInfo *WitnessTablePtrTI = nullptr;
   const LoadableTypeInfo *TypeMetadataPtrTI = nullptr;
   const LoadableTypeInfo *ObjCClassPtrTI = nullptr;
@@ -148,6 +149,7 @@ public:
   const LoadableTypeInfo &getNativeObjectTypeInfo();
   const LoadableTypeInfo &getUnknownObjectTypeInfo();
   const LoadableTypeInfo &getBridgeObjectTypeInfo();
+  const LoadableTypeInfo &getRawPointerTypeInfo();
   const LoadableTypeInfo &getTypeMetadataPtrTypeInfo();
   const LoadableTypeInfo &getObjCClassPtrTypeInfo();
   const LoadableTypeInfo &getWitnessTablePtrTypeInfo();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -550,6 +550,7 @@ public:
   const LoadableTypeInfo &getNativeObjectTypeInfo();
   const LoadableTypeInfo &getUnknownObjectTypeInfo();
   const LoadableTypeInfo &getBridgeObjectTypeInfo();
+  const LoadableTypeInfo &getRawPointerTypeInfo();
   llvm::Type *getStorageTypeForUnlowered(Type T);
   llvm::Type *getStorageTypeForLowered(CanType T);
   llvm::Type *getStorageType(SILType T);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -430,7 +430,7 @@ private:
       // parameter, print it.
       if (errorConvention && i == errorConvention->getErrorParameterIndex()) {
         os << piece << ":(";
-        print(errorConvention->getErrorParameterType(), OTK_None);
+        print(errorConvention->getErrorParameterType(), None);
         os << ")error";
         continue;
       }
@@ -918,10 +918,8 @@ private:
       return false;
 
     os << iter->second.first;
-    if (iter->second.second) {
-      // FIXME: Selectors and pointers should be nullable.
-      printNullability(OptionalTypeKind::OTK_ImplicitlyUnwrappedOptional);
-    }
+    if (iter->second.second)
+      printNullability(optionalKind);
     return true;
   }
   
@@ -930,13 +928,6 @@ private:
     os << "/* ";
     Ty->print(os);
     os << " */";
-  }
-
-  bool isClangObjectPointerType(const clang::TypeDecl *clangTypeDecl) const {
-    ASTContext &ctx = M.getASTContext();
-    auto &clangASTContext = ctx.getClangModuleLoader()->getClangASTContext();
-    clang::QualType clangTy = clangASTContext.getTypeDeclType(clangTypeDecl);
-    return clangTy->isObjCRetainableType();
   }
 
   bool isClangPointerType(const clang::TypeDecl *clangTypeDecl) const {
@@ -958,13 +949,9 @@ private:
       auto *clangTypeDecl = cast<clang::TypeDecl>(alias->getClangDecl());
       os << clangTypeDecl->getName();
 
-      // Print proper nullability for CF types, but _Null_unspecified for
-      // all other non-object Clang pointer types.
       if (aliasTy->hasReferenceSemantics() ||
-          isClangObjectPointerType(clangTypeDecl)) {
+          isClangPointerType(clangTypeDecl)) {
         printNullability(optionalKind);
-      } else if (isClangPointerType(clangTypeDecl)) {
-        printNullability(OptionalTypeKind::OTK_ImplicitlyUnwrappedOptional);
       }
       return;
     }
@@ -1069,8 +1056,7 @@ private:
     if (isConst)
       os << " const";
     os << " *";
-    // FIXME: Pointer types should be nullable.
-    printNullability(OptionalTypeKind::OTK_ImplicitlyUnwrappedOptional);
+    printNullability(optionalKind);
     return true;
   }
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -379,6 +379,10 @@ enum class ConventionsKind : uint8_t {
       // (An ObjC class type wouldn't be const-qualified.)
       if (clangTy->isPointerType()
           && clangTy->getPointeeType().isConstQualified()) {
+        // Peek through optionals.
+        if (auto substObjTy = substTy.getAnyOptionalObjectType())
+          substTy = substObjTy;
+
         // Void pointers aren't usefully indirectable.
         if (clangTy->isVoidPointerType())
           return false;
@@ -394,10 +398,6 @@ enum class ConventionsKind : uint8_t {
           // since we only ever indirect the 'self' parameter of functions
           // imported as methods.
           return false;
-        
-        // Peek through optionals.
-        if (auto substObjTy = substTy.getAnyOptionalObjectType())
-          substTy = substObjTy;
         
         if (clangTy->getPointeeType()->getAs<clang::RecordType>()) {
           // CF type as foreign class

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -300,9 +300,10 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
       Type PointerInt8Ty = BoundGenericType::get(PointerDecl,
                                                  nullptr,
                                                  Int8Decl->getDeclaredType());
+      Type OptPointerInt8Ty = OptionalType::get(PointerInt8Ty);
       PtrPtrInt8Ty = BoundGenericType::get(PointerDecl,
                                            nullptr,
-                                           PointerInt8Ty)
+                                           OptPointerInt8Ty)
         ->getCanonicalType();
     }
   }

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -46,8 +46,6 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &gen,
 
   // If the pointer itself is optional, we need to branch based on
   // whether it's really there.
-  // FIXME: this code is written expecting pointer types to actually
-  // be optional, as opposed to simply having a null inhabitant.
   OptionalTypeKind errorPtrOptKind;
   if (SILType errorPtrObjectTy =
         foreignErrorSlot->getType()

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -877,7 +877,7 @@ public:
                               ManagedValue input,
                               CanType inputTy,
                               CanType outputTy,
-                              SGFContext C);
+                              SGFContext C = SGFContext());
 
   ManagedValue emitClassMetatypeToObject(SILLocation loc,
                                          ManagedValue v,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4930,32 +4930,78 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     }
 
     case ConversionRestrictionKind::InoutToPointer: {
-      // Overwrite the l-value access kind to be read-only if we're
-      // converting to a non-mutable pointer type.
+      OptionalTypeKind optionalKind;
+      Type unwrappedTy = toType;
+      if (Type unwrapped = toType->getAnyOptionalObjectType(optionalKind))
+        unwrappedTy = unwrapped;
       PointerTypeKind pointerKind;
-      auto toEltType = toType->getAnyPointerElementType(pointerKind);
+      auto toEltType = unwrappedTy->getAnyPointerElementType(pointerKind);
       assert(toEltType && "not a pointer type?"); (void) toEltType;
       if (pointerKind == PTK_UnsafePointer) {
+        // Overwrite the l-value access kind to be read-only if we're
+        // converting to a non-mutable pointer type.
         cast<InOutExpr>(expr->getValueProvidingExpr())->getSubExpr()
           ->propagateLValueAccessKind(AccessKind::Read, /*overwrite*/ true);
       }
 
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
-      return new (tc.Context) InOutToPointerExpr(expr, toType);
+      Expr *result = new (tc.Context) InOutToPointerExpr(expr, unwrappedTy);
+      if (optionalKind != OTK_None)
+        result = new (tc.Context) InjectIntoOptionalExpr(result, toType);
+      return result;
     }
     
     case ConversionRestrictionKind::ArrayToPointer: {
+      OptionalTypeKind optionalKind;
+      Type unwrappedTy = toType;
+      if (Type unwrapped = toType->getAnyOptionalObjectType(optionalKind))
+        unwrappedTy = unwrapped;
+
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
-      return new (tc.Context) ArrayToPointerExpr(expr, toType);
+      Expr *result = new (tc.Context) ArrayToPointerExpr(expr, unwrappedTy);
+      if (optionalKind != OTK_None)
+        result = new (tc.Context) InjectIntoOptionalExpr(result, toType);
+      return result;
     }
     
     case ConversionRestrictionKind::StringToPointer: {
+      OptionalTypeKind optionalKind;
+      Type unwrappedTy = toType;
+      if (Type unwrapped = toType->getAnyOptionalObjectType(optionalKind))
+        unwrappedTy = unwrapped;
+
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
-      return new (tc.Context) StringToPointerExpr(expr, toType);
+      Expr *result = new (tc.Context) StringToPointerExpr(expr, unwrappedTy);
+      if (optionalKind != OTK_None)
+        result = new (tc.Context) InjectIntoOptionalExpr(result, toType);
+      return result;
     }
     
     case ConversionRestrictionKind::PointerToPointer: {
       tc.requirePointerArgumentIntrinsics(expr->getLoc());
+      Type unwrappedToTy = toType->getAnyOptionalObjectType();
+
+      // Optional to optional.
+      if (Type unwrappedFromTy = expr->getType()->getAnyOptionalObjectType()) {
+        assert(unwrappedToTy && "converting optional to non-optional");
+        Expr *boundOptional =
+          new (tc.Context) BindOptionalExpr(expr, SourceLoc(), /*depth*/0,
+                                            unwrappedFromTy);
+        Expr *converted =
+          new (tc.Context) PointerToPointerExpr(boundOptional, unwrappedToTy);
+        Expr *rewrapped =
+          new (tc.Context) InjectIntoOptionalExpr(converted, toType);
+        return new (tc.Context) OptionalEvaluationExpr(rewrapped, toType);
+      }
+
+      // Non-optional to optional.
+      if (unwrappedToTy) {
+        Expr *converted =
+            new (tc.Context) PointerToPointerExpr(expr, unwrappedToTy);
+        return new (tc.Context) InjectIntoOptionalExpr(converted, toType);
+      }
+
+      // Non-optional to non-optional.
       return new (tc.Context) PointerToPointerExpr(expr, toType);
     }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -292,7 +292,10 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
               AcceptableInOutExprs.insert(IOE);
           }
           // InOutExprs can be wrapped in some implicit casts.
-          if (auto *ICO = dyn_cast<ImplicitConversionExpr>(arg)) {
+          Expr *unwrapped = arg;
+          if (auto *IIO = dyn_cast<InjectIntoOptionalExpr>(arg))
+            unwrapped = IIO->getSubExpr();
+          if (auto *ICO = dyn_cast<ImplicitConversionExpr>(unwrapped)) {
             if (isa<InOutToPointerExpr>(ICO) ||
                 isa<ArrayToPointerExpr>(ICO) ||
                 isa<ErasureExpr>(ICO))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2798,7 +2798,7 @@ bool TypeChecker::isRepresentableInObjC(
       return false;
     }
 
-    // The error type is always AutoreleasingUnsafeMutablePointer<NSError?>.
+    // The error type is always 'AutoreleasingUnsafeMutablePointer<NSError?>?'.
     Type errorParameterType = getNSErrorType(dc);
     if (errorParameterType) {
       errorParameterType = OptionalType::get(errorParameterType);
@@ -2807,6 +2807,7 @@ bool TypeChecker::isRepresentableInObjC(
             Context.getAutoreleasingUnsafeMutablePointerDecl(),
             nullptr,
             errorParameterType);
+      errorParameterType = OptionalType::get(errorParameterType);
     }
 
     // Determine the parameter index at which the error will go.

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -1152,11 +1152,11 @@ public final class TestSuite {
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
 @_silgen_name("swift_stdlib_getSystemVersionPlistProperty")
 func _stdlib_getSystemVersionPlistPropertyImpl(
-  _ propertyName: UnsafePointer<CChar>) -> UnsafePointer<CChar>
+  _ propertyName: UnsafePointer<CChar>) -> UnsafePointer<CChar>?
 
 func _stdlib_getSystemVersionPlistProperty(_ propertyName: String) -> String? {
   let cs = _stdlib_getSystemVersionPlistPropertyImpl(propertyName)
-  return (cs != nil) ? String(cString: cs) : nil
+  return cs.map(String.init(cString:))
 }
 #endif
 

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -55,7 +55,7 @@ public struct _FDInputStream {
     let readResult: __swift_ssize_t = _buffer.withUnsafeMutableBufferPointer {
       (_buffer) in
       let fd = self.fd
-      let addr = _buffer.baseAddress + self._bufferUsed
+      let addr = _buffer.baseAddress! + self._bufferUsed
       let size = bufferFree
       return _swift_stdlib_read(fd, addr, size)
     }
@@ -107,7 +107,7 @@ public struct _FDOutputStream : OutputStream {
       let bufferSize = utf8.count - 1
       while writtenBytes != bufferSize {
         let result = _swift_stdlib_write(
-          self.fd, UnsafePointer(utf8.baseAddress + Int(writtenBytes)),
+          self.fd, UnsafePointer(utf8.baseAddress! + Int(writtenBytes)),
           bufferSize - writtenBytes)
         if result < 0 {
           fatalError("write() returned an error")

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -73,7 +73,7 @@ public func scatter<T>(_ a: [T], _ idx: [Int]) -> [T] {
 }
 
 public func withArrayOfCStrings<R>(
-  _ args: [String], _ body: ([UnsafeMutablePointer<CChar>]) -> R
+  _ args: [String], _ body: ([UnsafePointer<CChar>?]) -> R
 ) -> R {
 
   let argsCounts = Array(args.map { $0.utf8.count + 1 })
@@ -89,8 +89,8 @@ public func withArrayOfCStrings<R>(
 
   return argsBuffer.withUnsafeBufferPointer {
     (argsBuffer) in
-    let ptr = UnsafeMutablePointer<CChar>(argsBuffer.baseAddress)
-    var cStrings = argsOffsets.map { ptr + $0 }
+    let ptr = UnsafePointer<CChar>(argsBuffer.baseAddress!)
+    var cStrings: [UnsafePointer<CChar>?] = argsOffsets.map { ptr + $0 }
     cStrings[cStrings.count - 1] = nil
     return body(cStrings)
   }

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -21,8 +21,8 @@ public func _stdlib_mkstemps(_ template: inout String, _ suffixlen: CInt) -> CIn
   var utf8 = template.nulTerminatedUTF8
   let (fd, fileName) = utf8.withUnsafeMutableBufferPointer {
     (utf8) -> (CInt, String) in
-    let fd = mkstemps(UnsafeMutablePointer(utf8.baseAddress), suffixlen)
-    let fileName = String(cString: UnsafePointer(utf8.baseAddress))
+    let fd = mkstemps(UnsafeMutablePointer(utf8.baseAddress!), suffixlen)
+    let fileName = String(cString: UnsafePointer(utf8.baseAddress!))
     return (fd, fileName)
   }
   template = fileName
@@ -79,7 +79,7 @@ public struct _stdlib_fd_set {
 
 public func _stdlib_select(
   _ readfds: inout _stdlib_fd_set, _ writefds: inout _stdlib_fd_set,
-  _ errorfds: inout _stdlib_fd_set, _ timeout: UnsafeMutablePointer<timeval>
+  _ errorfds: inout _stdlib_fd_set, _ timeout: UnsafeMutablePointer<timeval>?
 ) -> CInt {
   return readfds._data.withUnsafeMutableBufferPointer {
     (readfds) in

--- a/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/PthreadBarriers.swift
@@ -43,8 +43,8 @@ public var _stdlib_PTHREAD_BARRIER_SERIAL_THREAD: CInt {
 }
 
 public struct _stdlib_pthread_barrier_t {
-  var mutex: UnsafeMutablePointer<pthread_mutex_t> = nil
-  var cond: UnsafeMutablePointer<pthread_cond_t> = nil
+  var mutex: UnsafeMutablePointer<pthread_mutex_t>? = nil
+  var cond: UnsafeMutablePointer<pthread_cond_t>? = nil
 
   /// The number of threads to synchronize.
   var count: CUnsignedInt = 0
@@ -59,7 +59,7 @@ public struct _stdlib_pthread_barrier_t {
 
 public func _stdlib_pthread_barrier_init(
   _ barrier: UnsafeMutablePointer<_stdlib_pthread_barrier_t>,
-  _ attr: UnsafeMutablePointer<_stdlib_pthread_barrierattr_t>,
+  _ attr: UnsafeMutablePointer<_stdlib_pthread_barrierattr_t>?,
   _ count: CUnsignedInt
 ) -> CInt {
   barrier.pointee = _stdlib_pthread_barrier_t()
@@ -68,12 +68,12 @@ public func _stdlib_pthread_barrier_init(
     return -1
   }
   barrier.pointee.mutex = UnsafeMutablePointer(allocatingCapacity: 1)
-  if pthread_mutex_init(barrier.pointee.mutex, nil) != 0 {
+  if pthread_mutex_init(barrier.pointee.mutex!, nil) != 0 {
     // FIXME: leaking memory.
     return -1
   }
   barrier.pointee.cond = UnsafeMutablePointer(allocatingCapacity: 1)
-  if pthread_cond_init(barrier.pointee.cond, nil) != 0 {
+  if pthread_cond_init(barrier.pointee.cond!, nil) != 0 {
     // FIXME: leaking memory, leaking a mutex.
     return -1
   }
@@ -84,34 +84,34 @@ public func _stdlib_pthread_barrier_init(
 public func _stdlib_pthread_barrier_destroy(
   _ barrier: UnsafeMutablePointer<_stdlib_pthread_barrier_t>
 ) -> CInt {
-  if pthread_cond_destroy(barrier.pointee.cond) != 0 {
+  if pthread_cond_destroy(barrier.pointee.cond!) != 0 {
     // FIXME: leaking memory, leaking a mutex.
     return -1
   }
-  if pthread_mutex_destroy(barrier.pointee.mutex) != 0 {
+  if pthread_mutex_destroy(barrier.pointee.mutex!) != 0 {
     // FIXME: leaking memory.
     return -1
   }
-  barrier.pointee.cond.deinitialize()
-  barrier.pointee.cond.deallocateCapacity(1)
-  barrier.pointee.mutex.deinitialize()
-  barrier.pointee.mutex.deallocateCapacity(1)
+  barrier.pointee.cond!.deinitialize()
+  barrier.pointee.cond!.deallocateCapacity(1)
+  barrier.pointee.mutex!.deinitialize()
+  barrier.pointee.mutex!.deallocateCapacity(1)
   return 0
 }
 
 public func _stdlib_pthread_barrier_wait(
   _ barrier: UnsafeMutablePointer<_stdlib_pthread_barrier_t>
 ) -> CInt {
-  if pthread_mutex_lock(barrier.pointee.mutex) != 0 {
+  if pthread_mutex_lock(barrier.pointee.mutex!) != 0 {
     return -1
   }
   barrier.pointee.numThreadsWaiting += 1
   if barrier.pointee.numThreadsWaiting < barrier.pointee.count {
     // Put the thread to sleep.
-    if pthread_cond_wait(barrier.pointee.cond, barrier.pointee.mutex) != 0 {
+    if pthread_cond_wait(barrier.pointee.cond!, barrier.pointee.mutex!) != 0 {
       return -1
     }
-    if pthread_mutex_unlock(barrier.pointee.mutex) != 0 {
+    if pthread_mutex_unlock(barrier.pointee.mutex!) != 0 {
       return -1
     }
     return 0
@@ -120,10 +120,10 @@ public func _stdlib_pthread_barrier_wait(
     barrier.pointee.numThreadsWaiting = 0
 
     // Wake up all threads.
-    if pthread_cond_broadcast(barrier.pointee.cond) != 0 {
+    if pthread_cond_broadcast(barrier.pointee.cond!) != 0 {
       return -1
     }
-    if pthread_mutex_unlock(barrier.pointee.mutex) != 0 {
+    if pthread_mutex_unlock(barrier.pointee.mutex!) != 0 {
       return -1
     }
     return _stdlib_PTHREAD_BARRIER_SERIAL_THREAD

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -49,10 +49,10 @@ internal class PthreadBlockContextImpl<Argument, Result>: PthreadBlockContext {
 
 /// Entry point for `pthread_create` that invokes a block context.
 internal func invokeBlockContext(
-  _ contextAsVoidPointer: UnsafeMutablePointer<Void>
-) -> UnsafeMutablePointer<Void> {
+  _ contextAsVoidPointer: UnsafeMutablePointer<Void>!
+) -> UnsafeMutablePointer<Void>! {
   // The context is passed in +1; we're responsible for releasing it.
-  let contextAsOpaque = OpaquePointer(contextAsVoidPointer)
+  let contextAsOpaque = OpaquePointer(contextAsVoidPointer!)
   let context = Unmanaged<PthreadBlockContext>.fromOpaque(contextAsOpaque)
     .takeRetainedValue()
 
@@ -61,7 +61,7 @@ internal func invokeBlockContext(
 
 /// Block-based wrapper for `pthread_create`.
 public func _stdlib_pthread_create_block<Argument, Result>(
-  _ attr: UnsafePointer<pthread_attr_t>,
+  _ attr: UnsafePointer<pthread_attr_t>?,
   _ start_routine: (Argument) -> Result,
   _ arg: Argument
 ) -> (CInt, pthread_t?) {
@@ -71,7 +71,7 @@ public func _stdlib_pthread_create_block<Argument, Result>(
   let contextAsOpaque = OpaquePointer(bitPattern: Unmanaged.passRetained(context))
   let contextAsVoidPointer = UnsafeMutablePointer<Void>(contextAsOpaque)
 
-  var threadID: pthread_t = _make_pthread_t()
+  var threadID = _make_pthread_t()
   let result = pthread_create(&threadID, attr,
     invokeBlockContext, contextAsVoidPointer)
   if result == 0 {
@@ -81,25 +81,27 @@ public func _stdlib_pthread_create_block<Argument, Result>(
   }
 }
 
-internal func _make_pthread_t() -> pthread_t {
 #if os(Linux)
+internal func _make_pthread_t() -> pthread_t {
   return pthread_t()
-#else
-  return nil
-#endif
 }
+#else
+internal func _make_pthread_t() -> pthread_t? {
+  return nil
+}
+#endif
 
 /// Block-based wrapper for `pthread_join`.
 public func _stdlib_pthread_join<Result>(
   _ thread: pthread_t,
   _ resultType: Result.Type
 ) -> (CInt, Result?) {
-  var threadResultPtr: UnsafeMutablePointer<Void> = nil
+  var threadResultPtr: UnsafeMutablePointer<Void>? = nil
   let result = pthread_join(thread, &threadResultPtr)
   if result == 0 {
-    let threadResult = UnsafeMutablePointer<Result>(threadResultPtr).pointee
-    threadResultPtr.deinitialize()
-    threadResultPtr.deallocateCapacity(1)
+    let threadResult = UnsafeMutablePointer<Result>(threadResultPtr!).pointee
+    threadResultPtr!.deinitialize()
+    threadResultPtr!.deallocateCapacity(1)
     return (result, threadResult)
   } else {
     return (result, nil)

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -335,7 +335,7 @@ internal var _ignore = _UnsupportedPlatformError()
 //===----------------------------------------------------------------------===//
 
 /// The value returned by `sem_open()` in the case of failure.
-public var SEM_FAILED: UnsafeMutablePointer<sem_t> {
+public var SEM_FAILED: UnsafeMutablePointer<sem_t>? {
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
   // The value is ABI.  Value verified to be correct for OS X, iOS, watchOS, tvOS.
   return UnsafeMutablePointer<sem_t>(bitPattern: -1)
@@ -352,7 +352,7 @@ public var SEM_FAILED: UnsafeMutablePointer<sem_t> {
 internal func _swift_Platform_sem_open2(
   _ name: UnsafePointer<CChar>,
   _ oflag: CInt
-) -> UnsafeMutablePointer<sem_t>
+) -> UnsafeMutablePointer<sem_t>?
 
 @warn_unused_result
 @_silgen_name("_swift_Platform_sem_open4")
@@ -361,13 +361,13 @@ internal func _swift_Platform_sem_open4(
   _ oflag: CInt,
   _ mode: mode_t,
   _ value: CUnsignedInt
-) -> UnsafeMutablePointer<sem_t>
+) -> UnsafeMutablePointer<sem_t>?
 
 @warn_unused_result
 public func sem_open(
   _ name: UnsafePointer<CChar>,
   _ oflag: CInt
-) -> UnsafeMutablePointer<sem_t> {
+) -> UnsafeMutablePointer<sem_t>? {
   return _swift_Platform_sem_open2(name, oflag)
 }
 
@@ -377,7 +377,7 @@ public func sem_open(
   _ oflag: CInt,
   _ mode: mode_t,
   _ value: CUnsignedInt
-) -> UnsafeMutablePointer<sem_t> {
+) -> UnsafeMutablePointer<sem_t>? {
   return _swift_Platform_sem_open4(name, oflag, mode, value)
 }
 
@@ -390,9 +390,9 @@ public func sem_open(
 @warn_unused_result
 @_silgen_name("_swift_FreeBSD_getEnv")
 func _swift_FreeBSD_getEnv(
-) -> UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<CChar>>>
+) -> UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>>
 
-public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>> {
+public var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
   return _swift_FreeBSD_getEnv().pointee
 }
 #endif

--- a/stdlib/public/SDK/AppKit/AppKit.swift
+++ b/stdlib/public/SDK/AppKit/AppKit.swift
@@ -64,7 +64,7 @@ public extension NSGradient {
 // argv as a const char**.
 @_silgen_name("NSApplicationMain")
 public func NSApplicationMain(
-  _ argc: Int32, _ argv: UnsafeMutablePointer<UnsafeMutablePointer<CChar>>
+  _ argc: Int32, _ argv: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
 ) -> Int32
 
 extension NSColor : _ColorLiteralConvertible {

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -69,7 +69,7 @@ extension AudioBufferList {
       "failed to allocate memory for an AudioBufferList")
 
     let abl = UnsafeMutableAudioBufferListPointer(
-        UnsafeMutablePointer<AudioBufferList>(ablMemory))
+        UnsafeMutablePointer<AudioBufferList>(ablMemory!))
     abl.count = maximumBuffers
     return abl
   }
@@ -84,6 +84,12 @@ public struct UnsafeMutableAudioBufferListPointer {
   /// Construct from an `AudioBufferList` pointer.
   public init(_ p: UnsafeMutablePointer<AudioBufferList>) {
     unsafeMutablePointer = p
+  }
+
+  /// Construct from an `AudioBufferList` pointer.
+  public init?(_ p: UnsafeMutablePointer<AudioBufferList>?) {
+    guard let unwrapped = p else { return nil }
+    self.init(unwrapped)
   }
 
   /// The number of `AudioBuffer`s in the `AudioBufferList`

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -523,8 +523,8 @@ extension NSDictionary : DictionaryLiteralConvertible {
     dictionaryLiteral elements: (NSCopying, AnyObject)...
   ) {
     self.init(
-      objects: elements.map { (AnyObject?)($0.1) },
-      forKeys: elements.map { (NSCopying?)($0.0) },
+      objects: elements.map { $0.1 },
+      forKeys: elements.map { $0.0 },
       count: elements.count)
   }
 }

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -415,11 +415,8 @@ public let NSNotFound: Int = .max
 extension NSArray : ArrayLiteralConvertible {
   /// Create an instance initialized with `elements`.
   public required convenience init(arrayLiteral elements: AnyObject...) {
-    // + (instancetype)arrayWithObjects:(const id [])objects count:(NSUInteger)cnt;
-    let x = _extractOrCopyToNativeArrayBuffer(elements._buffer)
-    self.init(
-      objects: UnsafeMutablePointer(x.firstElementAddress), count: x.count)
-    _fixLifetime(x)
+    // Let bridging take care of it.
+    self.init(array: elements)
   }
 }
 
@@ -661,15 +658,9 @@ final public class NSFastEnumerationIterator : IteratorProtocol {
   var count: Int
 
   /// Size of ObjectsBuffer, in ids.
-  var STACK_BUF_SIZE: Int { return 4 }
+  static var STACK_BUF_SIZE: Int { return 4 }
 
-  // FIXME: Replace with _CocoaFastEnumerationStackBuf.
-  /// Must have enough space for STACK_BUF_SIZE object references.
-  struct ObjectsBuffer {
-    var buf: (OpaquePointer, OpaquePointer, OpaquePointer, OpaquePointer) =
-      (nil, nil, nil, nil)
-  }
-  var objects: [ObjectsBuffer]
+  var objects: [Unmanaged<AnyObject>?]
 
   public func next() -> AnyObject? {
     if n == count {
@@ -678,18 +669,20 @@ final public class NSFastEnumerationIterator : IteratorProtocol {
       refresh()
       if count == 0 { return nil }
     }
-    let next: AnyObject = state[0].itemsPtr[n]!
+    let next: AnyObject = state[0].itemsPtr![n]!
     n += 1
     return next
   }
 
   func refresh() {
+    _sanityCheck(objects.count > 0)
     n = 0
-    count = enumerable.countByEnumerating(
-      with: state._baseAddressIfContiguous,
-      objects: AutoreleasingUnsafeMutablePointer(
-        objects._baseAddressIfContiguous),
-      count: STACK_BUF_SIZE)
+    objects.withUnsafeMutableBufferPointer {
+      count = enumerable.countByEnumerating(
+        with: &state,
+        objects: AutoreleasingUnsafeMutablePointer($0.baseAddress!),
+        count: $0.count)
+    }
   }
 
   public init(_ enumerable: NSFastEnumeration) {
@@ -698,7 +691,8 @@ final public class NSFastEnumerationIterator : IteratorProtocol {
       state: 0, itemsPtr: nil,
       mutationsPtr: _fastEnumerationStorageMutationsPtr,
       extra: (0, 0, 0, 0, 0)) ]
-    self.objects = [ ObjectsBuffer() ]
+    self.objects = Array(
+      repeating: nil, count: NSFastEnumerationIterator.STACK_BUF_SIZE)
     self.n = -1
     self.count = -1
   }
@@ -1006,7 +1000,7 @@ extension CGRectEdge {
 // NSError (as an out parameter).
 //===----------------------------------------------------------------------===//
 
-public typealias NSErrorPointer = AutoreleasingUnsafeMutablePointer<NSError?>
+public typealias NSErrorPointer = AutoreleasingUnsafeMutablePointer<NSError?>?
 
 // Note: NSErrorPointer becomes ErrorPointer in Swift 3.
 public typealias ErrorPointer = NSErrorPointer
@@ -1099,14 +1093,7 @@ extension NSMutableString {
 extension NSArray {
   // Overlay: - (instancetype)initWithObjects:(id)firstObj, ...
   public convenience init(objects elements: AnyObject...) {
-    // - (instancetype)initWithObjects:(const id [])objects count:(NSUInteger)cnt;
-    let x = _extractOrCopyToNativeArrayBuffer(elements._buffer)
-    // Use Imported:
-    // @objc(initWithObjects:count:)
-    //    init(withObjects objects: UnsafePointer<AnyObject?>,
-    //    count cnt: Int)
-    self.init(objects: UnsafeMutablePointer(x.firstElementAddress), count: x.count)
-    _fixLifetime(x)
+    self.init(array: elements)
   }
 }
 

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -64,6 +64,28 @@ func _countFormatSpecifiers(_ a: String) -> Int {
   return count
 }
 
+// We only need this for UnsafeMutablePointer, but there's not currently a way
+// to write that constraint.
+extension Optional {
+  /// Invokes `body` with `nil` if `self` is `nil`; otherwise, passes the
+  /// address of `object` to `body`.
+  ///
+  /// This is intended for use with Foundation APIs that return an Objective-C
+  /// type via out-parameter where it is important to be able to *ignore* that
+  /// parameter by passing `nil`. (For some APIs, this may allow the
+  /// implementation to avoid some work.)
+  ///
+  /// In most cases it would be simpler to just write this code inline, but if
+  /// `body` is complicated than that results in unnecessarily repeated code.
+  internal func _withNilOrAddress<NSType : AnyObject, ResultType>(
+    of object: inout NSType?,
+    body: @noescape AutoreleasingUnsafeMutablePointer<NSType?>? -> ResultType
+  ) -> ResultType {
+    return self == nil ? body(nil) : body(&object)
+  }
+}
+
+
 extension String {
 
   //===--- Bridging Helpers -----------------------------------------------===//
@@ -102,14 +124,12 @@ extension String {
   /// non-`nil`, convert the buffer to an `Index` and write it into the
   /// memory referred to by `index`
   func _withOptionalOutParameter<Result>(
-    _ index: UnsafeMutablePointer<Index>,
-    @noescape body: (UnsafeMutablePointer<Int>) -> Result
+    _ index: UnsafeMutablePointer<Index>?,
+    @noescape body: (UnsafeMutablePointer<Int>?) -> Result
   ) -> Result {
     var utf16Index: Int = 0
-    let result = index._withBridgeValue(&utf16Index) {
-      body($0)
-    }
-    index._setIfNonNil { self._index(utf16Index) }
+    let result = (index != nil ? body(&utf16Index) : body(nil))
+    index?.pointee = self._index(utf16Index)
     return result
   }
 
@@ -117,14 +137,12 @@ extension String {
   /// from non-`nil`, convert the buffer to a `Range<Index>` and write
   /// it into the memory referred to by `range`
   func _withOptionalOutParameter<Result>(
-    _ range: UnsafeMutablePointer<Range<Index>>,
-    @noescape body: (UnsafeMutablePointer<NSRange>) -> Result
+    _ range: UnsafeMutablePointer<Range<Index>>?,
+    @noescape body: (UnsafeMutablePointer<NSRange>?) -> Result
   ) -> Result {
     var nsRange = NSRange(location: 0, length: 0)
-    let result = range._withBridgeValue(&nsRange) {
-      body($0)
-    }
-    range._setIfNonNil { self._range(nsRange) }
+    let result = (range != nil ? body(&nsRange) : body(nil))
+    range?.pointee = self._range(nsRange)
     return result
   }
 
@@ -363,16 +381,16 @@ extension String {
   /// Returns the actual number of matching paths.
   @warn_unused_result
   public func completePath(
-    into outputName: UnsafeMutablePointer<String> = nil,
+    into outputName: UnsafeMutablePointer<String>? = nil,
     caseSensitive: Bool,
-    matchesInto matchesIntoArray: UnsafeMutablePointer<[String]> = nil,
+    matchesInto matchesIntoArray: UnsafeMutablePointer<[String]>? = nil,
     filterTypes: [String]? = nil
   ) -> Int {
     var nsMatches: NSArray?
     var nsOutputName: NSString?
 
-    let result = outputName._withBridgeObject(&nsOutputName) {
-      outputName in matchesIntoArray._withBridgeObject(&nsMatches) {
+    let result = outputName._withNilOrAddress(of: &nsOutputName) {
+      outputName in matchesIntoArray._withNilOrAddress(of: &nsMatches) {
         matchesIntoArray in
         self._ns.completePath(
           into: outputName, caseSensitive: caseSensitive,
@@ -384,11 +402,11 @@ extension String {
     if let matches = nsMatches {
       // Since this function is effectively a bridge thunk, use the
       // bridge thunk semantics for the NSArray conversion
-      matchesIntoArray._setIfNonNil { return matches as! [String] }
+      matchesIntoArray?.pointee = matches as! [String]
     }
 
     if let n = nsOutputName {
-      outputName._setIfNonNil { n as String }
+      outputName?.pointee = n as String
     }
     return result
   }
@@ -839,7 +857,7 @@ extension String {
   /// interpret the file.
   public init(
     contentsOfFile path: String,
-    usedEncoding: UnsafeMutablePointer<NSStringEncoding> = nil
+    usedEncoding: UnsafeMutablePointer<NSStringEncoding>? = nil
   ) throws {
     let ns = try NSString(contentsOfFile: path, usedEncoding: usedEncoding)
     self = ns as String
@@ -871,7 +889,7 @@ extension String {
   /// data.  Errors are written into the inout `error` argument.
   public init(
     contentsOf url: NSURL,
-    usedEncoding enc: UnsafeMutablePointer<NSStringEncoding> = nil
+    usedEncoding enc: UnsafeMutablePointer<NSStringEncoding>? = nil
   ) throws {
     let ns = try NSString(contentsOf: url, usedEncoding: enc)
     self = ns as String
@@ -1021,20 +1039,18 @@ extension String {
     scheme tagScheme: String,
     options opts: NSLinguisticTaggerOptions = [],
     orthography: NSOrthography? = nil,
-    tokenRanges: UnsafeMutablePointer<[Range<Index>]> = nil // FIXME:Can this be nil?
+    tokenRanges: UnsafeMutablePointer<[Range<Index>]>? = nil // FIXME:Can this be nil?
   ) -> [String] {
     var nsTokenRanges: NSArray? = nil
-    let result = tokenRanges._withBridgeObject(&nsTokenRanges) {
+    let result = tokenRanges._withNilOrAddress(of: &nsTokenRanges) {
       self._ns.linguisticTags(
         in: _toNSRange(range), scheme: tagScheme, options: opts,
-        orthography: orthography != nil ? orthography! : nil, tokenRanges: $0) as NSArray
+        orthography: orthography, tokenRanges: $0) as NSArray
     }
 
     if nsTokenRanges != nil {
-      tokenRanges._setIfNonNil {
-        (nsTokenRanges! as [AnyObject]).map {
-          self._range($0.rangeValue)
-        }
+      tokenRanges?.pointee = (nsTokenRanges! as [AnyObject]).map {
+        self._range($0.rangeValue)
       }
     }
 
@@ -1712,9 +1728,9 @@ extension String {
 
   @available(*, unavailable, renamed: "completePath(into:outputName:caseSensitive:matchesInto:filterTypes:)")
   public func completePathInto(
-    _ outputName: UnsafeMutablePointer<String> = nil,
+    _ outputName: UnsafeMutablePointer<String>? = nil,
     caseSensitive: Bool,
-    matchesInto matchesIntoArray: UnsafeMutablePointer<[String]> = nil,
+    matchesInto matchesIntoArray: UnsafeMutablePointer<[String]>? = nil,
     filterTypes: [String]? = nil
   ) -> Int {
     fatalError("unavailable function can't be called")
@@ -1818,7 +1834,7 @@ extension String {
     scheme tagScheme: String,
     options opts: NSLinguisticTaggerOptions = [],
     orthography: NSOrthography? = nil,
-    tokenRanges: UnsafeMutablePointer<[Range<Index>]> = nil
+    tokenRanges: UnsafeMutablePointer<[Range<Index>]>? = nil
   ) -> [String] {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -98,7 +98,7 @@ func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
 ///
 /// The compiler has special knowledge of this type.
 @_fixed_layout
-public struct Selector : StringLiteralConvertible, NilLiteralConvertible {
+public struct Selector : StringLiteralConvertible {
   var ptr : OpaquePointer
 
   /// Create a selector from a string.
@@ -121,12 +121,6 @@ public struct Selector : StringLiteralConvertible, NilLiteralConvertible {
   /// Create an instance initialized to `value`.
   public init(stringLiteral value: String) {
     self = sel_registerName(value)
-  }
-
-  /// Create an instance initialized with `nil`.
-  @_transparent
-  public init(nilLiteral: ()) {
-    ptr = nil
   }
 }
 
@@ -179,16 +173,8 @@ extension Selector : CustomReflectable {
 //===----------------------------------------------------------------------===//
 
 @_fixed_layout
-public struct NSZone : NilLiteralConvertible {
+public struct NSZone {
   var pointer : OpaquePointer
-
-  public init() { pointer = nil }
-
-  /// Create an instance initialized with `nil`.
-  @_transparent
-  public init(nilLiteral: ()) {
-    pointer = nil
-  }
 }
 
 // Note: NSZone becomes Zone in Swift 3.

--- a/stdlib/public/SwiftShims/FoundationShims.h
+++ b/stdlib/public/SwiftShims/FoundationShims.h
@@ -37,8 +37,8 @@ typedef struct {
 #ifdef __OBJC2__
 typedef struct {
     unsigned long state;
-    id __unsafe_unretained *itemsPtr;
-    unsigned long *mutationsPtr;
+    id __unsafe_unretained _Nullable * _Nullable itemsPtr;
+    unsigned long * _Nullable mutationsPtr;
     unsigned long extra[5];
 } _SwiftNSFastEnumerationState;
 #endif

--- a/stdlib/public/SwiftShims/RuntimeStubs.h
+++ b/stdlib/public/SwiftShims/RuntimeStubs.h
@@ -21,7 +21,8 @@
 
 #include "LibcShims.h"
 
-__swift_ssize_t swift_stdlib_readLine_stdin(char **LinePtr);
+__swift_ssize_t
+swift_stdlib_readLine_stdin(char * _Nullable * _Nonnull LinePtr);
 
 #endif // SWIFT_STDLIB_SHIMS_RUNTIMESTUBS_H_
 

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -241,12 +241,19 @@ extension _ArrayBuffer {
         return _native[bounds]
       }
 
+      let boundsCount = bounds.count
+      if boundsCount == 0 {
+        return _SliceBuffer(
+          _ContiguousArrayBuffer<Element>(),
+          shiftedToStartIndex: bounds.startIndex)
+      }
+
       // Look for contiguous storage in the NSArray
       let nonNative = self._nonNative
       let cocoa = _CocoaArrayWrapper(nonNative)
       let cocoaStorageBaseAddress = cocoa.contiguousStorage(self.indices)
 
-      if cocoaStorageBaseAddress != nil {
+      if let cocoaStorageBaseAddress = cocoaStorageBaseAddress {
         return _SliceBuffer(
           owner: nonNative,
           subscriptBaseAddress: UnsafeMutablePointer(cocoaStorageBaseAddress),
@@ -255,7 +262,6 @@ extension _ArrayBuffer {
       }
 
       // No contiguous storage found; we must allocate
-      let boundsCount = bounds.count
       let result = _ContiguousArrayBuffer<Element>(
         uninitializedCount: boundsCount, minimumCapacity: 0)
 
@@ -273,19 +279,16 @@ extension _ArrayBuffer {
     }
   }
 
-  public var _unconditionalMutableSubscriptBaseAddress:
-    UnsafeMutablePointer<Element> {
+  /// A pointer to the first element.
+  ///
+  /// - Precondition: The elements are known to be stored contiguously.
+  public var firstElementAddress: UnsafeMutablePointer<Element> {
     _sanityCheck(_isNative, "must be a native buffer")
     return _native.firstElementAddress
   }
 
-  /// If the elements are stored contiguously, a pointer to the first
-  /// element. Otherwise, `nil`.
-  public var firstElementAddress: UnsafeMutablePointer<Element> {
-    if (_fastPath(_isNative)) {
-      return _native.firstElementAddress
-    }
-    return nil
+  public var firstElementAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    return _fastPath(_isNative) ? firstElementAddress : nil
   }
 
   /// The number of elements the buffer stores.
@@ -419,12 +422,12 @@ extension _ArrayBuffer {
     @noescape _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     _sanityCheck(
-      firstElementAddress != nil || count == 0,
+      _isNative || count == 0,
       "Array is bridging an opaque NSArray; can't get a pointer to the elements"
     )
     defer { _fixLifetime(self) }
-    return try body(
-      UnsafeMutableBufferPointer(start: firstElementAddress, count: count))
+    return try body(UnsafeMutableBufferPointer(
+      start: firstElementAddressIfContiguous, count: count))
   }
   
   /// An object that keeps the elements stored in this buffer alive.

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -102,19 +102,18 @@ public protocol _ArrayBufferProtocol : MutableCollection {
   /// An object that keeps the elements stored in this buffer alive.
   var owner: AnyObject { get }
 
+  /// A pointer to the first element.
+  ///
+  /// - Precondition: The elements are known to be stored contiguously.
+  var firstElementAddress: UnsafeMutablePointer<Element> { get }
+
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  var firstElementAddress: UnsafeMutablePointer<Element> { get }
+  var firstElementAddressIfContiguous: UnsafeMutablePointer<Element>? { get }
 
   /// Returns a base address to which you can add an index `i` to get the
   /// address of the corresponding element at `i`.
   var subscriptBaseAddress: UnsafeMutablePointer<Element> { get }
-
-  /// Like `subscriptBaseAddress`, but can assume that `self` is a mutable,
-  /// uniquely referenced native representation.
-  /// - Precondition: `_isNative` is `true`.
-  var _unconditionalMutableSubscriptBaseAddress:
-    UnsafeMutablePointer<Element> { get }
 
   /// A value that identifies the storage used by the buffer.  Two
   /// buffers address the same elements when they have the same
@@ -127,11 +126,6 @@ public protocol _ArrayBufferProtocol : MutableCollection {
 extension _ArrayBufferProtocol {
   public var subscriptBaseAddress: UnsafeMutablePointer<Element> {
     return firstElementAddress
-  }
-
-  public var _unconditionalMutableSubscriptBaseAddress:
-    UnsafeMutablePointer<Element> {
-    return subscriptBaseAddress
   }
 
   public mutating func replace<
@@ -149,8 +143,6 @@ extension _ArrayBufferProtocol {
     self.count = oldCount + growth
 
     let elements = self.subscriptBaseAddress
-    _sanityCheck(elements != nil)
-
     let oldTailIndex = subRange.endIndex
     let oldTailStart = elements + oldTailIndex
     let newTailIndex = oldTailIndex + growth

--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -72,11 +72,15 @@ public func _arrayForceCast<SourceElement, TargetElement>(
     return result!
     
   case (.value, .verbatim):
+    if source.isEmpty {
+      return Array()
+    }
+
     var buf = _ContiguousArrayBuffer<TargetElement>(
       uninitializedCount: source.count, minimumCapacity: 0)
     
     let _: Void = buf.withUnsafeMutableBufferPointer {
-      var p = $0.baseAddress
+      var p = $0.baseAddress!
       for value in source {
         let bridged: AnyObject? = _bridgeToObjectiveC(value)
         _precondition(

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -30,7 +30,7 @@ protocol _ArrayProtocol
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  var _baseAddressIfContiguous: UnsafeMutablePointer<Element> { get }
+  var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? { get }
 
   subscript(index: Int) -> Iterator.Element { get set }
 

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -410,7 +410,7 @@ public struct ${Self}<Element>
   @warn_unused_result
   @_semantics("array.get_element_address")
   internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
-    return _buffer._unconditionalMutableSubscriptBaseAddress + index
+    return _buffer.subscriptBaseAddress + index
   }
 
 %if Self == 'Array':
@@ -581,7 +581,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     
     return (
       Array(_Buffer(innerBuffer, shiftedToStartIndex: 0)),
-      innerBuffer.firstElementAddress)
+        innerBuffer.firstElementAddress)
   }
 
   /// Entry point for aborting literal construction: deallocates
@@ -611,8 +611,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
 
   /// If the elements are stored contiguously, a pointer to the first
   /// element. Otherwise, `nil`.
-  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element> {
-    return _buffer.firstElementAddress
+  public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    return _buffer.firstElementAddressIfContiguous
   }
 
 %if Self != 'Array': # // Array does not necessarily have contiguous storage
@@ -776,7 +776,7 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      let r = try body(bufferPointer.baseAddress, bufferPointer.count)
+      let r = try body(bufferPointer.baseAddress!, bufferPointer.count)
       return r
     }
   }
@@ -836,13 +836,13 @@ extension ${Self} {
   @_versioned
   @_transparent
   @warn_unused_result
-  internal func _cPointerArgs() -> (AnyObject?, Builtin.RawPointer) {
+  internal func _cPointerArgs() -> (AnyObject?, UnsafePointer<Void>?) {
     let p = _baseAddressIfContiguous
     if _fastPath(p != nil || isEmpty) {
-      return (_owner, p._rawValue)
+      return (_owner, UnsafePointer(p))
     }
     let n = _extractOrCopyToNativeArrayBuffer(self._buffer)
-    return (n.owner, n.firstElementAddress._rawValue)
+    return (n.owner, UnsafePointer(n.firstElementAddress))
   }
 
 }

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -124,9 +124,9 @@ func _assertionFailed(
       file.withUTF8Buffer {
         (file) -> Void in
         _reportFatalErrorInFile(
-          prefix.baseAddress, UInt(prefix.count),
-          message.baseAddress, UInt(message.count),
-          file.baseAddress, UInt(file.count), line,
+          prefix.baseAddress!, UInt(prefix.count),
+          message.baseAddress!, UInt(message.count),
+          file.baseAddress!, UInt(file.count), line,
           flags: flags)
         Builtin.int_trap()
       }
@@ -156,9 +156,9 @@ func _assertionFailed(
       file.withUTF8Buffer {
         (file) -> Void in
         _reportFatalErrorInFile(
-          prefix.baseAddress, UInt(prefix.count),
-          messageUTF8.baseAddress, UInt(messageUTF8.count),
-          file.baseAddress, UInt(file.count), line,
+          prefix.baseAddress!, UInt(prefix.count),
+          messageUTF8.baseAddress!, UInt(messageUTF8.count),
+          file.baseAddress!, UInt(file.count), line,
           flags: flags)
       }
     }
@@ -189,9 +189,9 @@ func _fatalErrorMessage(
       file.withUTF8Buffer {
         (file) in
         _reportFatalErrorInFile(
-          prefix.baseAddress, UInt(prefix.count),
-          message.baseAddress, UInt(message.count),
-          file.baseAddress, UInt(file.count), line,
+          prefix.baseAddress!, UInt(prefix.count),
+          message.baseAddress!, UInt(message.count),
+          file.baseAddress!, UInt(file.count), line,
           flags: flags)
       }
     }
@@ -202,8 +202,8 @@ func _fatalErrorMessage(
     message.withUTF8Buffer {
       (message) in
       _reportFatalError(
-        prefix.baseAddress, UInt(prefix.count),
-        message.baseAddress, UInt(message.count),
+        prefix.baseAddress!, UInt(prefix.count),
+        message.baseAddress!, UInt(message.count),
         flags: flags)
     }
   }
@@ -234,9 +234,9 @@ func _unimplemented_initializer(className: StaticString,
         file.withUTF8Buffer {
           (file) in
           _reportUnimplementedInitializerInFile(
-            className.baseAddress, UInt(className.count),
-            initName.baseAddress, UInt(initName.count),
-            file.baseAddress, UInt(file.count), line, column,
+            className.baseAddress!, UInt(className.count),
+            initName.baseAddress!, UInt(initName.count),
+            file.baseAddress!, UInt(file.count), line, column,
             flags: 0)
         }
       }
@@ -247,8 +247,8 @@ func _unimplemented_initializer(className: StaticString,
       initName.withUTF8Buffer {
         (initName) in
         _reportUnimplementedInitializer(
-          className.baseAddress, UInt(className.count),
-          initName.baseAddress, UInt(initName.count),
+          className.baseAddress!, UInt(className.count),
+          initName.baseAddress!, UInt(initName.count),
           flags: 0)
       }
     }

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -15,14 +15,6 @@ import SwiftShims
 // Definitions that make elements of Builtin usable in real code
 // without gobs of boilerplate.
 
-/// An initialized raw pointer to use as a NULL value.
-@_versioned
-@_transparent
-internal var _nilRawPointer: Builtin.RawPointer {
-  let zero: Int8 = 0
-  return Builtin.inttoptr_Int8(zero._value)
-}
-
 /// Returns the contiguous memory footprint of `T`.
 ///
 /// Does not include any dynamically-allocated or "remote" storage.

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -24,7 +24,6 @@ extension String {
   ///
   /// - Precondition: `cString != nil`
   public init(cString: UnsafePointer<CChar>) {
-    _precondition(cString != nil, "cString must not be nil")
     self = String.decodeCString(UnsafePointer(cString), as: UTF8.self,
       repairingInvalidCodeUnits: true)!.result
   }
@@ -37,9 +36,8 @@ extension String {
   ///
   /// - Precondition: `cString != nil`
   public init?(validatingUTF8 cString: UnsafePointer<CChar>) {
-    _precondition(cString != nil, "cString must not be nil")
     guard let (result, _) = String.decodeCString(
-      UnsafePointer(cString),
+        UnsafePointer(cString),
         as: UTF8.self,
         repairingInvalidCodeUnits: false) else {
       return nil
@@ -50,17 +48,17 @@ extension String {
   /// Create a new `String` by copying the nul-terminated data
   /// referenced by a `cString` using `encoding`.
   ///
-  /// Returns `nil` if the `cString` is `NULL` or if it contains ill-formed code
+  /// Returns `nil` if the `cString` is `nil` or if it contains ill-formed code
   /// units and no repairing has been requested. Otherwise replaces
   /// ill-formed code units with replacement characters (U+FFFD).
   @warn_unused_result
   public static func decodeCString<Encoding : UnicodeCodec>(
-    _ cString: UnsafePointer<Encoding.CodeUnit>,
+    _ cString: UnsafePointer<Encoding.CodeUnit>?,
     as encoding: Encoding.Type,
     repairingInvalidCodeUnits isRepairing: Bool = true)
       -> (result: String, repairsMade: Bool)? {
 
-    if cString._isNull {
+    guard let cString = cString else {
       return nil
     }
     let len = Int(_swift_stdlib_strlen(UnsafePointer(cString)))
@@ -80,8 +78,8 @@ extension String {
 /// with possibly-transient lifetime, create a null-terminated array of 'C' char.
 /// Returns `nil` if passed a null pointer.
 @warn_unused_result
-public func _persistCString(_ s: UnsafePointer<CChar>) -> [CChar]? {
-  if s == nil {
+public func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
+  guard let s = p else {
     return nil
   }
   let count = Int(_swift_stdlib_strlen(s))

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -107,7 +107,7 @@ public struct Character :
     }
     else {
       if let native = s._core.nativeBuffer
-              where native.start == UnsafeMutablePointer(s._core._baseAddress) {
+              where native.start == UnsafeMutablePointer(s._core._baseAddress!){
         _representation = .large(native._storage)
         return
       }

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -38,17 +38,21 @@ internal struct _CocoaArrayWrapper : Collection {
     return buffer.objectAt(i)
   }
 
-  /// Returns a pointer to the first element in the given subRange if
-  /// the subRange is stored contiguously. Otherwise, return `nil`.
+  /// Returns a pointer to the first element in the given non-empty `subRange`
+  /// if the subRange is stored contiguously. Otherwise, return `nil`.
+  ///
+  /// The "non-empty" condition saves a branch within this method that can
+  /// likely be better handled in a caller.
   ///
   /// - Note: This method should only be used as an optimization; it
   ///   is sometimes conservative and may return `nil` even when
   ///   contiguous storage exists, e.g., if array doesn't have a smart
-  /// implementation of countByEnumeratingWith.
+  /// implementation of countByEnumerating.
   func contiguousStorage(
     _ subRange: Range<Int>
-  ) -> UnsafeMutablePointer<AnyObject>
+  ) -> UnsafeMutablePointer<AnyObject>?
   {
+    _sanityCheck(!subRange.isEmpty)
     var enumerationState = _makeSwiftNSFastEnumerationState()
 
     // This function currently returns nil unless the first
@@ -56,14 +60,13 @@ internal struct _CocoaArrayWrapper : Collection {
     // acceptable conservative behavior, but could potentially be
     // optimized for other cases.
     let contiguousCount = withUnsafeMutablePointer(&enumerationState) {
-      self.buffer.countByEnumeratingWith($0, objects: nil, count: 0)
+      self.buffer.countByEnumerating(with: $0, objects: nil, count: 0)
     }
     
     return contiguousCount >= subRange.endIndex
-    ? unsafeBitCast(
-      enumerationState.itemsPtr, to: UnsafeMutablePointer<AnyObject>.self
-      ) + subRange.startIndex
-    : nil
+      ? UnsafeMutablePointer<AnyObject>(enumerationState.itemsPtr!)
+        + subRange.startIndex
+      : nil
   }
 
   @_transparent

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -596,8 +596,7 @@ extension Sequence
   public func _copyContents(
     initializing ptr: UnsafeMutablePointer<Iterator.Element>
   ) -> UnsafeMutablePointer<Iterator.Element> {
-    let s = self._baseAddressIfContiguous
-    if s != nil {
+    if let s = self._baseAddressIfContiguous {
       let count = self.count
       ptr.initializeFrom(s, count: count)
       _fixLifetime(self._owner)

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -256,10 +256,13 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     return true
   }
 
-  /// If the elements are stored contiguously, a pointer to the first
-  /// element. Otherwise, `nil`.
+  /// A pointer to the first element.
   public var firstElementAddress: UnsafeMutablePointer<Element> {
     return __bufferPointer._elementPointer
+  }
+
+  public var firstElementAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    return firstElementAddress
   }
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
@@ -464,7 +467,7 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// Two buffers address the same elements when they have the same
   /// identity and count.
   public var identity: UnsafePointer<Void> {
-    return withUnsafeBufferPointer { UnsafePointer($0.baseAddress) }
+    return UnsafePointer(firstElementAddress)
   }
   
   /// Returns `true` iff we have storage for elements of the given

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -272,6 +272,11 @@ internal struct _UnmanagedAnyObjectArray {
     self.value = UnsafeMutablePointer(up)
   }
 
+  internal init?(_ up: UnsafeMutablePointer<AnyObject>?) {
+    guard let unwrapped = up else { return nil }
+    self.init(unwrapped)
+  }
+
   internal subscript(i: Int) -> AnyObject {
     get {
       return _reinterpretCastToAnyObject(value[i])
@@ -1805,7 +1810,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
       let alignment = UInt(alignof(UInt))
       let alignMask = alignment &- UInt(1)
       return UnsafeMutablePointer<UInt>(
-          bitPattern:(start &+ alignMask) & ~alignMask)
+          bitPattern:(start &+ alignMask) & ~alignMask)!
     }
   }
 
@@ -1819,7 +1824,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
       let alignment = UInt(alignof(Key))
       let alignMask = alignment &- UInt(1)
       return UnsafeMutablePointer<Key>(
-          bitPattern:(start &+ alignMask) & ~alignMask)
+          bitPattern:(start &+ alignMask) & ~alignMask)!
     }
   }
 
@@ -1832,7 +1837,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
       let alignment = UInt(alignof(Value))
       let alignMask = alignment &- UInt(1)
       return UnsafeMutablePointer<Value>(
-          bitPattern:(start &+ alignMask) & ~alignMask)
+          bitPattern:(start &+ alignMask) & ~alignMask)!
     }
   }
 %end
@@ -2461,8 +2466,8 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
-  internal func countByEnumeratingWith(
-    _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+  internal func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
     objects: UnsafeMutablePointer<AnyObject>,
     count: Int
   ) -> Int {
@@ -2564,7 +2569,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
   @objc(copyWithZone:)
   @warn_unused_result
-  internal func copy(with zone: _SwiftNSZone) -> AnyObject {
+  internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // Instances of this class should be visible outside of standard library as
     // having `NSSet` type, which is immutable.
     return self
@@ -2601,7 +2606,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
   @objc(copyWithZone:)
   @warn_unused_result
-  internal func copy(with zone: _SwiftNSZone) -> AnyObject {
+  internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // Instances of this class should be visible outside of standard library as
     // having `NSDictionary` type, which is immutable.
     return self
@@ -2609,8 +2614,8 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
   @objc
   internal func getObjects(
-    _ objects: UnsafeMutablePointer<AnyObject>,
-    andKeys keys: UnsafeMutablePointer<AnyObject>
+    _ objects: UnsafeMutablePointer<AnyObject>?,
+    andKeys keys: UnsafeMutablePointer<AnyObject>?
   ) {
     bridgedAllKeysAndValues(objects, keys)
   }
@@ -2734,50 +2739,44 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   }
 
   internal func bridgedAllKeysAndValues(
-    _ objects: UnsafeMutablePointer<AnyObject>,
-    _ keys: UnsafeMutablePointer<AnyObject>
+    _ objects: UnsafeMutablePointer<AnyObject>?,
+    _ keys: UnsafeMutablePointer<AnyObject>?
   ) {
     bridgeEverything()
     // The user is expected to provide a buffer of the correct size
     var i = 0 // Position in the input buffer
-    var position = 0 // Position in the dictionary storage
     let capacity = bridgedNativeStorage.capacity
-    let unmanagedKeys = _UnmanagedAnyObjectArray(keys)
-    let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
 
-    if keys == nil {
-      if objects == nil {
-        // do nothing, both are null
-      } else {
-        // keys null, objects nonnull
-        while position < capacity {
+    if let unmanagedKeys = _UnmanagedAnyObjectArray(keys) {
+      if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
+        // keys nonnull, objects nonnull
+        for position in 0..<capacity {
           if bridgedNativeStorage.isInitializedEntry(at: position) {
             unmanagedObjects[i] = bridgedNativeStorage.value(at: position)
+            unmanagedKeys[i] = bridgedNativeStorage.key(at: position)
             i += 1
           }
-          position += 1
+        }
+      } else {
+        // keys nonnull, objects null
+        for position in 0..<capacity {
+          if bridgedNativeStorage.isInitializedEntry(at: position) {
+            unmanagedKeys[i] = bridgedNativeStorage.key(at: position)
+            i += 1
+          }
         }
       }
     } else {
-      if objects == nil {
-        // keys nonnull, objects null
-        while position < capacity {
-          if bridgedNativeStorage.isInitializedEntry(at: position) {
-            unmanagedKeys[i] = bridgedNativeStorage.key(at: position)
-            i += 1
-          }
-          position += 1
-        }
-      } else {
-        // keys nonnull, objects nonnull
-        while position < capacity {
+      if let unmanagedObjects = _UnmanagedAnyObjectArray(objects) {
+        // keys null, objects nonnull
+        for position in 0..<capacity {
           if bridgedNativeStorage.isInitializedEntry(at: position) {
             unmanagedObjects[i] = bridgedNativeStorage.value(at: position)
-            unmanagedKeys[i] = bridgedNativeStorage.key(at: position)
             i += 1
           }
-          position += 1
         }
+      } else {
+        // do nothing, both are null
       }
     }
   }
@@ -2811,9 +2810,9 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
-  internal func countByEnumeratingWith(
-    _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-    objects: UnsafeMutablePointer<AnyObject>,
+  internal func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?,
     count: Int
   ) -> Int {
     var theState = state.pointee
@@ -2823,7 +2822,15 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
       theState.extra.0 = CUnsignedLong(nativeStorage.startIndex.offset)
     }
-    let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
+
+    // Test 'objects' rather than 'count' because (a) this is very rare anyway,
+    // and (b) the optimizer should then be able to optimize away the
+    // unwrapping check below.
+    if _slowPath(objects == nil) {
+      return 0
+    }
+
+    let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
     var currIndex = _Native${Self}Index<${TypeParameters}>(
         nativeStorage: nativeStorage, offset: Int(theState.extra.0))
     let endIndex = nativeStorage.endIndex
@@ -3948,8 +3955,8 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
       // properties, because doing so might introduce a writeback buffer, but
       // fast enumeration relies on the pointer identity of the enumeration
       // state struct.
-      itemCount = cocoa${Self}.countByEnumeratingWith(
-        _fastEnumerationStatePtr,
+      itemCount = cocoa${Self}.countByEnumerating(
+        with: _fastEnumerationStatePtr,
         objects: UnsafeMutablePointer(_fastEnumerationStackBufPtr),
         count: stackBufCount)
       if itemCount == 0 {
@@ -3959,7 +3966,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
       itemIndex = 0
     }
     let itemsPtrUP: UnsafeMutablePointer<AnyObject> =
-      UnsafeMutablePointer(_fastEnumerationState.itemsPtr)
+      UnsafeMutablePointer(_fastEnumerationState.itemsPtr!)
     let itemsPtr = _UnmanagedAnyObjectArray(itemsPtrUP)
     let key: AnyObject = itemsPtr[itemIndex]
     itemIndex += 1

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -23,8 +23,8 @@ import SwiftShims
 /// will be replaced by Unicode [replacement characters](http://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character).
 @warn_unused_result
 public func readLine(strippingNewline: Bool = true) -> String? {
-  var linePtr: UnsafeMutablePointer<CChar> = nil
-  var readBytes = swift_stdlib_readLine_stdin(&linePtr)
+  var linePtrVar: UnsafeMutablePointer<CChar>? = nil
+  var readBytes = swift_stdlib_readLine_stdin(&linePtrVar)
   if readBytes == -1 {
     return nil
   }
@@ -33,6 +33,8 @@ public func readLine(strippingNewline: Bool = true) -> String? {
   if readBytes == 0 {
     return ""
   }
+
+  let linePtr = linePtrVar!
   if strippingNewline {
     // FIXME: Unicode conformance.  To fix this, we need to reimplement the
     // code we call above to get a line, since it will only stop on LF.

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -37,7 +37,7 @@ extension String {
     @noescape _ f: (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
     return try self.nulTerminatedUTF8.withUnsafeBufferPointer {
-      try f(UnsafePointer($0.baseAddress))
+      try f(UnsafePointer($0.baseAddress!))
     }
   }
 }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -115,7 +115,7 @@ func _typeByName(_ name: String) -> Any.Type? {
 
   let nameUTF8 = Array(name.utf8)
   return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
-    let type = _getTypeByMangledName(nameUTF8.baseAddress,
+    let type = _getTypeByMangledName(nameUTF8.baseAddress!,
                                      UInt(nameUTF8.endIndex))
 
     return type
@@ -139,7 +139,7 @@ func _stdlib_demangleName(_ mangledName: String) -> String {
     (mangledNameUTF8) in
     let (_, demangledName) = _withUninitializedString {
       _stdlib_demangleNameImpl(
-        mangledNameUTF8.baseAddress, UInt(mangledNameUTF8.endIndex),
+        mangledNameUTF8.baseAddress!, UInt(mangledNameUTF8.endIndex),
         $0)
     }
     return demangledName

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -83,10 +83,10 @@ public protocol CustomDebugStringConvertible {
 //===----------------------------------------------------------------------===//
 
 @_silgen_name("swift_EnumCaseName")
-func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>
+func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?
 
 @_silgen_name("swift_OpaqueSummary")
-func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>
+func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
 
 /// Do our best to print a value that cannot be printed directly.
 internal func _adHocPrint_unlocked<T, TargetStream : OutputStream>(
@@ -136,8 +136,8 @@ internal func _adHocPrint_unlocked<T, TargetStream : OutputStream>(
         }
         target.write(")")
       case .`enum`:
-        let cString = _getEnumCaseName(value)
-        if cString != nil, let caseName = String(validatingUTF8: cString) {
+        if let cString = _getEnumCaseName(value),
+            let caseName = String(validatingUTF8: cString) {
           // Write the qualified type name in debugPrint.
           if isDebugPrint {
             printTypeName(mirror.subjectType)
@@ -165,8 +165,8 @@ internal func _adHocPrint_unlocked<T, TargetStream : OutputStream>(
     printTypeName(metatypeValue)
   } else {
     // Fall back to the type or an opaque summary of the kind
-    let cString = _opaqueSummary(mirror.subjectType)
-    if cString != nil, let opaqueSummary = String(validatingUTF8: cString) {
+    if let cString = _opaqueSummary(mirror.subjectType),
+        let opaqueSummary = String(validatingUTF8: cString) {
       target.write(opaqueSummary)
     } else {
       target.write(_typeName(mirror.subjectType, qualified: true))
@@ -305,8 +305,8 @@ internal func _dumpPrint_unlocked<T, TargetStream : OutputStream>(
       return
     case .`enum`:
       target.write(_typeName(mirror.subjectType, qualified: true))
-      let cString = _getEnumCaseName(value)
-      if cString != nil, let caseName = String(validatingUTF8: cString) {
+      if let cString = _getEnumCaseName(value),
+          let caseName = String(validatingUTF8: cString) {
         target.write(".")
         target.write(caseName)
       }

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -42,7 +42,33 @@ func _convertInOutToPointerArgument<
   return ToPointer(from)
 }
 
+/// Derive a pointer argument from a value array parameter.
+///
+/// This always produces a non-null pointer, even if the array doesn't have any
+/// storage.
+@_transparent
+@warn_unused_result
+public // COMPILER_INTRINSIC
+func _convertConstArrayToPointerArgument<
+  FromElement,
+  ToPointer: _Pointer
+>(_ arr: [FromElement]) -> (AnyObject?, ToPointer) {
+  let (owner, opaquePointer) = arr._cPointerArgs()
+
+  let validPointer: ToPointer
+  if let addr = opaquePointer {
+    validPointer = ToPointer(addr._rawValue)
+  } else {
+    let lastAlignedValue = ~(alignof(FromElement.self) - 1)
+    let lastAlignedPointer = UnsafePointer<Void>(bitPattern: lastAlignedValue)!
+    validPointer = ToPointer(lastAlignedPointer._rawValue)
+  }
+  return (owner, validPointer)
+}
+
 /// Derive a pointer argument from an inout array parameter.
+///
+/// This always produces a non-null pointer, even if the array's length is 0.
 @_transparent
 @warn_unused_result
 public // COMPILER_INTRINSIC
@@ -57,19 +83,7 @@ func _convertMutableArrayToPointerArgument<
   a.reserveCapacity(0)
   _debugPrecondition(a._baseAddressIfContiguous != nil || a.isEmpty)
 
-  return (a._owner, ToPointer(a._baseAddressIfContiguous._rawValue))
-}
-
-/// Derive a pointer argument from a value array parameter.
-@_transparent
-@warn_unused_result
-public // COMPILER_INTRINSIC
-func _convertConstArrayToPointerArgument<
-  FromElement,
-  ToPointer : _Pointer
->(_ arr: [FromElement]) -> (AnyObject?, ToPointer) {
-  let (owner, raw) = arr._cPointerArgs()
-  return (owner, ToPointer(raw))
+  return _convertConstArrayToPointerArgument(a)
 }
 
 /// Derive a UTF-8 pointer argument from a value string parameter.
@@ -78,10 +92,6 @@ public // COMPILER_INTRINSIC
 func _convertConstStringToUTF8PointerArgument<
   ToPointer : _Pointer
 >(_ str: String) -> (AnyObject?, ToPointer) {
-  // Convert the UTF-8 representation to a null-terminated array.
-  var utf8 = Array(str.utf8)
-  utf8.append(0)
-  // Extract the owner and pointer from the array.
-  let (owner, raw) = utf8._cPointerArgs()
-  return (owner, ToPointer(raw))
+  let utf8 = Array(str.nulTerminatedUTF8)
+  return _convertConstArrayToPointerArgument(utf8)
 }

--- a/stdlib/public/core/Process.swift
+++ b/stdlib/public/core/Process.swift
@@ -23,11 +23,11 @@ public enum Process {
   /// with which the current process was invoked.
   internal static func _computeArguments() -> [String] {
     var result: [String] = []
+    let argv = unsafeArgv
     for i in 0..<Int(argc) {
-      let arg = unsafeArgv[i]
-      result.append(
-       arg == nil ? "" : String(cString: arg)
-      )
+      let arg = argv[i]!
+      let converted = String(cString: arg)
+      result.append(converted)
     }
     return result 
   }
@@ -37,7 +37,7 @@ public enum Process {
 
   @_versioned
   internal static var _unsafeArgv:
-    UnsafeMutablePointer<UnsafeMutablePointer<Int8>>
+    UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?
     = nil
 
   /// Access to the raw argc value from C.
@@ -48,8 +48,8 @@ public enum Process {
   /// Access to the raw argv value from C. Accessing the argument vector
   /// through this pointer is unsafe.
   public static var unsafeArgv:
-    UnsafeMutablePointer<UnsafeMutablePointer<Int8>> {
-    return _unsafeArgv
+    UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> {
+    return _unsafeArgv!
   }
 
   /// Access to the swift arguments, also use lazy initialization of static
@@ -78,10 +78,10 @@ public enum Process {
 @_transparent
 public // COMPILER_INTRINSIC
 func _stdlib_didEnterMain(
-  argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>>
+  argc: Int32, argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
 ) {
   // Initialize the Process.argc and Process.unsafeArgv variables with the
   // values that were passed in to main.
   Process._argc = CInt(argc)
-  Process._unsafeArgv = UnsafeMutablePointer(argv)
+  Process._unsafeArgv = argv
 }

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -24,13 +24,17 @@ import SwiftShims
 @warn_unused_result
 public // @testable
 func _stdlib_atomicCompareExchangeStrongPtrImpl(
-  object target: UnsafeMutablePointer<OpaquePointer>,
-  expected: UnsafeMutablePointer<OpaquePointer>,
-  desired: OpaquePointer) -> Bool {
+  object target: UnsafeMutablePointer<OpaquePointer?>,
+  expected: UnsafeMutablePointer<OpaquePointer?>,
+  desired: OpaquePointer?) -> Bool {
 
-  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_RawPointer(
-    target._rawValue, expected.pointee._rawValue, desired._rawValue)
-  expected.pointee._rawValue = oldValue
+  // Bit-cast directly from 'OpaquePointer?' to 'Builtin.Word' because
+  // Builtin.RawPointer can't be nil.
+  let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+    target._rawValue,
+    unsafeBitCast(expected.pointee, to: Builtin.Word.self),
+    unsafeBitCast(desired, to: Builtin.Word.self))
+  expected.pointee = OpaquePointer(bitPattern: Int(oldValue))
   return Bool(won)
 }
 
@@ -79,7 +83,7 @@ public // @testable
 func _stdlib_atomicInitializeARCRef(
   object target: UnsafeMutablePointer<AnyObject?>,
   desired: AnyObject) -> Bool {
-  var expected: OpaquePointer = nil
+  var expected: OpaquePointer? = nil
   let desiredPtr = OpaquePointer(bitPattern: Unmanaged.passRetained(desired))
   let wonRace = _stdlib_atomicCompareExchangeStrongPtrImpl(
     object: UnsafeMutablePointer(target),
@@ -236,9 +240,9 @@ public func _swift_stdlib_atomicLoadInt(
 public // @testable
 func _swift_stdlib_atomicLoadPtrImpl(
   object target: UnsafeMutablePointer<OpaquePointer>
-) -> OpaquePointer {
-  let value = Builtin.atomicload_seqcst_RawPointer(target._rawValue)
-  return OpaquePointer(value)
+) -> OpaquePointer? {
+  let value = Builtin.atomicload_seqcst_Word(target._rawValue)
+  return OpaquePointer(bitPattern: Int(value))
 }
 
 @_transparent
@@ -249,8 +253,8 @@ func _stdlib_atomicLoadARCRef(
 ) -> AnyObject? {
   let result = _swift_stdlib_atomicLoadPtrImpl(
     object: UnsafeMutablePointer(target))
-  if result != nil {
-    return Unmanaged<AnyObject>.fromOpaque(result).takeUnretainedValue()
+  if let unwrapped = result {
+    return Unmanaged<AnyObject>.fromOpaque(unwrapped).takeUnretainedValue()
   }
   return nil
 }

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -30,9 +30,9 @@ public protocol _ShadowProtocol {}
 @objc
 public protocol _NSFastEnumeration : _ShadowProtocol {
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumeratingWith(
-    _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-    objects: UnsafeMutablePointer<AnyObject>, count: Int
+  func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int
 }
 
@@ -50,7 +50,7 @@ public typealias _SwiftNSZone = OpaquePointer
 @objc
 public protocol _NSCopying : _ShadowProtocol {
   @objc(copyWithZone:)
-  func copy(with zone: _SwiftNSZone) -> AnyObject
+  func copy(with zone: _SwiftNSZone?) -> AnyObject
 }
 
 /// A shadow for the "core operations" of NSArray.
@@ -67,9 +67,9 @@ public protocol _NSArrayCore :
   func getObjects(_: UnsafeMutablePointer<AnyObject>, range: _SwiftNSRange)
 
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumeratingWith(
-         _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-         objects: UnsafeMutablePointer<AnyObject>, count: Int
+  func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int
 
   var count: Int { get }
@@ -101,15 +101,15 @@ public protocol _NSDictionaryCore :
   // We also override the following methods for efficiency.
 
   @objc(copyWithZone:)
-  func copy(with zone: _SwiftNSZone) -> AnyObject
+  func copy(with zone: _SwiftNSZone?) -> AnyObject
 
-  func getObjects(_ objects: UnsafeMutablePointer<AnyObject>,
-    andKeys keys: UnsafeMutablePointer<AnyObject>)
+  func getObjects(_ objects: UnsafeMutablePointer<AnyObject>?,
+    andKeys keys: UnsafeMutablePointer<AnyObject>?)
 
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumeratingWith(
-    _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-    objects: UnsafeMutablePointer<AnyObject>, count: Int
+  func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int
 }
 
@@ -125,9 +125,9 @@ public protocol _NSDictionaryCore :
 public protocol _NSDictionary : _NSDictionaryCore {
   // Note! This API's type is different from what is imported by the clang
   // importer.
-  func getObjects(_ objects: UnsafeMutablePointer<AnyObject>,
-      andKeys keys: UnsafeMutablePointer<AnyObject>)
-}
+  func getObjects(_ objects: UnsafeMutablePointer<AnyObject>?,
+      andKeys keys: UnsafeMutablePointer<AnyObject>?)
+    }
 
 /// A shadow for the "core operations" of NSSet.
 ///
@@ -150,12 +150,12 @@ public protocol _NSSetCore :
   // We also override the following methods for efficiency.
 
   @objc(copyWithZone:)
-  func copy(with zone: _SwiftNSZone) -> AnyObject
+  func copy(with zone: _SwiftNSZone?) -> AnyObject
 
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumeratingWith(
-    _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-    objects: UnsafeMutablePointer<AnyObject>, count: Int
+  func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int
 }
 

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -124,6 +124,10 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol {
     return subscriptBaseAddress + startIndex
   }
 
+  public var firstElementAddressIfContiguous: UnsafeMutablePointer<Element>? {
+    return firstElementAddress
+  }
+
   /// [63:1: 63-bit index][0: has a native buffer]
   var endIndexAndFlags: UInt
 
@@ -341,7 +345,8 @@ extension _SliceBuffer {
     let result = _ContiguousArrayBuffer<Element>(
       uninitializedCount: count,
       minimumCapacity: 0)
-    result.firstElementAddress.initializeFrom(firstElementAddress, count: count)
+    result.firstElementAddress.initializeFrom(
+      firstElementAddress, count: count)
     return result
   }
 }

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -31,7 +31,7 @@ struct _StringBufferIVars {
 
   // This stored property should be stored at offset zero.  We perform atomic
   // operations on it using _HeapBuffer's pointer.
-  var usedEnd: UnsafeMutablePointer<_RawByte>
+  var usedEnd: UnsafeMutablePointer<_RawByte>?
 
   var capacityAndElementShift: Int
   var byteCapacity: Int {
@@ -145,7 +145,7 @@ public struct _StringBuffer {
   /// A past-the-end pointer for this buffer's stored data.
   var usedEnd: UnsafeMutablePointer<_RawByte> {
     get {
-      return _storage.value.usedEnd
+      return _storage.value.usedEnd!
     }
     set(newValue) {
       _storage.value.usedEnd = newValue

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -44,7 +44,7 @@ extension _StringCore {
         size: numericCast(utf16Count))
 
       return (i + utf16Count, result)
-    } else if _fastPath(!_baseAddress._isNull) {
+    } else if _fastPath(_baseAddress != nil) {
       return _encodeSomeContiguousUTF16AsUTF8(from: i)
     } else {
 #if _runtime(_ObjC)
@@ -60,7 +60,7 @@ extension _StringCore {
   @warn_unused_result
   func _encodeSomeContiguousUTF16AsUTF8(from i: Int) -> (Int, _UTF8Chunk) {
     _sanityCheck(elementWidth == 2)
-    _sanityCheck(!_baseAddress._isNull)
+    _sanityCheck(_baseAddress != nil)
 
     let storage = UnsafeBufferPointer(start: startUTF16, count: self.count)
     return _transcodeSomeUTF16AsUTF8(storage, i)
@@ -72,7 +72,7 @@ extension _StringCore {
   @warn_unused_result
   func _encodeSomeNonContiguousUTF16AsUTF8(from i: Int) -> (Int, _UTF8Chunk) {
     _sanityCheck(elementWidth == 2)
-    _sanityCheck(_baseAddress._isNull)
+    _sanityCheck(_baseAddress == nil)
 
     let storage = _CollectionOf<Int, UInt16>(
       startIndex: 0, endIndex: self.count) {
@@ -248,7 +248,7 @@ extension String {
     }
   }
 
-  public var _contiguousUTF8: UnsafeMutablePointer<UTF8.CodeUnit> {
+  public var _contiguousUTF8: UnsafeMutablePointer<UTF8.CodeUnit>? {
     return _core.elementWidth == 1 ? _core.startASCII : nil
   }
 

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -80,18 +80,20 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
           range.location + range.length, count: objects.count),
         "Array index out of range")
 
+      if objects.isEmpty { return }
+
       // These objects are "returned" at +0, so treat them as values to
       // avoid retains.
       UnsafeMutablePointer<Int>(aBuffer).initializeFrom(
-        UnsafeMutablePointer(objects.baseAddress + range.location),
+        UnsafeMutablePointer(objects.baseAddress! + range.location),
         count: range.length)
     }
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
-  internal func countByEnumeratingWith(
-    _ state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-    objects: UnsafeMutablePointer<AnyObject>, count: Int
+  internal func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int {
     var enumerationState = state.pointee
 
@@ -102,9 +104,8 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
     return withUnsafeBufferOfObjects {
       objects in
       enumerationState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      enumerationState.itemsPtr = unsafeBitCast(
-        objects.baseAddress,
-        to: AutoreleasingUnsafeMutablePointer<AnyObject?>.self)
+      enumerationState.itemsPtr =
+        AutoreleasingUnsafeMutablePointer(objects.baseAddress)
       enumerationState.state = 1
       state.pointee = enumerationState
       return objects.count
@@ -112,7 +113,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
   }
 
   @objc(copyWithZone:)
-  internal func copy(with _: _SwiftNSZone) -> AnyObject {
+  internal func copy(with _: _SwiftNSZone?) -> AnyObject {
     return self
   }
 }

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -31,12 +31,6 @@ public struct Unmanaged<Instance : AnyObject> {
   @_transparent
   @warn_unused_result
   public static func fromOpaque(_ value: OpaquePointer) -> Unmanaged {
-    // Null pointer check is a debug check, because it guards only against one
-    // specific bad pointer value.
-    _debugPrecondition(
-      value != nil,
-      "attempt to create an Unmanaged instance from a null pointer")
-
     return Unmanaged(_private: unsafeBitCast(value, to: Instance.self))
   }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -20,12 +20,12 @@ public struct UnsafeBufferPointerIterator<Element>
   public mutating func next() -> Element? {
     if _position == _end { return nil }
 
-    let result = _position.pointee
-    _position += 1
+    let result = _position!.pointee
+    _position! += 1
     return result
   }
 
-  internal var _position, _end: UnsafePointer<Element>
+  internal var _position, _end: UnsafePointer<Element>?
 }
 
 %for Mutable in ('Mutable', ''):
@@ -49,7 +49,7 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   /// reachable from `startIndex` by zero or more applications of
   /// `successor()`.
   public var endIndex: Int {
-    return _end - _position
+    return count
   }
 
   /// Access the `i`th element in the buffer.
@@ -57,24 +57,30 @@ public struct Unsafe${Mutable}BufferPointer<Element>
     get {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      return _position[i]
+      return _position![i]
     }
 %if Mutable:
     nonmutating set {
       _debugPrecondition(i >= 0)
       _debugPrecondition(i < endIndex)
-      _position[i] = newValue
+      _position![i] = newValue
     }
 %end
   }
 
   /// Construct an Unsafe${Mutable}Pointer over the `count` contiguous
   /// `Element` instances beginning at `start`.
-  public init(start: Unsafe${Mutable}Pointer<Element>, count: Int) {
+  ///
+  /// If `start` is nil, `count` must be 0. However, `count` may be 0 even for
+  /// a nonzero `start`.
+  public init(start: Unsafe${Mutable}Pointer<Element>?, count: Int) {
     _precondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
+    _precondition(
+      count == 0 || start != nil,
+      "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     _position = start
-    _end = start + count
+    _end = start.map { $0 + count }
   }
 
   /// Returns an iterator over the elements of this sequence.
@@ -85,23 +91,27 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   }
 
   /// A pointer to the first element of the buffer.
-  public var baseAddress: Unsafe${Mutable}Pointer<Element> {
+  public var baseAddress: Unsafe${Mutable}Pointer<Element>? {
     return _position
   }
 
   /// The number of elements in the buffer.
   public var count: Int {
-    return _end - _position
+    if _position == nil {
+      _sanityCheck(_end == nil)
+      return 0
+    }
+    return _end! - _position!
   }
 
-  let _position, _end: Unsafe${Mutable}Pointer<Element>
+  let _position, _end: Unsafe${Mutable}Pointer<Element>?
 }
 
 extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
   /// A textual representation of `self`, suitable for debugging.
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
-    + "(start: \(_position), count: \(_end - _position))"
+      + "(start: \(_position.map(String.init(_:)) ?? "nil"), count: \(count))"
   }
 }
 %end

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -33,8 +33,7 @@
 /// - Memory is allocated and value is initialized.
 @_fixed_layout
 public struct ${Self}<Pointee>
-  : RandomAccessIndex, Hashable,
-    NilLiteralConvertible, _Pointer {
+  : RandomAccessIndex, Hashable, _Pointer {
 
   public typealias Distance = Int
 
@@ -49,19 +48,30 @@ public struct ${Self}<Pointee>
 
   /// Convert from an opaque pointer to a typed pointer.
   @_transparent
-  public init(_ other : OpaquePointer) {
-    _rawValue = other._rawValue
+  public init(_ from : OpaquePointer) {
+    _rawValue = from._rawValue
+  }
+
+  /// Convert from an opaque pointer to a typed pointer.
+  ///
+  /// Returns nil if `from` is nil.
+  @_transparent
+  public init?(_ from : OpaquePointer?) {
+    guard let unwrapped = from else { return nil }
+    self.init(unwrapped)
   }
 
   /// Construct ${a_Self} with a given pattern of bits.
   @_transparent
-  public init(bitPattern: Int) {
+  public init?(bitPattern: Int) {
+    if bitPattern == 0 { return nil }
     self._rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
   /// Construct ${a_Self} with a given pattern of bits.
   @_transparent
-  public init(bitPattern: UInt) {
+  public init?(bitPattern: UInt) {
+    if bitPattern == 0 { return nil }
     self._rawValue = Builtin.inttoptr_Word(bitPattern._builtinWordValue)
   }
 
@@ -75,6 +85,19 @@ public struct ${Self}<Pointee>
     _rawValue = from._rawValue
   }
 
+  /// Convert from any `UnsafeMutablePointer`, possibly with a
+  /// different `Pointee`.
+  ///
+  /// Returns nil if `from` is nil.
+  ///
+  /// - Warning: the behavior of accesses to pointee as a type
+  ///   different from that to which it was initialized is undefined.
+  @_transparent
+  public init?<U>(_ from : UnsafeMutablePointer<U>?) {
+    guard let unwrapped = from else { return nil }
+    self.init(unwrapped)
+  }
+
   /// Convert from any `UnsafePointer`, possibly with a
   /// different `Pointee`.
   ///
@@ -85,10 +108,17 @@ public struct ${Self}<Pointee>
     _rawValue = from._rawValue
   }
 
-  /// Create an instance initialized with `nil`.
+  /// Convert from any `UnsafePointer`, possibly with a
+  /// different `Pointee`.
+  ///
+  /// Returns nil if `from` is nil.
+  ///
+  /// - Warning: the behavior of accesses to pointee as a type
+  ///   different from that to which it was initialized is undefined.
   @_transparent
-  public init(nilLiteral: ()) {
-    self._rawValue = _nilRawPointer
+  public init?<U>(_ from : UnsafePointer<U>?) {
+    guard let unwrapped = from else { return nil }
+    self.init(unwrapped)
   }
 
 %  if mutable:
@@ -367,11 +397,6 @@ public struct ${Self}<Pointee>
   }
 %  end
 
-  @_transparent public
-  var _isNull : Bool {
-    return self == nil
-  }
-
   /// Access the pointee at `self + i`.
   ///
   /// - Precondition: the pointee at `self + i` is initialized.
@@ -392,40 +417,6 @@ public struct ${Self}<Pointee>
     }
 %  end
   }
-
-% if mutable:
-  /// If self was converted from `nil`, writes the result of invoking body into
-  /// the pointee.
-  public // SPI(Foundation)
-  func _setIfNonNil(@noescape _ body: () -> Pointee) {
-    if self != nil {
-      pointee = body()
-    }
-  }
-
-#if _runtime(_ObjC)
-  /// Returns the result of invoking body.  If self was converted from
-  /// `nil`, passes `nil` as the argument.  Otherwise, passes the address
-  /// of a `Pointee` which is written into buffer before this method returns.
-  @_transparent public
-  func _withBridgeObject<U : AnyObject, R>(
-    _ buffer: inout U?,
-  @noescape body: AutoreleasingUnsafeMutablePointer<U?> -> R
-  ) -> R {
-    return self != nil ? body(&buffer) : body(nil)
-  }
-#endif
-
-  /// Returns the result of invoking body.  If self was converted from
-  /// `nil`, passes `nil` as the argument.  Otherwise, passes the address
-  /// of buffer.
-  @_transparent public
-  func _withBridgeValue<U, R>(
-    _ buffer: inout U, @noescape body: UnsafeMutablePointer<U> -> R
-  ) -> R {
-    return self != nil ? body(&buffer) : body(nil)
-  }
-% end
 
   //
   // Protocol conformance

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -74,6 +74,10 @@ const ValueWitnessTable swift::_TWVXwGSqBo_ =
 const ExtraInhabitantsValueWitnessTable swift::_TWVMBo =
   ValueWitnessTableForBox<PointerPointerBox>::table;
 
+/// The value-witness table for raw pointers.
+const ExtraInhabitantsValueWitnessTable swift::_TWVBp =
+  ValueWitnessTableForBox<RawPointerBox>::table;
+
 /// The value-witness table for BridgeObject.
 const ExtraInhabitantsValueWitnessTable swift::_TWVBb =
   ValueWitnessTableForBox<BridgeObjectBox>::table;
@@ -153,6 +157,7 @@ OPAQUE_METADATA(Bi128_)
 OPAQUE_METADATA(Bi256_)
 OPAQUE_METADATA(Bo)
 OPAQUE_METADATA(Bb)
+OPAQUE_METADATA(Bp)
 OPAQUE_METADATA(BB)
 #if SWIFT_OBJC_INTEROP
 OPAQUE_METADATA(BO)

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -519,6 +519,22 @@ struct PointerPointerBox : NativeBox<void**> {
   }
 };
 
+/// A box implementation class for raw pointers.
+///
+/// Note that this is used for imported `void * _Nonnull`, which may include
+/// reinterpret_cast-ed integers, so we only get NULL as an extra inhabitant.
+struct RawPointerBox : NativeBox<void*> {
+  static constexpr unsigned numExtraInhabitants = 1;
+
+  static void storeExtraInhabitant(void **dest, int index) {
+    *dest = nullptr;
+  }
+
+  static int getExtraInhabitantIndex(void* const *src) {
+    return *src == nullptr ? 0 : -1;
+  }
+};
+
 /// A box implementation class for unmanaged function pointers.
 /// @convention(thin) functions have this layout, as do the first elements of
 /// Swift thick functions.

--- a/test/1_stdlib/AssetsLibrary.swift
+++ b/test/1_stdlib/AssetsLibrary.swift
@@ -9,7 +9,7 @@ import AssetsLibrary
 
 let library = ALAssetsLibrary()
 library.enumerateGroupsWithTypes(ALAssetsGroupAll,
-  usingBlock: {(group: ALAssetsGroup!, stop: UnsafeMutablePointer<ObjCBool>) -> Void in
+  usingBlock: {(group: ALAssetsGroup!, stop: UnsafeMutablePointer<ObjCBool>!) -> Void in
                 print("Swift usingBlock")},
   failureBlock: {(error: NSError!) -> Void in
                   print("Swift failureBlock")})

--- a/test/1_stdlib/BridgeNonVerbatim.swift
+++ b/test/1_stdlib/BridgeNonVerbatim.swift
@@ -133,7 +133,7 @@ func testScope() {
     // FIXME: Can't elide signature and use $0 here <rdar://problem/17770732> 
     (buf: inout UnsafeMutableBufferPointer<Int>) -> () in
     nsx.getObjects(
-      UnsafeMutablePointer<AnyObject>(buf.baseAddress),
+      UnsafeMutablePointer<AnyObject>(buf.baseAddress!),
       range: _SwiftNSRange(location: 1, length: 2))
   }
 

--- a/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -92,7 +92,7 @@ class TestObjCKeyTy : NSObject, NSCopying {
   }
 
   @objc(copyWithZone:)
-  func copy(with zone: NSZone) -> AnyObject {
+  func copy(with zone: NSZone?) -> AnyObject {
     return TestObjCKeyTy(value)
   }
 
@@ -491,12 +491,12 @@ import SlurpFastEnumeration
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEqual(nil, state.mutationsPtr)
+    expectNotEmpty(state.mutationsPtr)
     if returnedCount == 0 {
       break
     }
     for i in 0..<returnedCount {
-      let value: AnyObject = state.itemsPtr[i]!
+      let value: AnyObject = state.itemsPtr![i]!
       sink(value)
       itemsReturned += 1
     }
@@ -510,7 +510,7 @@ import SlurpFastEnumeration
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEqual(nil, state.mutationsPtr)
+    expectNotEmpty(state.mutationsPtr)
     expectEqual(0, returnedCount)
   }
 }
@@ -533,12 +533,12 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEqual(nil, state.mutationsPtr)
+    expectNotEmpty(state.mutationsPtr)
     if returnedCount == 0 {
       break
     }
     for i in 0..<returnedCount {
-      let key: AnyObject = state.itemsPtr[i]!
+      let key: AnyObject = state.itemsPtr![i]!
       let value: AnyObject = d.object(forKey: key)!
       let kv = (key, value)
       sink(kv)
@@ -743,12 +743,12 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEqual(nil, state.mutationsPtr)
+    expectNotEmpty(state.mutationsPtr)
     if returnedCount == 0 {
       break
     }
     for i in 0..<returnedCount {
-      let value: AnyObject = state.itemsPtr[i]!
+      let value: AnyObject = state.itemsPtr![i]!
       sink(value)
       itemsReturned += 1
     }
@@ -762,7 +762,7 @@ typealias AnyObjectTuple2 = (AnyObject, AnyObject)
       with: &state, objects: AutoreleasingUnsafeMutablePointer(stackBuf.baseAddress),
       count: stackBufLength)
     expectNotEqual(0, state.state)
-    expectNotEqual(nil, state.mutationsPtr)
+    expectNotEmpty(state.mutationsPtr)
     expectEqual(0, returnedCount)
   }
 }

--- a/test/1_stdlib/KVO.swift
+++ b/test/1_stdlib/KVO.swift
@@ -53,7 +53,7 @@ class Observer : NSObject {
   override func observeValue(forKeyPath forKeyPath:String?,
                              of obj:AnyObject?,
                              change:Dictionary<String, AnyObject>?,
-                             context:UnsafeMutablePointer<Void>) {
+                             context:UnsafeMutablePointer<Void>?) {
     target!.print()
   }
 }
@@ -102,7 +102,7 @@ class ObserverKVO : NSObject {
   override func observeValue(forKeyPath forKeyPath:String?,
                              of obj:AnyObject?,
                              change:Dictionary<String, AnyObject>?,
-                             context:UnsafeMutablePointer<Void>) {
+                             context:UnsafeMutablePointer<Void>?) {
     if context == &kvoContext {
       target!.print()
     }

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -33,7 +33,7 @@ class NonContiguousNSString : NSString {
     super.init()
   }
 
-  @objc(copyWithZone:) override func copy(with zone: NSZone) -> AnyObject {
+  @objc(copyWithZone:) override func copy(with zone: NSZone?) -> AnyObject {
     // Ensure that copying this string produces a class that CoreFoundation
     // does not know about.
     return self

--- a/test/1_stdlib/NewArray.swift.gyb
+++ b/test/1_stdlib/NewArray.swift.gyb
@@ -80,7 +80,7 @@ func printSequence<T : Sequence>(_ x: T) {
   print("]")
 }
 
-typealias BufferID = UnsafePointer<Void>
+typealias BufferID = UnsafePointer<Void>?
 
 func bufferID<T : _ArrayProtocol>(_ x: T) -> BufferID {
   return x._buffer.identity
@@ -225,7 +225,7 @@ func nsArrayOfStrings() -> Array<NSString> {
   let src: ContiguousArray<NSString> = ["foo", "bar", "baz"]
 
   return src.withUnsafeBufferPointer {
-    let ns =  NSArray(objects: UnsafePointer($0.baseAddress), count: $0.count)
+    let ns =  NSArray(objects: UnsafePointer($0.baseAddress!), count: $0.count)
     return ns as! [NSString]
   }
 }

--- a/test/1_stdlib/Nil.swift
+++ b/test/1_stdlib/Nil.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-let opaqueNil: OpaquePointer = nil
+let opaqueNil: OpaquePointer? = nil
 if opaqueNil == nil {
   print("ok opaqueNil == nil")
   // CHECK: ok opaqueNil == nil
@@ -18,8 +18,8 @@ if opaqueNil != nil {
   // CHECK: ok opaqueNil != nil is false
 }
 
-let unsafeNil: UnsafeMutablePointer<Int> = nil
-if unsafeNil == (nil as UnsafeMutablePointer<Int>) {
+let unsafeNil: UnsafeMutablePointer<Int>? = nil
+if unsafeNil == nil {
   print("ok unsafeNil == (nil as UnsafeMutablePointer<Int>)")
   // CHECK: ok unsafeNil == (nil as UnsafeMutablePointer<Int>)
 }
@@ -31,7 +31,7 @@ do {
   // CHECK: ok !removed
 }
 
-var selNil: Selector = nil
+var selNil: Selector? = nil
 if selNil == nil { 
   print("ok selNil == nil")
   // CHECK: ok selNil == nil

--- a/test/1_stdlib/PrintPointer.swift
+++ b/test/1_stdlib/PrintPointer.swift
@@ -6,36 +6,35 @@ import StdlibUnittest
 
 let PrintTests = TestSuite("PrintPointer")
 PrintTests.test("Printable") {
-  let nullUP: UnsafeMutablePointer<Float> = nil
-  let fourByteUP = UnsafeMutablePointer<Float>(bitPattern: 0xabcd1234 as UInt)
+  let lowUP = UnsafeMutablePointer<Float>(bitPattern: 0x1)!
+  let fourByteUP = UnsafeMutablePointer<Float>(bitPattern: 0xabcd1234 as UInt)!
   
 #if !(arch(i386) || arch(arm))
   let eightByteAddr: UInt = 0xabcddcba12344321
-  let eightByteUP = UnsafeMutablePointer<Float>(bitPattern: eightByteAddr)
+  let eightByteUP = UnsafeMutablePointer<Float>(bitPattern: eightByteAddr)!
 #endif
   
 #if arch(i386) || arch(arm)
-  let expectedNull = "0x00000000"
+  let expectedLow = "0x00000001"
   expectPrinted("0xabcd1234", fourByteUP)
 #else
-  let expectedNull = "0x0000000000000000"
+  let expectedLow = "0x0000000000000001"
   expectPrinted("0x00000000abcd1234", fourByteUP)
   expectPrinted("0xabcddcba12344321", eightByteUP)
 #endif
   
-  expectPrinted(expectedNull, nullUP)
+  expectPrinted(expectedLow, lowUP)
   
-  expectPrinted("UnsafeBufferPointer(start: \(expectedNull), count: 0)",
-    UnsafeBufferPointer(start: nullUP, count: 0))
-  expectPrinted("UnsafeMutableBufferPointer(start: \(expectedNull), count: 0)",
-    UnsafeMutableBufferPointer(start: nullUP, count: 0))
+  expectPrinted("UnsafeBufferPointer(start: \(fourByteUP), count: 0)",
+    UnsafeBufferPointer(start: fourByteUP, count: 0))
+  expectPrinted("UnsafeMutableBufferPointer(start: \(fourByteUP), count: 0)",
+    UnsafeMutableBufferPointer(start: fourByteUP, count: 0))
   
-  let nullOpaque: OpaquePointer = nil
-  expectPrinted(expectedNull, nullOpaque)
-  expectPrinted(expectedNull, CVaListPointer(_fromUnsafeMutablePointer: nullUP))
+  let lowOpaque = OpaquePointer(lowUP)
+  expectPrinted(expectedLow, lowOpaque)
 #if _runtime(_ObjC)
-  let nullAutoUP: AutoreleasingUnsafeMutablePointer<Int> = nil
-  expectPrinted(expectedNull, nullAutoUP)
+  let lowAutoUP = AutoreleasingUnsafeMutablePointer<Int>(lowUP)
+  expectPrinted(expectedLow, lowAutoUP)
 #endif
 }
 

--- a/test/1_stdlib/Reflection.swift
+++ b/test/1_stdlib/Reflection.swift
@@ -191,15 +191,14 @@ dump(emptyCollectionOfInt)
 // CHECK-NEXT: by: 3.14
 dump(stride(from: 1.0, through: 12.15, by: 3.14))
 
-// CHECK-NEXT: 0x0000
-// CHECK-NEXT: - pointerValue: 0
-var nilUnsafeMutablePointerString: UnsafeMutablePointer<String> = nil
+// CHECK-NEXT: nil
+var nilUnsafeMutablePointerString: UnsafeMutablePointer<String>? = nil
 dump(nilUnsafeMutablePointerString)
 
 // CHECK-NEXT: 123456
 // CHECK-NEXT: - pointerValue: 1193046
 var randomUnsafeMutablePointerString = UnsafeMutablePointer<String>(
-  bitPattern: 0x123456)
+  bitPattern: 0x123456)!
 dump(randomUnsafeMutablePointerString)
 
 // CHECK-NEXT: Hello panda

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -329,9 +329,9 @@ Runtime.test("demangleName") {
 
 Runtime.test("_stdlib_atomicCompareExchangeStrongPtr") {
   typealias IntPtr = UnsafeMutablePointer<Int>
-  var origP1 = IntPtr(bitPattern: 0x10101010)
-  var origP2 = IntPtr(bitPattern: 0x20202020)
-  var origP3 = IntPtr(bitPattern: 0x30303030)
+  var origP1 = IntPtr(bitPattern: 0x10101010)!
+  var origP2 = IntPtr(bitPattern: 0x20202020)!
+  var origP3 = IntPtr(bitPattern: 0x30303030)!
 
   do {
     var object = origP1
@@ -1360,10 +1360,9 @@ Reflection.test("MirrorMirror") {
 
 Reflection.test("OpaquePointer/null") {
   // Don't crash on null pointers. rdar://problem/19708338
-  var sequence: OpaquePointer = nil
-  var mirror = Mirror(reflecting: sequence)
-  var child = mirror.children.first!
-  expectEqual("(Opaque Value)", "\(child.1)")
+  let pointer: OpaquePointer? = nil
+  let mirror = Mirror(reflecting: pointer)
+  expectEqual(0, mirror.children.count)
 }
 
 Reflection.test("StaticString/Mirror") {

--- a/test/1_stdlib/StringAPI.swift
+++ b/test/1_stdlib/StringAPI.swift
@@ -318,7 +318,7 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
 
 var CStringTests = TestSuite("CStringTests")
 
-func getNullCString() -> UnsafeMutablePointer<CChar> {
+func getNullCString() -> UnsafeMutablePointer<CChar>? {
   return nil
 }
 

--- a/test/1_stdlib/Unicode.swift
+++ b/test/1_stdlib/Unicode.swift
@@ -24,11 +24,11 @@ UnicodeInternals.test("copy") {
 
   u16.withUnsafeMutableBufferPointer {
     (u16) -> () in
-    let p16 = u16.baseAddress
+    let p16 = u16.baseAddress!
 
     u8.withUnsafeMutableBufferPointer {
       (u8) -> () in
-      let p8 = u8.baseAddress
+      let p8 = u8.baseAddress!
 
       UTF16._copy(source: p8, destination: p16, count: 3)
       expectEqual([ 0, 1, 2, 9, 10, 11 ], Array(u16))

--- a/test/1_stdlib/Unmanaged.swift
+++ b/test/1_stdlib/Unmanaged.swift
@@ -15,17 +15,6 @@ extension Unmanaged where Instance : TestProtocol1 {
 
 var UnmanagedTests = TestSuite("Unmanaged")
 
-UnmanagedTests.test("fromOpaque()/trap")
-  .skip(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "init(bitPattern:) does a _debugPrecondition() for null pointers"))
-  .code {
-  let null: OpaquePointer = getPointer(nil)
-  expectCrashLater()
-  let unmanaged = Unmanaged<AnyObject>.fromOpaque(null)
-  _blackHole(unmanaged)
-}
-
 class FooClass {}
 
 UnmanagedTests.test("unsafeBitCast(Unmanaged, Int)") {

--- a/test/1_stdlib/UnsafeBufferPointer.swift.gyb
+++ b/test/1_stdlib/UnsafeBufferPointer.swift.gyb
@@ -1,0 +1,135 @@
+// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/UnsafeBufferPointer.swift
+// RUN: %S/../../utils/line-directive %t/UnsafeBufferPointer.swift -- %target-build-swift %t/UnsafeBufferPointer.swift -o %t/a.out
+// RUN: %S/../../utils/line-directive %t/UnsafeBufferPointer.swift -- %target-run %t/a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+// Also import modules which are used by StdlibUnittest internally. This
+// workaround is needed to link all required libraries in case we compile
+// StdlibUnittest with -sil-serialize-all.
+import SwiftPrivate
+#if _runtime(_ObjC)
+import ObjectiveC
+#endif
+
+var UnsafeBufferPointerTestSuite = TestSuite("UnsafeBufferPointer")
+var UnsafeMutableBufferPointerTestSuite = TestSuite("UnsafeMutableBufferPointer")
+
+% for (SelfName, SelfType, PointerType) in [
+%         ('UnsafeBufferPointer', 'UnsafeBufferPointer<Float>', 'UnsafePointer<Float>'),
+%         ('UnsafeMutableBufferPointer', 'UnsafeMutableBufferPointer<Float>', 'UnsafeMutablePointer<Float>')]:
+
+${SelfName}TestSuite.test("nilBaseAddress") {
+  let emptyBuffer = ${SelfType}(start: nil, count: 0)
+  expectEmpty(emptyBuffer.baseAddress)
+  expectEqual(0, emptyBuffer.count)
+  expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
+
+  var iter = emptyBuffer.makeIterator()
+  expectEmpty(iter.next())
+
+  expectEqual([], Array(emptyBuffer))
+}
+
+${SelfName}TestSuite.test("nonNilButEmpty") {
+  let emptyAllocated = UnsafeMutablePointer<Float>(allocatingCapacity: 0)
+  defer { emptyAllocated.deallocateCapacity(0) }
+
+  let emptyBuffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: 0)
+  expectEqual(emptyAllocated, emptyBuffer.baseAddress)
+  expectEqual(0, emptyBuffer.count)
+  expectTrue(emptyBuffer.startIndex == emptyBuffer.endIndex)
+
+  var iter = emptyBuffer.makeIterator()
+  expectEmpty(iter.next())
+
+  expectEqual([], Array(emptyBuffer))
+}
+
+${SelfName}TestSuite.test("nonNilNonEmpty") {
+  let count = 4
+  let allocated = UnsafeMutablePointer<Float>(allocatingCapacity: count)
+  defer { allocated.deallocateCapacity(count) }
+  allocated.initialize(with: 1.0, count: count)
+  allocated[count - 1] = 2.0
+
+  let buffer = ${SelfType}(start: ${PointerType}(allocated), count: count - 1)
+  expectEqual(allocated, buffer.baseAddress)
+  expectEqual(count - 1, buffer.count)
+  expectEqual(count - 1, buffer.endIndex - buffer.startIndex)
+
+  allocated[1] = 0.0
+  expectEqual(1.0, buffer[0])
+  expectEqual(0.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  var iter = buffer.makeIterator()
+  expectEqual(1.0, iter.next())
+  expectEqual(0.0, iter.next())
+  expectEqual(1.0, iter.next())
+  expectEmpty(iter.next())
+
+  expectEqual([1.0, 0.0, 1.0], Array(buffer))
+
+  expectEqual(2.0, allocated[count-1])
+}
+
+${SelfName}TestSuite.test("badCount")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  expectCrashLater()
+
+  let emptyAllocated = UnsafeMutablePointer<Float>(allocatingCapacity: 0)
+  defer { emptyAllocated.deallocateCapacity(0) }
+
+  let buffer = ${SelfType}(start: ${PointerType}(emptyAllocated), count: -1)
+  _ = buffer
+}
+
+${SelfName}TestSuite.test("badNilCount")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .code {
+  expectCrashLater()
+
+  let buffer = ${SelfType}(start: nil, count: 1)
+  _ = buffer
+}
+
+% end
+
+UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
+  let count = 4
+  let allocated = UnsafeMutablePointer<Float>(allocatingCapacity: count)
+  defer { allocated.deallocateCapacity(count) }
+  allocated.initialize(with: 1.0, count: count)
+  allocated[count-1] = -1.0
+
+  var buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
+
+  buffer[1] = 0.0
+  expectEqual(1.0, buffer[0])
+  expectEqual(0.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  expectEqual(1.0, allocated[0])
+  expectEqual(0.0, allocated[1])
+  expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  buffer.sort()
+  expectEqual(0.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  expectEqual(0.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+}
+
+runAllTests()

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -66,29 +66,73 @@ ${SelfName}TestSuite.test("initFromOpaquePointer") {
   let other = OpaquePointer(bitPattern: 0x12345678)!
   let ptr = UnsafePointer<Float>(other)
   expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = UnsafePointer<Float>(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<OpaquePointer> = nil
+  let nilPointer = UnsafePointer<Float>(nilOther)
+  expectEmpty(nilPointer)
 }
 
 ${SelfName}TestSuite.test("initFromUnsafePointer") {
   let other = UnsafePointer<Double>(bitPattern: 0x12345678)!
   let ptr = ${SelfType}(other)
   expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = ${SelfType}(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<UnsafePointer<Double>> = nil
+  let nilPointer = ${SelfType}(nilOther)
+  expectEmpty(nilPointer)
 }
 
 ${SelfName}TestSuite.test("initFromUnsafeMutablePointer") {
   let other = UnsafeMutablePointer<Double>(bitPattern: 0x12345678)!
   let ptr = ${SelfType}(other)
   expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
+
+  let optionalOther: Optional = other
+  let optionalPointer = ${SelfType}(optionalOther)
+  expectNotEmpty(optionalPointer)
+  expectEqual(0x12345678, unsafeBitCast(optionalPointer, to: Int.self))
+
+  let nilOther: Optional<UnsafeMutablePointer<Double>> = nil
+  let nilPointer = ${SelfType}(nilOther)
+  expectEmpty(nilPointer)
 }
 
 ${SelfName}TestSuite.test("initFromInteger") {
   do {
     let word: Int = 0x12345678
     let ptr = ${SelfType}(bitPattern: word)
+    expectNotEmpty(ptr)
     expectEqual(word, unsafeBitCast(ptr, to: Int.self))
   }
   do {
     let uword: UInt = 0x12345678
     let ptr = ${SelfType}(bitPattern: uword)
+    expectNotEmpty(ptr)
+    expectEqual(uword, unsafeBitCast(ptr, to: UInt.self))
+  }
+}
+
+${SelfName}TestSuite.test("initFromNilBitPattern") {
+  do {
+    let word = unsafeBitCast(nil as ${SelfType}?, to: Int.self)
+    let ptr = ${SelfType}(bitPattern: word)
+    expectEmpty(ptr)
+    expectEqual(word, unsafeBitCast(ptr, to: Int.self))
+  }
+  do {
+    let uword = unsafeBitCast(nil as ${SelfType}?, to: UInt.self)
+    let ptr = ${SelfType}(bitPattern: uword)
+    expectEmpty(ptr)
     expectEqual(uword, unsafeBitCast(ptr, to: UInt.self))
   }
 }

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -58,29 +58,24 @@ var OpaquePointerTestSuite = TestSuite("OpaquePointer")
 %         ('OpaquePointer', 'OpaquePointer')]:
 
 ${SelfName}TestSuite.test("convertFromNil") {
-  let ptr: ${SelfType} = nil
-  expectEqual(0, unsafeBitCast(ptr, to: Int.self))
-}
-
-${SelfName}TestSuite.test("initNoArgs") {
-  let ptr: ${SelfType} = nil
+  let ptr: ${SelfType}? = nil
   expectEqual(0, unsafeBitCast(ptr, to: Int.self))
 }
 
 ${SelfName}TestSuite.test("initFromOpaquePointer") {
-  let other = OpaquePointer(bitPattern: 0x12345678)
+  let other = OpaquePointer(bitPattern: 0x12345678)!
   let ptr = UnsafePointer<Float>(other)
   expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
 }
 
 ${SelfName}TestSuite.test("initFromUnsafePointer") {
-  let other = UnsafePointer<Double>(bitPattern: 0x12345678)
+  let other = UnsafePointer<Double>(bitPattern: 0x12345678)!
   let ptr = ${SelfType}(other)
   expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
 }
 
 ${SelfName}TestSuite.test("initFromUnsafeMutablePointer") {
-  let other = UnsafeMutablePointer<Double>(bitPattern: 0x12345678)
+  let other = UnsafeMutablePointer<Double>(bitPattern: 0x12345678)!
   let ptr = ${SelfType}(other)
   expectEqual(0x12345678, unsafeBitCast(ptr, to: Int.self))
 }
@@ -100,9 +95,8 @@ ${SelfName}TestSuite.test("initFromInteger") {
 
 ${SelfName}TestSuite.test("Hashable") {
   let ptrs = [
-    ${SelfType}(bitPattern: 0x0),
-    ${SelfType}(bitPattern: 0x12345678),
-    ${SelfType}(bitPattern: 0x87654321 as UInt),
+    ${SelfType}(bitPattern: 0x12345678)!,
+    ${SelfType}(bitPattern: 0x87654321 as UInt)!,
   ]
   for i in ptrs.indices {
     for j in ptrs.indices {
@@ -267,7 +261,7 @@ UnsafePointerTestSuite.test("customMirror") {
   // Ensure that the custom mirror works properly, including when the raw value
   // is greater than Int.max
   let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafePointer<Float>(bitPattern: reallyBigInt)
+  let ptr = UnsafePointer<Float>(bitPattern: reallyBigInt)!
   let mirror = ptr.customMirror
   expectEqual(1, mirror.children.count)
 #if arch(i386) || arch(arm)
@@ -283,7 +277,7 @@ UnsafePointerTestSuite.test("customPlaygroundQuickLook") {
   // Ensure that the custom playground quicklook works properly, including when
   // the raw value is greater than Int.max
   let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafePointer<Float>(bitPattern: reallyBigInt)
+  let ptr = UnsafePointer<Float>(bitPattern: reallyBigInt)!
   if case let .text(desc) = ptr.customPlaygroundQuickLook {
 #if arch(i386) || arch(arm)
     expectEqual("UnsafePointer(0xFFFFFFFF80000000)", desc)
@@ -299,7 +293,7 @@ UnsafePointerTestSuite.test("customPlaygroundQuickLook") {
 
 UnsafeMutablePointerTestSuite.test("customMirror") {
   let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafeMutablePointer<Float>(bitPattern: reallyBigInt)
+  let ptr = UnsafeMutablePointer<Float>(bitPattern: reallyBigInt)!
   let mirror = ptr.customMirror
   expectEqual(1, mirror.children.count)
 #if arch(i386) || arch(arm)
@@ -313,7 +307,7 @@ UnsafeMutablePointerTestSuite.test("customMirror") {
 
 UnsafeMutablePointerTestSuite.test("customPlaygroundQuickLook") {
   let reallyBigInt: UInt = UInt(Int.max) + 1
-  let ptr = UnsafeMutablePointer<Float>(bitPattern: reallyBigInt)
+  let ptr = UnsafeMutablePointer<Float>(bitPattern: reallyBigInt)!
   let isProperDisposition : Bool
   if case let .text(desc) = ptr.customPlaygroundQuickLook {
 #if arch(i386) || arch(arm)

--- a/test/1_stdlib/VarArgs.swift
+++ b/test/1_stdlib/VarArgs.swift
@@ -46,17 +46,17 @@ func test_varArgs3() {
   var args = [CVarArg]()
 
   let format = "pointers: '%p' '%p' '%p' '%p' '%p'\n"
-  args.append(OpaquePointer(bitPattern: 0x1234_5670))
-  args.append(OpaquePointer(bitPattern: 0x1234_5671))
-  args.append(UnsafePointer<Int>(bitPattern: 0x1234_5672))
-  args.append(UnsafeMutablePointer<Float>(bitPattern: 0x1234_5673))
+  args.append(OpaquePointer(bitPattern: 0x1234_5670)!)
+  args.append(OpaquePointer(bitPattern: 0x1234_5671)!)
+  args.append(UnsafePointer<Int>(bitPattern: 0x1234_5672)!)
+  args.append(UnsafeMutablePointer<Float>(bitPattern: 0x1234_5673)!)
 
 #if _runtime(_ObjC)
   args.append(AutoreleasingUnsafeMutablePointer<AnyObject>(
-        UnsafeMutablePointer<AnyObject>(bitPattern: 0x1234_5674)))
+        UnsafeMutablePointer<AnyObject>(bitPattern: 0x1234_5674)!))
 #else
   //Linux does not support AutoreleasingUnsafeMutablePointer; put placeholder.
-  args.append(UnsafeMutablePointer<Float>(bitPattern: 0x1234_5674))
+  args.append(UnsafeMutablePointer<Float>(bitPattern: 0x1234_5674)!)
 #endif
 
   // CHECK: {{pointers: '(0x)?0*12345670' '(0x)?0*12345671' '(0x)?0*12345672' '(0x)?0*12345673' '(0x)?0*12345674'}}

--- a/test/ClangModules/MixedSource/mixed-nsuinteger.swift
+++ b/test/ClangModules/MixedSource/mixed-nsuinteger.swift
@@ -9,8 +9,8 @@ import user
 
 var ui: UInt = 5
 var i: Int = 56
-var p: UnsafeMutablePointer<NSFastEnumerationState> = nil
-var pp: AutoreleasingUnsafeMutablePointer<AnyObject?> = nil
+var p: UnsafeMutablePointer<NSFastEnumerationState>? = nil
+var pp: AutoreleasingUnsafeMutablePointer<AnyObject?>? = nil
 
 var userTypedObj = NSUIntTest()
 
@@ -31,18 +31,18 @@ ur = testFunctionWithPointerParam(pui)
 // The types are treated as system types when working with objects having
 // protocol type.
 var a: [NSFastEnumeration] = [NSUIntTest(), NSUIntTest()]
-var r: Int = a[0].countByEnumerating(with: p, objects: pp, count: i)
+var r: Int = a[0].countByEnumerating(with: p!, objects: pp!, count: i)
 
 // When working with instances typed as user-defined, NSUInteger comes
 // across as UInt.
-var rr: UInt = userTypedObj.countByEnumerating(with: p, objects: pp, count: ui)
+var rr: UInt = userTypedObj.countByEnumerating(with: p!, objects: pp!, count: ui)
 
 // Check exercising protocol conformance.
 func gen<T:NSFastEnumeration>(_ t:T) {
   let i: Int = 56
-  let p: UnsafeMutablePointer<NSFastEnumerationState> = nil
-  let pp: AutoreleasingUnsafeMutablePointer<AnyObject?> = nil
-  t.countByEnumerating(with: p, objects: pp, count: i)
+  let p: UnsafeMutablePointer<NSFastEnumerationState>? = nil
+  let pp: AutoreleasingUnsafeMutablePointer<AnyObject?>? = nil
+  t.countByEnumerating(with: p!, objects: pp!, count: i)
 }
 
 gen(userTypedObj)

--- a/test/ClangModules/Security_test.swift
+++ b/test/ClangModules/Security_test.swift
@@ -24,7 +24,7 @@ func testIntegration() {
 }
 
 func testAuthorizationIsNotCF() {
-  var auth: AuthorizationRef = nil
+  var auth: AuthorizationRef? = nil
   _ = AuthorizationCreate(&auth)
   _ = AuthorizationFree(auth)
 }

--- a/test/ClangModules/cf.swift
+++ b/test/ClangModules/cf.swift
@@ -112,7 +112,7 @@ func testOutParametersGood() {
 
 func testOutParametersBad() {
   let fridge: CCRefrigerator?
-  CCRefrigeratorCreateIndirect(fridge) // expected-error {{cannot convert value of type 'CCRefrigerator?' to expected argument type 'UnsafeMutablePointer<CCRefrigerator?>' (aka 'UnsafeMutablePointer<Optional<CCRefrigerator>>')}} 
+  CCRefrigeratorCreateIndirect(fridge) // expected-error {{cannot convert value of type 'CCRefrigerator?' to expected argument type 'UnsafeMutablePointer<CCRefrigerator?>?'}}
 
   let power: CCPowerSupply?
   CCRefrigeratorGetPowerSupplyIndirect(0, power) // expected-error {{cannot convert value of type 'Int' to expected argument type 'CCRefrigerator!'}}

--- a/test/ClangModules/cfuncs_parse.swift
+++ b/test/ClangModules/cfuncs_parse.swift
@@ -107,6 +107,32 @@ func test_pointer() {
   opaque_pointer_param(op)
 }
 
+func test_pointer_nonnull() {
+  var i: CInt = 0
+  var ia: [CInt] = [1, 2, 3]
+  var f: CFloat = 0
+  var fa: [CFloat] = [1, 2, 3]
+
+  nonnull_param_pointer(&i)
+  nonnull_param_pointer(&ia)
+
+  nonnull_param_const_pointer(&i)
+  nonnull_param_const_pointer(ia)
+  nonnull_param_const_pointer([1, 2, 3])
+
+  nonnull_param_void_pointer(&i)
+  nonnull_param_void_pointer(&ia)
+  nonnull_param_void_pointer(&f)
+  nonnull_param_void_pointer(&fa)
+
+  nonnull_param_const_void_pointer(&i)
+  nonnull_param_const_void_pointer(ia)
+  // FIXME: nonnull_param_const_void_pointer([1, 2, 3])
+  nonnull_param_const_void_pointer(&f)
+  nonnull_param_const_void_pointer(fa)
+  // FIXME: nonnull_param_const_void_pointer([1.0, 2.0, 3.0])
+}
+
 func test_decay() {
   decay_param_array(nil as UnsafeMutablePointer<CInt>?)
   var i: CInt = 0

--- a/test/ClangModules/cfuncs_parse.swift
+++ b/test/ClangModules/cfuncs_parse.swift
@@ -145,6 +145,16 @@ func test_decay() {
   decay_param_const_array([1, 2, 3])
 }
 
+func test_nested_pointers() {
+  nested_pointer(nil)
+  nested_pointer_audited(nil)
+  nested_pointer_audited2(nil) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<UnsafePointer<Int32>?>'}}
+
+  nested_pointer(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>?>!'}}
+  nested_pointer_audited(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>>?'}}
+  nested_pointer_audited2(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>?>'}}
+}
+
 func exit(_: Float) {} // expected-note {{found this candidate}}
 func test_ambiguous() {
   exit(5) // expected-error {{ambiguous use of 'exit'}}

--- a/test/ClangModules/cfuncs_parse.swift
+++ b/test/ClangModules/cfuncs_parse.swift
@@ -73,29 +73,29 @@ func test_pointer() {
   var f: CFloat = 0
   var fa: [CFloat] = [1, 2, 3]
 
-  param_pointer(nil as UnsafeMutablePointer<CInt>)
+  param_pointer(nil as UnsafeMutablePointer<CInt>?)
   param_pointer(&i)
   param_pointer(&ia)
 
-  param_const_pointer(nil as UnsafeMutablePointer<CInt>)
+  param_const_pointer(nil as UnsafeMutablePointer<CInt>?)
   param_const_pointer(&i)
   param_const_pointer(ia)
   param_const_pointer([1, 2, 3])
 
-  param_void_pointer(nil as UnsafeMutablePointer<Void>)
-  param_void_pointer(nil as UnsafeMutablePointer<CInt>)
-  param_void_pointer(nil as UnsafeMutablePointer<CFloat>)
+  param_void_pointer(nil as UnsafeMutablePointer<Void>?)
+  param_void_pointer(nil as UnsafeMutablePointer<CInt>?)
+  param_void_pointer(nil as UnsafeMutablePointer<CFloat>?)
   param_void_pointer(&i)
   param_void_pointer(&ia)
   param_void_pointer(&f)
   param_void_pointer(&fa)
 
-  param_const_void_pointer(nil as UnsafeMutablePointer<Void>)
-  param_const_void_pointer(nil as UnsafeMutablePointer<CInt>)
-  param_const_void_pointer(nil as UnsafeMutablePointer<CFloat>)
-  param_const_void_pointer(nil as UnsafePointer<Void>)
-  param_const_void_pointer(nil as UnsafePointer<CInt>)
-  param_const_void_pointer(nil as UnsafePointer<CFloat>)
+  param_const_void_pointer(nil as UnsafeMutablePointer<Void>?)
+  param_const_void_pointer(nil as UnsafeMutablePointer<CInt>?)
+  param_const_void_pointer(nil as UnsafeMutablePointer<CFloat>?)
+  param_const_void_pointer(nil as UnsafePointer<Void>?)
+  param_const_void_pointer(nil as UnsafePointer<CInt>?)
+  param_const_void_pointer(nil as UnsafePointer<CFloat>?)
   param_const_void_pointer(&i)
   param_const_void_pointer(ia)
   // FIXME: param_const_void_pointer([1, 2, 3])
@@ -103,17 +103,17 @@ func test_pointer() {
   param_const_void_pointer(fa)
   // FIXME: param_const_void_pointer([1.0, 2.0, 3.0])
 
-  let op: OpaquePointer = nil
+  let op: OpaquePointer? = nil
   opaque_pointer_param(op)
 }
 
 func test_decay() {
-  decay_param_array(nil as UnsafeMutablePointer<CInt>)
+  decay_param_array(nil as UnsafeMutablePointer<CInt>?)
   var i: CInt = 0
   var a: [CInt] = [1, 2, 3]
   decay_param_array(&i)
   decay_param_array(&a)
-  decay_param_const_array(nil as UnsafeMutablePointer<CInt>)
+  decay_param_const_array(nil as UnsafeMutablePointer<CInt>?)
   decay_param_const_array(&i)
   decay_param_const_array(a)
   decay_param_const_array([1, 2, 3])

--- a/test/ClangModules/ctypes_parse.swift
+++ b/test/ClangModules/ctypes_parse.swift
@@ -76,7 +76,7 @@ func testUnnamedStructs() {
 // FIXME: Import pointers to opaque types as unique types.
 
 func testPointers() {
-  _ = nil as HWND
+  _ = HWND(bitPattern: 0)
 }
 
 // Ensure that imported structs can be extended, even if typedef'ed on the C
@@ -200,11 +200,11 @@ func testFunctionPointers() {
   useFunctionPointer(wrapper.a)
   _ = wrapper.b as (@convention(c) (CInt) -> CInt)
 
-  var anotherFP: @convention(c) (CInt, CLong, UnsafeMutablePointer<Void>) -> Void
+  var anotherFP: @convention(c) (CInt, CLong, UnsafeMutablePointer<Void>!) -> Void
     = getFunctionPointer2()
 
   useFunctionPointer2(anotherFP)
-  anotherFP = fp // expected-error {{cannot assign value of type 'fptr!' to type '@convention(c) (CInt, CLong, UnsafeMutablePointer<Void>) -> Void'}}
+  anotherFP = fp // expected-error {{cannot assign value of type 'fptr!' to type '@convention(c) (CInt, CLong, UnsafeMutablePointer<Void>!) -> Void'}}
 }
 
 func testStructDefaultInit() {

--- a/test/ClangModules/objc_bridging.swift
+++ b/test/ClangModules/objc_bridging.swift
@@ -47,7 +47,7 @@ func allocateMagic(_ zone: NSZone) -> UnsafeMutablePointer<Void> {
   return allocate(zone)
 }
 
-func constPointerToObjC(_ objects: [AnyObject?]) -> NSArray {
+func constPointerToObjC(_ objects: [AnyObject]) -> NSArray {
   return NSArray(objects: objects, count: objects.count)
 }
 

--- a/test/ClangModules/objc_ir.swift
+++ b/test/ClangModules/objc_ir.swift
@@ -113,9 +113,9 @@ func pointerProperties(_ obj: PointerWrapper) {
   // CHECK: load i8*, i8** @"\01L_selector(setVoidPtr:)"
   // CHECK: load i8*, i8** @"\01L_selector(setIntPtr:)"
   // CHECK: load i8*, i8** @"\01L_selector(setIdPtr:)"
-  obj.voidPtr = nil as UnsafeMutablePointer
-  obj.intPtr = nil as UnsafeMutablePointer
-  obj.idPtr = nil as AutoreleasingUnsafeMutablePointer
+  obj.voidPtr = nil as UnsafeMutablePointer?
+  obj.intPtr = nil as UnsafeMutablePointer?
+  obj.idPtr = nil as AutoreleasingUnsafeMutablePointer?
 }
 
 // CHECK-LABEL: define hidden void @_TF7objc_ir20customFactoryMethodsFT_T_() {{.*}} {

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -16,7 +16,7 @@ public extension _ObjectiveCBridgeable {
 
 public class BridgedClass : NSObject, NSCopying {
   @objc(copyWithZone:)
-  public func copy(with zone: NSZone) -> AnyObject {
+  public func copy(with zone: NSZone?) -> AnyObject {
     return self
   }
 }

--- a/test/DebugInfo/typearg.swift
+++ b/test/DebugInfo/typearg.swift
@@ -9,12 +9,12 @@ class AClass : AProtocol {
 
 // CHECK: define hidden void @{{.*}}aFunction
 // CHECK:  call void @llvm.dbg.declare(metadata %swift.type** %{{.*}}, metadata ![[TYPEARG:.*]], metadata !{{[0-9]+}}),
-// CHECK: ![[VOIDPTR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "_TtBp", baseType: null
 // CHECK: ![[TYPEARG]] = !DILocalVariable(name: "$swift.type.T"
 // CHECK-SAME:                            type: ![[SWIFTMETATYPE:[^,)]+]]
 // CHECK-SAME:                            flags: DIFlagArtificial
 // CHECK: ![[SWIFTMETATYPE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$swift.type",
-// CHECK-SAME:                                baseType: ![[VOIDPTR]]
+// CHECK-SAME:                                baseType: ![[VOIDPTR:[0-9]+]]
+// CHECK: ![[VOIDPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "_TtBp", baseType: null
 func aFunction<T : AProtocol>(_ x: T) {
     print("I am in aFunction: \(x.f())")
 }

--- a/test/Generics/slice_test.swift
+++ b/test/Generics/slice_test.swift
@@ -30,7 +30,7 @@ func testslice(_ s: Array<Int>) {
 class Vector<T> {
   var length : Int
   var capacity : Int
-  var base : UnsafeMutablePointer<T>
+  var base : UnsafeMutablePointer<T>!
 
   init() {
     length = 0

--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -71,7 +71,7 @@ var <loc>fooIntVar</loc>: <ref:Struct>Int32</ref></decl>
 <decl:Func>/// Aaa.  fooFunc1.  Bbb.
 func <loc>fooFunc1(<decl:Param>_ a: <ref:Struct>Int32</ref></decl>)</loc> -> <ref:Struct>Int32</ref></decl>
 <decl:Func>func <loc>fooFunc1AnonymousParam(<decl:Param>_: <ref:Struct>Int32</ref></decl>)</loc> -> <ref:Struct>Int32</ref></decl>
-<decl:Func>func <loc>fooFunc3(<decl:Param>_ a: <ref:Struct>Int32</ref></decl>, <decl:Param>_ b: <ref:Struct>Float</ref></decl>, <decl:Param>_ c: <ref:Struct>Double</ref></decl>, <decl:Param>_ d: <ref:Struct>UnsafeMutablePointer</ref><<ref:Struct>Int32</ref>></decl>)</loc> -> <ref:Struct>Int32</ref></decl>
+<decl:Func>func <loc>fooFunc3(<decl:Param>_ a: <ref:Struct>Int32</ref></decl>, <decl:Param>_ b: <ref:Struct>Float</ref></decl>, <decl:Param>_ c: <ref:Struct>Double</ref></decl>, <decl:Param>_ d: <ref:Struct>UnsafeMutablePointer</ref><<ref:Struct>Int32</ref>>!</decl>)</loc> -> <ref:Struct>Int32</ref></decl>
 <decl:Func>func <loc>fooFuncWithBlock(<decl:Param>_ blk: ((<ref:Struct>Float</ref>) -> <ref:Struct>Int32</ref>)!</decl>)</loc></decl>
 <decl:Func>func <loc>fooFuncWithFunctionPointer(<decl:Param>_ fptr: (@convention(c) (<ref:Struct>Float</ref>) -> <ref:Struct>Int32</ref>)!</decl>)</loc></decl>
 <decl:Func>@noreturn func <loc>fooFuncNoreturn1()</loc></decl>

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -71,7 +71,7 @@ var fooIntVar: Int32
 /// Aaa.  fooFunc1.  Bbb.
 func fooFunc1(_ a: Int32) -> Int32
 func fooFunc1AnonymousParam(_: Int32) -> Int32
-func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>) -> Int32
+func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
 func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
 func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
 @noreturn func fooFuncNoreturn1()

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -88,7 +88,7 @@ var fooIntVar: Int32
 func fooFunc1(_ a: Int32) -> Int32
 
 func fooFunc1AnonymousParam(_: Int32) -> Int32
-func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>) -> Int32
+func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
 
 /*
   Very good

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -70,7 +70,7 @@ func testSwiftCompletions(foo: SwiftStruct) {
 // CLANG_FOO-DAG: Decl[GlobalVar]/OtherModule[Foo]:    fooIntVar[#Int32#]{{; name=.+$}}
 // CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFunc1({#(a): Int32#})[#Int32#]{{; name=.+$}}
 // CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFunc1AnonymousParam({#Int32#})[#Int32#]{{; name=.+$}}
-// CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFunc3({#(a): Int32#}, {#(b): Float#}, {#(c): Double#}, {#(d): UnsafeMutablePointer<Int32>#})[#Int32#]{{; name=.+$}}
+// CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFunc3({#(a): Int32#}, {#(b): Float#}, {#(c): Double#}, {#(d): UnsafeMutablePointer<Int32>!#})[#Int32#]{{; name=.+$}}
 // CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFuncWithBlock({#(blk): ((Float) -> Int32)!##(Float) -> Int32#})[#Void#]{{; name=.+$}}
 // CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFuncWithComment1()[#Void#]{{; name=.+$}}
 // CLANG_FOO-DAG: Decl[FreeFunction]/OtherModule[Foo]: fooFuncWithComment2()[#Void#]{{; name=.+$}}
@@ -157,7 +157,7 @@ func testCompleteModuleQualifiedFoo2() {
 // CLANG_QUAL_FOO_2-DAG: Decl[Enum]/OtherModule[Foo]:         .FooComparisonResult[#FooComparisonResult#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFunc1({#(a): Int32#})[#Int32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFunc1AnonymousParam({#Int32#})[#Int32#]{{; name=.+$}}
-// CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFunc3({#(a): Int32#}, {#(b): Float#}, {#(c): Double#}, {#(d): UnsafeMutablePointer<Int32>#})[#Int32#]{{; name=.+$}}
+// CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFunc3({#(a): Int32#}, {#(b): Float#}, {#(c): Double#}, {#(d): UnsafeMutablePointer<Int32>!#})[#Int32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFuncNoreturn1()[#Void#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFuncNoreturn2()[#Void#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[FreeFunction]/OtherModule[Foo]: .fooFuncWithBlock({#(blk): ((Float) -> Int32)!##(Float) -> Int32#})[#Void#]{{; name=.+$}}

--- a/test/IDE/infer_import_as_member.swift
+++ b/test/IDE/infer_import_as_member.swift
@@ -81,7 +81,7 @@ import InferImportAsMember
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension IAMMutableStruct1 {
 // PRINT-NEXT:    init(with withIAMStruct1: IAMStruct1)
-// PRINT-NEXT:    init(withURL url: UnsafePointer<Int8>)
+// PRINT-NEXT:    init(withURL url: UnsafePointer<Int8>!)
 // PRINT-NEXT:    func doSomething()
 // PRINT-NEXT:  }
 //

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -47,7 +47,7 @@
 
 // Note: Pointer-to-struct name matching; preposition splitting.
 //
-// CHECK-FOUNDATION: func copy(with: Zone = nil) -> AnyObject!
+// CHECK-FOUNDATION: func copy(with: Zone? = nil) -> AnyObject!
 
 // Note: Objective-C type parameter names.
 // CHECK-FOUNDATION: func object(forKey: Copying) -> AnyObject?
@@ -97,7 +97,7 @@
 // CHECK-FOUNDATION: var uppercased: String
 
 // Note: don't map base name down to a keyword.
-// CHECK-FOUNDATION: func doSelector(_: Selector)
+// CHECK-FOUNDATION: func doSelector(_: Selector!)
 
 // Note: Strip names preceded by a gerund.
 // CHECK-FOUNDATION: func startSquashing(_: Bee)
@@ -134,11 +134,11 @@
 // CHECK-FOUNDATION: static var reverse: EnumerationOptions
 
 // Note: usingBlock -> body
-// CHECK-FOUNDATION: func enumerateObjects(_: ((AnyObject!, Int, UnsafeMutablePointer<ObjCBool>) -> Void)!)
-// CHECK-FOUNDATION: func enumerateObjects(_: EnumerationOptions = [], using: ((AnyObject!, Int, UnsafeMutablePointer<ObjCBool>) -> Void)!)
+// CHECK-FOUNDATION: func enumerateObjects(_: ((AnyObject!, Int, UnsafeMutablePointer<ObjCBool>!) -> Void)!)
+// CHECK-FOUNDATION: func enumerateObjects(_: EnumerationOptions = [], using: ((AnyObject!, Int, UnsafeMutablePointer<ObjCBool>!) -> Void)!)
 
 // Note: WithBlock -> body, nullable closures default to nil.
-// CHECK-FOUNDATION: func enumerateObjectsRandomly(_: ((AnyObject!, Int, UnsafeMutablePointer<ObjCBool>) -> Void)? = nil)
+// CHECK-FOUNDATION: func enumerateObjectsRandomly(_: ((AnyObject!, Int, UnsafeMutablePointer<ObjCBool>!) -> Void)? = nil)
 
 // Note: id<Proto> treated as "Proto".
 // CHECK-FOUNDATION: func doSomething(with: Copying)
@@ -173,7 +173,7 @@
 // CHECK-FOUNDATION: var setShouldBeInfinite: Bool { get }
 
 // "UTF8" initialisms.
-// CHECK-FOUNDATION: init?(utf8String: UnsafePointer<Int8>)
+// CHECK-FOUNDATION: init?(utf8String: UnsafePointer<Int8>!)
 
 // Don't strip prefixes from globals.
 // CHECK-FOUNDATION: let NSGlobalConstant: String
@@ -201,7 +201,7 @@
 // CHECK-APPKIT: func same() -> Self
 
 // Note: Unsafe(Mutable)Pointers don't get defaulted to 'nil'
-// CHECK-APPKIT: func getRGBAComponents(_: UnsafeMutablePointer<Int8>)
+// CHECK-APPKIT: func getRGBAComponents(_: UnsafeMutablePointer<Int8>?)
 
 // Note: Skipping over "3D"
 // CHECK-APPKIT: func drawInAir(at: Point3D)
@@ -253,7 +253,7 @@
 // CHECK-APPKIT: func setContentHuggingPriority(_: NSLayoutPriority)
 
 // Look through typedefs of pointers.
-// CHECK-APPKIT: func layout(at: NSPointPointer)
+// CHECK-APPKIT: func layout(at: NSPointPointer!)
 
 // The presence of a property prevents us from stripping redundant
 // type information from the base name.
@@ -273,7 +273,7 @@
 // CHECK-OMIT-NEEDLESS-WORDS: func bookmark(with: [URL])
 // CHECK-OMIT-NEEDLESS-WORDS: func save(to: URL, forSaveOperation: Int)
 // CHECK-OMIT-NEEDLESS-WORDS: func index(withItemNamed: String)
-// CHECK-OMIT-NEEDLESS-WORDS: func methodAndReturnError(_: AutoreleasingUnsafeMutablePointer<Error?>)
+// CHECK-OMIT-NEEDLESS-WORDS: func methodAndReturnError(_: AutoreleasingUnsafeMutablePointer<Error?>!)
 
 // CHECK-OMIT-NEEDLESS-WORDS: func type(of: String)
 // CHECK-OMIT-NEEDLESS-WORDS: func type(ofNamedString: String)
@@ -294,10 +294,10 @@
 // CHECK-OMIT-NEEDLESS-WORDS: func slobbering(_: String) -> OmitNeedlessWords
 
 // Elements of C array types
-// CHECK-OMIT-NEEDLESS-WORDS: func drawPolygon(with: UnsafePointer<Point>, count: Int)
+// CHECK-OMIT-NEEDLESS-WORDS: func drawPolygon(with: UnsafePointer<Point>!, count: Int)
 
 // Typedef ending in "Array".
-// CHECK-OMIT-NEEDLESS-WORDS: func drawFilledPolygon(with: PointArray, count: Int)
+// CHECK-OMIT-NEEDLESS-WORDS: func drawFilledPolygon(with: PointArray!, count: Int)
 
 // Non-parameterized Objective-C class ending in "Array".
 // CHECK-OMIT-NEEDLESS-WORDS: func draw(_: SEGreebieArray)

--- a/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -7,19 +7,19 @@
 @interface NSMutableString : NSString
 @end
 
-@interface NSArray : NSObject
+@interface NSArray<ObjectType> : NSObject
 @end
 
-@interface NSMutableArray : NSObject
+@interface NSMutableArray<ObjectType> : NSArray<ObjectType>
 @end
 
-@interface NSDictionary : NSObject
+@interface NSDictionary<KeyType, ValueType> : NSObject
 @end
 
-@interface NSSet : NSObject
+@interface NSSet<ObjectType> : NSObject
 @end
 
-@interface NSMutableSet : NSObject
+@interface NSMutableSet<ObjectType> : NSSet<ObjectType>
 @end
 
 @interface NSNumber : NSObject

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -19,7 +19,7 @@ public func testStaticGlobal() {
 public func testCaptureGlobal() {
   var f: Float = 0
   var i: CInt = 0
-  var s: UnsafePointer<CChar> = nil
+  var s: UnsafePointer<CChar>! = nil
   // CHECK-LABEL: define linkonce_odr hidden void @_TFF9c_globals17testCaptureGlobalFT_T_U_FT_T_{{.*}} {
   blackHole({ () -> Void in
     // CHECK: @staticFloat

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -parse-as-library | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -119,7 +119,10 @@ class A<T> {
 }
 
 class B<T> {
-  var ptr : UnsafeMutablePointer<T> = nil
+  var ptr : UnsafeMutablePointer<T>
+  init(ptr: UnsafeMutablePointer<T>) {
+    self.ptr = ptr
+  }
   deinit {
     ptr.deinitialize()
   }

--- a/test/IRGen/mangle-anonclosure.swift
+++ b/test/IRGen/mangle-anonclosure.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -emit-ir %s -disable-access-control -parse-stdlib -o - | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -o - | FileCheck %s
 
-import Swift
+func someValidPointer<T>() -> UnsafeMutablePointer<T> { fatalError() }
 
 class HeapStorage<Value, Element> {
   public final func withUnsafeMutablePointerToElements<R>(
     body: (UnsafeMutablePointer<Element>) -> R
-  ) -> R { return body(nil) }
+  ) -> R { return body(someValidPointer()) }
 }
 struct CountAndCapacity {}
 class TestHeapStorage<T> : HeapStorage<CountAndCapacity,T> {

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -30,10 +30,16 @@ import gizmo
 // CHECK-tvos: private unnamed_addr constant [11 x i8] c"v24@0:8q16\00"
 
   @objc func testPrimitives(_ b: CBool, i: Int, f: Float, d: Double)
-    -> OpaquePointer { return nil }
+    -> OpaquePointer { fatalError() }
 // CHECK-macosx: private unnamed_addr constant [21 x i8] c"^v40@0:8c16q20f28d32\00"
 // CHECK-ios: private unnamed_addr constant [21 x i8] c"^v40@0:8B16q20f28d32\00"
 // CHECK-tvos: private unnamed_addr constant [21 x i8] c"^v40@0:8B16q20f28d32\00"
+
+  @objc func testOptionalPrimitives()
+    -> OpaquePointer? { return nil }
+    // CHECK-macosx: private unnamed_addr constant [9 x i8] c"^v16@0:8\00"
+    // CHECK-ios: private unnamed_addr constant [9 x i8] c"^v16@0:8\00"
+    // CHECK-tvos: private unnamed_addr constant [9 x i8] c"^v16@0:8\00"
 
   @objc func testCSignedTypes(_ a: CSignedChar, b: CShort, c: CInt, d: CLong, e: CLongLong) {}
 // CHECK-macosx: private unnamed_addr constant [23 x i8] c"v44@0:8c16s20i24q28q36\00"

--- a/test/IRGen/vtable_multi_file.swift
+++ b/test/IRGen/vtable_multi_file.swift
@@ -7,8 +7,8 @@ func markUsed<T>(_ t: T) {}
 // CHECK-LABEL: define hidden void @_TF17vtable_multi_file36baseClassVtablesIncludeImplicitInitsFT_T_() {{.*}} {
 func baseClassVtablesIncludeImplicitInits() {
   // CHECK: [[T0:%.*]] = call %swift.type* @_TMaC17vtable_multi_file8Subclass()
-  // CHECK: [[T1:%.*]] = bitcast %swift.type* [[T0]] to { i8*, i64, i64 } (%swift.type*)**
-  // CHECK: [[T2:%.*]] = getelementptr inbounds { i8*, i64, i64 } (%swift.type*)*, { i8*, i64, i64 } (%swift.type*)** [[T1]], i64 11
-  // CHECK: load { i8*, i64, i64 } (%swift.type*)*, { i8*, i64, i64 } (%swift.type*)** [[T2]]
+  // CHECK: [[T1:%.*]] = bitcast %swift.type* [[T0]] to { i64, i64, i64 } (%swift.type*)**
+  // CHECK: [[T2:%.*]] = getelementptr inbounds { i64, i64, i64 } (%swift.type*)*, { i64, i64, i64 } (%swift.type*)** [[T1]], i64 11
+  // CHECK: load { i64, i64, i64 } (%swift.type*)*, { i64, i64, i64 } (%swift.type*)** [[T2]]
   markUsed(Subclass.classProp)
 }

--- a/test/Inputs/clang-importer-sdk/swift-modules-without-ns/Darwin.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-without-ns/Darwin.swift
@@ -10,7 +10,7 @@ public let noErr: OSStatus = 0
 /// Foundation.
 ///
 /// The C type is a typedef for `unsigned char`.
-public struct DarwinBoolean : BooleanType, BooleanLiteralConvertible {
+public struct DarwinBoolean : Boolean, BooleanLiteralConvertible {
   var value: UInt8
 
   public init(_ value: Bool) {

--- a/test/Inputs/clang-importer-sdk/swift-modules-without-ns/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-without-ns/ObjectiveC.swift
@@ -59,13 +59,8 @@ public struct Selector : StringLiteralConvertible {
   }
 }
 
-public struct Zone: NilLiteralConvertible {
+public struct Zone {
   public var pointer : OpaquePointer
-
-  @_transparent public
-  init(nilLiteral: ()) {
-    pointer = nil
-  }
 }
 
 internal func _convertBoolToObjCBool(_ x: Bool) -> ObjCBool {

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
@@ -63,13 +63,8 @@ public struct Selector : StringLiteralConvertible {
   }
 }
 
-public struct NSZone: NilLiteralConvertible {
+public struct NSZone {
   public var pointer : OpaquePointer
-
-  @_transparent public
-  init(nilLiteral: ()) {
-    pointer = nil
-  }
 }
 
 internal func _convertBoolToObjCBool(_ x: Bool) -> ObjCBool {

--- a/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
@@ -30,6 +30,12 @@ void param_const_pointer(const int *p);
 void param_void_pointer(void *p);
 void param_const_void_pointer(const void *p);
 
+void nonnull_param_pointer(int * _Nonnull p);
+void nonnull_param_const_pointer(const int * _Nonnull p);
+
+void nonnull_param_void_pointer(void * _Nonnull p);
+void nonnull_param_const_void_pointer(const void * _Nonnull p);
+
 void decay_param_array(int p[]);
 void decay_param_const_array(const int p[]);
 

--- a/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
@@ -36,6 +36,10 @@ void nonnull_param_const_pointer(const int * _Nonnull p);
 void nonnull_param_void_pointer(void * _Nonnull p);
 void nonnull_param_const_void_pointer(const void * _Nonnull p);
 
+void nested_pointer(const int * const *p);
+void nested_pointer_audited(const int * _Nonnull const * _Nullable p);
+void nested_pointer_audited2(const int * _Nullable const * _Nonnull p);
+
 void decay_param_array(int p[]);
 void decay_param_const_array(const int p[]);
 

--- a/test/Interpreter/SDK/Inputs/errors.h
+++ b/test/Interpreter/SDK/Inputs/errors.h
@@ -1,0 +1,28 @@
+@import Foundation;
+
+#pragma clang assume_nonnull begin
+
+@protocol ErrorTest
+- (nullable id)succeedAndReturnError:(NSError **)error;
+- (nullable id)failAndReturnError:(NSError **)error;
+@end
+
+static id __nullable testSucceed(id <ErrorTest> __nonnull testObj) {
+  NSError *error = nil;
+  return [testObj succeedAndReturnError:&error];
+}
+
+static id __nullable testSucceedIgnoringError(id <ErrorTest> __nonnull testObj) {
+  return [testObj succeedAndReturnError:NULL];
+}
+
+static id __nullable testFail(id <ErrorTest> __nonnull testObj) {
+  NSError *error = nil;
+  return [testObj failAndReturnError:&error];
+}
+
+static id __nullable testFailIgnoringError(id <ErrorTest> __nonnull testObj) {
+  return [testObj failAndReturnError:NULL];
+}
+
+#pragma clang assume_nonnull end

--- a/test/Interpreter/SDK/KVO.swift
+++ b/test/Interpreter/SDK/KVO.swift
@@ -31,7 +31,7 @@ class Observer : NSObject {
     model.number = 42
   }
 
-  override func observeValue(forKeyPath keyPath: String?, of object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+  override func observeValue(forKeyPath keyPath: String?, of object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>?) {
     if context != &kvoContext {
       // FIXME: we shouldn't need to unwrap these here, but it doesn't work on
       // older SDKs where these are non-optional types.

--- a/test/Interpreter/SDK/Reflection_KVO.swift
+++ b/test/Interpreter/SDK/Reflection_KVO.swift
@@ -25,7 +25,7 @@ class ValueObserver: NSObject {
 		observedValue.removeObserver(self, forKeyPath: "amount")
 	}
 	
-	override func observeValue(forKeyPath keyPath: String?, of object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+	override func observeValue(forKeyPath keyPath: String?, of object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>?) {
 		if context == &observeContext {
       if let change_ = change {
         if let amount = change_[NSKeyValueChangeNewKey as String] as? Int {

--- a/test/Interpreter/SDK/archiving_generic_swift_class.swift
+++ b/test/Interpreter/SDK/archiving_generic_swift_class.swift
@@ -36,9 +36,9 @@ func WEXITSTATUS(_ status: Int32) -> Int32 {
 
 // FIXME: "environ" should be in the Darwin overlay too
 @_silgen_name("_NSGetEnviron")
-func _NSGetEnviron() -> UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<CChar>>>
+func _NSGetEnviron() -> UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>>
 
-var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>> {
+var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
   return _NSGetEnviron().pointee
 }
 
@@ -55,7 +55,7 @@ func driver() {
 
   do {
     // Set up the archiver's stdout to feed into our pipe.
-    var archiverActions: posix_spawn_file_actions_t = nil
+    var archiverActions: posix_spawn_file_actions_t? = nil
     guard posix_spawn_file_actions_init(&archiverActions) == 0 else {
       fatalError("posix_spawn_file_actions_init failed")
     }
@@ -70,7 +70,7 @@ func driver() {
     }
 
     // Spawn the archiver process.
-    let archiverArgv: [UnsafeMutablePointer<Int8>] = [
+    let archiverArgv: [UnsafeMutablePointer<Int8>?] = [
       Process.unsafeArgv[0],
       UnsafeMutablePointer(("-archive" as StaticString).utf8Start),
       nil
@@ -84,7 +84,7 @@ func driver() {
 
   do {
     // Set up the unarchiver's stdin to read from our pipe.
-    var unarchiverActions: posix_spawn_file_actions_t = nil
+    var unarchiverActions: posix_spawn_file_actions_t? = nil
     guard posix_spawn_file_actions_init(&unarchiverActions) == 0 else {
       fatalError("posix_spawn_file_actions_init failed")
     }
@@ -100,7 +100,7 @@ func driver() {
 
     // Spawn the unarchiver process.
     var unarchiver: pid_t = 0
-    let unarchiverArgv: [UnsafeMutablePointer<Int8>] = [
+    let unarchiverArgv: [UnsafeMutablePointer<Int8>?] = [
       Process.unsafeArgv[0],
       UnsafeMutablePointer(("-unarchive" as StaticString).utf8Start),
       nil

--- a/test/Interpreter/SDK/cf_extensions.swift
+++ b/test/Interpreter/SDK/cf_extensions.swift
@@ -25,9 +25,9 @@ extension CGColor {
     return CGColor(withColorSpace: colorSpace, components: components)!
   }
 
-  var r: CGFloat { return components[0] }
-  var g: CGFloat { return components[1] }
-  var b: CGFloat { return components[2] }
+  var r: CGFloat { return components![0] }
+  var g: CGFloat { return components![1] }
+  var b: CGFloat { return components![2] }
 }
 
 let pink = CGColor.create(colorSpace: .deviceRGB(),

--- a/test/Interpreter/SDK/errors.swift
+++ b/test/Interpreter/SDK/errors.swift
@@ -1,0 +1,56 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/errors.h -o %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+//
+// Tests for error handling.
+//
+
+import StdlibUnittest
+
+// Also import modules which are used by StdlibUnittest internally. This
+// workaround is needed to link all required libraries in case we compile
+// StdlibUnittest with -sil-serialize-all.
+import SwiftPrivate
+#if _runtime(_ObjC)
+import ObjectiveC
+#endif
+
+struct Problem : ErrorProtocol {}
+
+class ErrorImpl : NSObject, ErrorTest {
+  func succeed() throws -> AnyObject { return self }
+  func fail() throws -> AnyObject { throw Problem() }
+}
+
+
+var ErrorHandlingTests = TestSuite("ErrorHandling")
+
+ErrorHandlingTests.test("succeed") {
+  let obj = ErrorImpl()
+  let result = testSucceed(obj)
+  expectTrue(obj === result)
+}
+
+ErrorHandlingTests.test("succeedIgnoringError") {
+  let obj = ErrorImpl()
+  let result = testSucceedIgnoringError(obj)
+  expectTrue(obj === result)
+}
+
+ErrorHandlingTests.test("fail") {
+  let obj = ErrorImpl()
+  let result = testFail(obj)
+  expectEmpty(result)
+}
+
+ErrorHandlingTests.test("failIgnoringError") {
+  let obj = ErrorImpl()
+  let result = testFailIgnoringError(obj)
+  expectEmpty(result)
+}
+
+runAllTests()

--- a/test/Interpreter/SDK/glob.swift
+++ b/test/Interpreter/SDK/glob.swift
@@ -12,7 +12,7 @@ func Glob(_ g: String) -> Array<String> {
 	if rv == 0 {
 		var result = Array<String>()
 		for x in 0..<Int(gt.gl_pathc) {
-			var str = String(cString: gt.gl_pathv[x])
+			var str = String(cString: gt.gl_pathv[x]!)
 			result.append(str)
 		}
 		globfree(&gt)

--- a/test/Interpreter/SDK/interpret_with_options.swift
+++ b/test/Interpreter/SDK/interpret_with_options.swift
@@ -9,7 +9,7 @@ import ObjectiveC
 
 // FIXME: <rdar://problem/19302805> Crash when NSClassFromString returns nil
 @_silgen_name("objc_lookUpClass")
-func lookUpClassOpaque(_ name: UnsafePointer<CChar>) -> OpaquePointer
+func lookUpClassOpaque(_ name: UnsafePointer<CChar>) -> OpaquePointer?
 
 let ptr = lookUpClassOpaque("ClassFromLibrary")
 print("Loaded? \(ptr != nil)")

--- a/test/Interpreter/SDK/misc_osx.swift
+++ b/test/Interpreter/SDK/misc_osx.swift
@@ -8,7 +8,7 @@ func testFSEventStreamRef(stream: FSEventStreamRef) {
   // FIXME: These should be distinct types, constructible from one another.
   _ = stream as ConstFSEventStreamRef // works by coincidence because both are currently OpaquePointer
   _ = ConstFSEventStreamRef(stream) // expected-error {{cannot invoke initializer for type 'ConstFSEventStreamRef' with an argument list of type '(FSEventStreamRef)'}}
-  // expected-note @-1 {{overloads for 'ConstFSEventStreamRef' exist with these partially matching parameter lists: (UnsafePointer<T>), (UnsafeMutablePointer<T>)}}
+  // expected-note @-1 {{overloads for 'ConstFSEventStreamRef' exist with these partially matching parameter lists:}}
 
   // This is not a CF object.
   FSEventStreamRetain(stream) // no-warning

--- a/test/Interpreter/process_arguments.swift
+++ b/test/Interpreter/process_arguments.swift
@@ -5,17 +5,36 @@
 
 // REQUIRES: swift_interpreter
 
-print("Begin")
+print("Begin arguments")
 for arg in Process.arguments { print(arg) }
-print("End")
+print("End arguments")
 
-// CHECK-NONE: Begin
+// CHECK-NONE: Begin arguments
 // CHECK-NONE-NEXT: {{.*}}process_arguments.swift
-// CHECK-NONE-NEXT: End
+// CHECK-NONE-NEXT: End arguments
 
-// CHECK-THREE: Begin
+// CHECK-THREE: Begin arguments
 // CHECK-THREE-NEXT: {{.*}}process_arguments.swift
 // CHECK-THREE-NEXT: a
 // CHECK-THREE-NEXT: b
 // CHECK-THREE-NEXT: c
-// CHECK-THREE-NEXT: End
+// CHECK-THREE-NEXT: End arguments
+
+print("Begin unsafeArgv")
+for i in 0...Int(Process.argc) {
+  print(Process.unsafeArgv[i].map { String(cString: $0) } ?? "(null)")
+}
+print("End unsafeArgv")
+
+// CHECK-NONE: Begin unsafeArgv
+// CHECK-NONE-NEXT: {{.*}}process_arguments.swift
+// CHECK-NONE-NEXT: (null)
+// CHECK-NONE-NEXT: End unsafeArgv
+
+// CHECK-THREE: Begin unsafeArgv
+// CHECK-THREE-NEXT: {{.*}}process_arguments.swift
+// CHECK-THREE-NEXT: a
+// CHECK-THREE-NEXT: b
+// CHECK-THREE-NEXT: c
+// CHECK-THREE-NEXT: (null)
+// CHECK-THREE-NEXT: End unsafeArgv

--- a/test/Parse/pointer_conversion.swift
+++ b/test/Parse/pointer_conversion.swift
@@ -5,35 +5,35 @@
 class C {}
 class D {}
 
-func takesMutablePointer(_ x: UnsafeMutablePointer<Int>) {}
-func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>) {}
-func takesMutableInt8Pointer(_ x: UnsafeMutablePointer<Int8>) {} 
-func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>) {} 
-func takesConstPointer(_ x: UnsafePointer<Int>) -> Character { return "x" }
-func takesConstInt8Pointer(_ x: UnsafePointer<Int8>) {}
-func takesConstUInt8Pointer(_ x: UnsafePointer<UInt8>) {}
-func takesConstVoidPointer(_ x: UnsafePointer<Void>) {}
-func takesAutoreleasingPointer(_ x: AutoreleasingUnsafeMutablePointer<C>) {} 
+func takesMutablePointer(_ x: UnsafeMutablePointer<Int>?) {}
+func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>?) {}
+func takesMutableInt8Pointer(_ x: UnsafeMutablePointer<Int8>?) {}
+func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>?) {}
+func takesConstPointer(_ x: UnsafePointer<Int>?) -> Character { return "x" }
+func takesConstInt8Pointer(_ x: UnsafePointer<Int8>?) {}
+func takesConstUInt8Pointer(_ x: UnsafePointer<UInt8>?) {}
+func takesConstVoidPointer(_ x: UnsafePointer<Void>?) {}
+func takesAutoreleasingPointer(_ x: AutoreleasingUnsafeMutablePointer<C>?) {}
 
 func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
                              cp: UnsafePointer<Int>,
                              ap: AutoreleasingUnsafeMutablePointer<Int>) {
   takesMutablePointer(nil)
   takesMutablePointer(p)
-  takesMutablePointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>'}}
-  takesMutablePointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  takesMutablePointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>?'}}
   var i: Int = 0
   var f: Float = 0
   takesMutablePointer(&i)
   takesMutablePointer(&f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
-  takesMutablePointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Int>'}}
-  takesMutablePointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  takesMutablePointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Int>?'}}
   var ii: [Int] = [0, 1, 2]
   var ff: [Float] = [0, 1, 2]
   takesMutablePointer(&ii)
   takesMutablePointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'Int'}}
-  takesMutablePointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Int>'}}
-  takesMutablePointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  takesMutablePointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafeMutablePointer<Int>?'}}
 
   takesMutableArrayPointer(&i) // expected-error{{cannot convert value of type 'Int' to expected argument type '[Int]'}}
   takesMutableArrayPointer(&ii)
@@ -51,27 +51,27 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableVoidPointer(nil)
   takesMutableVoidPointer(p)
   takesMutableVoidPointer(fp)
-  takesMutableVoidPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
-  takesMutableVoidPointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
+  takesMutableVoidPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableVoidPointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>?'}}
   var i: Int = 0
   var f: Float = 0
   takesMutableVoidPointer(&i)
   takesMutableVoidPointer(&f)
-  takesMutableVoidPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
-  takesMutableVoidPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
+  takesMutableVoidPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableVoidPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Void>?'}}
   var ii: [Int] = [0, 1, 2]
   var dd: [CInt] = [1, 2, 3]
   var ff: [Int] = [0, 1, 2]
   takesMutableVoidPointer(&ii)
   takesMutableVoidPointer(&dd)
   takesMutableVoidPointer(&ff)
-  takesMutableVoidPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
-  takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
+  takesMutableVoidPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>?'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutablePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
-  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
+  var x: UnsafeMutablePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutablePointer<Void>'}}
+  x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutablePointer<Void>'}}
+  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' (aka 'inout Array<Int>') to type 'UnsafeMutablePointer<Void>'}}
   _ = x
 }
 
@@ -92,7 +92,7 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstPointer(&ii)
   takesConstPointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'Int'}}
   takesConstPointer(ii)
-  takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>'}}
+  takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>?'}}
   takesConstPointer([0, 1, 2])
   // <rdar://problem/22308330> QoI: CSDiags doesn't handle array -> pointer impl conversions well
   takesConstPointer([0.0, 1.0, 2.0]) // expected-error{{cannot convert value of type 'Double' to expected element type 'Int'}}
@@ -150,12 +150,12 @@ func stringArguments(_ s: String) {
   takesConstVoidPointer(s)
   takesConstInt8Pointer(s)
   takesConstUInt8Pointer(s)
-  takesConstPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafePointer<Int>'}}
+  takesConstPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafePointer<Int>?'}}
 
-  takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>')}}
-  takesMutableInt8Pointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int8>'}}
+  takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableInt8Pointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int8>?'}}
   takesMutableInt8Pointer(&s) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int8'}}
-  takesMutablePointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  takesMutablePointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int>?'}}
   takesMutablePointer(&s) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
 }
 
@@ -163,16 +163,16 @@ func autoreleasingPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                    cp: UnsafePointer<Int>,
                                    ap: AutoreleasingUnsafeMutablePointer<C>) {
   takesAutoreleasingPointer(nil)
-  takesAutoreleasingPointer(p) // expected-error{{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>'}}
-  takesAutoreleasingPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>'}}
+  takesAutoreleasingPointer(p) // expected-error{{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
+  takesAutoreleasingPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
   takesAutoreleasingPointer(ap)
 
   var c: C = C()
   takesAutoreleasingPointer(&c)
-  takesAutoreleasingPointer(c) // expected-error{{cannot convert value of type 'C' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>'}}
+  takesAutoreleasingPointer(c) // expected-error{{cannot convert value of type 'C' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
   var d: D = D()
   takesAutoreleasingPointer(&d) // expected-error{{cannot convert value of type 'D' to expected argument type 'C'}}
-  takesAutoreleasingPointer(d) // expected-error{{cannot convert value of type 'D' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>'}}
+  takesAutoreleasingPointer(d) // expected-error{{cannot convert value of type 'D' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
   var cc: [C] = [C(), C()]
   var dd: [D] = [D(), D()]
   takesAutoreleasingPointer(&cc) // expected-error{{cannot convert value of type '[C]' to expected argument type 'C'}}

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -1,39 +1,56 @@
-// RUN: %target-parse-verify-swift
+// RUN: rm -rf %t && mkdir -p %t
 
-// XFAIL: linux
+// RUN: %S/../../utils/gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
+// RUN: %S/../../utils/line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift
+
+// RUN: %S/../../utils/gyb -DOPT_KIND=Optional %s -o %t/pointer_conversion_opt.swift
+// RUN: %S/../../utils/line-directive %t/pointer_conversion_opt.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_opt.swift
+
+// RUN: %S/../../utils/gyb -DOPT_KIND=ImplicitlyUnwrappedOptional %s -o %t/pointer_conversion_iuo.swift
+// RUN: %S/../../utils/line-directive %t/pointer_conversion_iuo.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_iuo.swift
+
+%{
+if OPT_KIND == 'Optional':
+  suffix='?'
+elif OPT_KIND == 'ImplicitlyUnwrappedOptional':
+  suffix='!'
+else:
+  suffix=''
+}%
 
 class C {}
 class D {}
 
-func takesMutablePointer(_ x: UnsafeMutablePointer<Int>?) {}
-func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>?) {}
-func takesMutableInt8Pointer(_ x: UnsafeMutablePointer<Int8>?) {}
-func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>?) {}
-func takesConstPointer(_ x: UnsafePointer<Int>?) -> Character { return "x" }
-func takesConstInt8Pointer(_ x: UnsafePointer<Int8>?) {}
-func takesConstUInt8Pointer(_ x: UnsafePointer<UInt8>?) {}
-func takesConstVoidPointer(_ x: UnsafePointer<Void>?) {}
-func takesAutoreleasingPointer(_ x: AutoreleasingUnsafeMutablePointer<C>?) {}
+func takesMutablePointer(_ x: UnsafeMutablePointer<Int>${suffix}) {}
+func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>${suffix}) {}
+func takesMutableInt8Pointer(_ x: UnsafeMutablePointer<Int8>${suffix}) {}
+func takesMutableArrayPointer(_ x: UnsafeMutablePointer<[Int]>${suffix}) {}
+func takesConstPointer(_ x: UnsafePointer<Int>${suffix}) -> Character { return "x" }
+func takesConstInt8Pointer(_ x: UnsafePointer<Int8>${suffix}) {}
+func takesConstUInt8Pointer(_ x: UnsafePointer<UInt8>${suffix}) {}
+func takesConstVoidPointer(_ x: UnsafePointer<Void>${suffix}) {}
 
 func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
-                             cp: UnsafePointer<Int>,
-                             ap: AutoreleasingUnsafeMutablePointer<Int>) {
+                             cp: UnsafePointer<Int>) {
   takesMutablePointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
   takesMutablePointer(p)
-  takesMutablePointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>?'}}
-  takesMutablePointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
   var i: Int = 0
   var f: Float = 0
   takesMutablePointer(&i)
   takesMutablePointer(&f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'Int'}}
-  takesMutablePointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Int>?'}}
-  takesMutablePointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
+  takesMutablePointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
   var ii: [Int] = [0, 1, 2]
   var ff: [Float] = [0, 1, 2]
   takesMutablePointer(&ii)
   takesMutablePointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'Int'}}
-  takesMutablePointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Int>?'}}
-  takesMutablePointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
+  takesMutablePointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
 
   takesMutableArrayPointer(&i) // expected-error{{cannot convert value of type 'Int' to expected argument type '[Int]'}}
   takesMutableArrayPointer(&ii)
@@ -46,27 +63,29 @@ func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
 
 func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                  cp: UnsafePointer<Int>,
-                                 ap: AutoreleasingUnsafeMutablePointer<Int>,
                                  fp: UnsafeMutablePointer<Float>) {
   takesMutableVoidPointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
   takesMutableVoidPointer(p)
   takesMutableVoidPointer(fp)
-  takesMutableVoidPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>?'}}
-  takesMutableVoidPointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableVoidPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
   var i: Int = 0
   var f: Float = 0
   takesMutableVoidPointer(&i)
   takesMutableVoidPointer(&f)
-  takesMutableVoidPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Void>?'}}
-  takesMutableVoidPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableVoidPointer(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(f) // expected-error{{cannot convert value of type 'Float' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
   var ii: [Int] = [0, 1, 2]
   var dd: [CInt] = [1, 2, 3]
   var ff: [Int] = [0, 1, 2]
   takesMutableVoidPointer(&ii)
   takesMutableVoidPointer(&dd)
   takesMutableVoidPointer(&ff)
-  takesMutableVoidPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>?'}}
-  takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>?'}}
+  takesMutableVoidPointer(ii) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
 
   // We don't allow these conversions outside of function arguments.
   var x: UnsafeMutablePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutablePointer<Void>'}}
@@ -76,12 +95,14 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
 }
 
 func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
-                           cp: UnsafePointer<Int>,
-                           ap: AutoreleasingUnsafeMutablePointer<Int>) {
+                           cp: UnsafePointer<Int>) {
   takesConstPointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
   takesConstPointer(p)
   takesConstPointer(cp)
-  takesConstPointer(ap)
 
   var i: Int = 0
   var f: Float = 0
@@ -92,7 +113,7 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstPointer(&ii)
   takesConstPointer(&ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'Int'}}
   takesConstPointer(ii)
-  takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>?'}}
+  takesConstPointer(ff) // expected-error{{cannot convert value of type '[Float]' to expected argument type 'UnsafePointer<Int>${suffix}'}}
   takesConstPointer([0, 1, 2])
   // <rdar://problem/22308330> QoI: CSDiags doesn't handle array -> pointer impl conversions well
   takesConstPointer([0.0, 1.0, 2.0]) // expected-error{{cannot convert value of type 'Double' to expected element type 'Int'}}
@@ -101,22 +122,21 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   var x: UnsafePointer<Int> = &i // expected-error{{cannot pass immutable value of type 'Int' as inout argument}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafePointer<Int>'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafePointer<Int>'}}
-  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafePointer<Int>'}}
 }
 
 func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                fp: UnsafeMutablePointer<Float>,
                                cp: UnsafePointer<Int>,
-                               cfp: UnsafePointer<Float>,
-                               ap: AutoreleasingUnsafeMutablePointer<Int>,
-                               afp: AutoreleasingUnsafeMutablePointer<Float>) {
+                               cfp: UnsafePointer<Float>) {
   takesConstVoidPointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
   takesConstVoidPointer(p)
   takesConstVoidPointer(fp)
   takesConstVoidPointer(cp)
   takesConstVoidPointer(cfp)
-  takesConstVoidPointer(ap)
-  takesConstVoidPointer(afp)
 
   var i: Int = 0
   var f: Float = 0
@@ -128,10 +148,10 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer(&ff)
   takesConstVoidPointer(ii)
   takesConstVoidPointer(ff)
-                                
+
   // TODO: These two should be accepted, tracked by rdar://17444930.
   takesConstVoidPointer([0, 1, 2]) // expected-error {{cannot convert value of type 'Int' to expected element type '()'}}
-takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{cannot convert value of type 'Double' to expected element type '()'}}
+  takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{cannot convert value of type 'Double' to expected element type '()'}}
 
   // We don't allow these conversions outside of function arguments.
   var x: UnsafePointer<Void> = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
@@ -140,8 +160,6 @@ takesConstVoidPointer([0.0, 1.0, 2.0])  // expected-error {{cannot convert value
   x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
   x = cp // expected-error{{cannot assign value of type 'UnsafePointer<Int>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
   x = cfp // expected-error{{cannot assign value of type 'UnsafePointer<Float>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
-  x = afp // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Float>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
   _ = x
 }
 
@@ -150,39 +168,30 @@ func stringArguments(_ s: String) {
   takesConstVoidPointer(s)
   takesConstInt8Pointer(s)
   takesConstUInt8Pointer(s)
-  takesConstPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafePointer<Int>?'}}
+  takesConstPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafePointer<Int>${suffix}'}}
 
-  takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Void>?'}}
-  takesMutableInt8Pointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int8>?'}}
+  takesMutableVoidPointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesMutableInt8Pointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int8>${suffix}'}}
   takesMutableInt8Pointer(&s) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int8'}}
-  takesMutablePointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int>?'}}
+  takesMutablePointer(s) // expected-error{{cannot convert value of type 'String' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
   takesMutablePointer(&s) // expected-error{{cannot convert value of type 'String' to expected argument type 'Int'}}
 }
 
-func autoreleasingPointerArguments(_ p: UnsafeMutablePointer<Int>,
-                                   cp: UnsafePointer<Int>,
-                                   ap: AutoreleasingUnsafeMutablePointer<C>) {
-  takesAutoreleasingPointer(nil)
-  takesAutoreleasingPointer(p) // expected-error{{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
-  takesAutoreleasingPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
-  takesAutoreleasingPointer(ap)
-
-  var c: C = C()
-  takesAutoreleasingPointer(&c)
-  takesAutoreleasingPointer(c) // expected-error{{cannot convert value of type 'C' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
-  var d: D = D()
-  takesAutoreleasingPointer(&d) // expected-error{{cannot convert value of type 'D' to expected argument type 'C'}}
-  takesAutoreleasingPointer(d) // expected-error{{cannot convert value of type 'D' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>?'}}
-  var cc: [C] = [C(), C()]
-  var dd: [D] = [D(), D()]
-  takesAutoreleasingPointer(&cc) // expected-error{{cannot convert value of type '[C]' to expected argument type 'C'}}
-  takesAutoreleasingPointer(&dd) // expected-error{{cannot convert value of type '[D]' to expected argument type 'C'}}
-
-  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error{{cannot pass immutable value of type 'C' as inout argument}}
-}
 
 func pointerConstructor(_ x: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<Float> {
   return UnsafeMutablePointer(x)
+}
+
+func optionality(_ op: UnsafeMutablePointer<Float>?) {
+  takesMutableVoidPointer(op)
+% if not suffix:
+  // expected-error@-2 {{value of optional type 'UnsafeMutablePointer<Float>?' not unwrapped}}
+% end
+
+  takesConstVoidPointer(op)
+% if not suffix:
+  // expected-error@-2 {{value of optional type 'UnsafeMutablePointer<Float>?' not unwrapped}}
+% end
 }
 
 func pointerArithmetic(_ x: UnsafeMutablePointer<Int>, y: UnsafeMutablePointer<Int>,
@@ -246,10 +255,7 @@ func f23202128() {
   var pipe2: [Int] = [0, 0]
   UMP(&pipe2) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Int32'}}
 
-  
+
   UP(pipe)    // ok
   UP(&pipe)   // expected-error {{'&' is not allowed passing array value as 'UnsafePointer<Int32>' argument}} {{6-7=}}
 }
-
-
-

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -1,0 +1,70 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %S/../../utils/gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
+// RUN: %S/../../utils/line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift
+
+// RUN: %S/../../utils/gyb -DOPT_KIND=Optional %s -o %t/pointer_conversion_opt.swift
+// RUN: %S/../../utils/line-directive %t/pointer_conversion_opt.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_opt.swift
+
+// RUN: %S/../../utils/gyb -DOPT_KIND=ImplicitlyUnwrappedOptional %s -o %t/pointer_conversion_iuo.swift
+// RUN: %S/../../utils/line-directive %t/pointer_conversion_iuo.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_iuo.swift
+
+// REQUIRES: objc_interop
+
+%{
+if OPT_KIND == 'Optional':
+  suffix='?'
+elif OPT_KIND == 'ImplicitlyUnwrappedOptional':
+  suffix='!'
+else:
+  suffix=''
+}%
+
+class C {}
+class D {}
+
+func takesMutablePointer(_ x: UnsafeMutablePointer<Int>${suffix}) {}
+func takesMutableVoidPointer(_ x: UnsafeMutablePointer<Void>${suffix}) {}
+func takesConstPointer(_ x: UnsafePointer<Int>${suffix}) -> Character { return "x" }
+func takesConstVoidPointer(_ x: UnsafePointer<Void>${suffix}) {}
+
+func takesAutoreleasingPointer(_ x: AutoreleasingUnsafeMutablePointer<C>${suffix}) {}
+
+func pointerArgumentsObjC(ap: AutoreleasingUnsafeMutablePointer<Int>,
+                          afp: AutoreleasingUnsafeMutablePointer<Float>) {
+  takesMutablePointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Int>${suffix}'}}
+  takesMutableVoidPointer(ap) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<Int>' to expected argument type 'UnsafeMutablePointer<Void>${suffix}'}}
+  takesConstPointer(ap)
+  takesConstVoidPointer(ap)
+  takesConstVoidPointer(afp)
+
+  var x: UnsafePointer<Void>
+  x = ap // expected-error{{cannot assign value of type 'AutoreleasingUnsafeMutablePointer<Int>' to type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>')}}
+  _ = x
+}
+
+func autoreleasingPointerArguments(p: UnsafeMutablePointer<Int>,
+                                   cp: UnsafePointer<Int>,
+                                   ap: AutoreleasingUnsafeMutablePointer<C>) {
+  takesAutoreleasingPointer(nil)
+% if not suffix:
+  // expected-error@-2 {{nil is not compatible with expected argument type}}
+% end
+
+  takesAutoreleasingPointer(p) // expected-error{{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>${suffix}'}}
+  takesAutoreleasingPointer(cp) // expected-error{{cannot convert value of type 'UnsafePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>${suffix}'}}
+  takesAutoreleasingPointer(ap)
+
+  var c: C = C()
+  takesAutoreleasingPointer(&c)
+  takesAutoreleasingPointer(c) // expected-error{{cannot convert value of type 'C' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>${suffix}'}}
+  var d: D = D()
+  takesAutoreleasingPointer(&d) // expected-error{{cannot convert value of type 'D' to expected argument type 'C'}}
+  takesAutoreleasingPointer(d) // expected-error{{cannot convert value of type 'D' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>${suffix}'}}
+  var cc: [C] = [C(), C()]
+  var dd: [D] = [D(), D()]
+  takesAutoreleasingPointer(&cc) // expected-error{{cannot convert value of type '[C]' to expected argument type 'C'}}
+  takesAutoreleasingPointer(&dd) // expected-error{{cannot convert value of type '[D]' to expected argument type 'C'}}
+
+  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error{{cannot pass immutable value of type 'C' as inout argument}}
+}

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -128,9 +128,9 @@ class NotObjC {}
 // CHECK-LABEL: @interface Methods{{$}}
 // CHECK-NEXT: - (void)test;
 // CHECK-NEXT: + (void)test2;
-// CHECK-NEXT: - (void * _Null_unspecified)testPrimitives:(BOOL)b i:(NSInteger)i f:(float)f d:(double)d u:(NSUInteger)u;
+// CHECK-NEXT: - (void * _Nonnull)testPrimitives:(BOOL)b i:(NSInteger)i f:(float)f d:(double)d u:(NSUInteger)u;
 // CHECK-NEXT: - (void)testString:(NSString * _Nonnull)s;
-// CHECK-NEXT: - (void)testSelector:(SEL _Null_unspecified)sel boolean:(BOOL)b;
+// CHECK-NEXT: - (void)testSelector:(SEL _Nonnull)sel boolean:(BOOL)b;
 // CHECK-NEXT: - (void)testCSignedTypes:(signed char)a b:(short)b c:(int)c d:(long)d e:(long long)e;
 // CHECK-NEXT: - (void)testCUnsignedTypes:(unsigned char)a b:(unsigned short)b c:(unsigned int)c d:(unsigned long)d e:(unsigned long long)e;
 // CHECK-NEXT: - (void)testCChars:(char)basic wchar:(wchar_t)wide char16:(char16_t)char16 char32:(char32_t)char32;
@@ -167,7 +167,7 @@ class NotObjC {}
   class func test2() {}
 
   func testPrimitives(_ b: Bool, i: Int, f: Float, d: Double, u: UInt)
-    -> OpaquePointer { return nil }
+    -> OpaquePointer { return OpaquePointer(bitPattern: -1)! }
   func testString(_ s: String) {}
   func testSelector(_ sel: Selector, boolean b: ObjCBool) {}
 
@@ -228,7 +228,7 @@ typealias AliasForNSRect = NSRect
 // CHECK-NEXT: - (NSArray * _Nonnull)emptyArray;
 // CHECK-NEXT: - (NSArray * _Nullable)maybeArray;
 // CHECK-NEXT: - (NSRuncingMode)someEnum;
-// CHECK-NEXT: - (struct _NSZone * _Null_unspecified)zone;
+// CHECK-NEXT: - (struct _NSZone * _Nullable)zone;
 // CHECK-NEXT: - (CFTypeRef _Nullable)cf:(CFTreeRef _Nonnull)x str:(CFStringRef _Nonnull)str str2:(CFMutableStringRef _Nonnull)str2 obj:(CFAliasForTypeRef _Nonnull)obj;
 // CHECK-NEXT: - (void)appKitInImplementation;
 // CHECK-NEXT: - (NSURL * _Nullable)returnsURL;
@@ -244,7 +244,7 @@ typealias AliasForNSRect = NSRect
 
   func someEnum() -> NSRuncingMode { return .mince }
 
-  func zone() -> NSZone { return nil }
+  func zone() -> NSZone? { return nil }
 
   func cf(_ x: CFTree, str: CFString, str2: CFMutableString, obj: CFAliasForType) -> CFTypeRef? { return nil }
 
@@ -256,14 +256,16 @@ typealias AliasForNSRect = NSRect
 }
 
 // CHECK-LABEL: @interface MethodsWithPointers
-// CHECK-NEXT: - (id _Nonnull * _Null_unspecified)test:(NSInteger * _Null_unspecified)a;
-// CHECK-NEXT: - (void)testNested:(NSInteger * _Null_unspecified * _Null_unspecified)a;
-// CHECK-NEXT: - (void)testBridging:(NSInteger const * _Null_unspecified)a b:(NSInteger * _Null_unspecified)b c:(Methods * _Nonnull * _Null_unspecified)c;
-// CHECK-NEXT: - (void)testBridgingVoid:(void * _Null_unspecified)a b:(void const * _Null_unspecified)b;
+// CHECK-NEXT: - (id _Nonnull * _Nonnull)test:(NSInteger * _Nonnull)a;
+// CHECK-NEXT: - (void)testNested:(NSInteger * _Nonnull * _Nonnull)a;
+// CHECK-NEXT: - (void)testBridging:(NSInteger const * _Nonnull)a b:(NSInteger * _Nonnull)b c:(Methods * _Nonnull * _Nonnull)c;
+// CHECK-NEXT: - (void)testBridgingVoid:(void * _Nonnull)a b:(void const * _Nonnull)b;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class MethodsWithPointers {
-  func test(_ a: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<AnyObject> { return nil }
+  func test(_ a: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<AnyObject> {
+    return UnsafeMutablePointer(bitPattern: -1)!
+  }
 
   func testNested(_ a: UnsafeMutablePointer<UnsafeMutablePointer<Int>>) {}
 
@@ -572,13 +574,13 @@ public class NonObjCClass { }
 }
 
 // CHECK-LABEL: @interface Throwing1
-// CHECK-NEXT: - (BOOL)method1AndReturnError:(NSError * _Nullable * _Null_unspecified)error;
-// CHECK-NEXT: - (Throwing1 * _Nullable)method2AndReturnError:(NSError * _Nullable * _Null_unspecified)error;
-// CHECK-NEXT: - (NSArray<NSString *> * _Nullable)method3:(NSInteger)x error:(NSError * _Nullable * _Null_unspecified)error;
-// CHECK-NEXT: - (nullable instancetype)method4AndReturnError:(NSError * _Nullable * _Null_unspecified)error;
-// CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Null_unspecified)error OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nullable instancetype)initWithString:(NSString * _Nonnull)string error:(NSError * _Nullable * _Null_unspecified)error OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Null_unspecified)error fn:(NSInteger (^ _Nonnull)(NSInteger))fn OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (BOOL)method1AndReturnError:(NSError * _Nullable * _Nullable)error;
+// CHECK-NEXT: - (Throwing1 * _Nullable)method2AndReturnError:(NSError * _Nullable * _Nullable)error;
+// CHECK-NEXT: - (NSArray<NSString *> * _Nullable)method3:(NSInteger)x error:(NSError * _Nullable * _Nullable)error;
+// CHECK-NEXT: - (nullable instancetype)method4AndReturnError:(NSError * _Nullable * _Nullable)error;
+// CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nullable instancetype)initWithString:(NSString * _Nonnull)string error:(NSError * _Nullable * _Nullable)error OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nullable instancetype)initAndReturnError:(NSError * _Nullable * _Nullable)error fn:(NSInteger (^ _Nonnull)(NSInteger))fn OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 @objc class Throwing1 {
   func method1() throws { }

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -260,6 +260,7 @@ typealias AliasForNSRect = NSRect
 // CHECK-NEXT: - (void)testNested:(NSInteger * _Nonnull * _Nonnull)a;
 // CHECK-NEXT: - (void)testBridging:(NSInteger const * _Nonnull)a b:(NSInteger * _Nonnull)b c:(Methods * _Nonnull * _Nonnull)c;
 // CHECK-NEXT: - (void)testBridgingVoid:(void * _Nonnull)a b:(void const * _Nonnull)b;
+// CHECK-NEXT: - (void)testBridgingOptionality:(NSInteger const * _Nullable)a b:(NSInteger * _Null_unspecified)b c:(Methods * _Nullable * _Nullable)c;
 // CHECK-NEXT: init
 // CHECK-NEXT: @end
 @objc class MethodsWithPointers {
@@ -271,6 +272,8 @@ typealias AliasForNSRect = NSRect
 
   func testBridging(_ a: UnsafePointer<Int>, b: UnsafeMutablePointer<Int>, c: AutoreleasingUnsafeMutablePointer<Methods>) {}
   func testBridgingVoid(_ a: UnsafeMutablePointer<Void>, b: UnsafePointer<Void>) {}
+
+  func testBridgingOptionality(_ a: UnsafePointer<Int>?, b: UnsafeMutablePointer<Int>!, c: AutoreleasingUnsafeMutablePointer<Methods?>?) {}
 }
 
 // CHECK-LABEL: @interface MyObject : NSObject

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -243,7 +243,7 @@ struct _ForkJoinMutex {
 }
 
 struct _ForkJoinCond {
-  var _cond: UnsafeMutablePointer<pthread_cond_t> = nil
+  var _cond: UnsafeMutablePointer<pthread_cond_t>
 
   init() {
     _cond = UnsafeMutablePointer(allocatingCapacity: 1)

--- a/test/SILGen/Inputs/AppKit.swift
+++ b/test/SILGen/Inputs/AppKit.swift
@@ -5,6 +5,6 @@ import Foundation
 // argv as a const char**.
 @_silgen_name("NSApplicationMain")
 public func NSApplicationMain(
-  _ argc: Int32, _ argv: UnsafeMutablePointer<UnsafeMutablePointer<CChar>>
+  _ argc: Int32, _ argv: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
 ) -> Int32
 

--- a/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/SILGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -5,8 +5,8 @@
 
 @interface NSString : NSObject<NSCopying>
 
-- (__null_unspecified NSString*)uppercaseString;
-- (id) copyWithZone: (nullable NSZone*)zone;
+- (null_unspecified NSString*)uppercaseString;
+- (id) copyWithZone: (nullable void*)zone;
 
 @end
 
@@ -15,11 +15,11 @@
 - (instancetype)initWithObjects:(const ObjectType *)objects count:(int)count;
 - (instancetype)initWithArray:(NSArray<ObjectType>*)array;
 
-- (id)objectAtIndexedSubscript:(NSInteger)i;
+- (nonnull ObjectType)objectAtIndexedSubscript:(NSInteger)i;
 
 @end
 
-@interface NSDictionary<KeyType, ObjectType> : NSObject
+@interface NSDictionary<KeyType, ValueType> : NSObject
 @end
 
 @interface NSSet<ObjectType> : NSObject

--- a/test/SILGen/Inputs/usr/include/Gizmo.h
+++ b/test/SILGen/Inputs/usr/include/Gizmo.h
@@ -46,10 +46,10 @@ typedef long NSInteger;
 + (void) runce;
 - (void) funge;
 - (void) foo;
-- (void*) getBytes NS_RETURNS_INNER_POINTER;
+- (void* _Nonnull) getBytes NS_RETURNS_INNER_POINTER;
 
-@property void *innerProperty;
-- (void*) innerProperty NS_RETURNS_INNER_POINTER;
+@property (nonnull) void *innerProperty;
+- (void* _Nonnull) innerProperty NS_RETURNS_INNER_POINTER;
 - (void) setInnerProperty: (void*)p;
 
 @property void (^block)(void);

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -17,6 +17,9 @@ class A { var array = OrdinarySub() }
 func index0() -> Int { return 0 }
 func index1() -> Int { return 1 }
 
+func someValidPointer<T>() -> UnsafePointer<T> { fatalError() }
+func someValidPointer<T>() -> UnsafeMutablePointer<T> { fatalError() }
+
 // Verify that there is no unnecessary extra retain of ref.array.
 // rdar://19002913
 func test0(_ ref: A) {
@@ -163,8 +166,8 @@ struct RecInner {
 }
 struct RecOuter {
   var inner : RecInner {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidPointer() }
+    unsafeMutableAddress { return someValidPointer() }
   }
 }
 func test_rec(_ outer: inout RecOuter) -> Int {
@@ -181,8 +184,8 @@ struct Rec2Inner {
 }
 struct Rec2Outer {
   var inner : Rec2Inner {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidPointer() }
+    unsafeMutableAddress { return someValidPointer() }
   }
 }
 func test_rec2(_ outer: inout Rec2Outer) -> Int {

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -3,8 +3,11 @@
 
 import Swift
 
+func someValidPointer<T>() -> UnsafePointer<T> { fatalError() }
+func someValidPointer<T>() -> UnsafeMutablePointer<T> { fatalError() }
+
 struct A {
-  var base: UnsafeMutablePointer<Int32> = nil
+  var base: UnsafeMutablePointer<Int32> = someValidPointer()
 
   subscript(index: Int32) -> Int32 {
     unsafeAddress {
@@ -108,8 +111,8 @@ protocol Subscriptable {
 
 struct B : Subscriptable {
   subscript(i: Int32) -> Int32 {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidPointer() }
+    unsafeMutableAddress { return someValidPointer() }
   }
 }
 
@@ -133,7 +136,7 @@ func test_B(_ b: inout B) {
 
 // Test that we handle abstraction difference.
 struct CArray<T> {
-  var storage: UnsafeMutablePointer<T> = nil
+  var storage: UnsafeMutablePointer<T>
   subscript(index: Int) -> T {
     unsafeAddress { return UnsafePointer(storage) + index }
     unsafeMutableAddress { return storage + index }
@@ -165,7 +168,7 @@ func test_carray(_ array: inout CArray<Int32 -> Int32>) -> Int32 {
 struct D : Subscriptable {
   subscript(i: Int32) -> Int32 {
     get { return i }
-    unsafeMutableAddress { return nil }
+    unsafeMutableAddress { return someValidPointer() }
   }
 }
 // Setter.
@@ -226,8 +229,8 @@ func test_d(_ array: inout D) -> Int32 {
 
 struct E {
   var value: Int32 {
-    unsafeAddress { return nil }
-    nonmutating unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidPointer() }
+    nonmutating unsafeMutableAddress { return someValidPointer() }
   }
 }
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -10,6 +10,9 @@ enum HomeworkError : ErrorProtocol {
   case CatAteIt(Cat)
 }
 
+func someValidPointer<T>() -> UnsafePointer<T> { fatalError() }
+func someValidPointer<T>() -> UnsafeMutablePointer<T> { fatalError() }
+
 // CHECK: sil hidden @_TF6errors10make_a_cat{{.*}} : $@convention(thin) () -> (@owned Cat, @error ErrorProtocol) {
 // CHECK:      [[T0:%.*]] = function_ref @_TFC6errors3CatC{{.*}} : $@convention(method) (@thick Cat.Type) -> @owned Cat
 // CHECK-NEXT: [[T1:%.*]] = metatype $@thick Cat.Type 
@@ -610,8 +613,8 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 struct OwnedBridge {
   var owner : Builtin.UnknownObject
   subscript(name: String) -> Pylon {
-    addressWithOwner { return (nil, owner) }
-    mutableAddressWithOwner { return (nil, owner) }
+    addressWithOwner { return (someValidPointer(), owner) }
+    mutableAddressWithOwner { return (someValidPointer(), owner) }
   }
 }
 func supportStructure(_ b: inout OwnedBridge, name: String) throws {
@@ -646,8 +649,8 @@ func supportStructure(_ b: inout OwnedBridge, name: String) throws {
 struct PinnedBridge {
   var owner : Builtin.NativeObject
   subscript(name: String) -> Pylon {
-    addressWithPinnedNativeOwner { return (nil, owner) }
-    mutableAddressWithPinnedNativeOwner { return (nil, owner) }
+    addressWithPinnedNativeOwner { return (someValidPointer(), owner) }
+    mutableAddressWithPinnedNativeOwner { return (someValidPointer(), owner) }
   }
 }
 func supportStructure(_ b: inout PinnedBridge, name: String) throws {

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -1,7 +1,4 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %build-clang-importer-objc-overlays
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-silgen -parse-as-library %s | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -parse-as-library %s | FileCheck %s
 
 // REQUIRES: objc_interop
 
@@ -11,7 +8,7 @@ import errors
 // CHECK: sil hidden @_TF14foreign_errors5test0FzT_T_ : $@convention(thin) () -> @error ErrorProtocol
 func test0() throws {
   // CHECK: [[SELF:%.*]] = metatype $@thick ErrorProne.Type
-  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $@thick ErrorProne.Type, #ErrorProne.fail!1.foreign : ErrorProne.Type -> () throws -> () , $@convention(objc_method) (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @objc_metatype ErrorProne.Type) -> Bool
+  // CHECK: [[METHOD:%.*]] = class_method [volatile] [[SELF]] : $@thick ErrorProne.Type, #ErrorProne.fail!1.foreign : ErrorProne.Type -> () throws -> () , $@convention(objc_method) (ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Bool
   // CHECK: [[OBJC_SELF:%.*]] = thick_to_objc_metatype [[SELF]]
 
   //   Create a strong temporary holding nil.
@@ -56,59 +53,73 @@ extension NSObject {
   @objc func abort() throws {
     throw NSError(domain: "", code: 1, userInfo: [:])
   }
-// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject5abort{{.*}} : $@convention(objc_method) (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, NSObject) -> Bool
+// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject5abort{{.*}} : $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSObject) -> Bool
 // CHECK: [[T0:%.*]] = function_ref @_TFE14foreign_errorsCSo8NSObject5abort{{.*}} : $@convention(method) (@guaranteed NSObject) -> @error ErrorProtocol
 // CHECK: try_apply [[T0]](
 // CHECK: bb1(
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK:   [[T1:%.*]] = struct $Bool ([[T0]] : $Builtin.Int1)
-// CHECK:   br bb3([[T1]] : $Bool)
+// CHECK:   br bb6([[T1]] : $Bool)
 // CHECK: bb2([[ERR:%.*]] : $ErrorProtocol):
+// CHECK:   switch_enum %0 : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, case #Optional.some!enumelt.1: bb3, case #Optional.none!enumelt: bb4
+// CHECK: bb3([[UNWRAPPED_OUT:%.+]] : $AutoreleasingUnsafeMutablePointer<Optional<NSError>>):
 // CHECK:   [[T0:%.*]] = function_ref @swift_convertErrorProtocolToNSError : $@convention(thin) (@owned ErrorProtocol) -> @owned NSError
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[ERR]])
 // CHECK:   [[OBJCERR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt.1, [[T1]] : $NSError
 // CHECK:   [[SETTER:%.*]] = function_ref @_TFVs33AutoreleasingUnsafeMutablePointers7pointeex :
 // CHECK:   [[TEMP:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   store [[OBJCERR]] to [[TEMP]]
-// CHECK:   apply [[SETTER]]<Optional<NSError>>([[TEMP]], %0)
+// CHECK:   apply [[SETTER]]<Optional<NSError>>([[TEMP]], [[UNWRAPPED_OUT]])
 // CHECK:   dealloc_stack [[TEMP]]
+// CHECK:   br bb5
+// CHECK: bb4:
+// CHECK:   strong_release [[ERR]] : $ErrorProtocol
+// CHECK:   br bb5
+// CHECK: bb5:
 // CHECK:   [[T0:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK:   [[T1:%.*]] = struct $Bool ([[T0]] : $Builtin.Int1)
-// CHECK:   br bb3([[T1]] : $Bool)
-// CHECK: bb3([[T0:%.*]] : $Bool):
+// CHECK:   br bb6([[T1]] : $Bool)
+// CHECK: bb6([[T0:%.*]] : $Bool):
 // CHECK:   return [[T0]] : $Bool
 
   @objc func badDescription() throws -> String {
     throw NSError(domain: "", code: 1, userInfo: [:])
   }
-// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject14badDescription{{.*}} : $@convention(objc_method) (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, NSObject) -> @autoreleased Optional<NSString>
+// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject14badDescription{{.*}} : $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSObject) -> @autoreleased Optional<NSString>
 // CHECK: [[T0:%.*]] = function_ref @_TFE14foreign_errorsCSo8NSObject14badDescription{{.*}} : $@convention(method) (@guaranteed NSObject) -> (@owned String, @error ErrorProtocol)
 // CHECK: try_apply [[T0]](
 // CHECK: bb1([[RESULT:%.*]] : $String):
-// CHECK:   [[T0:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString
+// CHECK:   [[T0:%.*]] = function_ref @_TFE10FoundationSS19_bridgeToObjectiveCfT_CSo8NSString : $@convention(method) (@guaranteed String) -> @owned NSString
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[RESULT]])
 // CHECK:   [[T2:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[T1]] : $NSString
-// CHECK:   br bb3([[T2]] : $Optional<NSString>)
+// CHECK:   br bb6([[T2]] : $Optional<NSString>)
 // CHECK: bb2([[ERR:%.*]] : $ErrorProtocol):
+// CHECK:   switch_enum %0 : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, case #Optional.some!enumelt.1: bb3, case #Optional.none!enumelt: bb4
+// CHECK: bb3([[UNWRAPPED_OUT:%.+]] : $AutoreleasingUnsafeMutablePointer<Optional<NSError>>):
 // CHECK:   [[T0:%.*]] = function_ref @swift_convertErrorProtocolToNSError : $@convention(thin) (@owned ErrorProtocol) -> @owned NSError
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[ERR]])
 // CHECK:   [[OBJCERR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt.1, [[T1]] : $NSError
 // CHECK:   [[SETTER:%.*]] = function_ref @_TFVs33AutoreleasingUnsafeMutablePointers7pointeex :
 // CHECK:   [[TEMP:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   store [[OBJCERR]] to [[TEMP]]
-// CHECK:   apply [[SETTER]]<Optional<NSError>>([[TEMP]], %0)
+// CHECK:   apply [[SETTER]]<Optional<NSError>>([[TEMP]], [[UNWRAPPED_OUT]])
 // CHECK:   dealloc_stack [[TEMP]]
+// CHECK:   br bb5
+// CHECK: bb4:
+// CHECK:   strong_release [[ERR]] : $ErrorProtocol
+// CHECK:   br bb5
+// CHECK: bb5:
 // CHECK:   [[T0:%.*]] = enum $Optional<NSString>, #Optional.none!enumelt
-// CHECK:   br bb3([[T0]] : $Optional<NSString>)
-// CHECK: bb3([[T0:%.*]] : $Optional<NSString>):
+// CHECK:   br bb6([[T0]] : $Optional<NSString>)
+// CHECK: bb6([[T0:%.*]] : $Optional<NSString>):
 // CHECK:   return [[T0]] : $Optional<NSString>
 
-// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject7takeInt{{.*}} : $@convention(objc_method) (Int, AutoreleasingUnsafeMutablePointer<Optional<NSError>>, NSObject) -> Bool
-// CHECK: bb0([[I:%[0-9]+]] : $Int, [[ERROR:%[0-9]+]] : $AutoreleasingUnsafeMutablePointer<Optional<NSError>>, [[SELF:%[0-9]+]] : $NSObject)
+// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject7takeInt{{.*}} : $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSObject) -> Bool
+// CHECK: bb0([[I:%[0-9]+]] : $Int, [[ERROR:%[0-9]+]] : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[SELF:%[0-9]+]] : $NSObject)
   @objc func takeInt(_ i: Int) throws { }
 
-// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject10takeDouble{{.*}} : $@convention(objc_method) (Double, Int, AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @convention(block) (Int) -> Int, NSObject) -> Bool
-// CHECK: bb0([[D:%[0-9]+]] : $Double, [[INT:%[0-9]+]] : $Int, [[ERROR:%[0-9]+]] : $AutoreleasingUnsafeMutablePointer<Optional<NSError>>, [[CLOSURE:%[0-9]+]] : $@convention(block) (Int) -> Int, [[SELF:%[0-9]+]] : $NSObject):
+// CHECK-LABEL: sil hidden [thunk] @_TToFE14foreign_errorsCSo8NSObject10takeDouble{{.*}} : $@convention(objc_method) (Double, Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @convention(block) (Int) -> Int, NSObject) -> Bool
+// CHECK: bb0([[D:%[0-9]+]] : $Double, [[INT:%[0-9]+]] : $Int, [[ERROR:%[0-9]+]] : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[CLOSURE:%[0-9]+]] : $@convention(block) (Int) -> Int, [[SELF:%[0-9]+]] : $NSObject):
   @objc func takeDouble(_ d: Double, int: Int, closure: (Int) -> Int) throws {
     throw NSError(domain: "", code: 1, userInfo: [:])
   }
@@ -122,7 +133,7 @@ let fn = ErrorProne.fail
 
 // CHECK-LABEL: sil shared [thunk] @_TTOZFCSo10ErrorProne4fail{{.*}} : $@convention(method) (@thick ErrorProne.Type) -> @error ErrorProtocol {
 // CHECK:      [[SELF:%.*]] = thick_to_objc_metatype %0 : $@thick ErrorProne.Type to $@objc_metatype ErrorProne.Type
-// CHECK:      [[METHOD:%.*]] = class_method [volatile] [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.fail!1.foreign : ErrorProne.Type -> () throws -> () , $@convention(objc_method) (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @objc_metatype ErrorProne.Type) -> Bool
+// CHECK:      [[METHOD:%.*]] = class_method [volatile] [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.fail!1.foreign : ErrorProne.Type -> () throws -> () , $@convention(objc_method) (ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Bool
 // CHECK:      [[TEMP:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]({{%.*}}, [[SELF]])
 // CHECK:      cond_br
@@ -135,13 +146,13 @@ func testArgs() throws {
   try ErrorProne.consume(nil)
 }
 // CHECK: sil hidden @_TF14foreign_errors8testArgsFzT_T_ : $@convention(thin) () -> @error ErrorProtocol
-// CHECK:   class_method [volatile] %0 : $@thick ErrorProne.Type, #ErrorProne.consume!1.foreign : ErrorProne.Type -> (AnyObject!) throws -> () , $@convention(objc_method) (ImplicitlyUnwrappedOptional<AnyObject>, AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @objc_metatype ErrorProne.Type) -> Bool
+// CHECK:   class_method [volatile] %0 : $@thick ErrorProne.Type, #ErrorProne.consume!1.foreign : ErrorProne.Type -> (AnyObject!) throws -> () , $@convention(objc_method) (ImplicitlyUnwrappedOptional<AnyObject>, ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Bool
 
 func testBridgedResult() throws {
   let array = try ErrorProne.collection(withCount: 0)
 }
 // CHECK: sil hidden @_TF14foreign_errors17testBridgedResultFzT_T_ : $@convention(thin) () -> @error ErrorProtocol {
-// CHECK:   class_method [volatile] %0 : $@thick ErrorProne.Type, #ErrorProne.collection!1.foreign : ErrorProne.Type -> (withCount: Int) throws -> [AnyObject] , $@convention(objc_method) (Int, AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @objc_metatype ErrorProne.Type) -> @autoreleased Optional<NSArray>
+// CHECK:   class_method [volatile] %0 : $@thick ErrorProne.Type, #ErrorProne.collection!1.foreign : ErrorProne.Type -> (withCount: Int) throws -> [AnyObject] , $@convention(objc_method) (Int, ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> @autoreleased Optional<NSArray>
 
 // rdar://20861374
 // Clear out the self box before delegating.
@@ -156,7 +167,7 @@ class VeryErrorProne : ErrorProne {
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[PB]]
 // CHECK:      [[T0:%.*]] = load [[MARKED_BOX]]
 // CHECK-NEXT: [[T1:%.*]] = upcast [[T0]] : $VeryErrorProne to $ErrorProne
-// CHECK-NEXT: [[T2:%.*]] = super_method [volatile] [[T0]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : ErrorProne.Type -> (one: AnyObject?) throws -> ErrorProne , $@convention(objc_method) (Optional<AnyObject>, AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
+// CHECK-NEXT: [[T2:%.*]] = super_method [volatile] [[T0]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : ErrorProne.Type -> (one: AnyObject?) throws -> ErrorProne , $@convention(objc_method) (Optional<AnyObject>, ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
 // CHECK:      {{$}}
 // CHECK-NOT:  [[BOX]]{{^[0-9]}}
 // CHECK-NOT:  [[MARKED_BOX]]{{^[0-9]}}
@@ -167,12 +178,12 @@ class VeryErrorProne : ErrorProne {
 func testProtocol(_ p: ErrorProneProtocol) throws {
   // CHECK:   [[T0:%.*]] = open_existential_ref %0 : $ErrorProneProtocol to $[[OPENED:@opened(.*) ErrorProneProtocol]]
   // CHECK:   [[T1:%.*]] = witness_method [volatile] $[[OPENED]], #ErrorProneProtocol.obliterate!1.foreign, [[T0]] : $[[OPENED]] :
-  // CHECK:   apply [[T1]]<[[OPENED]]>({{%.*}}, [[T0]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : ErrorProneProtocol> (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, τ_0_0) -> Bool
+  // CHECK:   apply [[T1]]<[[OPENED]]>({{%.*}}, [[T0]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : ErrorProneProtocol> (ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, τ_0_0) -> Bool
   try p.obliterate()
 
   // CHECK:   [[T0:%.*]] = open_existential_ref %0 : $ErrorProneProtocol to $[[OPENED:@opened(.*) ErrorProneProtocol]]
   // CHECK:   [[T1:%.*]] = witness_method [volatile] $[[OPENED]], #ErrorProneProtocol.invigorate!1.foreign, [[T0]] : $[[OPENED]] :
-  // CHECK:   apply [[T1]]<[[OPENED]]>({{%.*}}, {{%.*}}, [[T0]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : ErrorProneProtocol> (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, ImplicitlyUnwrappedOptional<@convention(block) () -> ()>, τ_0_0) -> Bool
+  // CHECK:   apply [[T1]]<[[OPENED]]>({{%.*}}, {{%.*}}, [[T0]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : ErrorProneProtocol> (ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, ImplicitlyUnwrappedOptional<@convention(block) () -> ()>, τ_0_0) -> Bool
   try p.invigorate(callback: {})
 }
 
@@ -181,7 +192,7 @@ class ExtremelyErrorProne : ErrorProne {
   override func conflict3(_ obj: AnyObject, error: ()) throws {}
 }
 // CHECK: sil hidden @_TFC14foreign_errors19ExtremelyErrorProne9conflict3{{.*}}
-// CHECK: sil hidden [thunk] @_TToFC14foreign_errors19ExtremelyErrorProne9conflict3{{.*}} : $@convention(objc_method) (AnyObject, AutoreleasingUnsafeMutablePointer<Optional<NSError>>, ExtremelyErrorProne) -> Bool
+// CHECK: sil hidden [thunk] @_TToFC14foreign_errors19ExtremelyErrorProne9conflict3{{.*}} : $@convention(objc_method) (AnyObject, ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, ExtremelyErrorProne) -> Bool
 
 // These conventions are usable because of swift_error. rdar://21715350
 func testNonNilError() throws -> Float {
@@ -189,7 +200,7 @@ func testNonNilError() throws -> Float {
 }
 // CHECK: sil hidden @_TF14foreign_errors15testNonNilErrorFzT_Sf :
 // CHECK:   [[T0:%.*]] = metatype $@thick ErrorProne.Type
-// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.bounce!1.foreign : ErrorProne.Type -> () throws -> Float , $@convention(objc_method) (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @objc_metatype ErrorProne.Type) -> Float
+// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.bounce!1.foreign : ErrorProne.Type -> () throws -> Float , $@convention(objc_method) (ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Float
 // CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
 // CHECK:   assign {{%.*}} to [[OPTERR]]
@@ -205,7 +216,7 @@ func testPreservedResult() throws -> CInt {
 }
 // CHECK: sil hidden @_TF14foreign_errors19testPreservedResultFzT_Vs5Int32
 // CHECK:   [[T0:%.*]] = metatype $@thick ErrorProne.Type
-// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.ounce!1.foreign : ErrorProne.Type -> () throws -> Int32 , $@convention(objc_method) (AutoreleasingUnsafeMutablePointer<Optional<NSError>>, @objc_metatype ErrorProne.Type) -> Int32
+// CHECK:   [[T1:%.*]] = class_method [volatile] [[T0]] : $@thick ErrorProne.Type, #ErrorProne.ounce!1.foreign : ErrorProne.Type -> () throws -> Int32 , $@convention(objc_method) (ImplicitlyUnwrappedOptional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
 // CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
 // CHECK:   [[T0:%.*]] = struct_extract [[RESULT]]

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -52,24 +52,24 @@ func curry_bridged(_ x: CurryTest) -> String! -> String! {
 // CHECK:   strong_release %1
 // CHECK:   return {{%.*}} : $ImplicitlyUnwrappedOptional<String>
 
-func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutablePointer<Void> {
+func curry_returnsInnerPointer(_ x: CurryTest) -> () -> UnsafeMutablePointer<Void>! {
   return x.returnsInnerPointer
 }
-// CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSpT__ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> UnsafeMutablePointer<()> {
-// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER:@_TTOFCSo9CurryTest19returnsInnerPointerFT_GSpT__]]
+// CHECK-LABEL: sil hidden @_TF13objc_currying25curry_returnsInnerPointerFCSo9CurryTestFT_GSQGSpT___ : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>> {
+// CHECK:         [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER:@_TTOFCSo9CurryTest19returnsInnerPointerFT_GSQGSpT___]]
 // CHECK:         [[FN:%.*]] = apply [[THUNK]](%0)
 // CHECK:         return [[FN]]
 
-// CHECK: sil shared [thunk] [[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> UnsafeMutablePointer<()>
-// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER_2:@_TTOFCSo9CurryTest19returnsInnerPointerfT_GSpT__]]
+// CHECK: sil shared [thunk] [[THUNK_RETURNSINNERPOINTER]] : $@convention(thin) (@owned CurryTest) -> @owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
+// CHECK:   [[THUNK:%.*]] = function_ref [[THUNK_RETURNSINNERPOINTER_2:@_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQGSpT___]]
 // CHECK:   [[FN:%.*]] = partial_apply [[THUNK]](%0)
 // CHECK:   return [[FN]]
 
-// CHECK: sil shared [thunk] @_TTOFCSo9CurryTest19returnsInnerPointerfT_GSpT__ : $@convention(method) (@guaranteed CurryTest) -> UnsafeMutablePointer<()>
+// CHECK: sil shared [thunk] @_TTOFCSo9CurryTest19returnsInnerPointerfT_GSQGSpT___ : $@convention(method) (@guaranteed CurryTest) -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
 // CHECK:  bb0([[ARG1:%.*]] : 
 // CHECK:   strong_retain [[ARG1]]
 // CHECK:   [[METHOD:%.*]] = class_method [volatile] %0 : $CurryTest, #CurryTest.returnsInnerPointer!1.foreign
-// CHECK:   [[RES:%.*]] = apply [[METHOD]](%0) : $@convention(objc_method) (CurryTest) -> @unowned_inner_pointer UnsafeMutablePointer<()>
+// CHECK:   [[RES:%.*]] = apply [[METHOD]](%0) : $@convention(objc_method) (CurryTest) -> @unowned_inner_pointer ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
 // CHECK:   autorelease_value %0
 // CHECK:   return [[RES]]
 
@@ -125,12 +125,12 @@ func curry_returnsSelf_AnyObject(_ x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!
 }
 
-// CHECK-LABEL: sil hidden @_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSpT__
+// CHECK-LABEL: sil hidden @_TF13objc_currying35curry_returnsInnerPointer_AnyObjectFPs9AnyObject_FT_GSQGSpT___
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsInnerPointer!1.foreign, [[HAS_METHOD:bb[0-9]+]]
-// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer UnsafeMutablePointer<()>):
+// CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @unowned_inner_pointer ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[PA]]{{.*}}@owned @callee_owned () -> UnsafeMutablePointer<()>
+// CHECK:         [[PA]]{{.*}}@owned @callee_owned () -> ImplicitlyUnwrappedOptional<UnsafeMutablePointer<()>>
 
-func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutablePointer<Void> {
+func curry_returnsInnerPointer_AnyObject(_ x: AnyObject) -> () -> UnsafeMutablePointer<Void>! {
   return x.returnsInnerPointer!
 }

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -8,7 +8,7 @@ func markUsed<T>(_ t: T) {}
 
 
 // CHECK-LABEL: sil @main
-// CHECK: bb0({{%.*}} : $Int32, {{%.*}} : $UnsafeMutablePointer<UnsafeMutablePointer<Int8>>):
+// CHECK: bb0({{%.*}} : $Int32, {{%.*}} : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
 // -- initialize x
 // CHECK: alloc_global @_Tv8toplevel1xSi

--- a/test/Serialization/transparent.swift
+++ b/test/Serialization/transparent.swift
@@ -8,7 +8,7 @@
 
 import def_transparent
 
-// SIL-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<UnsafeMutablePointer<Int8>>) -> Int32 {
+// SIL-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 // SIL: [[RAW:%.+]] = global_addr @_Tv11transparent3rawSb : $*Bool
 // SIL: [[FUNC:%.+]] = function_ref @_TF15def_transparent15testTransparentFT1xSb_Sb : $@convention(thin) (Bool) -> Bool
 // SIL: [[RESULT:%.+]] = apply [[FUNC]]({{%.+}}) : $@convention(thin) (Bool) -> Bool

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -225,7 +225,7 @@ typealias FooTypedef1 = Int32
 var fooIntVar: Int32
 func fooFunc1(_ a: Int32) -> Int32
 func fooFunc1AnonymousParam(_ _: Int32) -> Int32
-func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>) -> Int32
+func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
 func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
 func fooFuncWithFunctionPointer(_ fptr: ((Float) -> Int32)!)
 @noreturn func fooFuncNoreturn1()
@@ -3804,1948 +3804,1948 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4581,
+    key.offset: 4582,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4587,
+    key.offset: 4588,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4592,
+    key.offset: 4593,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4609,
+    key.offset: 4610,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4611,
+    key.offset: 4612,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4611,
+    key.offset: 4612,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 4618,
+    key.offset: 4619,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4628,
+    key.offset: 4629,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4637,
+    key.offset: 4638,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4642,
+    key.offset: 4643,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4669,
+    key.offset: 4670,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4671,
+    key.offset: 4672,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4671,
+    key.offset: 4672,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 4679,
+    key.offset: 4680,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4689,
+    key.offset: 4690,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4698,
+    key.offset: 4699,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4708,
+    key.offset: 4709,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4713,
+    key.offset: 4714,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4732,
+    key.offset: 4733,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4742,
+    key.offset: 4743,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4747,
+    key.offset: 4748,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4766,
+    key.offset: 4767,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4771,
+    key.offset: 4772,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4793,
+    key.offset: 4794,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4798,
+    key.offset: 4799,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4820,
+    key.offset: 4821,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4825,
+    key.offset: 4826,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4847,
+    key.offset: 4848,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4852,
+    key.offset: 4853,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4874,
+    key.offset: 4875,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4879,
+    key.offset: 4880,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4901,
+    key.offset: 4902,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4906,
+    key.offset: 4907,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4939,
+    key.offset: 4940,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4941,
+    key.offset: 4942,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4941,
+    key.offset: 4942,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4944,
+    key.offset: 4945,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 4954,
+    key.offset: 4955,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4960,
+    key.offset: 4961,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4969,
+    key.offset: 4970,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4992,
+    key.offset: 4993,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4997,
+    key.offset: 4998,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5017,
+    key.offset: 5018,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5022,
+    key.offset: 5023,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5063,
+    key.offset: 5064,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5068,
+    key.offset: 5069,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5109,
+    key.offset: 5110,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5116,
+    key.offset: 5117,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5121,
+    key.offset: 5122,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5146,
+    key.offset: 5147,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5150,
+    key.offset: 5151,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5164,
+    key.offset: 5165,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5172,
+    key.offset: 5173,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5176,
+    key.offset: 5177,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5187,
+    key.offset: 5188,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5191,
+    key.offset: 5192,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5205,
+    key.offset: 5206,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5213,
+    key.offset: 5214,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5217,
+    key.offset: 5218,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5228,
+    key.offset: 5229,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5232,
+    key.offset: 5233,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5246,
+    key.offset: 5247,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5254,
+    key.offset: 5255,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5262,
+    key.offset: 5263,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5271,
+    key.offset: 5272,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
-    key.offset: 5292,
+    key.offset: 5293,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5312,
+    key.offset: 5313,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5318,
+    key.offset: 5319,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5338,
+    key.offset: 5339,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5343,
+    key.offset: 5344,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5371,
+    key.offset: 5372,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5376,
+    key.offset: 5377,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5397,
+    key.offset: 5398,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5399,
+    key.offset: 5400,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5399,
+    key.offset: 5400,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 5409,
+    key.offset: 5410,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5424,
+    key.offset: 5425,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5443,
+    key.offset: 5444,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5456,
+    key.offset: 5457,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5468,
+    key.offset: 5469,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5474,
+    key.offset: 5475,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5480,
+    key.offset: 5481,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5474,
+    key.offset: 5475,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5480,
+    key.offset: 5481,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 5483,
+    key.offset: 5484,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5495,
+    key.offset: 5496,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5500,
+    key.offset: 5501,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5537,
+    key.offset: 5538,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5543,
+    key.offset: 5544,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5548,
+    key.offset: 5549,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5573,
+    key.offset: 5574,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5578,
+    key.offset: 5579,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 5598,
+    key.offset: 5599,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5614,
+    key.offset: 5615,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5619,
+    key.offset: 5620,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 5639,
+    key.offset: 5640,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5655,
+    key.offset: 5656,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5660,
+    key.offset: 5661,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 5681,
+    key.offset: 5682,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5697,
+    key.offset: 5698,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5702,
+    key.offset: 5703,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 5722,
+    key.offset: 5723,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5735,
+    key.offset: 5736,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5741,
+    key.offset: 5742,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5759,
+    key.offset: 5760,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 5773,
+    key.offset: 5774,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5799,
+    key.offset: 5800,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5803,
+    key.offset: 5804,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5817,
+    key.offset: 5818,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5828,
+    key.offset: 5829,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5832,
+    key.offset: 5833,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5846,
+    key.offset: 5847,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5857,
+    key.offset: 5858,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5861,
+    key.offset: 5862,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5875,
+    key.offset: 5876,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5883,
+    key.offset: 5884,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5894,
+    key.offset: 5895,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5899,
+    key.offset: 5900,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5923,
+    key.offset: 5924,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5928,
+    key.offset: 5929,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5945,
+    key.offset: 5946,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5947,
+    key.offset: 5948,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5947,
+    key.offset: 5948,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5950,
+    key.offset: 5951,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5962,
+    key.offset: 5963,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5967,
+    key.offset: 5968,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5984,
+    key.offset: 5985,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5986,
+    key.offset: 5987,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5986,
+    key.offset: 5987,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 5989,
+    key.offset: 5990,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5996,
+    key.offset: 5997,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6002,
+    key.offset: 6003,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5996,
+    key.offset: 5997,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6002,
+    key.offset: 6003,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6005,
+    key.offset: 6006,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6017,
+    key.offset: 6018,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6022,
+    key.offset: 6023,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6059,
+    key.offset: 6060,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6065,
+    key.offset: 6066,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6070,
+    key.offset: 6071,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6091,
+    key.offset: 6092,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6096,
+    key.offset: 6097,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6116,
+    key.offset: 6117,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6132,
+    key.offset: 6133,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6137,
+    key.offset: 6138,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6157,
+    key.offset: 6158,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6173,
+    key.offset: 6174,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6178,
+    key.offset: 6179,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6199,
+    key.offset: 6200,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6215,
+    key.offset: 6216,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6220,
+    key.offset: 6221,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6240,
+    key.offset: 6241,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6253,
+    key.offset: 6254,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6257,
+    key.offset: 6258,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6270,
+    key.offset: 6271,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6278,
+    key.offset: 6279,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6284,
+    key.offset: 6285,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6288,
+    key.offset: 6289,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6301,
+    key.offset: 6302,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6309,
+    key.offset: 6310,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6315,
+    key.offset: 6316,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6319,
+    key.offset: 6320,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6332,
+    key.offset: 6333,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6340,
+    key.offset: 6341,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6346,
+    key.offset: 6347,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6350,
+    key.offset: 6351,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 6363,
+    key.offset: 6364,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6372,
+    key.offset: 6373,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6378,
+    key.offset: 6379,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6382,
+    key.offset: 6383,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt64",
     key.usr: "s:Vs6UInt64",
-    key.offset: 6395,
+    key.offset: 6396,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6404,
+    key.offset: 6405,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6410,
+    key.offset: 6411,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6414,
+    key.offset: 6415,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6433,
+    key.offset: 6434,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6441,
+    key.offset: 6442,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6447,
+    key.offset: 6448,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6451,
+    key.offset: 6452,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6470,
+    key.offset: 6471,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6478,
+    key.offset: 6479,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6484,
+    key.offset: 6485,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6489,
+    key.offset: 6490,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6508,
+    key.offset: 6509,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6513,
+    key.offset: 6514,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6537,
+    key.offset: 6538,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6544,
+    key.offset: 6545,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6567,
+    key.offset: 6568,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6571,
+    key.offset: 6572,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6574,
+    key.offset: 6575,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6585,
+    key.offset: 6586,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6597,
+    key.offset: 6598,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6602,
+    key.offset: 6603,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6604,
+    key.offset: 6605,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6602,
+    key.offset: 6603,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6604,
+    key.offset: 6605,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6607,
+    key.offset: 6608,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6616,
+    key.offset: 6617,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6626,
+    key.offset: 6627,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6646,
+    key.offset: 6647,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6651,
+    key.offset: 6652,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6671,
+    key.offset: 6672,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6684,
+    key.offset: 6685,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6694,
+    key.offset: 6695,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6714,
+    key.offset: 6715,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6719,
+    key.offset: 6720,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6739,
+    key.offset: 6740,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6755,
+    key.offset: 6756,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6760,
+    key.offset: 6761,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6781,
+    key.offset: 6782,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6794,
+    key.offset: 6795,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6804,
+    key.offset: 6805,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6824,
+    key.offset: 6825,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6829,
+    key.offset: 6830,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6849,
+    key.offset: 6850,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6862,
+    key.offset: 6863,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6871,
+    key.offset: 6872,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6889,
+    key.offset: 6890,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6895,
+    key.offset: 6896,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 6919,
+    key.offset: 6920,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6937,
+    key.offset: 6938,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6943,
+    key.offset: 6944,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6971,
+    key.offset: 6972,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6991,
+    key.offset: 6992,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7007,
+    key.offset: 7008,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7011,
+    key.offset: 7012,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7023,
+    key.offset: 7024,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7039,
+    key.offset: 7040,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7055,
+    key.offset: 7056,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7059,
+    key.offset: 7060,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7077,
+    key.offset: 7078,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7093,
+    key.offset: 7094,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7097,
+    key.offset: 7098,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7109,
+    key.offset: 7110,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7125,
+    key.offset: 7126,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7129,
+    key.offset: 7130,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7140,
+    key.offset: 7141,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7156,
+    key.offset: 7157,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7167,
+    key.offset: 7168,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7171,
+    key.offset: 7172,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7181,
+    key.offset: 7182,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7197,
+    key.offset: 7198,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7202,
+    key.offset: 7203,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7206,
+    key.offset: 7207,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7215,
+    key.offset: 7216,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7231,
+    key.offset: 7232,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7235,
+    key.offset: 7236,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 7243,
+    key.offset: 7244,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7254,
+    key.offset: 7255,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7259,
+    key.offset: 7260,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7279,
+    key.offset: 7280,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7295,
+    key.offset: 7296,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7300,
+    key.offset: 7301,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7320,
+    key.offset: 7321,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7336,
+    key.offset: 7337,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7341,
+    key.offset: 7342,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7362,
+    key.offset: 7363,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7378,
+    key.offset: 7379,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7383,
+    key.offset: 7384,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7403,
+    key.offset: 7404,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7416,
+    key.offset: 7417,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7422,
+    key.offset: 7423,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 7446,
+    key.offset: 7447,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7466,
+    key.offset: 7467,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7478,
+    key.offset: 7479,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7484,
+    key.offset: 7485,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7488,
+    key.offset: 7489,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7484,
+    key.offset: 7485,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7488,
+    key.offset: 7489,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 7491,
+    key.offset: 7492,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7503,
+    key.offset: 7504,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7509,
+    key.offset: 7510,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7514,
+    key.offset: 7515,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7522,
+    key.offset: 7523,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7524,
+    key.offset: 7525,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7524,
+    key.offset: 7525,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 7527,
+    key.offset: 7528,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 7537,
+    key.offset: 7538,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7548,
+    key.offset: 7549,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7553,
+    key.offset: 7554,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7572,
+    key.offset: 7573,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7577,
+    key.offset: 7578,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7601,
+    key.offset: 7602,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7606,
+    key.offset: 7607,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7624,
+    key.offset: 7625,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7629,
+    key.offset: 7630,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7659,
+    key.offset: 7660,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7664,
+    key.offset: 7665,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7694,
+    key.offset: 7695,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7699,
+    key.offset: 7700,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7728,
+    key.offset: 7729,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7733,
+    key.offset: 7734,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7764,
+    key.offset: 7765,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7769,
+    key.offset: 7770,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7802,
+    key.offset: 7803,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7807,
+    key.offset: 7808,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7840,
+    key.offset: 7841,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7845,
+    key.offset: 7846,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7877,
+    key.offset: 7878,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7882,
+    key.offset: 7883,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7916,
+    key.offset: 7917,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7921,
+    key.offset: 7922,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7941,
+    key.offset: 7942,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7957,
+    key.offset: 7958,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7962,
+    key.offset: 7963,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 7982,
+    key.offset: 7983,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7998,
+    key.offset: 7999,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8003,
+    key.offset: 8004,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 8024,
+    key.offset: 8025,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8040,
+    key.offset: 8041,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8045,
+    key.offset: 8046,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 8065,
+    key.offset: 8066,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8078,
+    key.offset: 8079,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8088,
+    key.offset: 8089,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 8103,
+    key.offset: 8104,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8113,
+    key.offset: 8114,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8119,
+    key.offset: 8120,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8133,
+    key.offset: 8134,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8138,
+    key.offset: 8139,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8155,
+    key.offset: 8156,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8157,
+    key.offset: 8158,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 8160,
+    key.offset: 8161,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8172,
+    key.offset: 8173,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8177,
+    key.offset: 8178,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8189,
+    key.offset: 8190,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8191,
+    key.offset: 8192,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8191,
+    key.offset: 8192,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 8194,
+    key.offset: 8195,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 8204,
+    key.offset: 8205,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8210,
+    key.offset: 8211,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8217,
+    key.offset: 8218,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:Ps16RawRepresentable",
-    key.offset: 8231,
+    key.offset: 8232,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:Ps9Equatable",
-    key.offset: 8249,
+    key.offset: 8250,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8266,
+    key.offset: 8267,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8271,
+    key.offset: 8272,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8273,
+    key.offset: 8274,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8273,
+    key.offset: 8274,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 8283,
+    key.offset: 8284,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8296,
+    key.offset: 8297,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 8301,
+    key.offset: 8302,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 8310,
+    key.offset: 8311,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8301,
+    key.offset: 8302,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8310,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "UInt32",
-    key.usr: "s:Vs6UInt32",
-    key.offset: 8320,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8333,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8337,
+    key.offset: 8311,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 8347,
+    key.offset: 8321,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8356,
+    key.offset: 8334,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8360,
+    key.offset: 8338,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:Vs6UInt32",
+    key.offset: 8348,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 8357,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 8361,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8374,
+    key.offset: 8375,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8388,
+    key.offset: 8389,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8394,
+    key.offset: 8395,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8398,
+    key.offset: 8399,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8412,
+    key.offset: 8413,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8426,
+    key.offset: 8427,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8432,
+    key.offset: 8433,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8436,
+    key.offset: 8437,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 8463,
+    key.offset: 8464,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 8469,
+    key.offset: 8470,
     key.length: 3
   }
 ]
@@ -7718,8 +7718,8 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFunc3(_:_:_:_:)",
     key.usr: "c:@F@fooFunc3",
     key.offset: 4493,
-    key.length: 93,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>d</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct>&gt;</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.length: 94,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>d</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct>&gt;!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -7747,7 +7747,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.keyword: "_",
         key.name: "d",
         key.offset: 4549,
-        key.length: 27
+        key.length: 28
       }
     ]
   },
@@ -7755,7 +7755,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithBlock(_:)",
     key.usr: "c:@F@fooFuncWithBlock",
-    key.offset: 4587,
+    key.offset: 4588,
     key.length: 49,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithBlock</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>blk</decl.var.parameter.name>: <decl.var.parameter.type>((<ref.struct usr=\"s:Sf\">Float</ref.struct>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -7763,7 +7763,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "blk",
-        key.offset: 4616,
+        key.offset: 4617,
         key.length: 19
       }
     ]
@@ -7772,7 +7772,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithFunctionPointer(_:)",
     key.usr: "c:@F@fooFuncWithFunctionPointer",
-    key.offset: 4637,
+    key.offset: 4638,
     key.length: 60,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithFunctionPointer</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>fptr</decl.var.parameter.name>: <decl.var.parameter.type>((<ref.struct usr=\"s:Sf\">Float</ref.struct>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -7780,7 +7780,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "fptr",
-        key.offset: 4677,
+        key.offset: 4678,
         key.length: 19
       }
     ]
@@ -7789,7 +7789,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn1()",
     key.usr: "c:@F@fooFuncNoreturn1",
-    key.offset: 4698,
+    key.offset: 4699,
     key.length: 33,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@noreturn</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn1</decl.name>()</decl.function.free>"
   },
@@ -7797,7 +7797,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn2()",
     key.usr: "c:@F@fooFuncNoreturn2",
-    key.offset: 4732,
+    key.offset: 4733,
     key.length: 33,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@noreturn</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn2</decl.name>()</decl.function.free>"
   },
@@ -7806,7 +7806,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment1()",
     key.usr: "c:@F@fooFuncWithComment1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"88\" column=\"6\"><Name>fooFuncWithComment1</Name><USR>c:@F@fooFuncWithComment1</USR><Declaration>func fooFuncWithComment1()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment1.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4766,
+    key.offset: 4767,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment1</decl.name>()</decl.function.free>"
   },
@@ -7815,7 +7815,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment2()",
     key.usr: "c:@F@fooFuncWithComment2",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"93\" column=\"6\"><Name>fooFuncWithComment2</Name><USR>c:@F@fooFuncWithComment2</USR><Declaration>func fooFuncWithComment2()</Declaration><Abstract><Para>  Aaa.  fooFuncWithComment2.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4793,
+    key.offset: 4794,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment2</decl.name>()</decl.function.free>"
   },
@@ -7824,7 +7824,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment3()",
     key.usr: "c:@F@fooFuncWithComment3",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"101\" column=\"6\"><Name>fooFuncWithComment3</Name><USR>c:@F@fooFuncWithComment3</USR><Declaration>func fooFuncWithComment3()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment3.  Bbb.</Para></Abstract><Discussion><Para> Ccc.</Para></Discussion></Function>",
-    key.offset: 4820,
+    key.offset: 4821,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment3</decl.name>()</decl.function.free>"
   },
@@ -7833,7 +7833,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment4()",
     key.usr: "c:@F@fooFuncWithComment4",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"107\" column=\"6\"><Name>fooFuncWithComment4</Name><USR>c:@F@fooFuncWithComment4</USR><Declaration>func fooFuncWithComment4()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment4.  Bbb.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4847,
+    key.offset: 4848,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment4</decl.name>()</decl.function.free>"
   },
@@ -7842,7 +7842,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment5()",
     key.usr: "c:@F@fooFuncWithComment5",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"113\" column=\"6\"><Name>fooFuncWithComment5</Name><USR>c:@F@fooFuncWithComment5</USR><Declaration>func fooFuncWithComment5()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment5.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4874,
+    key.offset: 4875,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment5</decl.name>()</decl.function.free>"
   },
@@ -7851,7 +7851,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
     key.usr: "c:@F@redeclaredInMultipleModulesFunc1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"117\" column=\"5\"><Name>redeclaredInMultipleModulesFunc1</Name><USR>c:@F@redeclaredInMultipleModulesFunc1</USR><Declaration>func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32</Declaration><Abstract><Para> Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4901,
+    key.offset: 4902,
     key.length: 58,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>redeclaredInMultipleModulesFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -7859,7 +7859,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 4944,
+        key.offset: 4945,
         key.length: 5
       }
     ]
@@ -7869,7 +7869,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"120\" column=\"11\"><Name>FooProtocolBase</Name><USR>c:objc(pl)FooProtocolBase</USR><Declaration>protocol FooProtocolBase</Declaration><Abstract><Para> Aaa.  FooProtocolBase.  Bbb.</Para></Abstract></Other>",
-    key.offset: 4960,
+    key.offset: 4961,
     key.length: 301,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolBase</decl.name></decl.protocol>",
     key.entities: [
@@ -7878,7 +7878,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFunc",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"124\" column=\"1\"><Name>fooProtoFunc</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFunc</USR><Declaration>func fooProtoFunc()</Declaration><Abstract><Para> Aaa.  fooProtoFunc.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4992,
+        key.offset: 4993,
         key.length: 19,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFunc</decl.name>()</decl.function.method.instance>"
       },
@@ -7887,7 +7887,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation1()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"128\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation1</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1</USR><Declaration>func fooProtoFuncWithExtraIndentation1()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 5017,
+        key.offset: 5018,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation1</decl.name>()</decl.function.method.instance>"
       },
@@ -7896,7 +7896,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation2()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"134\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation2</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2</USR><Declaration>func fooProtoFuncWithExtraIndentation2()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 5063,
+        key.offset: 5064,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation2</decl.name>()</decl.function.method.instance>"
       },
@@ -7904,7 +7904,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.static,
         key.name: "fooProtoClassFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(cm)fooProtoClassFunc",
-        key.offset: 5109,
+        key.offset: 5110,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoClassFunc</decl.name>()</decl.function.method.static>"
       },
@@ -7912,7 +7912,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty1",
-        key.offset: 5146,
+        key.offset: 5147,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7920,7 +7920,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty2",
-        key.offset: 5187,
+        key.offset: 5188,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7928,7 +7928,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty3",
-        key.offset: 5228,
+        key.offset: 5229,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -7938,7 +7938,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 5262,
+    key.offset: 5263,
     key.length: 49,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolDerived</decl.name> : <ref.protocol usr=\"c:objc(pl)FooProtocolBase\">FooProtocolBase</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -7953,7 +7953,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 5312,
+    key.offset: 5313,
     key.length: 422,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassBase</decl.name></decl.class>",
     key.entities: [
@@ -7961,7 +7961,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc0",
-        key.offset: 5338,
+        key.offset: 5339,
         key.length: 27,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -7969,7 +7969,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc1:",
-        key.offset: 5371,
+        key.offset: 5372,
         key.length: 66,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>anObject</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>!</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -7977,7 +7977,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "anObject",
-            key.offset: 5409,
+            key.offset: 5410,
             key.length: 10
           }
         ]
@@ -7986,7 +7986,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "c:objc(cs)FooClassBase(im)init",
-        key.offset: 5443,
+        key.offset: 5444,
         key.length: 7,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>!()</decl.function.constructor>"
       },
@@ -7994,7 +7994,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(float:)",
         key.usr: "c:objc(cs)FooClassBase(im)initWithFloat:",
-        key.offset: 5456,
+        key.offset: 5457,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>float</decl.var.parameter.argument_label> <decl.var.parameter.name>f</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -8002,7 +8002,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "float",
             key.name: "f",
-            key.offset: 5483,
+            key.offset: 5484,
             key.length: 5
           }
         ]
@@ -8011,7 +8011,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFuncOverridden",
-        key.offset: 5495,
+        key.offset: 5496,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>"
       },
@@ -8019,7 +8019,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooBaseClassFunc0()",
         key.usr: "c:objc(cs)FooClassBase(cm)fooBaseClassFunc0",
-        key.offset: 5537,
+        key.offset: 5538,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseClassFunc0</decl.name>()</decl.function.method.class>"
       },
@@ -8027,7 +8027,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 5573,
+        key.offset: 5574,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8035,7 +8035,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 5614,
+        key.offset: 5615,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8043,7 +8043,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 5655,
+        key.offset: 5656,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8051,7 +8051,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 5697,
+        key.offset: 5698,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8062,7 +8062,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooClassDerived",
     key.usr: "c:objc(cs)FooClassDerived",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"157\" column=\"12\"><Name>FooClassDerived</Name><USR>c:objc(cs)FooClassDerived</USR><Declaration>class FooClassDerived : FooClassBase, FooProtocolDerived</Declaration><Abstract><Para> Aaa.  FooClassDerived.  Bbb.</Para></Abstract></Other>",
-    key.offset: 5735,
+    key.offset: 5736,
     key.length: 517,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassDerived</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>, <ref.protocol usr=\"c:objc(pl)FooProtocolDerived\">FooProtocolDerived</ref.protocol></decl.class>",
     key.inherits: [
@@ -8084,7 +8084,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty1",
-        key.offset: 5799,
+        key.offset: 5800,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8092,7 +8092,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty2",
-        key.offset: 5828,
+        key.offset: 5829,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8100,7 +8100,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty3",
-        key.offset: 5857,
+        key.offset: 5858,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8108,7 +8108,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc0",
-        key.offset: 5894,
+        key.offset: 5895,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -8116,7 +8116,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc1:",
-        key.offset: 5923,
+        key.offset: 5924,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -8124,7 +8124,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5950,
+            key.offset: 5951,
             key.length: 5
           }
         ]
@@ -8133,7 +8133,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc2(_:withB:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc2:withB:",
-        key.offset: 5962,
+        key.offset: 5963,
         key.length: 49,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>withB</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -8141,14 +8141,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5989,
+            key.offset: 5990,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "withB",
             key.name: "b",
-            key.offset: 6005,
+            key.offset: 6006,
             key.length: 5
           }
         ]
@@ -8157,7 +8157,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooBaseInstanceFuncOverridden",
-        key.offset: 6017,
+        key.offset: 6018,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>",
         key.inherits: [
@@ -8172,7 +8172,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooClassFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(cm)fooClassFunc0",
-        key.offset: 6059,
+        key.offset: 6060,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooClassFunc0</decl.name>()</decl.function.method.class>"
       },
@@ -8181,7 +8181,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6091,
+        key.offset: 6092,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8190,7 +8190,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6132,
+        key.offset: 6133,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8199,7 +8199,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6173,
+        key.offset: 6174,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8208,7 +8208,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassDerived",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 6215,
+        key.offset: 6216,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8218,7 +8218,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_1",
     key.usr: "c:Foo.h@3647@macro@FOO_MACRO_1",
-    key.offset: 6253,
+    key.offset: 6254,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8226,7 +8226,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_2",
     key.usr: "c:Foo.h@3669@macro@FOO_MACRO_2",
-    key.offset: 6284,
+    key.offset: 6285,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8234,7 +8234,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_3",
     key.usr: "c:Foo.h@3691@macro@FOO_MACRO_3",
-    key.offset: 6315,
+    key.offset: 6316,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_3</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8242,7 +8242,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_4",
     key.usr: "c:Foo.h@3755@macro@FOO_MACRO_4",
-    key.offset: 6346,
+    key.offset: 6347,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_4</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8250,7 +8250,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_5",
     key.usr: "c:Foo.h@3787@macro@FOO_MACRO_5",
-    key.offset: 6378,
+    key.offset: 6379,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_5</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt64\">UInt64</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8258,7 +8258,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_1",
     key.usr: "c:Foo.h@3937@macro@FOO_MACRO_REDEF_1",
-    key.offset: 6410,
+    key.offset: 6411,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_1</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8266,7 +8266,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_2",
     key.usr: "c:Foo.h@3994@macro@FOO_MACRO_REDEF_2",
-    key.offset: 6447,
+    key.offset: 6448,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_2</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8274,7 +8274,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "theLastDeclInFoo()",
     key.usr: "c:@F@theLastDeclInFoo",
-    key.offset: 6484,
+    key.offset: 6485,
     key.length: 23,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>theLastDeclInFoo</decl.name>()</decl.function.free>"
   },
@@ -8282,7 +8282,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "_internalTopLevelFunc()",
     key.usr: "c:@F@_internalTopLevelFunc",
-    key.offset: 6508,
+    key.offset: 6509,
     key.length: 28,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalTopLevelFunc</decl.name>()</decl.function.free>"
   },
@@ -8290,7 +8290,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "_InternalStruct",
     key.usr: "c:@S@_InternalStruct",
-    key.offset: 6537,
+    key.offset: 6538,
     key.length: 78,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>_InternalStruct</decl.name></decl.struct>",
     key.entities: [
@@ -8298,7 +8298,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@_InternalStruct@FI@x",
-        key.offset: 6567,
+        key.offset: 6568,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -8306,7 +8306,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:FVSC15_InternalStructcFT_S_",
-        key.offset: 6585,
+        key.offset: 6586,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -8314,7 +8314,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:FVSC15_InternalStructcFT1xVs5Int32_S_",
-        key.offset: 6597,
+        key.offset: 6598,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -8322,7 +8322,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 6607,
+            key.offset: 6608,
             key.length: 5
           }
         ]
@@ -8331,7 +8331,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6616,
+    key.offset: 6617,
     key.length: 67,
     key.extends: {
       key.kind: source.lang.swift.ref.class,
@@ -8343,7 +8343,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 6646,
+        key.offset: 6647,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8351,7 +8351,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6684,
+    key.offset: 6685,
     key.length: 109,
     key.extends: {
       key.kind: source.lang.swift.ref.class,
@@ -8363,7 +8363,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6714,
+        key.offset: 6715,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8371,7 +8371,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6755,
+        key.offset: 6756,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8379,7 +8379,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6794,
+    key.offset: 6795,
     key.length: 67,
     key.extends: {
       key.kind: source.lang.swift.ref.class,
@@ -8391,7 +8391,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6824,
+        key.offset: 6825,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8401,7 +8401,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 6862,
+    key.offset: 6863,
     key.length: 26,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>_InternalProt</decl.name></decl.protocol>"
   },
@@ -8409,7 +8409,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "ClassWithInternalProt",
     key.usr: "c:objc(cs)ClassWithInternalProt",
-    key.offset: 6889,
+    key.offset: 6890,
     key.length: 47,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>ClassWithInternalProt</decl.name> : <ref.protocol usr=\"c:objc(pl)_InternalProt\">_InternalProt</ref.protocol></decl.class>",
     key.conforms: [
@@ -8424,7 +8424,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassPropertyOwnership",
     key.usr: "c:objc(cs)FooClassPropertyOwnership",
-    key.offset: 6937,
+    key.offset: 6938,
     key.length: 478,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassPropertyOwnership</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -8439,7 +8439,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "assignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
-        key.offset: 6991,
+        key.offset: 6992,
         key.length: 42,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8447,7 +8447,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "unsafeAssignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
-        key.offset: 7039,
+        key.offset: 7040,
         key.length: 48,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8455,7 +8455,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "retainable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)retainable",
-        key.offset: 7093,
+        key.offset: 7094,
         key.length: 26,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>retainable</decl.name>: <decl.var.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8463,7 +8463,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "strongRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)strongRef",
-        key.offset: 7125,
+        key.offset: 7126,
         key.length: 25,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>strongRef</decl.name>: <decl.var.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8471,7 +8471,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "copyable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)copyable",
-        key.offset: 7156,
+        key.offset: 7157,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@NSCopying</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>copyable</decl.name>: <decl.var.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8479,7 +8479,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "weakRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
-        key.offset: 7197,
+        key.offset: 7198,
         key.length: 28,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8487,7 +8487,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "scalar",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)scalar",
-        key.offset: 7231,
+        key.offset: 7232,
         key.length: 17,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>scalar</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -8496,7 +8496,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 7254,
+        key.offset: 7255,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8505,7 +8505,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 7295,
+        key.offset: 7296,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8514,7 +8514,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 7336,
+        key.offset: 7337,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8523,7 +8523,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooClassPropertyOwnership",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 7378,
+        key.offset: 7379,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8533,7 +8533,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 7416,
+    key.offset: 7417,
     key.length: 661,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooUnavailableMembers</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -8548,7 +8548,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(int:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 7466,
+        key.offset: 7467,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>int</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -8556,7 +8556,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "int",
             key.name: "i",
-            key.offset: 7491,
+            key.offset: 7492,
             key.length: 5
           }
         ]
@@ -8565,7 +8565,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "withInt(_:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 7503,
+        key.offset: 7504,
         key.length: 39,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>withInt</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooUnavailableMembers\">Self</ref.class>!</decl.function.returntype></decl.function.method.class>",
         key.entities: [
@@ -8573,7 +8573,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "i",
-            key.offset: 7527,
+            key.offset: 7528,
             key.length: 5
           }
         ],
@@ -8590,7 +8590,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "unavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)unavailable",
-        key.offset: 7548,
+        key.offset: 7549,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>unavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8606,7 +8606,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "swiftUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)swiftUnavailable",
-        key.offset: 7572,
+        key.offset: 7573,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>swiftUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8621,7 +8621,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "deprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)deprecated",
-        key.offset: 7601,
+        key.offset: 7602,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8637,7 +8637,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroduced()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroduced",
-        key.offset: 7624,
+        key.offset: 7625,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8652,7 +8652,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecated",
-        key.offset: 7659,
+        key.offset: 7660,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8671,7 +8671,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoleted()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoleted",
-        key.offset: 7694,
+        key.offset: 7695,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoleted</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8687,7 +8687,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailable",
-        key.offset: 7728,
+        key.offset: 7729,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8703,7 +8703,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroducedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroducedMsg",
-        key.offset: 7764,
+        key.offset: 7765,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8719,7 +8719,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecatedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecatedMsg",
-        key.offset: 7802,
+        key.offset: 7803,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecatedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8738,7 +8738,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoletedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoletedMsg",
-        key.offset: 7840,
+        key.offset: 7841,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoletedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8755,7 +8755,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailableMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailableMsg",
-        key.offset: 7877,
+        key.offset: 7878,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailableMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -8773,7 +8773,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 7916,
+        key.offset: 7917,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8782,7 +8782,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 7957,
+        key.offset: 7958,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8791,7 +8791,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 7998,
+        key.offset: 7999,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -8800,7 +8800,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 8040,
+        key.offset: 8041,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -8810,7 +8810,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "FooCFTypeRef",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 8078,
+    key.offset: 8079,
     key.length: 34,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooCFTypeRef</decl.name> = <ref.class usr=\"c:Foo.h@T@FooCFTypeRef\">FooCFType</ref.class></decl.typealias>",
     key.attributes: [
@@ -8825,7 +8825,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 8113,
+    key.offset: 8114,
     key.length: 19,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooCFType</decl.name></decl.class>"
   },
@@ -8833,14 +8833,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "FooCFTypeRelease(_:)",
     key.usr: "c:@F@FooCFTypeRelease",
-    key.offset: 8133,
+    key.offset: 8134,
     key.length: 38,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>FooCFTypeRelease</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"c:Foo.h@T@FooCFTypeRef\">FooCFType</ref.class>!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 8160,
+        key.offset: 8161,
         key.length: 10
       }
     ],
@@ -8857,7 +8857,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooSubFunc1(_:)",
     key.usr: "c:@F@fooSubFunc1",
-    key.offset: 8172,
+    key.offset: 8173,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -8865,7 +8865,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 8194,
+        key.offset: 8195,
         key.length: 5
       }
     ]
@@ -8874,7 +8874,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 8210,
+    key.offset: 8211,
     key.length: 145,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:Ps16RawRepresentable\">RawRepresentable</ref.protocol>, <ref.protocol usr=\"s:Ps9Equatable\">Equatable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -8894,7 +8894,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:FVSC11FooSubEnum1cFVs6UInt32S_",
-        key.offset: 8266,
+        key.offset: 8267,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -8902,7 +8902,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 8283,
+            key.offset: 8284,
             key.length: 6
           }
         ]
@@ -8911,7 +8911,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:FVSC11FooSubEnum1cFT8rawValueVs6UInt32_S_",
-        key.offset: 8296,
+        key.offset: 8297,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.conforms: [
@@ -8926,7 +8926,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 8320,
+            key.offset: 8321,
             key.length: 6
           }
         ]
@@ -8935,7 +8935,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:vVSC11FooSubEnum18rawValueVs6UInt32",
-        key.offset: 8333,
+        key.offset: 8334,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
         key.conforms: [
@@ -8952,7 +8952,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 8356,
+    key.offset: 8357,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8960,7 +8960,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 8394,
+    key.offset: 8395,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -8968,7 +8968,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 8432,
+    key.offset: 8433,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -113,7 +113,7 @@ public var fooIntVar: Int32
 public func fooFunc1(_ a: Int32) -> Int32
 
 public func fooFunc1AnonymousParam(_: Int32) -> Int32
-public func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>) -> Int32
+public func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
 
 /*
   Very good
@@ -1483,1742 +1483,1742 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2209,
+    key.offset: 2210,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2216,
+    key.offset: 2217,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2263,
+    key.offset: 2264,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2270,
+    key.offset: 2271,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2275,
+    key.offset: 2276,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2292,
+    key.offset: 2293,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2294,
+    key.offset: 2295,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2301,
+    key.offset: 2302,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2311,
+    key.offset: 2312,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2321,
+    key.offset: 2322,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2328,
+    key.offset: 2329,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2333,
+    key.offset: 2334,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2360,
+    key.offset: 2361,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2362,
+    key.offset: 2363,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.id,
-    key.offset: 2369,
+    key.offset: 2370,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2370,
+    key.offset: 2371,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2381,
+    key.offset: 2382,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2385,
+    key.offset: 2386,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2395,
+    key.offset: 2396,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2405,
+    key.offset: 2406,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2415,
+    key.offset: 2416,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2422,
+    key.offset: 2423,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2427,
+    key.offset: 2428,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2446,
+    key.offset: 2447,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2456,
+    key.offset: 2457,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2463,
+    key.offset: 2464,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2468,
+    key.offset: 2469,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2488,
+    key.offset: 2489,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2551,
+    key.offset: 2552,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2558,
+    key.offset: 2559,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2563,
+    key.offset: 2564,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2586,
+    key.offset: 2587,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2629,
+    key.offset: 2630,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2636,
+    key.offset: 2637,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2641,
+    key.offset: 2642,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2664,
+    key.offset: 2665,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2708,
+    key.offset: 2709,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2724,
+    key.offset: 2725,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2731,
+    key.offset: 2732,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2736,
+    key.offset: 2737,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2759,
+    key.offset: 2760,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2803,
+    key.offset: 2804,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2812,
+    key.offset: 2813,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2819,
+    key.offset: 2820,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2824,
+    key.offset: 2825,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2847,
+    key.offset: 2848,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2884,
+    key.offset: 2885,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2893,
+    key.offset: 2894,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2897,
+    key.offset: 2898,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2906,
+    key.offset: 2907,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2913,
+    key.offset: 2914,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2918,
+    key.offset: 2919,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2941,
+    key.offset: 2942,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2991,
+    key.offset: 2992,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2998,
+    key.offset: 2999,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3003,
+    key.offset: 3004,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3036,
+    key.offset: 3037,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3038,
+    key.offset: 3039,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3041,
+    key.offset: 3042,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3051,
+    key.offset: 3052,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3058,
+    key.offset: 3059,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3091,
+    key.offset: 3092,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3098,
+    key.offset: 3099,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3107,
+    key.offset: 3108,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3135,
+    key.offset: 3136,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3169,
+    key.offset: 3170,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3182,
+    key.offset: 3183,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3189,
+    key.offset: 3190,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3194,
+    key.offset: 3195,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3219,
+    key.offset: 3220,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3274,
+    key.offset: 3275,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3287,
+    key.offset: 3288,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3294,
+    key.offset: 3295,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3299,
+    key.offset: 3300,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3345,
+    key.offset: 3346,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3427,
+    key.offset: 3428,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3434,
+    key.offset: 3435,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3439,
+    key.offset: 3440,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3485,
+    key.offset: 3486,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3492,
+    key.offset: 3493,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3499,
+    key.offset: 3500,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3504,
+    key.offset: 3505,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3534,
+    key.offset: 3535,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3541,
+    key.offset: 3542,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3545,
+    key.offset: 3546,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3559,
+    key.offset: 3560,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3567,
+    key.offset: 3568,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3571,
+    key.offset: 3572,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3582,
+    key.offset: 3583,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3589,
+    key.offset: 3590,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3593,
+    key.offset: 3594,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3607,
+    key.offset: 3608,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3615,
+    key.offset: 3616,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3619,
+    key.offset: 3620,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3630,
+    key.offset: 3631,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3637,
+    key.offset: 3638,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3641,
+    key.offset: 3642,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3655,
+    key.offset: 3656,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3663,
+    key.offset: 3664,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3672,
+    key.offset: 3673,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3679,
+    key.offset: 3680,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3688,
+    key.offset: 3689,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3709,
+    key.offset: 3710,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3730,
+    key.offset: 3731,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3737,
+    key.offset: 3738,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3743,
+    key.offset: 3744,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3763,
+    key.offset: 3764,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3770,
+    key.offset: 3771,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3775,
+    key.offset: 3776,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3803,
+    key.offset: 3804,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3810,
+    key.offset: 3811,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3815,
+    key.offset: 3816,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3836,
+    key.offset: 3837,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3838,
+    key.offset: 3839,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3848,
+    key.offset: 3849,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3863,
+    key.offset: 3864,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3882,
+    key.offset: 3883,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3889,
+    key.offset: 3890,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3902,
+    key.offset: 3903,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3909,
+    key.offset: 3910,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3921,
+    key.offset: 3922,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3927,
+    key.offset: 3928,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3933,
+    key.offset: 3934,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3936,
+    key.offset: 3937,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3948,
+    key.offset: 3949,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3955,
+    key.offset: 3956,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3960,
+    key.offset: 3961,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4002,
+    key.offset: 4003,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4009,
+    key.offset: 4010,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4015,
+    key.offset: 4016,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4020,
+    key.offset: 4021,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 4043,
+    key.offset: 4044,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4076,
+    key.offset: 4077,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4083,
+    key.offset: 4084,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4089,
+    key.offset: 4090,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4107,
+    key.offset: 4108,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4121,
+    key.offset: 4122,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4152,
+    key.offset: 4153,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4159,
+    key.offset: 4160,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4163,
+    key.offset: 4164,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4177,
+    key.offset: 4178,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4188,
+    key.offset: 4189,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4195,
+    key.offset: 4196,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4199,
+    key.offset: 4200,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4213,
+    key.offset: 4214,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4224,
+    key.offset: 4225,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4231,
+    key.offset: 4232,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4235,
+    key.offset: 4236,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4249,
+    key.offset: 4250,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4257,
+    key.offset: 4258,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4273,
+    key.offset: 4274,
     key.length: 64
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4342,
+    key.offset: 4343,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4349,
+    key.offset: 4350,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4354,
+    key.offset: 4355,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4378,
+    key.offset: 4379,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4385,
+    key.offset: 4386,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4390,
+    key.offset: 4391,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4407,
+    key.offset: 4408,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4409,
+    key.offset: 4410,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4412,
+    key.offset: 4413,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4424,
+    key.offset: 4425,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4431,
+    key.offset: 4432,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4436,
+    key.offset: 4437,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4453,
+    key.offset: 4454,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4455,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4458,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4465,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4471,
+    key.offset: 4456,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4474,
+    key.offset: 4459,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4466,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4472,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4475,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4491,
+    key.offset: 4492,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4498,
+    key.offset: 4499,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4503,
+    key.offset: 4504,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4545,
+    key.offset: 4546,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4552,
+    key.offset: 4553,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4558,
+    key.offset: 4559,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4563,
+    key.offset: 4564,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4582,
+    key.offset: 4583,
     key.length: 31
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4614,
+    key.offset: 4615,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4621,
+    key.offset: 4622,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4625,
+    key.offset: 4626,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4638,
+    key.offset: 4639,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4646,
+    key.offset: 4647,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4652,
+    key.offset: 4653,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4659,
+    key.offset: 4660,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4663,
+    key.offset: 4664,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4676,
+    key.offset: 4677,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4684,
+    key.offset: 4685,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4690,
+    key.offset: 4691,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4697,
+    key.offset: 4698,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4701,
+    key.offset: 4702,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4714,
+    key.offset: 4715,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4722,
+    key.offset: 4723,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4728,
+    key.offset: 4729,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4767,
+    key.offset: 4768,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4774,
+    key.offset: 4775,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4778,
+    key.offset: 4779,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4791,
+    key.offset: 4792,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4800,
+    key.offset: 4801,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4806,
+    key.offset: 4807,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4813,
+    key.offset: 4814,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4817,
+    key.offset: 4818,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4830,
+    key.offset: 4831,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4839,
+    key.offset: 4840,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4846,
+    key.offset: 4847,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4853,
+    key.offset: 4854,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4857,
+    key.offset: 4858,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4876,
+    key.offset: 4877,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4884,
+    key.offset: 4885,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4891,
+    key.offset: 4892,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4898,
+    key.offset: 4899,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4902,
+    key.offset: 4903,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4921,
+    key.offset: 4922,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4929,
+    key.offset: 4930,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4936,
+    key.offset: 4937,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4943,
+    key.offset: 4944,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4948,
+    key.offset: 4949,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4968,
+    key.offset: 4969,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4975,
+    key.offset: 4976,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4980,
+    key.offset: 4981,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5005,
+    key.offset: 5006,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5012,
+    key.offset: 5013,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5019,
+    key.offset: 5020,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5042,
+    key.offset: 5043,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5049,
+    key.offset: 5050,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5053,
+    key.offset: 5054,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5056,
+    key.offset: 5057,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5067,
+    key.offset: 5068,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5074,
+    key.offset: 5075,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5086,
+    key.offset: 5087,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5093,
+    key.offset: 5094,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5098,
+    key.offset: 5099,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5101,
+    key.offset: 5102,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5111,
+    key.offset: 5112,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5121,
+    key.offset: 5122,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5141,
+    key.offset: 5142,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5148,
+    key.offset: 5149,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5153,
+    key.offset: 5154,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5173,
+    key.offset: 5174,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 5187,
+    key.offset: 5188,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5232,
+    key.offset: 5233,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5242,
+    key.offset: 5243,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5262,
+    key.offset: 5263,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5269,
+    key.offset: 5270,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5274,
+    key.offset: 5275,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5294,
+    key.offset: 5295,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5310,
+    key.offset: 5311,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5317,
+    key.offset: 5318,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5322,
+    key.offset: 5323,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5343,
+    key.offset: 5344,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5357,
+    key.offset: 5358,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5367,
+    key.offset: 5368,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5387,
+    key.offset: 5388,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5394,
+    key.offset: 5395,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5399,
+    key.offset: 5400,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5419,
+    key.offset: 5420,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5433,
+    key.offset: 5434,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5440,
+    key.offset: 5441,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5449,
+    key.offset: 5450,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5468,
+    key.offset: 5469,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5475,
+    key.offset: 5476,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5481,
+    key.offset: 5482,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5505,
+    key.offset: 5506,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5524,
+    key.offset: 5525,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5531,
+    key.offset: 5532,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5537,
+    key.offset: 5538,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5565,
+    key.offset: 5566,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5585,
+    key.offset: 5586,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5601,
+    key.offset: 5602,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5608,
+    key.offset: 5609,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5612,
+    key.offset: 5613,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5624,
+    key.offset: 5625,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5640,
+    key.offset: 5641,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5656,
+    key.offset: 5657,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5663,
+    key.offset: 5664,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5667,
+    key.offset: 5668,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5685,
+    key.offset: 5686,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5701,
+    key.offset: 5702,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5708,
+    key.offset: 5709,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5712,
+    key.offset: 5713,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5724,
+    key.offset: 5725,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5740,
+    key.offset: 5741,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5747,
+    key.offset: 5748,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5751,
+    key.offset: 5752,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5762,
+    key.offset: 5763,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5778,
+    key.offset: 5779,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5789,
+    key.offset: 5790,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5796,
+    key.offset: 5797,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5800,
+    key.offset: 5801,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5810,
+    key.offset: 5811,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5826,
+    key.offset: 5827,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5831,
+    key.offset: 5832,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5838,
+    key.offset: 5839,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5842,
+    key.offset: 5843,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5851,
+    key.offset: 5852,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5867,
+    key.offset: 5868,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5874,
+    key.offset: 5875,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5878,
+    key.offset: 5879,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5886,
+    key.offset: 5887,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5895,
+    key.offset: 5896,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5902,
+    key.offset: 5903,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5908,
+    key.offset: 5909,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5932,
+    key.offset: 5933,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5952,
+    key.offset: 5953,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5959,
+    key.offset: 5960,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5971,
+    key.offset: 5972,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5977,
+    key.offset: 5978,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5981,
+    key.offset: 5982,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5984,
+    key.offset: 5985,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6001,
+    key.offset: 6002,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6015,
+    key.offset: 6016,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6027,
+    key.offset: 6028,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6036,
+    key.offset: 6037,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6045,
+    key.offset: 6046,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6052,
+    key.offset: 6053,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6057,
+    key.offset: 6058,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6080,
+    key.offset: 6081,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6091,
+    key.offset: 6092,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6095,
+    key.offset: 6096,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6108,
+    key.offset: 6109,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6115,
+    key.offset: 6116,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6120,
+    key.offset: 6121,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6155,
+    key.offset: 6156,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6166,
+    key.offset: 6167,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6171,
+    key.offset: 6172,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6183,
+    key.offset: 6184,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6189,
+    key.offset: 6190,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6198,
+    key.offset: 6199,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6207,
+    key.offset: 6208,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6214,
+    key.offset: 6215,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6219,
+    key.offset: 6220,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6250,
+    key.offset: 6251,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6257,
+    key.offset: 6258,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6263,
+    key.offset: 6264,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6277,
+    key.offset: 6278,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6284,
+    key.offset: 6285,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6290,
+    key.offset: 6291,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6317,
+    key.offset: 6318,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6324,
+    key.offset: 6325,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6329,
+    key.offset: 6330,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6336,
+    key.offset: 6337,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6343,
+    key.offset: 6344,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6349,
+    key.offset: 6350,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6374,
+    key.offset: 6375,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6378,
+    key.offset: 6379,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6405,
+    key.offset: 6406,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6414,
+    key.offset: 6415,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6421,
+    key.offset: 6422,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6426,
+    key.offset: 6427,
     key.length: 1
   }
 ]
@@ -3531,296 +3531,296 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2209,
+    key.offset: 2210,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2301,
+    key.offset: 2302,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2311,
+    key.offset: 2312,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2385,
+    key.offset: 2386,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2395,
+    key.offset: 2396,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3041,
+    key.offset: 3042,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3051,
+    key.offset: 3052,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3559,
+    key.offset: 3560,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3607,
+    key.offset: 3608,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3655,
+    key.offset: 3656,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3709,
+    key.offset: 3710,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3848,
+    key.offset: 3849,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3863,
+    key.offset: 3864,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3936,
+    key.offset: 3937,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 4107,
+    key.offset: 4108,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 4121,
+    key.offset: 4122,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4177,
+    key.offset: 4178,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4213,
+    key.offset: 4214,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4249,
+    key.offset: 4250,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4412,
+    key.offset: 4413,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4458,
+    key.offset: 4459,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4474,
+    key.offset: 4475,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4638,
+    key.offset: 4639,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4676,
+    key.offset: 4677,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4714,
+    key.offset: 4715,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4791,
+    key.offset: 4792,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4830,
+    key.offset: 4831,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4876,
+    key.offset: 4877,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4921,
+    key.offset: 4922,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5056,
+    key.offset: 5057,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5101,
+    key.offset: 5102,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5121,
+    key.offset: 5122,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5173,
+    key.offset: 5174,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5242,
+    key.offset: 5243,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5294,
+    key.offset: 5295,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5343,
+    key.offset: 5344,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5367,
+    key.offset: 5368,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5419,
+    key.offset: 5420,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5505,
+    key.offset: 5506,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5565,
+    key.offset: 5566,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5624,
+    key.offset: 5625,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5685,
+    key.offset: 5686,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5724,
+    key.offset: 5725,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5762,
+    key.offset: 5763,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5810,
+    key.offset: 5811,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5851,
+    key.offset: 5852,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5886,
+    key.offset: 5887,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5932,
+    key.offset: 5933,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5984,
+    key.offset: 5985,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 6374,
+    key.offset: 6375,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6378,
+    key.offset: 6379,
     key.length: 19
   }
 ]
@@ -4552,9 +4552,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc3(_:_:_:_:)",
     key.offset: 2121,
-    key.length: 93,
+    key.length: 94,
     key.nameoffset: 2126,
-    key.namelength: 79,
+    key.namelength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
@@ -4587,8 +4587,8 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
         key.offset: 2172,
-        key.length: 32,
-        key.typename: "UnsafeMutablePointer<Int32>",
+        key.length: 33,
+        key.typename: "UnsafeMutablePointer<Int32>!",
         key.nameoffset: 0,
         key.namelength: 0
       }
@@ -4598,15 +4598,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
-    key.offset: 2270,
+    key.offset: 2271,
     key.length: 49,
-    key.nameoffset: 2275,
+    key.nameoffset: 2276,
     key.namelength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
-        key.offset: 2292,
+        key.offset: 2293,
         key.length: 26,
         key.typename: "((Float) -> Int32)!",
         key.nameoffset: 0,
@@ -4618,15 +4618,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2328,
+    key.offset: 2329,
     key.length: 75,
-    key.nameoffset: 2333,
+    key.nameoffset: 2334,
     key.namelength: 70,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2360,
+        key.offset: 2361,
         key.length: 42,
         key.typename: "(@convention(c) (Float) -> Int32)!",
         key.nameoffset: 0,
@@ -4638,9 +4638,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2422,
+    key.offset: 2423,
     key.length: 23,
-    key.nameoffset: 2427,
+    key.nameoffset: 2428,
     key.namelength: 18,
     key.attributes: [
       {
@@ -4652,9 +4652,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2463,
+    key.offset: 2464,
     key.length: 23,
-    key.nameoffset: 2468,
+    key.nameoffset: 2469,
     key.namelength: 18,
     key.attributes: [
       {
@@ -4666,60 +4666,60 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2558,
+    key.offset: 2559,
     key.length: 26,
-    key.nameoffset: 2563,
+    key.nameoffset: 2564,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2636,
+    key.offset: 2637,
     key.length: 26,
-    key.nameoffset: 2641,
+    key.nameoffset: 2642,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2731,
+    key.offset: 2732,
     key.length: 26,
-    key.nameoffset: 2736,
+    key.nameoffset: 2737,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2819,
+    key.offset: 2820,
     key.length: 26,
-    key.nameoffset: 2824,
+    key.nameoffset: 2825,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 2913,
+    key.offset: 2914,
     key.length: 26,
-    key.nameoffset: 2918,
+    key.nameoffset: 2919,
     key.namelength: 21
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 2998,
+    key.offset: 2999,
     key.length: 58,
-    key.nameoffset: 3003,
+    key.nameoffset: 3004,
     key.namelength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 3036,
+        key.offset: 3037,
         key.length: 10,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -4731,48 +4731,48 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 3098,
+    key.offset: 3099,
     key.length: 572,
     key.runtime_name: "_TtP4main15FooProtocolBase_",
-    key.nameoffset: 3107,
+    key.nameoffset: 3108,
     key.namelength: 15,
-    key.bodyoffset: 3124,
+    key.bodyoffset: 3125,
     key.bodylength: 545,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3189,
+        key.offset: 3190,
         key.length: 19,
-        key.nameoffset: 3194,
+        key.nameoffset: 3195,
         key.namelength: 14
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3294,
+        key.offset: 3295,
         key.length: 40,
-        key.nameoffset: 3299,
+        key.nameoffset: 3300,
         key.namelength: 35
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3434,
+        key.offset: 3435,
         key.length: 40,
-        key.nameoffset: 3439,
+        key.nameoffset: 3440,
         key.namelength: 35
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3492,
+        key.offset: 3493,
         key.length: 31,
-        key.nameoffset: 3504,
+        key.nameoffset: 3505,
         key.namelength: 19
       },
       {
@@ -4780,12 +4780,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3541,
+        key.offset: 3542,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3545,
+        key.nameoffset: 3546,
         key.namelength: 12,
-        key.bodyoffset: 3566,
+        key.bodyoffset: 3567,
         key.bodylength: 9
       },
       {
@@ -4793,24 +4793,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3589,
+        key.offset: 3590,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3593,
+        key.nameoffset: 3594,
         key.namelength: 12,
-        key.bodyoffset: 3614,
+        key.bodyoffset: 3615,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3637,
+        key.offset: 3638,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3641,
+        key.nameoffset: 3642,
         key.namelength: 12,
-        key.bodyoffset: 3662,
+        key.bodyoffset: 3663,
         key.bodylength: 5
       }
     ]
@@ -4819,12 +4819,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3679,
+    key.offset: 3680,
     key.length: 49,
     key.runtime_name: "_TtP4main18FooProtocolDerived_",
-    key.nameoffset: 3688,
+    key.nameoffset: 3689,
     key.namelength: 18,
-    key.bodyoffset: 3726,
+    key.bodyoffset: 3727,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -4834,7 +4834,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3709,
+        key.offset: 3710,
         key.length: 15
       }
     ]
@@ -4843,36 +4843,36 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooClassBase",
-    key.offset: 3737,
+    key.offset: 3738,
     key.length: 304,
     key.runtime_name: "_TtC4main12FooClassBase",
-    key.nameoffset: 3743,
+    key.nameoffset: 3744,
     key.namelength: 12,
-    key.bodyoffset: 3757,
+    key.bodyoffset: 3758,
     key.bodylength: 283,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3770,
+        key.offset: 3771,
         key.length: 27,
-        key.nameoffset: 3775,
+        key.nameoffset: 3776,
         key.namelength: 22
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3810,
+        key.offset: 3811,
         key.length: 66,
-        key.nameoffset: 3815,
+        key.nameoffset: 3816,
         key.namelength: 44,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3836,
+            key.offset: 3837,
             key.length: 22,
             key.typename: "AnyObject!",
             key.nameoffset: 0,
@@ -4884,18 +4884,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3889,
+        key.offset: 3890,
         key.length: 7,
-        key.nameoffset: 3889,
+        key.nameoffset: 3890,
         key.namelength: 7
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3921,
+        key.offset: 3922,
         key.length: 21,
-        key.nameoffset: 3921,
+        key.nameoffset: 3922,
         key.namelength: 21,
         key.attributes: [
           {
@@ -4906,10 +4906,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3927,
+            key.offset: 3928,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3927,
+            key.nameoffset: 3928,
             key.namelength: 5
           }
         ]
@@ -4918,18 +4918,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3955,
+        key.offset: 3956,
         key.length: 36,
-        key.nameoffset: 3960,
+        key.nameoffset: 3961,
         key.namelength: 31
       },
       {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 4009,
+        key.offset: 4010,
         key.length: 30,
-        key.nameoffset: 4020,
+        key.nameoffset: 4021,
         key.namelength: 19
       }
     ]
@@ -4938,12 +4938,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooClassDerived",
-    key.offset: 4083,
+    key.offset: 4084,
     key.length: 497,
     key.runtime_name: "_TtC4main15FooClassDerived",
-    key.nameoffset: 4089,
+    key.nameoffset: 4090,
     key.namelength: 15,
-    key.bodyoffset: 4141,
+    key.bodyoffset: 4142,
     key.bodylength: 438,
     key.inheritedtypes: [
       {
@@ -4956,12 +4956,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4107,
+        key.offset: 4108,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4121,
+        key.offset: 4122,
         key.length: 18
       }
     ],
@@ -4971,10 +4971,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 4159,
+        key.offset: 4160,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4163,
+        key.nameoffset: 4164,
         key.namelength: 12
       },
       {
@@ -4982,10 +4982,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 4195,
+        key.offset: 4196,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4199,
+        key.nameoffset: 4200,
         key.namelength: 12
       },
       {
@@ -4993,34 +4993,34 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 4231,
+        key.offset: 4232,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4235,
+        key.nameoffset: 4236,
         key.namelength: 12
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooInstanceFunc0()",
-        key.offset: 4349,
+        key.offset: 4350,
         key.length: 23,
-        key.nameoffset: 4354,
+        key.nameoffset: 4355,
         key.namelength: 18
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4385,
+        key.offset: 4386,
         key.length: 33,
-        key.nameoffset: 4390,
+        key.nameoffset: 4391,
         key.namelength: 28,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4407,
+            key.offset: 4408,
             key.length: 10,
             key.typename: "Int32",
             key.nameoffset: 0,
@@ -5032,15 +5032,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4431,
+        key.offset: 4432,
         key.length: 49,
-        key.nameoffset: 4436,
+        key.nameoffset: 4437,
         key.namelength: 44,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4453,
+            key.offset: 4454,
             key.length: 10,
             key.typename: "Int32",
             key.nameoffset: 0,
@@ -5049,10 +5049,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4465,
+            key.offset: 4466,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4465,
+            key.nameoffset: 4466,
             key.namelength: 5
           }
         ]
@@ -5061,18 +5061,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4498,
+        key.offset: 4499,
         key.length: 36,
-        key.nameoffset: 4503,
+        key.nameoffset: 4504,
         key.namelength: 31
       },
       {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooClassFunc0()",
-        key.offset: 4552,
+        key.offset: 4553,
         key.length: 26,
-        key.nameoffset: 4563,
+        key.nameoffset: 4564,
         key.namelength: 15
       }
     ]
@@ -5082,10 +5082,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4621,
+    key.offset: 4622,
     key.length: 22,
     key.typename: "Int32",
-    key.nameoffset: 4625,
+    key.nameoffset: 4626,
     key.namelength: 11
   },
   {
@@ -5093,10 +5093,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4659,
+    key.offset: 4660,
     key.length: 22,
     key.typename: "Int32",
-    key.nameoffset: 4663,
+    key.nameoffset: 4664,
     key.namelength: 11
   },
   {
@@ -5104,10 +5104,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4697,
+    key.offset: 4698,
     key.length: 22,
     key.typename: "Int32",
-    key.nameoffset: 4701,
+    key.nameoffset: 4702,
     key.namelength: 11
   },
   {
@@ -5115,10 +5115,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4774,
+    key.offset: 4775,
     key.length: 23,
     key.typename: "UInt32",
-    key.nameoffset: 4778,
+    key.nameoffset: 4779,
     key.namelength: 11
   },
   {
@@ -5126,10 +5126,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4813,
+    key.offset: 4814,
     key.length: 23,
     key.typename: "UInt64",
-    key.nameoffset: 4817,
+    key.nameoffset: 4818,
     key.namelength: 11
   },
   {
@@ -5137,10 +5137,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 4853,
+    key.offset: 4854,
     key.length: 28,
     key.typename: "Int32",
-    key.nameoffset: 4857,
+    key.nameoffset: 4858,
     key.namelength: 17
   },
   {
@@ -5148,39 +5148,39 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 4898,
+    key.offset: 4899,
     key.length: 28,
     key.typename: "Int32",
-    key.nameoffset: 4902,
+    key.nameoffset: 4903,
     key.namelength: 17
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 4943,
+    key.offset: 4944,
     key.length: 23,
-    key.nameoffset: 4948,
+    key.nameoffset: 4949,
     key.namelength: 18
   },
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 4975,
+    key.offset: 4976,
     key.length: 28,
-    key.nameoffset: 4980,
+    key.nameoffset: 4981,
     key.namelength: 23
   },
   {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5012,
+    key.offset: 5013,
     key.length: 97,
-    key.nameoffset: 5019,
+    key.nameoffset: 5020,
     key.namelength: 15,
-    key.bodyoffset: 5036,
+    key.bodyoffset: 5037,
     key.bodylength: 72,
     key.substructure: [
       {
@@ -5188,37 +5188,37 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5049,
+        key.offset: 5050,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5053,
+        key.nameoffset: 5054,
         key.namelength: 1
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5074,
+        key.offset: 5075,
         key.length: 6,
-        key.nameoffset: 5074,
+        key.nameoffset: 5075,
         key.namelength: 6
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5093,
+        key.offset: 5094,
         key.length: 14,
-        key.nameoffset: 5093,
+        key.nameoffset: 5094,
         key.namelength: 14,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5098,
+            key.offset: 5099,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5098,
+            key.nameoffset: 5099,
             key.namelength: 1
           }
         ]
@@ -5228,20 +5228,20 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5111,
+    key.offset: 5112,
     key.length: 74,
-    key.nameoffset: 5121,
+    key.nameoffset: 5122,
     key.namelength: 12,
-    key.bodyoffset: 5135,
+    key.bodyoffset: 5136,
     key.bodylength: 49,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "_internalMeth1()",
-        key.offset: 5148,
+        key.offset: 5149,
         key.length: 35,
-        key.nameoffset: 5153,
+        key.nameoffset: 5154,
         key.namelength: 16
       }
     ]
@@ -5249,29 +5249,29 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5232,
+    key.offset: 5233,
     key.length: 123,
-    key.nameoffset: 5242,
+    key.nameoffset: 5243,
     key.namelength: 12,
-    key.bodyoffset: 5256,
+    key.bodyoffset: 5257,
     key.bodylength: 98,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "_internalMeth2()",
-        key.offset: 5269,
+        key.offset: 5270,
         key.length: 35,
-        key.nameoffset: 5274,
+        key.nameoffset: 5275,
         key.namelength: 16
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "nonInternalMeth()",
-        key.offset: 5317,
+        key.offset: 5318,
         key.length: 36,
-        key.nameoffset: 5322,
+        key.nameoffset: 5323,
         key.namelength: 17
       }
     ]
@@ -5279,20 +5279,20 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5357,
+    key.offset: 5358,
     key.length: 74,
-    key.nameoffset: 5367,
+    key.nameoffset: 5368,
     key.namelength: 12,
-    key.bodyoffset: 5381,
+    key.bodyoffset: 5382,
     key.bodylength: 49,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "_internalMeth3()",
-        key.offset: 5394,
+        key.offset: 5395,
         key.length: 35,
-        key.nameoffset: 5399,
+        key.nameoffset: 5400,
         key.namelength: 16
       }
     ]
@@ -5301,24 +5301,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5440,
+    key.offset: 5441,
     key.length: 26,
     key.runtime_name: "_TtP4main13_InternalProt_",
-    key.nameoffset: 5449,
+    key.nameoffset: 5450,
     key.namelength: 13,
-    key.bodyoffset: 5464,
+    key.bodyoffset: 5465,
     key.bodylength: 1
   },
   {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ClassWithInternalProt",
-    key.offset: 5475,
+    key.offset: 5476,
     key.length: 47,
     key.runtime_name: "_TtC4main21ClassWithInternalProt",
-    key.nameoffset: 5481,
+    key.nameoffset: 5482,
     key.namelength: 21,
-    key.bodyoffset: 5520,
+    key.bodyoffset: 5521,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5328,7 +5328,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5505,
+        key.offset: 5506,
         key.length: 13
       }
     ]
@@ -5337,12 +5337,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5531,
+    key.offset: 5532,
     key.length: 362,
     key.runtime_name: "_TtC4main25FooClassPropertyOwnership",
-    key.nameoffset: 5537,
+    key.nameoffset: 5538,
     key.namelength: 25,
-    key.bodyoffset: 5579,
+    key.bodyoffset: 5580,
     key.bodylength: 313,
     key.inheritedtypes: [
       {
@@ -5352,7 +5352,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5565,
+        key.offset: 5566,
         key.length: 12
       }
     ],
@@ -5362,10 +5362,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "assignable",
-        key.offset: 5608,
+        key.offset: 5609,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 5612,
+        key.nameoffset: 5613,
         key.namelength: 10,
         key.attributes: [
           {
@@ -5378,10 +5378,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "unsafeAssignable",
-        key.offset: 5663,
+        key.offset: 5664,
         key.length: 32,
         key.typename: "AnyObject!",
-        key.nameoffset: 5667,
+        key.nameoffset: 5668,
         key.namelength: 16,
         key.attributes: [
           {
@@ -5394,10 +5394,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "retainable",
-        key.offset: 5708,
+        key.offset: 5709,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 5712,
+        key.nameoffset: 5713,
         key.namelength: 10
       },
       {
@@ -5405,10 +5405,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "strongRef",
-        key.offset: 5747,
+        key.offset: 5748,
         key.length: 25,
         key.typename: "AnyObject!",
-        key.nameoffset: 5751,
+        key.nameoffset: 5752,
         key.namelength: 9
       },
       {
@@ -5416,10 +5416,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "copyable",
-        key.offset: 5796,
+        key.offset: 5797,
         key.length: 24,
         key.typename: "AnyObject!",
-        key.nameoffset: 5800,
+        key.nameoffset: 5801,
         key.namelength: 8,
         key.attributes: [
           {
@@ -5432,10 +5432,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "weakRef",
-        key.offset: 5838,
+        key.offset: 5839,
         key.length: 23,
         key.typename: "AnyObject!",
-        key.nameoffset: 5842,
+        key.nameoffset: 5843,
         key.namelength: 7,
         key.attributes: [
           {
@@ -5448,10 +5448,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "scalar",
-        key.offset: 5874,
+        key.offset: 5875,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 5878,
+        key.nameoffset: 5879,
         key.namelength: 6
       }
     ]
@@ -5460,12 +5460,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooUnavailableMembers",
-    key.offset: 5902,
+    key.offset: 5903,
     key.length: 346,
     key.runtime_name: "_TtC4main21FooUnavailableMembers",
-    key.nameoffset: 5908,
+    key.nameoffset: 5909,
     key.namelength: 21,
-    key.bodyoffset: 5946,
+    key.bodyoffset: 5947,
     key.bodylength: 301,
     key.inheritedtypes: [
       {
@@ -5475,7 +5475,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5932,
+        key.offset: 5933,
         key.length: 12
       }
     ],
@@ -5484,9 +5484,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 5971,
+        key.offset: 5972,
         key.length: 19,
-        key.nameoffset: 5971,
+        key.nameoffset: 5972,
         key.namelength: 19,
         key.attributes: [
           {
@@ -5497,10 +5497,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 5977,
+            key.offset: 5978,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 5977,
+            key.nameoffset: 5978,
             key.namelength: 3
           }
         ]
@@ -5509,9 +5509,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "deprecated()",
-        key.offset: 6052,
+        key.offset: 6053,
         key.length: 17,
-        key.nameoffset: 6057,
+        key.nameoffset: 6058,
         key.namelength: 12,
         key.attributes: [
           {
@@ -5523,9 +5523,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "availabilityIntroduced()",
-        key.offset: 6115,
+        key.offset: 6116,
         key.length: 29,
-        key.nameoffset: 6120,
+        key.nameoffset: 6121,
         key.namelength: 24,
         key.attributes: [
           {
@@ -5537,9 +5537,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6214,
+        key.offset: 6215,
         key.length: 32,
-        key.nameoffset: 6219,
+        key.nameoffset: 6220,
         key.namelength: 27,
         key.attributes: [
           {
@@ -5553,33 +5553,33 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6257,
+    key.offset: 6258,
     key.length: 19,
     key.runtime_name: "_TtC4main9FooCFType",
-    key.nameoffset: 6263,
+    key.nameoffset: 6264,
     key.namelength: 9,
-    key.bodyoffset: 6274,
+    key.bodyoffset: 6275,
     key.bodylength: 1
   },
   {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6284,
+    key.offset: 6285,
     key.length: 50,
     key.runtime_name: "_TtC4main19FooOverlayClassBase",
-    key.nameoffset: 6290,
+    key.nameoffset: 6291,
     key.namelength: 19,
-    key.bodyoffset: 6311,
+    key.bodyoffset: 6312,
     key.bodylength: 22,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6324,
+        key.offset: 6325,
         key.length: 8,
-        key.nameoffset: 6329,
+        key.nameoffset: 6330,
         key.namelength: 3
       }
     ]
@@ -5588,12 +5588,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6343,
+    key.offset: 6344,
     key.length: 88,
     key.runtime_name: "_TtC4main22FooOverlayClassDerived",
-    key.nameoffset: 6349,
+    key.nameoffset: 6350,
     key.namelength: 22,
-    key.bodyoffset: 6399,
+    key.bodyoffset: 6400,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -5603,7 +5603,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6374,
+        key.offset: 6375,
         key.length: 23
       }
     ],
@@ -5612,9 +5612,9 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6421,
+        key.offset: 6422,
         key.length: 8,
-        key.nameoffset: 6426,
+        key.nameoffset: 6427,
         key.namelength: 3,
         key.attributes: [
           {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1103,6 +1103,9 @@ class infer_instanceVar1 {
   var var_Optional9: protocol<Protocol_ObjC1>.Type?
   var var_Optional10: protocol<Protocol_ObjC1, Protocol_ObjC2>?
   var var_Optional11: protocol<Protocol_ObjC1, Protocol_ObjC2>.Type?
+  var var_Optional12: OpaquePointer?
+  var var_Optional13: UnsafeMutablePointer<Int>?
+  var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
 
 // CHECK-LABEL: @objc var var_Optional1: Class_ObjC1?
 // CHECK-LABEL: @objc var var_Optional2: Protocol_ObjC1?
@@ -1115,6 +1118,9 @@ class infer_instanceVar1 {
 // CHECK-LABEL: @objc var var_Optional9: Protocol_ObjC1.Type?
 // CHECK-LABEL: @objc var var_Optional10: protocol<Protocol_ObjC1, Protocol_ObjC2>?
 // CHECK-LABEL: @objc var var_Optional11: protocol<Protocol_ObjC1, Protocol_ObjC2>.Type?
+// CHECK-LABEL: @objc var var_Optional12: OpaquePointer?
+// CHECK-LABEL: @objc var var_Optional13: UnsafeMutablePointer<Int>?
+// CHECK-LABEL: @objc var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
 
 
   var var_ImplicitlyUnwrappedOptional1: Class_ObjC1!
@@ -1151,9 +1157,6 @@ class infer_instanceVar1 {
   var var_Optional_fail12: Int?
   var var_Optional_fail13: Bool?
   var var_Optional_fail14: CBool?
-  var var_Optional_fail16: OpaquePointer?
-  var var_Optional_fail17: UnsafeMutablePointer<Int>?
-  var var_Optional_fail18: UnsafeMutablePointer<Class_ObjC1>?
   var var_Optional_fail20: AnyObject??
   var var_Optional_fail21: AnyObject.Type??
 // CHECK-NOT: @objc{{.*}}Optional_fail
@@ -1656,7 +1659,7 @@ class HasNSManaged {
 
   func mutableAutoreleasingUnsafeMutablePointerToAnyObject(p: AutoreleasingUnsafeMutablePointer<AnyObject>) {}
   // CHECK-LABEL: {{^}} @objc func mutableAutoreleasingUnsafeMutablePointerToAnyObject(p: AutoreleasingUnsafeMutablePointer<AnyObject>) {
-}
+  }
 
 // @objc with nullary names
 @objc(NSObjC2)
@@ -1937,11 +1940,11 @@ class ClassThrows1 {
 // CHECK-DUMP-LABEL: class_decl "ImplicitClassThrows1"
 @objc class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
-  // CHECK-DUMP: func_decl "methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
-  // CHECK-DUMP: func_decl "methodReturnsObjCClass()" {{.*}}foreign_error=NilResult,unowned,param=0,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>
+  // CHECK-DUMP: func_decl "methodReturnsObjCClass()" {{.*}}foreign_error=NilResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
@@ -1956,18 +1959,18 @@ class ClassThrows1 {
   func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil }
 
   // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int, fn3: (Int) -> Int)
-  // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int, fn3: (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
-  // CHECK-DUMP: constructor_decl "init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>
+  // CHECK-DUMP: constructor_decl "init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
   init(degrees: Double) throws { }
 }
 
 // CHECK-DUMP-LABEL: class_decl "SubclassImplicitClassThrows1"
 @objc class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: ((Int) -> Int), fn3: ((Int) -> Int))
-  // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   override func methodWithTrailingClosures(_ s: String, fn1: ((Int) -> Int), fn2: ((Int) -> Int), fn3: ((Int) -> Int)) throws { }
 }
 
@@ -2000,20 +2003,20 @@ class ThrowsObjCName {
 
   @objc(method7) func method7(x: Int) throws { } // expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
 
-  // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   @objc(method8:fn1:error:fn2:)
   func method8(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   @objc(method9AndReturnError:s:fn1:fn2:)
   func method9(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
-  // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   override func method8(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=AutoreleasingUnsafeMutablePointer<Optional<NSError>>,resulttype=Bool
+  // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=Bool
   override func method9(_ s: String, fn1: ((Int) -> Int), fn2: (Int) -> Int) throws { }
 }
 

--- a/test/decl/subscript/addressors.swift
+++ b/test/decl/subscript/addressors.swift
@@ -2,8 +2,11 @@
 
 import Swift
 
+func someValidAddress<T>() -> UnsafeMutablePointer<T> { fatalError() }
+func someValidAddress<T>() -> UnsafePointer<T> { fatalError() }
+
 struct ValidImmutable {
-  var base: UnsafePointer<Int> = nil
+  var base: UnsafePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeAddress {
@@ -13,7 +16,7 @@ struct ValidImmutable {
 }
 
 struct ValidBoth {
-  var base: UnsafeMutablePointer<Int> = nil
+  var base: UnsafeMutablePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeAddress {
@@ -26,7 +29,7 @@ struct ValidBoth {
 }
 
 struct OnlyMutable {
-  var base: UnsafeMutablePointer<Int> = nil
+  var base: UnsafeMutablePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeMutableAddress { // expected-error {{subscript must provide either a getter or 'address' if it provides 'mutableAddress'}}
@@ -36,7 +39,7 @@ struct OnlyMutable {
 }
 
 struct Repeated {
-  var base: UnsafeMutablePointer<Int> = nil
+  var base: UnsafeMutablePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeAddress { // expected-note {{previous definition}}
@@ -49,7 +52,7 @@ struct Repeated {
 }
 
 struct RepeatedMutable {
-  var base: UnsafeMutablePointer<Int> = nil
+  var base: UnsafeMutablePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeAddress {
@@ -65,7 +68,7 @@ struct RepeatedMutable {
 }
 
 struct AddressorAndGet {
-  var base: UnsafePointer<Int> = nil
+  var base: UnsafePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeAddress { // expected-error {{subscript cannot provide both 'address' and a getter}}
@@ -78,7 +81,7 @@ struct AddressorAndGet {
 }
 
 struct AddressorAndSet {
-  var base: UnsafePointer<Int> = nil
+  var base: UnsafePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeAddress {
@@ -90,7 +93,7 @@ struct AddressorAndSet {
 }
 
 struct MutableAddressorAndGet {
-  var base: UnsafeMutablePointer<Int> = nil
+  var base: UnsafeMutablePointer<Int>
 
   subscript(index: Int) -> Int {
     unsafeMutableAddress {
@@ -111,20 +114,20 @@ protocol HasMutableSubscript {
 
 struct DisobedientImmutableAddressor: HasMutableSubscript { // expected-error {{does not conform}}
   subscript(index: Int) -> Int { // expected-note {{candidate is not settable}}
-    unsafeAddress { return nil }
+    unsafeAddress { return someValidAddress() }
   }
 }
 
 struct ObedientImmutableAddressor: HasImmutableSubscript {
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
+    unsafeAddress { return someValidAddress() }
   }
 }
 
 struct ObedientMutableAddressor: HasMutableSubscript {
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidAddress() }
+    unsafeMutableAddress { return someValidAddress() }
   }
 }
 
@@ -139,20 +142,20 @@ protocol HasMutatingMutableSubscript {
 
 struct DisobedientImmutableAddressor2: HasMutatingMutableSubscript { // expected-error {{does not conform}}
   subscript(index: Int) -> Int { // expected-note {{candidate is not settable}}
-    unsafeAddress { return nil }
+    unsafeAddress { return someValidAddress() }
   }
 }
 
 struct ObedientImmutableAddressor2: HasMutatingImmutableSubscript {
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
+    unsafeAddress { return someValidAddress() }
   }
 }
 
 struct ObedientMutableAddressor2: HasMutatingMutableSubscript {
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidAddress() }
+    unsafeMutableAddress { return someValidAddress() }
   }
 }
 
@@ -164,15 +167,15 @@ protocol HasNonMutatingMutableSubscript {
 
 struct DisobedientNonMutatingMutableAddressor: HasNonMutatingMutableSubscript { // expected-error {{does not conform}}
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil } // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
+    unsafeAddress { return someValidAddress() }
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
   }
 }
 
 struct ObedientNonMutatingMutableAddressor: HasNonMutatingMutableSubscript {
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    nonmutating unsafeMutableAddress { return nil }
+    unsafeAddress { return someValidAddress() }
+    nonmutating unsafeMutableAddress { return someValidAddress() }
   }
 }
 
@@ -181,46 +184,46 @@ struct ObedientNonMutatingMutableAddressor: HasNonMutatingMutableSubscript {
 struct RedundantAddressors1 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil } // expected-note {{previous definition of addressor is here}}
-    addressWithNativeOwner { return (nil, owner)  } // expected-error {{subscript already has a addressor}}
+    unsafeAddress { return someValidAddress() } // expected-note {{previous definition of addressor is here}}
+    addressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
   }
 }
 struct RedundantAddressors2 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil } // expected-note {{previous definition of addressor is here}}
-    addressWithPinnedNativeOwner { return (nil, owner)  } // expected-error {{subscript already has a addressor}}
+    unsafeAddress { return someValidAddress() } // expected-note {{previous definition of addressor is here}}
+    addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
   }
 }
 struct RedundantAddressors3 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    addressWithNativeOwner { return nil } // expected-note {{previous definition of addressor is here}}
-    addressWithPinnedNativeOwner { return (nil, owner)  } // expected-error {{subscript already has a addressor}}
+    addressWithNativeOwner { return someValidAddress() } // expected-note {{previous definition of addressor is here}}
+    addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
   }
 }
 
 struct RedundantMutableAddressors1 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil } // expected-note {{previous definition of mutable addressor is here}}
-    mutableAddressWithNativeOwner { return (nil, owner)  } // expected-error {{subscript already has a mutable addressor}}
+    unsafeAddress { return someValidAddress() }
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor is here}}
+    mutableAddressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a mutable addressor}}
   }
 }
 struct RedundantMutableAddressors2 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil } // expected-note {{previous definition of mutable addressor is here}}
-    mutableAddressWithNativeOwner { return (nil, owner)  } // expected-error {{subscript already has a mutable addressor}}
+    unsafeAddress { return someValidAddress() }
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor is here}}
+    mutableAddressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a mutable addressor}}
   }
 }
 struct RedundantMutableAddressors3 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return nil }
-    unsafeMutableAddress { return nil } // expected-note {{previous definition of mutable addressor is here}}
-    mutableAddressWithNativeOwner { return (nil, owner)  } // expected-error {{subscript already has a mutable addressor}}
+    unsafeAddress { return someValidAddress() }
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor is here}}
+    mutableAddressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a mutable addressor}}
   }
 }

--- a/test/decl/var/NSCopying.swift
+++ b/test/decl/var/NSCopying.swift
@@ -6,7 +6,9 @@ import Foundation
 
 class NotCopyable {}
 class CopyableClass : NSCopying {
-  @objc(copyWithZone:) func copy(with zone: NSZone) -> AnyObject { return self }
+  @objc(copyWithZone:) func copy(with zone: NSZone?) -> AnyObject {
+    return self
+  }
 }
 
 @NSCopying  // expected-error {{@NSCopying may only be used on 'var' declarations}}}}

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -128,7 +128,7 @@ func test() {
 
 func test4() {
   // expected-warning @+1 {{variable 'dest' was never mutated; consider changing to 'let' constant}} {{3-6=let}}
-  var dest = UnsafeMutablePointer<Int>(bitPattern: 0)
+  var dest = UnsafeMutablePointer<Int>(bitPattern: 0)!
 
   dest[0] = 0
 }

--- a/validation-test/IDE/complete_from_cocoa.swift
+++ b/validation-test/IDE/complete_from_cocoa.swift
@@ -13,7 +13,7 @@ import Cocoa
 func testUnqualified() {
   #^T1^#
 // T1: Begin completions
-// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>>#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>#})[#CFArray!#]{{; name=.+$}}
+// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
 // T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayGetCount({#(theArray): CFArray!#})[#CFIndex#]{{; name=.+$}}
 // T1-DAG: Decl[Class]/OtherModule[ObjectiveC.NSObject]:        NSObject[#NSObject#]{{; name=.+$}}
 // T1: End completions

--- a/validation-test/IDE/complete_from_cocoa_2.swift
+++ b/validation-test/IDE/complete_from_cocoa_2.swift
@@ -13,7 +13,7 @@ import Cocoa
 func testQualifiedWithDot() {
   Cocoa.#^T1^#
 // T1: Begin completions
-// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>>#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>#})[#CFArray!#]{{; name=.+$}}
+// T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
 // T1-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: CFArrayGetCount({#(theArray): CFArray!#})[#CFIndex#]{{; name=.+$}}
 // T1-DAG: Decl[Class]/OtherModule[ObjectiveC.NSObject]:        NSObject[#NSObject#]{{; name=.+$}}
 // T1: End completions
@@ -22,7 +22,7 @@ func testQualifiedWithDot() {
 func testQualifiedWithoutDot() {
   Cocoa#^T2^#
 // T2: Begin completions
-// T2-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: .CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>>#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>#})[#CFArray!#]{{; name=.+$}}
+// T2-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: .CFArrayCreate({#(allocator): CFAllocator!#}, {#(values): UnsafeMutablePointer<UnsafePointer<Void>?>!#}, {#(numValues): CFIndex#}, {#(callBacks): UnsafePointer<CFArrayCallBacks>!#})[#CFArray!#]{{; name=.+$}}
 // T2-DAG: Decl[FreeFunction]/OtherModule[CoreFoundation.CFArray]: .CFArrayGetCount({#(theArray): CFArray!#})[#CFIndex#]{{; name=.+$}}
 // T2-DAG: Decl[Class]/OtherModule[ObjectiveC.NSObject]:        .NSObject[#NSObject#]{{; name=.+$}}
 // T2: End completions

--- a/validation-test/StdlibUnittest/Common.swift
+++ b/validation-test/StdlibUnittest/Common.swift
@@ -566,7 +566,9 @@ AssertionsTestSuite.test("UnexpectedCrash/RuntimeTrap") {
 // CHECK: [     FAIL ] Assertions.UnexpectedCrash/RuntimeTrap
 
 AssertionsTestSuite.test("UnexpectedCrash/NullPointerDereference") {
-  let ptr: UnsafePointer<Int> = _opaqueIdentity(nil)
+  let nilValue: UnsafePointer<Int>? = nil
+  let ptr: UnsafePointer<Int> =
+    _opaqueIdentity(unsafeBitCast(nilValue, to: UnsafePointer.self))
   _blackHole(ptr.pointee)
 }
 // CHECK: [ RUN      ] Assertions.UnexpectedCrash/NullPointerDereference

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -244,7 +244,7 @@ func isCocoaArray<Element>(_ a: Array<Element>) -> Bool {
 }
 
 func getAsImmutableNSArray(_ a: Array<Int>) -> NSArray {
-  var elements = a.map { TestObjCValueTy($0) as AnyObject? }
+  var elements = a.map { TestObjCValueTy($0) as AnyObject }
   return NSArray(objects: &elements, count: elements.count)
 }
 
@@ -273,7 +273,7 @@ class CustomImmutableNSArray : NSArray {
     super.init()
   }
 
-  override init(objects: UnsafePointer<AnyObject?>, count: Int) {
+  override init(objects: UnsafePointer<AnyObject>, count: Int) {
     super.init(objects: objects, count: count)
   }
 
@@ -302,7 +302,7 @@ class CustomImmutableNSArray : NSArray {
   @objc
   override func countByEnumerating(
     with state: UnsafeMutablePointer<NSFastEnumerationState>,
-    objects: AutoreleasingUnsafeMutablePointer<AnyObject?>,
+    objects: AutoreleasingUnsafeMutablePointer<AnyObject>,
     count: Int
   ) -> Int {
     var theState = state.pointee

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -282,7 +282,7 @@ class CustomImmutableNSArray : NSArray {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     CustomImmutableNSArray.timesCopyWithZoneWasCalled += 1
     return self
   }

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -242,9 +242,6 @@ ArrayTestSuite.test("${array_type}/emptyAllocation") {
   // Empty arrays all use the same buffer
   expectEqual(arr0._buffer.identity, arr1._buffer.identity)
 
-  let hasNilBuffer = arr1.identity == nil
-  expectFalse(hasNilBuffer)
-
   let arr2: ${array_type}<LifetimeTracked> = []
   let emptyLiteralsShareBuffer = arr0._buffer.identity == arr2._buffer.identity
   expectTrue(emptyLiteralsShareBuffer)

--- a/validation-test/stdlib/CoreAudio.swift
+++ b/validation-test/stdlib/CoreAudio.swift
@@ -42,7 +42,7 @@ CoreAudioTestSuite.test("UnsafeBufferPointer.init(_: AudioBuffer)") {
       mData: UnsafeMutablePointer<Void>(bitPattern: 0x1234_5678))
     let result: UnsafeBufferPointer<Float> = UnsafeBufferPointer(audioBuffer)
     expectEqual(
-      UnsafePointer<Float>(audioBuffer.mData),
+      UnsafePointer<Float>(audioBuffer.mData!),
       result.baseAddress)
     expectEqual(256, result.count)
   }
@@ -65,7 +65,7 @@ CoreAudioTestSuite.test("UnsafeMutableBufferPointer.init(_: AudioBuffer)") {
     let result: UnsafeMutableBufferPointer<Float> =
       UnsafeMutableBufferPointer(audioBuffer)
     expectEqual(
-      UnsafeMutablePointer<Float>(audioBuffer.mData),
+      UnsafeMutablePointer<Float>(audioBuffer.mData!),
       result.baseAddress)
     expectEqual(256, result.count)
   }
@@ -165,19 +165,30 @@ CoreAudioTestSuite.test(
   "UnsafeMutableAudioBufferListPointer.unsafeMutablePointer") {
   do {
     let ablPtrWrapper = UnsafeMutableAudioBufferListPointer(nil)
-    expectEqual(nil, ablPtrWrapper.unsafePointer)
-    expectEqual(nil, ablPtrWrapper.unsafeMutablePointer)
+    expectEmpty(ablPtrWrapper)
   }
 
   do {
     let ablPtrWrapper = UnsafeMutableAudioBufferListPointer(
-      UnsafeMutablePointer<AudioBufferList>(bitPattern: 0x1234_5678))
+      UnsafeMutablePointer<AudioBufferList>(bitPattern: 0x1234_5678)!)
     expectEqual(
       UnsafePointer<AudioBufferList>(bitPattern: 0x1234_5678),
       ablPtrWrapper.unsafePointer)
     expectEqual(
       UnsafePointer<AudioBufferList>(bitPattern: 0x1234_5678),
       ablPtrWrapper.unsafeMutablePointer)
+  }
+
+  do {
+    let ablPtrWrapper = UnsafeMutableAudioBufferListPointer(
+      UnsafeMutablePointer<AudioBufferList>(bitPattern: 0x1234_5678))
+    expectNotEmpty(ablPtrWrapper)
+    expectEqual(
+      UnsafePointer<AudioBufferList>(bitPattern: 0x1234_5678),
+      ablPtrWrapper!.unsafePointer)
+    expectEqual(
+      UnsafePointer<AudioBufferList>(bitPattern: 0x1234_5678),
+      ablPtrWrapper!.unsafeMutablePointer)
   }
 }
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1249,7 +1249,7 @@ class ParallelArrayDictionary : NSDictionary {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     // Ensure that copying this dictionary does not produce a CoreFoundation
     // object.
     return self
@@ -1312,7 +1312,7 @@ class CustomImmutableNSDictionary : NSDictionary {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     CustomImmutableNSDictionary.timesCopyWithZoneWasCalled += 1
     return self
   }
@@ -3436,7 +3436,7 @@ class MockDictionaryWithCustomCount : NSDictionary {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     // Ensure that copying this dictionary produces an object of the same
     // dynamic type.
     return self
@@ -3831,16 +3831,15 @@ DictionaryTestSuite.test("getObjects:andKeys:") {
     start: UnsafeMutablePointer<NSNumber>(allocatingCapacity: 2), count: 2)
   var values = UnsafeMutableBufferPointer(
     start: UnsafeMutablePointer<NSString>(allocatingCapacity: 2), count: 2)
-  var kp = AutoreleasingUnsafeMutablePointer<AnyObject?>(keys.baseAddress)
-  var vp = AutoreleasingUnsafeMutablePointer<AnyObject?>(values.baseAddress)
-  var null: AutoreleasingUnsafeMutablePointer<AnyObject?> = nil
+  var kp = AutoreleasingUnsafeMutablePointer<AnyObject?>(keys.baseAddress!)
+  var vp = AutoreleasingUnsafeMutablePointer<AnyObject?>(values.baseAddress!)
 
-  d.getObjects(null, andKeys: null) // don't segfault
+  d.getObjects(nil, andKeys: nil) // don't segfault
 
-  d.getObjects(null, andKeys: kp)
+  d.getObjects(nil, andKeys: kp)
   expectEqual([2, 1] as [NSNumber], Array(keys))
 
-  d.getObjects(vp, andKeys: null)
+  d.getObjects(vp, andKeys: nil)
   expectEqual(["two", "one"] as [NSString], Array(values))
 
   d.getObjects(vp, andKeys: kp)

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1238,8 +1238,8 @@ class ParallelArrayDictionary : NSDictionary {
   }
 
   override init(
-    objects: UnsafePointer<AnyObject?>,
-    forKeys keys: UnsafePointer<NSCopying?>,
+    objects: UnsafePointer<AnyObject>,
+    forKeys keys: UnsafePointer<NSCopying>,
     count: Int) {
     super.init(objects: objects, forKeys: keys, count: count)
   }
@@ -1257,7 +1257,7 @@ class ParallelArrayDictionary : NSDictionary {
 
   override func countByEnumerating(
       with state: UnsafeMutablePointer<NSFastEnumerationState>,
-      objects: AutoreleasingUnsafeMutablePointer<AnyObject?>, count: Int) -> Int {
+      objects: AutoreleasingUnsafeMutablePointer<AnyObject>, count: Int) -> Int {
     var theState = state.pointee
     if theState.state == 0 {
       theState.state = 1
@@ -1300,8 +1300,8 @@ class CustomImmutableNSDictionary : NSDictionary {
   }
 
   override init(
-    objects: UnsafePointer<AnyObject?>,
-    forKeys keys: UnsafePointer<NSCopying?>,
+    objects: UnsafePointer<AnyObject>,
+    forKeys keys: UnsafePointer<NSCopying>,
     count: Int) {
     expectUnreachable()
     super.init(objects: objects, forKeys: keys, count: count)
@@ -3424,8 +3424,8 @@ class MockDictionaryWithCustomCount : NSDictionary {
   }
 
   override init(
-    objects: UnsafePointer<AnyObject?>,
-    forKeys keys: UnsafePointer<NSCopying?>,
+    objects: UnsafePointer<AnyObject>,
+    forKeys keys: UnsafePointer<NSCopying>,
     count: Int) {
     expectUnreachable()
     super.init(objects: objects, forKeys: keys, count: count)
@@ -3831,8 +3831,8 @@ DictionaryTestSuite.test("getObjects:andKeys:") {
     start: UnsafeMutablePointer<NSNumber>(allocatingCapacity: 2), count: 2)
   var values = UnsafeMutableBufferPointer(
     start: UnsafeMutablePointer<NSString>(allocatingCapacity: 2), count: 2)
-  var kp = AutoreleasingUnsafeMutablePointer<AnyObject?>(keys.baseAddress!)
-  var vp = AutoreleasingUnsafeMutablePointer<AnyObject?>(values.baseAddress!)
+  var kp = AutoreleasingUnsafeMutablePointer<AnyObject>(keys.baseAddress!)
+  var vp = AutoreleasingUnsafeMutablePointer<AnyObject>(values.baseAddress!)
 
   d.getObjects(nil, andKeys: nil) // don't segfault
 

--- a/validation-test/stdlib/OpenCLSDKOverlay.swift
+++ b/validation-test/stdlib/OpenCLSDKOverlay.swift
@@ -86,14 +86,11 @@ tests.test("clSetKernelArgsListAPPLE") {
   var global: size_t                      // global domain size for our calculation
   var local: size_t = 0                       // local domain size for our calculation
 
-  var device_id: cl_device_id = nil             // compute device id 
-  var context: cl_context                 // compute context
-  var commands: cl_command_queue          // compute command queue
-  var program: cl_program                 // compute program
-  var kernel: cl_kernel                   // compute kernel
-  
-  var input: cl_mem                       // device memory used for the input array
-  var output: cl_mem                      // device memory used for the output array
+  var device_id: cl_device_id? = nil             // compute device id
+  var context: cl_context?                 // compute context
+  var commands: cl_command_queue?          // compute command queue
+  var program: cl_program?                 // compute program
+  var kernel: cl_kernel?                   // compute kernel
   
   // Fill our data set with random float values
   //
@@ -133,8 +130,8 @@ tests.test("clSetKernelArgsListAPPLE") {
   // Create the compute program from the source buffer
   //
   program = KernelSource.withCString {
-    (s: UnsafePointer<CChar>)->cl_program in
-    var s = s
+    (p: UnsafePointer<CChar>)->cl_program in
+    var s: UnsafePointer? = p
     return withUnsafeMutablePointer(&s) {
       return clCreateProgramWithSource(context, 1, $0, nil, &err)
     }
@@ -172,13 +169,11 @@ tests.test("clSetKernelArgsListAPPLE") {
 
   // Create the input and output arrays in device memory for our calculation
   //
-  input = clCreateBuffer(context,  cl_mem_flags(CL_MEM_READ_ONLY),  sizeof(Float.self) * count, nil, nil)
-  output = clCreateBuffer(context, cl_mem_flags(CL_MEM_WRITE_ONLY), sizeof(Float.self) * count, nil, nil)
-  if (input == nil || output == nil)
-  {
+  guard var input = clCreateBuffer(context,  cl_mem_flags(CL_MEM_READ_ONLY),  sizeof(Float.self) * count, nil, nil),
+        var output = clCreateBuffer(context, cl_mem_flags(CL_MEM_WRITE_ONLY), sizeof(Float.self) * count, nil, nil) else {
     print("Error: Failed to allocate device memory!")
     exit(1)
-  }    
+  }
   
   // Write our data set into the input array in device memory 
   //
@@ -195,7 +190,7 @@ tests.test("clSetKernelArgsListAPPLE") {
   err = withUnsafePointers(&input, &output, &count) {
     inputPtr, outputPtr, countPtr in
     clSetKernelArgsListAPPLE(
-      kernel, 3,
+      kernel!, 3,
       0, sizeof(cl_mem.self), inputPtr,
       1, sizeof(cl_mem.self), outputPtr,
       2, sizeofValue(count), countPtr)

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1177,7 +1177,7 @@ class CustomImmutableNSSet : NSSet {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     CustomImmutableNSSet.timesCopyWithZoneWasCalled += 1
     return self
   }
@@ -3424,7 +3424,7 @@ class MockSetWithCustomCount : NSSet {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     // Ensure that copying this set produces an object of the same
     // dynamic type.
     return self

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1167,7 +1167,7 @@ class CustomImmutableNSSet : NSSet {
     super.init()
   }
 
-  override init(objects: UnsafePointer<AnyObject?>, count: Int) {
+  override init(objects: UnsafePointer<AnyObject>, count: Int) {
     expectUnreachable()
     super.init(objects: objects, count: count)
   }
@@ -3414,7 +3414,7 @@ class MockSetWithCustomCount : NSSet {
     super.init()
   }
 
-  override init(objects: UnsafePointer<AnyObject?>, count: Int) {
+  override init(objects: UnsafePointer<AnyObject>, count: Int) {
     expectUnreachable()
     super.init(objects: objects, count: count)
   }

--- a/validation-test/stdlib/StringSlicesConcurrentAppend.swift
+++ b/validation-test/stdlib/StringSlicesConcurrentAppend.swift
@@ -30,12 +30,12 @@ enum ThreadID {
   case Secondary
 }
 
-var barrierVar: UnsafeMutablePointer<_stdlib_pthread_barrier_t> = nil
+var barrierVar: UnsafeMutablePointer<_stdlib_pthread_barrier_t>? = nil
 var sharedString: String = ""
 var secondaryString: String = ""
 
 func barrier() {
-  var ret = _stdlib_pthread_barrier_wait(barrierVar)
+  var ret = _stdlib_pthread_barrier_wait(barrierVar!)
   expectTrue(ret == 0 || ret == _stdlib_PTHREAD_BARRIER_SERIAL_THREAD)
 }
 
@@ -89,8 +89,8 @@ func sliceConcurrentAppendThread(_ tid: ThreadID) {
 
 StringTestSuite.test("SliceConcurrentAppend") {
   barrierVar = UnsafeMutablePointer(allocatingCapacity: 1)
-  barrierVar.initialize(with: _stdlib_pthread_barrier_t())
-  var ret = _stdlib_pthread_barrier_init(barrierVar, nil, 2)
+  barrierVar!.initialize(with: _stdlib_pthread_barrier_t())
+  var ret = _stdlib_pthread_barrier_init(barrierVar!, nil, 2)
   expectEqual(0, ret)
 
   let (createRet1, tid1) = _stdlib_pthread_create_block(
@@ -107,11 +107,11 @@ StringTestSuite.test("SliceConcurrentAppend") {
   expectEqual(0, joinRet1)
   expectEqual(0, joinRet2)
 
-  ret = _stdlib_pthread_barrier_destroy(barrierVar)
+  ret = _stdlib_pthread_barrier_destroy(barrierVar!)
   expectEqual(0, ret)
 
-  barrierVar.deinitialize()
-  barrierVar.deallocateCapacity(1)
+  barrierVar!.deinitialize()
+  barrierVar!.deallocateCapacity(1)
 }
 
 runAllTests()

--- a/validation-test/stdlib/Unicode.swift
+++ b/validation-test/stdlib/Unicode.swift
@@ -2200,7 +2200,7 @@ class NonContiguousNSString : NSString {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
+  override func copy(with zone: NSZone?) -> AnyObject {
     // Ensure that copying this string produces a class that CoreFoundation
     // does not know about.
     return self

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -106,8 +106,7 @@ class NonContiguousNSString : NSString {
   }
 
   @objc(copyWithZone:)
-  override func copy(with zone: NSZone) -> AnyObject {
-
+  override func copy(with zone: NSZone?) -> AnyObject {
     // Ensure that copying this string produces a class that CoreFoundation
     // does not know about.
     return self


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

An implementation of [SE-0055: Make unsafe pointer nullability explicit using Optional](https://github.com/apple/swift-evolution/blob/master/proposals/0055-optional-unsafe-pointers.md), which touches quite a few things across the compiler and standard library. I'm opening this pull request early even though the review session hasn't completed in anticipation of the proposal being accepted in _some_ form.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] The proposal needs to be accepted.
- [x] Tricky bits should be signed off by appropriate reviewers.
- [ ] <del>Test pull request on Swift continuous integration.</del>
- [ ] Have patches ready to go for the other projects (swiftpm, Foundation, etc)

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
