### PR TITLE
Fix FreeBSD build: link with libexecinfo, fix Runtime/Mutex.h

### DIFF
--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -17,7 +17,7 @@
 #ifndef SWIFT_RUNTIME_MUTEX_H
 #define SWIFT_RUNTIME_MUTEX_H
 
-#if (defined(__APPLE__) || defined(__linux__) || defined(__CYGWIN__))
+#if (defined(__APPLE__) || defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD__))
 #define SWIFT_RUNTIME_MUTEX_HAVE_PHTREADS
 #else
 #error "Must implement the following if your platform doesn't support phtreads."

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -167,6 +167,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
   list(APPEND swift_core_link_flags "${ENV_SYSTEMROOT}/system32/psapi.dll")
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  find_library(EXECINFO_LIBRARY execinfo)
+  list(APPEND swift_core_private_link_libraries
+      ${EXECINFO_LIBRARY})
+endif()
+
 option(SWIFT_CHECK_ESSENTIAL_STDLIB
     "Check core standard library layering by linking its essential subset"
     FALSE)

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -16,6 +16,11 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
       swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
       swiftStdlibUnittest${SWIFT_PRIMARY_VARIANT_SUFFIX}
       )
+  elseif(SWIFT_HOST_VARIANT STREQUAL "freebsd")
+    find_library(EXECINFO_LIBRARY execinfo)
+    list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
+      ${EXECINFO_LIBRARY}
+      )
   endif()
 
   add_swift_unittest(SwiftRuntimeTests


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

This pull request fixes two more build breakages on FreeBSD introduced recently:
- Add FreeBSD to the list of platforms with pthread support in Runtime/Mutex.h
- Link core library with libexecinfo which is required for backtrace_symbols
- Link unit tests runtime with libexecinfo for the same reason

<!-- Description about pull request. -->

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
