### PR TITLE
[Swift 2.2.1] CodeFormat: Correctly indenting the end of closures

### DIFF
--- a/test/SourceKit/CodeFormat/indent-closure.swift
+++ b/test/SourceKit/CodeFormat/indent-closure.swift
@@ -23,6 +23,15 @@ func foo3() {
   }
 }
 
+func foo4() {
+    test = {
+        return 0
+    }()
+    let test = {
+        return 0
+    }()
+}
+
 // RUN: %sourcekitd-test -req=format -line=3 -length=1 %s >%t.response
 // RUN: %sourcekitd-test -req=format -line=4 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >>%t.response
@@ -31,6 +40,12 @@ func foo3() {
 // RUN: %sourcekitd-test -req=format -line=8 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=14 -length=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=22 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=27 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=28 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=29 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=30 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=31 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=32 -length=1 %s >>%t.response
 // RUN: FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "        var abc = 1"
@@ -44,3 +59,12 @@ func foo3() {
 // CHECK: key.sourcetext: "  }()"
 //                        "  foo1(1)"
 // CHECK: key.sourcetext: "  {"
+
+// CHECK: key.sourcetext: "    test = {"
+// CHECK: key.sourcetext: "        return 0"
+// CHECK: key.sourcetext: "    }()"
+
+
+// CHECK: key.sourcetext: "    let test = {"
+// CHECK: key.sourcetext: "        return 0"
+// CHECK: key.sourcetext: "    }()"

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1822,6 +1822,13 @@ public:
         if (Loc.isValid() && SM.getLineNumber(Loc) == Line) {
           return false;
         }
+      } else if (auto *Seq = dyn_cast_or_null<SequenceExpr>(Cursor->getAsExpr())) {
+        ArrayRef<Expr*> Elements = Seq->getElements();
+        if (Elements.size() == 3 &&
+            Elements[1]->getKind() == ExprKind::Assign &&
+            SM.getLineAndColumn(Elements[2]->getEndLoc()).first == Line) {
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This fixed an issue that we add an extra level of indentation at the end of a closure when the closure appears at the RHS of an assignment expression. rdar://25423245
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…sure is on the RHS of an assignment expression. rdar://24507930
