### PR TITLE
Build the Swift runtime using the locally built clang compliler.

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -1,4 +1,8 @@
 # Create convenience targets for the Swift standard library.
+
+set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
+set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+
 add_custom_target(swift-stdlib-all)
 foreach(SDK ${SWIFT_SDKS})
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}")

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -258,8 +258,7 @@ extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
 // This implementation is copied here to avoid a new dependency
 // on compiler-rt on Linux.
 // FIXME: rdar://14883575 Libcompiler_rt omits muloti4
-#if (defined(__APPLE__) && defined(__arm64__)) || \
-    (defined(__linux__) && defined(__x86_64__)) || \
+#if (defined(__linux__) && defined(__x86_64__)) || \
     (defined(__linux__) && defined(__aarch64__)) || \
     (defined(__linux__) && defined(__powerpc64__))
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2083,7 +2083,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             BUILT_CXX_INCLUDE_DIR="$llvm_build_dir/include"
 
             echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
-            ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR/c++"
+            ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR"
 
             { set +x; } 2>/dev/null
         fi

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2068,21 +2068,24 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
 
         # When we are building LLVM create symlinks to the c++ headers.
         if [[ "${product}" == "llvm" ]]; then
+            set -x
 
-          # Find the location of the c++ header dir.
-          if [[ "$(uname -s)" == "Darwin" ]] ; then
-            HOST_CXX_DIR=$(dirname ${HOST_CXX})
-            HOST_CXX_HEADERS_DIR="$HOST_CXX_DIR/../../usr/include/c++"
-          else # Linux
-            HOST_CXX_HEADERS_DIR="/usr/include/c++"
-          fi
+            # Find the location of the c++ header dir.
+            if [[ "$(uname -s)" == "Darwin" ]] ; then
+              HOST_CXX_DIR=$(dirname ${HOST_CXX})
+              HOST_CXX_HEADERS_DIR="$HOST_CXX_DIR/../../usr/include/c++"
+            else # Linux
+              HOST_CXX_HEADERS_DIR="/usr/include/c++"
+            fi
 
-          # Find the path in which the local clang build is expecting to find
-          # the c++ header files.
-          BUILT_CXX_INCLUDE_DIR="$llvm_build_dir/include"
+            # Find the path in which the local clang build is expecting to find
+            # the c++ header files.
+            BUILT_CXX_INCLUDE_DIR="$llvm_build_dir/include"
 
-          echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
-          ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR/c++"
+            echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
+            ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR/c++"
+
+            { set +x; } 2>/dev/null
         fi
     done
 done

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2065,6 +2065,25 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product}) -- ${BUILD_ARGS} ${build_targets[@]}
             { set +x; } 2>/dev/null
         fi
+
+        # When we are building LLVM create symlinks to the c++ headers.
+        if [[ "${product}" == "llvm" ]]; then
+
+          # Find the location of the c++ header dir.
+          if [[ "$(uname -s)" == "Darwin" ]] ; then
+            HOST_CXX_DIR=$(dirname ${HOST_CXX})
+            HOST_CXX_HEADERS_DIR="$HOST_CXX_DIR/../../usr/include/c++"
+          else # Linux
+            HOST_CXX_HEADERS_DIR="/usr/include/c++"
+          fi
+
+          # Find the path in which the local clang build is expecting to find
+          # the c++ header files.
+          BUILT_CXX_INCLUDE_DIR="$llvm_build_dir/include"
+
+          echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
+          ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR/c++"
+        fi
     done
 done
 # END OF BUILD PHASE
@@ -2568,3 +2587,4 @@ if [[ "${INSTALLABLE_PACKAGE}" ]] ; then
         { set +x; } 2>/dev/null
     fi
 fi
+


### PR DESCRIPTION
 Build the Swift runtime using the locally built clang compliler.

```
This commit makes the swift build scripts use the clang that we build as part of
the build process in order to build the Swift runtime, and not the host
compiler. This change is necessary for using new clang features immediately after they are introduced.
One example for such feature is new function calling conventions, or new c-level attributes.
```
