### PR TITLE
[StdlibUnittest] Allow Interpreter to Expect Crashes

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -432,7 +432,14 @@ func _stdlib_getline() -> String? {
 
 func _printDebuggingAdvice(_ fullTestName: String) {
   print("To debug, run:")
-  print("$ \(Process.arguments[0]) " +
+  var invocation = [Process.arguments[0]]
+  let interpreter = getenv("SWIFT_INTERPRETER")
+  if interpreter != nil {
+    if let interpreterCmd = String(validatingUTF8: interpreter) {
+        invocation.insert(interpreterCmd, at: 0)
+    }
+  }
+  print("$ \(invocation.joined(separator: " ")) " +
     "--stdlib-unittest-in-process --stdlib-unittest-filter \"\(fullTestName)\"")
 }
 

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -109,9 +109,17 @@ public func spawnChild(_ args: [String])
   }
 
   var pid: pid_t = -1
-  let spawnResult = withArrayOfCStrings([ Process.arguments[0] ] as Array + args) {
+  var childArgs = args
+  childArgs.insert(Process.arguments[0], at: 0)
+  let interpreter = getenv("SWIFT_INTERPRETER")
+  if interpreter != nil {
+    if let invocation = String(validatingUTF8: interpreter) {
+      childArgs.insert(invocation, at: 0)
+    }
+  }
+  let spawnResult = withArrayOfCStrings(childArgs) {
     swift_posix_spawn(
-      &pid, Process.arguments[0], &fileActions, nil, $0, _getEnviron())
+      &pid, childArgs[0], &fileActions, nil, $0, _getEnviron())
   }
   if spawnResult != 0 {
     print(String(cString: strerror(spawnResult)))

--- a/test/1_stdlib/BridgeNonVerbatim.swift
+++ b/test/1_stdlib/BridgeNonVerbatim.swift
@@ -19,7 +19,6 @@
 // RUN: %target-run-stdlib-swift %s | FileCheck %s
 // REQUIRES: executable_test
 //
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 import Swift

--- a/test/1_stdlib/Bridgeable.swift
+++ b/test/1_stdlib/Bridgeable.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift | FileCheck %s
 // REQUIRES: executable_test
 
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 // FIXME: Should go into the standard library.

--- a/test/1_stdlib/Builtins.swift
+++ b/test/1_stdlib/Builtins.swift
@@ -15,8 +15,6 @@
 // RUN: %target-run %t/Builtins
 // REQUIRES: executable_test
 
-// XFAIL: interpret
-
 import Swift
 import SwiftShims
 import StdlibUnittest

--- a/test/1_stdlib/Character.swift
+++ b/test/1_stdlib/Character.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test
 
-// XFAIL: interpret
-
 import StdlibUnittest
 import Swift
 import SwiftPrivate

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -3,8 +3,6 @@
 // RUN: %S/../../utils/line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
-// XFAIL: interpret
-
 import Swift
 import StdlibUnittest
 

--- a/test/1_stdlib/InputStream.swift.gyb
+++ b/test/1_stdlib/InputStream.swift.gyb
@@ -16,8 +16,6 @@
 // RUN: %S/../../utils/line-directive %t/InputStream.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
-// XFAIL: interpret
-
 import StdlibUnittest
 
 

--- a/test/1_stdlib/Interval.swift
+++ b/test/1_stdlib/Interval.swift
@@ -12,7 +12,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
-// XFAIL: interpret
 
 import StdlibUnittest
 

--- a/test/1_stdlib/NSValueBridging.swift
+++ b/test/1_stdlib/NSValueBridging.swift
@@ -12,7 +12,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 import StdlibUnittest

--- a/test/1_stdlib/Range.swift
+++ b/test/1_stdlib/Range.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// XFAIL: interpret
-
 import StdlibUnittest
 
 

--- a/test/1_stdlib/Strideable.swift
+++ b/test/1_stdlib/Strideable.swift
@@ -12,7 +12,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 //
-// XFAIL: interpret
 
 import StdlibUnittest
 

--- a/test/1_stdlib/Unmanaged.swift
+++ b/test/1_stdlib/Unmanaged.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// XFAIL: interpret
-
 import StdlibUnittest
 
 

--- a/test/Interpreter/FunctionConversion.swift
+++ b/test/Interpreter/FunctionConversion.swift
@@ -13,7 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: rdar24874073
 //
-// XFAIL: interpret
 
 import StdlibUnittest
 

--- a/test/Interpreter/SDK/CoreGraphics_CGFloat.swift
+++ b/test/Interpreter/SDK/CoreGraphics_CGFloat.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
-// XFAIL: interpret
 
 import CoreGraphics
 import Foundation

--- a/test/Interpreter/SDK/Foundation_printing.swift
+++ b/test/Interpreter/SDK/Foundation_printing.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/Interpreter/SDK/autorelease.swift
+++ b/test/Interpreter/SDK/autorelease.swift
@@ -7,8 +7,6 @@
 // optimization on i386, even in the iOS simulator.
 // XFAIL: CPU=i386
 
-// XFAIL: interpret
-
 import Foundation
 
 class PrintOnDeinit: NSObject {

--- a/test/Interpreter/imported_objc_generics.swift
+++ b/test/Interpreter/imported_objc_generics.swift
@@ -6,7 +6,6 @@
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -5,7 +5,6 @@
 // RUN: %target-run %t/a.out
 
 // REQUIRES: executable_test
-// XFAIL: interpret
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -613,14 +613,16 @@ if run_vendor == 'apple':
 
         if 'interpret' in lit_config.params:
             target_run_base = (
-                xcrun_prefix + '%s %s -module-name main %s %s'
-                % (config.swift, target_options, config.swift_test_options,
+                '%s %s %s -module-name main %s %s'
+                % (xcrun_prefix, config.swift, target_options,
+                   config.swift_test_options,
                    swift_execution_tests_extra_flags))
             config.target_run_simple_swift = (
                 "%s %%s" % (target_run_base))
             config.target_run_stdlib_swift = (
                 "%s -Xfrontend -disable-access-control %%s" % (target_run_base))
             config.available_features.add('interpret')
+            config.environment['SWIFT_INTERPRETER'] = config.swift
 
         (sw_vers_name, sw_vers_vers, sw_vers_build) = \
             darwin_get_sw_vers()
@@ -699,6 +701,7 @@ elif run_os == 'linux-gnu' or run_os == 'linux-gnueabihf' or run_os == 'freebsd'
         config.target_run_stdlib_swift = (
             '%s -Xfrontend -disable-access-control %%s' % (target_run_base))
         config.available_features.add('interpret')
+        config.environment['SWIFT_INTERPRETER'] = config.swift
     config.target_sil_opt = (
         '%s -target %s %s %s' %
         (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt))


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Teach StdlibUnittest to run a sub-interpreter when run using the interpreter.
This allows interpreter-led tests to expect crashes and safely handle them.

<!-- Description about pull request. -->
#### Resolved bug number: (rdar://18080980)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
