### PR TITLE
WIP [SR-1058] Extend aliases in protocols to be included in ArchetypeType.

### DIFF
--- a/include/swift/AST/ArchetypeBuilder.h
+++ b/include/swift/AST/ArchetypeBuilder.h
@@ -253,6 +253,10 @@ public:
   bool addGenericSignature(GenericSignature *sig, bool adoptArchetypes,
                            bool treatRequirementsAsExplicit = false);
 
+  /// Append any self protocol type aliases as nested types to the given
+  /// archetype type.
+  void addTypeAliasesToArchetype(ArchetypeType *arch);
+  
   /// \brief Get a generic signature based on the provided complete list
   /// of generic parameter types.
   ///
@@ -599,6 +603,11 @@ public:
   /// \brief Retrieve (or build) the type corresponding to the potential
   /// archetype.
   ArchetypeType::NestedType getType(ArchetypeBuilder &builder);
+  
+  /// Append any protocol type aliases as nested types to the given
+  /// archetype type.
+  void addTypeAliasesToArchetype(ArchetypeBuilder &builder,
+                                 ArchetypeType *arch);
 
   /// Retrieve the dependent type that describes this potential
   /// archetype.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3617,19 +3617,20 @@ public:
   /// A nested type. Either a dependent associated archetype, or a concrete
   /// type (which may be a bound archetype from an outer context).
   class NestedType {
-    llvm::PointerIntPair<TypeBase *, 1> TypeAndIsConcrete;
-    NestedType(Type type, bool isConcrete)
-      : TypeAndIsConcrete(type.getPointer(), isConcrete) {}
+    llvm::PointerIntPair<TypeBase *, 2> TypeAndIsConcrete;
+    NestedType(Type type, bool isConcrete, bool isAlias)
+      : TypeAndIsConcrete(type.getPointer(), (isAlias << 1) | isConcrete) {}
   public:
     NestedType() { assert(!*this && "empty nested type isn't false"); }
-    static NestedType forArchetype(ArchetypeType *archetype) {
-      return { archetype, false };
+    static NestedType forArchetype(ArchetypeType *archetype, bool isAlias = false) {
+      return { archetype, false, isAlias };
     }
     static NestedType forConcreteType(Type concrete) {
-      return { concrete, true };
+      return { concrete, true, false };
     }
     operator bool() const { return TypeAndIsConcrete.getOpaqueValue() != 0; }
-    bool isConcreteType() const { return TypeAndIsConcrete.getInt(); }
+    bool isConcreteType() const { return TypeAndIsConcrete.getInt() & 1; }
+    bool isAlias() const { return TypeAndIsConcrete.getInt() >> 1 & 1; }
     Type getValue() const { return TypeAndIsConcrete.getPointer(); }
 
     /// Check whether this nested type is a concrete type.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2769,6 +2769,9 @@ namespace {
         } else if (auto concrete = nestedType.second.getAsConcreteType()) {
           PrintWithColorRAII(OS, TypeColor) << "concrete";
           OS << "=" << concrete.getString();
+        } else if (nestedType.second.isAlias()) {
+          PrintWithColorRAII(OS, TypeColor) << "alias";
+          OS << "=" << static_cast<void *>(nestedType.second.getAsArchetype());
         } else {
           PrintWithColorRAII(OS, TypeColor) << "archetype";
           OS << "=" << static_cast<void *>(nestedType.second.getAsArchetype());

--- a/lib/AST/ArchetypeBuilder.cpp
+++ b/lib/AST/ArchetypeBuilder.cpp
@@ -350,15 +350,17 @@ bool ArchetypeBuilder::PotentialArchetype::addConformance(
   // nested types of this potential archetype.
   for (auto member : proto->getMembers()) {
     auto assocType = dyn_cast<AssociatedTypeDecl>(member);
-    if (!assocType)
+    auto typeAlias = dyn_cast<TypeAliasDecl>(member);
+    if (!assocType && !typeAlias)
       continue;
 
-    auto known = NestedTypes.find(assocType->getName());
+    auto name = typeAlias ? typeAlias->getName() : assocType->getName();
+    auto known = NestedTypes.find(name);
     if (known == NestedTypes.end())
       continue;
 
     // If the nested type was not already resolved, do so now.
-    if (!known->second.front()->getResolvedAssociatedType()) {
+    if (assocType && !known->second.front()->getResolvedAssociatedType()) {
       known->second.front()->resolveAssociatedType(assocType, builder);
 
       // If there's a superclass constraint that conforms to the protocol,
@@ -371,7 +373,11 @@ bool ArchetypeBuilder::PotentialArchetype::addConformance(
 
     // Otherwise, create a new potential archetype for this associated type
     // and make it equivalent to the first potential archetype we encountered.
-    auto otherPA = new PotentialArchetype(this, assocType);
+    PotentialArchetype *otherPA;
+    if (assocType)
+      otherPA = new PotentialArchetype(this, assocType);
+    else
+      otherPA = new PotentialArchetype(this, typeAlias);
     auto frontRep = known->second.front()->getRepresentative();
     otherPA->Representative = frontRep;
     frontRep->EquivalenceClass.push_back(otherPA);
@@ -597,7 +603,15 @@ static Type substConcreteTypesForDependentTypes(ArchetypeBuilder &builder,
 
 ArchetypeType::NestedType
 ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
+  bool isAlias = getTypeAliasDecl() != nullptr;
   auto representative = getRepresentative();
+  
+  if (isAlias) {
+    if (representative == this)
+      return NestedType::forConcreteType(ErrorType::get(builder.getASTContext()));
+    auto arch = representative->getType(builder).getAsArchetype();
+    return NestedType::forArchetype(arch, /* isAlias: */ true);
+  }
 
   // Retrieve the archetype from the archetype anchor in this equivalence class.
   auto archetypeAnchor = getArchetypeAnchor();
@@ -743,16 +757,25 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
                             superclass, isRecursive());
 
   representative->ArchetypeOrConcreteType = NestedType::forArchetype(arch);
-  
+
+  // Make sure any typealiases in conforming protos get added to NestedTypes
+  // so that they'll make it into the ArchetypeType as nested types. Except: if we haven't
+  // yet resolved underlying types for the proto, we can't include aliases yet or
+  // we'll recurse trying to resolve their types. In that case, addTypeAliasesToArchetype
+  // gets called afterwards.
+  for (auto protoPair : ConformsTo)
+    if (!protoPair.first->isBeingTypeChecked())
+      for (auto member : protoPair.first->getMembers())
+        if (auto alias = dyn_cast<TypeAliasDecl>(member))
+          if (alias->hasUnderlyingType())
+            getNestedType(alias->getName(), builder);
+
   // Collect the set of nested types of this archetype, and put them into
   // the archetype itself.
   if (!NestedTypes.empty()) {
     builder.getASTContext().registerLazyArchetype(arch, builder, this);
     SmallVector<std::pair<Identifier, NestedType>, 4> FlatNestedTypes;
     for (auto Nested : NestedTypes) {
-      // Skip type aliases, which are just shortcuts.
-      if (Nested.second.front()->getTypeAliasDecl())
-        continue;
       bool anyNotRenamed = false;
       for (auto NestedPA : Nested.second) {
         if (!NestedPA->wasRenamed()) {
@@ -777,6 +800,51 @@ ArchetypeBuilder::PotentialArchetype::getType(ArchetypeBuilder &builder) {
   return NestedType::forArchetype(arch);
 }
 
+void ArchetypeBuilder::PotentialArchetype::addTypeAliasesToArchetype(ArchetypeBuilder &builder,
+                                                                     ArchetypeType *arch) {
+  // Make sure any typealiases in conforming protos get added to NestedTypes
+  // so that they'll make it into the ArchetypeType as nested types.
+  SmallVector<std::pair<Identifier, NestedType>, 4> ArchetypeTypes;
+  
+  for (auto pair : arch->getNestedTypes()) {
+    ArchetypeTypes.push_back(pair);
+  }
+  
+  bool foundAliases = false;
+  bool unresolved = false;
+  for (auto protoPair : ConformsTo) {
+    for (auto member : protoPair.first->getMembers()) {
+      if (auto alias = dyn_cast<TypeAliasDecl>(member)) {
+        auto name = alias->getName();
+        if (!NestedTypes[name].empty())
+          continue;
+        
+        unresolved |= getNestedType(name, builder)->getTypeAliasDecl() == nullptr;
+        ArchetypeTypes.push_back({ alias->getName(), NestedType() });
+        foundAliases = true;
+      }
+    }
+  }
+  
+  if (!foundAliases || unresolved)
+    return;
+
+  builder.getASTContext().registerLazyArchetype(arch, builder, this);
+  arch->setNestedTypes(builder.getASTContext(), ArchetypeTypes);
+  arch->getNestedTypes();
+  builder.getASTContext().unregisterLazyArchetype(arch);
+}
+
+void ArchetypeBuilder::addTypeAliasesToArchetype(ArchetypeType *arch) {
+  
+  auto proto = arch->getSelfProtocol();
+  auto genericParam = proto->getProtocolSelf();
+  auto known = Impl->PotentialArchetypes.find(
+                                              GenericTypeParamKey::forDecl(genericParam));
+  auto pa = known->second;
+  pa->addTypeAliasesToArchetype(*this, arch);
+}
+
 Type ArchetypeBuilder::PotentialArchetype::getDependentType(
        ArchetypeBuilder &builder,
        bool allowUnresolved) {
@@ -788,6 +856,9 @@ Type ArchetypeBuilder::PotentialArchetype::getDependentType(
     // If we've resolved to an associated type, use it.
     if (auto assocType = getResolvedAssociatedType())
       return DependentMemberType::get(parentType, assocType, builder.Context);
+    
+    // If we are an alias, our representative is a pointer to the real type.
+    //if (getTypeAliasDecl() && getRepresentative() != this) {
 
     // If typo correction renamed this type, get the renamed type.
     if (wasRenamed())
@@ -1783,6 +1854,9 @@ ArrayRef<ArchetypeType *> ArchetypeBuilder::getAllArchetypes() {
         continue;
 
       PotentialArchetype *PA = Entry.second;
+      if (PA->getTypeAliasDecl())
+        continue;
+      
       auto Archetype = PA->getType(*this).castToArchetype();
       if (KnownArchetypes.insert(Archetype).second)
         Impl->AllArchetypes.push_back(Archetype);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -578,6 +578,8 @@ void GenericParamList::addNestedArchetypes(ArchetypeType *archetype,
                                       SmallPtrSetImpl<ArchetypeType*> &known,
                                       SmallVectorImpl<ArchetypeType*> &all) {
   for (auto nested : archetype->getNestedTypes()) {
+    if (nested.second.isAlias())
+      continue;
     auto nestedArch = nested.second.getAsArchetype();
     if (!nestedArch)
       continue;

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1053,6 +1053,8 @@ static void profileArchetypeConstraints(
   
   // Recursively profile nested archetypes.
   for (auto nested : arch->getNestedTypes()) {
+    if (nested.second.isAlias())
+      continue;    
     profileArchetypeConstraints(nested.second.getValue(), ID, seen);
   }
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6585,6 +6585,11 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
           assocType->computeType();
       }
     }
+    
+    // Now that all the associated types have archetypes set, we can
+    // safely try to resolve types for any typealiases.
+    proto->setIsBeingTypeChecked(false);
+    builder.addTypeAliasesToArchetype(selfArchetype);
 
     // If the protocol is @objc, it may only refine other @objc protocols.
     // FIXME: Revisit this restriction.


### PR DESCRIPTION
Previously I thought I could get away with the aliases only being in the PotentialArchetypes, but with inherited protocols we can get asked for the dependent type (of the aliases name) of a base ArchetypeType and there’s no way to get the ‘destination’ of the alias unless it’s already a NestedType of the ArchetypeType.

So now there’s an additional flag bit on NestedType for whether this archetype is an alias (meaning it is for lookups only and shouldn’t be a separate generic parameter) and there’s some extra machinery for making sure that all aliases get recorded as NestedTypes in the archetypes.

Before this gets pulled in it needs more tests, and the alias flag bit needs to be de/serializable.
