### PR TITLE
[Swift 2.2.1] SR-2015: [ClangImporter] Correctly set up inherited protocol conformances

### DIFF
--- a/test/ClangModules/Inputs/inherited-protocols-sil.h
+++ b/test/ClangModules/Inputs/inherited-protocols-sil.h
@@ -1,0 +1,13 @@
+@protocol BaseProto
+@end
+
+@protocol SubProto <BaseProto>
+@end
+
+@interface UnrelatedBaseClass
+@end
+
+@interface Impl : UnrelatedBaseClass <SubProto>
+- (instancetype)init;
++ (instancetype)implWithChild:(id<BaseProto>)child;
+@end

--- a/test/ClangModules/inherited-protocols-sil.swift
+++ b/test/ClangModules/inherited-protocols-sil.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -sdk "" -emit-sil %s -import-objc-header %S/Inputs/inherited-protocols-sil.h -O
+
+// REQUIRES: objc_interop
+
+// <rdar://problem/24547884> Protocol Extensions May Crash Swift Compiler when Whole-Module Optimization is Enabled
+
+extension SubProto {
+  func foo() -> Impl {
+    return Impl(child: self)
+  }
+}
+
+_ = Impl().foo()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Backport #1820 to Swift 2.2, resolving a crash involving imported Objective-C protocols that inherit from other protocols.

Resolves [SR-1015](https://bugs.swift.org/browse/SR-1015) "Swift 2.2/Xcode 7.3 Segmentation fault in release build" and rdar://problem/24547884.

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
