### PR TITLE
Don't include revisions in --version output by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ set(SWIFT_COMPILER_VERSION "" CACHE STRING
 set(CLANG_COMPILER_VERSION "" CACHE STRING
     "The internal version of the Clang compiler")
 
+option(SWIFT_INCLUDE_REVISIONS_IN_VERSION
+       "Include version control revision ids in '--version' output" OFF)
+
 # Indicate whether Swift should attempt to use the gold linker.
 # This is not used on Darwin.
 set(SWIFT_ENABLE_GOLD_LINKER FALSE CACHE BOOL

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -29,11 +29,21 @@ endmacro()
 
 set(get_svn_script "${LLVM_MAIN_SRC_DIR}/cmake/modules/GetSVN.cmake")
 
+function(get_revision_inc_path revision_inc_var name)
+  set(${revision_inc_var} "${CMAKE_CURRENT_BINARY_DIR}/${name}Revision.inc"
+    PARENT_SCOPE)
+endfunction()
+
+function(remove_revision_inc name)
+  get_revision_inc_path(revision_inc "${name}")
+  file(REMOVE "${revision_inc}")
+endfunction()
+
 function(generate_revision_inc revision_inc_var name dir)
   find_first_existing_vc_file(dep_file "${dir}")
   if(DEFINED dep_file)
     # Create custom target to generate the VC revision include.
-    set(revision_inc "${CMAKE_CURRENT_BINARY_DIR}/${name}Revision.inc")
+    get_revision_inc_path(revision_inc "${name}")
     string(TOUPPER ${name} upper_name)
     add_custom_command(OUTPUT "${revision_inc}"
       DEPENDS "${dep_file}" "${get_svn_script}"
@@ -51,12 +61,20 @@ function(generate_revision_inc revision_inc_var name dir)
   endif()
 endfunction()
 
-generate_revision_inc(llvm_revision_inc LLVM "${LLVM_MAIN_SRC_DIR}")
-generate_revision_inc(clang_revision_inc Clang "${CLANG_MAIN_SRC_DIR}")
-generate_revision_inc(swift_revision_inc Swift "${SWIFT_SOURCE_DIR}")
+if(SWIFT_INCLUDE_REVISIONS_IN_VERSION)
+  generate_revision_inc(llvm_revision_inc LLVM "${LLVM_MAIN_SRC_DIR}")
+  generate_revision_inc(clang_revision_inc Clang "${CLANG_MAIN_SRC_DIR}")
+  generate_revision_inc(swift_revision_inc Swift "${SWIFT_SOURCE_DIR}")
 
-set(version_inc_files
-  ${llvm_revision_inc} ${clang_revision_inc} ${swift_revision_inc})
+  set(version_inc_files
+    ${llvm_revision_inc} ${clang_revision_inc} ${swift_revision_inc})
+else()
+  remove_revision_inc(LLVM)
+  remove_revision_inc(Clang)
+  remove_revision_inc(Swift)
+
+  set(version_inc_files)
+endif()
 
 add_swift_library(swiftBasic
   Cache.cpp

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -40,6 +40,7 @@ build-swift-static-stdlib
 build-swift-stdlib-unittest-extra
 
 compiler-vendor=apple
+swift-include-revisions-in-version
 
 install-swift
 
@@ -203,6 +204,7 @@ build-ninja
 build-swift-stdlib-unittest-extra
 
 compiler-vendor=apple
+swift-include-revisions-in-version=0
 
 
 [preset: buildbot_incremental_base_all_platforms]
@@ -606,6 +608,7 @@ foundation
 
 dash-dash
 
+swift-include-revisions-in-version
 install-foundation
 reconfigure
 
@@ -679,6 +682,7 @@ build-ninja
 build-swift-static-stdlib
 build-swift-stdlib-unittest-extra
 compiler-vendor=apple
+swift-include-revisions-in-version
 swift-sdks=OSX;IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR
 
 install-swift

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -170,6 +170,7 @@ KNOWN_SETTINGS=(
     swift-user-visible-version  "3.0"            "user-visible version of the Swift language"
     swift-compiler-version      ""               "string that indicates a compiler version for Swift"
     clang-compiler-version      ""               "string that indicates a compiler version for Clang"
+    swift-include-revisions-in-version ""        "set to include version control revisions in 'swiftc --version' output"
     embed-bitcode-section       "0"              "embed an LLVM bitcode section in stdlib/overlay binaries for supported platforms"
     darwin-crash-reporter-client ""              "whether to enable CrashReporter integration"
     darwin-stdlib-install-name-dir ""            "the directory of the install_name for standard library dylibs"
@@ -1572,6 +1573,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
 
     swift_cmake_options=(
         "${swift_cmake_options[@]}"
+        -DSWIFT_INCLUDE_REVISIONS_IN_VERSION=$(true_false "${SWIFT_INCLUDE_REVISIONS_IN_VERSION}")
         -DSWIFT_AST_VERIFIER:BOOL=$(true_false "${SWIFT_ENABLE_AST_VERIFIER}")
         -DSWIFT_SIL_VERIFY_ALL:BOOL=$(true_false "${SIL_VERIFY_ALL}")
         -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=$(true_false "${SWIFT_RUNTIME_ENABLE_LEAK_CHECKER}")

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1500,7 +1500,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                 -DSWIFT_VENDOR=Apple
                 -DSWIFT_VENDOR_UTI=com.apple.compilers.llvm.swift
                 -DSWIFT_VERSION="${SWIFT_USER_VISIBLE_VERSION}"
-                -DSWIFT_COMPILER_VERSION="${SWIFT_COMPILER_VERSION}"
             )
             ;;
         *)
@@ -1523,7 +1522,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
         swift_cmake_options=(
             "${swift_cmake_options[@]}"
             -DCLANG_COMPILER_VERSION="${CLANG_COMPILER_VERSION}"
-            -DSWIFT_COMPILER_VERSION="${SWIFT_COMPILER_VERSION}"
         )
     fi
     if [[ "${SWIFT_COMPILER_VERSION}" ]] ; then


### PR DESCRIPTION
New build-script-impl option `swift-include-revisions-in-version`, which controls whether revision numbers show up in `--version` output. Turning this on results in the compiler being rebuilt every time the current checked-out revision changes, which then results in the standard library being rebuilt unnecessarily. The default is off.

As far as the standard presets go, this is turned on for non-incremental buildbot builds and package builds, and off in incremental buildbot builds.

Present for @dabrahams. 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
