### PR TITLE
[unittests] Ignore googletest DWARF directories

### DIFF
--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -40,6 +40,14 @@ config.name = 'Swift-Unit'
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = []
 
+# excludes: A path component to ignore when discovering tests.
+# The Swift build system does not generate DWARF symbols in the unittests build
+# directory. For build systems that do, however, files would be generated with
+# the test suffix "Tests". These need to be excluded because otherwise
+# `lit.formats.GoogleTest` tries to execute them.
+# See http://reviews.llvm.org/D18647 for details.
+config.excludes = ['DWARF']
+
 # test_source_root: The root path where tests are located.
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(swift_obj_root, 'unittests')


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The Swift build system does not generate DWARF symbols in the unittests build directory. For build systems that do, however, files would be generated with the test suffix "Tests". These need to be excluded because otherwise `lit.formats.GoogleTest` tries to execute them. See http://reviews.llvm.org/D18647 for details.

/cc @ddunbar 
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
