### PR TITLE
[swiftc] Add test case for crash triggered in swift::CanType::isReferenceTypeImpl(…)

### DIFF
--- a/validation-test/compiler_crashers/28284-swift-cantype-isreferencetypeimpl.swift
+++ b/validation-test/compiler_crashers/28284-swift-cantype-isreferencetypeimpl.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+class A{}protocol A{typealias e:e:weak var f:e


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
6  swift           0x00000000031482cd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
7  swift           0x00000000010ccce3 swift::CanType::isReferenceTypeImpl(swift::CanType, bool) + 419
8  swift           0x0000000000f8cf0e swift::TypeChecker::checkOwnershipAttr(swift::VarDecl*, swift::OwnershipAttr*) + 190
9  swift           0x0000000000f8cc5c swift::TypeChecker::checkTypeModifyingDeclAttributes(swift::VarDecl*) + 76
10 swift           0x0000000000ebaa37 swift::TypeChecker::coercePatternToType(swift::Pattern*&, swift::DeclContext*, swift::Type, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 2295
11 swift           0x0000000000eba066 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 1062
16 swift           0x0000000000e796d7 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 6423
17 swift           0x00000000010bc7ac swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, unsigned int, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 3612
18 swift           0x00000000010bae70 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2400
19 swift           0x0000000000eb6e8b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
22 swift           0x0000000000ee2c9e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
24 swift           0x0000000000ee3bb4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
25 swift           0x0000000000ee2b9a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
26 swift           0x0000000000f9b2ef swift::IterativeTypeChecker::processResolveInheritedClauseEntry(std::pair<llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>, unsigned int>, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 159
27 swift           0x0000000000f78a8d swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
28 swift           0x0000000000e74b89 swift::TypeChecker::resolveInheritanceClause(llvm::PointerUnion<swift::TypeDecl*, swift::ExtensionDecl*>) + 137
29 swift           0x0000000000e782f6 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1334
31 swift           0x0000000000e7d8c6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
32 swift           0x0000000000ea0702 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 994
33 swift           0x0000000000cd703f swift::CompilerInstance::performSema() + 3087
35 swift           0x000000000078f80c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
36 swift           0x000000000078a285 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28284-swift-cantype-isreferencetypeimpl.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28284-swift-cantype-isreferencetypeimpl-051e9e.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28284-swift-cantype-isreferencetypeimpl.swift:9:1
2.  While resolving type e at [validation-test/compiler_crashers/28284-swift-cantype-isreferencetypeimpl.swift:9:33 - line:9:33] RangeText="e"
3.  While type-checking 'A' at validation-test/compiler_crashers/28284-swift-cantype-isreferencetypeimpl.swift:9:10
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
