### PR TITLE
Add SILCombine+SimplifyCFG passes between the ClosureSpecializer (and…

### DIFF
--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -330,6 +330,11 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   // Speculate virtual call targets.
   PM.addSpeculativeDevirtualization();
 
+  // There should be at least one SILCombine+SimplifyCFG between the
+  // ClosureSpecializer, etc. and the last inliner. Cleaning up after these
+  // passes can expose more inlining opportunities.
+  AddSimplifyCFGSILCombine(PM);
+
   // We do this late since it is a pass like the inline caches that we only want
   // to run once very late. Make sure to run at least one round of the ARC
   // optimizer after this.

--- a/test/SILOptimizer/closure_spec_and_inline.swift
+++ b/test/SILOptimizer/closure_spec_and_inline.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -emit-sil | FileCheck %s
+
+func closure(a: Int, b: Int) -> Bool {
+  return a < b
+}
+
+// Check that closure() is inlined into call_closure after call_closure is
+// specialized for it.
+
+// CHECK-LABEL: sil shared [noinline] @_TTSf1n_n_cl27_TF4test7closureFTSi1bSi_Sb___TF4test12call_closureFTSiSiFTSiSi_Sb_Sb
+// CHECK-NOT: apply
+// CHECK: builtin "cmp_slt_Int64"
+// CHECK-NOT: apply
+// CHECK: return
+@inline(never)
+func call_closure(a: Int, _ b: Int, _ f: (Int , Int) -> Bool) -> Bool {
+  return f(a, b)
+}
+
+public func testit() -> Bool {
+  return call_closure(0, 1, closure)
+}
+

--- a/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
+++ b/test/SILOptimizer/devirt_single_module_in_multiple_files.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -module-name devirt_single_module_in_multiple_files -O  %s %S/Inputs/BaseProblem.swift %S/Inputs/Problems.swift -parse-as-library -emit-sil 2>&1 | FileCheck %s
+// RUN: %target-swiftc_driver -module-name devirt_single_module_in_multiple_files -O  %s %S/Inputs/BaseProblem.swift %S/Inputs/Problems.swift -parse-as-library -Xllvm -sil-disable-pass="Performance Inliner" -emit-sil 2>&1 | FileCheck %s
 
 public func test() {
   let e = Evaluator()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… other passes) and the last inliner.

Without this we can end up not inlining in some trivial cases.
For example, the ClosureSpecializer may generate a function_ref - convert_function - apply sequence.
This must be cleaned up by SILCombine before we can inline the function.

rdar://problem/22309472
