### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::applyUnboundGenericArguments(…)

### DIFF
--- a/validation-test/compiler_crashers/28286-swift-typechecker-applyunboundgenericarguments.swift
+++ b/validation-test/compiler_crashers/28286-swift-typechecker-applyunboundgenericarguments.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct d=typealias f=B)typealias B<T>:d typealias B<T>:B<T>


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/Sema/TypeCheckType.cpp:484: swift::Type swift::TypeChecker::applyUnboundGenericArguments(swift::UnboundGenericType *, swift::SourceLoc, swift::DeclContext *, MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver *): Assertion `TAD->getGenericParams()->getAllArchetypes().size() == genericArgs.size() && "argument arity mismatch"' failed.
8  swift           0x0000000000ee8e4b swift::TypeChecker::applyUnboundGenericArguments(swift::UnboundGenericType*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) + 1259
9  swift           0x0000000000ee880f swift::TypeChecker::applyGenericArguments(swift::Type, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, bool, swift::GenericTypeResolver*) + 431
13 swift           0x0000000000ee8fde swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
15 swift           0x0000000000ee9ef4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
16 swift           0x0000000000ee8eda swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
17 swift           0x0000000000fa283a swift::IterativeTypeChecker::processResolveTypeDecl(swift::TypeDecl*, llvm::function_ref<bool (swift::TypeCheckRequest)>) + 202
18 swift           0x0000000000f7f2cd swift::IterativeTypeChecker::satisfy(swift::TypeCheckRequest) + 493
21 swift           0x0000000000e7f3eb swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 3739
23 swift           0x0000000000e84056 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
24 swift           0x0000000000ea6df2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 994
25 swift           0x0000000000cdd0bf swift::CompilerInstance::performSema() + 3295
27 swift           0x0000000000790c7f frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2495
28 swift           0x000000000078b6f5 main + 2837
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28286-swift-typechecker-applyunboundgenericarguments.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28286-swift-typechecker-applyunboundgenericarguments-a4ff63.o
1.  While type-checking 'B' at validation-test/compiler_crashers/28286-swift-typechecker-applyunboundgenericarguments.swift:10:24
2.  While type-checking 'B' at validation-test/compiler_crashers/28286-swift-typechecker-applyunboundgenericarguments.swift:10:41
3.  While resolving type B<T> at [validation-test/compiler_crashers/28286-swift-typechecker-applyunboundgenericarguments.swift:10:56 - line:10:59] RangeText="B<T>"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
