### PR TITLE
[Swift 2.2.1] Mangle private discriminators into typealias names.

### DIFF
--- a/lib/AST/Mangle.cpp
+++ b/lib/AST/Mangle.cpp
@@ -964,18 +964,17 @@ void Mangler::mangleType(Type type, unsigned uncurryLevel) {
     assert(DWARFMangling && "sugared types are only legal for the debugger");
     auto NameAliasTy = cast<NameAliasType>(tybase);
     TypeAliasDecl *decl = NameAliasTy->getDecl();
-    if (decl->getModuleContext() == decl->getASTContext().TheBuiltinModule)
+    if (decl->getModuleContext() == decl->getASTContext().TheBuiltinModule) {
       // It's not possible to mangle the context of the builtin module.
       return mangleType(decl->getUnderlyingType(), uncurryLevel);
+    }
     
     Buffer << "a";
     // For the DWARF output we want to mangle the type alias + context,
     // unless the type alias references a builtin type.
     ContextStack context(*this);
-    while (DeclCtx && !DeclCtx->isInnermostContextGeneric())
-      DeclCtx = DeclCtx->getParent();
     mangleContextOf(decl, BindGenerics::None);
-    mangleIdentifier(decl->getName());
+    mangleDeclName(decl);
     return;
   }
 

--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -4,16 +4,22 @@ func markUsed<T>(t: T) {}
 
 class DWARF {
 // CHECK-DAG: ![[DIEOFFSET:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtaC9typealias5DWARF9DIEOffset",{{.*}} line: [[@LINE+1]], baseType: !"_TtVs6UInt32")
-    typealias DIEOffset = UInt32
+  typealias DIEOffset = UInt32
+  // CHECK-DAG: ![[PRIVATETYPE:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtaC9typealias5DWARFP{{.+}}11PrivateType",{{.*}} line: [[@LINE+1]], baseType: !"_TtT_")
+  private typealias PrivateType = ()
+  private static func usePrivateType() -> PrivateType { return () }
 }
 
 func main () {
   // CHECK-DAG: !DILocalVariable(name: "a",{{.*}} type: ![[DIEOFFSET]]
-    var a : DWARF.DIEOffset = 123
-    markUsed("a is \(a)")
+  var a : DWARF.DIEOffset = 123
+  markUsed(a)
   // CHECK-DAG: !DILocalVariable(name: "b",{{.*}} type: ![[DIEOFFSET]]
-    var b = DWARF.DIEOffset(456) as DWARF.DIEOffset
-    markUsed("b is \(b)")
+  var b = DWARF.DIEOffset(456) as DWARF.DIEOffset
+  markUsed(b)
+  
+  // CHECK-DAG: !DILocalVariable(name: "c",{{.*}} type: ![[PRIVATETYPE]]
+  let c = DWARF.usePrivateType()
 }
 
 main();

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -180,6 +180,7 @@ _TF8manglingoi2qqFTSiSi_T_ ---> mangling.?? infix (Swift.Int, Swift.Int) -> ()
 _TFE11ext_structAV11def_structA1A4testfT_T_ ---> (extension in ext_structA):def_structA.A.test () -> ()
 _TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> devirt_access.(getPrivateClass in _DISC) () -> devirt_access.(PrivateClass in _DISC)
 _TF4mainP5_mainX3wxaFT_T_ ---> main.(λ in _main) () -> ()
+_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> main.(abc in _main) () -> main.(xyz in _DISC)
 _TtPMP_ ---> protocol<>.Type
 _TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> Swift._NSSwiftArray.canStoreElementsOfDynamicType (protocol<>.Type) -> Swift.Bool
 _TFCs13_NSSwiftArrayg17staticElementTypePMP_ ---> Swift._NSSwiftArray.staticElementType.getter : protocol<>.Type

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -167,6 +167,7 @@ _TF8manglingoi2qqFTSiSi_T_ ---> ?? infix(Int, Int) -> ()
 _TFE11ext_structAV11def_structA1A4testfT_T_ ---> A.test() -> ()
 _TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> (getPrivateClass in _DISC)() -> (PrivateClass in _DISC)
 _TF4mainP5_mainX3wxaFT_T_ ---> (λ in _main)() -> ()
+_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> (abc in _main)() -> (xyz in _DISC)
 _TtPMP_ ---> protocol<>.Type
 _TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> _NSSwiftArray.canStoreElementsOfDynamicType(protocol<>.Type) -> Bool
 _TFCs13_NSSwiftArrayg17staticElementTypePMP_ ---> _NSSwiftArray.staticElementType.getter

--- a/test/Demangle/lookup.swift
+++ b/test/Demangle/lookup.swift
@@ -15,6 +15,8 @@
 // RUN: not %target-swift-ide-test -source-filename=%s -print-ast-typechecked -find-mangled=_TtCC14swift_ide_test5OuterP1_12PrivateInner
 // RUN: %target-swift-ide-test -source-filename=%s -print-ast-typechecked -find-mangled=_TtCC14swift_ide_test5OuterP33_5CB4BCC03C4B9CB2AEEDDFF10FE7BD1E12PrivateInner
 // RUN: %target-swift-ide-test -source-filename=%s -print-ast-typechecked -find-mangled=_TtCC14swift_ide_testP33_5CB4BCC03C4B9CB2AEEDDFF10FE7BD1E12PrivateOuter5Inner
+// RUN: %target-swift-ide-test -source-filename=%s -print-ast-typechecked -find-mangled=_Tta14swift_ide_testP33_5CB4BCC03C4B9CB2AEEDDFF10FE7BD1E16PrivateTypealias
+// RUN: %target-swift-ide-test -source-filename=%s -print-ast-typechecked -find-mangled=_TtaC14swift_ide_test5OuterP33_5CB4BCC03C4B9CB2AEEDDFF10FE7BD1E16PrivateTypealias
 
 // RUN: %target-swiftc_driver -emit-module -o %t %s %S/Inputs/lookup_other.swift -module-name Lookup
 // RUN: echo 'import Lookup' > %t/test.swift
@@ -31,9 +33,12 @@ private struct PrivateStruct {
   let fromMainFile: Int
 }
 
+private typealias PrivateTypealias = Int
+
 class Outer {
   class Inner {}
   private class PrivateInner {}
+  private typealias PrivateTypealias = Int
 }
 
 private class PrivateOuter {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1360,9 +1360,10 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
   case NodeKind::Enum:
   case NodeKind::Protocol:
   case NodeKind::Structure:
+  case NodeKind::TypeAlias:
     break;
   default:
-    llvm::errs() << "Name does not refer to a nominal type.\n";
+    llvm::errs() << "Name does not refer to a nominal type or typealias.\n";
     return EXIT_FAILURE;
   }
 
@@ -1370,17 +1371,6 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
 
   SmallVector<std::pair<DeclName, Identifier>, 4> identifiers;
   do {
-    switch (node->getKind()) {
-    case NodeKind::Class:
-    case NodeKind::Enum:
-    case NodeKind::Protocol:
-    case NodeKind::Structure:
-      break;
-    default:
-      llvm::errs() << "Name does not refer to a nominal type.\n";
-      return EXIT_FAILURE;
-    }
-
     auto nameNode = node->getChild(1);
     switch (nameNode->getKind()) {
     case NodeKind::Identifier:
@@ -1399,6 +1389,20 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
     }
 
     node = node->getChild(0);
+
+    switch (node->getKind()) {
+    case NodeKind::Module:
+      // Will break out of loop below.
+      break;
+    case NodeKind::Class:
+    case NodeKind::Enum:
+    case NodeKind::Protocol:
+    case NodeKind::Structure:
+      break;
+    default:
+      llvm::errs() << "Name does not refer to a nominal type.\n";
+      return EXIT_FAILURE;
+    }
   } while (node->getKind() != NodeKind::Module);
 
   Module *M = getModuleByFullName(ctx, node->getText());


### PR DESCRIPTION
Fix an issue where we generated incorrect debug info for private and local typealiases, leading to LLDB not understanding values with those types.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
