### PR TITLE
Fix IOKit dependencies in swift 2.2

### DIFF
--- a/stdlib/public/SDK/CoreAudio/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreAudio/CMakeLists.txt
@@ -2,7 +2,7 @@ add_swift_library(swiftCoreAudio IS_SDK_OVERLAY
   CoreAudio.swift
 
   TARGET_SDKS OSX IOS IOS_SIMULATOR TVOS TVOS_SIMULATOR
-  SWIFT_MODULE_DEPENDS Dispatch
-  # Also depends on: CoreFoundation IOKit
+  SWIFT_MODULE_DEPENDS Dispatch IOKit
+  # Also depends on: CoreFoundation
   FRAMEWORK_DEPENDS CoreAudio)
 

--- a/stdlib/public/SDK/CoreGraphics/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreGraphics/CMakeLists.txt
@@ -4,6 +4,6 @@ add_swift_library(swiftCoreGraphics IS_SDK_OVERLAY
   CoreGraphicsMirrors.swift.gyb
   # rdar://problem/20891746
   # SWIFT_COMPILE_FLAGS -Xfrontend -sil-serialize-all
-  SWIFT_MODULE_DEPENDS ObjectiveC Dispatch Darwin
+  SWIFT_MODULE_DEPENDS ObjectiveC Dispatch Darwin IOKit
   FRAMEWORK_DEPENDS CoreGraphics)
 

--- a/stdlib/public/SDK/IOKit/CMakeLists.txt
+++ b/stdlib/public/SDK/IOKit/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_swift_library(swiftIOKit IS_SDK_OVERLAY
   IOKit.swift
   TARGET_SDKS OSX
+  SWIFT_MODULE_DEPENDS ObjectiveC
   FRAMEWORK_DEPENDS IOKit)

--- a/stdlib/public/SDK/IOKit/CMakeLists.txt
+++ b/stdlib/public/SDK/IOKit/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_swift_library(swiftIOKit IS_SDK_OVERLAY
   IOKit.swift
   TARGET_SDKS OSX
-  SWIFT_MODULE_DEPENDS ObjectiveC
+  SWIFT_MODULE_DEPENDS ObjectiveC Dispatch
   FRAMEWORK_DEPENDS IOKit)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This fixes the build after #1942 .  That pull request was missing two fixes to the IOKit dependencies, which causes builds to fail to link non-deterministically.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
