### PR TITLE
StdlibUnittest: make TestSuite and other helper classes final

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -891,7 +891,7 @@ public func runAllTests() {
   }
 }
 
-public class TestSuite {
+public final class TestSuite {
   public init(_ name: String) {
     self.name = name
     _precondition(
@@ -980,7 +980,7 @@ public class TestSuite {
     var _name: String
     var _data: _Data = _Data()
 
-    class _Data {
+    internal final class _Data {
       var _xfail: [TestRunPredicate] = []
       var _skip: [TestRunPredicate] = []
       var _stdinText: String? = nil


### PR DESCRIPTION
These classes are not meant to be subclassed.
