### PR TITLE
Suppress warnings for non-primary inputs

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -410,7 +410,9 @@ void CompilerInstance::performSema() {
 
     auto &Diags = NextInput->getASTContext().Diags;
     auto DidSuppressWarnings = Diags.getSuppressWarnings();
-    Diags.setSuppressWarnings(DidSuppressWarnings || BufferID != PrimaryBufferID);
+    auto IsPrimary
+      = PrimaryBufferID == NO_SUCH_BUFFER || BufferID == PrimaryBufferID;
+    Diags.setSuppressWarnings(DidSuppressWarnings || !IsPrimary);
 
     bool Done;
     do {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -408,6 +408,10 @@ void CompilerInstance::performSema() {
     if (BufferID == PrimaryBufferID)
       setPrimarySourceFile(NextInput);
 
+    auto &Diags = NextInput->getASTContext().Diags;
+    auto DidSuppressWarnings = Diags.getSuppressWarnings();
+    Diags.setSuppressWarnings(DidSuppressWarnings || BufferID != PrimaryBufferID);
+
     bool Done;
     do {
       // Parser may stop at some erroneous constructions like #else, #endif
@@ -415,6 +419,8 @@ void CompilerInstance::performSema() {
       parseIntoSourceFile(*NextInput, BufferID, &Done, nullptr,
                           &PersistentState, DelayedCB.get());
     } while (!Done);
+
+    Diags.setSuppressWarnings(DidSuppressWarnings);
 
     performNameBinding(*NextInput);
   }
@@ -449,6 +455,11 @@ void CompilerInstance::performSema() {
 
     SourceFile &MainFile =
       MainModule->getMainSourceFile(Invocation.getSourceFileKind());
+
+    auto &Diags = MainFile.getASTContext().Diags;
+    auto DidSuppressWarnings = Diags.getSuppressWarnings();
+    Diags.setSuppressWarnings(DidSuppressWarnings || !mainIsPrimary);
+
     SILParserState SILContext(TheSILModule.get());
     unsigned CurTUElem = 0;
     bool Done;
@@ -466,6 +477,8 @@ void CompilerInstance::performSema() {
       }
       CurTUElem = MainFile.Decls.size();
     } while (!Done);
+
+    Diags.setSuppressWarnings(DidSuppressWarnings);
     
     if (mainIsPrimary && !Context->hadError() &&
         Invocation.getFrontendOptions().PlaygroundTransform)

--- a/test/Parse/Inputs/warning_nonprimary_file.swift
+++ b/test/Parse/Inputs/warning_nonprimary_file.swift
@@ -1,0 +1,6 @@
+#if os(asdf)
+public func bar(x: Int, _ y: Int) -> Int {
+  return x + y
+}
+#endif
+

--- a/test/Parse/warning_primary_file.swift
+++ b/test/Parse/warning_primary_file.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -parse -verify -primary-file %s %S/Inputs/warning_nonprimary_file.swift
+
+// Tests that parse warnings are only emitted for the primary
+// input. Below, we expect a warning diagnostic to be emitted
+// because this is the primary file.
+//
+// However, we also pull in ./warning_nonprimary_file.swift,
+// which would emit a warning for an unknown operating system
+// configuration argument, but doesn't because it's not the
+// primary input.
+
+public func foo(x: Int, y: Int) -> Int {
+  return x + y
+}
+
+public func baz(x: Int, y: Int) -> Int {
+  var z = x // expected-warning {{variable 'z' was never mutated}}
+  return z + y
+}
+


### PR DESCRIPTION
Simply, this suppresses warnings for non-primary input files.

https://bugs.swift.org/browse/SR-1012
rdar://problem/25282622
