### PR TITLE
Correct an error in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 Swift 3.0
 -------
 
-* The "none" members of imported NS_OPTIONS option sets are not marked as unavailable
+* The "none" members of imported NS_OPTIONS option sets are marked as unavailable
   when they are imported.  Use [] to make an empty option set, instead of a None member.
 
 * [SE-0043](https://github.com/apple/swift-evolution/blob/master/proposals/0043-declare-variables-in-case-labels-with-multiple-patterns.md)


### PR DESCRIPTION
The "none" members of imported NS_OPTIONS option sets are ~~**not**~~ marked as unavailable

668d224b624ef73af628eedc43382e6b11c69000

> Fix rdar://problem/25168818 Don't import None members in NS_OPTIONS types
> 
> When importing members of an NS_OPTIONS (aka an option set), mark imported
>     members that have a value of 0 with an unavailable error.
