### PR TITLE
Make _Strideable visible in generated interface

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -94,7 +94,7 @@ set(SWIFTLIB_ESSENTIAL
   Slice.swift.gyb
   Sort.swift.gyb
   StaticString.swift
-  Stride.swift
+  Stride.swift.gyb
   StringCharacterView.swift # ORDER DEPENDENCY: Must precede String.swift
   String.swift
   StringBridge.swift

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -13,9 +13,16 @@
 // WORKAROUND rdar://25214598 - should be:
 // protocol Strideable : Comparable {...}
 
+% for Self in ['_Strideable', 'Strideable']:
+
+%{
+    Conformance = (
+      'Equatable' if Self == '_Strideable' else '_Strideable, Comparable'
+    )
+}%
 /// Conforming types are notionally continuous, one-dimensional
 /// values that can be offset and measured.
-public protocol _Strideable : Equatable {
+public protocol ${Self} : ${Conformance} {
   // FIXME(ABI)(compiler limitation): We'd like to name this type "Distance"
   // but for <rdar://problem/17619038>
   /// A type that can represent the distance between two values of `Self`.
@@ -44,8 +51,7 @@ public protocol _Strideable : Equatable {
   associatedtype _DisabledRangeIndex = _DisabledRangeIndex_
 }
 
-// WORKAROUND rdar://25214598 (see above)
-public protocol Strideable : _Strideable, Comparable {}
+% end
 
 /// Compare two `Strideable`s.
 public func < <T : Strideable>(x: T, y: T) -> Bool {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

@gribozavr, I was wrong, it's `_Strideable` that needs to be visible under the new indexing model, not `_Incrementable`. `Strideable` has no declarations of its own.
#### Resolved bug number: [SR-984](https://bugs.swift.org/browse/SR-984)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
