### PR TITLE
[frontend] Add frontend option -disable-red-zone

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -156,6 +156,9 @@ public:
   /// measurements on a non-clean build directory.
   unsigned UseIncrementalLLVMCodeGen : 1;
 
+  // Should red zone be disabled
+  unsigned NoRedZone : 1;
+
   IRGenOptions() : OutputKind(IRGenOutputKind::LLVMAssembly), Verify(true),
                    Optimize(false), Sanitize(SanitizerKind::None),
                    DebugInfoKind(IRGenDebugInfoKind::None),
@@ -166,7 +169,7 @@ public:
                    PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
                    HasValueNamesSetting(false), ValueNames(false),
                    StripReflectionNames(true), StripReflectionMetadata(true),
-                   CmdArgs(), UseIncrementalLLVMCodeGen(true)
+                   CmdArgs(), UseIncrementalLLVMCodeGen(true), NoRedZone(false)
                    {}
 
   /// Gets the name of the specified output filename.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -184,6 +184,9 @@ def disable_llvm_verify : Flag<["-"], "disable-llvm-verify">,
 def disable_llvm_value_names : Flag<["-"], "disable-llvm-value-names">,
   HelpText<"Don't add names to local values in LLVM IR">;
 
+def disable_red_zone : Flag<["-"], "disable-red-zone">,
+  HelpText<"Do not emit code that uses the red zone">;
+
 def enable_llvm_value_names : Flag<["-"], "enable-llvm-value-names">,
   HelpText<"Add names to local values in LLVM IR">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1217,6 +1217,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.DisableAutolinkFrameworks.push_back(A->getValue());
   }
 
+  Opts.NoRedZone |= Args.hasArg(OPT_disable_red_zone);
   Opts.GenerateProfile |= Args.hasArg(OPT_profile_generate);
   Opts.PrintInlineTree |= Args.hasArg(OPT_print_llvm_inline_tree);
 

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -54,6 +54,9 @@ IRGenFunction::IRGenFunction(IRGenModule &IGM,
   if (IGM.Opts.Sanitize == SanitizerKind::Address)
     Fn->addFnAttr(llvm::Attribute::SanitizeAddress);
 
+  if (IGM.Opts.NoRedZone)
+    Fn->addFnAttr(llvm::Attribute::NoRedZone);
+
   emitPrologue();
 }
 

--- a/test/Frontend/disable-red-zone.swift
+++ b/test/Frontend/disable-red-zone.swift
@@ -1,0 +1,9 @@
+// REQUIRES: CPU=x86_64
+// RUN: %target-swift-frontend -disable-red-zone -emit-ir  %s | FileCheck --check-prefix=CHECK %s
+
+
+func test1() {
+}
+
+// CHECK: ; Function Attrs: noredzone
+// CHECK: attributes #{{[0-9]+}} = { noredzone


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add a -disable-red-zone option to the frontend for compiling Swift code with out using the red zone.

I copied the option name and help text from clang. Im new to LLVM but I think I only needed to make  the one change in IRGenFunction

A followup PR will have a change to build a version of Stdlib without using the red zone

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
