### PR TITLE
InheritedProtocolConformance: Return the conforming type's DeclContext

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -606,7 +606,7 @@ public:
   /// Get the declaration context that contains the conforming extension or
   /// nominal type declaration.
   DeclContext *getDeclContext() const {
-    return InheritedConformance->getDeclContext();
+    return getType()->getClassOrBoundGenericClass();
   }
 
   /// Retrieve the state of this conformance.

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -27,7 +27,7 @@ bb0(%0 : $Int, %1 : $Int):
 
   // CHECK: [[STACK:%[0-9]+]] = alloc_stack $MMString
   %37 = alloc_stack $MMString
-  // CHECK: [[ID:%[0-9]+]] = function_ref @_TTSg5C7inherit8MMStringCS_8MMObjects8HashableS__GSQCS_6MMFont___callee : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool
+  // CHECK: [[ID:%[0-9]+]] = function_ref @_TTSg5C7inherit8MMStringS0_s8HashableS__GSQCS_6MMFont___callee : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool
   %34 = function_ref @callee : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in τ_0_0, Int, @owned MMStorage<τ_0_0, τ_0_1>) -> Bool
   // CHECK: apply [[ID]]([[STACK]], %1, %{{[0-9]+}}) : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool
   %45 = apply %34<MMString, MMFont!>(%37, %1, %14) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in τ_0_0, Int, @owned MMStorage<τ_0_0, τ_0_1>) -> Bool
@@ -36,7 +36,7 @@ bb0(%0 : $Int, %1 : $Int):
   return %14 : $MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>
 }
 
-// CHECK-LABEL: @_TTSg5C7inherit8MMStringCS_8MMObjects8HashableS__GSQCS_6MMFont___callee : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool {
+// CHECK-LABEL: @_TTSg5C7inherit8MMStringS0_s8HashableS__GSQCS_6MMFont___callee : $@convention(method) (@in MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool {
 // CHECK: [[META:%[0-9]+]] = metatype $@thick MMString.Type
 // CHECK: [[ID3:%[0-9]+]] = witness_method $MMObject, #Equatable."=="!1 :
 // CHECK: [[STACK2:%[0-9]+]] = alloc_stack $MMString

--- a/test/decl/class/Inputs/inheritance_protocol_multi_module_2.swift
+++ b/test/decl/class/Inputs/inheritance_protocol_multi_module_2.swift
@@ -1,0 +1,16 @@
+import Mod
+
+class ClassLevel3: ClassLevel2 {
+    override init() {
+        super.init()
+    }
+}
+
+public func createClassLevel3() -> MyProtocol {
+    return ClassLevel3()
+}
+
+public func createClassLevel3() -> MyProtocol2 {
+    return ClassLevel3()
+}
+

--- a/test/decl/class/inheritance_protocol_multi_module.swift
+++ b/test/decl/class/inheritance_protocol_multi_module.swift
@@ -1,0 +1,15 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-swift-frontend -emit-module-path %t/Mod.swiftmodule -module-name Mod %s
+// RUN: %target-swift-frontend -parse -verify -I %t %S/Inputs/inheritance_protocol_multi_module_2.swift
+
+/* module Mod */
+
+public protocol MyProtocol  {}
+public protocol MyProtocol2  {}
+public class ClassLevel1: MyProtocol {
+    public init() {}
+}
+public class ClassLevel2: ClassLevel1, MyProtocol2 {
+    public override init () {}
+}


### PR DESCRIPTION
Not the superclass's. This can cause mapping types out of context to not
resolve archetypes, because the DeclContexts won't match, e.g:

internal class _IteratorBox<Base: IteratorProtocol> :
_AnyIteratorBoxBase<Base.Element> { internal override func next() ->
Base.Element?  }

Here, _IteratorBox's associated type Element for IteratorProtocol is
Base.Element, but the conformance comes from the superclass,
_AnyIteratorBoxBase. This meant that Base.Element couldn't be mapped to
an interface type, which should be:

(dependent-member
  (generic-type-parameter depth=0 index=0) member=Element)

The old behavior also broke inherited conformances across serialization boundaries, because subclasses would fail to inherit conformances a deserialized class inherited itself from a base class (SR-1158).
