### PR TITLE
IRGen: Pretend to satisfy generic parameters from the 'Self' parameter to extension methods.

### DIFF
--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -105,6 +105,7 @@ static bool isLeafTypeMetadata(CanType type) {
 ///   metadata for the given type, false if it might be a subtype
 bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
                                         IsExact_t isExact,
+                                        bool isSelfParameter,
                                         unsigned source, MetadataPath &&path,
                                         const InterestingKeysCallback &keys) {
 
@@ -114,7 +115,8 @@ bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
     // If the type isn't a leaf type, also check it as an inexact match.
     bool hadFulfillment = false;
     if (!isLeafTypeMetadata(type)) {
-      hadFulfillment |= searchTypeMetadata(IGM, type, IsInexact, source,
+      hadFulfillment |= searchTypeMetadata(IGM, type, IsInexact,
+                                           isSelfParameter, source,
                                            MetadataPath(path), keys);
     }
 
@@ -129,8 +131,8 @@ bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
     return searchNominalTypeMetadata(IGM, nomTy, source, std::move(path), keys);
   }
   if (auto boundTy = dyn_cast<BoundGenericType>(type)) {
-    return searchBoundGenericTypeMetadata(IGM, boundTy, source, std::move(path),
-                                          keys);
+    return searchBoundGenericTypeMetadata(IGM, boundTy, source, isSelfParameter,
+                                          std::move(path), keys);
   }
 
   // TODO: tuples
@@ -217,7 +219,8 @@ bool FulfillmentMap::searchParentTypeMetadata(IRGenModule &IGM,
 
   // If we do, it has to be nominal one way or another.
   path.addNominalParentComponent();
-  return searchTypeMetadata(IGM, parent, IsExact, source, std::move(path), keys);
+  return searchTypeMetadata(IGM, parent, IsExact, /*is self*/ false,
+                            source, std::move(path), keys);
 }
 
 bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
@@ -234,11 +237,27 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
 bool FulfillmentMap::searchBoundGenericTypeMetadata(IRGenModule &IGM,
                                                     CanBoundGenericType type,
                                                     unsigned source,
+                                                    bool isSelfParameter,
                                                     MetadataPath &&path,
                                          const InterestingKeysCallback &keys) {
-  if (type->getDecl()->hasClangNode())
-    return false;
-
+  // Objective-C generics don't preserve their generic parameters at runtime,
+  // so they aren't able to fulfill type metadata requirements. However,
+  // if we have a method defined in Swift on an ObjC generic class, that
+  // method is restricted not to have access to the generic parameters, since
+  // it wouldn't be able to polymorphically. In this case, we still have to
+  // consider the self type to "fulfill" the type parameters so they don't
+  // get emitted as separate parameters.
+  if (type->getDecl()->hasClangNode()) {
+    if (isSelfParameter) {
+      // Represent the path as "impossible" so we crash if we accidentally do
+      // anything that needs the metadata.
+      path = MetadataPath();
+      path.addImpossibleComponent();
+    } else {
+      return false;
+    }
+  }
+  
   bool hadFulfillment = false;
 
   GenericTypeRequirements requirements(IGM, type->getDecl());
@@ -255,7 +274,8 @@ bool FulfillmentMap::searchBoundGenericTypeMetadata(IRGenModule &IGM,
       MetadataPath argPath = path;
       argPath.addNominalTypeArgumentComponent(reqtIndex);
       hadFulfillment |=
-        searchTypeMetadata(IGM, arg, IsExact, source, std::move(argPath), keys);
+        searchTypeMetadata(IGM, arg, IsExact, /*is self*/ false,
+                           source, std::move(argPath), keys);
       return;
     }
 

--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -97,6 +97,7 @@ public:
   ///
   /// \return true if any fulfillments were added by this search.
   bool searchTypeMetadata(IRGenModule &IGM, CanType type, IsExact_t isExact,
+                          bool isSelfParameter,
                           unsigned sourceIndex, MetadataPath &&path,
                           const InterestingKeysCallback &interestingKeys);
 
@@ -150,7 +151,8 @@ private:
                                  const InterestingKeysCallback &keys);
 
   bool searchBoundGenericTypeMetadata(IRGenModule &IGM, CanBoundGenericType type,
-                                      unsigned source, MetadataPath &&path,
+                                      unsigned source, bool isSelfParameter,
+                                      MetadataPath &&path,
                                       const InterestingKeysCallback &keys);
 
   /// Search the given witness table for useful fulfillments.

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -259,6 +259,7 @@ void LocalTypeDataCache::addAbstractForTypeMetadata(IRGenFunction &IGF,
   // anything, stop.
   FulfillmentMap fulfillments;
   if (!fulfillments.searchTypeMetadata(IGF.IGM, type, isExact,
+                                       /*isSelf*/ false,
                                        /*source*/ 0, MetadataPath(),
                                        FulfillmentMap::Everything())) {
     return;

--- a/test/IRGen/objc_generic_class_convention.sil
+++ b/test/IRGen/objc_generic_class_convention.sil
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -enable-import-objc-generics -emit-ir | FileCheck %s
+
+// REQUIRES: objc_interop
+
+sil_stage canonical
+
+import Swift
+import Foundation
+import objc_generics
+
+// If we define a method on an ObjC generic class in Swift, we don't have
+// access to Self's type parameters, and shouldn't try to emit type parameters
+// for them either, since they wouldn't be available through the polymorphic
+// convention for class methods.
+
+// CHECK-LABEL: define void @method(i64, %CSo12GenericClass*)
+sil @method : $@convention(method) <T: AnyObject> (Int64, @guaranteed GenericClass<T>) -> () {
+entry(%0 : $Int64, %1 : $GenericClass<T>):
+  return undef : $()
+}
+
+// CHECK-LABEL: define void @objcMethod(i8*, i8*, i64)
+sil @objcMethod : $@convention(objc_method) <T: AnyObject> (Int64, @guaranteed GenericClass<T>) -> () {
+entry(%0 : $Int64, %1 : $GenericClass<T>):
+  return undef : $()
+}

--- a/test/Interpreter/imported_objc_generics.swift
+++ b/test/Interpreter/imported_objc_generics.swift
@@ -13,8 +13,6 @@ import Foundation
 import StdlibUnittest
 import ObjCClasses
 
-let wut = Container<NSString>.self
-
 var ImportedObjCGenerics = TestSuite("ImportedObjCGenerics")
 
 ImportedObjCGenerics.test("Creation") {

--- a/test/Interpreter/imported_objc_generics_extension.swift
+++ b/test/Interpreter/imported_objc_generics_extension.swift
@@ -1,0 +1,31 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+// RUN: %target-build-swift -Xfrontend -enable-import-objc-generics -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// XFAIL: interpret
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+import ObjCClasses
+
+var ImportedObjCGenericExtension = TestSuite("ImportedObjCGenericExtension")
+
+extension Container {
+  func returnSelf() -> Self {
+    return self
+  }
+}
+
+ImportedObjCGenericExtension.test("ExtensionFromSwift") {
+  let gc = Container<NSString>(object: "")
+  expectTrue(gc.returnSelf() === gc)
+  let gc2: Unmanaged<AnyObject>! = gc.perform(#selector(Container<NSString>.returnSelf))
+  expectTrue(gc2!.takeUnretainedValue() === gc)
+}
+
+runAllTests()


### PR DESCRIPTION
We prevent the generic parameters to an ObjC generic from being used in an extension method at the sema level, and we don't want the polymorphic convention to try to generate independent parameters since that would break the method convention. Trick the polymorphic convention by producing "impossible" fulfillments for the generic parameters derivable from an ObjC generic method's self type.
