### PR TITLE
Provide non-atomic versions of many reference counting operations.

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -212,9 +212,34 @@ extern "C"
 void (*SWIFT_CC(RegisterPreservingCC) _swift_retain_n)(HeapObject *object,
                                                        uint32_t n);
 
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C"
+void swift_nonatomic_retain(HeapObject *object)
+    SWIFT_CC(RegisterPreservingCC);
+
+SWIFT_RUNTIME_EXPORT
+extern "C"
+void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain)(HeapObject *object);
+
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C"
+void swift_nonatomic_retain_n(HeapObject *object, uint32_t n)
+    SWIFT_CC(RegisterPreservingCC);
+
+SWIFT_RUNTIME_EXPORT
+extern "C"
+void (*SWIFT_CC(RegisterPreservingCC) _swift_nonatomic_retain_n)(HeapObject *object,
+                                                       uint32_t n);
+
 static inline void _swift_retain_inlined(HeapObject *object) {
   if (object) {
     object->refCount.increment();
+  }
+}
+
+static inline void _swift_nonatomic_retain_inlined(HeapObject *object) {
+  if (object) {
+    object->refCount.incrementNonAtomic();
   }
 }
 
@@ -249,12 +274,20 @@ SWIFT_RT_ENTRY_VISIBILITY
 extern "C" HeapObject *swift_tryPin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C" HeapObject *swift_nonatomic_tryPin(HeapObject *object)
+    SWIFT_CC(RegisterPreservingCC);
+
 /// Given that an object is pinned, atomically unpin it and decrement
 /// the reference count.
 ///
 /// The object reference may be nil (to simplify the protocol).
 SWIFT_RT_ENTRY_VISIBILITY
 extern "C" void swift_unpin(HeapObject *object)
+    SWIFT_CC(RegisterPreservingCC);
+
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C" void swift_nonatomic_unpin(HeapObject *object)
     SWIFT_CC(RegisterPreservingCC);
 
 /// Atomically decrements the retain count of an object.  If the
@@ -281,6 +314,15 @@ SWIFT_RUNTIME_EXPORT
 extern "C" void (*SWIFT_CC(RegisterPreservingCC)
                      _swift_release)(HeapObject *object);
 
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C" void swift_nonatomic_release(HeapObject *object)
+    SWIFT_CC(RegisterPreservingCC);
+
+SWIFT_RUNTIME_EXPORT
+extern "C" void (*SWIFT_CC(RegisterPreservingCC)
+                     _swift_nonatomic_release)(HeapObject *object);
+
+
 /// Atomically decrements the retain count of an object n times. If the retain
 /// count reaches zero, the object is destroyed
 SWIFT_RT_ENTRY_VISIBILITY
@@ -297,6 +339,15 @@ extern "C" void (*SWIFT_CC(RegisterPreservingCC)
 /// retain the object during executing this function.
 SWIFT_RUNTIME_EXPORT
 extern "C" void swift_setDeallocating(HeapObject *object);
+
+SWIFT_RT_ENTRY_VISIBILITY
+extern "C"
+void swift_nonatomic_release_n(HeapObject *object, uint32_t n)
+    SWIFT_CC(RegisterPreservingCC);
+
+SWIFT_RUNTIME_EXPORT
+extern "C" void (*SWIFT_CC(RegisterPreservingCC)
+                     _swift_nonatomic_release_n)(HeapObject *object, uint32_t n);
 
 // Refcounting observation hooks for memory tools. Don't use these.
 SWIFT_RUNTIME_EXPORT
@@ -663,6 +714,15 @@ SWIFT_RUNTIME_EXPORT
     extern "C" void *swift_bridgeObjectRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
+SWIFT_RUNTIME_EXPORT
+extern "C" void *swift_nonatomic_bridgeObjectRetain(void *value)
+    SWIFT_CC(DefaultCC);
+
+/// Increment the strong retain count of a bridged object by n.
+SWIFT_RUNTIME_EXPORT
+    extern "C" void *swift_nonatomic_bridgeObjectRetain_n(void *value, int n)
+    SWIFT_CC(DefaultCC);
+
 /*****************************************************************************/
 /************************ UNKNOWN REFERENCE-COUNTING *************************/
 /*****************************************************************************/
@@ -680,6 +740,18 @@ SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownRetain_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
+/// Increment the strong retain count of an object which might not be a native
+/// Swift object.
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_nonatomic_unknownRetain(void *value)
+    SWIFT_CC(DefaultCC);
+/// Increment the strong retain count of an object which might not be a native
+/// Swift object by n.
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_nonatomic_unknownRetain_n(void *value, int n)
+    SWIFT_CC(DefaultCC);
+
+
 #else
 
 static inline void swift_unknownRetain(void *value)
@@ -692,6 +764,17 @@ static inline void swift_unknownRetain_n(void *value, int n)
   swift_retain_n(static_cast<HeapObject *>(value), n);
 }
 
+static inline void swift_nonatomic_unknownRetain(void *value)
+    SWIFT_CC(DefaultCC) {
+  swift_nonatomic_retain(static_cast<HeapObject *>(value));
+}
+
+static inline void swift_nonatomic_unknownRetain_n(void *value, int n)
+    SWIFT_CC(DefaultCC) {
+  swift_nonatomic_retain_n(static_cast<HeapObject *>(value), n);
+}
+
+
 #endif /* SWIFT_OBJC_INTEROP */
 
 SWIFT_RUNTIME_EXPORT
@@ -700,6 +783,14 @@ extern "C" void swift_bridgeObjectRelease(void *value)
 /// Decrement the strong retain count of a bridged object by n.
 SWIFT_RUNTIME_EXPORT
 extern "C" void swift_bridgeObjectRelease_n(void *value, int n)
+    SWIFT_CC(DefaultCC);
+
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_nonatomic_bridgeObjectRelease(void *value)
+    SWIFT_CC(DefaultCC);
+/// Decrement the strong retain count of a bridged object by n.
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_nonatomic_bridgeObjectRelease_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
 #if SWIFT_OBJC_INTEROP
@@ -715,6 +806,17 @@ SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unknownRelease_n(void *value, int n)
     SWIFT_CC(DefaultCC);
 
+/// Decrement the strong retain count of an object which might not be a native
+/// Swift object.
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_nonatomic_unknownRelease(void *value)
+    SWIFT_CC(DefaultCC);
+/// Decrement the strong retain count of an object which might not be a native
+/// Swift object by n.
+SWIFT_RUNTIME_EXPORT
+extern "C" void swift_nonatomic_unknownRelease_n(void *value, int n)
+    SWIFT_CC(DefaultCC);
+
 #else
 
 static inline void swift_unknownRelease(void *value)
@@ -725,6 +827,16 @@ static inline void swift_unknownRelease(void *value)
 static inline void swift_unknownRelease_n(void *value, int n)
     SWIFT_CC(RegisterPreservingCC) {
   swift_release_n(static_cast<HeapObject *>(value), n);
+}
+
+static inline void swift_nonatomic_unknownRelease(void *value)
+    SWIFT_CC(RegisterPreservingCC) {
+  swift_nonatomic_release(static_cast<HeapObject *>(value));
+}
+
+static inline void swift_nonatomic_unknownRelease_n(void *value, int n)
+    SWIFT_CC(RegisterPreservingCC) {
+  swift_nonatomic_release_n(static_cast<HeapObject *>(value), n);
 }
 
 #endif /* SWIFT_OBJC_INTEROP */

--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -33,6 +33,8 @@ extern "C" void (*_swift_retain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_retain_n)(HeapObject *object, uint32_t n);
 SWIFT_RUNTIME_EXPORT
+extern "C" void (*_swift_nonatomic_retain)(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
 extern "C" HeapObject *(*_swift_tryRetain)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 extern "C" bool (*_swift_isDeallocating)(HeapObject *object);
@@ -40,6 +42,8 @@ SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_release)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 extern "C" void (*_swift_release_n)(HeapObject *object, uint32_t n);
+SWIFT_RUNTIME_EXPORT
+extern "C" void (*_swift_nonatomic_release)(HeapObject *object);
 
 // liboainject on iOS 8 patches the function pointers below if present. 
 // Do not reuse these names unless you do what oainject expects you to do.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -174,6 +174,20 @@ FUNCTION(NativeSetDeallocating, swift_setDeallocating,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
+// void swift_nonatomic_retain_n(void *ptr, int32_t n);
+FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongRetainN, swift_nonatomic_retain_n,
+         _swift_nonatomic_retain_n, _swift_nonatomic_retain_n_, RegisterPreservingCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy, Int32Ty),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_release_n(void *ptr, int32_t n);
+FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongReleaseN, swift_nonatomic_release_n,
+         _swift_nonatomic_release_n, _swift_nonatomic_release_n_,  RegisterPreservingCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy, Int32Ty),
+         ATTRS(NoUnwind))
+
 // void swift_unknownRetain_n(void *ptr, int32_t n);
 FUNCTION(UnknownRetainN, swift_unknownRetain_n,
          DefaultCC,
@@ -183,6 +197,20 @@ FUNCTION(UnknownRetainN, swift_unknownRetain_n,
 
 // void swift_unknownRelease_n(void *ptr, int32_t n);
 FUNCTION(UnknownReleaseN, swift_unknownRelease_n,
+         DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy, Int32Ty),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_unknownRetain_n(void *ptr, int32_t n);
+FUNCTION(NonAtomicUnknownRetainN, swift_nonatomic_unknownRetain_n,
+         DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy, Int32Ty),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_unknownRelease_n(void *ptr, int32_t n);
+FUNCTION(NonAtomicUnknownReleaseN, swift_nonatomic_unknownRelease_n,
          DefaultCC,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy, Int32Ty),
@@ -202,9 +230,37 @@ FUNCTION(BridgeObjectReleaseN, swift_bridgeObjectRelease_n,
          ARGS(BridgeObjectPtrTy, Int32Ty),
          ATTRS(NoUnwind))
 
+// void swift_nonatomic_bridgeObjectRetain_n(void *ptr, int32_t n);
+FUNCTION(NonAtomicBridgeObjectRetainN, swift_nonatomic_bridgeObjectRetain_n,
+         DefaultCC,
+         RETURNS(BridgeObjectPtrTy),
+         ARGS(BridgeObjectPtrTy, Int32Ty),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_bridgeObjectRelease_n(void *ptr, int32_t n);
+FUNCTION(NonAtomicBridgeObjectReleaseN, swift_nonatomic_bridgeObjectRelease_n,
+         DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(BridgeObjectPtrTy, Int32Ty),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_retain(void *ptr);
+FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongRetain, swift_nonatomic_retain,
+         _swift_nonatomic_retain, _swift_nonatomic_retain_, RegisterPreservingCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
 // void *swift_tryPin(void *ptr);
 FUNCTION(NativeTryPin, swift_tryPin, RegisterPreservingCC,
          RETURNS(RefCountedPtrTy),
+         ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_release(void *ptr);
+FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(NativeNonAtomicStrongRelease, swift_nonatomic_release,
+         _swift_nonatomic_release, _swift_nonatomic_release_, RegisterPreservingCC,
+         RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
@@ -228,6 +284,18 @@ FUNCTION_WITH_GLOBAL_SYMBOL_AND_IMPL(IsDeallocating, swift_isDeallocating,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind, ZExt))
 
+// void *swift_nonatomic_tryPin(void *ptr);
+FUNCTION(NonAtomicNativeTryPin, swift_nonatomic_tryPin, RegisterPreservingCC,
+         RETURNS(RefCountedPtrTy),
+         ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_unpin(void *ptr);
+FUNCTION(NonAtomicNativeUnpin, swift_nonatomic_unpin, RegisterPreservingCC,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
 // void swift_unknownRetain(void *ptr);
 FUNCTION(UnknownRetain, swift_unknownRetain, DefaultCC,
          RETURNS(VoidTy),
@@ -236,6 +304,18 @@ FUNCTION(UnknownRetain, swift_unknownRetain, DefaultCC,
 
 // void swift_unknownRelease(void *ptr);
 FUNCTION(UnknownRelease, swift_unknownRelease, DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(UnknownRefCountedPtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_unknownRetain(void *ptr);
+FUNCTION(NonAtomicUnknownRetain, swift_nonatomic_unknownRetain, DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(UnknownRefCountedPtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_unknownRelease(void *ptr);
+FUNCTION(NonAtomicUnknownRelease, swift_nonatomic_unknownRelease, DefaultCC,
          RETURNS(VoidTy),
          ARGS(UnknownRefCountedPtrTy),
          ATTRS(NoUnwind))
@@ -251,6 +331,19 @@ FUNCTION(BridgeObjectStrongRelease, swift_bridgeObjectRelease, DefaultCC,
          RETURNS(VoidTy),
          ARGS(BridgeObjectPtrTy),
          ATTRS(NoUnwind))
+
+// void *swift_nonatomic_bridgeObjectRetain(void *ptr);
+FUNCTION(NonAtomicBridgeObjectStrongRetain, swift_nonatomic_bridgeObjectRetain, DefaultCC,
+         RETURNS(BridgeObjectPtrTy),
+         ARGS(BridgeObjectPtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_nonatomic_bridgeRelease(void *ptr);
+FUNCTION(NonAtomicBridgeObjectStrongRelease, swift_nonatomic_bridgeObjectRelease, DefaultCC,
+         RETURNS(VoidTy),
+         ARGS(BridgeObjectPtrTy),
+         ATTRS(NoUnwind))
+
 
 // error *swift_errorRetain(error *ptr);
 FUNCTION(ErrorStrongRetain, swift_errorRetain, DefaultCC,

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -95,10 +95,22 @@ class StrongRefCount {
     __atomic_fetch_add(&refCount, RC_ONE, __ATOMIC_RELAXED);
   }
 
+  void incrementNonAtomic() {
+    uint32_t val = __atomic_load_n(&refCount, __ATOMIC_RELAXED);
+    val += RC_ONE;
+    __atomic_store_n(&refCount, val, __ATOMIC_RELAXED);
+  }
+
   // Increment the reference count by n.
   void increment(uint32_t n) {
     __atomic_fetch_add(&refCount, n << RC_FLAGS_COUNT, __ATOMIC_RELAXED);
   }
+
+  void incrementNonAtomic(uint32_t n) {
+    uint32_t val = __atomic_load_n(&refCount, __ATOMIC_RELAXED);
+    val += n << RC_FLAGS_COUNT;
+    __atomic_store_n(&refCount, val, __ATOMIC_RELAXED);
+ }
 
   // Try to simultaneously set the pinned flag and increment the
   // reference count.  If the flag is already set, don't increment the
@@ -128,6 +140,19 @@ class StrongRefCount {
     }
   }
 
+  bool tryIncrementAndPinNonAtomic() {
+    uint32_t oldval = __atomic_load_n(&refCount, __ATOMIC_RELAXED);
+    // If the flag is already set, just fail.
+    if (oldval & RC_PINNED_FLAG) {
+      return false;
+    }
+
+    // Try to simultaneously set the flag and increment the reference count.
+    uint32_t newval = oldval + (RC_PINNED_FLAG + RC_ONE);
+    __atomic_store_n(&refCount, newval, __ATOMIC_RELAXED);
+    return true;
+  }
+
   // Increment the reference count, unless the object is deallocating.
   bool tryIncrement() {
     // FIXME: this could be better on LL/SC architectures like arm64
@@ -148,10 +173,18 @@ class StrongRefCount {
     return doDecrementShouldDeallocate<true>();
   }
 
+  bool decrementAndUnpinShouldDeallocateNonAtomic() {
+    return doDecrementShouldDeallocateNonAtomic<true>();
+  }
+
   // Decrement the reference count.
   // Return true if the caller should now deallocate the object.
   bool decrementShouldDeallocate() {
     return doDecrementShouldDeallocate<false>();
+  }
+
+  bool decrementShouldDeallocateNonAtomic() {
+    return doDecrementShouldDeallocateNonAtomic<false>();
   }
 
   bool decrementShouldDeallocateN(uint32_t n) {
@@ -163,7 +196,11 @@ class StrongRefCount {
   // Precondition: the reference count must be 1
   void decrementFromOneAndDeallocateNonAtomic() {
     assert(refCount == RC_ONE && "Expect a count of 1");
-    refCount = RC_DEALLOCATING_FLAG;
+    __atomic_store_n(&refCount, RC_DEALLOCATING_FLAG, __ATOMIC_RELAXED);
+  }
+
+  bool decrementShouldDeallocateNNonAtomic(uint32_t n) {
+    return doDecrementShouldDeallocateNNonAtomic<false>(n);
   }
 
   // Return the reference count.
@@ -239,11 +276,90 @@ private:
   }
 
   template <bool ClearPinnedFlag>
+  bool doDecrementShouldDeallocateNonAtomic() {
+    // If we're being asked to clear the pinned flag, we can assume
+    // it's already set.
+    constexpr uint32_t quantum =
+      (ClearPinnedFlag ? RC_ONE + RC_PINNED_FLAG : RC_ONE);
+    uint32_t val = __atomic_load_n(&refCount, __ATOMIC_RELAXED);
+    val -= quantum;
+    __atomic_store_n(&refCount, val, __ATOMIC_RELEASE);
+    uint32_t newval = refCount;
+
+    assert((!ClearPinnedFlag || !(newval & RC_PINNED_FLAG)) &&
+           "unpinning reference that was not pinned");
+    assert(newval + quantum >= RC_ONE &&
+           "releasing reference with a refcount of zero");
+
+    // If we didn't drop the reference count to zero, or if the
+    // deallocating flag is already set, we're done; don't start
+    // deallocation.  We can assume that the pinned flag isn't set
+    // unless the refcount is nonzero, and or'ing it in gives us a
+    // more efficient mask: the check just becomes "is newval nonzero".
+    if ((newval & (RC_COUNT_MASK | RC_PINNED_FLAG | RC_DEALLOCATING_FLAG))
+          != 0) {
+      // Refcount is not zero. We definitely do not need to deallocate.
+      return false;
+    }
+
+    // Refcount is now 0 and is not already deallocating.  Try to set
+    // the deallocating flag.  This must be atomic because it can race
+    // with weak retains.
+    //
+    // This also performs the before-deinit acquire barrier if we set the flag.
+    static_assert(RC_FLAGS_COUNT == 2,
+                  "fix decrementShouldDeallocate() if you add more flags");
+    uint32_t oldval = 0;
+    newval = RC_DEALLOCATING_FLAG;
+    return __atomic_compare_exchange(&refCount, &oldval, &newval, 0,
+                                     __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+  }
+
+  template <bool ClearPinnedFlag>
   bool doDecrementShouldDeallocateN(uint32_t n) {
     // If we're being asked to clear the pinned flag, we can assume
     // it's already set.
     uint32_t delta = (n << RC_FLAGS_COUNT) + (ClearPinnedFlag ? RC_PINNED_FLAG : 0);
     uint32_t newval = __atomic_sub_fetch(&refCount, delta, __ATOMIC_RELEASE);
+
+    assert((!ClearPinnedFlag || !(newval & RC_PINNED_FLAG)) &&
+           "unpinning reference that was not pinned");
+    assert(newval + delta >= RC_ONE &&
+           "releasing reference with a refcount of zero");
+
+    // If we didn't drop the reference count to zero, or if the
+    // deallocating flag is already set, we're done; don't start
+    // deallocation.  We can assume that the pinned flag isn't set
+    // unless the refcount is nonzero, and or'ing it in gives us a
+    // more efficient mask: the check just becomes "is newval nonzero".
+    if ((newval & (RC_COUNT_MASK | RC_PINNED_FLAG | RC_DEALLOCATING_FLAG))
+          != 0) {
+      // Refcount is not zero. We definitely do not need to deallocate.
+      return false;
+    }
+
+    // Refcount is now 0 and is not already deallocating.  Try to set
+    // the deallocating flag.  This must be atomic because it can race
+    // with weak retains.
+    //
+    // This also performs the before-deinit acquire barrier if we set the flag.
+    static_assert(RC_FLAGS_COUNT == 2,
+                  "fix decrementShouldDeallocate() if you add more flags");
+    uint32_t oldval = 0;
+    newval = RC_DEALLOCATING_FLAG;
+    return __atomic_compare_exchange(&refCount, &oldval, &newval, 0,
+                                     __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+  }
+
+  template <bool ClearPinnedFlag>
+  bool doDecrementShouldDeallocateNNonAtomic(uint32_t n) {
+    // If we're being asked to clear the pinned flag, we can assume
+    // it's already set.
+    uint32_t delta = (n << RC_FLAGS_COUNT) + (ClearPinnedFlag ? RC_PINNED_FLAG : 0);
+    uint32_t val = __atomic_load_n(&refCount, __ATOMIC_RELAXED);
+    val -= delta;
+    __atomic_store_n(&refCount, val, __ATOMIC_RELEASE);
+    uint32_t newval = val;
 
     assert((!ClearPinnedFlag || !(newval & RC_PINNED_FLAG)) &&
            "unpinning reference that was not pinned");

--- a/unittests/runtime/Refcounting.cpp
+++ b/unittests/runtime/Refcounting.cpp
@@ -152,3 +152,97 @@ TEST(RefcountingTest, unowned_retain_release_n) {
   swift_release(object);
   EXPECT_EQ(1u, value);
 }
+
+//////////////////////////////////////////
+// Non-atomic referenece counting tests //
+//////////////////////////////////////////
+
+TEST(RefcountingTest, nonatomic_release) {
+  size_t value = 0;
+  auto object = allocTestObject(&value, 1);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_release(object);
+  EXPECT_EQ(1u, value);
+}
+
+TEST(RefcountingTest, nonatomic_retain_release) {
+  size_t value = 0;
+  auto object = allocTestObject(&value, 1);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_retain(object);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_release(object);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_release(object);
+  EXPECT_EQ(1u, value);
+}
+
+TEST(RefcountingTest, nonatomic_pin_unpin) {
+  size_t value = 0;
+  auto object = allocTestObject(&value, 1);
+  EXPECT_EQ(0u, value);
+  auto pinResult = swift_nonatomic_tryPin(object);
+  EXPECT_EQ(object, pinResult);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_release(object);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_unpin(object);
+  EXPECT_EQ(1u, value);
+}
+
+TEST(RefcountingTest, nonatomic_pin_pin_unpin_unpin) {
+  size_t value = 0;
+  auto object = allocTestObject(&value, 1);
+  EXPECT_EQ(0u, value);
+  auto pinResult = swift_nonatomic_tryPin(object);
+  EXPECT_EQ(object, pinResult);
+  EXPECT_EQ(0u, value);
+  auto pinResult2 = swift_nonatomic_tryPin(object);
+  EXPECT_EQ(nullptr, pinResult2);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_unpin(pinResult2);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_release(object);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_unpin(object);
+  EXPECT_EQ(1u, value);
+}
+
+TEST(RefcountingTest, nonatomic_retain_release_n) {
+  size_t value = 0;
+  auto object = allocTestObject(&value, 1);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_retain_n(object, 32);
+  swift_nonatomic_retain(object);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(34u, swift_retainCount(object));
+  swift_nonatomic_release_n(object, 31);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(3u, swift_retainCount(object));
+  swift_nonatomic_release(object);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(2u, swift_retainCount(object));
+  swift_nonatomic_release_n(object, 1);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(1u, swift_retainCount(object));
+}
+
+TEST(RefcountingTest, nonatomic_unknown_retain_release_n) {
+  size_t value = 0;
+  auto object = allocTestObject(&value, 1);
+  EXPECT_EQ(0u, value);
+  swift_nonatomic_unknownRetain_n(object, 32);
+  swift_nonatomic_unknownRetain(object);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(34u, swift_retainCount(object));
+  swift_nonatomic_unknownRelease_n(object, 31);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(3u, swift_retainCount(object));
+  swift_nonatomic_unknownRelease(object);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(2u, swift_retainCount(object));
+  swift_nonatomic_unknownRelease_n(object, 1);
+  EXPECT_EQ(0u, value);
+  EXPECT_EQ(1u, swift_retainCount(object));
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Provide non-atomic versions of many reference counting operations.

Non-atomic reference counting operations are much faster than their atomic counterparts.

These new entry points will be used by optimizations, which would replace atomic reference counting operations by non-atomic reference counting operations when it is safe to do so. 
#### Resolved bug number: ([SR-248](https://bugs.swift.org/browse/SR-248))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
