### PR TITLE
[gardening] Fix recently introduced typo: "a llvm" → "an llvm"

### DIFF
--- a/test/AutolinkExtract/linker-order.ll
+++ b/test/AutolinkExtract/linker-order.ll
@@ -3,7 +3,7 @@
 
 ; Ensure that the options in the object file preserve ordering.  The linker
 ; options are order dependent, and we would accidentally reorder them because we
-; used a std::set rather than a llvm::SmallSetVector.
+; used a std::set rather than an llvm::SmallSetVector.
 
 @_swift1_autolink_entries_1 = private constant [7 x i8] c"Saleem\00", section ".swift1_autolink_entries", align 8
 @_swift1_autolink_entries_0 = private constant [8 x i8] c"Naureen\00", section ".swift1_autolink_entries", align 8


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

[gardening] Fix recently introduced typo: "a llvm" → "an llvm"
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
