### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::finalize(…)

### DIFF
--- a/validation-test/compiler_crashers/28283-swift-archetypebuilder-finalize.swift
+++ b/validation-test/compiler_crashers/28283-swift-archetypebuilder-finalize.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{class B<U:U.a
+typealias h}}extension A{
+let e=B
+typealias h:n


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A typo in `typoCorrectNestedType`? :-)

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:1683: swift::Identifier typoCorrectNestedType(ArchetypeBuilder::PotentialArchetype *): Assertion `dist > 0 && "nested type should have matched associated type"' failed.
8  swift           0x0000000000f940a1 swift::ArchetypeBuilder::finalize(swift::SourceLoc) + 2209
9  swift           0x0000000000ea4c07 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 183
10 swift           0x0000000000ea4f76 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
11 swift           0x0000000000e682cf swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 367
12 swift           0x00000000010abe8c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 3612
13 swift           0x00000000010aa550 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2400
14 swift           0x0000000000ea714b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
15 swift           0x0000000000e53e26 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 102
17 swift           0x0000000001009f13 swift::Expr::walk(swift::ASTWalker&) + 19
18 swift           0x0000000000e5541d swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 125
19 swift           0x0000000000e5bc00 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 576
20 swift           0x0000000000e5cdc2 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 162
21 swift           0x0000000000e5cf9b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
26 swift           0x0000000000e6dc66 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
27 swift           0x0000000000e909c2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 994
28 swift           0x0000000000cd4cff swift::CompilerInstance::performSema() + 3087
30 swift           0x000000000078ee8c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
31 swift           0x0000000000789915 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28283-swift-archetypebuilder-finalize.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28283-swift-archetypebuilder-finalize-cbd0df.o
1.  While type-checking declaration 0x6784470 at validation-test/compiler_crashers/28283-swift-archetypebuilder-finalize.swift:11:14
2.  While type-checking expression at [validation-test/compiler_crashers/28283-swift-archetypebuilder-finalize.swift:12:7 - line:12:7] RangeText="B"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
