### PR TITLE
Make the option of building using the host clang the default

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -86,7 +86,7 @@ KNOWN_SETTINGS=(
     enable-ubsan                ""               "enable Undefined Behavior Sanitizer"
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
-    build-runtime-with-host-compiler   ""        "use the host c++ compiler to build everything"
+    build-runtime-with-host-compiler   "1"       "use the host c++ compiler to build everything"
     user-config-args            ""               "User-supplied arguments to cmake when used to do configuration"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"


### PR DESCRIPTION
Make the option of building using the host clang the default.  We need to disable building with the internal clang until we figure out the situation with the ASAN bot. 
