### PR TITLE
Revert "Runtime: Fix problems with nil-to-nil casts"

### DIFF
--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -12,6 +12,17 @@ import SwiftPrivate
 import ObjectiveC
 #endif
 
+class DeinitTester {
+  private let onDeinit: () -> ()
+
+  init(onDeinit: () -> ()) {
+    self.onDeinit = onDeinit
+  }
+  deinit {
+    onDeinit()
+  }
+}
+
 let OptionalTests = TestSuite("Optional")
 
 protocol TestProtocol1 {}
@@ -82,7 +93,6 @@ OptionalTests.test("Equatable") {
 
 struct X {}
 class C {}
-class D {}
 
 class E : Equatable {}
 func == (_: E, _: E) -> Bool { return true }
@@ -180,19 +190,9 @@ OptionalTests.test("flatMap") {
   expectEmpty((3 as Int32?).flatMap(half))
 }
 
-// FIXME: @inline(never) does not inhibit specialization
-
 @inline(never)
 func anyToAny<T, U>(a: T, _ : U.Type) -> U {
   return a as! U
-}
-@inline(never)
-func anyToAnyIs<T, U>(a: T, _ : U.Type) -> Bool {
-  return a is U
-}
-@inline(never)
-func anyToAnyIsOptional<T, U>(a: T?, _ : U.Type) -> Bool {
-  return a is U?
 }
 @inline(never)
 func anyToAnyOrNil<T, U>(a: T, _ : U.Type) -> U? {
@@ -202,35 +202,15 @@ func canGenericCast<T, U>(a: T, _ ty : U.Type) -> Bool {
   return anyToAnyOrNil(a, ty) != nil
 }
 
-protocol TestExistential {}
-extension Int : TestExistential {}
-
 OptionalTests.test("Casting Optional") {
   let x = C()
   let sx: C? = x
   let nx: C? = nil
   expectTrue(anyToAny(x, Optional<C>.self)! === x)
-  expectTrue(anyToAnyIs(x, Optional<C>.self))
-  expectFalse(anyToAnyIs(x, Optional<D>.self))
-
   expectTrue(anyToAny(sx, C.self) === x)
-  expectTrue(anyToAnyIs(sx, C.self))
-  expectFalse(anyToAnyIs(sx, D.self))
-
   expectTrue(anyToAny(sx, Optional<C>.self)! === x)
-  expectTrue(anyToAnyIs(sx, Optional<C>.self))
-  expectTrue(anyToAnyIsOptional(sx, C.self))
-  expectFalse(anyToAnyIsOptional(sx, D.self))
 
   expectTrue(anyToAny(nx, Optional<C>.self) == nil)
-  expectTrue(anyToAnyIs(nx, Optional<C>.self))
-
-  // You can cast a nil of any type to a nil of any other type
-  // successfully
-  expectTrue(anyToAnyIs(nx, Optional<D>.self))
-
-  expectTrue(anyToAnyIsOptional(nx, C.self))
-
   expectTrue(anyToAnyOrNil(nx, C.self) == nil)
 
   let i = Int.max
@@ -249,45 +229,18 @@ OptionalTests.test("Casting Optional") {
   expectTrue(anyToAnyOrNil(ni, Int.self) == nil)
 
   // Test for SR-459: Weakened optionals don't zero.
-  var t = LifetimeTracked(0)
-  _ = anyToAny(Optional(t), CustomDebugStringConvertible.self)
-  expectTrue(anyToAnyIs(Optional(t), CustomDebugStringConvertible.self))
-
-  // Test for SR-912: Runtime exception casting an Any nil to an Optional.
-  let oi: Int? = nil
-  expectTrue(anyToAny(oi as Any, Optional<Int>.self) == nil)
-  expectTrue(anyToAnyIs(oi as Any, Optional<Int>.self))
-  // For good measure test an existential that Optional does not conform to.
-  expectTrue(anyToAny(3 as TestExistential, Optional<Int>.self) == 3)
-  // And a type that is not convertible to its target.
-  anyToAny(nx as Any, Optional<Int>.self)
-
-  // Double-wrapped optional
-  expectTrue(anyToAnyIsOptional(oi as Any, Int.self))
-
-  // And a type that is not convertible to its target.
-  expectTrue(anyToAny(nx as Any, Optional<Int>.self) == nil)
-  expectTrue(anyToAnyIs(nx as Any, Optional<Int>.self))
-  expectTrue(anyToAnyIsOptional(nx as Any, Int.self))
-
-  expectTrue(anyToAnyOrNil(sx as Any, Optional<Int>.self) == nil)
-  expectFalse(anyToAnyIs(sx as Any, Optional<Int>.self))
-  expectFalse(anyToAnyIsOptional(sx as Any, Int.self))
-
-  // OK to convert nil of any type to optional of any other type
-  expectTrue(anyToAnyIs(Optional<(String, String)>.None, Optional<Bool>.self))
-  expectTrue(anyToAnyIsOptional(Optional<(String, String)>.None, Bool.self))
+  var deinitRan = false
+  do {
+    var t = DeinitTester { deinitRan = true }
+    _ = anyToAny(Optional(t), CustomDebugStringConvertible.self)
+  }
+  expectTrue(deinitRan)
 }
 
 OptionalTests.test("Casting Optional Traps") {
   let nx: C? = nil
   expectCrashLater()
   anyToAny(nx, Int.self)
-}
-OptionalTests.test("Casting Optional Any Traps") {
-  let nx: X? = X()
-  expectCrashLater()
-  _blackHole(anyToAny(nx as Any, Optional<Int>.self))
 }
 
 class TestNoString {}


### PR DESCRIPTION
Reverts apple/swift#1948
