### PR TITLE
Fix for memory leak when partially applying function with @autoreleased return value

### DIFF
--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -32,13 +32,26 @@ SILType SILBuilder::getPartialApplyResultType(SILType origTy, unsigned argCount,
   auto extInfo = SILFunctionType::ExtInfo(
                                         SILFunctionType::Representation::Thick,
                                         /*noreturn*/ FTI->isNoReturn());
-  
+
+  // If the original method has an @unowned_inner_pointer return, the partial
+  // application thunk will lifetime-extend 'self' for us, converting the
+  // return value to @unowned.
+  //
+  // If the original method has an @autoreleased return, the partial application
+  // thunk will retain it for us, converting the return value to @owned.
+  SILResultInfo result = FTI->getResult();
+  if (result.getConvention() == ResultConvention::UnownedInnerPointer)
+    result = SILResultInfo(result.getType(), ResultConvention::Unowned);
+  else if (result.getConvention() == ResultConvention::Autoreleased)
+    result = SILResultInfo(result.getType(), ResultConvention::Owned);
+
   auto appliedFnType = SILFunctionType::get(nullptr, extInfo,
                                             ParameterConvention::Direct_Owned,
                                             newParams,
-                                            FTI->getResult(),
+                                            result,
                                             FTI->getOptionalErrorResult(),
                                             M.getASTContext());
+
   return SILType::getPrimitiveObjectType(appliedFnType);
 }
 

--- a/lib/SIL/Verifier.cpp
+++ b/lib/SIL/Verifier.cpp
@@ -877,6 +877,18 @@ public:
       require(resultInfo->getResult() == expectedResult,
               "result type of result function type for partially applied "
               "@unowned_inner_pointer function should have @unowned convention");
+
+    // The "autoreleased" convention doesn't survive through a
+    // partial application, since the thunk takes responsibility for
+    // retaining the return value.
+    } else if (expectedResult.getConvention() == ResultConvention::Autoreleased)
+    {
+      expectedResult = SILResultInfo(expectedResult.getType(),
+                                     ResultConvention::Owned);
+      require(resultInfo->getResult() == expectedResult,
+              "result type of result function type for partially applied "
+              "@autoreleased function should have @owned convention");
+
     } else {
       require(resultInfo->getResult() == expectedResult,
               "result type of result function type does not match original "

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4258,30 +4258,10 @@ static SILValue emitDynamicPartialApply(SILGenFunction &gen,
                                         SILValue method,
                                         SILValue self,
                                         CanFunctionType methodTy) {
-  // Pop the self type off of the function type.
-  // Just to be weird, partially applying an objc method produces a native
-  // function (?!)
-  auto fnTy = method.getType().castTo<SILFunctionType>();
-  // If the original method has an @unowned_inner_pointer return, the partial
-  // application thunk will lifetime-extend 'self' for us, converting the
-  // return value to @unowned.
-  //
-  // If the original method has an @autoreleased return, the partial application
-  // thunk will retain it for us, converting the return value to @owned.
-  auto resultInfo = fnTy->getResult();
-  if (resultInfo.getConvention() == ResultConvention::UnownedInnerPointer)
-    resultInfo = SILResultInfo(resultInfo.getType(), ResultConvention::Unowned);
-  else if (resultInfo.getConvention() == ResultConvention::Autoreleased)
-    resultInfo = SILResultInfo(resultInfo.getType(), ResultConvention::Owned);
-
-  auto partialApplyTy = SILFunctionType::get(fnTy->getGenericSignature(),
-                     fnTy->getExtInfo()
-                       .withRepresentation(SILFunctionType::Representation::Thick),
-                     ParameterConvention::Direct_Owned,
-                     fnTy->getParameters()
-                       .slice(0, fnTy->getParameters().size() - 1),
-                     resultInfo, fnTy->getOptionalErrorResult(),
-                     gen.getASTContext());
+  auto partialApplyTy = SILBuilder::getPartialApplyResultType(method.getType(),
+                                                              /*argCount*/1,
+                                                              gen.SGM.M,
+                                                              /*subs*/{});
 
   // Retain 'self' because the partial apply will take ownership.
   // We can't simply forward 'self' because the partial apply is conditional.
@@ -4295,11 +4275,11 @@ static SILValue emitDynamicPartialApply(SILGenFunction &gen,
 #endif
 
   SILValue result = gen.B.createPartialApply(loc, method, method.getType(), {},
-                        self, SILType::getPrimitiveObjectType(partialApplyTy));
+                                             self, partialApplyTy);
   // If necessary, thunk to the native ownership conventions and bridged types.
   auto nativeTy = gen.getLoweredLoadableType(methodTy).castTo<SILFunctionType>();
 
-  if (nativeTy != partialApplyTy) {
+  if (nativeTy != partialApplyTy.getSwiftRValueType()) {
     result = gen.emitBlockToFunc(loc, ManagedValue::forUnmanaged(result),
                                  nativeTy).forward(gen);
   }

--- a/test/ClangModules/Inputs/serialization-sil.h
+++ b/test/ClangModules/Inputs/serialization-sil.h
@@ -1,0 +1,7 @@
+@protocol Test
+@optional
+- (nonnull id)normalObject;
+- (nonnull void *)innerPointer __attribute__((objc_returns_inner_pointer));
+@property (nonnull) id normalObjectProp;
+@property (nonnull) void *innerPointerProp __attribute__((objc_returns_inner_pointer));
+@end

--- a/test/ClangModules/serialization-sil.swift
+++ b/test/ClangModules/serialization-sil.swift
@@ -1,0 +1,45 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-swift-frontend -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h
+// RUN: %target-sil-extract %t/Test.swiftmodule -func=_TF4Test16testPartialApplyFPSo4Test_T_ -o - | FileCheck %s
+
+// REQUIRES: objc_interop
+
+// @_transparent to force serialization.
+@_transparent
+public func testPartialApply(obj: Test) {
+  // CHECK-LABEL: @_TF4Test16testPartialApplyFPSo4Test_T_ : $@convention(thin) (@owned Test) -> () {
+  if let curried1 = obj.normalObject {
+    // CHECK: dynamic_method_br [[CURRIED1_OBJ:%.+]] : $@opened([[CURRIED1_EXISTENTIAL:.+]]) Test, #Test.normalObject!1.foreign, [[CURRIED1_TRUE:[^, ]+]], [[CURRIED1_FALSE:[^, ]+]]
+    // CHECK: [[CURRIED1_TRUE]]([[CURRIED1_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject):
+    // CHECK: [[CURRIED1_PARTIAL:%.+]] = partial_apply [[CURRIED1_METHOD]]([[CURRIED1_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
+    // CHECK: [[CURRIED1_THUNK:%.+]] = function_ref @_TTRXFo__oPs9AnyObject__XFo_iT__iPS___ : $@convention(thin) (@out AnyObject, @in (), @owned @callee_owned () -> @owned AnyObject) -> ()
+    // CHECK: = partial_apply [[CURRIED1_THUNK]]([[CURRIED1_PARTIAL]]) : $@convention(thin) (@out AnyObject, @in (), @owned @callee_owned () -> @owned AnyObject) -> ()
+    // CHECK: [[CURRIED1_FALSE]]:
+    curried1()
+  }
+  if let curried2 = obj.innerPointer {
+    // CHECK: dynamic_method_br [[CURRIED2_OBJ:%.+]] : $@opened([[CURRIED2_EXISTENTIAL:.+]]) Test, #Test.innerPointer!1.foreign, [[CURRIED2_TRUE:[^, ]+]], [[CURRIED2_FALSE:[^, ]+]]
+    // CHECK: [[CURRIED2_TRUE]]([[CURRIED2_METHOD:%.+]] : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>):
+    // CHECK: [[CURRIED2_PARTIAL:%.+]] = partial_apply [[CURRIED2_METHOD]]([[CURRIED2_OBJ]]) : $@convention(objc_method) (@opened([[CURRIED2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>
+    // CHECK: [[CURRIED2_THUNK:%.+]] = function_ref @_TTRXFo__dGSpT___XFo_iT__iGSpT___ : $@convention(thin) (@out UnsafeMutablePointer<()>, @in (), @owned @callee_owned () -> UnsafeMutablePointer<()>) -> ()
+    // CHECK: = partial_apply [[CURRIED2_THUNK]]([[CURRIED2_PARTIAL]]) : $@convention(thin) (@out UnsafeMutablePointer<()>, @in (), @owned @callee_owned () -> UnsafeMutablePointer<()>) -> ()
+    // CHECK: [[CURRIED2_FALSE]]:
+    curried2()
+  }
+  if let prop1 = obj.normalObjectProp {
+    // CHECK: dynamic_method_br [[PROP1_OBJ:%.+]] : $@opened([[PROP1_EXISTENTIAL:.+]]) Test, #Test.normalObjectProp!getter.1.foreign, [[PROP1_TRUE:[^, ]+]], [[PROP1_FALSE:[^, ]+]]
+    // CHECK: [[PROP1_TRUE]]([[PROP1_METHOD:%.+]] : $@convention(objc_method) (@opened([[PROP1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject):
+    // CHECK: [[PROP1_PARTIAL:%.+]] = partial_apply [[PROP1_METHOD]]([[PROP1_OBJ]]) : $@convention(objc_method) (@opened([[PROP1_EXISTENTIAL]]) Test) -> @autoreleased AnyObject
+    // CHECK: = apply [[PROP1_PARTIAL]]() : $@callee_owned () -> @owned AnyObject
+    // CHECK: [[PROP1_FALSE]]:
+    _ = prop1
+  }
+  if let prop2 = obj.innerPointerProp {
+    // CHECK: dynamic_method_br [[PROP2_OBJ:%.+]] : $@opened([[PROP2_EXISTENTIAL:.+]]) Test, #Test.innerPointerProp!getter.1.foreign, [[PROP2_TRUE:[^, ]+]], [[PROP2_FALSE:[^, ]+]]
+    // CHECK: [[PROP2_TRUE]]([[PROP2_METHOD:%.+]] : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>):
+    // CHECK: [[PROP2_PARTIAL:%.+]] = partial_apply [[PROP2_METHOD]]([[PROP2_OBJ]]) : $@convention(objc_method) (@opened([[PROP2_EXISTENTIAL]]) Test) -> @unowned_inner_pointer UnsafeMutablePointer<()>
+    // CHECK: = apply [[PROP2_PARTIAL]]() : $@callee_owned () -> UnsafeMutablePointer<()>
+    // CHECK: [[PROP2_FALSE]]:
+    _ = prop2
+  }
+} // CHECK: {{^}$}}

--- a/test/Interpreter/SDK/objc_protocol_lookup.swift
+++ b/test/Interpreter/SDK/objc_protocol_lookup.swift
@@ -37,3 +37,44 @@ func check(x: AnyObject) {
 check(NSString()) // CHECK: true true
 check(C()) // CHECK: true true
 check(D()) // CHECK: true true
+
+// Make sure partial application of methods with @autoreleased
+// return values works
+
+var count = 0
+
+class Juice : NSObject {
+  override init() {
+    count += 1
+  }
+
+  deinit {
+    count -= 1
+  }
+}
+
+@objc protocol Fruit {
+  optional var juice: Juice { get }
+}
+
+class Durian : NSObject, Fruit {
+  init(juice: Juice) {
+    self.juice = juice
+  }
+
+  var juice: Juice
+}
+
+func consume(fruit: Fruit) {
+  _ = fruit.juice
+}
+
+autoreleasepool {
+  let tasty = Durian(juice: Juice())
+  print(count) // CHECK: 1
+  consume(tasty)
+}
+
+do {
+  print(count) // CHECK: 0
+}

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -201,3 +201,33 @@ func downcast(var obj: AnyObject) -> X {
   // CHECK-NEXT: return [[X]] : $X
   return obj as! X
 }
+
+@objc class Juice { }
+
+@objc protocol Fruit {
+  optional var juice: Juice { get }
+}
+
+// CHECK-LABEL: sil hidden @_TF14dynamic_lookup7consumeFPS_5Fruit_T_
+// CHECK: bb0(%0 : $Fruit):
+// CHECK:        [[BOX:%.*]] = alloc_stack $Optional<Juice>
+// CHECK:        dynamic_method_br [[SELF:%.*]] : $@opened("{{.*}}") Fruit, #Fruit.juice!getter.1.foreign, bb1, bb2
+
+// CHECK: bb1([[FN:%.*]] : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice):
+// CHECK:        [[METHOD:%.*]] = partial_apply [[FN]]([[SELF]]) : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice
+// CHECK:        [[RESULT:%.*]] = apply [[METHOD]]() : $@callee_owned () -> @owned Juice
+// CHECK:        [[PAYLOAD:%.*]] = init_enum_data_addr [[BOX]] : $*Optional<Juice>, #Optional.Some!enumelt.1
+// CHECK:        store [[RESULT]] to [[PAYLOAD]]
+// CHECK:        inject_enum_addr [[BOX]] : $*Optional<Juice>, #Optional.Some!enumelt.1
+// CHECK:        br bb3
+
+// CHECK: bb2:
+// CHECK:        inject_enum_addr [[BOX]] : $*Optional<Juice>, #Optional.None!enumelt
+// CHECK:        br bb3
+
+// CHECK: bb3:
+// CHECK:        return
+
+func consume(fruit: Fruit) {
+  _ = fruit.juice
+}

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -84,7 +84,7 @@ func curry_pod_AnyObject(x: AnyObject) -> Int -> Int {
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.normalOwnership!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (ImplicitlyUnwrappedOptional<CurryTest>, @opened({{.*}}) AnyObject) -> @autoreleased ImplicitlyUnwrappedOptional<CurryTest>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo9CurryTest__aGSQS___XFo_oGSQS___oGSQS___
+// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo9CurryTest__oGSQS___XFo_oGSQS___oGSQS___
 // CHECK:         partial_apply [[THUNK]]([[PA]])
 func curry_normalOwnership_AnyObject(x: AnyObject) -> CurryTest! -> CurryTest! {
   return x.normalOwnership!
@@ -105,7 +105,7 @@ func curry_weirdOwnership_AnyObject(x: AnyObject) -> CurryTest! -> CurryTest! {
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.bridged!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (ImplicitlyUnwrappedOptional<NSString>, @opened({{.*}}) AnyObject) -> @autoreleased ImplicitlyUnwrappedOptional<NSString>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo8NSString__aGSQS___XFo_oGSQSS__oGSQSS__ 
+// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo_dGSQCSo8NSString__oGSQS___XFo_oGSQSS__oGSQSS__
 // CHECK:         partial_apply [[THUNK]]([[PA]])
 func curry_bridged_AnyObject(x: AnyObject) -> String! -> String! {
   return x.bridged!
@@ -117,7 +117,7 @@ func curry_bridged_AnyObject(x: AnyObject) -> String! -> String! {
 // CHECK:         dynamic_method_br [[SELF:%.*]] : $@opened({{.*}}) AnyObject, #CurryTest.returnsSelf!1.foreign, [[HAS_METHOD:bb[0-9]+]]
 // CHECK:       [[HAS_METHOD]]([[METHOD:%.*]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> @autoreleased ImplicitlyUnwrappedOptional<AnyObject>):
 // CHECK:         [[PA:%.*]] = partial_apply [[METHOD]]([[SELF]])
-// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo__aGSQPs9AnyObject___XFo__oGSQPS____
+// CHECK:         [[THUNK:%.*]] = function_ref @_TTRXFo__oGSQPs9AnyObject___XFo_iT__iGSQPS____
 // CHECK:         partial_apply [[THUNK]]([[PA]])
 func curry_returnsSelf_AnyObject(x: AnyObject) -> () -> AnyObject! {
   return x.returnsSelf!


### PR DESCRIPTION
This is a backport of the fix for rdar://problem/24805609 to Swift 2.2.
