### PR TITLE
SIL devirtualization: Conservatively avoid filtering devirt candidates on generic base classes.

### DIFF
--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -377,8 +377,16 @@ static bool tryToSpeculateTarget(FullApplySite AI,
             return false;
           // Handle the usual case here: the class in question
           // should be a real subclass of a bound generic class.
-          return !ClassType.isSuperclassOf(
-              SILType::getPrimitiveObjectType(SubCanTy));
+          // FIXME: `isSuperclassOf` is the wrong check for a generic class,
+          // since a subclass may inherit a more specific instantiation of the
+          // generic, as in:
+          //   class Base<T> {}
+          //   class Sub: Base<Int> {}
+          //   class Sub2<U: Foo>: Base<U> {}
+          // This is more comprehensively fixed in Swift 3. As a spot fix for
+          // Swift 2.2, avoid filtering subclasses of generic bases.
+          return !ClassType.is<BoundGenericType>() &&
+            !ClassType.isSuperclassOf(SILType::getPrimitiveObjectType(SubCanTy));
         });
     Subs.erase(RemovedIt, Subs.end());
   }

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -73,8 +73,16 @@ static void getAllSubclasses(ClassHierarchyAnalysis *CHA,
             return false;
           // Handle the usual case here: the class in question
           // should be a real subclass of a bound generic class.
-          return !ClassType.isSuperclassOf(
-              SILType::getPrimitiveObjectType(SubCanTy));
+          // FIXME: `isSuperclassOf` is the wrong check for a generic class,
+          // since a subclass may inherit a more specific instantiation of the
+          // generic, as in:
+          //   class Base<T> {}
+          //   class Sub: Base<Int> {}
+          //   class Sub2<U: Foo>: Base<U> {}
+          // This is more comprehensively fixed in Swift 3. As a spot fix for
+          // Swift 2.2, avoid filtering subclasses of generic bases.
+          return !ClassType.is<BoundGenericType>() &&
+            !ClassType.isSuperclassOf(SILType::getPrimitiveObjectType(SubCanTy));
         });
     Subs.erase(RemovedIt, Subs.end());
   }

--- a/test/Interpreter/classes.swift
+++ b/test/Interpreter/classes.swift
@@ -170,3 +170,23 @@ print((b as Bank).transferMoney(Account(owner: "A"), to: Account(owner: "B")))
 print((b as Bank).transferMoney(nil, to: nil))
 print((b as Bank).deposit(Account(owner: "Cyberdyne Systems")))
 print((b as Bank).deposit(Account(owner: "A")))
+
+// rdar://25412647
+
+private class Parent <T> {
+    func doSomething() {
+        overriddenMethod()
+    }
+
+    func overriddenMethod() {
+        fatalError("You should override this method in child class")
+    }
+}
+
+private class Child: Parent<String> {
+    override func overriddenMethod() {
+        print("Heaven!")
+    }
+}
+
+Child().doSomething() // CHECK: Heaven!

--- a/test/SILOptimizer/devirt_concrete_subclass_of_generic_class.swift
+++ b/test/SILOptimizer/devirt_concrete_subclass_of_generic_class.swift
@@ -56,3 +56,84 @@ print(test3())
 print(test4(Derived()))
 
 print(test5(Derived()))
+
+// Check that we handle indirect devirtualization through an intermediate
+// method. rdar://problem/24993618
+
+private class IndirectMethodCall<T> {
+    func bug() {
+        overrideMe()
+    }
+    
+    @inline(never)
+    func overrideMe() { }
+}
+
+private class IndirectChildConcrete: IndirectMethodCall<Int> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+private class IndirectChildTuple<U>: IndirectMethodCall<(U, U)> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+private class IndirectChildTupleConcrete: IndirectChildTuple<Int> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+private class IndirectChildMeta<U>: IndirectMethodCall<U.Type> {
+    @inline(never)
+    override func overrideMe() { }
+}
+private class IndirectChildMetaConcrete: IndirectChildMeta<Int> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+private class IndirectChildBoundGeneric<U>: IndirectMethodCall<Array<U>> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+private class IndirectChildBoundGenericConcrete:
+      IndirectChildBoundGeneric<Int> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+private class IndirectChildFunction<U>: IndirectMethodCall<U -> U> {
+    @inline(never)
+    override func overrideMe() { }
+}
+private class IndirectChildFunctionConcrete: IndirectChildFunction<Int> {
+    @inline(never)
+    override func overrideMe() { }
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}test6
+@inline(never)
+func test6() {
+  // CHECK: function_ref @{{.*}}IndirectChildConcrete{{.*}}overrideMe
+  IndirectChildConcrete().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildTuple{{.*}}overrideMe
+  IndirectChildTuple<Int>().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildTupleConcrete{{.*}}overrideMe
+  IndirectChildTupleConcrete().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildMeta{{.*}}overrideMe
+  IndirectChildMeta<Int>().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildMetaConcrete{{.*}}overrideMe
+  IndirectChildMetaConcrete().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildBoundGeneric{{.*}}overrideMe
+  IndirectChildBoundGeneric<Int>().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildBoundGenericConcrete{{.*}}overrideMe
+  IndirectChildBoundGenericConcrete().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildFunction{{.*}}overrideMe
+  IndirectChildFunction<Int>().bug()
+  // CHECK: function_ref @{{.*}}IndirectChildFunctionConcrete{{.*}}overrideMe
+  IndirectChildFunctionConcrete().bug()
+}
+
+print(test6())


### PR DESCRIPTION
This is more comprehensively (but invasively) fixed in master by 77dd9b29920f5e161a1ec4cc0daac4a26aa6c78a. As a spot fix for 2.2, make devirt more conservative by not filtering devirt candidates on generic base classes at all. Fixes rdar://problem/25412647.
