### PR TITLE
Resolve SR-1028

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -542,6 +542,14 @@ matchCallArguments(ConstraintSystem &cs, TypeMatchKind kind,
     if (argType->is<InOutType>()) {
       return ConstraintSystem::SolutionKind::Error;
     }
+    // If the param type is an empty existential composition, the function can
+    // only have one argument. Check if exactly one arguement was passed to this
+    // function, otherwise we obviously have a mismatch
+    if (auto tupleArgType = argType->getAs<TupleType>()) {
+      if (tupleArgType->getNumElements() != 1) {
+        return ConstraintSystem::SolutionKind::Error;
+      }
+    }
     return ConstraintSystem::SolutionKind::Solved;
   }
 

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -75,3 +75,8 @@ A().a(text:"sometext") // expected-error {{argument labels '(text:)' do not matc
 func r22451001() -> AnyObject {}
 print(r22451001(5))  // expected-error {{argument passed to call that takes no arguments}}
 
+
+// SR-590 Passing two parameters to a function that takes one argument of type Any crashes the compiler
+func sr590(x: Any) {}
+sr590(3,4) // expected-error {{extra argument in call}}
+

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -77,6 +77,7 @@ print(r22451001(5))  // expected-error {{argument passed to call that takes no a
 
 
 // SR-590 Passing two parameters to a function that takes one argument of type Any crashes the compiler
+// SR-1028: Segmentation Fault: 11 when superclass init takes parameter of type 'Any'
 func sr590(x: Any) {}
 sr590(3,4) // expected-error {{extra argument in call}}
-
+sr590() // expected-error {{missing argument for parameter #1 in call}}


### PR DESCRIPTION
#### What's in this pull request?

A fix for SR-1028, which is an Xcode 7.3 regression. This just cherry-picks the fix for SR-590 (b54976) and adds an additional test (6db942).
#### Resolved bug number: ([SR-1028](https://bugs.swift.org/browse/SR-1028))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
