### PR TITLE
Allow subclasses of specific instantiations of ObjC generic classes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1457,8 +1457,9 @@ NOTE(class_here,none,
      "class %0 declared here", (Identifier))
 ERROR(inheritance_from_final_class,none,
       "inheritance from a final class %0", (Identifier))
-ERROR(inheritance_from_objc_generic_class,none,
-      "inheritance from a generic Objective-C class %0", (Identifier))
+ERROR(inheritance_from_unspecialized_objc_generic_class,none,
+      "inheritance from a generic Objective-C class %0 must bind "
+      "type parameters of %0 to specific concrete types", (Identifier))
 ERROR(inheritance_from_objc_runtime_visible_class,none,
       "inheritance from an Objective-C class %0 only visible via the runtime", (Identifier))
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -857,7 +857,7 @@ namespace {
     }
 
     llvm::Constant *getMetaclassRefOrNull(ClassDecl *theClass) {
-      if (theClass->isGenericContext()) {
+      if (theClass->isGenericContext() && !theClass->hasClangNode()) {
         return llvm::ConstantPointerNull::get(IGM.ObjCClassPtrTy);
       } else {
         return IGM.getAddrOfMetaclassObject(theClass, NotForDefinition);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2254,7 +2254,7 @@ llvm::Constant *IRGenModule::getAddrOfSwiftMetaclassStub(ClassDecl *theClass,
 /// on whether the class is published as an ObjC class.
 llvm::Constant *IRGenModule::getAddrOfMetaclassObject(ClassDecl *decl,
                                                 ForDefinition_t forDefinition) {
-  assert(!decl->isGenericContext()
+  assert((!decl->isGenericContext() || decl->hasClangNode())
          && "generic classes do not have a static metaclass object");
   if (decl->checkObjCAncestry() != ObjCClassKind::NonObjC ||
       decl->hasClangNode()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3836,8 +3836,10 @@ public:
           return;
         }
 
-        if (Super->hasClangNode() && Super->getGenericParams()) {
-          TC.diagnose(CD, diag::inheritance_from_objc_generic_class,
+        if (Super->hasClangNode() && Super->getGenericParams()
+            && superclassTy->hasTypeParameter()) {
+          TC.diagnose(CD,
+                      diag::inheritance_from_unspecialized_objc_generic_class,
                       Super->getName());
         }
 

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -129,3 +129,33 @@ extension GenericClass {
     _ = #selector(GenericClass.doesntUseGenericParam3)
   }
 }
+
+// expected-error@+1{{inheritance from a generic Objective-C class 'GenericClass' must bind type parameters of 'GenericClass' to specific concrete types}}
+class SwiftGenericSubclassA<X: AnyObject>: GenericClass<X> {}
+// expected-error@+1{{inheritance from a generic Objective-C class 'GenericClass' must bind type parameters of 'GenericClass' to specific concrete types}}
+class SwiftGenericSubclassB<X: AnyObject>: GenericClass<GenericClass<X>> {}
+// expected-error@+1{{inheritance from a generic Objective-C class 'GenericClass' must bind type parameters of 'GenericClass' to specific concrete types}}
+class SwiftGenericSubclassC<X: NSCopying>: GenericClass<X> {}
+
+class SwiftConcreteSubclassA: GenericClass<AnyObject> {
+  override init(thing: AnyObject) { }
+  override func thing() -> AnyObject? { }
+  override func count() -> Int32 { }
+  override class func classThing() -> AnyObject? { }
+  override func arrayOfThings() -> [AnyObject] {}
+}
+class SwiftConcreteSubclassB: GenericClass<NSString> {
+  override init(thing: NSString) { }
+  override func thing() -> NSString? { }
+  override func count() -> Int32 { }
+  override class func classThing() -> NSString? { }
+  override func arrayOfThings() -> [NSString] {}
+}
+class SwiftConcreteSubclassC<T>: GenericClass<NSString> {
+  override init(thing: NSString) { }
+  override func thing() -> NSString? { }
+  override func count() -> Int32 { }
+  override class func classThing() -> NSString? { }
+  override func arrayOfThings() -> [NSString] {}
+}
+

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -8,6 +8,14 @@ import Swift
 import Foundation
 import objc_generics
 
+// CHECK-LABEL: @"OBJC_METACLASS_$__TtC27objc_generic_class_metadata8Subclass" = hidden global %objc_class
+// CHECK:         %objc_class* @"OBJC_METACLASS_$_NSObject"
+// CHECK:         %objc_class* @"OBJC_METACLASS_$_GenericClass"
+// CHECK-LABEL: @_TMfC27objc_generic_class_metadata8Subclass = internal global
+// CHECK:         %objc_class* @"OBJC_METACLASS_$__TtC27objc_generic_class_metadata8Subclass"
+// CHECK:         %objc_class* @"OBJC_CLASS_$_GenericClass"
+class Subclass: GenericClass<NSString> {}
+
 sil @metatype_sink : $@convention(thin) <T> (@thick T.Type) -> ()
 sil @objc_class_sink : $@convention(thin) <T: AnyObject> (@objc_metatype T.Type) -> ()
 

--- a/test/Interpreter/imported_objc_generics.swift
+++ b/test/Interpreter/imported_objc_generics.swift
@@ -146,4 +146,47 @@ ImportedObjCGenerics.test("InheritanceFromNongeneric") {
   expectTrue(Container<NSObject>.self == Container<NSString>.self)
 }
 
+public class InheritInSwift: Container<NSString> {
+  public override init(object: NSString) {
+    super.init(object: object.lowercase)
+  }
+  public override var object: NSString {
+    get {
+      return super.object.uppercase
+    }
+    set {
+      super.object = newValue.lowercase
+    }
+  }
+
+  public var superObject: NSString {
+    get {
+      return super.object
+    }
+  }
+}
+
+ImportedObjCGenerics.test("InheritInSwift") {
+  let s = InheritInSwift(object: "HEllo")
+  let sup: Container = s
+
+  expectEqual(s.superObject, "hello")
+  expectEqual(s.object, "HELLO")
+  expectEqual(sup.object, "HELLO")
+
+  s.object = "GOodbye"
+  expectEqual(s.superObject, "goodbye")
+  expectEqual(s.object, "GOODBYE")
+  expectEqual(sup.object, "GOODBYE")
+
+  s.processObject { o in
+    expectEqual(o, "GOODBYE")
+  }
+
+  s.updateObject { "Aloha" }
+  expectEqual(s.superObject, "aloha")
+  expectEqual(s.object, "ALOHA")
+  expectEqual(sup.object, "ALOHA")
+}
+
 runAllTests()


### PR DESCRIPTION
If a subclass grounds all the type parameters from its base class, we don't have to worry about any erasure edge cases. We should be able to support this, giving existing code that subclasses the nongeneric form of the class a migration path. Spot-fix some places in IRGen where we assume we can't emit static references to ObjC generic classes or metaclasses.
