### PR TITLE
Add a flag to disable the use of the just-built compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ option(SWIFT_INCLUDE_DOCS
     "Create targets for building docs."
     TRUE)
 
+option(SWIFT_HOST_COMPILER_ONLY
+       "Use the host compiler and not the internal clang to build the swift runtime"
+       FALSE)
+
 set(SWIFT_ANALYZE_CODE_COVERAGE FALSE CACHE STRING
     "Build Swift with code coverage instrumenting enabled [FALSE, NOT-MERGED, MERGED]")
 set_property(CACHE SWIFT_ANALYZE_CODE_COVERAGE PROPERTY

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Create convenience targets for the Swift standard library.
 
-set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
-set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+if(SWIFT_HOST_COMPILER_ONLY)
+  message(WARNING "Building swift using the host compiler, and not the just-built clang.")
+else()
+  set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
+  set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+endif()
 
 add_custom_target(swift-stdlib-all)
 foreach(SDK ${SWIFT_SDKS})

--- a/utils/build-script
+++ b/utils/build-script
@@ -547,6 +547,10 @@ build the Debug variant of the Swift standard library and SDK overlay""",
         "--skip-test-cygwin",
         help="skip testing Swift stdlibs for Cygwin",
         action="store_true")
+    parser.add_argument(
+        "--host-compiler-only",
+        help="Use the host compiler, not the self-built one to compile swift",
+        action="store_true")
 
     parser.add_argument(
         "-o", "--test-optimized",
@@ -1091,6 +1095,8 @@ the number of parallel build jobs to use""",
         build_script_impl_args += ["--skip-test-watchos-host"]
     if args.skip_test_watchos_simulator:
         build_script_impl_args += ["--skip-test-watchos-simulator"]
+    if args.host_compiler_only:
+        build_script_impl_args += ["--host-compiler-only"]
     build_script_impl_args += build_script_impl_inferred_args
 
     # If we have extra_swift_args, combine all of them together and then add

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -86,6 +86,7 @@ KNOWN_SETTINGS=(
     enable-ubsan                ""               "enable Undefined Behavior Sanitizer"
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
+    host-compiler-only          ""               "use the host c++ compiler to build everything"
     user-config-args            ""               "User-supplied arguments to cmake when used to do configuration"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"
@@ -1752,6 +1753,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     -DSWIFT_INSTALL_COMPONENTS:STRING="${SWIFT_INSTALL_COMPONENTS}"
                     -DSWIFT_EMBED_BITCODE_SECTION:BOOL=$(true_false "${EMBED_BITCODE_SECTION}")
                     -DSWIFT_ENABLE_LTO:BOOL=$(true_false "${SWIFT_ENABLE_LTO}")
+                    -DSWIFT_HOST_COMPILER_ONLY:BOOL=$(true_false "${HOST_COMPILER_ONLY}")
                     "${swift_cmake_options[@]}"
                     "${SWIFT_SOURCE_DIR}"
                 )
@@ -2082,9 +2084,12 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             # the c++ header files.
             BUILT_CXX_INCLUDE_DIR="$llvm_build_dir/include"
 
-            echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
-            ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR"
-
+            if [[ "${HOST_COMPILER_ONLY}" ]]; then
+                echo "Using the host compiler to build Swift."
+            else
+                echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
+                ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR"
+            fi
             { set +x; } 2>/dev/null
         fi
     done


### PR DESCRIPTION
Add a flag to disable the use of the just-built clang compiler.
