### PR TITLE
Stamp Swift binaries with the language's major/minor version

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -891,7 +891,6 @@ void IRGenModuleDispatcher::emitAssociatedTypeMetadataRecords() {
   }
 }
 
-
 /// Emit any lazy definitions (of globals or functions or whatever
 /// else) that we require.
 void IRGenModuleDispatcher::emitLazyDefinitions() {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -586,6 +586,8 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       IGM.emitAssociatedTypeMetadataRecords();
     }
 
+    IGM.emitSwiftReflectionVersion();
+
     // Okay, emit any definitions that we suddenly need.
     dispatcher.emitLazyDefinitions();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/Basic/Dwarf.h"
+#include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Runtime/RuntimeFnWrappersGen.h"
 #include "swift/Runtime/Config.h"
@@ -926,6 +927,26 @@ void IRGenModule::emitAutolinkInfo() {
                                    llvm::Constant::getNullValue(Int1Ty),
                                    buf.str());
   }
+}
+
+void IRGenModuleDispatcher::emitSwiftReflectionVersion() {
+  for (auto &m : *this) {
+    m.second->emitSwiftReflectionVersion();
+  }
+}
+
+llvm::Constant*
+IRGenModule::emitSwiftReflectionVersion() {
+  auto Init = llvm::ConstantInt::get(Int32Ty, REFLECTION_VERSION);
+
+  auto Version = new llvm::GlobalVariable(Module, Int32Ty,
+                                               /*constant*/ true,
+                                          llvm::GlobalValue::LinkOnceODRLinkage,
+                                               Init,
+                                               "__swift_reflection_version");
+  addUsedGlobal(Version);
+
+  return Version;
 }
 
 void IRGenModule::cleanupClangCodeGenMetadata() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -126,6 +126,8 @@ namespace irgen {
 
 class IRGenModule;
 
+const uint32_t REFLECTION_VERSION = 1;
+
 /// A type descriptor for a field type accessor.
 class FieldTypeInfo {
   llvm::PointerIntPair<CanType, 1, unsigned> Info;
@@ -217,6 +219,9 @@ public:
 
   /// Emit associated type references for nominal types for reflection purposes.
   void emitAssociatedTypeMetadataRecords();
+
+  // Stamp the binary with the major and minor language version.
+  void emitSwiftReflectionVersion();
 
   /// Emit everything which is reachable from already emitted IR.
   void emitLazyDefinitions();
@@ -613,6 +618,7 @@ public:
   llvm::Constant *emitTypeMetadataRecords();
   llvm::Constant *emitFieldTypeMetadataRecords();
   llvm::Constant *emitAssociatedTypeMetadataRecords();
+  llvm::Constant *emitSwiftReflectionVersion();
   llvm::Constant *getAddrOfStringForTypeRef(StringRef Str);
   llvm::Constant *getAddrOfFieldName(StringRef Name);
   std::string getFieldTypeMetadataSectionName();

--- a/test/IRGen/autolink_elf.swift
+++ b/test/IRGen/autolink_elf.swift
@@ -11,5 +11,5 @@ import Empty
 // as used.
 
 // CHECK-DAG: @_swift1_autolink_entries = private constant [13 x i8] c"-lswiftEmpty\00", section ".swift1_autolink_entries", align 8
-// CHECK-DAG: @llvm.used = appending global [1 x i8*] [i8* getelementptr inbounds ([13 x i8], [13 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata", align 8
+// CHECK-DAG: @llvm.used = appending global [2 x i8*] [i8* bitcast (i32* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata"
 

--- a/test/IRGen/reflection_version.swift
+++ b/test/IRGen/reflection_version.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | FileCheck %s
+
+func foo() {}
+
+// CHECK: @__swift_reflection_version = linkonce_odr constant i32
+

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -45,8 +45,8 @@ bb0:
   return %1 : $()
 }
 
-// CHECK-macho: @llvm.used = appending global [1 x i8*] [i8* bitcast (void ()* @frieda to i8*)], section "llvm.metadata", align 8
-// CHECK-elf: @llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* getelementptr inbounds ([0 x i8], [0 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata", align 8
+// CHECK-macho: @llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32* @__swift_reflection_version to i8*)], section "llvm.metadata"
+// CHECK-elf: @llvm.used = appending global [3 x i8*] [i8* bitcast (void ()* @frieda to i8*), i8* bitcast (i32* @__swift_reflection_version to i8*), i8* getelementptr inbounds ([0 x i8], [0 x i8]* @_swift1_autolink_entries, i32 0, i32 0)], section "llvm.metadata"
 
 // CHECK: define linkonce_odr hidden void @qux()
 // CHECK: define hidden void @fred()


### PR DESCRIPTION
This will be cross-checked with SwiftRemoteMirror's version
compatibility, although this could potentially be used for
other things.

rdar://problem/25559468
