### PR TITLE
implement retain release code motion.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -179,6 +179,12 @@ PASS(PredictableMemoryOptimizations, "predictable-memopt",
      "Predictable early memory optimizations")
 PASS(ReleaseDevirtualizer, "release-devirtualizer",
      "Devirtualize release-instructions")
+PASS(RetainSinking, "retain-sinking",
+     "Sink retains")
+PASS(ReleaseHoisting, "release-hoisting",
+     "Hoist releases")
+PASS(LateReleaseHoisting, "late-release-hoisting",
+     "Hoist releases")
 PASS(RemovePins, "remove-pins",
      "Remove pin/unpin pairs")
 PASS(SideEffectsDumper, "side-effects-dump",

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.cpp
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.cpp
@@ -33,7 +33,7 @@
 
 using namespace swift;
 
-llvm::cl::opt<bool> DisableARCRRMotion("disable-code-motion-arc", llvm::cl::init(false));
+llvm::cl::opt<bool> DisableARCRRMotion("disable-code-motion-arc", llvm::cl::init(true));
 
 //===----------------------------------------------------------------------===//
 //                          ARC Matching Set Builder

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -649,7 +649,7 @@ findMatchingRetains(SILBasicBlock *BB) {
 ConsumedArgToEpilogueReleaseMatcher::
 ConsumedArgToEpilogueReleaseMatcher(RCIdentityFunctionInfo *RCFI,
                                     SILFunction *F, ExitKind Kind)
-   : F(F), RCFI(RCFI), Kind(Kind) {
+   : F(F), RCFI(RCFI), Kind(Kind), ProcessedBlock(nullptr) {
   recompute();
 }
 
@@ -668,10 +668,10 @@ void ConsumedArgToEpilogueReleaseMatcher::recompute() {
   }
 
   if (BB == F->end()) {
-    HasBlock = false;
+    ProcessedBlock = nullptr;
     return;
   }
-  HasBlock = true;
+  ProcessedBlock = &*BB;
   findMatchingReleases(&*BB);
 }
 

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -238,6 +238,7 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
   PM.addDCE();
 
   PM.addEarlyCodeMotion();
+  PM.addReleaseHoisting();
   PM.addARCSequenceOpts();
 
   PM.addSimplifyCFG();
@@ -249,6 +250,7 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
   } else
     PM.addEarlyCodeMotion();
 
+  PM.addRetainSinking();
   PM.addARCSequenceOpts();
   PM.addRemovePins();
 }
@@ -379,6 +381,10 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   // Remove dead code.
   PM.addDCE();
   PM.addSimplifyCFG();
+
+  // Try to hoist all releases, including epilogue releases. This should be
+  // after FSO.
+  PM.addLateReleaseHoisting();
 
   PM.runOneIteration();
 

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TRANSFORMS_SOURCES
   Transforms/RedundantLoadElimination.cpp
   Transforms/RedundantOverflowCheckRemoval.cpp
   Transforms/ReleaseDevirtualizer.cpp
+  Transforms/RetainReleaseCodeMotion.cpp
   Transforms/RemovePin.cpp
   Transforms/SILCleanup.cpp
   Transforms/SILCodeMotion.cpp

--- a/lib/SILOptimizer/Transforms/RetainReleaseCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/RetainReleaseCodeMotion.cpp
@@ -1,0 +1,1095 @@
+//===--- RetainReleaseCodeMotion.cpp - SIL Retain and Release Code Motion -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This pass moves retains down and releases up. This, hopefully, will help
+/// ARC sequence opt to remove retain and release pairs without worrying too
+/// much about control flows.
+///
+/// It uses an optimistic iterative data flow to compute where to insert the
+/// retains and releases for every reference-counted root. It then removes all
+/// the old retain and release instructions and create the new ones.
+///
+/// This pass is more sophisticated than SILCodeMotion, as arc optimizations
+/// can be very beneficial, use an optimistic global data flow to achieve
+/// optimiality.
+///
+/// Proof of Correctness:
+/// -------------------
+///
+/// 1. Retains are blocked by MayDecrements. Its straightforward to prove that
+/// retain sinking is correct. 
+/// 
+/// If a retain is sunk from Region A to Region B, that means there is no
+/// blocking operation between where the retain was in Region A to where it is
+/// sunk to in Region B. Since we only sink retains (we do not move any other
+/// instructions) which themselves are NOT MayDecrement operations, and moving
+/// retains cant turn non-decrement instruction MayDecrement.
+///
+/// 2. Releases are blocked by MayInterfere. If a release is hoisted from
+/// Region B to Region A, that means there is no blocking operation from where
+/// the release was in Region B and where the release is hoisted to in Region A.
+///
+/// The question is whether we can introduce such operation while we hoist other
+/// releases. The answer is NO. because if such releases exist, they would be
+/// blocked by the old release (we remove old release and recreate new ones at
+/// the end of the pass) and will not be able to be hoisted beyond the old 
+/// release.
+///
+/// This proof also hinges on the fact that if release A interferes with
+/// releases B then release B must interfere with release A. i.e. the 2
+/// releases must have the symmetric property. Consider the 2 releases as 2
+/// function calls, i.e. CallA (release A) and CallB (release B), if CallA
+/// interferes with CallB, that means CallA must share some program states
+/// (through read or write) with CallB. Then it is not possible for CallB
+/// to not share any states with CallA. And if they do share states, then
+/// its not possible for CallB to block CallA and CallA not to block CallB.
+///
+/// TODO: Sinking retains can block releases to be hoisted, and hoisting
+/// releases can block retains to be sunk. Investigate when to sink retains and
+/// when to hoist releases and their ordering in the pass pipeline.
+///
+/// TODO: Consider doing retain hoisting and release sinking. This can help
+/// to discover disjoint lifetimes and we can try to stitch them together.
+///
+/// TODO: There are a lot of code duplications between retain and release code
+/// motion in the data flow part. Consider whether we can share them.
+/// Essentially, we can implement the release code motion by inverting the retain
+/// code motion, but this can also make the code less readable.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-rr-code-motion"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
+#include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
+#include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
+#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ValueTracking.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+STATISTIC(NumRetainsSunk, "Number of retains sunk");
+STATISTIC(NumReleasesHoisted, "Number of releases hoisted");
+
+//===----------------------------------------------------------------------===//
+//                             Utility 
+//===----------------------------------------------------------------------===//
+
+static bool isRetainInstruction(SILInstruction *I) {
+  return isa<StrongRetainInst>(I) || isa<RetainValueInst>(I);
+}
+
+static bool isReleaseInstruction(SILInstruction *I) {
+  return isa<StrongReleaseInst>(I) || isa<ReleaseValueInst>(I);
+}
+
+/// Creates an increment on \p Ptr before insertion point \p InsertPt that
+/// creates a strong_retain if \p Ptr has reference semantics itself or a
+/// retain_value if \p Ptr is a non-trivial value without reference-semantics.
+static SILInstruction *
+createIncrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
+  // Set up the builder we use to insert at our insertion point.
+  SILBuilder B(InsertPt);
+  auto Loc = RegularLocation(SourceLoc());
+
+  // If Ptr is refcounted itself, create the strong_retain and
+  // return.
+  if (Ptr->getType().isReferenceCounted(B.getModule()))
+    return B.createStrongRetain(Loc, Ptr, Atomicity::Atomic);
+
+  // Otherwise, create the retain_value.
+  return B.createRetainValue(Loc, Ptr, Atomicity::Atomic);
+}
+
+/// Creates a decrement on \p Ptr before insertion point \p InsertPt that
+/// creates a strong_release if \p Ptr has reference semantics itself or
+/// a release_value if \p Ptr is a non-trivial value without reference-semantics.
+static SILInstruction *
+createDecrementBefore(SILValue Ptr, SILInstruction *InsertPt) {
+  // Setup the builder we will use to insert at our insertion point.
+  SILBuilder B(InsertPt);
+  auto Loc = RegularLocation(SourceLoc());
+
+  // If Ptr has reference semantics itself, create a strong_release.
+  if (Ptr->getType().isReferenceCounted(B.getModule()))
+    return B.createStrongRelease(Loc, Ptr, Atomicity::Atomic);
+
+  // Otherwise create a release value.
+  return B.createReleaseValue(Loc, Ptr, Atomicity::Atomic);
+}
+
+//===----------------------------------------------------------------------===//
+//                             Block State 
+//===----------------------------------------------------------------------===//
+
+struct BlockState {
+  /// A bit vector for which the ith bit represents the ith refcounted root in
+  /// RCRootVault.
+  ///
+  /// NOTE: we could do the data flow with BBSetIn or BBSetOut, but that would
+  /// require us to create a temporary copy to check whether the BBSet has
+  /// changed after the genset and killset has been applied.
+  llvm::SmallBitVector BBSetIn;
+
+  /// A bit vector for which the ith bit represents the ith refcounted root in
+  /// RCRootVault.
+  llvm::SmallBitVector BBSetOut;
+
+  /// A bit vector for which the ith bit represents the ith refcounted root in
+  /// RCRootVault. If the bit is set, that means this basic block creates a
+  /// retain which can be sunk or a release which can be hoisted.
+  llvm::SmallBitVector BBGenSet;
+
+  /// A bit vector for which the ith bit represents the ith refcounted root in
+  /// RCRootVault. If this bit is set, that means this basic block stops retain
+  /// or release of the refcounted root to be moved across.
+  llvm::SmallBitVector BBKillSet;
+
+  /// A bit vector for which the ith bit represents the ith refcounted root in
+  /// RCRootVault. If this bit is set, that means this is potentially a retain
+  /// or release that can be sunk or hoisted to this point. This is used to
+  /// optimize the time for computing genset and killset.
+  /// NOTE: this vector contains an approximation of whether there will be a
+  /// retain or release to a certain point of a basic block.
+  llvm::SmallBitVector BBMaxSet;
+};
+
+/// CodeMotionContext - This is the base class which retain code motion and
+/// release code motion inherits from. It defines an interface as to how the
+/// code motion precedure should be.
+class CodeMotionContext {
+protected:
+  /// Dataflow needs multiple iteration to converge. If this is false, then we
+  /// do not need to generate the genset or killset, i.e. we can simply do 1
+  /// pessimistic data flow iteration.
+  bool MultiIteration;
+
+  /// The allocator we are currently using.
+  llvm::BumpPtrAllocator &BPA;
+
+  /// Current function we are analyzing.
+  SILFunction *F;
+
+  /// Current post-order we are using.
+  PostOrderFunctionInfo *PO;
+
+  /// Current alias analysis we are using.
+  AliasAnalysis *AA;
+
+  /// Current rc-identity we are using.
+  RCIdentityFunctionInfo *RCFI;
+
+  /// All the unique refcount roots retained or released in the function.
+  llvm::SetVector<SILValue> RCRootVault;
+
+  /// Contains a map between rc roots to their index in the RCRootVault.
+  /// used to facilitate fast rc roots to index lookup.
+  llvm::DenseMap<SILValue, unsigned> RCRootIndex;
+
+  /// All the retains or releases originally in the function. Eventually
+  /// they will all be removed after all the new ones are generated.
+  llvm::SmallPtrSet<SILInstruction *, 8> RCInstructions;
+
+  /// All the places to place the new retains or releases after code motion.
+  using InsertPointList = llvm::SmallVector<SILInstruction *, 2>;
+  llvm::SmallDenseMap<SILValue, InsertPointList> InsertPoints;
+
+  /// These are the blocks that have a RC instruction to process or it blocks
+  /// some RC instructions. If the basic block has neither, we do not need to
+  /// process the block again in the last iteration. We populate this set when
+  /// we compute the genset and killset.
+  llvm::SmallPtrSet<SILBasicBlock *, 8> InterestBlocks;
+
+  /// An RC-identity cache.
+  /// TODO: this should be cached in RCIdentity analysis.
+  llvm::DenseMap<SILValue, SILValue> RCCache;
+
+  /// Return the rc-identity root of the SILValue.
+  SILValue getRCRoot(SILValue R) {
+    auto Iter = RCCache.find(R);
+    if (Iter != RCCache.end())
+      return Iter->second;
+     return RCCache[R] = RCFI->getRCIdentityRoot(R);
+  }
+
+  /// Return the rc-identity root of the rc instruction, i.e.
+  /// retain or release.
+  SILValue getRCRoot(SILInstruction *I) {
+    assert(isRetainInstruction(I) || isReleaseInstruction(I) &&
+           "Extracting RC root from Invalid instruction");
+    return getRCRoot(I->getOperand(0));
+  }
+
+public:
+  /// Constructor.
+  CodeMotionContext(llvm::BumpPtrAllocator &BPA, SILFunction *F,
+                    PostOrderFunctionInfo *PO, AliasAnalysis *AA,
+                    RCIdentityFunctionInfo *RCFI)
+    : MultiIteration(true), BPA(BPA), F(F), PO(PO), AA(AA), RCFI(RCFI) {}
+
+  /// virtual destructor.
+  virtual ~CodeMotionContext() {}
+
+  /// Run the data flow to move retains and releases.
+  bool run();
+
+  /// Check whether we need to run an optimitic iteration data flow.
+  /// or a pessimistic would suffice.
+  virtual bool requireIteration() = 0;
+
+  /// Initialize necessary things to run the iterative data flow.
+  virtual void initializeCodeMotionDataFlow() = 0;
+
+  /// Initialize the basic block maximum refcounted set.
+  virtual void initializeCodeMotionBBMaxSet() = 0;
+
+  /// Compute the genset and killset for every root in every basic block.
+  virtual void computeCodeMotionGenKillSet() = 0;
+
+  /// Run the iterative data flow to converge.
+  virtual void convergeCodeMotionDataFlow() = 0; 
+
+  /// Use the data flow results, come up with places to insert the new inst.
+  virtual void computeCodeMotionInsertPoints() = 0;
+
+  /// Remove the old retains and create the new *moved* refcounted instructions
+  virtual bool performCodeMotion() = 0;
+
+  /// Merge the data flow states.
+  virtual void mergeBBDataFlowStates(SILBasicBlock *BB) = 0;
+
+  /// Compute the BBSetIn and BBSetOut for the current basic
+  /// block with the generated gen and kill set.
+  virtual bool processBBWithGenKillSet(SILBasicBlock *BB) = 0;
+
+  /// Return true if the instruction blocks the Ptr to be moved further.
+  virtual bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) = 0;
+};
+
+bool CodeMotionContext::run() {
+  // Initialize the data flow.
+  initializeCodeMotionDataFlow();
+
+  // Converge the BBSetOut with iterative data flow.
+  if (MultiIteration) {
+    initializeCodeMotionBBMaxSet();
+    computeCodeMotionGenKillSet();
+    convergeCodeMotionDataFlow();
+  }
+
+  // Compute the insertion point where each RC root can be moved to.
+  computeCodeMotionInsertPoints();
+
+  // Finally, generate new retains and remove the old retains.
+  return performCodeMotion();
+}
+
+//===----------------------------------------------------------------------===//
+//                          Retain Code Motion 
+//===----------------------------------------------------------------------===//
+
+class RetainBlockState : public BlockState {
+public:
+  /// Check whether the BBSetOut has changed. If it does, we need to rerun
+  /// the data flow on this block's successors to reach fixed point.
+  bool updateBBSetOut(llvm::SmallBitVector &X) {
+    if (BBSetOut == X)
+      return false;
+    BBSetOut = X;
+    return true;
+  }
+
+  /// constructor.
+  RetainBlockState(bool IsEntry, unsigned size, bool MultiIteration) {
+    // Iterative forward data flow.
+    BBSetIn.resize(size, false);
+    BBSetOut.resize(size, MultiIteration);
+    BBMaxSet.resize(size, !IsEntry && MultiIteration);
+  
+    // Genset and Killset are initially empty.
+    BBGenSet.resize(size, false);
+    BBKillSet.resize(size, false);
+  }
+};
+
+/// RetainCodeMotionContext - Context to perform retain code motion.
+class RetainCodeMotionContext : public CodeMotionContext {
+  /// All the retain block state for all the basic blocks in the function. 
+  llvm::SmallDenseMap<SILBasicBlock *, RetainBlockState *> BlockStates;
+
+  /// Return true if the instruction blocks the Ptr to be moved further.
+  bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) {
+    // NOTE: If more checks are to be added, place the most expensive in the
+    // end, this function is called many times.
+    //
+    // These terminator instructions block.
+    if (isa<ReturnInst>(II) || isa<ThrowInst>(II) || isa<UnreachableInst>(II))
+      return true;
+    // Identical rc root blocks code motion, we will be able to move this retain
+    // further once we move the blocking retain.
+    if (isRetainInstruction(II) && getRCRoot(II) == Ptr)
+      return true;
+    // Ref count checks do not have side effects, but are barriers for retains.
+    if (mayCheckRefCount(II))
+      return true;
+    // mayDecrement reference count stops code motion.
+    if (mayDecrementRefCount(II, Ptr, AA)) 
+      return true;
+    // This instruction does not block the retain code motion.
+    return false;
+  }
+
+public:
+  /// Constructor.
+  RetainCodeMotionContext(llvm::BumpPtrAllocator &BPA, SILFunction *F,
+                          PostOrderFunctionInfo *PO, AliasAnalysis *AA,
+                          RCIdentityFunctionInfo *RCFI)
+      : CodeMotionContext(BPA, F, PO, AA, RCFI) {
+    MultiIteration = requireIteration();
+  }
+
+  /// virtual destructor.
+  virtual ~RetainCodeMotionContext() {}
+
+  /// Return true if we do not need optimistic data flow.
+  bool requireIteration();
+
+  /// Initialize necessary things to run the iterative data flow.
+  void initializeCodeMotionDataFlow();
+
+  /// Initialize the basic block maximum refcounted set.
+  void initializeCodeMotionBBMaxSet();
+
+  /// Compute the genset and killset for every root in every basic block.
+  void computeCodeMotionGenKillSet();
+
+  /// Run the iterative data flow to converge.
+  void convergeCodeMotionDataFlow(); 
+
+  /// Use the data flow results, come up with places to insert the new inst.
+  void computeCodeMotionInsertPoints();
+
+  /// Remove the old retains and create the new *moved* refcounted instructions
+  bool performCodeMotion();
+
+  /// Compute the BBSetIn and BBSetOut for the current basic block with the
+  /// generated gen and kill set.
+  bool processBBWithGenKillSet(SILBasicBlock *BB);
+
+  /// Merge the data flow states.
+  void mergeBBDataFlowStates(SILBasicBlock *BB);
+};
+
+bool RetainCodeMotionContext::requireIteration() {
+  // If all basic blocks will have their predecessors processed if the basic
+  // blocks in the functions are iterated in reverse post order. Then this
+  // function can be processed in one iteration, i.e. no need to generate the
+  // genset and killset.
+  llvm::SmallPtrSet<SILBasicBlock *, 4> PBBs;
+  for (SILBasicBlock *B : PO->getReversePostOrder()) {
+    for (auto X : B->getPreds()) {
+      if (!PBBs.count(X))
+        return true;
+    }
+    PBBs.insert(B);
+  }
+  return false;
+}
+
+void RetainCodeMotionContext::initializeCodeMotionDataFlow() {
+  // Find all the RC roots in the function.
+  for (auto &BB : *F) {
+    for (auto &II : BB) {
+      if (!isRetainInstruction(&II))
+        continue;
+      RCInstructions.insert(&II);
+      SILValue Root = getRCRoot(&II);
+      if (RCRootIndex.find(Root) != RCRootIndex.end())
+        continue;
+      RCRootIndex[Root] = RCRootVault.size();
+      RCRootVault.insert(Root);
+    }
+  }
+
+  // Initialize all the data flow bit vector for all basic blocks.
+  for (auto &BB : *F) {
+    BlockStates[&BB] = new (BPA) RetainBlockState(&BB == &*F->begin(),
+                                 RCRootVault.size(), MultiIteration);
+  }
+}
+
+void RetainCodeMotionContext::initializeCodeMotionBBMaxSet() {
+  for (SILBasicBlock *BB : PO->getReversePostOrder()) {
+    // If basic block has no predecessor, do nothing.
+    BlockState *State = BlockStates[BB];
+    if (BB->pred_empty()) {
+      State->BBMaxSet.reset();
+    } else {
+      // Intersect in all predecessors' BBSetOut.
+      State->BBMaxSet.set();
+      for (auto E = BB->pred_end(), I = BB->pred_begin(); I != E; ++I) {
+        State->BBMaxSet &= BlockStates[*I]->BBMaxSet;
+     }
+   }
+
+   // Process the instructions in the basic block to find what refcounted
+   // roots are retained. If we know that a rc root cant be retained at a
+   // basic block, then we know we do not need to consider it for the killset.
+   // NOTE: this is a conservative approximation, because some retains may be
+   // blocked before it reaches this block.
+   for (auto &II : *BB) {
+      if (!isRetainInstruction(&II))
+        continue;
+      State->BBMaxSet.set(RCRootIndex[getRCRoot(&II)]);
+    }
+  }
+}
+
+void RetainCodeMotionContext::computeCodeMotionGenKillSet() {
+  for (SILBasicBlock *BB : PO->getReversePostOrder()) {
+    auto *State = BlockStates[BB];
+    bool InterestBlock = false; 
+    for (auto &I : *BB) {
+      // Check whether this instruction blocks any RC root code motion.
+      for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+        if (!State->BBMaxSet.test(i) || !mayBlockCodeMotion(&I, RCRootVault[i]))
+          continue;
+        // This is a blocking instruction for the rcroot.
+        InterestBlock = true;
+        State->BBKillSet.set(i);
+        State->BBGenSet.reset(i);
+      }
+      // If this is a retain instruction, it also generates.
+      if (isRetainInstruction(&I)) {
+        unsigned idx = RCRootIndex[getRCRoot(&I)];
+        State->BBGenSet.set(idx);
+        assert(State->BBKillSet.test(idx) && "Killset computed incorrectly");
+        State->BBKillSet.reset(idx);
+        InterestBlock = true;
+      }
+    }
+
+    // Is this a block thats interesting to the last iteration of the data flow.
+    if (!InterestBlock)
+      continue;
+    InterestBlocks.insert(BB);
+  }
+}
+
+bool RetainCodeMotionContext::performCodeMotion() {
+  bool Changed = false;
+  // Create the new retain instructions.
+  for (auto RC : InsertPoints) {
+    for (auto IP : RC.second) {
+      createIncrementBefore(RC.first, IP);
+      Changed = true;
+    }
+  }
+  // Remove the old retain instructions.
+  for (auto R : RCInstructions) {
+    ++NumRetainsSunk;
+    recursivelyDeleteTriviallyDeadInstructions(R, true);
+  }
+  return Changed;
+}
+
+void RetainCodeMotionContext::mergeBBDataFlowStates(SILBasicBlock *BB) {
+  BlockState *State = BlockStates[BB];
+  State->BBSetIn.reset();
+  // If basic block has no predecessor, simply reset and return.
+  if (BB->pred_empty())
+    return;
+
+  // Intersect in all predecessors' BBSetOuts.
+  auto Iter = BB->pred_begin();
+  State->BBSetIn = BlockStates[*Iter]->BBSetOut;
+  Iter = std::next(Iter);
+  for (auto E = BB->pred_end(); Iter != E; ++Iter) {
+    State->BBSetIn &= BlockStates[*Iter]->BBSetOut;
+  }
+}
+
+bool RetainCodeMotionContext::processBBWithGenKillSet(SILBasicBlock *BB) {
+  RetainBlockState *State = BlockStates[BB];
+  // Compute the BBSetOut at the end of the basic block.
+  mergeBBDataFlowStates(BB);
+
+  // Compute the BBSetIn at the beginning of the basic block.
+  State->BBSetIn.reset(State->BBKillSet);
+  State->BBSetIn |= State->BBGenSet;
+ 
+  // If BBSetIn changes, then keep iterating until reached a fixed point.
+  return State->updateBBSetOut(State->BBSetIn);
+}
+
+void RetainCodeMotionContext::convergeCodeMotionDataFlow() {
+  // Process each basic block with the genset and killset. Every time the
+  // BBSetOut of a basic block changes, the optimization is rerun on its
+  // successors. 
+  llvm::SmallVector<SILBasicBlock *, 16> WorkList;
+  llvm::SmallPtrSet<SILBasicBlock *, 4> HandledBBs;
+  // Push into reverse post order so that we can pop from the back and get
+  // post order.
+  for (SILBasicBlock *B : PO->getReversePostOrder()) {
+    WorkList.push_back(B);
+    HandledBBs.insert(B);
+  }
+  while (!WorkList.empty()) {
+    SILBasicBlock *BB = WorkList.pop_back_val();
+    HandledBBs.erase(BB);
+    if (processBBWithGenKillSet(BB)) {
+      for (auto &X : BB->getSuccessors()) {
+        // We do not push basic block into the worklist if its already 
+        // in the worklist.
+        if (HandledBBs.count(X))
+          continue;
+        WorkList.push_back(X);
+      }
+    }
+  }
+}
+
+void RetainCodeMotionContext::computeCodeMotionInsertPoints() {
+  // The BBSetOuts have converged, run last iteration and figure out
+  // insertion point for each refcounted root.
+  for (SILBasicBlock *BB : PO->getReversePostOrder()) {
+    mergeBBDataFlowStates(BB);
+    RetainBlockState *S = BlockStates[BB];
+
+    // Compute insertion point generated by the edge value transition.
+    // If there is a transition from 1 to 0, that means we have a partial
+    // merge, which means the retain can NOT be sunk to the current block,
+    // so place it at the end of the predecessors.
+    for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+      if (S->BBSetIn[i])
+        continue;
+      for (auto Pred : BB->getPreds()) {
+        BlockState *PBB = BlockStates[Pred];
+        if (!PBB->BBSetOut[i])
+          continue;
+        InsertPoints[RCRootVault[i]].push_back(Pred->getTerminator());
+      }
+    }
+
+    // Is this block interesting. If we are sure this block does not generate
+    // retains nor does it block any retains (i.e. no insertion point will be
+    // created), we can skip it, as the BBSetOut has been converged if this is
+    // a multiiteration function.
+    if (MultiIteration && !InterestBlocks.count(BB))
+      continue;
+
+    // Compute insertion point within the basic block. Process instructions in
+    // the basic block in reverse post-order fashion.
+    for (auto I = BB->begin(), E = BB->end(); I != E; ++I) {
+      for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+        if (!S->BBSetIn[i] || !mayBlockCodeMotion(&*I, RCRootVault[i]))
+          continue;
+        S->BBSetIn.reset(i);
+        InsertPoints[RCRootVault[i]].push_back(&*I);
+      }
+
+      // If this is a retain instruction, it also generates.
+      if (isRetainInstruction(&*I)) {
+        S->BBSetIn.set(RCRootIndex[getRCRoot(&*I)]);
+      }
+    }
+
+    // Lastly update the BBSetOut, only necessary when we are running a single
+    // iteration dataflow.
+    if (!MultiIteration) {
+      S->updateBBSetOut(S->BBSetIn);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                          Release Code Motion 
+//===----------------------------------------------------------------------===//
+
+class ReleaseBlockState : public BlockState {
+public:
+  /// Check whether the BBSetIn has changed. If it does, we need to rerun
+  /// the data flow on this block's predecessors to reach fixed point.
+  bool updateBBSetIn(llvm::SmallBitVector &X) {
+    if (BBSetIn == X)
+      return false;
+    BBSetIn = X;
+    return true;
+  }
+
+  /// constructor.
+  ReleaseBlockState(bool IsExit, unsigned size, bool MultiIteration) {
+    // backward data flow.
+    BBSetIn.resize(size, MultiIteration);
+    BBSetOut.resize(size, false);
+    BBMaxSet.resize(size, !IsExit && MultiIteration);
+  
+    // Genset and Killset are initially empty.
+    BBGenSet.resize(size, false);
+    BBKillSet.resize(size, false);
+  }
+};
+
+/// ReleaseCodeMotionContext - Context to peroform release code motion.
+class ReleaseCodeMotionContext : public CodeMotionContext {
+  /// All the release block state for all the basic blocks in the function. 
+  llvm::SmallDenseMap<SILBasicBlock *, ReleaseBlockState *> BlockStates;
+
+  /// We are not moving epilogue releases.
+  bool FreezeEpilogueReleases;
+
+  /// The epilogue release matcher we are currently using.
+  ConsumedArgToEpilogueReleaseMatcher &ERM;
+
+  /// Return true if the instruction blocks the Ptr to be moved further.
+  bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) {
+    // NOTE: If more checks are to be added, place the most expensive in the end.
+    // This function is called many times.
+    //
+    // We can not move a release above the instruction that defines the
+    // released value.
+    if (II == Ptr)
+      return true;
+    // Identical rc root blocks code motion, we will be able to move this release
+    // further once we move the blocking release.
+    if (isReleaseInstruction(II) && getRCRoot(II) == Ptr)
+      return true;
+    // TODO: we now consider deinit. Rename mayUseValue, maybe call it may interfere.
+    // Stop at may use.
+    if (mayUseValue(II, Ptr, AA))
+      return true;
+    // This instruction does not block the release.
+    return false;
+  }
+
+public:
+  /// Constructor.
+  ReleaseCodeMotionContext(llvm::BumpPtrAllocator &BPA, SILFunction *F,
+                           PostOrderFunctionInfo *PO, AliasAnalysis *AA,
+                           RCIdentityFunctionInfo *RCFI,
+                           bool FreezeEpilogueReleases,
+                           ConsumedArgToEpilogueReleaseMatcher &ERM)
+      : CodeMotionContext(BPA, F, PO, AA, RCFI),
+        FreezeEpilogueReleases(FreezeEpilogueReleases), ERM(ERM) {
+    MultiIteration = requireIteration(); 
+  }
+
+  /// virtual destructor.
+  virtual ~ReleaseCodeMotionContext() {}
+
+  /// Return true if the data flow can converge in 1 iteration.
+  bool requireIteration(); 
+
+  /// Initialize necessary things to run the iterative data flow.
+  void initializeCodeMotionDataFlow();
+
+  /// Initialize the basic block maximum refcounted set.
+  void initializeCodeMotionBBMaxSet();
+
+  /// Compute the genset and killset for every root in every basic block.
+  void computeCodeMotionGenKillSet();
+
+  /// Run the iterative data flow to converge.
+  void convergeCodeMotionDataFlow(); 
+
+  /// Use the data flow results, come up with places to insert the new inst.
+  void computeCodeMotionInsertPoints();
+
+  /// Remove the old retains and create the new *moved* refcounted instructions
+  bool performCodeMotion();
+
+  /// Compute the BBSetIn and BBSetOut for the current basic
+  /// block with the generated gen and kill set.
+  bool processBBWithGenKillSet(SILBasicBlock *BB);
+
+  /// Merge the data flow states.
+  void mergeBBDataFlowStates(SILBasicBlock *BB);
+};
+
+bool ReleaseCodeMotionContext::requireIteration() {
+  // If all basic blocks will have their successors processed if the basic
+  // blocks in the functions are iterated in post order. Then this function
+  // can be processed in one iteration, i.e. no need to generate the genset
+  // and killset.
+  llvm::SmallPtrSet<SILBasicBlock *, 4> PBBs;
+  for (SILBasicBlock *B : PO->getPostOrder()) {
+    for (auto &X : B->getSuccessors()) {
+      if (!PBBs.count(X))
+        return true;
+    }
+    PBBs.insert(B);
+  }
+  return false;
+}
+
+void ReleaseCodeMotionContext::initializeCodeMotionDataFlow() {
+  // Find all the RC roots in the function.
+  for (auto &BB : *F) {
+    for (auto &II : BB) {
+      if (!isReleaseInstruction(&II))
+        continue;
+      // Do not try to enumerate if we are not hoisting epilogue releases.
+      if (FreezeEpilogueReleases && ERM.isEpilogueRelease(&II))
+        continue;
+      SILValue Root = getRCRoot(&II);
+      RCInstructions.insert(&II);
+      if (RCRootIndex.find(Root) != RCRootIndex.end())
+        continue;
+      RCRootIndex[Root] = RCRootVault.size();
+      RCRootVault.insert(Root);
+    }
+  }
+
+  // Initialize all the data flow bit vector for all basic blocks.
+  llvm::SmallPtrSet<SILBasicBlock *, 2> Exits;
+  auto Return = F->findReturnBB();
+  auto Throw = F->findThrowBB();
+  if (Return != F->end())
+    Exits.insert(&*Return);
+  if (Throw != F->end())
+    Exits.insert(&*Throw);
+  for (auto &BB : *F) {
+    BlockStates[&BB] = new (BPA) ReleaseBlockState(Exits.count(&BB),
+                                 RCRootVault.size(), MultiIteration);
+  }
+}
+
+void ReleaseCodeMotionContext::initializeCodeMotionBBMaxSet() {
+  for (SILBasicBlock *BB : PO->getPostOrder()) {
+    // If basic block has no successor, do nothing.
+    BlockState *State = BlockStates[BB];
+    if (BB->succ_empty()) {
+      State->BBMaxSet.reset();
+    } else {
+      // Intersect in all successors' BBMaxOuts.
+      State->BBMaxSet.set();
+      for (auto E = BB->succ_end(), I = BB->succ_begin(); I != E; ++I) {
+        State->BBMaxSet &= BlockStates[*I]->BBMaxSet;
+     }
+   }
+
+   // Process the instructions in the basic block to find what refcounted
+   // roots are released. If we know that a rc root cant be released at a
+   // basic block, then we know we do not need to consider it for the killset.
+   // NOTE: this is a conservative approximation, because some releases may be
+   // blocked before it reaches this block.
+   for (auto II = BB->rbegin(), IE = BB->rend(); II != IE; ++II) {
+      if (!isReleaseInstruction(&*II))
+        continue;
+      State->BBMaxSet.set(RCRootIndex[getRCRoot(&*II)]);
+    }
+  }
+}
+
+void ReleaseCodeMotionContext::computeCodeMotionGenKillSet() {
+  for (SILBasicBlock *BB : PO->getPostOrder()) {
+    auto *State = BlockStates[BB];
+    bool InterestBlock = false;
+    for (auto I = BB->rbegin(), E = BB->rend(); I != E; ++I) {
+      // Check whether this instruction blocks any RC root code motion.
+      for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+        if (!State->BBMaxSet.test(i) || !mayBlockCodeMotion(&*I, RCRootVault[i]))
+          continue;
+        // This instruction blocks this rc root.
+        InterestBlock = true;
+        State->BBKillSet.set(i);
+        State->BBGenSet.reset(i);
+      }
+
+      // If this is an epilogue release and we are freezing epilogue release
+      // simply continue.
+      if (FreezeEpilogueReleases && ERM.isEpilogueRelease(&*I))
+        continue;
+
+      // If this is a release instruction, it also generates.
+      if (isReleaseInstruction(&*I)) {
+        unsigned idx = RCRootIndex[getRCRoot(&*I)];
+        State->BBGenSet.set(idx);
+        assert(State->BBKillSet.test(idx) && "Killset computed incorrectly");
+        State->BBKillSet.reset(idx);
+        InterestBlock = true;
+      }
+    }
+
+    // Handle SILArgument, SILArgument can invalidate.
+    for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+      SILArgument *A = dyn_cast<SILArgument>(RCRootVault[i]);
+      if (!A || A->getParent() != BB)
+        continue;
+      InterestBlock = true;
+      State->BBKillSet.set(i);
+      State->BBGenSet.reset(i);
+    }
+
+    // Is this interesting to the last iteration of the data flow.
+    if (!InterestBlock)
+      continue;
+    InterestBlocks.insert(BB);
+  }
+}
+
+void ReleaseCodeMotionContext::mergeBBDataFlowStates(SILBasicBlock *BB) {
+  BlockState *State = BlockStates[BB];
+  State->BBSetOut.reset();
+  // If basic block has no successor, simply reset and return.
+  if (BB->succ_empty())
+    return;
+
+  // Intersect in all successors' BBSetIn.
+  auto Iter = BB->succ_begin();
+  State->BBSetOut = BlockStates[*Iter]->BBSetIn;
+  Iter = std::next(Iter);
+  for (auto E = BB->succ_end(); Iter != E; ++Iter) {
+    State->BBSetOut &= BlockStates[*Iter]->BBSetIn;
+  }
+}
+
+bool ReleaseCodeMotionContext::performCodeMotion() {
+  bool Changed = false;
+  // Create the new releases at each anchor point.
+  for (auto RC : InsertPoints) {
+    for (auto IP : RC.second) {
+      createDecrementBefore(RC.first, IP);
+      Changed = true;
+    }
+  }
+  // Remove the old release instructions.
+  for (auto R : RCInstructions) {
+    ++NumReleasesHoisted;
+    recursivelyDeleteTriviallyDeadInstructions(R, true);
+  }
+  return Changed;
+}
+
+bool ReleaseCodeMotionContext::processBBWithGenKillSet(SILBasicBlock *BB) {
+  ReleaseBlockState *State = BlockStates[BB];
+  // Compute the BBSetOut at the end of the basic block.
+  mergeBBDataFlowStates(BB);
+
+  // Compute the BBSetIn at the beginning of the basic block.
+  State->BBSetOut.reset(State->BBKillSet);
+  State->BBSetOut |= State->BBGenSet;
+ 
+  // If BBSetIn changes, then keep iterating until reached a fixed point.
+  return State->updateBBSetIn(State->BBSetOut);
+}
+
+void ReleaseCodeMotionContext::convergeCodeMotionDataFlow() {
+  // Process each basic block with the gen and kill set. Every time the
+  // BBSetIn of a basic block changes, the optimization is rerun on its
+  // predecessors.
+  llvm::SmallVector<SILBasicBlock *, 16> WorkList;
+  llvm::SmallPtrSet<SILBasicBlock *, 8> HandledBBs;
+  // Push into reverse post order so that we can pop from the back and get
+  // post order.
+  for (SILBasicBlock *B : PO->getPostOrder()) {
+    WorkList.push_back(B);
+    HandledBBs.insert(B);
+  }
+  while (!WorkList.empty()) {
+    SILBasicBlock *BB = WorkList.pop_back_val();
+    HandledBBs.erase(BB);
+    if (processBBWithGenKillSet(BB)) {
+      for (auto X : BB->getPreds()) {
+        // We do not push basic block into the worklist if its already 
+        // in the worklist.
+        if (HandledBBs.count(X))
+          continue;
+        WorkList.push_back(X);
+      }
+    }
+  }
+}
+
+void ReleaseCodeMotionContext::computeCodeMotionInsertPoints() {
+  // The BBSetIns have converged, run last iteration and figure out insertion
+  // point for each rc root.
+  for (SILBasicBlock *BB : PO->getPostOrder()) {
+    // Intersect in the successor BBSetIns.
+    mergeBBDataFlowStates(BB);
+    ReleaseBlockState *S = BlockStates[BB];
+
+    // Compute insertion point generated by the edge value transition.
+    // If there is a transition from 1 to 0, that means we have a partial
+    // merge, which means the release can NOT be hoisted to the current block.
+    // place it at the successors.
+    for (unsigned i = 0; i < RCRootVault.size(); ++i) {  
+      if (S->BBSetOut[i])
+        continue;
+      for (auto &Succ : BB->getSuccessors()) {
+        BlockState *SBB = BlockStates[Succ];
+        if (!SBB->BBSetIn[i])
+          continue;
+        InsertPoints[RCRootVault[i]].push_back(&*(*Succ).begin());
+      }
+    }
+
+    // Is this block interesting ?
+    if (MultiIteration && !InterestBlocks.count(BB))
+      continue;
+
+    // Compute insertion point generated by MayUse terminator inst.
+    // If terminator instruction can block the rc root. We will have no
+    // choice but to anchor the release instructions in the successor blocks.
+    for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+      SILInstruction *Term = BB->getTerminator();
+      if (!S->BBSetOut[i] || !mayBlockCodeMotion(Term, RCRootVault[i]))
+        continue;
+      for (auto &Succ : BB->getSuccessors()) {
+        BlockState *SBB = BlockStates[Succ];
+        if (!SBB->BBSetIn[i])
+          continue;
+        InsertPoints[RCRootVault[i]].push_back(&*(*Succ).begin());
+      }
+      S->BBSetOut.reset(i);
+    }
+
+    // Compute insertion point generated within the basic block. Process
+    // instructions in post-order fashion.
+    for (auto I = std::next(BB->rbegin()), E = BB->rend(); I != E; ++I) {
+      for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+        if (!S->BBSetOut[i] || !mayBlockCodeMotion(&*I, RCRootVault[i]))
+          continue;
+        auto *InsertPt = &*std::next(SILBasicBlock::iterator(&*I));
+        InsertPoints[RCRootVault[i]].push_back(InsertPt);
+        S->BBSetOut.reset(i);
+      }
+
+      // If we are freezing this epilogue release. Simply continue.
+      if (FreezeEpilogueReleases && ERM.isEpilogueRelease(&*I))
+        continue;
+
+      // This release generates.
+      if (isReleaseInstruction(&*I)) {
+        S->BBSetOut.set(RCRootIndex[getRCRoot(&*I)]);
+      }
+    }
+
+    // Compute insertion point generated by SILArgument. SILArgument blocks if
+    // it defines the released value.
+    for (unsigned i = 0; i < RCRootVault.size(); ++i) {
+      if (!S->BBSetOut[i]) 
+        continue;
+      SILArgument *A = dyn_cast<SILArgument>(RCRootVault[i]);
+      if (!A || A->getParent() != BB)
+        continue;
+      InsertPoints[RCRootVault[i]].push_back(&*BB->begin());
+      S->BBSetOut.reset(i);
+    }
+   
+    // Lastly update the BBSetIn, only necessary when we are running a single
+    // iteration dataflow.
+    if (!MultiIteration) {
+      S->updateBBSetIn(S->BBSetOut);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Code motion kind.
+enum CMKind : unsigned { Retain = 0, Release = 1};
+
+class RRCodeMotion : public SILFunctionTransform {
+  /// Whether to hoist releases or sink retains.
+  CMKind Kind;
+
+  /// Freeze epilogue release or not.
+  bool FreezeEpilogueReleases;
+
+public:
+  StringRef getName() override { return "SIL Retain Release Code Motion"; }
+
+  /// Constructor.
+  RRCodeMotion(CMKind H, bool F) : Kind(H), FreezeEpilogueReleases(F) {}
+
+  /// The entry point to the transformation.
+  void run() override {
+    // Respect function no.optimize.
+    SILFunction *F = getFunction();
+    if (!F->shouldOptimize())
+      return;
+
+    DEBUG(llvm::dbgs() << "*** RRCM on function: " << F->getName() << " ***\n");
+    // Split all critical edges.
+    //
+    // TODO: maybe we can do this lazily or maybe we should disallow SIL passes
+    // to create critical edges.
+    bool EdgeChanged = splitAllCriticalEdges(*F, false, nullptr, nullptr);
+
+    llvm::BumpPtrAllocator BPA;
+    auto *PO = PM->getAnalysis<PostOrderAnalysis>()->get(F);
+    auto *AA = PM->getAnalysis<AliasAnalysis>();
+    auto *RCFI = PM->getAnalysis<RCIdentityAnalysis>()->get(F);
+
+    bool InstChanged = false;
+    if (Kind == Release) {
+      // TODO: we should consider Throw block as well, or better we should
+      // abstract the Return block or Throw block away in the matcher.
+      ConsumedArgToEpilogueReleaseMatcher ERM(RCFI, F, 
+            ConsumedArgToEpilogueReleaseMatcher::ExitKind::Return);
+
+      ReleaseCodeMotionContext RelCM(BPA, F, PO, AA, RCFI, 
+                                     FreezeEpilogueReleases, ERM); 
+      // Run release hoisting.
+      InstChanged |= RelCM.run();
+    } else {
+      RetainCodeMotionContext RetCM(BPA, F, PO, AA, RCFI);
+      // Run retain sinking.
+      InstChanged |= RetCM.run();
+    }
+
+    if (EdgeChanged) {
+      // We splitted critical edges.
+      invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
+      return;
+    }
+    if (InstChanged) {
+      // We moved instructions.
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+};
+
+} // end anonymous namespace
+
+/// Sink Retains.
+SILTransform *swift::createRetainSinking() {
+  return new RRCodeMotion(CMKind::Retain, false);
+}
+
+/// Hoist releases, but not epilogue release.
+SILTransform *swift::createReleaseHoisting() {
+  return new RRCodeMotion(CMKind::Release, true);
+}
+
+/// Hoist all releases.
+SILTransform *swift::createLateReleaseHoisting() {
+  return new RRCodeMotion(CMKind::Release, false);
+}

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -arc-loop-opts %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts -disable-code-motion-arc=0 %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts -disable-code-motion-arc=0 %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -arc-loop-opts -disable-code-motion-arc=0 %s | FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/arcsequenceopts_loops.sil
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts -disable-code-motion-arc=0 %s | FileCheck %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -O -primary-file %s -emit-sil -sil-inline-threshold 1000 -sil-verify-all | FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -O -Xllvm -disable-sil-cm-rr-cm=0  -primary-file %s -emit-sil -sil-inline-threshold 1000 -sil-verify-all | FileCheck %s
 
 // Make sure that we can dig all the way through the class hierarchy and
 // protocol conformances with covariant return types correctly. The verifier

--- a/test/SILOptimizer/devirt_default_case.swift
+++ b/test/SILOptimizer/devirt_default_case.swift
@@ -91,31 +91,18 @@ class C2 : A2 {}
 class D2: B2 {}
 class E2 :C2 {}
 
-
-public func testfoo1() -> Int {
-  return foo(E2())
-}
-
 class A3 { @inline(never) func f() -> Int { return 0 } }
 class B3 : A3 { @inline(never) override func f() -> Int { return 1 }}
 class C3 : A3 {}
 class D3: C3 {}
 class E3 :C3 {}
 
-// A, C,D,E all use the same implementation. 
-// B has its own implementation.
-@inline(never)
-func foo(_ a: A3) -> Int {
-// Check that call to A3.f() can be devirtualized.
-//
-// CHECK-NORMAL: sil{{( hidden)?}} [noinline] @_TF19devirt_default_case3fooFCS_2A3Si
 // CHECK-TESTABLE: sil{{( hidden)?}} [thunk] [always_inline] @_TF19devirt_default_case3fooFCS_2A3Si
-// CHECK-NORMAL: function_ref @{{.*}}TFC19devirt_default_case2B31f
-// CHECK-NORMAL: function_ref @{{.*}}TFC19devirt_default_case2A31f
-// CHECK-NORMAL-NOT: class_method
-// CHECK: }
-  return a.f()
+
+public func testfoo1() -> Int {
+  return foo(E2())
 }
+
 
 public func testfoo3() -> Int {
   return foo(E3())
@@ -136,6 +123,21 @@ class Base4 {
   }
   
   @inline(never) func foo() { }
+}
+
+
+// A, C,D,E all use the same implementation. 
+// B has its own implementation.
+@inline(never)
+func foo(_ a: A3) -> Int {
+// Check that call to A3.f() can be devirtualized.
+//
+// CHECK-NORMAL: sil{{( hidden)?}} [noinline] @_TTSf4g___TF19devirt_default_case3fooFCS_2A3Si
+// CHECK-NORMAL: function_ref @{{.*}}TFC19devirt_default_case2B31f
+// CHECK-NORMAL: function_ref @{{.*}}TFC19devirt_default_case2A31f
+// CHECK-NORMAL-NOT: class_method
+// CHECK: }
+  return a.f()
 }
 
 class Derived4 : Base4 {

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all %s -early-codemotion | FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all %s -early-codemotion -disable-sil-cm-rr-cm=0 | FileCheck %s
 
 import Builtin
 

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -late-codemotion | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -late-codemotion -disable-sil-cm-rr-cm=0 | FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -195,9 +195,9 @@ public func testClassLet1(_ f: inout Foo1) -> Int32 {
 
 // CHECK: sil [thunk] [always_inline] @_TF19let_properties_opts12testClassLetFCS_3FooVs5Int32 : $@convention(thin) (@owned Foo) -> Int32
 // CHECK: bb0
+// CHECK-NEXT: strong_release
 // CHECK: integer_literal $Builtin.Int32, 75
 // CHECK-NEXT: struct $Int32
-// CHECK-NEXT: strong_release
 // CHECK-NEXT: return
 public func testClassLet(_ f: Foo) -> Int32 {
   return f.Prop1 + f.Prop1 + f.Prop2 + f.Prop3
@@ -214,9 +214,9 @@ public func testClassLet(_ f: inout Foo) -> Int32 {
 
 // CHECK-LABEL: sil [thunk] [always_inline] @_TF19let_properties_opts18testClassPublicLetFCS_3FooVs5Int32 : $@convention(thin) (@owned Foo) -> Int32
 // CHECK: bb0
+// CHECK-NEXT: strong_release
 // CHECK: integer_literal $Builtin.Int32, 1
 // CHECK-NEXT: struct $Int32
-// CHECK-NEXT: strong_release
 // CHECK-NEXT: return
 public func testClassPublicLet(_ f: Foo) -> Int32 {
   return f.Prop0

--- a/test/SILOptimizer/polymorphic_inline_caches.sil
+++ b/test/SILOptimizer/polymorphic_inline_caches.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  -dce -early-codemotion | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -specdevirt -code-sinking  -dce -early-codemotion -disable-sil-cm-rr-cm=0 | FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -1,0 +1,404 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -retain-sinking -late-release-hoisting %s | FileCheck %s
+
+import Builtin
+import Swift
+
+struct Int {
+  var value : Builtin.Int64
+}
+
+struct Int32 {
+  var value : Builtin.Int32
+}
+
+struct Int64 {
+  var value : Builtin.Int64
+}
+
+struct UInt64 {
+  var value : Builtin.Int64
+}
+
+struct Bool {
+  var value : Builtin.Int1
+}
+
+struct A {
+  var i : Builtin.Int32
+}
+
+class fuzz { }
+
+enum Boo {
+  case one
+  case two
+}
+
+class B { }
+class E : B { }
+
+class C {}
+
+class C2  {
+ var current: A
+ init()
+}
+
+struct S {
+  var ptr : Builtin.NativeObject
+}
+
+struct foo {
+  var a: Int
+  init(a: Int)
+  init()
+}
+
+enum Optional<T> {
+  case none
+  case some(T)
+}
+
+sil @use_C2 : $@convention(thin) (C2) -> ()
+sil @user : $@convention(thin) (Builtin.NativeObject) -> ()
+sil @user_int : $@convention(thin) (Int) -> ()
+sil @optional_user : $@convention(thin) (Optional<Builtin.Int32>) -> ()
+sil @blocker : $@convention(thin) () -> ()
+sil @get_object : $@convention(thin) () -> Builtin.NativeObject
+sil @foo_init : $@convention(thin) (@thin foo.Type) -> foo
+sil [fragile] @guaranteed_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+sil [fragile] @guaranteed_throwing_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @error ErrorProtocol
+
+// CHECK-LABEL: sil @sink_retains_from_preds : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK: bb1:
+// CHECK-NOT: strong_retain
+// CHECK: bb2:
+// CHECK-NOT: strong_retain
+// CHECK: bb3:
+// CHECK: strong_retain 
+sil @sink_retains_from_preds : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_release %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %0 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  strong_retain %0 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %1 = tuple()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil @hoist_releases_from_succs : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK: bb0(
+// CHECK: strong_release
+// CHECK: bb1:
+// CHECK-NOT: strong_release
+// CHECK: bb2:
+// CHECK-NOT: strong_release
+sil @hoist_releases_from_succs : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_release %0 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  strong_release %0 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  retain_value %0 : $Builtin.NativeObject
+  %1 = tuple()
+  return %1 : $()
+}
+
+// Make sure that we do not move retains over unreachable terminator.
+// CHECK-LABEL: sil @no_return_stops_codemotion : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK: strong_retain
+// CHECK-NEXT: unreachable
+sil @no_return_stops_codemotion : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_ref $C
+  strong_retain %1 : $C
+  unreachable
+}
+
+// CHECK-LABEL: sil @retain_blocked_by_maydecrement
+// CHECK: strong_retain
+// CHECK-NEXT: apply
+sil @retain_blocked_by_maydecrement : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  release_value %0 : $Builtin.NativeObject
+  strong_retain %0 : $Builtin.NativeObject
+  %2 = function_ref @blocker : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+  br bb1
+
+bb1:
+  %1 = tuple()
+  return %1 : $()
+}
+
+// Make sure release is not hoisted above define.
+// CHECK-LABEL: sil @define_stops_codemotion : $@convention(thin) () -> () {
+// CHECK: alloc_ref
+// CHECK-NEXT: strong_release
+sil @define_stops_codemotion : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref $C
+  %2 = tuple()
+  strong_release %1 : $C
+  %3 = tuple()
+  return %3 : $()
+}
+
+// Make sure bb3 silargument blocks the release to be hoisted.
+// CHECK-LABEL: sil @silargument_stops_codemotion
+// CHECK: bb3([[IN:%[0-9]+]] : $C):
+// CHECK: release
+// CHECK: return
+sil @silargument_stops_codemotion : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref $C
+  %2 = alloc_ref $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%1 : $C)
+
+bb2:
+  br bb3(%2 : $C)
+
+bb3(%3 : $C):
+  strong_release %3 : $C
+  %4 = tuple()
+  return %4 : $()
+}
+  
+// Make sure retain instruction is sunk across copy_addr inst, as copy_addr
+// dest is initialized.
+//
+// CHECK-LABEL: retain_not_blocked_by_copyaddrinit
+// CHECK: bb0
+// CHECK-NEXT: strong_release
+// CHECK-NEXT: copy_addr 
+// CHECK-NEXT: tuple 
+// CHECK-NEXT: strong_retain
+sil hidden @retain_not_blocked_by_copyaddrinit : $@convention(thin) <T> (@in T, B) -> @out T {
+bb0(%0 : $*T, %1 : $*T, %2 : $B):
+  strong_release %2 : $B
+  strong_retain %2 : $B
+  copy_addr [take] %1 to [initialization] %0 : $*T // id: %3
+  %4 = tuple ()                                   // user: %5
+  return %4 : $()                                 // id: %5
+}
+
+// Make sure that is_unique stops code motion.
+// CHECK-LABEL: sil @is_unique_stops_codemotion : $@convention(thin) (@inout Builtin.NativeObject) -> () {
+// CHECK: bb0([[IN:%[0-9]+]] : $*Builtin.NativeObject):
+// CHECK: [[LD:%[0-9]+]] = load [[IN]] : $*Builtin.NativeObject
+// CHECK: strong_retain [[LD]] : $Builtin.NativeObject
+// CHECK: is_unique [[IN]] : $*Builtin.NativeObject
+sil @is_unique_stops_codemotion : $@convention(thin) (@inout Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject):
+  %1 = load %0 : $*Builtin.NativeObject
+  strong_retain %1 : $Builtin.NativeObject
+  is_unique %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @sink_retain_partially_block : $@convention(thin) (Builtin.NativeObject) -> () {
+// CHECK: bb3:
+// CHECK-NOT: string_retain
+// CHECK: return
+sil @sink_retain_partially_block : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = function_ref @blocker : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3: 
+  %5 = tuple()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil @hoist_release_partially_available_retain
+// CHECK: bb0
+// CHECK: cond_br undef, bb1, bb2
+// CHECK: bb1:
+// CHECK: strong_retain
+// CHECK: strong_release
+// CHECK: br bb3
+// CHECK: bb2:
+// CHECK: strong_retain
+// CHECK: apply
+// CHECK: strong_release
+// CHECK: br bb3
+// CHECK: bb3:
+// CHECK-NOT: strong_release
+// CHECK: return
+sil @hoist_release_partially_available_retain : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1: $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %0: $Builtin.NativeObject
+  br bb3
+
+bb2:
+  strong_retain %0: $Builtin.NativeObject
+  %2 = function_ref @blocker : $@convention(thin) () -> ()
+  apply %2() : $@convention(thin) () -> ()
+  br bb3
+
+bb3:
+  strong_release %0: $Builtin.NativeObject
+  %5 = tuple()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil [fragile] @try_apply_blocks_release_hoisting : $@convention(thin) (Builtin.NativeObject) -> @error ErrorProtocol {
+// CHECK: bb0(
+// CHECK: strong_retain
+// CHECK: try_apply
+// CHECK: bb1(
+// CHECK: strong_release
+// CHECK: bb2(
+// CHECK: strong_release
+sil [fragile] @try_apply_blocks_release_hoisting : $@convention(thin) (Builtin.NativeObject) -> @error ErrorProtocol {
+bb0(%0 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  %1 = function_ref @guaranteed_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %1(%0) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = function_ref @guaranteed_throwing_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @error ErrorProtocol
+  try_apply %2(%0) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @error ErrorProtocol, normal bb1, error bb2
+
+bb1(%3 : $()):
+  strong_release %0 : $Builtin.NativeObject
+  return undef : $()
+
+bb2(%4 : $ErrorProtocol):
+  strong_release %0 : $Builtin.NativeObject
+  throw %4 : $ErrorProtocol
+}
+
+
+// Make sure release can be hoisted across memory that do not escape.
+// CHECK-LABEL: sil @hoist_release_across_local_memory_use
+// CHECK: bb1:
+// CHECK: strong_release
+// CHECK: br bb3
+// CHECK: bb2:
+// CHECK: strong_release
+// CHECK: br bb3
+// CHECK: bb3:
+// CHECK-NOT: strong_release
+// CHECK: return 
+sil @hoist_release_across_local_memory_use : $@convention(thin) (Builtin.NativeObject) ->() {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_stack $A
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %0 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %2 = integer_literal $Builtin.Int32, 0
+  %3 = struct $A (%2 : $Builtin.Int32)
+  store %3 to %1 : $*A
+  strong_release %0 : $Builtin.NativeObject
+  dealloc_stack %1 : $*A
+  %5 = tuple()
+  return %5 : $()
+}
+
+// Make sure release can not be hoisted across memory that do escape. i.e. the release
+// deinit can read or write to the memory.
+// CHECK-LABEL: sil @hoist_release_across_escaping_param_memory_use
+// CHECK: bb1:
+// CHECK-NOT: strong_release
+// CHECK: br bb3
+// CHECK: bb2:
+// CHECK-NOT: strong_release
+// CHECK: br bb3
+// CHECK: bb3:
+// CHECK: store
+// CHECK: strong_release
+// CHECK: return
+sil @hoist_release_across_escaping_param_memory_use : $@convention(thin) (Builtin.NativeObject, C2) ->() {
+bb0(%0 : $Builtin.NativeObject, %1 : $C2):
+  %2 = ref_element_addr %1 : $C2, #C2.current
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %0 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %3 = integer_literal $Builtin.Int32, 0
+  %4 = struct $A (%3 : $Builtin.Int32)
+  store %4 to %2 : $*A
+  strong_release %0 : $Builtin.NativeObject
+  %5 = tuple()
+  return %5 : $()
+}
+
+// Make sure release can not be hoisted across memory that do escape, even though its allocated locally.
+// i.e. the release
+// deinit can read or write to the memory.
+// CHECK-LABEL: sil @hoist_release_across_escaping_local_alloc_memory_use
+// CHECK: bb1:
+// CHECK-NOT: strong_release
+// CHECK: br bb3
+// CHECK: bb2:
+// CHECK-NOT: strong_release
+// CHECK: br bb3
+// CHECK: bb3:
+// CHECK: store
+// CHECK: strong_release
+// CHECK: return
+sil @hoist_release_across_escaping_local_alloc_memory_use : $@convention(thin) (Builtin.NativeObject) ->() {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = alloc_ref $C2
+  %2 = ref_element_addr %1 : $C2, #C2.current
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %0 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %22 = function_ref @use_C2 : $@convention(thin) (C2) -> ()
+  %23 = apply %22(%1) : $@convention(thin) (C2) -> ()
+  %3 = integer_literal $Builtin.Int32, 0
+  %4 = struct $A (%3 : $Builtin.Int32)
+  store %4 to %2 : $*A
+  strong_release %0 : $Builtin.NativeObject
+  %5 = tuple()
+  return %5 : $()
+}

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -232,7 +232,7 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK-LABEL: sil shared [noinline] @_TTSg5C37specialize_unconditional_checked_cast1C___TF37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{.*}} : $@convention(thin) (@owned C, @owned C) -> @owned C {
 // CHECK: bb0(%0 : $C, %1 : $C):
 // CHECK: strong_release %1
-// CHECK-NEXT: return %0
+// CHECK: return %0
 
 // x -> y where x is a class but y is not.
 // CHECK-LABEL: sil shared [noinline] @_TTSg5Vs5UInt8___TF37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{.*}} : $@convention(thin) (@owned C, UInt8) -> UInt8 {
@@ -294,7 +294,7 @@ SuperToArchetypeC(c: c, t: b)
 // CHECK-LABEL: sil shared [noinline] @_TTSg5C37specialize_unconditional_checked_cast1C___TF37specialize_unconditional_checked_cast17SuperToArchetypeC{{.*}} : $@convention(thin) (@owned C, @owned C) -> @owned C {
 // CHECK: bb0(%0 : $C, %1 : $C):
 // CHECK: strong_release %1
-// CHECK-NEXT: return %0
+// CHECK: return %0
 
 // x -> y where x is a super class of y.
 // CHECK-LABEL: sil shared [noinline] @_TTSg5C37specialize_unconditional_checked_cast1D___TF37specialize_unconditional_checked_cast17SuperToArchetypeC{{.*}} : $@convention(thin) (@owned C, @owned D) -> @owned D {
@@ -326,7 +326,7 @@ SuperToArchetypeD(d: d, t: d)
 // CHECK-LABEL: sil shared [noinline] @_TTSg5C37specialize_unconditional_checked_cast1D___TF37specialize_unconditional_checked_cast17SuperToArchetypeD{{.*}} : $@convention(thin) (@owned D, @owned D) -> @owned D {
 // CHECK: bb0(%0 : $D, %1 : $D):
 // CHECK: strong_release %1
-// CHECK-NEXT: return %0
+// CHECK: return %0
 
 //////////////////////////////
 // Existential To Archetype //
@@ -351,7 +351,7 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 // CHECK-LABEL: sil shared [noinline] @_TTSg5Ps9AnyObject____TF37specialize_unconditional_checked_cast22ExistentialToArchetype{{.*}} : $@convention(thin) (@owned AnyObject, @owned AnyObject) -> @owned AnyObject {
 // CHECK: bb0(%0 : $AnyObject, %1 : $AnyObject):
 // CHECK: strong_release %1
-// CHECK-NEXT: return %0
+// CHECK: return %0
 
 ExistentialToArchetype(o: o, t: c)
 ExistentialToArchetype(o: o, t: b)


### PR DESCRIPTION
Implement a retain and release code motion pass.

Iterative data flow retain sinking and release hoisting.

This allows us to sink retains and hoist releases across harmless loops.  which is an improvement on the SILCodeMotion retain sinking and release hoisting.

This should eventually replace RR code motion in SILcodemotion and insertion point in ARCsequence opts.
