### PR TITLE
[stdlib] New indexing model: Fix LazyFilterCollection index moving

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -192,7 +192,11 @@ public struct LazyFilterCollection<
   /// - Complexity: O(N), where N is the ratio between unfiltered and
   ///   filtered collection counts.
   public var startIndex: Index {
-    return LazyFilterIndex(base: _nextFiltered(_base.startIndex))
+    var index = _base.startIndex
+    while index != _base.endIndex && !_predicate(_base[index]) {
+      _base.formSuccessor(&index)
+    }
+    return LazyFilterIndex(base: index)
   }
 
   /// The collection's "past the end" position.
@@ -253,12 +257,11 @@ public struct LazyFilterCollection<
     return index
   }
 
-  /// Advances `index` until one of the following:
-  /// 
-  /// - an element matches `self._predicate`
-  /// - `index == self._base.endIndex`
+  /// Returns the first index `i` following `index` where either
+  /// `_predicate(base[i]) == true` or `i == _base.endIndex`.
   ///
   /// - Precondition: `index != endIndex`
+  /// - Postcondition: `i > index`
   @inline(__always)
   internal func _nextFilteredInPlace(index: inout Base.Index) {
     _precondition(index != _base.endIndex, "can't advance past endIndex")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

The index moving methods weren't functioning correctly. They didn't trap on advancing past `endIndex` and in some cases did not terminate at all.

``` swift
let a = [0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0]
let b = a.lazy.filter { $0 != 0 }
print(b.count)   // doesn't return
```
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
