### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::typeCheckPattern(…)

### DIFF
--- a/validation-test/compiler_crashers/28285-swift-typechecker-typecheckpattern.swift
+++ b/validation-test/compiler_crashers/28285-swift-typechecker-typecheckpattern.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class a b{if let f as a:{


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash with stack trace:

```
swift: /path/to/swift/include/swift/AST/Pattern.h:111: swift::Type swift::Pattern::getType() const: Assertion `hasType()' failed.
8  swift           0x0000000000ebebae swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 1198
9  swift           0x0000000000e720ed swift::TypeChecker::typeCheckStmtCondition(llvm::MutableArrayRef<swift::StmtConditionElement>&, swift::DeclContext*, swift::Diag<>) + 189
13 swift           0x0000000000ee251a swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
14 swift           0x0000000000f0c66c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 812
15 swift           0x0000000000e703ca swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 746
17 swift           0x0000000000ee2666 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
18 swift           0x0000000000ea523d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1117
19 swift           0x0000000000cdbaef swift::CompilerInstance::performSema() + 3279
21 swift           0x000000000079001c frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2492
22 swift           0x000000000078aa95 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28285-swift-typechecker-typecheckpattern.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28285-swift-typechecker-typecheckpattern-437ef8.o
1.  While type-checking expression at [validation-test/compiler_crashers/28285-swift-typechecker-typecheckpattern.swift:10:10 - line:10:25] RangeText="{if let f as a:{"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
