### PR TITLE
[Type Checker] Check subpattern storage instead of whole pattern.

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -163,6 +163,9 @@ public:
     });
   }
 
+  /// Does this binding declare something that requires storage?
+  bool hasStorage() const;
+
   static bool classof(const Pattern *P) { return true; }
   
   //*** Allocation Routines ************************************************/

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1132,14 +1132,10 @@ StaticSpellingKind PatternBindingDecl::getCorrectStaticSpelling() const {
 bool PatternBindingDecl::hasStorage() const {
   // Walk the pattern, to check to see if any of the VarDecls included in it
   // have storage.
-  bool HasStorage = false;
   for (auto entry : getPatternList())
-    entry.getPattern()->forEachVariable([&](VarDecl *VD) {
-      if (VD->hasStorage())
-        HasStorage = true;
-    });
-
-  return HasStorage;
+    if (entry.getPattern()->hasStorage())
+      return true;
+  return false;
 }
 
 void PatternBindingDecl::setPattern(unsigned i, Pattern *P) {

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -237,6 +237,16 @@ void Pattern::forEachNode(const std::function<void(Pattern*)> &f) {
   }
 }
 
+bool Pattern::hasStorage() const {
+  bool HasStorage = false;
+  forEachVariable([&](VarDecl *VD) {
+    if (VD->hasStorage())
+      HasStorage = true;
+  });
+
+  return HasStorage;
+}
+
 /// Return true if this is a non-resolved ExprPattern which is syntactically
 /// irrefutable.
 static bool isIrrefutableExprPattern(const ExprPattern *EP) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2866,7 +2866,7 @@ public:
         // default-initializable. If so, do it.
         if (PBD->getPattern(i)->hasType() &&
             !PBD->getInit(i) &&
-            PBD->hasStorage() &&
+            PBD->getPattern(i)->hasStorage() &&
             !PBD->getPattern(i)->getType()->is<ErrorType>()) {
 
           // If we have a type-adjusting attribute (like ownership), apply it now.

--- a/test/decl/var/NSManaged_properties.swift
+++ b/test/decl/var/NSManaged_properties.swift
@@ -50,6 +50,9 @@ class SwiftGizmo : A {
   @NSManaged func mutableArrayValueForB() {} // expected-error {{NSManaged method cannot have a body; it must be provided at runtime}}
   @NSManaged class func mutableArrayValueForA() {} // expected-error {{@NSManaged only allowed on an instance property or method}}
 
+  // SR-1050: don't assert
+  @NSManaged var multiA, multiB, multiC : NSNumber?
+
   override init() {}
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fixes SR-1050, where @NSManaged subpatterns were not yet visited, and
thus still were deemed 'stored', by the time getStorage() was called
on the whole pattern. Change this to check the subpattern storage as
we go. Test case added.

This is a cherry-pick of PR1953 https://github.com/apple/swift/pull/1953

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-1050](https://bugs.swift.org/browse/SR-1050))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Fixes SR-1050, where @NSManaged subpatterns were not yet visited, and
thus still were deemed 'stored', by the time getStorage() was called
on the whole pattern. Change this to check the subpattern storage as
we go. Test case added.
