### PR TITLE
[Frontend] Nicer assert when -dump-parse foo.sil

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -531,7 +531,8 @@ void CompilerInstance::performParseOnly() {
   Module *MainModule = getMainModule();
   Context->LoadedModules[MainModule->getName()] = MainModule;
 
-  assert(Kind == InputFileKind::IFK_Swift || Kind == InputFileKind::IFK_Swift_Library);
+  assert((Kind == InputFileKind::IFK_Swift || Kind == InputFileKind::IFK_Swift_Library) &&
+    "only supports parsing a single .swift file");
   assert(BufferIDs.size() == 1 && "only supports parsing a single file");
 
   if (Kind == InputFileKind::IFK_Swift)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Invoking the following command to `-dump-parse` a file containing SIL triggers an assertion from within the Swift compiler frontend:

```
swiftc -dump-parse foo.sil
```

The assertion is not coupled with a description of what went wrong. It turns out the frontend doesn't support `-dump-parse` for SIL files, although `swiftc -help` wouldn't inform users of that:

```
-dump-parse      Parse input file(s) and dump AST(s)
```

As a result, a user may invoke `-dump-parse` on a SIL file and not know what went wrong. Add an assertion message to inform the user that only Swift code may be parsed. (`IFK_Swift_Library` here is for the case where `swiftc -parse-as-library -dump-parse foo.swift` is invoked.)
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
