### PR TITLE
Make Array's conformance to RangeReplaceableCollection visible

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -489,7 +489,7 @@ public func _deallocateUninitialized${Self}<Element>(
 }
 %end
 
-extension ${Self} : _ArrayProtocol {
+extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// Construct an empty ${Self}.
   @_semantics("array.init")
   public init() {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This adds explicit `RangeReplaceableCollection` conformance to `Array`, `ContiguousArray`, and `ArraySlice`. These types already conform to the protocol by way of `_ArrayProtocol`, but that conformance is hidden in the generated header for the standard library. This change has no other effects, as far as I can tell.
#### Resolved bug number: [SR-984](https://bugs.swift.org/browse/SR-984)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
