### PR TITLE
[stdlib] Expected behaviour for advancedBy:Limit:

### DIFF
--- a/stdlib/public/core/Index.swift
+++ b/stdlib/public/core/Index.swift
@@ -394,7 +394,7 @@ extension RandomAccessIndex {
   @warn_unused_result
   public func advanced(by n: Distance, limit: Self) -> Self {
     let d = self.distance(to: limit)
-    if d == 0 || (d > 0 ? d <= n : d >= n) {
+    if n >= 0 ? d <= n : d >= n {
       return limit
     }
     return self.advanced(by: n)


### PR DESCRIPTION
advancedBy:Limit: now doesn’t advance anymore and returns the limit
when the index was already behind [or before if traveling the opposite
way] the limit
