### PR TITLE
[SR-933] rename flatten to flattened

### DIFF
--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -21,7 +21,7 @@ extension LazySequenceProtocol {
   public func flatMap<SegmentOfResult : Sequence>(
     _ transform: (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazySequence<
-    FlattenSequence<LazyMapSequence<Elements, SegmentOfResult>>> {
+    FlattenedSequence<LazyMapSequence<Elements, SegmentOfResult>>> {
     return self.map(transform).flattened()
   }
 }

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -14,7 +14,7 @@ extension LazySequenceProtocol {
   /// Returns the concatenated results of mapping `transform` over
   /// `self`.  Equivalent to 
   ///
-  ///     self.map(transform).flatten()
+  ///     self.map(transform).flattened()
   ///
   /// - Complexity: O(1)
   @warn_unused_result
@@ -22,7 +22,7 @@ extension LazySequenceProtocol {
     _ transform: (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazySequence<
     FlattenSequence<LazyMapSequence<Elements, SegmentOfResult>>> {
-    return self.map(transform).flatten()
+    return self.map(transform).flattened()
   }
 }
 
@@ -30,7 +30,7 @@ extension LazyCollectionProtocol {
   /// Returns the concatenated results of mapping `transform` over
   /// `self`.  Equivalent to 
   ///
-  ///     self.map(transform).flatten()
+  ///     self.map(transform).flattened()
   ///
   /// - Complexity: O(1)
   @warn_unused_result
@@ -40,7 +40,7 @@ extension LazyCollectionProtocol {
     FlattenCollection<
       LazyMapCollection<Elements, SegmentOfResult>>
   > {
-    return self.map(transform).flatten()
+    return self.map(transform).flattened()
   }
 }
 
@@ -49,7 +49,7 @@ extension LazyCollectionProtocol where Elements.Index : BidirectionalIndex
   /// Returns the concatenated results of mapping `transform` over
   /// `self`.  Equivalent to 
   ///
-  ///     self.map(transform).flatten()
+  ///     self.map(transform).flattened()
   ///
   /// - Complexity: O(1)
   @warn_unused_result
@@ -62,6 +62,6 @@ extension LazyCollectionProtocol where Elements.Index : BidirectionalIndex
     FlattenBidirectionalCollection<
       LazyMapCollection<Elements, SegmentOfResult>
   >> {
-    return self.map(transform).flatten()
+    return self.map(transform).flattened()
   }
 }

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -16,7 +16,7 @@
 /// The elements traversed are the concatenation of those in each
 /// segment produced by the base iterator.
 ///
-/// - Note: This is the `IteratorProtocol` used by `FlattenSequence`,
+/// - Note: This is the `IteratorProtocol` used by `FlattenedSequence`,
 ///   `FlattenCollection`, and `BidirectionalFlattenCollection`.
 public struct FlattenIterator<
   Base : IteratorProtocol where Base.Element : Sequence
@@ -69,7 +69,7 @@ public struct FlattenIterator<
 /// * `s.lazy.flattened().map(f)` maps lazily and returns a `LazyMapSequence`
 ///
 /// - See also: `FlattenCollection`
-public struct FlattenSequence<
+public struct FlattenedSequence<
   Base : Sequence where Base.Iterator.Element : Sequence
 > : Sequence {
 
@@ -93,8 +93,8 @@ public struct FlattenSequence<
 extension Sequence where Iterator.Element : Sequence {
   /// A concatenation of the elements of `self`.
   @warn_unused_result
-  public func flattened() -> FlattenSequence<Self> {
-    return FlattenSequence(self)
+  public func flattened() -> FlattenedSequence<Self> {
+    return FlattenedSequence(self)
   }
 }
 
@@ -106,9 +106,9 @@ extension LazySequenceProtocol
   /// A concatenation of the elements of `self`.
   @warn_unused_result
   public func flattened() -> LazySequence<
-    FlattenSequence<Elements>
+    FlattenedSequence<Elements>
   > {
-    return FlattenSequence(elements).lazy
+    return FlattenedSequence(elements).lazy
   }
 }
 
@@ -238,7 +238,7 @@ public func == <BaseElements> (
 ///   general operations on `${Collection}` instances may not have the
 ///   documented complexity.
 ///
-/// - See also: `FlattenSequence`
+/// - See also: `FlattenedSequence`
 public struct ${Collection}<
   Base: Collection where ${constraints % {'Base': 'Base.'}}
 > : Collection {
@@ -330,7 +330,7 @@ public struct FlattenGenerator<
   Base : IteratorProtocol where Base.Element : Sequence
 > {}
 
-extension FlattenSequence {
+extension FlattenedSequence {
   @available(*, unavailable, renamed: "makeIterator")
   public func generate() -> FlattenIterator<Base.Iterator> {
     fatalError("unavailable function can't be called")
@@ -367,7 +367,7 @@ extension LazyCollectionProtocol
 
 extension Sequence where Iterator.Element : Sequence {
   @available(*, unavailable, renamed: "flattened")
-  public func flatten() -> FlattenSequence<Self> {
+  public func flatten() -> FlattenedSequence<Self> {
     fatalError("unavailable function can't be called")
   }
 }
@@ -379,7 +379,7 @@ extension LazySequenceProtocol
 
   @available(*, unavailable, renamed: "flattened")
   public func flatten() -> LazySequence<
-    FlattenSequence<Elements>
+    FlattenedSequence<Elements>
   > {
     fatalError("unavailable function can't be called")
   }

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -60,13 +60,13 @@ public struct FlattenIterator<
 /// The elements of this view are a concatenation of the elements of
 /// each sequence in the base.
 ///
-/// The `flatten` property is always lazy, but does not implicitly
+/// The `flattened` property is always lazy, but does not implicitly
 /// confer laziness on algorithms applied to its result.  In other
 /// words, for ordinary sequences `s`:
 ///
-/// * `s.flatten()` does not create new storage
-/// * `s.flatten().map(f)` maps eagerly and returns a new array
-/// * `s.lazy.flatten().map(f)` maps lazily and returns a `LazyMapSequence`
+/// * `s.flattened()` does not create new storage
+/// * `s.flattened().map(f)` maps eagerly and returns a new array
+/// * `s.lazy.flattened().map(f)` maps lazily and returns a `LazyMapSequence`
 ///
 /// - See also: `FlattenCollection`
 public struct FlattenSequence<
@@ -93,7 +93,7 @@ public struct FlattenSequence<
 extension Sequence where Iterator.Element : Sequence {
   /// A concatenation of the elements of `self`.
   @warn_unused_result
-  public func flatten() -> FlattenSequence<Self> {
+  public func flattened() -> FlattenSequence<Self> {
     return FlattenSequence(self)
   }
 }
@@ -105,7 +105,7 @@ extension LazySequenceProtocol
 
   /// A concatenation of the elements of `self`.
   @warn_unused_result
-  public func flatten() -> LazySequence<
+  public func flattened() -> LazySequence<
     FlattenSequence<Elements>
   > {
     return FlattenSequence(elements).lazy
@@ -226,9 +226,9 @@ public func == <BaseElements> (
 /// confer laziness on algorithms applied to its result.  In other
 /// words, for ordinary collections `c`:
 ///
-/// * `c.flatten()` does not create new storage
-/// * `c.flatten().map(f)` maps eagerly and returns a new array
-/// * `c.lazy.flatten().map(f)` maps lazily and returns a `LazyMapCollection`
+/// * `c.flattened()` does not create new storage
+/// * `c.flattened().map(f)` maps eagerly and returns a new array
+/// * `c.lazy.flattened().map(f)` maps lazily and returns a `LazyMapCollection`
 ///
 /// - Note: The performance of accessing `startIndex`, `first`, any methods
 ///   that depend on `startIndex`, or of advancing a `${Collection}Index`
@@ -307,7 +307,7 @@ public struct ${Collection}<
 extension Collection where ${constraints % {'Base': ''}} {
   /// A concatenation of the elements of `self`.
   @warn_unused_result
-  public func flatten() -> ${Collection}<Self> {
+  public func flattened() -> ${Collection}<Self> {
     return ${Collection}(self)
   }
 }
@@ -318,7 +318,7 @@ extension LazyCollectionProtocol
   Iterator.Element == Elements.Iterator.Element {
   /// A concatenation of the elements of `self`.
   @warn_unused_result
-  public func flatten() -> LazyCollection<${Collection}<Elements>> {
+  public func flattened() -> LazyCollection<${Collection}<Elements>> {
     return ${Collection}(elements).lazy
   }
 }
@@ -346,4 +346,41 @@ extension ${Collection} {
     fatalError("unavailable function can't be called")
   }
 }
-%end
+
+extension Collection where ${constraints % {'Base': ''}} {
+  @available(*, unavailable, renamed: "flattened")
+  public func flatten() -> ${Collection}<Self> {
+    fatalError("unavailable function can't be called")
+  }
+}
+
+extension LazyCollectionProtocol
+  where ${constraints % {'Base': ''}}, 
+  ${constraints % {'Base': 'Elements.'}},
+  Iterator.Element == Elements.Iterator.Element {
+  @available(*, unavailable, renamed: "flattened")
+  public func flatten() -> LazyCollection<${Collection}<Elements>> {
+    fatalError("unavailable function can't be called")
+  }
+}
+% end
+
+extension Sequence where Iterator.Element : Sequence {
+  @available(*, unavailable, renamed: "flattened")
+  public func flatten() -> FlattenSequence<Self> {
+    fatalError("unavailable function can't be called")
+  }
+}
+
+extension LazySequenceProtocol
+  where
+  Elements.Iterator.Element == Iterator.Element,
+  Iterator.Element : Sequence {
+
+  @available(*, unavailable, renamed: "flattened")
+  public func flatten() -> LazySequence<
+    FlattenSequence<Elements>
+  > {
+    fatalError("unavailable function can't be called")
+  }
+}

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -380,7 +380,7 @@ extension Sequence {
 
     if i != ringBuffer.startIndex {
       return AnySequence(
-        [ringBuffer[i..<ringBuffer.endIndex], ringBuffer[0..<i]].flatten())
+        [ringBuffer[i..<ringBuffer.endIndex], ringBuffer[0..<i]].flattened())
     }
     return AnySequence(ringBuffer)
   }

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -386,7 +386,7 @@ extension Sequence {
   ///
   /// is equivalent to
   ///
-  ///     Array(s.map(transform).flatten())
+  ///     Array(s.map(transform).flattened())
   ///
   /// - Complexity: O(*M* + *N*), where *M* is the length of `self`
   ///   and *N* is the length of the result.

--- a/test/Interpreter/algorithms.swift
+++ b/test/Interpreter/algorithms.swift
@@ -25,7 +25,7 @@ print(two_one)
 // CHECK: [2, 1]
 
 // rdar://problem/18208283
-func flatten<Element, Seq: Sequence, InnerSequence: Sequence
+func flattened<Element, Seq: Sequence, InnerSequence: Sequence
        where Seq.Iterator.Element == InnerSequence, InnerSequence.Iterator.Element == Element> (_ outerSequence: Seq) -> [Element] {
   var result = [Element]()
 
@@ -37,7 +37,7 @@ func flatten<Element, Seq: Sequence, InnerSequence: Sequence
 }
 
 // CHECK: [1, 2, 3, 4, 5, 6]
-let flat = flatten([[1,2,3], [4,5,6]])
+let flat = flattened([[1,2,3], [4,5,6]])
 print(flat)
 
 // rdar://problem/19416848

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -170,7 +170,7 @@ public struct ArrayBuilder<T> : CollectionBuilder {
     _resultParts.append(_resultTail)
     _resultTail = []
     // FIXME: optimize.  parallelize.
-    return Array(_resultParts.flatten())
+    return Array(_resultParts.flattened())
   }
 }
 

--- a/validation-test/stdlib/Concatenate.swift
+++ b/validation-test/stdlib/Concatenate.swift
@@ -34,21 +34,21 @@ let expected = ContiguousArray(0..<8)
 
 for (expected, source) in samples {
   ConcatenateTests.test("forward-\(source)") {
-    checkBidirectionalCollection(expected, source.flatten())
+    checkBidirectionalCollection(expected, source.flattened())
   }
 
   ConcatenateTests.test("reverse-\(source)") {
     // FIXME: separate 'expected' and 'reversed' variables are a workaround
     // for: <rdar://problem/20789500>
     let expected = ContiguousArray(expected.lazy.reversed())
-    let reversed = source.flatten().reversed()
+    let reversed = source.flattened().reversed()
     checkBidirectionalCollection(expected, reversed)
   }
 
   ConcatenateTests.test("sequence-\(source)") {
     checkSequence(
       ContiguousArray(expected),
-      AnySequence(source).flatten())
+      AnySequence(source).flattened())
   }
 }
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -817,7 +817,7 @@ do {
     let expected = sample.expected
     let data = sample.data
 
-    tests.test("FlattenSequence/\(data)") {
+    tests.test("FlattenedSequence/\(data)") {
       var base = MinimalSequence(
         elements: data.map { MinimalSequence(elements: $0) })
       checkSequence(expected, base.flattened(), resiliencyChecks: .none)
@@ -835,7 +835,7 @@ do {
         "unexpected laziness in \(flattened.dynamicType)")
     }
 
-    tests.test("FlattenSequence/Lazy/\(data)") {
+    tests.test("FlattenedSequence/Lazy/\(data)") {
       // Checking that flatten doesn't remove laziness
       let base = MinimalSequence(
         elements: data.map { MinimalSequence(elements: $0) }

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -820,14 +820,14 @@ do {
     tests.test("FlattenSequence/\(data)") {
       var base = MinimalSequence(
         elements: data.map { MinimalSequence(elements: $0) })
-      checkSequence(expected, base.flatten(), resiliencyChecks: .none)
+      checkSequence(expected, base.flattened(), resiliencyChecks: .none)
 
       // Checking that flatten doesn't introduce laziness
 
       // checkSequence consumed base, so reassign
       base = MinimalSequence(
         elements: data.map { MinimalSequence(elements: $0) })
-      let flattened = base.flatten()
+      let flattened = base.flattened()
       var calls = 0
       _ = flattened.map { _ in calls += 1 }
       expectEqual(
@@ -841,7 +841,7 @@ do {
         elements: data.map { MinimalSequence(elements: $0) }
       ).lazy.map { $0 }
 
-      let flattened = base.flatten()
+      let flattened = base.flattened()
       var calls = 0
       _ = flattened.map { _ in calls += 1 }
       expectEqual(0, calls, "unexpected eagerness in \(flattened.dynamicType)")
@@ -853,7 +853,7 @@ do {
       let base = Minimal${traversal}Collection(
         elements: data.map { Minimal${traversal}Collection(elements: $0) })
 
-      let flattened = base.flatten()
+      let flattened = base.flattened()
       check${traversal}Collection(expected, flattened, resiliencyChecks: .none)
 
       // Checking that flatten doesn't introduce laziness
@@ -870,7 +870,7 @@ do {
         elements: data.map { Minimal${traversal}Collection(elements: $0) }
       ).lazy.map { $0 }
 
-      let flattened = base.flatten()
+      let flattened = base.flattened()
 
       var calls = 0
       _ = flattened.map { _ in calls += 1 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

> The 'flatten()' method didn't get the Swift 3 API renaming treatment it should have, to go along with reversed, sorted, joined, etc.

So I renamed the function.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-933](https://bugs.swift.org/browse/SR-933))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
