### PR TITLE
[windows] IRGen: add support for DLL Storage semantics

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1489,9 +1489,13 @@ void irgen::emitBlockHeader(IRGenFunction &IGF,
   
   //
   // Initialize the "isa" pointer, which is _NSConcreteStackBlock.
-  auto NSConcreteStackBlock
-    = IGF.IGM.getModule()->getOrInsertGlobal("_NSConcreteStackBlock",
+  auto NSConcreteStackBlock =
+      IGF.IGM.getModule()->getOrInsertGlobal("_NSConcreteStackBlock",
                                              IGF.IGM.ObjCClassStructTy);
+  if (IGF.IGM.Triple.isOSBinFormatCOFF())
+    cast<llvm::GlobalVariable>(NSConcreteStackBlock)
+        ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
+
   //
   // Set the flags.
   // - HAS_COPY_DISPOSE unless the capture type is POD

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3977,10 +3977,13 @@ static void emitObjCClassSymbol(IRGenModule &IGM,
   auto *metadataTy = cast<llvm::PointerType>(metadata->getType());
 
   // Create the alias.
-  llvm::GlobalAlias::create(metadataTy->getElementType(),
-                            metadataTy->getAddressSpace(),
-                            metadata->getLinkage(), classSymbol.str(),
-                            metadata, IGM.getModule());
+  auto *alias = llvm::GlobalAlias::create(metadataTy->getElementType(),
+                                          metadataTy->getAddressSpace(),
+                                          metadata->getLinkage(),
+                                          classSymbol.str(), metadata,
+                                          IGM.getModule());
+  if (IGM.TargetInfo.OutputObjectFormat == llvm::Triple::COFF)
+    alias->setDLLStorageClass(metadata->getDLLStorageClass());
 }
 
 /// Emit the type metadata or metadata template for a class.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -452,6 +452,11 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
   if (auto fn = dyn_cast<llvm::Function>(cache)) {
     fn->setCallingConv(cc);
 
+    if (llvm::Triple(Module.getTargetTriple()).isOSBinFormatCOFF() &&
+        (fn->getLinkage() == llvm::GlobalValue::ExternalLinkage ||
+         fn->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage))
+      fn->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
+
     llvm::AttrBuilder buildFnAttr;
     llvm::AttrBuilder buildRetAttr;
 
@@ -510,6 +515,7 @@ llvm::Constant *swift::getWrapperFn(llvm::Module &Module,
     // and leave only one copy.
     fun->setLinkage(llvm::Function::LinkOnceODRLinkage);
     fun->setVisibility(llvm::Function::HiddenVisibility);
+    fun->setDLLStorageClass(llvm::Function::DefaultStorageClass);
     fun->setDoesNotThrow();
 
     // Add the body of a wrapper.
@@ -526,6 +532,8 @@ llvm::Constant *swift::getWrapperFn(llvm::Module &Module,
     auto *globalFnPtr =
         new llvm::GlobalVariable(Module, fnPtrTy, false,
                                  llvm::GlobalValue::ExternalLinkage, 0, symbol);
+    if (llvm::Triple(Module.getTargetTriple()).isOSBinFormatCOFF())
+      globalFnPtr->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
 
     // Forward all arguments.
     llvm::SmallVector<llvm::Value *, 4> args;
@@ -640,17 +648,25 @@ llvm::Constant *IRGenModule::getEmptyTupleMetadata() {
   if (EmptyTupleMetadata)
     return EmptyTupleMetadata;
 
-  return EmptyTupleMetadata =
-    Module.getOrInsertGlobal("_TMT_", FullTypeMetadataStructTy);
+  EmptyTupleMetadata =
+      Module.getOrInsertGlobal("_TMT_", FullTypeMetadataStructTy);
+  if (Triple.isOSBinFormatCOFF())
+    cast<llvm::GlobalVariable>(EmptyTupleMetadata)
+        ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
+  return EmptyTupleMetadata;
 }
 
 llvm::Constant *IRGenModule::getObjCEmptyCachePtr() {
-  if (ObjCEmptyCachePtr) return ObjCEmptyCachePtr;
+  if (ObjCEmptyCachePtr)
+    return ObjCEmptyCachePtr;
 
   if (ObjCInterop) {
     // struct objc_cache _objc_empty_cache;
     ObjCEmptyCachePtr = Module.getOrInsertGlobal("_objc_empty_cache",
                                                  OpaquePtrTy->getElementType());
+    if (Triple.isOSBinFormatCOFF())
+      cast<llvm::GlobalVariable>(ObjCEmptyCachePtr)
+          ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
   } else {
     // FIXME: Remove even the null value per rdar://problem/18801263
     ObjCEmptyCachePtr = llvm::ConstantPointerNull::get(OpaquePtrTy);
@@ -680,7 +696,10 @@ Address IRGenModule::getAddrOfObjCISAMask() {
   // isa masking.
   assert(TargetInfo.hasISAMasking());
   if (!ObjCISAMaskPtr) {
-    ObjCISAMaskPtr =  Module.getOrInsertGlobal("swift_isaMask", IntPtrTy);
+    ObjCISAMaskPtr = Module.getOrInsertGlobal("swift_isaMask", IntPtrTy);
+    if (Triple.isOSBinFormatCOFF())
+      cast<llvm::GlobalVariable>(ObjCISAMaskPtr)
+          ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
   }
   return Address(ObjCISAMaskPtr, getPointerAlignment());
 }
@@ -844,6 +863,9 @@ void IRGenModule::addLinkLibrary(const LinkLibrary &linkLib) {
     llvm::SmallString<64> buf;
     encodeForceLoadSymbolName(buf, linkLib.getName());
     auto symbolAddr = Module.getOrInsertGlobal(buf.str(), Int1Ty);
+    if (Triple.isOSBinFormatCOFF())
+      cast<llvm::GlobalVariable>(symbolAddr)
+          ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
 
     buf += "_$";
     appendEncodedName(buf, IRGen.Opts.ModuleName);

--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -609,6 +609,7 @@ class LinkInfo {
   llvm::SmallString<32> Name;
   llvm::GlobalValue::LinkageTypes Linkage;
   llvm::GlobalValue::VisibilityTypes Visibility;
+  llvm::GlobalValue::DLLStorageClassTypes DLLStorageClass;
   ForDefinition_t ForDefinition;
 
 public:
@@ -624,6 +625,9 @@ public:
   }
   llvm::GlobalValue::VisibilityTypes getVisibility() const {
     return Visibility;
+  }
+  llvm::GlobalValue::DLLStorageClassTypes getDLLStorage() const {
+    return DLLStorageClass;
   }
 
   llvm::Function *createFunction(IRGenModule &IGM,
@@ -641,11 +645,12 @@ public:
                                   StringRef DebugName = StringRef());
 
   bool isUsed() const {
-    return ForDefinition && isUsed(Linkage, Visibility);
+    return ForDefinition && isUsed(Linkage, Visibility, DLLStorageClass);
   }
-  
+
   static bool isUsed(llvm::GlobalValue::LinkageTypes Linkage,
-                     llvm::GlobalValue::VisibilityTypes Visibility);
+                     llvm::GlobalValue::VisibilityTypes Visibility,
+                     llvm::GlobalValue::DLLStorageClassTypes DLLStorage);
 };
 
 } // end namespace irgen

--- a/lib/IRGen/TypeLayoutVerifier.cpp
+++ b/lib/IRGen/TypeLayoutVerifier.cpp
@@ -42,8 +42,11 @@ irgen::emitTypeLayoutVerifier(IRGenFunction &IGF,
                                               verifierArgTys,
                                               /*var arg*/ false);
   auto verifierFn = IGF.IGM.Module.getOrInsertFunction(
-                                       "_swift_debug_verifyTypeLayoutAttribute",
-                                       verifierFnTy);
+      "_swift_debug_verifyTypeLayoutAttribute", verifierFnTy);
+  if (IGF.IGM.Triple.isOSBinFormatCOFF())
+    if (auto *F = dyn_cast<llvm::Function>(verifierFn))
+      F->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
+
   struct VerifierArgumentBuffers {
     Address runtimeBuf, staticBuf;
   };

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -270,8 +270,11 @@ private:
     AttrList = AttrList.addAttribute(
         M.getContext(), AttributeSet::FunctionIndex, Attribute::NoUnwind);
     CheckUnowned = M.getOrInsertFunction("swift_checkUnowned", AttrList,
-                                          Type::getVoidTy(M.getContext()),
-                                          ObjectPtrTy, nullptr);
+                                         Type::getVoidTy(M.getContext()),
+                                         ObjectPtrTy, nullptr);
+    if (llvm::Triple(M.getTargetTriple()).isOSBinFormatCOFF())
+      if (auto *F = llvm::dyn_cast<llvm::Function>(CheckUnowned.get()))
+        F->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
     return CheckUnowned.get();
   }
 

--- a/lib/LLVMPasses/LLVMStackPromotion.cpp
+++ b/lib/LLVMPasses/LLVMStackPromotion.cpp
@@ -216,6 +216,9 @@ bool SwiftStackPromotion::runOnFunction(Function &F) {
                                          {MetaDataTy, HeapObjTy},
                                          false);
         initFunc = M->getOrInsertFunction("swift_initStackObject", NewFTy);
+        if (llvm::Triple(M->getTargetTriple()).isOSBinFormatCOFF())
+          if (auto *F = dyn_cast<llvm::Function>(initFunc))
+            F->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
       }
       // Replace the allocation call with an alloca.
       Value *AllocA = new AllocaInst(AllocType, ConstantInt::get(IntType, size),
@@ -235,6 +238,9 @@ bool SwiftStackPromotion::runOnFunction(Function &F) {
       if (!allocFunc) {
         allocFunc = M->getOrInsertFunction("swift_bufferAllocate",
                                            Callee->getFunctionType());
+        if (llvm::Triple(M->getTargetTriple()).isOSBinFormatCOFF())
+          if (auto *F = dyn_cast<llvm::Function>(allocFunc))
+            F->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
       }
       CI->setCalledFunction(allocFunc);
     }

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -1,0 +1,47 @@
+// RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -parse-stdlib -module-name dllexport %s -o - | FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
+// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -parse-stdlib -module-name dllexport %s -o - | FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
+
+@noreturn
+@_silgen_name("_swift_fatalError")
+func fatalError()
+
+public protocol p {
+  func f()
+}
+
+public class c {
+  public init() { }
+}
+
+public var ci : c = c()
+
+public class d {
+  @noreturn
+  private func m() {
+    fatalError()
+  }
+}
+
+// CHECK-DAG: @_Tv9dllexport2ciCS_1c = dllexport global %C9dllexport1c* null, align 4
+// CHECK-DAG: @_TMp9dllexport1p = dllexport constant %swift.protocol
+// CHECK-DAG: @_TMnC9dllexport1c = dllexport constant
+// CHECK-DAG: @_TMLC9dllexport1c = dllexport global %swift.type* null, align 4
+// CHECK-DAG: @_TMLC9dllexport1d = dllexport global %swift.type* null, align 4
+// CHECK-DAG: @_TMC9dllexport1c = dllexport alias %swift.type
+// CHECK-DAG: @_TMC9dllexport1d = dllexport alias %swift.type, bitcast ({{.*}})
+// CHECK-DAG-OPT: @_TFC9dllexport1dP33_C57BA610BA35E21738CC992438E660E91mfT_T_ = dllexport alias void (), void ()* @_swift_dead_method_stub
+// CHECK-DAG-OPT: @_TFC9dllexport1dcfT_S0_ = dllexport alias void (), void ()* @_swift_dead_method_stub
+// CHECK-DAG-OPT: @_TFC9dllexport1ccfT_S0_ = dllexport alias void (), void ()* @_swift_dead_method_stub
+// CHECK-DAG-OPT: @_TFC9dllexport1cCfT_S0_ = dllexport alias void (), void ()* @_swift_dead_method_stub
+// CHECK-DAG: define dllexport %swift.refcounted* @_TFC9dllexport1cd(%C9dllexport1c*{{.*}})
+// CHECK-DAG-NO-OPT: define dllexport %C9dllexport1c* @_TFC9dllexport1ccfT_S0_(%C9dllexport1c*)
+// CHECK-DAG-NO-OPT: define dllexport %C9dllexport1c* @_TFC9dllexport1cCfT_S0_(%swift.type*)
+// CHECK-DAG: define dllexport i8* @_TF9dllexportau2ciCS_1c()
+// CHECK-DAG-NO-OPT: define dllexport void @_TFC9dllexport1dP33_C57BA610BA35E21738CC992438E660E91mfT_T_(%C9dllexport1d*)
+// CHECK-DAG-NO-OPT: define dllexport void @_TFC9dllexport1dD(%C9dllexport1d*)
+// CHECK-DAG: define dllexport %swift.refcounted* @_TFC9dllexport1dd(%C9dllexport1d*{{.*}})
+// CHECK-DAG: define dllexport %swift.type* @_TMaC9dllexport1c()
+// CHECK-DAG: define dllexport %swift.type* @_TMaC9dllexport1d()
+// CHECK-DAG-NO-OPT: define dllexport %C9dllexport1d* @_TFC9dllexport1dcfT_S0_(%C9dllexport1d*)
+// CHECK-DAG-OPT: define dllexport void @_TFC9dllexport1dD(%C9dllexport1d*)
+

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -1,0 +1,56 @@
+// RUN: %swift -target thumbv7--windows-itanium -emit-ir -parse-as-library -parse-stdlib -module-name dllimport %s -o - -enable-source-import -I %S | FileCheck %s -check-prefix CHECK -check-prefix CHECK-NO-OPT
+// RUN: %swift -target thumbv7--windows-itanium -O -emit-ir -parse-as-library -parse-stdlib -module-name dllimport %s -o - -enable-source-import -I %S | FileCheck %s -check-prefix CHECK -check-prefix CHECK-OPT
+
+import dllexport
+
+public func get_ci() -> dllexport.c {
+  return dllexport.ci
+}
+
+public func get_c_type() -> dllexport.c.Type {
+  return dllexport.c
+}
+
+public class d : c {
+  override init() {
+    super.init()
+  }
+
+  @inline(never)
+  func f(_ : dllexport.c) { }
+}
+
+struct s : p {
+  func f() { }
+}
+
+func f(di : d) {
+  di.f(get_ci())
+}
+
+func blackhole<F>(_ : F) { }
+
+public func g() {
+  blackhole({ () -> () in })
+}
+
+// CHECK-DAG: @_swift_retain = external dllimport global void (%swift.refcounted*)
+// CHECK-DAG-NO-OPT: @_swift_release = external dllimport global void (%swift.refcounted*)
+// CHECK-DAG-NO-OPT: @_swift_deallocObject = external dllimport global void (%swift.refcounted*, i32, i32)*
+// CHECK-DAG-NO-OPT: @_swift_allocObject = external dllimport global %swift.refcounted* (%swift.type*, i32, i32)*
+// CHECK-DAG-NO-OPT: @_TMT_ = external dllimport global %swift.full_type
+// CHECK-DAG: @_TWVBo = external dllimport global i8*
+// CHECK-DAG: @_TMC9dllexport1c = external dllimport global %swift.type
+// CHECK-DAG: @_TMp9dllexport1p = external dllimport global %swift.protocol
+// CHECK-DAG: @_swift_slowAlloc = external dllimport global i8* (i32, i32)*
+// CHECK-DAG: @_swift_slowDealloc = external dllimport global void (i8*, i32, i32)*
+// CHECK-DAG: declare dllimport i8* @_TF9dllexportau2ciCS_1c()
+// CHECK-DAG: declare dllimport %swift.type* @_TMaC9dllexport1c()
+// CHECK-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)
+// CHECK-DAG: declare dllimport %swift.refcounted* @_TFC9dllexport1cd(%C9dllexport1c*)
+// CHECK-DAG-NO-OPT: define linkonce_odr hidden void @rt_swift_retain(%swift.refcounted*)
+// CHECK-DAG-NO-OPT: define linkonce_odr hidden i8* @rt_swift_slowAlloc(i32, i32)
+// CHECK-DAG-NO-OPT: define linkonce_odr hidden void @rt_swift_slowDealloc(i8*, i32, i32)
+// CHECK-DAG-NO-OPT: define linkonce_odr hidden void @rt_swift_release(%swift.refcounted*)
+// CHECK-OPT-DAG: declare dllimport void @swift_deletedMethodError()
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Add initial support for modelling DLL Storage semantics for global values.  This
is needed to support the indirect addressing mechanism used on Windows.
