### PR TITLE
Generic super capture fix (2.2)

### DIFF
--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -798,6 +798,13 @@ namespace {
         captureList[entryNumber-1] = capture;
       }
 
+      // Visit the type of the capture. If we capture 'self' via a 'super' call,
+      // and the superclass is not generic, there might not be any generic
+      // parameter types in the closure body, so we have to account for them
+      // here.
+      if (VD->hasType())
+        checkType(VD->getType());
+
       // If VD is a noescape decl, then the closure we're computing this for
       // must also be noescape.
       if (VD->getAttrs().hasAttribute<NoEscapeAttr>() &&

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -542,3 +542,25 @@ class UnownedSelfNestedCapture {
     {[unowned self] in { self } }()()
   }
 }
+
+// Check that capturing 'self' via a 'super' call also captures the generic
+// signature if the base class is concrete and the derived class is generic
+
+class ConcreteBase {
+  func swim() {}
+}
+
+// CHECK-LABEL: sil shared @_TFFC8closures14GenericDerived4swimFT_T_U_FT_T_ : $@convention(thin) <Ocean> (@owned GenericDerived<Ocean>) -> ()
+// CHECK:         [[SUPER:%.*]] = upcast %0 : $GenericDerived<Ocean> to $ConcreteBase
+// CHECK:         [[METHOD:%.*]] = super_method %0 : $GenericDerived<Ocean>, #ConcreteBase.swim!1 : (ConcreteBase) -> () -> () , $@convention(method) (@guaranteed ConcreteBase) -> ()
+// CHECK:         apply [[METHOD]]([[SUPER]]) : $@convention(method) (@guaranteed ConcreteBase) -> ()
+
+class GenericDerived<Ocean> : ConcreteBase {
+  override func swim() {
+    withFlotationAid {
+      super.swim()
+    }
+  }
+
+  func withFlotationAid(fn: () -> ()) {}
+}


### PR DESCRIPTION
This fixes rdar://25439564, a Swift 2.2 regression where a crash could occur while compiling a closure satisfying a very specific set of conditions detailed in the bug report and tests.
