### PR TITLE
[test] Add an xfail test demonstrating SR-1129

### DIFF
--- a/test/Interpreter/Inputs/public_var_private_setter.swift
+++ b/test/Interpreter/Inputs/public_var_private_setter.swift
@@ -1,0 +1,3 @@
+public class BaseClass {
+  public internal(set) var variable: Int = 0
+}

--- a/test/Interpreter/use_public_var_private_setter.swift
+++ b/test/Interpreter/use_public_var_private_setter.swift
@@ -1,0 +1,10 @@
+// RUN: %target-build-swift -emit-module -emit-library %S/Inputs/public_var_private_setter.swift
+// RUN: %target-build-swift -I . -L . -lpublic_var_private_setter %s -o use_public_var_private_setter
+
+// On Linux, the linker step of this test fails with "Bad value", specifically:
+// "hidden symbol `_TFC25public_var_private_setter9BaseClasscfT_S0_' isn't defined".
+// XFAIL: linux
+
+import public_var_private_setter
+
+class Class: BaseClass {}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

[SR-1129](https://bugs.swift.org/browse/SR-1129) tracks an issue in which the linking step fails if a base class, defined in an imported module with a `public private(set) var`, is subclassed by another module. This adds a test that XFAILs on Linux. The test passed on OS X.

This issue is currently forcing swift-corelibs-xctest and swift-corelibs-foundation to mark several privately-used variables as `public`.
#### ~~Resolved~~ Related bug number: ([SR-1129](https://bugs.swift.org/browse/SR-1129))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
