### PR TITLE
[stdlib][swift-3-indexing-model] Implement _writeBackMutableSlice

### DIFF
--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -190,7 +190,6 @@ extension MutableCollection {
   }
 }
 
-// TODO: swift-3-indexing-model - review the following
 internal func _writeBackMutableSlice<
   C : MutableCollection,
   Slice_ : Collection
@@ -198,9 +197,8 @@ internal func _writeBackMutableSlice<
   C._Element == Slice_.Iterator.Element,
   C.Index == Slice_.Index
 >(self_: inout C, bounds: Range<C.Index>, slice: Slice_) {
-  fatalError("FIXME: swift-3-indexing-model")
-  /*
-  C._failEarlyRangeCheck(bounds, self_.startIndex..<self_.endIndex)
+  
+  self_._failEarlyRangeCheck(bounds, bounds: self_.startIndex..<self_.endIndex)
   
   // FIXME(performance): can we use
   // _withUnsafeMutableBufferPointerIfSupported?  Would that create inout
@@ -215,8 +213,8 @@ internal func _writeBackMutableSlice<
     newElementIndex != newElementsEndIndex {
 
     self_[selfElementIndex] = slice[newElementIndex]
-    selfElementIndex._successorInPlace()
-    newElementIndex._successorInPlace()
+    self_.successor(updating: &selfElementIndex)
+    slice.successor(updating: &newElementIndex)
   }
 
   _precondition(
@@ -225,7 +223,6 @@ internal func _writeBackMutableSlice<
   _precondition(
     newElementIndex == newElementsEndIndex,
     "Cannot replace a slice of a MutableCollection with a slice of a smaller size")
-  */
 }
 
 @available(*, unavailable, renamed: "MutableCollection")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This removes the fatal errors in `_writeBackMutableSlice` and updates the range check/index moves.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
