### PR TITLE
Sema: Set the interface type of lazy properties during validation.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1184,10 +1184,12 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   NameBuf += ".storage";
   auto StorageName = Context.getIdentifier(NameBuf);
   auto StorageTy = OptionalType::get(VD->getType());
+  auto StorageInterfaceTy = OptionalType::get(VD->getInterfaceType());
 
   auto *Storage = new (Context) VarDecl(/*isStatic*/false, /*isLet*/false,
                                         VD->getLoc(), StorageName, StorageTy,
                                         VD->getDeclContext());
+  Storage->setInterfaceType(StorageInterfaceTy);
   Storage->setUserAccessible(false);
   addMemberToContextIfNeeded(Storage, VD->getDeclContext(), VD);
 

--- a/test/decl/var/Inputs/lazy_properties_multi_file_2.swift
+++ b/test/decl/var/Inputs/lazy_properties_multi_file_2.swift
@@ -1,0 +1,4 @@
+struct MyGenericStruct<T> {
+    lazy var prop2 = [AnotherGenericStruct<T>]()
+}
+struct AnotherGenericStruct<T> { }

--- a/test/decl/var/lazy_properties_multi_file.swift
+++ b/test/decl/var/lazy_properties_multi_file.swift
@@ -1,0 +1,7 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-swift-frontend %s -verify -O -primary-file %s %S/Inputs/lazy_properties_multi_file_2.swift -c -o %t/lazy_properties_multi_file.o
+
+class MyClass {
+    var myProperty = MyGenericStruct<Int>()
+}


### PR DESCRIPTION
Otherwise, we end up treating the contextual type as the interface type in situations where the lazy property is seen from other files. Fixes SR-837.
