### PR TITLE
Revert "[Type Checker] Check subpattern storage instead of whole pattern."

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -163,9 +163,6 @@ public:
     });
   }
 
-  /// Does this binding declare something that requires storage?
-  bool hasStorage() const;
-
   static bool classof(const Pattern *P) { return true; }
   
   //*** Allocation Routines ************************************************/

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1132,10 +1132,14 @@ StaticSpellingKind PatternBindingDecl::getCorrectStaticSpelling() const {
 bool PatternBindingDecl::hasStorage() const {
   // Walk the pattern, to check to see if any of the VarDecls included in it
   // have storage.
+  bool HasStorage = false;
   for (auto entry : getPatternList())
-    if (entry.getPattern()->hasStorage())
-      return true;
-  return false;
+    entry.getPattern()->forEachVariable([&](VarDecl *VD) {
+      if (VD->hasStorage())
+        HasStorage = true;
+    });
+
+  return HasStorage;
 }
 
 void PatternBindingDecl::setPattern(unsigned i, Pattern *P) {

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -237,16 +237,6 @@ void Pattern::forEachNode(const std::function<void(Pattern*)> &f) {
   }
 }
 
-bool Pattern::hasStorage() const {
-  bool HasStorage = false;
-  forEachVariable([&](VarDecl *VD) {
-    if (VD->hasStorage())
-      HasStorage = true;
-  });
-
-  return HasStorage;
-}
-
 /// Return true if this is a non-resolved ExprPattern which is syntactically
 /// irrefutable.
 static bool isIrrefutableExprPattern(const ExprPattern *EP) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2866,7 +2866,7 @@ public:
         // default-initializable. If so, do it.
         if (PBD->getPattern(i)->hasType() &&
             !PBD->getInit(i) &&
-            PBD->getPattern(i)->hasStorage() &&
+            PBD->hasStorage() &&
             !PBD->getPattern(i)->getType()->is<ErrorType>()) {
 
           // If we have a type-adjusting attribute (like ownership), apply it now.

--- a/test/decl/var/NSManaged_properties.swift
+++ b/test/decl/var/NSManaged_properties.swift
@@ -50,9 +50,6 @@ class SwiftGizmo : A {
   @NSManaged func mutableArrayValueForB() {} // expected-error {{NSManaged method cannot have a body; it must be provided at runtime}}
   @NSManaged class func mutableArrayValueForA() {} // expected-error {{@NSManaged only allowed on an instance property or method}}
 
-  // SR-1050: don't assert
-  @NSManaged var multiA, multiB, multiC : NSNumber?
-
   override init() {}
 }
 


### PR DESCRIPTION
Reverts apple/swift#1996

This change may possibly be causing the timeout on the iOS tester:

https://ci.swift.org/view/swift-2.2-branch/job/oss-swift-2.2_tools-RA_stdlib-DA_test-simulator/5270/
