### PR TITLE
IRGen: Set instanceStart correctly in ObjC rodata when first stored property is empty.

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -988,7 +988,9 @@ namespace {
             || Layout->getElements().size() == FirstFieldIndex) {
           instanceStart = instanceSize;
         } else if (Layout->getElement(FirstFieldIndex).getKind()
-                     == ElementLayout::Kind::Fixed) {
+                     == ElementLayout::Kind::Fixed ||
+                   Layout->getElement(FirstFieldIndex).getKind()
+                     == ElementLayout::Kind::Empty) {
           // FIXME: assumes layout is always sequential!
           instanceStart = Layout->getElement(FirstFieldIndex).getByteOffset();
         } else {

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -307,7 +307,8 @@ void StructLayoutBuilder::addNonFixedSizeElement(ElementLayout &elt) {
 
 /// Add an empty element to the aggregate.
 void StructLayoutBuilder::addEmptyElement(ElementLayout &elt) {
-  elt.completeEmpty(elt.getType().isPOD(ResilienceExpansion::Maximal));
+  elt.completeEmpty(elt.getType().isPOD(ResilienceExpansion::Maximal),
+                    CurSize);
 }
 
 /// Add an element at the fixed offset of the current end of the

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -137,9 +137,13 @@ public:
     Index = other.Index;
   }
 
-  void completeEmpty(IsPOD_t isPOD) {
+  void completeEmpty(IsPOD_t isPOD, Size byteOffset) {
     TheKind = unsigned(Kind::Empty);
     IsPOD = unsigned(isPOD);
+    // We still want to give empty fields an offset for use by things like
+    // ObjC ivar emission. We use the first field in a class layout as the
+    // instanceStart.
+    ByteOffset = byteOffset.getValue();
     Index = 0; // make a complete write of the bitfield
   }
 
@@ -187,7 +191,8 @@ public:
 
   /// Given that this element has a fixed offset, return that offset in bytes.
   Size getByteOffset() const {
-    assert(isCompleted() && getKind() == Kind::Fixed);
+    assert(isCompleted() &&
+           (getKind() == Kind::Fixed || getKind() == Kind::Empty));
     return Size(ByteOffset);
   }
 

--- a/test/IRGen/objc_class_empty_fields.swift
+++ b/test/IRGen/objc_class_empty_fields.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+
+// SR-1055
+
+// CHECK-64: @_DATA__TtC23objc_class_empty_fields14OneEnumWrapper = private constant { {{.*}}* } { i32 {{[0-9]+}}, i32 16, i32 24
+// CHECK-32: @_DATA__TtC23objc_class_empty_fields14OneEnumWrapper = private constant { {{.*}}* } { i32 {{[0-9]+}}, i32 12, i32 16
+
+enum OneCaseEnum {
+    case X
+}
+
+class OneEnumWrapper {
+    var myVar: OneCaseEnum
+    var whyVar: OneCaseEnum
+    var x: Int
+
+    init(v: OneCaseEnum)
+    {
+        self.myVar = v
+        self.whyVar = v
+        self.x = 0
+    }
+}
+
+let e = OneCaseEnum.X
+print(e)
+let x = OneEnumWrapper(v: e)
+print(x)


### PR DESCRIPTION
Give empty fields a notional byte offset so we can still use the offset of the first field as an approximation of the instanceStart of a class.

Fixes SR-1055.
