### PR TITLE
Revert "Disable ASAN on the LLVM build, keep it on Swift."

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1174,6 +1174,13 @@ if [[ "${ENABLE_UBSAN}" ]] ; then
     )
 fi
 
+if [[ -n "${SANITIZERS[@]}" ]] ; then
+    COMMON_CMAKE_OPTIONS=(
+        "${COMMON_CMAKE_OPTIONS[@]}"
+        -DLLVM_USE_SANITIZER=$(join_array_with_delimiter ";" "${SANITIZERS[@]}")
+    )
+fi
+
 if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
     COMMON_CMAKE_OPTIONS=(
         "${COMMON_CMAKE_OPTIONS[@]}"
@@ -1669,13 +1676,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_ENABLE_GOLD_LINKER=TRUE
-                    )
-                fi
-
-                if [[ -n "${SANITIZERS[@]}" ]] ; then
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DLLVM_USE_SANITIZER=$(join_array_with_delimiter ";" "${SANITIZERS[@]}")
                     )
                 fi
 


### PR DESCRIPTION
Reverts apple/swift#1998

This need to be discussed more on swift-dev, as they may be problems with not instrumenting the LLVM and Clang pieces of the Swift compiler build even if all we want to do is find bugs in the Swift compiler part.
