### PR TITLE
IRGen: Imported protocol extensions

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1254,7 +1254,6 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
 /// Generic functions and protocol witnesses carry polymorphic parameters.
 bool irgen::hasPolymorphicParameters(CanSILFunctionType ty) {
   switch (ty->getRepresentation()) {
-  case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Block:
     // Should never be polymorphic.
     assert(!ty->isPolymorphic() && "polymorphic C function?!");
@@ -1265,6 +1264,7 @@ bool irgen::hasPolymorphicParameters(CanSILFunctionType ty) {
   case SILFunctionTypeRepresentation::Method:
     return ty->isPolymorphic();
 
+  case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::ObjCMethod:
     // May be polymorphic at the SIL level, but no type metadata is actually
     // passed.

--- a/test/IDE/Inputs/custom-modules/ImportAsMemberProto.h
+++ b/test/IDE/Inputs/custom-modules/ImportAsMemberProto.h
@@ -17,8 +17,11 @@ typedef NSObject<IAMProto> * IAMProto_t;
 void mutateSomeState(IAMProto_t)
 __attribute__((swift_name("IAMProto.mutateSomeState(self:)")));
 
-void mutateSomeStateWithOtherProto(IAMProto_t, IAMProto_t other)
-__attribute__((swift_name("IAMProto.mutateSomeState(self:otherProto:)")));
+void mutateSomeStateWithParameter(IAMProto_t, NSInteger)
+__attribute__((swift_name("IAMProto.mutateSomeState(self:withParameter:)")));
+
+void mutateSomeStateWithFirstParameter(NSInteger, IAMProto_t)
+__attribute__((swift_name("IAMProto.mutateSomeState(withFirstParameter:self:)")));
 
 int getSomeValue(IAMProto_t)
 __attribute__((swift_name("getter:IAMProto.someValue(self:)")));

--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -58,7 +58,8 @@
 // PRINT-PROTO-NEXT:  typealias IAMProto_t = IAMProto
 // PRINT-PROTO-NEXT:  extension IAMProto {
 // PRINT-PROTO-NEXT:    func mutateSomeState()
-// PRINT-PROTO-NEXT:    func mutateSomeState(otherProto other: IAMProto_t!)
+// PRINT-PROTO-NEXT:    func mutateSomeState(withParameter _: Int)
+// PRINT-PROTO-NEXT:    func mutateSomeState(withFirstParameter _: Int)
 // PRINT-PROTO-NEXT:    var someValue: Int32
 // PRINT-PROTO-NEXT:  }
 

--- a/test/IRGen/cf_members.sil
+++ b/test/IRGen/cf_members.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir -verify -I %S/../IDE/Inputs/custom-modules %s
+// REQUIRES: objc_interop
 
 sil_stage canonical
 
@@ -9,6 +10,7 @@ import ImportAsMember
 sil @IAMStruct1CreateSimple : $@convention(c) () -> Struct1
 sil @IAMStruct1Rotate : $@convention(c) (@in Struct1, Double) -> Struct1
 sil @IAMStruct1SetAltitude : $@convention(c) (@inout Struct1, Double) -> ()
+sil @mutateSomeState : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0) -> ()
 
 sil @invoke_methods : $@convention(thin) (Double) -> () {
 entry(%z : $Double):
@@ -21,5 +23,16 @@ entry(%z : $Double):
   %f = function_ref @IAMStruct1SetAltitude : $@convention(c) (@inout Struct1, Double) -> ()
   apply %f(%c, %z) : $@convention(c) (@inout Struct1, Double) -> ()
   dealloc_stack %c : $*Struct1
+  return undef : $()
+}
+
+// CHECK-LABEL: define void @invoke_protocol_methods(%objc_object*)
+sil @invoke_protocol_methods : $@convention(thin) (IAMProto) -> () {
+entry(%z : $IAMProto):
+  %a = open_existential_ref %z : $IAMProto to $@opened("01234567-89AB-CDEF-0123-000000000000") IAMProto
+  %b = function_ref @mutateSomeState : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0) -> ()
+  // CHECK: [[CAST:%.*]] = bitcast %objc_object* %0 to i8*
+  // CHECK: call void @mutateSomeState(i8* [[CAST]])
+  apply %b<@opened("01234567-89AB-CDEF-0123-000000000000") IAMProto>(%a) : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0) -> ()
   return undef : $()
 }

--- a/test/Interpreter/classes.swift
+++ b/test/Interpreter/classes.swift
@@ -170,3 +170,23 @@ print((b as Bank).transferMoney(Account(owner: "A"), to: Account(owner: "B")))
 print((b as Bank).transferMoney(nil, to: nil))
 print((b as Bank).deposit(Account(owner: "Cyberdyne Systems")))
 print((b as Bank).deposit(Account(owner: "A")))
+
+// rdar://25412647
+
+private class Parent <T> {
+    func doSomething() {
+        overriddenMethod()
+    }
+
+    func overriddenMethod() {
+        fatalError("You should override this method in child class")
+    }
+}
+
+private class Child: Parent<String> {
+    override func overriddenMethod() {
+        print("Heaven!")
+    }
+}
+
+Child().doSomething() // CHECK: Heaven!

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -237,3 +237,17 @@ public func bar(x: Double) {
   c()
 }
 
+// CHECK-LABEL: sil @_TF10cf_members16importAsProtocolFPSo8IAMProto_T_
+public func importAsProtocol(x: IAMProto_t) {
+  // CHECK: function_ref @mutateSomeState : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0) -> ()
+  x.mutateSomeState()
+  // CHECK: function_ref @mutateSomeStateWithParameter : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0, Int) -> ()
+  x.mutateSomeState(withParameter: 0)
+  // CHECK: function_ref @mutateSomeStateWithFirstParameter : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (Int, τ_0_0) -> ()
+  x.mutateSomeState(withFirstParameter: 0)
+
+  // CHECK: function_ref @getSomeValue : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0) -> Int32
+  let y = x.someValue
+  // CHECK: function_ref @setSomeValue : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0, Int32) -> Int32
+  x.someValue = y
+}


### PR DESCRIPTION
Fix crashes when calling C functions imported as protocol extension methods.
