### PR TITLE
[stdlib] Return constant for infinity and NaN to string conversion

### DIFF
--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -361,6 +361,17 @@ func _float${bits}ToStringImpl(
 
 @warn_unused_result
 func _float${bits}ToString(value: Float${bits}, debug: Bool) -> String {
+
+% # FIXME: support Float80
+% if bits != 80:
+  if value.isInfinite {
+    return value.isSignMinus ? "-inf" : "inf"
+  }
+  if value.isNaN {
+    return "nan"
+  }
+% end
+
   _sanityCheck(sizeof(_Buffer32.self) == 32)
   _sanityCheck(sizeof(_Buffer72.self) == 72)
 

--- a/test/1_stdlib/PrintFloat.swift
+++ b/test/1_stdlib/PrintFloat.swift
@@ -4,10 +4,13 @@
 // RUN: %target-run %t/main.out
 // RUN: %target-run %t/main.out --locale ru_RU.UTF-8
 // REQUIRES: executable_test
-// XFAIL: linux
 
 import StdlibUnittest
-import Darwin
+#if os(Linux) || os(FreeBSD)
+  import Glibc
+#else
+  import Darwin
+#endif
 import PrintTestTypes
 
 // Also import modules which are used by StdlibUnittest internally. This
@@ -58,6 +61,7 @@ PrintTests.test("Printable") {
   expectPrinted("inf", Float.infinity)
   expectPrinted("-inf", -Float.infinity)
   expectPrinted("nan", Float.nan)
+  expectPrinted("nan", -Float.nan)
   expectPrinted("0.0", asFloat32(0.0))
   expectPrinted("1.0", asFloat32(1.0))
   expectPrinted("-1.0", asFloat32(-1.0))
@@ -67,6 +71,7 @@ PrintTests.test("Printable") {
   expectPrinted("inf", Double.infinity)
   expectPrinted("-inf", -Double.infinity)
   expectPrinted("nan", Double.nan)
+  expectPrinted("nan", -Double.nan)
   expectPrinted("0.0", asFloat64(0.0))
   expectPrinted("1.0", asFloat64(1.0))
   expectPrinted("-1.0", asFloat64(-1.0))

--- a/test/1_stdlib/tgmath.swift
+++ b/test/1_stdlib/tgmath.swift
@@ -130,7 +130,7 @@ MathTests.test("Unary functions") {
   expectEqual("tan 0.100334672085451 0.100335 tan", print3("tan", d1, f1, g1))
 
   (d1, f1, g1) = (acosh(dx), acosh(fx), acosh(gx))
-  expectEqual("acosh true true acosh", print3("acosh", d1.isNaN, f1.isNaN, g1.isNaN))
+  expectEqual("acosh nan nan acosh", print3("acosh", d1, f1, g1))
 
   (d1, f1, g1) = (asinh(dx), asinh(fx), asinh(gx))
   expectEqual("asinh 0.0998340788992076 0.0998341 asinh",


### PR DESCRIPTION
#### What's in this pull request?

`Float` / `Double` to `String` conversions are implemented with standard C `sprintf` family function, that outputs infinity and NaN in implementation-defined way. Thus, platform-dependent.
For better compatibility, this PR guarantees:

``` swift
expectPrinted("inf", Double.infinity)
expectPrinted("-inf", -Double.infinity)
expectPrinted("nan", Double.nan)
expectPrinted("nan", -Double.nan)
```
#### Resolved bug number: N/A

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
