### PR TITLE
Add _withUnsafeGuaranteedRef to Unmanaged

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2497,6 +2497,36 @@ Performs a copy of an Objective-C block. Unlike retains of other
 reference-counted types, this can produce a different value from the operand
 if the block is copied from the stack to the heap.
 
+builtin "unsafeGuaranteed"
+```````````````````````````
+
+::
+
+  sil-instruction := 'builtin' '"unsafeGuaranteed"' '<' sil-type '>' '(' sil-operand')' ':' sil-type
+
+  %1 = builtin "unsafeGuaranteed"<T>(%0 : $T) : ($T, Builtin.Int1)
+  // $T must be of AnyObject type.
+
+Asserts that there exists another reference of the value ``%0`` for the scope
+delinated by the call of this builtin up to the first call of a ``builtin
+"unsafeGuaranteedEnd"`` instruction that uses the second element ``%1.1`` of the
+returned value. If no such instruction can be found nothing can be assumed. This
+assertions holds for uses of the first tuple element of the returned value
+``%1.0`` within this scope. The returned reference value equals the input
+``%0``.
+
+builtin "unsafeGuaranteedEnd"
+```````````````````````````
+
+::
+
+  sil-instruction := 'builtin' '"unsafeGuaranteedEnd"' '(' sil-operand')'
+
+  %1 = builtin "unsafeGuaranteedEnd"(%0 : $Builtin.Int1)
+  // $T must be of AnyObject type.
+
+Ends the scope for the ``builtin "unsafeGuaranteed"`` instruction.
+
 Literals
 ~~~~~~~~
 

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -434,6 +434,12 @@ BUILTIN_MISC_OPERATION(CopyArray, "copyArray", "", Special)
 BUILTIN_MISC_OPERATION(TakeArrayFrontToBack, "takeArrayFrontToBack", "", Special)
 BUILTIN_MISC_OPERATION(TakeArrayBackToFront, "takeArrayBackToFront", "", Special)
 
+// unsafeGuaranteed has type <T: AnyObject> T -> (T, Builtin.Int8)
+BUILTIN_MISC_OPERATION(UnsafeGuaranteed, "unsafeGuaranteed", "", Special)
+
+// unsafeGuaranteedEnd has type (Builtin.Int8) -> ()
+BUILTIN_MISC_OPERATION(UnsafeGuaranteedEnd, "unsafeGuaranteedEnd", "", Special)
+
 #undef BUILTIN_MISC_OPERATION
 
 // BUILTIN_TYPE_TRAIT_OPERATION - Compile-time type trait operations.

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -212,6 +212,9 @@ PASS(StripDebugInfo, "strip-debug-info",
      "Strip debug info")
 PASS(SwiftArrayOpts, "array-specialize",
      "Specialize arrays")
+PASS(UnsafeGuaranteedPeephole, "unsafe-guaranteed-peephole",
+     "Peephole retain/release removal for regions denoted by "
+     "Builtin.unsafeGuaranteed")
 PASS(UsePrespecialized, "use-prespecialized",
      "Use pre-specialized functions")
 PASS_RANGE(AllPasses, AADumper, UsePrespecialized)

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -782,6 +782,23 @@ static ValueDecl *getCastFromBridgeObjectOperation(ASTContext &C,
   }
 }
 
+static ValueDecl *getUnsafeGuaranteed(ASTContext &C, Identifier Id) {
+  // <T : AnyObject> T -> (T, Int8Ty)
+  //
+  GenericSignatureBuilder builder(C);
+  auto T = makeGenericParam();
+  builder.addParameter(T);
+  Type Int8Ty = BuiltinIntegerType::get(8, C);
+  builder.setResult(makeTuple(T, makeConcrete(Int8Ty)));
+  return builder.build(Id);
+}
+
+static ValueDecl *getUnsafeGuaranteedEnd(ASTContext &C, Identifier Id) {
+  // Int8Ty -> ()
+  Type Int8Ty = BuiltinIntegerType::get(8, C);
+  return getBuiltinFunction(Id, { Int8Ty }, TupleType::getEmpty(C));
+}
+
 static ValueDecl *getCastReferenceOperation(ASTContext &ctx,
                                             Identifier name) {
   // <T, U> T -> U
@@ -1574,10 +1591,17 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
     if (Types.size() != 1) return nullptr;
     return getCheckedConversionOperation(Context, Id, Types[0]);
 
+  case BuiltinValueKind::UnsafeGuaranteed:
+    return getUnsafeGuaranteed(Context, Id);
+
+  case BuiltinValueKind::UnsafeGuaranteedEnd:
+    return getUnsafeGuaranteedEnd(Context, Id);
+
   case BuiltinValueKind::IntToFPWithOverflow:
     if (Types.size() != 2) return nullptr;
     return getIntToFPWithOverflowOperation(Context, Id, Types[0], Types[1]);
   }
+
   llvm_unreachable("bad builtin value!");
 }
 

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1734,6 +1734,22 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, Identifier FnId,
   // Decompose the function's name into a builtin name and type list.
   const BuiltinInfo &Builtin = IGF.IGM.SILMod->getBuiltinInfo(FnId);
 
+  if (Builtin.ID == BuiltinValueKind::UnsafeGuaranteedEnd) {
+    // Just consume the incoming argument.
+    assert(args.size() == 1 && "Expecting one incoming argument");
+    args.claimAll();
+    return;
+  }
+
+  if (Builtin.ID == BuiltinValueKind::UnsafeGuaranteed) {
+    // Just forward the incoming argument.
+    assert(args.size() == 1 && "Expecting one incoming argument");
+    out = std::move(args);
+    // This is a token.
+    out.add(llvm::ConstantInt::get(IGF.IGM.Int8Ty, 0));
+    return;
+  }
+
   // These builtins don't care about their argument:
   if (Builtin.ID == BuiltinValueKind::Sizeof) {
     args.claimAll();

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -241,10 +241,12 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
   PM.addARCSequenceOpts();
 
   PM.addSimplifyCFG();
-  // Only hoist releases very late.
-  if (OpLevel == OptimizationLevelKind::LowLevel)
+  if (OpLevel == OptimizationLevelKind::LowLevel) {
+    // Remove retain/releases based on Builtin.unsafeGuaranteed
+    PM.addUnsafeGuaranteedPeephole();
+    // Only hoist releases very late.
     PM.addLateCodeMotion();
-  else
+  } else
     PM.addEarlyCodeMotion();
 
   PM.addARCSequenceOpts();
@@ -369,6 +371,7 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   // Remove dead code.
   PM.addDCE();
   PM.addSimplifyCFG();
+
   PM.runOneIteration();
 
   PM.resetAndRemoveTransformations();

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -25,4 +25,5 @@ set(TRANSFORMS_SOURCES
   Transforms/Sink.cpp
   Transforms/SpeculativeDevirtualizer.cpp
   Transforms/StackPromotion.cpp
+  Transforms/UnsafeGuaranteedPeephole.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
+++ b/lib/SILOptimizer/Transforms/UnsafeGuaranteedPeephole.cpp
@@ -1,0 +1,253 @@
+//===--- UnsafeGuaranteedPeephole.cpp - UnsafeGuaranteed Peephole ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Optimize retain/release pairs based on Builtin.unsafeGuaranteed
+//
+//   strong_retain %0 : $Foo
+//   %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+//   %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+//   %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+//   %9 = function_ref @beep : $@convention(method) (@guaranteed Foo) -> ()
+//   %10 = apply %9(%0) : $@convention(method) (@guaranteed Foo) -> ()
+//   strong_release %5 : $Foo
+//   %12 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+//
+// Based on the assertion that there is another reference to "%0" that keeps
+// "%0" alive for the scope between the two builtin calls we can remove the
+// retain/release pair and the builtins.
+//
+//   %9 = function_ref @beep : $@convention(method) (@guaranteed Foo) -> ()
+//   %10 = apply %9(%0) : $@convention(method) (@guaranteed Foo) -> ()
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "unsafe-guaranteed-peephole"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+
+using namespace swift;
+
+/// Get the (GuaranteedValue, Token) tuple from a call to "unsafeGuaranteed"
+/// if the tuple elements are identified by a single tuple_extract use.
+/// Otherwise, return a (nullptr, nullptr) tuple.
+static std::pair<SILInstruction *, SILInstruction *>
+getSingleUnsafeGuaranteedValueResult(BuiltinInst *BI) {
+  assert(BI->getBuiltinKind() &&
+         *BI->getBuiltinKind() == BuiltinValueKind::UnsafeGuaranteed &&
+         "Expecting a unsafeGuaranteed builtin");
+
+  SILInstruction *GuaranteedValue = nullptr;
+  SILInstruction *Token = nullptr;
+
+  auto Failed = std::make_pair(nullptr, nullptr);
+
+  for (auto *Operand : getNonDebugUses(BI)) {
+    auto *TE = dyn_cast<TupleExtractInst>(Operand->getUser());
+    if (!TE || TE->getOperand() != BI)
+      return Failed;
+
+    if (TE->getFieldNo() == 0 && !GuaranteedValue) {
+      GuaranteedValue = TE;
+      continue;
+    }
+    if (TE->getFieldNo() == 1 && !Token) {
+      Token = TE;
+      continue;
+    }
+    return Failed;
+  }
+
+  if (!GuaranteedValue || !Token)
+    return Failed;
+
+  return std::make_pair(GuaranteedValue, Token);
+}
+
+/// Walk backwards from an unsafeGuaranteedEnd builtin instruction looking for a
+/// release on the reference returned by the matching unsafeGuaranteed builtin
+/// ignoring releases on the way.
+///
+///    %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+///    %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+///    %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+///    strong_release %5 : $Foo // <-- Matching release.
+///    strong_release %6 : $Foo // Ignore.
+///    %12 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+///
+static SILBasicBlock::iterator
+findReleaseToMatchUnsafeGuaranteedValue(SILInstruction *UnsafeGuaranteedEndI,
+                                        SILValue UnsafeGuaranteedValue,
+                                        SILBasicBlock &BB) {
+  auto LastReleaseIt = std::prev(SILBasicBlock::iterator(UnsafeGuaranteedEndI));
+  while (LastReleaseIt != BB.begin() &&
+         (isa<StrongReleaseInst>(*LastReleaseIt) ||
+          isa<ReleaseValueInst>(*LastReleaseIt)) &&
+         LastReleaseIt->getOperand(0) != UnsafeGuaranteedValue)
+    --LastReleaseIt;
+  if ((!isa<StrongReleaseInst>(*LastReleaseIt) &&
+       !isa<ReleaseValueInst>(*LastReleaseIt)) ||
+      LastReleaseIt->getOperand(0) != UnsafeGuaranteedValue) {
+    return BB.end();
+  }
+  return LastReleaseIt;
+}
+
+/// Remove retain/release pairs around builtin "unsafeGuaranteed" instruction
+/// sequences.
+static bool removeGuaranteedRetainReleasePairs(SILFunction &F) {
+  bool Changed = false;
+  for (auto &BB : F) {
+    auto It = BB.begin(), End = BB.end();
+    llvm::DenseMap<SILValue, SILInstruction *> LastRetain;
+    while (It != End) {
+      auto *CurInst = &*It;
+      ++It;
+
+      // Memorize the last retain.
+      if (isa<StrongRetainInst>(CurInst) || isa<RetainValueInst>(CurInst)) {
+        LastRetain[CurInst->getOperand(0)] = CurInst;
+        continue;
+      }
+
+      // Look for a builtin "unsafeGuaranteed" instruction.
+      auto *UnsafeGuaranteedI = dyn_cast<BuiltinInst>(CurInst);
+      if (!UnsafeGuaranteedI || !UnsafeGuaranteedI->getBuiltinKind() ||
+          *UnsafeGuaranteedI->getBuiltinKind() !=
+              BuiltinValueKind::UnsafeGuaranteed)
+        continue;
+
+      auto Opd = UnsafeGuaranteedI->getOperand(0);
+      if (!LastRetain.count(Opd)) {
+        DEBUG(llvm::dbgs() << "LastRetain failed\n");
+        continue;
+      }
+
+      // This code is very conservative. Check that there is a matching retain
+      // before the unsafeGuaranteed builtin with only retains inbetween.
+      auto *LastRetainInst = LastRetain[Opd];
+      auto NextInstIter = std::next(SILBasicBlock::iterator(LastRetainInst));
+      while (NextInstIter != BB.end() && &*NextInstIter != CurInst &&
+             (isa<RetainValueInst>(*NextInstIter) ||
+              isa<StrongRetainInst>(*NextInstIter)))
+       ++NextInstIter;
+      if (&*NextInstIter != CurInst) {
+        DEBUG(llvm::dbgs() << "Last retain right before match failed\n");
+        continue;
+      }
+
+      DEBUG(llvm::dbgs() << "Saw " << *UnsafeGuaranteedI);
+      DEBUG(llvm::dbgs() << "  with operand " << *Opd);
+
+      // Match the reference and token result.
+      //  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo)
+      //  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+      //  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+      SILInstruction *UnsafeGuaranteedValue;
+      SILInstruction *UnsafeGuaranteedToken;
+      std::tie(UnsafeGuaranteedValue, UnsafeGuaranteedToken) =
+          getSingleUnsafeGuaranteedValueResult(UnsafeGuaranteedI);
+
+      if (!UnsafeGuaranteedValue) {
+        DEBUG(llvm::dbgs() << "  no single unsafeGuaranteed value use\n");
+        continue;
+      }
+
+      // Look for a builtin "unsafeGuaranteedEnd" instruction that uses the
+      // token.
+      //   builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+      BuiltinInst *UnsafeGuaranteedEndI = nullptr;
+      for (auto *Operand : getNonDebugUses(UnsafeGuaranteedToken)) {
+        if (UnsafeGuaranteedEndI) {
+          DEBUG(llvm::dbgs() << "  multiple unsafeGuaranteedEnd users\n");
+          UnsafeGuaranteedEndI = nullptr;
+          break;
+        }
+        auto *BI = dyn_cast<BuiltinInst>(Operand->getUser());
+        if (!BI || !BI->getBuiltinKind() ||
+            *BI->getBuiltinKind() != BuiltinValueKind::UnsafeGuaranteedEnd) {
+          DEBUG(llvm::dbgs() << "  wrong unsafeGuaranteed token user "
+                             << *Operand->getUser());
+          break;
+        }
+
+        UnsafeGuaranteedEndI = BI;
+      }
+
+      if (!UnsafeGuaranteedEndI) {
+        DEBUG(llvm::dbgs() << "  no single unsafeGuaranteedEnd use found\n");
+        continue;
+      }
+
+      if (SILBasicBlock::iterator(UnsafeGuaranteedEndI) ==
+          UnsafeGuaranteedEndI->getParent()->end())
+        continue;
+
+      // Find the release to match with the unsafeGuaranteedValue.
+      auto &UnsafeGuaranteedEndBB = *UnsafeGuaranteedEndI->getParent();
+      auto LastReleaseIt = findReleaseToMatchUnsafeGuaranteedValue(
+          UnsafeGuaranteedEndI, UnsafeGuaranteedValue, UnsafeGuaranteedEndBB);
+      if (LastReleaseIt == UnsafeGuaranteedEndBB.end()) {
+        DEBUG(llvm::dbgs() << "  no release before unsafeGuaranteedEnd found\n");
+        continue;
+      }
+      SILInstruction *LastRelease = &*LastReleaseIt;
+
+      // Restart iteration before the earliest instruction we remove.
+      bool RestartAtBeginningOfBlock = false;
+      auto LastRetainIt = SILBasicBlock::iterator(LastRetainInst);
+      if (LastRetainIt != BB.begin()) {
+        It = std::prev(LastRetainIt);
+      } else RestartAtBeginningOfBlock = true;
+
+      // Okay we found a post dominating release. Let's remove the
+      // retain/unsafeGuaranteed/release combo.
+      //
+      LastRetainInst->eraseFromParent();
+      LastRelease->eraseFromParent();
+      UnsafeGuaranteedEndI->eraseFromParent();
+      deleteAllDebugUses(UnsafeGuaranteedValue);
+      deleteAllDebugUses(UnsafeGuaranteedToken);
+      deleteAllDebugUses(UnsafeGuaranteedI);
+      UnsafeGuaranteedValue->replaceAllUsesWith(Opd);
+      UnsafeGuaranteedValue->eraseFromParent();
+      UnsafeGuaranteedToken->eraseFromParent();
+      UnsafeGuaranteedI->eraseFromParent();
+
+      if (RestartAtBeginningOfBlock)
+        ++It = BB.begin();
+
+      Changed = true;
+    }
+  }
+  return Changed;
+}
+
+namespace {
+class UnsafeGuaranteedPeephole : public swift::SILFunctionTransform {
+
+  void run() override {
+    if (removeGuaranteedRetainReleasePairs(*getFunction()))
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+
+  StringRef getName() override { return "UnsafeGuaranteed Peephole"; }
+};
+} // end anonymous namespace.
+
+SILTransform *swift::createUnsafeGuaranteedPeephole() {
+  return new UnsafeGuaranteedPeephole();
+}

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -87,6 +87,107 @@ public struct Unmanaged<Instance : AnyObject> {
     return result
   }
 
+  /// Get the value of the unmanaged referenced as a managed reference without
+  /// consuming an unbalanced retain of it and pass it to the closure. Asserts
+  /// that there is some other reference ('the owning reference') to the
+  /// instance referenced by the unmanaged reference that guarantees the
+  /// lifetime of the instance for the duration of the
+  /// '_withUnsafeGuaranteedRef' call.
+  ///
+  /// NOTE: You are responsible for ensuring this by making the owning
+  /// reference's lifetime fixed for the duration of the
+  /// '_withUnsafeGuaranteedRef' call.
+  ///
+  /// Violation of this will incur undefined behavior.
+  ///
+  /// A lifetime of a reference 'the instance' is fixed over a point in the
+  /// programm if:
+  ///
+  /// * There exists a global variable that references 'the instance'.
+  ///
+  ///   import Foundation
+  ///   var globalReference = Instance()
+  ///   func aFunction() {
+  ///      point()
+  ///   }
+  ///
+  /// Or if:
+  ///
+  /// * There is another managed reference to 'the instance' whose life time is
+  ///   fixed over the point in the program by means of 'withExtendedLifetime'
+  ///   dynamically closing over this point.
+  ///
+  ///   var owningReference = Instance()
+  ///   ...
+  ///   withExtendedLifetime(owningReference) {
+  ///       point($0)
+  ///   }
+  ///
+  /// Or if:
+  ///
+  /// * There is a class, or struct instance ('owner') whose lifetime is fixed
+  ///   at the point and which has a stored property that references
+  ///   'the instance' for the duration of the fixed lifetime of the 'owner'.
+  ///
+  ///  class Owned {
+  ///  }
+  ///
+  ///  class Owner {
+  ///    final var owned : Owned
+  ///
+  ///    func foo() {
+  ///        withExtendedLifetime(self) {
+  ///            doSomething(...)
+  ///        } // Assuming: No stores to owned occur for the dynamic lifetime of
+  ///          //           the withExtendedLifetime invocation.
+  ///    }
+  ///
+  ///    func doSomething() {
+  ///       // both 'self' and 'owned''s lifetime is fixed over this point.
+  ///       point(self, owned)
+  ///    }
+  ///  }
+  ///
+  /// The last rule applies transitively through a chains of stored references
+  /// and nested structs.
+  ///
+  /// Examples:
+  ///
+  ///   var owningReference = Instance()
+  ///   ...
+  ///   withExtendedLifetime(owningReference) {
+  ///     let u = Unmanaged.passUnretained(owningReference)
+  ///     for i in 0 ..< 100 {
+  ///       u._withUnsafeGuaranteedRef {
+  ///         $0.doSomething()
+  ///       }
+  ///     }
+  ///   }
+  ///
+  ///  class Owner {
+  ///    final var owned : Owned
+  ///
+  ///    func foo() {
+  ///        withExtendedLifetime(self) {
+  ///            doSomething(Unmanaged.passUnretained(owned))
+  ///        }
+  ///    }
+  ///
+  ///    func doSomething(u : Unmanged<Owned>) {
+  ///      u._withUnsafeGuaranteedRef {
+  ///        $0.doSomething()
+  ///      }
+  ///    }
+  ///  }
+  public func _withUnsafeGuaranteedRef<Result>(
+    @noescape closure: (Instance) throws -> Result
+  ) rethrows {
+    let instance = _value
+    let (guaranteedInstance, token) = Builtin.unsafeGuaranteed(instance)
+    try closure(guaranteedInstance)
+    Builtin.unsafeGuaranteedEnd(token)
+  }
+
   /// Perform an unbalanced retain of the object.
   @_transparent
   public func retain() -> Unmanaged {

--- a/test/1_stdlib/Unmanaged.swift
+++ b/test/1_stdlib/Unmanaged.swift
@@ -47,5 +47,22 @@ UnmanagedTests.test("unsafeBitCast(Unmanaged, Int)") {
   _fixLifetime(ref)
 }
 
+class Foobar {
+  func foo() -> Int { return 1 }
+}
+
+UnmanagedTests.test("_withUnsafeGuaranteedRef") {
+  var ref = Foobar()
+  var unmanaged = Unmanaged.passUnretained(ref)
+  withExtendedLifetime(ref) {
+    unmanaged._withUnsafeGuaranteedRef {
+      expectTrue(ref === $0)
+    }
+    unmanaged._withUnsafeGuaranteedRef {
+      expectEqual(1, $0.foo())
+    }
+  }
+}
+
 runAllTests()
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -702,6 +702,34 @@ func ispod_test() {
   var f = Builtin.ispod(Builtin.NativeObject)
 }
 
+// CHECK-LABEL: define {{.*}} @{{.*}}generic_unsafeGuaranteed_test
+// CHECK:  call void @swift_{{.*}}etain({{.*}}* %0)
+// CHECK:  call void @swift_{{.*}}elease({{.*}}* %0)
+// CHECK:  ret %objc_object* %0
+func generic_unsafeGuaranteed_test<T: AnyObject>(t : T) -> T {
+  let (g, _) = Builtin.unsafeGuaranteed(t)
+  return g
+}
+
+// CHECK-LABEL: define {{.*}} @{{.*}}unsafeGuaranteed_test
+// CHECK:  [[LOCAL:%.*]] = alloca %swift.refcounted*
+// CHECK:  call void @rt_swift_retain(%swift.refcounted* %0)
+// CHECK:  store %swift.refcounted* %0, %swift.refcounted** [[LOCAL]]
+// CHECK:  call void @rt_swift_release(%swift.refcounted* %0)
+// CHECK:  ret %swift.refcounted* %0
+func unsafeGuaranteed_test(x: Builtin.NativeObject) -> Builtin.NativeObject {
+  var (g,t) = Builtin.unsafeGuaranteed(x)
+  Builtin.unsafeGuaranteedEnd(t)
+  return g
+}
+
+// CHECK-LABEL: define {{.*}} @{{.*}}unsafeGuaranteedEnd_test
+// CHECK-NEXT: {{.*}}:
+// CHECK-NEXT: ret void
+func unsafeGuaranteedEnd_test(x: Builtin.Int8) {
+  Builtin.unsafeGuaranteedEnd(x)
+}
+
 // CHECK-LABEL: define {{.*}} @{{.*}}atomicload
 func atomicload(p: Builtin.RawPointer) {
   // CHECK: [[A:%.*]] = load atomic i8*, i8** {{%.*}} unordered, align 8

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -703,9 +703,9 @@ func ispod_test() {
 }
 
 // CHECK-LABEL: define {{.*}} @{{.*}}generic_unsafeGuaranteed_test
-// CHECK:  call void @swift_{{.*}}etain({{.*}}* %0)
-// CHECK:  call void @swift_{{.*}}elease({{.*}}* %0)
-// CHECK:  ret %objc_object* %0
+// CHECK:  call void @{{.*}}swift_{{.*}}etain({{.*}}* %0)
+// CHECK:  call void @{{.*}}swift_{{.*}}elease({{.*}}* %0)
+// CHECK:  ret {{.*}}* %0
 func generic_unsafeGuaranteed_test<T: AnyObject>(t : T) -> T {
   let (g, _) = Builtin.unsafeGuaranteed(t)
   return g

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -739,3 +739,55 @@ func refcast_pclass_any(o: PClass) -> AnyObject {
 func refcast_any_punknown(o: AnyObject) -> PUnknown {
   return Builtin.castReference(o)
 }
+
+// CHECK-LABEL: sil hidden @_TF8builtins22unsafeGuaranteed_class
+// CHECK: bb0([[P:%.*]] : $A):
+// CHECK:   strong_retain  [[P]]
+// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<A>([[P]] : $A)
+// CHECK:   [[R:%.*]] = tuple_extract [[T]] : $(A, Builtin.Int8), 0
+// CHECK:   [[K:%.*]] = tuple_extract [[T]] : $(A, Builtin.Int8), 1
+// CHECK:   strong_release [[R]] : $A
+// CHECK:   return [[P]] : $A
+// CHECK: }
+func unsafeGuaranteed_class(a: A) -> A {
+  Builtin.unsafeGuaranteed(a)
+  return a
+}
+
+// CHECK-LABEL: _TF8builtins24unsafeGuaranteed_generic
+// CHECK: bb0([[P:%.*]] : $T):
+// CHECK:   strong_retain  [[P]]
+// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P]] : $T)
+// CHECK:   [[R:%.*]] = tuple_extract [[T]] : $(T, Builtin.Int8), 0
+// CHECK:   [[K:%.*]] = tuple_extract [[T]] : $(T, Builtin.Int8), 1
+// CHECK:   strong_release [[R]] : $T
+// CHECK:   return [[P]] : $T
+// CHECK: }
+func unsafeGuaranteed_generic<T: AnyObject> (a: T) -> T {
+  Builtin.unsafeGuaranteed(a)
+  return a
+}
+
+// CHECK_LABEL: sil hidden @_TF8builtins31unsafeGuaranteed_generic_return
+// CHECK: bb0([[P:%.*]] : $T):
+// CHECK:   strong_retain [[P]]
+// CHECK:   [[T:%.*]] = builtin "unsafeGuaranteed"<T>([[P]] : $T)
+// CHECK:   [[R]] = tuple_extract [[T]] : $(T, Builtin.Int8), 0
+// CHECK:   [[K]] = tuple_extract [[T]] : $(T, Builtin.Int8), 1
+// CHECK:   strong_release [[P]]
+// CHECK:   [[S:%.*]] = tuple ([[R]] : $T, [[K]] : $Builtin.Int8)
+// CHECK:   return [[S]] : $(T, Builtin.Int8)
+// CHECK: }
+func unsafeGuaranteed_generic_return<T: AnyObject> (a: T) -> (T, Builtin.Int8) {
+  return Builtin.unsafeGuaranteed(a)
+}
+
+// CHECK-LABEL: sil hidden @_TF8builtins19unsafeGuaranteedEnd
+// CHECK: bb0([[P:%.*]] : $Builtin.Int8):
+// CHECK:   builtin "unsafeGuaranteedEnd"([[P]] : $Builtin.Int8)
+// CHECK:   [[S:%.*]] = tuple ()
+// CHECK:   return [[S]] : $()
+// CHECK: }
+func unsafeGuaranteedEnd(t: Builtin.Int8) {
+  Builtin.unsafeGuaranteedEnd(t)
+}

--- a/test/SILOptimizer/unsafe_guaranteed_peephole.sil
+++ b/test/SILOptimizer/unsafe_guaranteed_peephole.sil
@@ -1,0 +1,207 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -unsafe-guaranteed-peephole %s | FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+public class Foo {
+  public func beep()
+}
+
+sil @beep : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_simple
+// CHECK: bb0([[P:%.*]] : $Foo):
+// CHECK-NOT: retain
+// CHECK-NOT: unsafeGuaranteed
+// CHECK:   [[M:%.*]] = class_method [[P]] : $Foo, #Foo.beep
+// CHECK:   apply [[M]]([[P]])
+// CHECK-NOT: release
+// CHECK-NOT: unsafeGuaranteedEnd
+// CHECK:   [[T:%.*]] = tuple ()
+// CHECK:   return [[T]]
+// CHECK: }
+sil @testUnsafeGuaranteed_simple : $@convention(method) (@guaranteed Foo) -> () {
+bb0(%0 : $Foo):
+  strong_retain %0 : $Foo
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  strong_release %5 : $Foo
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_noretain
+// CHECK: bb0([[P:%.*]] : $Foo):
+// CHECK:   [[G:%.*]] = builtin "unsafeGuaranteed"
+// CHECK:   [[GV:%.*]] = tuple_extract [[G]]{{.*}}, 0
+// CHECK:   [[M:%.*]] = class_method [[GV]] : $Foo, #Foo.beep
+// CHECK:   apply [[M]]([[GV]])
+// CHECK:   release
+// CHECK:   unsafeGuaranteedEnd
+// CHECK:   [[T:%.*]] = tuple ()
+// CHECK:   return [[T]]
+// CHECK: }
+sil @testUnsafeGuaranteed_noretain : $@convention(method) (@guaranteed Foo) -> () {
+bb0(%0 : $Foo):
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  strong_release %5 : $Foo
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_norelease
+// CHECK: bb0([[P:%.*]] : $Foo):
+// CHECK:   retain [[P]]
+// CHECK:   [[G:%.*]] = builtin "unsafeGuaranteed"
+// CHECK:   [[GV:%.*]] = tuple_extract [[G]]{{.*}}, 0
+// CHECK:   [[M:%.*]] = class_method [[GV]] : $Foo, #Foo.beep
+// CHECK:   apply [[M]]([[GV]])
+// CHECK:   unsafeGuaranteedEnd
+// CHECK:   [[T:%.*]] = tuple ()
+// CHECK:   return [[T]]
+// CHECK: }
+sil @testUnsafeGuaranteed_norelease : $@convention(method) (@guaranteed Foo) -> () {
+bb0(%0 : $Foo):
+  strong_retain %0 : $Foo
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_skip_rr
+// CHECK: bb0([[P:%.*]] : $Foo, [[P2:%.*]] : $Foo):
+// CHECK-NOT: retain [[P]]
+// CHECK-NOT: unsafeGuaranteed
+// CHECK:   retain [[P2]]
+// CHECK:   [[M:%.*]] = class_method [[P]] : $Foo, #Foo.beep
+// CHECK:   apply [[M]]([[P]])
+// CHECK-NOT: release [[P]]
+// CHECK:   release [[P2]]
+// CHECK-NOT: unsafeGuaranteedEnd
+// CHECK:   [[T:%.*]] = tuple ()
+// CHECK:   return [[T]]
+// CHECK: }
+sil @testUnsafeGuaranteed_skip_rr : $@convention(method) (@guaranteed Foo, @guaranteed Foo) -> () {
+bb0(%0 : $Foo, %1: $Foo):
+  strong_retain %0 : $Foo
+  strong_retain %1 : $Foo
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  strong_release %5 : $Foo
+  strong_release %1 : $Foo
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_other_inst_between_retain
+// CHECK: bb0
+// CHECK:   strong_retain [[P]]
+// CHECK:   cond_fail
+// CHECK:   builtin "unsafeGuaranteed"
+// CHECK:   class_method {{.*}} : $Foo, #Foo.beep
+// CHECK:   apply
+// CHECK:   strong_release
+// CHECK:   builtin "unsafeGuaranteedEnd"
+// CHECK: }
+sil @testUnsafeGuaranteed_other_inst_between_retain: $@convention(method) (@guaranteed Foo, Builtin.Int1) -> () {
+bb0(%0 : $Foo, %1 : $Builtin.Int1):
+  strong_retain %0 : $Foo
+  cond_fail %1 : $Builtin.Int1
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  strong_release %5 : $Foo
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_other_inst_between_release
+// CHECK: bb0
+// CHECK:   strong_retain [[P]]
+// CHECK:   builtin "unsafeGuaranteed"
+// CHECK:   class_method {{.*}} : $Foo, #Foo.beep
+// CHECK:   apply
+// CHECK:   strong_release
+// CHECK:   cond_fail
+// CHECK:   builtin "unsafeGuaranteedEnd"
+// CHECK: }
+sil @testUnsafeGuaranteed_other_inst_between_release: $@convention(method) (@guaranteed Foo, Builtin.Int1) -> () {
+bb0(%0 : $Foo, %1 : $Builtin.Int1):
+  strong_retain %0 : $Foo
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  strong_release %5 : $Foo
+  cond_fail %1 : $Builtin.Int1
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+}
+
+// CHECK-LABEL: sil @testUnsafeGuaranteed_cfg
+// CHECK: bb0([[P:%.*]] : $Foo):
+// CHECK-NOT: retain
+// CHECK-NOT: unsafeGuaranteed
+// CHECK:   checked_cast_br [exact] [[P]] : $Foo to $Foo, bb1, bb3
+// CHECK: bb1([[P2:%.*]] : $Foo):
+// CHECK:   function_ref @beep : $@convention(thin) () -> ()
+// CHECK:   %4 = apply %3() : $@convention(thin) () -> ()
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK-NOT: release
+// CHECK-NOT: unsafeGuaranteedEnd
+// CHECK:   [[T:%.*]] = tuple ()
+// CHECK:   return [[T]]
+// CHECK: bb3:
+// CHECK:   [[M:%.*]] = class_method %0 : $Foo, #Foo.beep
+// CHECK:   apply [[M]]([[P]])
+// CHECK:   br bb2
+// CHECK: }
+sil @testUnsafeGuaranteed_cfg : $@convention(method) (@guaranteed Foo) -> () {
+bb0(%0 : $Foo):
+  strong_retain %0 : $Foo
+  %4 = builtin "unsafeGuaranteed"<Foo>(%0 : $Foo) : $(Foo, Builtin.Int8)
+  %5 = tuple_extract %4 : $(Foo, Builtin.Int8), 0
+  %6 = tuple_extract %4 : $(Foo, Builtin.Int8), 1
+  checked_cast_br [exact] %5 : $Foo to $Foo, bb1, bb3
+
+bb1(%11 : $Foo):
+  %12 = function_ref @beep : $@convention(thin) () -> ()
+  %13 = apply %12() : $@convention(thin) () -> ()
+  br bb2
+
+bb2:
+  strong_release %5 : $Foo
+  %16 = builtin "unsafeGuaranteedEnd"(%6 : $Builtin.Int8) : $()
+  %17 = tuple ()
+  return %17 : $()
+
+bb3:
+  %19 = class_method %5 : $Foo, #Foo.beep!1 : (Foo) -> () -> () , $@convention(method) (@guaranteed Foo) -> ()
+  %20 = apply %19(%5) : $@convention(method) (@guaranteed Foo) -> ()
+  br bb2
+}


### PR DESCRIPTION
#### What's in this pull request?

This is an internal method that will go away in the future.

Get the value of the unmanaged referenced as a managed reference without
consuming an unbalanced retain of it and pass it to the closure. Asserts
that there is some other reference ('the owning reference') to the
unmanaged reference that guarantees the lifetime of the unmanaged reference
for the duration of the '_withUnsafeGuaranteedRef' call.

``` swift
  var owningReference = Instance()
  ... 
  withFixedLifetime(owningReference) {
    let u = Unmanaged.passUnretained(owningReference)

    for i in 0 ..< 100 {

      // Assert that the reference in 'u' is kept alive by another storage
      // location or value that holds the same reference.
      u._withUnsafeGuaranteedRef {
        $0.doSomething()
      }

    } 
  } // owningReference's lifetime (reference count > 0) is guaranteed
```
