### PR TITLE
[CodeSize] remove transparent attribute from bridgeing function.

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -73,7 +73,6 @@ func _convertConstArrayToPointerArgument<
 }
 
 /// Derive a UTF-8 pointer argument from a value string parameter.
-@_transparent
 @warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertConstStringToUTF8PointerArgument<


### PR DESCRIPTION
@swift-ci Please test
