### PR TITLE
stdlib: update syntax for @availability

### DIFF
--- a/stdlib/public/SDK/PassKit/PassKit.swift
+++ b/stdlib/public/SDK/PassKit/PassKit.swift
@@ -1,7 +1,7 @@
 @_exported import PassKit
 import Foundation
 
-@available(iOS, introduced=6.0)
+@available(iOS, introduced: 6.0)
 extension PKPassKitErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return PKPassKitErrorDomain }
 }

--- a/stdlib/public/SDK/WatchConnectivity/WatchConnectivity.swift
+++ b/stdlib/public/SDK/WatchConnectivity/WatchConnectivity.swift
@@ -1,7 +1,7 @@
 @_exported import WatchConnectivity
 import Foundation
 
-@available(iOS, introduced=9.0)
+@available(iOS, introduced: 9.0)
 extension WCErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return WCErrorDomain }
 }

--- a/stdlib/public/SDK/WatchKit/WatchKit.swift
+++ b/stdlib/public/SDK/WatchKit/WatchKit.swift
@@ -18,7 +18,7 @@ extension WatchKitErrorCode : _BridgedNSError {
   public static var _nsErrorDomain: String { return WatchKitErrorDomain }
 }
 
-@available(iOS, introduced=8.2)
+@available(iOS, introduced: 8.2)
 extension WKInterfaceController {
   // Swift convenience type (class) method for
   // reloadRootControllersWithNames:contexts: that takes an array of tuples


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

The iPhoneOS SDK was not updated with the associated syntax change in the
language.  This cleans up the deprecation warnings in the iPhoneOS stdlib build.
NFC.
