### PR TITLE
WIP: Change all uses of 'CInt' to 'Int32' in the SDK overlay.

### DIFF
--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -1,6 +1,6 @@
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
-@objc public enum MachError : CInt {
+@objc public enum MachError : Int32 {
   case KERN_SUCCESS                   = 0
 
   /// Specified address is not currently valid.

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -2,7 +2,7 @@
 
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing POSIX error codes.
-@objc public enum POSIXError : CInt {
+@objc public enum POSIXError : Int32 {
   // FIXME: These are the values for Darwin. We need to get the Linux
   // values as well.
   case EPERM           = 1               /// Operation not permitted.

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -159,94 +159,94 @@ public var stderr : UnsafeMutablePointer<FILE> {
 @_silgen_name("_swift_Platform_open")
 func _swift_Platform_open(
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt,
+  _ oflag: Int32,
   _ mode: mode_t
-) -> CInt
+) -> Int32
 
 @warn_unused_result
 @_silgen_name("_swift_Platform_openat")
 func _swift_Platform_openat(
-  _ fd: CInt,
+  _ fd: Int32,
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt,
+  _ oflag: Int32,
   _ mode: mode_t
-) -> CInt
+) -> Int32
 
 @warn_unused_result
 public func open(
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt
-) -> CInt {
+  _ oflag: Int32
+) -> Int32 {
   return _swift_Platform_open(path, oflag, 0)
 }
 
 @warn_unused_result
 public func open(
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt,
+  _ oflag: Int32,
   _ mode: mode_t
-) -> CInt {
+) -> Int32 {
   return _swift_Platform_open(path, oflag, mode)
 }
 
 @warn_unused_result
 public func openat(
-  _ fd: CInt,
+  _ fd: Int32,
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt
-) -> CInt {
+  _ oflag: Int32
+) -> Int32 {
   return _swift_Platform_openat(fd, path, oflag, 0)
 }
 
 @warn_unused_result
 public func openat(
-  _ fd: CInt,
+  _ fd: Int32,
   _ path: UnsafePointer<CChar>,
-  _ oflag: CInt,
+  _ oflag: Int32,
   _ mode: mode_t
-) -> CInt {
+) -> Int32 {
   return _swift_Platform_openat(fd, path, oflag, mode)
 }
 
 @warn_unused_result
 @_silgen_name("_swift_Platform_fcntl")
 internal func _swift_Platform_fcntl(
-  _ fd: CInt,
-  _ cmd: CInt,
-  _ value: CInt
-) -> CInt
+  _ fd: Int32,
+  _ cmd: Int32,
+  _ value: Int32
+) -> Int32
 
 @warn_unused_result
 @_silgen_name("_swift_Platform_fcntlPtr")
 internal func _swift_Platform_fcntlPtr(
-  _ fd: CInt,
-  _ cmd: CInt,
+  _ fd: Int32,
+  _ cmd: Int32,
   _ ptr: UnsafeMutablePointer<Void>
-) -> CInt
+) -> Int32
 
 @warn_unused_result
 public func fcntl(
-  _ fd: CInt,
-  _ cmd: CInt
-) -> CInt {
+  _ fd: Int32,
+  _ cmd: Int32
+) -> Int32 {
   return _swift_Platform_fcntl(fd, cmd, 0)
 }
 
 @warn_unused_result
 public func fcntl(
-  _ fd: CInt,
-  _ cmd: CInt,
-  _ value: CInt
-) -> CInt {
+  _ fd: Int32,
+  _ cmd: Int32,
+  _ value: Int32
+) -> Int32 {
   return _swift_Platform_fcntl(fd, cmd, value)
 }
 
 @warn_unused_result
 public func fcntl(
-  _ fd: CInt,
-  _ cmd: CInt,
+  _ fd: Int32,
+  _ cmd: Int32,
   _ ptr: UnsafeMutablePointer<Void>
-) -> CInt {
+) -> Int32 {
   return _swift_Platform_fcntlPtr(fd, cmd, ptr)
 }
 
@@ -351,14 +351,14 @@ public var SEM_FAILED: UnsafeMutablePointer<sem_t> {
 @_silgen_name("_swift_Platform_sem_open2")
 internal func _swift_Platform_sem_open2(
   _ name: UnsafePointer<CChar>,
-  _ oflag: CInt
+  _ oflag: Int32
 ) -> UnsafeMutablePointer<sem_t>
 
 @warn_unused_result
 @_silgen_name("_swift_Platform_sem_open4")
 internal func _swift_Platform_sem_open4(
   _ name: UnsafePointer<CChar>,
-  _ oflag: CInt,
+  _ oflag: Int32,
   _ mode: mode_t,
   _ value: CUnsignedInt
 ) -> UnsafeMutablePointer<sem_t>
@@ -366,7 +366,7 @@ internal func _swift_Platform_sem_open4(
 @warn_unused_result
 public func sem_open(
   _ name: UnsafePointer<CChar>,
-  _ oflag: CInt
+  _ oflag: Int32
 ) -> UnsafeMutablePointer<sem_t> {
   return _swift_Platform_sem_open2(name, oflag)
 }
@@ -374,7 +374,7 @@ public func sem_open(
 @warn_unused_result
 public func sem_open(
   _ name: UnsafePointer<CChar>,
-  _ oflag: CInt,
+  _ oflag: Int32,
   _ mode: mode_t,
   _ value: CUnsignedInt
 ) -> UnsafeMutablePointer<sem_t> {

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -243,7 +243,7 @@ public func modf(_ value: ${T}) -> (${T}, ${T}) {
 @_transparent
 @warn_unused_result
 public func ldexp(_ x: ${T}, _ n: Int) -> ${T} {
-  return ${T}(ldexp${f}(${CT}(x), CInt(n)))
+  return ${T}(ldexp${f}(${CT}(x), Int32(n)))
 }
 
 % end
@@ -253,7 +253,7 @@ public func ldexp(_ x: ${T}, _ n: Int) -> ${T} {
 @_transparent
 @warn_unused_result
 public func frexp(_ value: ${T}) -> (${T}, Int) {
-  var exp = CInt(0)
+  var exp = Int32(0)
   let frac = frexp${f}(${CT}(value), &exp)
   return (${T}(frac), Int(exp))
 }
@@ -265,7 +265,7 @@ public func frexp(_ value: ${T}) -> (${T}, Int) {
 @_transparent
 @warn_unused_result
 public func ilogb(_ x: ${T}) -> Int {
-  return Int(ilogb${f}(${CT}(x)) as CInt)
+  return Int(ilogb${f}(${CT}(x)) as Int32)
 }
 
 % end
@@ -275,7 +275,7 @@ public func ilogb(_ x: ${T}) -> Int {
 @_transparent
 @warn_unused_result
 public func scalbn(_ x: ${T}, _ n: Int) -> ${T} {
-  return ${T}(scalbn${f}(${CT}(x), CInt(n)))
+  return ${T}(scalbn${f}(${CT}(x), Int32(n)))
 }
 
 % end
@@ -286,7 +286,7 @@ public func scalbn(_ x: ${T}, _ n: Int) -> ${T} {
 @_transparent
 @warn_unused_result
 public func lgamma(_ x: ${T}) -> (${T}, Int) {
-  var sign = CInt(0)
+  var sign = Int32(0)
   let value = lgamma${f}_r(${CT}(x), &sign)
   return (${T}(value), Int(sign))
 }
@@ -297,14 +297,14 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 @warn_unused_result
 @_silgen_name("_swift_Darwin_lgamma${f}_r")
 func _swift_Darwin_lgamma${f}_r(_: ${CT},
-                                _: UnsafeMutablePointer<CInt>) -> ${CT}
+                                _: UnsafeMutablePointer<Int32>) -> ${CT}
 
 @_transparent
 @warn_unused_result
 public func lgamma(_ x: ${T}) -> (${T}, Int) {
-  var sign = CInt(0)
+  var sign = Int32(0)
   let value = withUnsafeMutablePointer(&sign) { 
-    (signp: UnsafeMutablePointer<CInt>) -> ${CT} in
+    (signp: UnsafeMutablePointer<Int32>) -> ${CT} in
     return _swift_Darwin_lgamma${f}_r(${CT}(x), signp)
   }
   return (${T}(value), Int(sign))
@@ -318,7 +318,7 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 @_transparent
 @warn_unused_result
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
-  var quo = CInt(0)
+  var quo = Int32(0)
   let rem = remquo${f}(${CT}(x), ${CT}(y), &quo)
   return (${T}(rem), Int(quo))
 }
@@ -347,13 +347,13 @@ public func fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} {
 @_transparent
 @warn_unused_result
 public func jn(_ n: Int, _ x: Double) -> Double {
-  return jn(CInt(n), x)
+  return jn(Int32(n), x)
 }
 
 @_transparent
 @warn_unused_result
 public func yn(_ n: Int, _ x: Double) -> Double {
-  return yn(CInt(n), x)
+  return yn(Int32(n), x)
 }
 
 % end

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -40,7 +40,7 @@ public typealias CSignedChar = Int8
 public typealias CShort = Int16
 
 /// The C 'int' type.
-public typealias Int32 = Int32
+public typealias CInt = Int32
 
 /// The C 'long' type.
 public typealias CLong = Int

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -40,7 +40,7 @@ public typealias CSignedChar = Int8
 public typealias CShort = Int16
 
 /// The C 'int' type.
-public typealias CInt = Int32
+public typealias Int32 = Int32
 
 /// The C 'long' type.
 public typealias CLong = Int

--- a/stdlib/public/core/Process.swift
+++ b/stdlib/public/core/Process.swift
@@ -33,7 +33,7 @@ public enum Process {
   }
 
   @_versioned
-  internal static var _argc: CInt = CInt()
+  internal static var _argc: Int32 = Int32()
 
   @_versioned
   internal static var _unsafeArgv:
@@ -41,7 +41,7 @@ public enum Process {
     = nil
 
   /// Access to the raw argc value from C.
-  public static var argc: CInt {
+  public static var argc: Int32 {
     return _argc
   }
 
@@ -82,6 +82,6 @@ func _stdlib_didEnterMain(
 ) {
   // Initialize the Process.argc and Process.unsafeArgv variables with the
   // values that were passed in to main.
-  Process._argc = CInt(argc)
+  Process._argc = Int32(argc)
   Process._unsafeArgv = UnsafeMutablePointer(argv)
 }

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -122,7 +122,7 @@ public func _encodeBitsAsWords<T : CVarArg>(_ x: T) -> [Int] {
 }
 
 // CVarArg conformances for the integer types.  Everything smaller
-// than a CInt must be promoted to CInt or CUnsignedInt before
+// than a Int32 must be promoted to Int32 or CUnsignedInt before
 // encoding.
 
 // Signed types
@@ -161,7 +161,7 @@ extension Int16 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   public var _cVarArgEncoding: [Int] {
-    return _encodeBitsAsWords(CInt(self))
+    return _encodeBitsAsWords(Int32(self))
   }
 }
 
@@ -169,7 +169,7 @@ extension Int8 : CVarArg {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.
   public var _cVarArgEncoding: [Int] {
-    return _encodeBitsAsWords(CInt(self))
+    return _encodeBitsAsWords(Int32(self))
   }
 }
 


### PR DESCRIPTION
Replace all instances of CInt in the SDK Overlay with Int32.  Everything in the SDK overlay should use the same type, and there is no reason to have both.
