### PR TITLE
[cmake] Work around relocation R_X86_64_PC32 link error

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -801,6 +801,19 @@ function(_add_swift_library_single target name)
     list(APPEND link_flags "-fuse-ld=gold")
   endif()
 
+  CMAKE_MINIMUM_REQUIRED(VERSION 2.8 FATAL_ERROR)
+  INCLUDE(CheckCXXCompilerFlag)
+  SET(CMAKE_REQUIRED_FLAGS "-Wl,-z,nocopyreloc")
+  CHECK_CXX_COMPILER_FLAG("" LINKER_SUPPORTS_NOCOPYRELOC)
+  IF(LINKER_SUPPORTS_NOCOPYRELOC)
+      list(APPEND link_flags ${CMAKE_REQUIRED_FLAGS})
+  ENDIF()
+  SET(CMAKE_REQUIRED_FLAGS "-Wl,-z,noextern-protected-data")
+  CHECK_CXX_COMPILER_FLAG("" LINKER_SUPPORTS_NOEXTERN_PROTECTED_DATA)
+  IF(LINKER_SUPPORTS_NOEXTERN_PROTECTED_DATA)
+      list(APPEND link_flags ${CMAKE_REQUIRED_FLAGS})
+  ENDIF()
+
   # Configure plist creation for OS X.
   set(PLIST_INFO_PLIST "Info.plist" CACHE STRING "Plist name")
   if(APPLE AND SWIFTLIB_SINGLE_IS_STDLIB)
@@ -1415,6 +1428,18 @@ function(_add_swift_executable_single name)
     # Extend the link_flags for the gold linker.
     list(APPEND link_flags "-fuse-ld=gold")
   endif()
+
+  INCLUDE(CheckCXXCompilerFlag)
+  SET(CMAKE_REQUIRED_FLAGS "-Wl,-z,nocopyreloc")
+  CHECK_CXX_COMPILER_FLAG("" LINKER_SUPPORTS_NOCOPYRELOC)
+  IF(LINKER_SUPPORTS_NOCOPYRELOC)
+      list(APPEND link_flags ${CMAKE_REQUIRED_FLAGS})
+  ENDIF()
+  SET(CMAKE_REQUIRED_FLAGS "-Wl,-z,noextern-protected-data")
+  CHECK_CXX_COMPILER_FLAG("" LINKER_SUPPORTS_NOEXTERN_PROTECTED_DATA)
+  IF(LINKER_SUPPORTS_NOEXTERN_PROTECTED_DATA)
+      list(APPEND link_flags ${CMAKE_REQUIRED_FLAGS})
+  ENDIF()
 
   # Find the names of dependency library targets.
   #

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1288,6 +1288,9 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(Target));
   }
 
+  Arguments.push_back("-Wl,-z,nocopyreloc");
+  Arguments.push_back("-Wl,-z,noextern-protected-data");
+
   // Add the runtime library link path, which is platform-specific and found
   // relative to the compiler.
   llvm::SmallString<128> RuntimeLibPath;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This is the first patch to begin working around the dynamic resolution of protected symbols. This behavior was introduced in `binutils` 2.26.

A more complete discussion of the error and its background can be found in [SR-1023](https://bugs.swift.org/browse/SR-1023).

The brief overview is that in versions of `ld` that would be effected by this dynamic relocation issue there are two flags: `-z nocopyreloc` and `-z noextern-protected-data`. If `ld` supports the flags then they are sent to the linker. This patch checks that the linker supports the flags and then optionally sets them.

The code to check if `ld` supports the flags is inspired by this CMake mailing list entry.

https://cmake.org/pipermail/cmake/2011-July/045525.html
#### Resolves bug number: ([SR-1023](https://bugs.swift.org/browse/SR-1023))

~~While this pull does not entirely resolve [SR-1023](https://bugs.swift.org/browse/SR-1023) I do think it is a good first step.~~

**Update 1:** I've now provided a Driver patch too. This branch should now work on binutils 2.26 (e.g., Ubuntu 16.04). The patch does not work on binutils builds that do _not_ support these flags (e.g., Ubuntu 14.04/15.10). A conditional still needs to be written for the Driver to apply the new flags conditionally. I'm looking for feedback on how to best address that.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
