### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -141,7 +141,7 @@ public func spawnChild(args: [String])
 }
 
 internal func _make_posix_spawn_file_actions_t() -> posix_spawn_file_actions_t {
-#if os(Linux) || os(FreeBSD)
+#if os(Linux)
   return posix_spawn_file_actions_t()
 #else
   return nil

--- a/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
+++ b/stdlib/private/SwiftPrivatePthreadExtras/SwiftPrivatePthreadExtras.swift
@@ -82,7 +82,7 @@ public func _stdlib_pthread_create_block<Argument, Result>(
 }
 
 internal func _make_pthread_t() -> pthread_t {
-#if os(Linux) || os(FreeBSD)
+#if os(Linux)
   return pthread_t()
 #else
   return nil


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Fix _make_posix_spawn_file_actions_t and _make_pthread_t functions for FreeBSD. On FreBSD pthread_t and posix_spawn_file_actions_t are opaque pointers so they should be initialized with nil as on Darwin

<!-- Description about pull request. -->

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
