### PR TITLE
[Swift 2.2.1] [SILGen] Fix for 'try?' leaking the error value

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -988,7 +988,11 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // If control branched to the failure block, inject .None into the
   // result type.
   SGF.B.emitBlock(catchBB);
-  (void)catchBB->createBBArg(SILType::getExceptionType(SGF.getASTContext()));
+  FullExpr catchCleanups(SGF.Cleanups, E);
+  auto *errorArg = catchBB->createBBArg(
+      SILType::getExceptionType(SGF.getASTContext()));
+  (void) SGF.emitManagedRValueWithCleanup(errorArg);
+  catchCleanups.pop();
 
   if (isByAddress) {
     SGF.emitInjectOptionalNothingInto(E, optInit->getAddress(), optTL);

--- a/test/Interpreter/errors.swift
+++ b/test/Interpreter/errors.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+//
+// Tests for error handling.
+//
+
+import StdlibUnittest
+
+// Also import modules which are used by StdlibUnittest internally. This
+// workaround is needed to link all required libraries in case we compile
+// StdlibUnittest with -sil-serialize-all.
+import SwiftPrivate
+#if _runtime(_ObjC)
+import ObjectiveC
+#endif
+
+enum Excuse : ErrorType { case CatAteHomework(LifetimeTracked) }
+
+var ErrorHandlingTests = TestSuite("ErrorHandling")
+
+func furball(b: Bool) throws -> LifetimeTracked {
+  if b {
+    throw Excuse.CatAteHomework(LifetimeTracked(0))
+  } else {
+    return LifetimeTracked(1)
+  }
+}
+
+ErrorHandlingTests.test("tryCatch") {
+  do {
+    try expectEqual(furball(false), LifetimeTracked(1))
+  } catch {
+    expectUnreachable() 
+  }
+
+  do {
+    try furball(true)
+    expectUnreachable() 
+  } catch let e {
+    if case Excuse.CatAteHomework(let c) = e {
+      expectEqual(c, LifetimeTracked(0))
+    } else {
+      expectUnreachable()
+    }
+  }
+}
+
+ErrorHandlingTests.test("tryOptional") {
+  expectEqual(LifetimeTracked(1), try? furball(false))
+  expectEqual(Optional<LifetimeTracked>.None, try? furball(true))
+}
+
+runAllTests()

--- a/test/Interpreter/failable_initializers.swift
+++ b/test/Interpreter/failable_initializers.swift
@@ -13,35 +13,23 @@ import ObjectiveC
 
 var FailableInitTestSuite = TestSuite("FailableInit")
 
-class Canary {
-  static var count: Int = 0
-
-  init() {
-    Canary.count += 1
-  }
-
-  deinit {
-    Canary.count -= 1
-  }
-}
-
 class Bear {
-  let x: Canary
+  let x: LifetimeTracked
 
   /* Designated */
   init(n: Int) {
-    x = Canary()
+    x = LifetimeTracked(0)
   }
 
   init?(n: Int, before: Bool) {
     if before {
       return nil
     }
-    self.x = Canary()
+    self.x = LifetimeTracked(0)
   }
 
   init?(n: Int, after: Bool) {
-    self.x = Canary()
+    self.x = LifetimeTracked(0)
     if after {
       return nil
     }
@@ -51,7 +39,7 @@ class Bear {
     if before {
       return nil
     }
-    self.x = Canary()
+    self.x = LifetimeTracked(0)
     if after {
       return nil
     }
@@ -121,11 +109,11 @@ class Bear {
 }
 
 class PolarBear : Bear {
-  let y: Canary
+  let y: LifetimeTracked
 
   /* Designated */
   override init(n: Int) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
   }
 
@@ -133,17 +121,17 @@ class PolarBear : Bear {
     if before {
       return nil
     }
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
   }
 
   init?(n: Int, during: Bool) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n, before: during)
   }
 
   init?(n: Int, before: Bool, during: Bool) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     if before {
       return nil
     }
@@ -151,7 +139,7 @@ class PolarBear : Bear {
   }
 
   override init?(n: Int, after: Bool) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
     if after {
       return nil
@@ -159,7 +147,7 @@ class PolarBear : Bear {
   }
 
   init?(n: Int, during: Bool, after: Bool) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n, before: during)
     if after {
       return nil
@@ -170,7 +158,7 @@ class PolarBear : Bear {
     if before {
       return nil
     }
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
     if after {
       return nil
@@ -181,7 +169,7 @@ class PolarBear : Bear {
     if before {
       return nil
     }
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n, before: during)
     if after {
       return nil
@@ -190,50 +178,50 @@ class PolarBear : Bear {
 }
 
 class GuineaPig<T> : Bear {
-  let y: Canary
+  let y: LifetimeTracked
   let t: T
 
   init?(t: T, during: Bool) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     self.t = t
     super.init(n: 0, before: during)
   }
 }
 
 struct Chimera {
-  let x: Canary
-  let y: Canary
+  let x: LifetimeTracked
+  let y: LifetimeTracked
 
   init?(before: Bool) {
     if before {
       return nil
     }
-    x = Canary()
-    y = Canary()
+    x = LifetimeTracked(0)
+    y = LifetimeTracked(0)
   }
 
   init?(during: Bool) {
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       return nil
     }
-    y = Canary()
+    y = LifetimeTracked(0)
   }
 
   init?(before: Bool, during: Bool) {
     if before {
       return nil
     }
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       return nil
     }
-    y = Canary()
+    y = LifetimeTracked(0)
   }
 
   init?(after: Bool) {
-    x = Canary()
-    y = Canary()
+    x = LifetimeTracked(0)
+    y = LifetimeTracked(0)
     if after {
       return nil
     }
@@ -243,19 +231,19 @@ struct Chimera {
     if before {
       return nil
     }
-    x = Canary()
-    y = Canary()
+    x = LifetimeTracked(0)
+    y = LifetimeTracked(0)
     if after {
       return nil
     }
   }
 
   init?(during: Bool, after: Bool) {
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       return nil
     }
-    y = Canary()
+    y = LifetimeTracked(0)
     if after {
       return nil
     }
@@ -265,11 +253,11 @@ struct Chimera {
     if before {
       return nil
     }
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       return nil
     }
-    y = Canary()
+    y = LifetimeTracked(0)
     if after {
       return nil
     }
@@ -287,8 +275,6 @@ FailableInitTestSuite.test("FailableInitFailure_Root") {
   mustFail { Bear(n: 0, after: true) }
   mustFail { Bear(n: 0, before: true, after: false) }
   mustFail { Bear(n: 0, before: false, after: true) }
-
-  expectEqual(0, Canary.count)
 }
 
 FailableInitTestSuite.test("FailableInitFailure_Derived") {
@@ -304,14 +290,10 @@ FailableInitTestSuite.test("FailableInitFailure_Derived") {
   mustFail { PolarBear(n: 0, before: true, during: false, after: false) }
   mustFail { PolarBear(n: 0, before: false, during: true, after: false) }
   mustFail { PolarBear(n: 0, before: false, during: false, after: true) }
-
-  expectEqual(0, Canary.count)
 }
 
 FailableInitTestSuite.test("DesignatedInitFailure_DerivedGeneric") {
-  mustFail { GuineaPig<Canary>(t: Canary(), during: true) }
-
-  expectEqual(0, Canary.count)
+  mustFail { GuineaPig<LifetimeTracked>(t: LifetimeTracked(0), during: true) }
 }
 
 FailableInitTestSuite.test("ConvenienceInitFailure_Root") {
@@ -330,8 +312,6 @@ FailableInitTestSuite.test("ConvenienceInitFailure_Root") {
 
   _ = Bear(IUO: false)
   _ = Bear(force: false)
-
-  expectEqual(0, Canary.count)
 }
 
 FailableInitTestSuite.test("ConvenienceInitFailure_Derived") {
@@ -347,8 +327,6 @@ FailableInitTestSuite.test("ConvenienceInitFailure_Derived") {
   mustFail { PolarBear(before: true, during: false, after: false) }
   mustFail { PolarBear(before: false, during: true, after: false) }
   mustFail { PolarBear(before: false, during: false, after: true) }
-
-  expectEqual(0, Canary.count)
 }
 
 FailableInitTestSuite.test("InitFailure_Struct") {
@@ -364,8 +342,6 @@ FailableInitTestSuite.test("InitFailure_Struct") {
   mustFail { Chimera(before: true, during: false, after: false) }
   mustFail { Chimera(before: false, during: true, after: false) }
   mustFail { Chimera(before: false, during: false, after: true) }
-
-  expectEqual(0, Canary.count)
 }
 
 runAllTests()

--- a/test/Interpreter/throwing_initializers.swift
+++ b/test/Interpreter/throwing_initializers.swift
@@ -24,35 +24,23 @@ func unwrap(b: Bool) throws -> Int {
   return 0
 }
 
-class Canary {
-  static var count: Int = 0
-
-  init() {
-    Canary.count += 1
-  }
-
-  deinit {
-    Canary.count -= 1
-  }
-}
-
 class Bear {
-  let x: Canary
+  let x: LifetimeTracked
 
   /* Designated */
   init(n: Int) {
-    x = Canary()
+    x = LifetimeTracked(0)
   }
 
   init(n: Int, before: Bool) throws {
     if before {
       throw E.X
     }
-    self.x = Canary()
+    self.x = LifetimeTracked(0)
   }
 
   init(n: Int, after: Bool) throws {
-    self.x = Canary()
+    self.x = LifetimeTracked(0)
     if after {
       throw E.X
     }
@@ -62,7 +50,7 @@ class Bear {
     if before {
       throw E.X
     }
-    self.x = Canary()
+    self.x = LifetimeTracked(0)
     if after {
       throw E.X
     }
@@ -122,11 +110,11 @@ class Bear {
 }
 
 class PolarBear : Bear {
-  let y: Canary
+  let y: LifetimeTracked
 
   /* Designated */
   override init(n: Int) {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
   }
 
@@ -134,17 +122,17 @@ class PolarBear : Bear {
     if before {
       throw E.X
     }
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
   }
 
   init(n: Int, during: Bool) throws {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     try super.init(n: n, before: during)
   }
 
   init(n: Int, before: Bool, during: Bool) throws {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     if before {
       throw E.X
     }
@@ -152,7 +140,7 @@ class PolarBear : Bear {
   }
 
   override init(n: Int, after: Bool) throws {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
     if after {
       throw E.X
@@ -160,7 +148,7 @@ class PolarBear : Bear {
   }
 
   init(n: Int, during: Bool, after: Bool) throws {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     try super.init(n: n, before: during)
     if after {
       throw E.X
@@ -171,7 +159,7 @@ class PolarBear : Bear {
     if before {
       throw E.X
     }
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     super.init(n: n)
     if after {
       throw E.X
@@ -182,7 +170,7 @@ class PolarBear : Bear {
     if before {
       throw E.X
     }
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     try super.init(n: n, before: during)
     if after {
       throw E.X
@@ -191,50 +179,50 @@ class PolarBear : Bear {
 }
 
 class GuineaPig<T> : Bear {
-  let y: Canary
+  let y: LifetimeTracked
   let t: T
 
   init(t: T, during: Bool) throws {
-    self.y = Canary()
+    self.y = LifetimeTracked(0)
     self.t = t
     try super.init(n: 0, before: during)
   }
 }
 
 struct Chimera {
-  let x: Canary
-  let y: Canary
+  let x: LifetimeTracked
+  let y: LifetimeTracked
 
   init(before: Bool) throws {
     if before {
       throw E.X
     }
-    x = Canary()
-    y = Canary()
+    x = LifetimeTracked(0)
+    y = LifetimeTracked(0)
   }
 
   init(during: Bool) throws {
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       throw E.X
     }
-    y = Canary()
+    y = LifetimeTracked(0)
   }
 
   init(before: Bool, during: Bool) throws {
     if before {
       throw E.X
     }
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       throw E.X
     }
-    y = Canary()
+    y = LifetimeTracked(0)
   }
 
   init(after: Bool) throws {
-    x = Canary()
-    y = Canary()
+    x = LifetimeTracked(0)
+    y = LifetimeTracked(0)
     if after {
       throw E.X
     }
@@ -244,19 +232,19 @@ struct Chimera {
     if before {
       throw E.X
     }
-    x = Canary()
-    y = Canary()
+    x = LifetimeTracked(0)
+    y = LifetimeTracked(0)
     if after {
       throw E.X
     }
   }
 
   init(during: Bool, after: Bool) throws {
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       throw E.X
     }
-    y = Canary()
+    y = LifetimeTracked(0)
     if after {
       throw E.X
     }
@@ -266,11 +254,11 @@ struct Chimera {
     if before {
       throw E.X
     }
-    x = Canary()
+    x = LifetimeTracked(0)
     if during {
       throw E.X
     }
-    y = Canary()
+    y = LifetimeTracked(0)
     if after {
       throw E.X
     }
@@ -289,8 +277,6 @@ ThrowingInitTestSuite.test("DesignatedInitFailure_Root") {
   mustThrow { try Bear(n: 0, after: true) }
   mustThrow { try Bear(n: 0, before: true, after: false) }
   mustThrow { try Bear(n: 0, before: false, after: true) }
-
-  expectEqual(0, Canary.count)
 }
 
 ThrowingInitTestSuite.test("DesignatedInitFailure_Derived") {
@@ -306,14 +292,10 @@ ThrowingInitTestSuite.test("DesignatedInitFailure_Derived") {
   mustThrow { try PolarBear(n: 0, before: true, during: false, after: false) }
   mustThrow { try PolarBear(n: 0, before: false, during: true, after: false) }
   mustThrow { try PolarBear(n: 0, before: false, during: false, after: true) }
-
-  expectEqual(Canary.count, 0)
 }
 
 ThrowingInitTestSuite.test("DesignatedInitFailure_DerivedGeneric") {
-  mustThrow { try GuineaPig<Canary>(t: Canary(), during: true) }
-
-  expectEqual(Canary.count, 0)
+  mustThrow { try GuineaPig(t: LifetimeTracked(0), during: true) }
 }
 
 ThrowingInitTestSuite.test("ConvenienceInitFailure_Root") {
@@ -336,8 +318,6 @@ ThrowingInitTestSuite.test("ConvenienceInitFailure_Root") {
   mustThrow { try Bear(before: false, before2: true, during: false, after: false) }
   mustThrow { try Bear(before: false, before2: false, during: true, after: false) }
   mustThrow { try Bear(before: false, before2: false, during: false, after: true) }
-
-  expectEqual(Canary.count, 0)
 }
 
 ThrowingInitTestSuite.test("ConvenienceInitFailure_Derived") {
@@ -360,8 +340,6 @@ ThrowingInitTestSuite.test("ConvenienceInitFailure_Derived") {
   mustThrow { try PolarBear(before: false, before2: true, during: false, after: false) }
   mustThrow { try PolarBear(before: false, before2: false, during: true, after: false) }
   mustThrow { try PolarBear(before: false, before2: false, during: false, after: true) }
-
-  expectEqual(Canary.count, 0)
 }
 
 ThrowingInitTestSuite.test("InitFailure_Struct") {
@@ -377,8 +355,6 @@ ThrowingInitTestSuite.test("InitFailure_Struct") {
   mustThrow { try Chimera(before: true, during: false, after: false) }
   mustThrow { try Chimera(before: false, during: true, after: false) }
   mustThrow { try Chimera(before: false, during: false, after: true) }
-
-  expectEqual(Canary.count, 0)
 }
 
 runAllTests()

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -693,7 +693,8 @@ func testForcePeephole(f: () throws -> Int?) -> Int {
 // CHECK-NEXT: release_value [[RESULT]] : $Optional<Cat>
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
-// CHECK: [[FAILURE:.+]]({{%.+}} : $ErrorType):
+// CHECK: [[FAILURE:.+]]([[ERROR:%.*]] : $ErrorType):
+// CHECK-NEXT: strong_release [[ERROR]]
 // CHECK-NEXT: [[NONE:%.+]] = enum $Optional<Cat>, #Optional.None!enumelt
 // CHECK-NEXT: br [[DONE]]([[NONE]] : $Optional<Cat>)
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $ErrorType):
@@ -717,7 +718,8 @@ func testOptionalTry() {
 // CHECK-NEXT: strong_release [[BOX]]#0 : $@box Optional<Cat>
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
-// CHECK: [[FAILURE:.+]]({{%.+}} : $ErrorType):
+// CHECK: [[FAILURE:.+]]([[ERROR:%.*]] : $ErrorType):
+// CHECK-NEXT: strong_release [[ERROR]]
 // CHECK-NEXT: inject_enum_addr [[BOX]]#1 : $*Optional<Cat>, #Optional.None!enumelt
 // CHECK-NEXT: br [[DONE]]
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $ErrorType):
@@ -745,7 +747,8 @@ func testOptionalTryVar() {
 // CHECK-NEXT: destroy_addr %0 : $*T
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
-// CHECK: [[FAILURE:.+]]({{%.+}} : $ErrorType):
+// CHECK: [[FAILURE:.+]]([[ERROR:%.*]] : $ErrorType):
+// CHECK-NEXT: strong_release [[ERROR]]
 // CHECK-NEXT: inject_enum_addr [[BOX]] : $*Optional<T>, #Optional.None!enumelt
 // CHECK-NEXT: br [[DONE]]
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $ErrorType):
@@ -773,7 +776,8 @@ func testOptionalTryAddressOnly<T>(obj: T) {
 // CHECK-NEXT: destroy_addr %0 : $*T
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
-// CHECK: [[FAILURE:.+]]({{%.+}} : $ErrorType):
+// CHECK: [[FAILURE:.+]]([[ERROR:%.*]] : $ErrorType):
+// CHECK-NEXT: strong_release [[ERROR]]
 // CHECK-NEXT: inject_enum_addr [[BOX]]#1 : $*Optional<T>, #Optional.None!enumelt
 // CHECK-NEXT: br [[DONE]]
 // CHECK: [[CLEANUPS]]([[ERROR:%.+]] : $ErrorType):
@@ -799,7 +803,8 @@ func testOptionalTryAddressOnlyVar<T>(obj: T) {
 // CHECK-NEXT: release_value [[RESULT]] : $Optional<(Cat, Cat)>
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
-// CHECK: [[FAILURE:.+]]({{%.+}} : $ErrorType):
+// CHECK: [[FAILURE:.+]]([[ERROR:%.*]] : $ErrorType):
+// CHECK-NEXT: strong_release [[ERROR]]
 // CHECK-NEXT: [[NONE:%.+]] = enum $Optional<(Cat, Cat)>, #Optional.None!enumelt
 // CHECK-NEXT: br [[DONE]]([[NONE]] : $Optional<(Cat, Cat)>)
 // CHECK: [[CLEANUPS_1]]([[ERROR:%.+]] : $ErrorType):

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -521,9 +521,10 @@ struct ThrowStruct {
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    return [[NEW_SELF]] : $Optional<ThrowStruct>
 // CHECK:       bb6:
+// CHECK-NEXT:    strong_release [[ERROR:%.*]] : $ErrorType
 // CHECK-NEXT:    [[NEW_SELF:%.*]] = enum $Optional<ThrowStruct>, #Optional.None!enumelt
 // CHECK-NEXT:    br bb2([[NEW_SELF]] : $Optional<ThrowStruct>)
-// CHECK:       bb7([[ERROR:%.*]] : $ErrorType):
+// CHECK:       bb7([[ERROR]] : $ErrorType):
 // CHECK-NEXT:    br bb6
   init?(throwsToOptional: Int) {
     try? self.init(failDuringDelegation: throwsToOptional)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Backport the fix for `try?` memory leakage to Swift 2.2. This was the original PR to master: https://github.com/apple/swift/pull/1740. @tkremenek  please consider merging it for a 2.2.x release.
#### Resolved bug number: ([SR-972](https://bugs.swift.org/browse/SR-972))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
