### PR TITLE
Provide Metadata for ivar_getTypeEncoding()

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1364,7 +1364,10 @@ namespace {
       auto name = IGM.getAddrOfGlobalString(ivar->getName().str());
 
       // TODO: clang puts this in __TEXT,__objc_methtype,cstring_literals
-      auto typeEncode = IGM.getAddrOfGlobalString("");
+      std::string typeEnc;
+      if (requiresObjCPropertyDescriptor(IGM, ivar))
+        getObjCEncodingForPropertyType(IGM, ivar, typeEnc);
+      auto typeEncode = IGM.getAddrOfGlobalString(typeEnc.c_str());
 
       Size size;
       Alignment alignment;

--- a/test/Interpreter/type_encoding.swift
+++ b/test/Interpreter/type_encoding.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-swift | FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+import Foundation
+
+class c1: NSObject {
+    let a = 99.0
+    let b = 99
+}
+
+class c2 {
+}
+
+struct s1 {
+}
+
+class t: NSObject {
+    let d: Double = 99.0
+    let f: Float = 99.0
+    let q: Int = 99
+    let i: CInt = 99
+    let c: Int8 = 99
+    let b = true
+    let s = ""
+    let array = [String]()
+    let dict = ["":1]
+    let set = Set<String>()
+    let w: () -> () = {}
+    let x = c1()
+    let y = c2()
+    let z = s1()
+}
+
+var ic: UInt32 = 0
+let ivars = class_copyIvarList( t.self, &ic )
+for i in 0..<ic {
+    print("\(String.fromCString(ivar_getName(ivars[Int(i)]))!) \(String.fromCString(ivar_getTypeEncoding(ivars[Int(i)]))!)")
+}
+
+// CHECK: d d
+// CHECK: f f
+// CHECK: q q
+// CHECK: i i
+// CHECK: c c
+// CHECK: b c
+// CHECK: s @"NSString"
+// CHECK: array @"NSArray"
+// CHECK: dict @"NSDictionary"
+// CHECK: set @"NSSet"
+// CHECK: w @?
+// CHECK: x @"_TtC4main2c1"
+// CHECK: y
+// CHECK: z


### PR DESCRIPTION
#### What's in this pull request?

A minor change to GenClass.cpp to populate at least some information about the type of ivars so it can be accessed by ivar_getTypeEncoding(). This sort of introspection is useful to implement automated JSON or databse table mapping into Swift objects and vice versa along with generic object inspectors.

It is not strictly correct in that it yields the type of the property but in practice this would be more useful as for object types the property accessors should be used to convert to/from an Objective-C accessible type anyway. It’s an improvement over the existing code which makes no attempt to provide information.

Tested by building toolchain and compiling a large project with a variety of Swift code. Also used from inside an example project containing largely the same code as is included in the test with this PR. Does not apply to Linux.
#### Resolved bug number:

rdar://17637431
