### PR TITLE
[driver] Disable -filelist option when invoking the swift-update tool.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -250,6 +250,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     auto *IA = cast<InputAction>(context.InputActions[0]);
     const Arg &PrimaryInputArg = IA->getInputArg();
 
+    // FIXME: Remove disabling of -filelist once swift-update can handle it.
     if (context.OI.CompilerMode != OutputInfo::Mode::UpdateCode &&
         (context.Args.hasArg(options::OPT_driver_use_filelists) ||
         context.getTopLevelInputFiles().size() > TOO_MANY_FILES)) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -250,8 +250,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     auto *IA = cast<InputAction>(context.InputActions[0]);
     const Arg &PrimaryInputArg = IA->getInputArg();
 
-    if (context.Args.hasArg(options::OPT_driver_use_filelists) ||
-        context.getTopLevelInputFiles().size() > TOO_MANY_FILES) {
+    if (context.OI.CompilerMode != OutputInfo::Mode::UpdateCode &&
+        (context.Args.hasArg(options::OPT_driver_use_filelists) ||
+        context.getTopLevelInputFiles().size() > TOO_MANY_FILES)) {
       Arguments.push_back("-filelist");
       Arguments.push_back(context.getAllSourcesPath());
       Arguments.push_back("-primary-file");
@@ -363,8 +364,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
 
   // Add the output file argument if necessary.
   if (context.Output.getPrimaryOutputType() != types::TY_Nothing) {
-    if (context.Args.hasArg(options::OPT_driver_use_filelists) ||
-        context.Output.getPrimaryOutputFilenames().size() > TOO_MANY_FILES) {
+    if (context.OI.CompilerMode != OutputInfo::Mode::UpdateCode &&
+        (context.Args.hasArg(options::OPT_driver_use_filelists) ||
+        context.Output.getPrimaryOutputFilenames().size() > TOO_MANY_FILES)) {
       Arguments.push_back("-output-filelist");
       Arguments.push_back(context.getTemporaryFilePath("outputs", ""));
       II.FilelistInfo = {Arguments.back(),
@@ -570,8 +572,9 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   // mode options.
   Arguments.push_back("-emit-module");
 
-  if (context.Args.hasArg(options::OPT_driver_use_filelists) ||
-      context.Inputs.size() > TOO_MANY_FILES) {
+  if (context.OI.CompilerMode != OutputInfo::Mode::UpdateCode &&
+      (context.Args.hasArg(options::OPT_driver_use_filelists) ||
+      context.Inputs.size() > TOO_MANY_FILES)) {
     Arguments.push_back("-filelist");
     Arguments.push_back(context.getTemporaryFilePath("inputs", ""));
     II.FilelistInfo = {Arguments.back(), types::TY_SwiftModuleFile,
@@ -859,8 +862,9 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   InvocationInfo II{"ld"};
   ArgStringList &Arguments = II.Arguments;
 
-  if (context.Args.hasArg(options::OPT_driver_use_filelists) ||
-      context.Inputs.size() > TOO_MANY_FILES) {
+  if (context.OI.CompilerMode != OutputInfo::Mode::UpdateCode &&
+      (context.Args.hasArg(options::OPT_driver_use_filelists) ||
+       context.Inputs.size() > TOO_MANY_FILES)) {
     Arguments.push_back("-filelist");
     Arguments.push_back(context.getTemporaryFilePath("inputs", "LinkFileList"));
     II.FilelistInfo = {Arguments.back(), types::TY_Object, FilelistInfo::Input};

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -42,6 +42,7 @@
 // RUN: ln -s "swiftc" %t/DISTINCTIVE-PATH/usr/bin/swift-update
 // RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -update-code -driver-use-filelists -c -target x86_64-apple-macosx10.9 -emit-module -emit-module-path %t.mod %s 2>&1 > %t.upd.txt
 // RUN: FileCheck -check-prefix UPDATE-CODE %s < %t.upd.txt
+// RUN: FileCheck -check-prefix UPDATE-CODE-FILELIST %s < %t.upd.txt
 // Clean up the test executable because hard links are expensive.
 // RUN: rm -rf %t/DISTINCTIVE-PATH/usr/bin/swiftc
 
@@ -113,14 +114,14 @@
 // FILELIST: -primary-file {{.*/(driver-compile.swift|empty.swift)}}
 // FILELIST: -output-filelist {{[^-]}}
 
-// UPDATE-CODE-NOT: -filelist
-// UPDATE-CODE-NOT: -output-filelist
 // UPDATE-CODE: DISTINCTIVE-PATH/usr/bin/swift-update
 // UPDATE-CODE: -c{{ }}
 // UPDATE-CODE: -o {{.+}}.remap
 // UPDATE-CODE: DISTINCTIVE-PATH/usr/bin/swift-update
 // UPDATE-CODE: -emit-module{{ }}
 // UPDATE-CODE: -o {{.+}}.mod
+// UPDATE-CODE-FILELIST-NOT: -filelist
+// UPDATE-CODE-FILELIST-NOT: -output-filelist
 
 // FIXIT-CODE: bin/swift
 // FIXIT-CODE: -c{{ }}

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -40,7 +40,7 @@
 // RUN: rm -rf %t && mkdir -p %t/DISTINCTIVE-PATH/usr/bin/
 // RUN: ln %swift_driver_plain %t/DISTINCTIVE-PATH/usr/bin/swiftc
 // RUN: ln -s "swiftc" %t/DISTINCTIVE-PATH/usr/bin/swift-update
-// RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -update-code -c -target x86_64-apple-macosx10.9 -emit-module -emit-module-path %t.mod %s 2>&1 > %t.upd.txt
+// RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -update-code -driver-use-filelists -c -target x86_64-apple-macosx10.9 -emit-module -emit-module-path %t.mod %s 2>&1 > %t.upd.txt
 // RUN: FileCheck -check-prefix UPDATE-CODE %s < %t.upd.txt
 // Clean up the test executable because hard links are expensive.
 // RUN: rm -rf %t/DISTINCTIVE-PATH/usr/bin/swiftc
@@ -113,6 +113,8 @@
 // FILELIST: -primary-file {{.*/(driver-compile.swift|empty.swift)}}
 // FILELIST: -output-filelist {{[^-]}}
 
+// UPDATE-CODE-NOT: -filelist
+// UPDATE-CODE-NOT: -output-filelist
 // UPDATE-CODE: DISTINCTIVE-PATH/usr/bin/swift-update
 // UPDATE-CODE: -c{{ }}
 // UPDATE-CODE: -o {{.+}}.remap


### PR DESCRIPTION
This disables -filelist option from the driver when invoking the swift-update tool, which cannot handle it.

Resolves rdar://25320355
