### PR TITLE
[Sema] Fixed SR-1062: Coercion in single expression closure with invalid signature caused segmentation fault

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2850,6 +2850,15 @@ namespace {
         return { false, expr };
       }
 
+      // Don't visit CoerceExpr with an empty sub expression. They may occur
+      // if the body of a closure was not visited while pre-checking because
+      // of an error in the closure's signature
+      if (auto coerceExpr = dyn_cast<CoerceExpr>(expr)) {
+        if (!coerceExpr->getSubExpr()) {
+          return { false, expr };
+        }
+      }
+
       return { true, expr };
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1643,7 +1643,7 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
   }
     
   // Type-check the initializer.
-  bool hadError =typeCheckExpression(initializer, DC, contextualType,
+  bool hadError = typeCheckExpression(initializer, DC, contextualType,
                                      contextualPurpose,
                                      TypeCheckExprFlags::ConvertTypeIsOnlyAHint,
                                      &listener);

--- a/test/Sema/single_expression_closure.swift
+++ b/test/Sema/single_expression_closure.swift
@@ -1,0 +1,12 @@
+// RUN: %target-parse-verify-swift
+
+// SR-1062: 
+// Coercion in single expression closure with invalid signature caused segfault
+protocol SR_1062_EmptyProtocol {}
+
+struct SR_1062_EmptyStruct {}
+struct SR_1062_GenericStruct<T: SR_1062_EmptyProtocol> {}
+
+let _ = { (_: SR_1062_GenericStruct<SR_1062_EmptyStruct>) -> Void in // expected-error{{type 'SR_1062_EmptyStruct' does not conform to protocol 'SR_1062_EmptyProtocol'}}
+  SR_1062_EmptyStruct() as SR_1062_EmptyStruct
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fixed a segmentation fault that occurred if a cast using `as` (CoerceExpr) was the only expression in a closure that had  an error in its type signature (e.g. when a generic constraint could not be satisfied) Example:

``` swift
protocol P {}

struct S {}
struct G<T: P> {}

let _ = { (_: G<S>) in // Error: Type 'S' does not conform to protocol 'P'
  S() as S // This line used to cause a segfault if it was the only expression in the closure’s body
}
```
#### Resolved bug number: ([SR-1062](https://bugs.swift.org/browse/SR-1062))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
