### PR TITLE
Add a test for rdar://21775089, which is fixed now

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0042-rdar21775089.swift
+++ b/validation-test/compiler_crashers_2_fixed/0042-rdar21775089.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend %s -emit-ir
+
+struct MySlice<Base : MyIndexableType> : MyCollectionType {}
+struct MyMutableSlice<Base : MyMutableCollectionType> : MyMutableCollectionType {}
+
+protocol MySequenceType {}
+protocol MyIndexableType {}
+
+protocol MyCollectionType : MySequenceType, MyIndexableType {
+  typealias SubSequence = MySlice<Self>
+  func makeSubSequence() -> SubSequence
+}
+extension MyCollectionType {
+  func makeSubSequence() -> MySlice<Self> {
+    typealias S = Self
+    return MySlice<S>()
+  }
+}
+
+protocol MyMutableCollectionType : MyCollectionType {
+  typealias SubSequence = MyMutableSlice<Self>
+}
+extension MyMutableCollectionType {
+  func makeSubSequence() -> MyMutableSlice<Self> {
+    typealias S = Self
+    return MyMutableSlice<S>()
+  }
+}
+


### PR DESCRIPTION
We used to go into infinite recursion in IRGen:

```
    frame #21776: 0x00000001000bf49b swift`llvm::Value* swift::CanTypeVisitor<(anonymous namespace)::EmitTypeMetadataRef, llvm::Value*>::visit<>(swift::CanType) + 331
    frame #21777: 0x00000001000b3177 swift`swift::irgen::IRGenFunction::emitTypeMetadataRef(swift::CanType) + 87
    frame #21778: 0x00000001000c0ed3 swift`emitNominalMetadataRef(swift::irgen::IRGenFunction&, swift::NominalTypeDecl*, swift::CanType) + 771
    frame #21779: 0x00000001000bf49b swift`llvm::Value* swift::CanTypeVisitor<(anonymous namespace)::EmitTypeMetadataRef, llvm::Value*>::visit<>(swift::CanType) + 331
    frame #21780: 0x00000001000b3177 swift`swift::irgen::IRGenFunction::emitTypeMetadataRef(swift::CanType) + 87
    frame #21781: 0x00000001000c0ed3 swift`emitNominalMetadataRef(swift::irgen::IRGenFunction&, swift::NominalTypeDecl*, swift::CanType) + 771
    frame #21782: 0x00000001000bf49b swift`llvm::Value* swift::CanTypeVisitor<(anonymous namespace)::EmitTypeMetadataRef, llvm::Value*>::visit<>(swift::CanType) + 331
    frame #21783: 0x00000001000b3177 swift`swift::irgen::IRGenFunction::emitTypeMetadataRef(swift::CanType) + 87
    frame #21784: 0x00000001000c0ed3 swift`emitNominalMetadataRef(swift::irgen::IRGenFunction&, swift::NominalTypeDecl*, swift::CanType) + 771
    frame #21785: 0x00000001000bf49b swift`llvm::Value* swift::CanTypeVisitor<(anonymous namespace)::EmitTypeMetadataRef, llvm::Value*>::visit<>(swift::CanType) + 331
    frame #21786: 0x00000001000b3177 swift`swift::irgen::IRGenFunction::emitTypeMetadataRef(swift::CanType) + 87
    frame #21787: 0x00000001000f5d3f swift`swift::irgen::emitPolymorphicArguments(swift::irgen::IRGenFunction&, swift::CanTypeWrapper<swift::SILFunctionType>, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::Substitution>, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&) + 847
    frame #21788: 0x0000000100155f9e swift`(anonymous namespace)::IRGenSILFunction::visitFullApplySite(swift::FullApplySite) + 1374
    frame #21789: 0x0000000100142211 swift`(anonymous namespace)::IRGenSILFunction::emitSILFunction() + 11889
    frame #21790: 0x000000010013f025 swift`swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) + 725
    frame #21791: 0x000000010008a67c swift`swift::irgen::IRGenModuleDispatcher::emitGlobalTopLevel() + 412
    frame #21792: 0x00000001001257b7 swift`performIRGeneration(swift::IRGenOptions&, swift::ModuleDecl*, swift::SILModule*, llvm::StringRef, llvm::LLVMContext&, swift::SourceFile*, unsigned int) + 855
    frame #21793: 0x0000000100125d16 swift`swift::performIRGeneration(swift::IRGenOptions&, swift::SourceFile&, swift::SILModule*, llvm::StringRef, llvm::LLVMContext&, unsigned int) + 70
    frame #21794: 0x000000010000d116 swift`performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&) + 12070
    frame #21795: 0x0000000100009fce swift`frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2638
    frame #21796: 0x00000001000061d3 swift`main + 2131
    frame #21797: 0x00007fff9a29e5ad libdyld.dylib`start + 1
    frame #21798: 0x00007fff9a29e5ad libdyld.dylib`start + 1
(lldb) ^D
```
