### PR TITLE
build-script: unset *_DEPLOYMENT_TARGET variables

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1115,7 +1115,9 @@ the number of parallel build jobs to use""",
             'MAKEFLAGS',
             'SDKROOT',
             'MACOSX_DEPLOYMENT_TARGET',
-            'IPHONEOS_DEPLOYMENT_TARGET']:
+            'IPHONEOS_DEPLOYMENT_TARGET',
+            'TVOS_DEPLOYMENT_TARGET',
+            'WATCHOS_DEPLOYMENT_TARGET']:
         os.environ.pop(v, None)
 
     if args.show_sdks:


### PR DESCRIPTION
These variables interfere with cross-compiling of the standard library
and runtime.
