### PR TITLE
[stdlib/cygwin] Fix finding NT header in DLL.

### DIFF
--- a/stdlib/public/runtime/CygwinPort.cpp
+++ b/stdlib/public/runtime/CygwinPort.cpp
@@ -91,7 +91,9 @@ uint8_t *swift::_swift_getSectionDataPE(void *handle, const char *sectionName,
   // This is relying on undocumented feature of Windows API LoadLibrary().
   unsigned char *peStart = (unsigned char *)handle;
 
-  int ntHeadersOffset = peStart[0x3C];
+  const int kLocationOfNtHeaderOffset = 0x3C;
+  int ntHeadersOffset =
+      *reinterpret_cast<int32_t *>(peStart + kLocationOfNtHeaderOffset);
 
   bool assert1 =
       peStart[ntHeadersOffset] == 'P' && peStart[ntHeadersOffset + 1] == 'E';


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: N/A

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

In PE-COFF formatted file, the offset of NT header can be greater than 0xFF. MS library defines it as LONG (32bit signed integer) in struct _IMAGE_DOS_HEADER.
