### PR TITLE
[Sema] Add "unused result" warning for #selector.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2132,6 +2132,8 @@ WARNING(expression_unused_result_nonmutating,none,
         "use %1 to mutate in-place", (DeclName, DeclName))
 WARNING(expression_unused_optional_try,none,
         "result of 'try?' is unused", ())
+WARNING(expression_unused_selector_result, none,
+        "result of '#selector' is unused", ())
 
 ERROR(assignment_lhs_not_lvalue,none,
       "cannot assign to immutable expression of type %0", (Type))

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -986,7 +986,14 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   }
 
   auto valueE = E->getValueProvidingExpr();
-
+  
+  // Complain about '#selector'.
+  if (auto *ObjCSE = dyn_cast<ObjCSelectorExpr>(valueE)) {
+    diagnose(ObjCSE->getLoc(), diag::expression_unused_selector_result)
+      .highlight(E->getSourceRange());
+    return;
+  }
+    
   // Always complain about 'try?'.
   if (auto *OTE = dyn_cast<OptionalTryExpr>(valueE)) {
     diagnose(OTE->getTryLoc(), diag::expression_unused_optional_try)

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -88,6 +88,10 @@ func testAmbiguity() {
   _ = #selector(C1.method3) // expected-error{{ambiguous use of 'method3(_:b:)'}}
 }
 
+func testUnusedSelector() {
+    #selector(C1.getC1) // expected-warning{{result of '#selector' is unused}}
+}
+
 func testProperties(c1: C1) {
   _ = #selector(c1.a) // expected-error{{argument of '#selector' cannot refer to a property}}
   _ = #selector(C1.a) // FIXME poor diagnostic: expected-error{{instance member 'a' cannot be used on type 'C1'}}
@@ -98,15 +102,15 @@ func testNonObjC(c1: C1) {
 }
 
 func testParseErrors1() {
-  #selector foo // expected-error{{expected '(' following '#selector'}}
+  _ = #selector foo // expected-error{{expected '(' following '#selector'}}
 }
 
 func testParseErrors2() {
-  #selector( // expected-error{{expected expression naming a method within '#selector(...)'}}
+  _ = #selector( // expected-error{{expected expression naming a method within '#selector(...)'}}
 }
 
 func testParseErrors3(c1: C1) {
-  #selector( // expected-note{{to match this opening '('}}
+  _ = #selector( // expected-note{{to match this opening '('}}
       c1.method1(_:b:) // expected-error{{expected ')' to complete '#selector' expression}}
 }
 


### PR DESCRIPTION
#### What's in this pull request?

We now have a nice warning when a selector is unused:

```
import Foundation
func test() {
warning: result of '#selector' is unused
  #selector(NSObject.copy)
  ^~~~~~~~~~~~~~~~~~~~~~~~
}
```
#### Resolved bug number: ([SR-1022](https://bugs.swift.org/browse/SR-1022))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
