### PR TITLE
Access static stored properties declared in Swift directly.

### DIFF
--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -57,3 +57,16 @@ extension SubSub {
     }
   }
 }
+
+// SR-1025
+extension Base {
+  private static var x = 1
+}
+
+// CHECK-LABEL: sil hidden @_TF15objc_extensions19testStaticVarAccessFT_T_
+func testStaticVarAccess() {
+  // CHECK: [[F:%.*]] = function_ref @_TFE15objc_extensionsCSo4BaseauP33_1F05E59585E0BB585FCA206FBFF1A92D1xSi
+  // CHECK: [[PTR:%.*]] = apply [[F]]()
+  // CHECK: [[ADDR:%.*]] = pointer_to_address [[PTR]]
+  _ = Base.x
+}


### PR DESCRIPTION
Targeted fix for SR-1025.
