### PR TITLE
[gardening] Fix typos: refererences → references, accross → across, is → it

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -532,7 +532,7 @@ alive.
 
     // The call to ``withExtendedLifetime(Head)`` makes sure that the lifetime of
     // Head is guaranteed to extend over the region of code that uses Unmanaged
-    // refererences. Because there exists a reference to Head for the duration
+    // references. Because there exists a reference to Head for the duration
     // of the scope and we don't modify the list of ``Node``s there also exist a
     // reference through the chain of ``Head.next``, ``Head.next.next``, ...
     // instances.
@@ -544,7 +544,7 @@ alive.
 
       // Use the unmanaged reference in a call/variable access. The use of
       // _withUnsafeGuaranteedRef allows the compiler to remove the ultimate
-      // retain/release accross the call/access.
+      // retain/release across the call/access.
 
       while let Next = Ref._withUnsafeGuaranteedRef { $0.next } {
         ...

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -291,7 +291,7 @@ void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
   // Translate the context.
   auto contextOpt = translateContext(effectiveContext);
   if (!contextOpt) {
-    // If is is a declaration with a swift_name attribute, we might be
+    // If it is a declaration with a swift_name attribute, we might be
     // able to resolve this later.
     if (auto decl = newEntry.dyn_cast<clang::NamedDecl *>()) {
       if (decl->hasAttr<clang::SwiftNameAttr>()) {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix typos: refererences → references, accross → across, is → it
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
