### PR TITLE
[WIP][Clang][SR-1052] Imported C decls w/o warn_unused_result get @discardableResult

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5604,6 +5604,12 @@ void ClangImporter::Implementation::importAttributes(
     MappedDecl->getAttrs().add(new (C) WarnUnusedResultAttr(SourceLoc(),
                                                             SourceLoc(),
                                                             false));
+  } else {
+    if (auto MD = dyn_cast<FuncDecl>(MappedDecl)) {
+      if (!MD->getResultType()->isVoid()) {
+        MD->getAttrs().add(new (C) DiscardableResultAttr(/*implicit*/false));
+      }
+    }
   }
   // Map __attribute__((const)).
   if (ClangDecl->hasAttr<clang::ConstAttr>()) {

--- a/test/ClangModules/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangModules/Inputs/SwiftPrivateAttr.txt
@@ -8,19 +8,26 @@ class Foo : NSObject, __PrivProto {
   func __noArgs()
   func __oneArg(_ arg: Int32)
   func __twoArgs(_ arg: Int32, other arg2: Int32)
+  @discardableResult
   class func __foo() -> Self!
+  @discardableResult
   class func __withNoArgs() -> Self!
   convenience init!(__oneArg arg: Int32)
   @available(*, unavailable, message: "use object construction 'Foo(__oneArg:)'")
+  @discardableResult
   class func __withOneArg(_ arg: Int32) -> Self!
   convenience init!(__twoArgs arg: Int32, other arg2: Int32)
   @available(*, unavailable, message: "use object construction 'Foo(__twoArgs:other:)'")
+  @discardableResult
   class func __withTwoArgs(_ arg: Int32, other arg2: Int32) -> Self!
   convenience init!(__ arg: Int32)
   @available(*, unavailable, message: "use object construction 'Foo(__:)'")
+  @discardableResult
   class func __foo(_ arg: Int32) -> Self!
+  @discardableResult
   func objectForKeyedSubscript(_ index: AnyObject!) -> AnyObject!
   func __setObject(_ object: AnyObject!, forKeyedSubscript index: AnyObject!)
+  @discardableResult
   func __objectAtIndexedSubscript(_ index: Int32) -> AnyObject!
   func setObject(_ object: AnyObject!, atIndexedSubscript index: Int32)
   init()

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -69,8 +69,11 @@ typealias FooTypedef1 = Int32
 var fooIntVar: Int32
 
 /// Aaa.  fooFunc1.  Bbb.
+@discardableResult
 func fooFunc1(_ a: Int32) -> Int32
+@discardableResult
 func fooFunc1AnonymousParam(_: Int32) -> Int32
+@discardableResult
 func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
 func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
 func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
@@ -111,8 +114,10 @@ func fooFuncWithComment4()
 func fooFuncWithComment5()
 
 /// Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.
+@discardableResult
 func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32
 @available(*, unavailable, message: "Variadic function is unavailable")
+@discardableResult
 func fooFuncUsingVararg(_ a: Int32, _ varargs: Any...) -> Int32
 
 /// Aaa.  FooProtocolBase.  Bbb.
@@ -141,7 +146,9 @@ protocol FooProtocolDerived : FooProtocolBase {
 class FooClassBase {
   class func fooBaseInstanceFunc0()
   func fooBaseInstanceFunc0()
+  @discardableResult
   class func fooBaseInstanceFunc1(_ anObject: AnyObject!) -> FooClassBase!
+  @discardableResult
   func fooBaseInstanceFunc1(_ anObject: AnyObject!) -> FooClassBase!
   init!()
   convenience init!(float f: Float)
@@ -150,6 +157,7 @@ class FooClassBase {
   class func fooBaseClassFunc0()
   /*not inherited*/ init!(_ x: Int32)
   @available(*, unavailable, message: "use object construction 'FooClassBase(_:)'")
+  @discardableResult
   class func fooClassBase(_ x: Int32) -> FooClassBase!
 }
 
@@ -196,17 +204,25 @@ struct _InternalStruct {
   init(x: Int32)
 }
 extension FooClassBase {
+  @discardableResult
   class func _internalMeth1() -> AnyObject!
+  @discardableResult
   func _internalMeth1() -> AnyObject!
 }
 extension FooClassBase {
+  @discardableResult
   class func _internalMeth2() -> AnyObject!
+  @discardableResult
   func _internalMeth2() -> AnyObject!
+  @discardableResult
   class func nonInternalMeth() -> AnyObject!
+  @discardableResult
   func nonInternalMeth() -> AnyObject!
 }
 extension FooClassBase {
+  @discardableResult
   class func _internalMeth3() -> AnyObject!
+  @discardableResult
   func _internalMeth3() -> AnyObject!
 }
 protocol _InternalProt {
@@ -238,6 +254,7 @@ class FooClassWithClassProperties : FooClassBase {
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
   @available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")
+  @discardableResult
   class func withInt(_ i: Int32) -> Self!
   @available(*, unavailable, message: "x")
   func unavailable()
@@ -293,6 +310,7 @@ enum SCNFilterMode : Int {
   @available(*, unavailable)
   case SCNNoFiltering
 }
+@discardableResult
 func fooSubFunc1(_ a: Int32) -> Int32
 struct FooSubEnum1 : RawRepresentable, Equatable {
   init(_ rawValue: UInt32)

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -85,9 +85,12 @@ typealias FooTypedef1 = Int32
 var fooIntVar: Int32
 
 /// Aaa.  fooFunc1.  Bbb.
+@discardableResult
 func fooFunc1(_ a: Int32) -> Int32
 
+@discardableResult
 func fooFunc1AnonymousParam(_: Int32) -> Int32
+@discardableResult
 func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
 
 /*
@@ -135,9 +138,11 @@ func fooFuncWithComment4()
 func fooFuncWithComment5()
 
 /// Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.
+@discardableResult
 func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32
 
 @available(*, unavailable, message: "Variadic function is unavailable")
+@discardableResult
 func fooFuncUsingVararg(_ a: Int32, _ varargs: Any...) -> Int32 // This comment should not show without decl.
 
 /// Aaa.  FooProtocolBase.  Bbb.
@@ -170,7 +175,9 @@ protocol FooProtocolDerived : FooProtocolBase {
 class FooClassBase {
   class func fooBaseInstanceFunc0()
   func fooBaseInstanceFunc0()
+  @discardableResult
   class func fooBaseInstanceFunc1(_ anObject: AnyObject!) -> FooClassBase!
+  @discardableResult
   func fooBaseInstanceFunc1(_ anObject: AnyObject!) -> FooClassBase!
   init!()
   convenience init!(float f: Float)
@@ -180,6 +187,7 @@ class FooClassBase {
   class func fooBaseClassFunc0()
   /*not inherited*/ init!(_ x: Int32)
   @available(*, unavailable, message: "use object construction 'FooClassBase(_:)'")
+  @discardableResult
   class func fooClassBase(_ x: Int32) -> FooClassBase!
 }
 
@@ -239,20 +247,28 @@ struct _InternalStruct {
 }
 
 extension FooClassBase {
+  @discardableResult
   class func _internalMeth1() -> AnyObject!
+  @discardableResult
   func _internalMeth1() -> AnyObject!
 }
 
 /* Extending FooClassBase with cool stuff */
 extension FooClassBase {
+  @discardableResult
   class func _internalMeth2() -> AnyObject!
+  @discardableResult
   func _internalMeth2() -> AnyObject!
+  @discardableResult
   class func nonInternalMeth() -> AnyObject!
+  @discardableResult
   func nonInternalMeth() -> AnyObject!
 }
 
 extension FooClassBase {
+  @discardableResult
   class func _internalMeth3() -> AnyObject!
+  @discardableResult
   func _internalMeth3() -> AnyObject!
 }
 
@@ -289,6 +305,7 @@ class FooClassWithClassProperties : FooClassBase {
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
   @available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")
+  @discardableResult
   class func withInt(_ i: Int32) -> Self!
   
   @available(*, unavailable, message: "x")

--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -19,13 +19,17 @@
 // PRINT-NEXT:   static var globalVar: Double
 // PRINT-NEXT:   init(value value: Double)
 // PRINT-NEXT:   init(specialLabel specialLabel: ())
+// PRINT-NEXT:   @discardableResult
 // PRINT-NEXT:   func inverted() -> Struct1
 // PRINT-NEXT:   mutating func invert()
+// PRINT-NEXT:   @discardableResult
 // PRINT-NEXT:   func translate(radians radians: Double) -> Struct1
+// PRINT-NEXT:   @discardableResult
 // PRINT-NEXT:   func scale(_ radians: Double) -> Struct1
 // PRINT-NEXT:   var radius: Double { get nonmutating set }
 // PRINT-NEXT:   var altitude: Double{{$}}
 // PRINT-NEXT:   var magnitude: Double { get }
+// PRINT-NEXT:   @discardableResult
 // PRINT-NEXT:   static func staticMethod() -> Int32
 // PRINT-NEXT:   static var property: Int32
 // PRINT-NEXT:   static var getOnlyProperty: Int32 { get }

--- a/test/IDE/infer_import_as_member.swift
+++ b/test/IDE/infer_import_as_member.swift
@@ -25,8 +25,10 @@ import InferImportAsMember
 // PRINT-NEXT:    init(specialLabel specialLabel: ())
 //
 // PRINT-LABEL:   /// Methods
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    func invert() -> IAMStruct1
 // PRINT-NEXT:    mutating func invertInPlace()
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    func rotate(radians radians: Double) -> IAMStruct1
 // PRINT-NEXT:    func selfComesLast(x x: Double)
 // PRINT-NEXT:    func selfComesThird(a a: Double, b b: Float, x x: Double)
@@ -38,26 +40,34 @@ import InferImportAsMember
 // PRINT-NEXT:    var length: Double
 //
 // PRINT-LABEL:   /// Various instance functions that can't quite be imported as properties.
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    func getNonPropertyNumParams() -> Float
 // PRINT-NEXT:    func setNonPropertyNumParams(a a: Float, b b: Float)
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    func getNonPropertyType() -> Float
 // PRINT-NEXT:    func setNonPropertyType(x x: Double)
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    func getNonPropertyNoSelf() -> Float
 // PRINT-NEXT:    static func setNonPropertyNoSelf(x x: Double, y y: Double)
 // PRINT-NEXT:    func setNonPropertyNoGet(x x: Double)
 //
 // PRINT-LABEL:   /// Various static functions that can't quite be imported as properties.
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    static func staticGetNonPropertyNumParams() -> Float
 // PRINT-NEXT:    static func staticSetNonPropertyNumParams(a a: Float, b b: Float)
 // PRINT-NEXT:    static func staticGetNonPropertyNumParamsGetter(d d: Double)
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    static func staticGetNonPropertyType() -> Float
 // PRINT-NEXT:    static func staticSetNonPropertyType(x x: Double)
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    static func staticGetNonPropertyNoSelf() -> Float
 // PRINT-NEXT:    static func staticSetNonPropertyNoSelf(x x: Double, y y: Double)
 // PRINT-NEXT:    static func staticSetNonPropertyNoGet(x x: Double)
 //
 // PRINT-LABEL:   /// Static method
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    static func staticMethod() -> Double
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    static func tlaThreeLetterAcronym() -> Double
 //
 // PRINT-LABEL:   /// Static computed properties
@@ -65,6 +75,7 @@ import InferImportAsMember
 // PRINT-NEXT:    static var staticOnlyProperty: Double { get }
 //
 // PRINT-LABEL:   /// Omit needless words
+// PRINT-NEXT:    @discardableResult
 // PRINT-NEXT:    static func onwNeedlessTypeArgLabel(_ Double: Double) -> Double
 //
 // PRINT-LABEL:   /// Fuzzy
@@ -73,6 +84,7 @@ import InferImportAsMember
 // PRINT-NEXT:    init(fuzzyName fuzzyName: ())
 // PRINT-NEXT:  }
 //
+// PRINT-NEXT:  @discardableResult
 // PRINT-NEXT:  func __IAMStruct1IgnoreMe(_ s: IAMStruct1) -> Double
 //
 // PRINT-LABEL: /// Mutable

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -10,20 +10,29 @@
 
 // stdbool.h uses #define, so this test does as well.
 
+@discardableResult
 func testCBool(_: Bool) -> Bool
+@discardableResult
 func testObjCBool(_: Bool) -> Bool
+@discardableResult
 func testDarwinBoolean(_: Bool) -> Bool
 
 typealias CBoolTypedef = Bool
 typealias ObjCBoolTypedef = ObjCBool
 typealias DarwinBooleanTypedef = DarwinBoolean
 
+@discardableResult
 func testCBoolTypedef(_: CBoolTypedef) -> CBoolTypedef
+@discardableResult
 func testObjCBoolTypedef(_: Bool) -> Bool
+@discardableResult
 func testDarwinBooleanTypedef(_: Bool) -> Bool
 
+@discardableResult
 func testCBoolPointer(_: UnsafeMutablePointer<Bool>) -> UnsafePointer<Bool>
+@discardableResult
 func testObjCBoolPointer(_: UnsafeMutablePointer<ObjCBool>) -> UnsafePointer<ObjCBool>
+@discardableResult
 func testDarwinBooleanPointer(_: UnsafeMutablePointer<DarwinBoolean>) -> UnsafePointer<DarwinBoolean>
 
 typealias CBoolFn = @convention(c) (Bool) -> Bool
@@ -34,12 +43,18 @@ typealias CBoolBlock = (Bool) -> Bool
 typealias ObjCBoolBlock = (Bool) -> Bool
 typealias DarwinBooleanBlock = (Bool) -> Bool
 
+@discardableResult
 func testCBoolFnToBlock(_: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
+@discardableResult
 func testObjCBoolFnToBlock(_: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
+@discardableResult
 func testDarwinBooleanFnToBlock(_: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
 
+@discardableResult
 func testCBoolFnToBlockTypedef(_: CBoolFn) -> CBoolBlock
+@discardableResult
 func testObjCBoolFnToBlockTypedef(_: ObjCBoolFn) -> ObjCBoolBlock
+@discardableResult
 func testDarwinBooleanFnToBlockTypedef(_: DarwinBooleanFn) -> DarwinBooleanBlock
 
 typealias CBoolFnToBlockType = (CBoolFn) -> CBoolBlock
@@ -59,16 +74,22 @@ class Test : NSObject {
   var propObjCBool: Bool
   var propDarwinBoolean: Bool
   
+  @discardableResult
   func testCBool(_ b: Bool) -> Bool
+  @discardableResult
   func testObjCBool(_ b: Bool) -> Bool
+  @discardableResult
   func testDarwinBoolean(_ b: Bool) -> Bool
   
   var propCBoolBlock: (Bool) -> Bool
   var propObjCBoolBlock: (Bool) -> Bool
   var propDarwinBooleanBlock: (Bool) -> Bool
   
+  @discardableResult
   func testCBoolFn(toBlock fp: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
+  @discardableResult
   func testObjCBoolFn(toBlock fp: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
+  @discardableResult
   func testDarwinBooleanFn(toBlock fp: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
   
   func produceCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (Bool) -> Bool)?>)

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -80,13 +80,14 @@
 // Skip through unavailable typedefs when importing types.
 // TAG_DECLS_AND_TYPEDEFS: @available(*, unavailable, message: "use double")
 // TAG_DECLS_AND_TYPEDEFS-NEXT: typealias real_t = Double
+// TAG_DECLS_AND_TYPEDEFS-NEXT: @discardableResult
 // TAG_DECLS_AND_TYPEDEFS-NEXT: func realSin(_ value: Double) -> Double
 
 // NEGATIVE-NOT: typealias FooStructTypedef2
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSArray.  Bbb.{{$}}
 // FOUNDATION-NEXT: {{^}}class NSArray : NSObject {{{$}}
-// FOUNDATION-NEXT  func objectAtIndex(_ index: Int) -> AnyObject!
+// FOUNDATION-NEXT: subscript(idx: Int) -> AnyObject { get }
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSRuncingMode.  Bbb.{{$}}
 // FOUNDATION-NEXT: {{^}}enum NSRuncingMode : UInt {{{$}}

--- a/test/IDE/print_clang_decls_AppKit.swift
+++ b/test/IDE/print_clang_decls_AppKit.swift
@@ -19,7 +19,9 @@
 
 // APPKIT-LABEL: {{^}}class NSView : NSObject, NSCoding, NSAccessibility {{{$}}
 // APPKIT-NEXT: init?(coder aDecoder: NSCoder)
+// APPKIT-NEXT: @discardableResult
 // APPKIT-NEXT: func isDescendant(of aView: NSView) -> Bool
+// APPKIT-NEXT: @discardableResult
 // APPKIT-NEXT: func ancestorShared(with aView: NSView) -> NSView?
 // APPKIT-NEXT: func addSubview(_ aView: NSView)
 // APPKIT-NEXT: func addSubview(_ aView: NSView, positioned place: UInt32, relativeTo otherView: NSView?)

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -15,29 +15,38 @@ class Test : NSObject {
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
   @available(*, unavailable, message: "use object construction 'Test()'")
+  @discardableResult
   class func a() -> Self
   convenience init(dummyParam: ())
   @available(*, unavailable, message: "use object construction 'Test(dummyParam:)'")
+  @discardableResult
   class func b() -> Self
   
   convenience init(cc x: AnyObject)
   @available(*, unavailable, message: "use object construction 'Test(cc:)'")
+  @discardableResult
   class func c(_ x: AnyObject) -> Self
   convenience init(_ x: AnyObject)
   @available(*, unavailable, message: "use object construction 'Test(_:)'")
+  @discardableResult
   class func d(_ x: AnyObject) -> Self
   
   convenience init(aa a: AnyObject, _ b: AnyObject, cc c: AnyObject)
   @available(*, unavailable, message: "use object construction 'Test(aa:_:cc:)'")
+  @discardableResult
   class func e(_ a: AnyObject, e b: AnyObject, e c: AnyObject) -> Self
   
   /*not inherited*/ init(fixedType: ())
   @available(*, unavailable, message: "use object construction 'Test(fixedType:)'")
+  @discardableResult
   class func f() -> Test
   
   // Would-be initializers.
+  @discardableResult
   class func zz() -> Self
+  @discardableResult
   class func yy(aa x: AnyObject) -> Self
+  @discardableResult
   class func xx(_ x: AnyObject, bb xx: AnyObject) -> Self
   
   init()
@@ -47,31 +56,42 @@ class TestError : NSObject {
   // Factory methods with NSError.
   convenience init(error: ()) throws
   @available(*, unavailable, message: "use object construction 'TestError(error:)'")
+  @discardableResult
   class func err1() throws -> Self
   convenience init(aa x: AnyObject?, error: ()) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:error:)'")
+  @discardableResult
   class func err2(_ x: AnyObject?) throws -> Self
   convenience init(aa x: AnyObject?, error: (), block: () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:error:block:)'")
+  @discardableResult
   class func err3(_ x: AnyObject?, callback block: () -> Void) throws -> Self
   convenience init(error: (), block: () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(error:block:)'")
+  @discardableResult
   class func err4(callback block: () -> Void) throws -> Self
   
   convenience init(aa x: AnyObject?) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:)'")
+  @discardableResult
   class func err5(_ x: AnyObject?) throws -> Self
   convenience init(aa x: AnyObject?, block: () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(aa:block:)'")
+  @discardableResult
   class func err6(_ x: AnyObject?, callback block: () -> Void) throws -> Self
   convenience init(block: () -> Void) throws
   @available(*, unavailable, message: "use object construction 'TestError(block:)'")
+  @discardableResult
   class func err7(callback block: () -> Void) throws -> Self
   
   // Would-be initializers.
+  @discardableResult
   class func ww(_ x: AnyObject?) throws -> Self
+  @discardableResult
   class func w2(_ x: AnyObject?, error: ()) throws -> Self
+  @discardableResult
   class func vv() throws -> Self
+  @discardableResult
   class func v2(error: ()) throws -> Self
   init()
 }

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -7683,10 +7683,10 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFunc1(_:)",
     key.usr: "c:@F@fooFunc1",
-    key.doc.full_as_xml: "<Function file=Foo.h line=\"65\" column=\"5\"><Name>fooFunc1</Name><USR>c:@F@fooFunc1</USR><Declaration>func fooFunc1(_ a: Int32) -> Int32</Declaration><Abstract><Para> Aaa.  fooFunc1.  Bbb.</Para></Abstract></Function>",
+    key.doc.full_as_xml: "<Function file=Foo.h line=\"65\" column=\"5\"><Name>fooFunc1</Name><USR>c:@F@fooFunc1</USR><Declaration>@discardableResult func fooFunc1(_ a: Int32) -> Int32</Declaration><Abstract><Para> Aaa.  fooFunc1.  Bbb.</Para></Abstract></Function",
     key.offset: 4409,
     key.length: 34,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -7703,7 +7703,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.usr: "c:@F@fooFunc1AnonymousParam",
     key.offset: 4444,
     key.length: 48,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1AnonymousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1AnonymousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -7719,7 +7719,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.usr: "c:@F@fooFunc3",
     key.offset: 4493,
     key.length: 94,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>d</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct>&gt;!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>d</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct>&gt;!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -7850,10 +7850,10 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
     key.usr: "c:@F@redeclaredInMultipleModulesFunc1",
-    key.doc.full_as_xml: "<Function file=Foo.h line=\"117\" column=\"5\"><Name>redeclaredInMultipleModulesFunc1</Name><USR>c:@F@redeclaredInMultipleModulesFunc1</USR><Declaration>func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32</Declaration><Abstract><Para> Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.</Para></Abstract></Function>",
+    key.doc.full_as_xml: "<Function file=Foo.h line=\"117\" column=\"5\"><Name>redeclaredInMultipleModulesFunc1</Name><USR>c:@F@redeclaredInMultipleModulesFunc1</USR><Declaration>@discardableResult func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32</Declaration><Abstract><Para> Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.</Para></Abstract></Function>",
     key.offset: 4902,
     key.length: 58,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>redeclaredInMultipleModulesFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>redeclaredInMultipleModulesFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -7971,7 +7971,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc1:",
         key.offset: 5372,
         key.length: 66,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>anObject</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>!</decl.function.returntype></decl.function.method.instance>",
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>anObject</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>!</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -8029,7 +8029,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 5574,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8037,7 +8037,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
         key.offset: 5615,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8045,7 +8045,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
         key.offset: 5656,
         key.length: 36,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8053,7 +8053,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 5698,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8183,7 +8183,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 6092,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8192,7 +8192,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
         key.offset: 6133,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8201,7 +8201,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
         key.offset: 6174,
         key.length: 36,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8210,7 +8210,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 6216,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8345,7 +8345,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 6647,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8365,7 +8365,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
         key.offset: 6715,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8373,7 +8373,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
         key.offset: 6756,
         key.length: 36,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8393,7 +8393,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 6825,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8498,7 +8498,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 7255,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8507,7 +8507,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
         key.offset: 7296,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8516,7 +8516,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
         key.offset: 7337,
         key.length: 36,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8525,7 +8525,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 7379,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8567,7 +8567,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
         key.offset: 7504,
         key.length: 39,
-        key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>withInt</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooUnavailableMembers\">Self</ref.class>!</decl.function.returntype></decl.function.method.class>",
+        key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>withInt</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooUnavailableMembers\">Self</ref.class>!</decl.function.returntype></decl.function.method.class>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -8775,7 +8775,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
         key.offset: 7917,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8784,7 +8784,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
         key.offset: 7958,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8793,7 +8793,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
         key.offset: 7999,
         key.length: 36,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
@@ -8802,7 +8802,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
         key.offset: 8041,
         key.length: 35,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
     ]
   },
@@ -8859,7 +8859,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.usr: "c:@F@fooSubFunc1",
     key.offset: 8173,
     key.length: 37,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,


### PR DESCRIPTION
#### What's in this pull request?

Part 3 for SR-1052: Add `@discardableResult` attr to imported C declarations without the Clang `warn_unused_result` attribute.
#### Resolved bug number: Part 3 of [SR-1052](https://bugs.swift.org/browse/SR-1052)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
