### PR TITLE
<rdar://problem/25034414> Enable unit tests for test methods that thr…

### DIFF
--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -228,8 +228,6 @@ XCTestTestSuite.test("XCTAsserts with throwing expressions") {
     
 }
 
-/* Disabling these tests for now: <rdar://problem/25034414> Enable unit tests for test methods that throw once the open source CI is on 7.3
-
 XCTestTestSuite.test("Test methods that wind up throwing") {
     class ErrorTestCase: XCTestCase {
         var doThrow = true
@@ -276,7 +274,6 @@ XCTestTestSuite.test("Test methods that wind up throwing") {
     }
     
 }
-*/
 
 runAllTests()
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

This pull request enables a couple tests for the XCTest overlay that require Xcode 7.3. Now that 7.3 is released and the swift-ci machines are updated to it, these tests can be enabled.

<!-- Description about pull request. -->

This resolves radar rdar://problem/25034414 Enable unit tests for test methods that throw once the open source CI is on 7.3

<!-- If this pull request resolves any bugs from Swift bug tracker -->
