### PR TITLE
The initial version of the NonAtomicRC optimization pass.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -165,6 +165,8 @@ PASS(LSLocationPrinter, "lslocation-dump",
      "Dump LSLocation results from analyzing all accessed locations")
 PASS(MergeCondFails, "merge-cond_fails",
      "Remove redundant overflow checks")
+PASS(NonAtomicRC, "non-atomic-rc",
+     "Use non-atomic reference counting whenever possible")
 PASS(NoReturnFolding, "noreturn-folding",
      "Add 'unreachable' after noreturn calls")
 PASS(RCIdentityDumper, "rc-id-dumper",

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -297,6 +297,10 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
   // Do the first stack promotion on high-level SIL.
   PM.addStackPromotion();
 
+  // Replace atomic RC instructions by non-atomic RC
+  // whenever possible.
+  PM.addNonAtomicRC();
+
   PM.runOneIteration();
   PM.resetAndRemoveTransformations();
 
@@ -329,6 +333,12 @@ void swift::runSILOptimizationPasses(SILModule &Module) {
 
   // Do the second stack promotion on low-level SIL.
   PM.addStackPromotion();
+
+  // Replace atomic RC instructions by non-atomic RC
+  // whenever possible.
+  PM.addNonAtomicRC();
+
+
 
   // Speculate virtual call targets.
   PM.addSpeculativeDevirtualization();

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TRANSFORMS_SOURCES
   Transforms/GenericSpecializer.cpp
   Transforms/MergeCondFail.cpp
   Transforms/PerformanceInliner.cpp
+  Transforms/NonAtomicRC.cpp
   Transforms/RedundantLoadElimination.cpp
   Transforms/RedundantOverflowCheckRemoval.cpp
   Transforms/ReleaseDevirtualizer.cpp

--- a/lib/SILOptimizer/Transforms/NonAtomicRC.cpp
+++ b/lib/SILOptimizer/Transforms/NonAtomicRC.cpp
@@ -1,0 +1,165 @@
+//===-------  NonAtomicRC.cpp - Use non-atomic reference counting  -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "non-atomic-rc"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILCloner.h"
+#include "swift/SILOptimizer/Analysis/ArraySemantic.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Generics.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/Statistic.h"
+
+STATISTIC(NumNonAtomicRC, "Number of non-atomic RC operations");
+
+llvm::cl::opt<bool> PerformNonAtomicOpts(
+    "non-atomic-opts", llvm::cl::init(true),
+    llvm::cl::desc("Enable non-atomic reference counting optimizations"));
+
+using namespace swift;
+
+namespace {
+
+typedef SILAnalysis::InvalidationKind StateChanges;
+
+class NonAtomicRCTransformer {
+  SILPassManager *PM;
+  SILFunction *F;
+  EscapeAnalysis::ConnectionGraph *ConGraph;
+  EscapeAnalysis *EA;
+  RCIdentityFunctionInfo *RCIFI;
+
+public:
+  NonAtomicRCTransformer(SILPassManager *PM, SILFunction *F,
+                         EscapeAnalysis::ConnectionGraph *ConGraph,
+                         EscapeAnalysis *EA, RCIdentityFunctionInfo *RCIFI)
+      : PM(PM), F(F), ConGraph(ConGraph), EA(EA), RCIFI(RCIFI) {}
+
+  StateChanges process();
+
+private:
+  StateChanges processNonEscapingRefCountingInsts();
+  bool isEligableRefCountingInst(SILInstruction *I);
+  StateChanges tryNonAtomicRC(SILInstruction *I);
+};
+
+static void markAsNonAtomic(RefCountingInst *I) {
+  SILValue Op = I->getOperand(0);
+  I->setNonAtomic();
+}
+
+/// Is it a reference counting instruction that is eligable to
+/// be promoted to a non-atomic version?
+bool NonAtomicRCTransformer::isEligableRefCountingInst(SILInstruction *I) {
+  return isa<RefCountingInst>(I) && !cast<RefCountingInst>(I)->isNonAtomic();
+}
+
+/// Try to promote a reference counting instruction to its non-atomic
+/// variant.
+StateChanges NonAtomicRCTransformer::tryNonAtomicRC(SILInstruction *I) {
+  assert(isa<RefCountingInst>(I));
+  auto *RCInst = cast<RefCountingInst>(I);
+  auto Root = stripAddressProjections(RCInst->getOperand(0)); // stripUniq...???
+  auto *Node = ConGraph->getNodeOrNull(RCInst->getOperand(0), EA);
+  if (!Node)
+    return SILAnalysis::InvalidationKind::Nothing;
+
+  // As long as the value does not escape the function, it is fine.
+  if (Node->escapesInsideFunction(false))
+    return SILAnalysis::InvalidationKind::Nothing;
+
+  // This value does not escape, which means that it is
+  // thread-local.
+  // Use non-atomic RC instructions for it.
+  markAsNonAtomic(RCInst);
+  NumNonAtomicRC++;
+  DEBUG(llvm::dbgs() << "Marking the RC instruction as non-atomic:\n";
+        RCInst->dumpInContext(););
+  return SILAnalysis::InvalidationKind::Instructions;
+}
+
+// Perform a basic scan over a function, look for RC instructions.
+// If any of these instruction have a non-escaping operand, it
+// is safe to make them non-atomic.
+StateChanges NonAtomicRCTransformer::processNonEscapingRefCountingInsts() {
+  StateChanges Changes = SILAnalysis::InvalidationKind::Nothing;
+  // Search the whole function for stack promotable allocations.
+  for (SILBasicBlock &BB : *F) {
+    for (auto Iter = BB.begin(); Iter != BB.end();) {
+      // The allocation instruction may be moved, so increment Iter prior to
+      // doing the optimization.
+      SILInstruction *I = &*Iter++;
+      if (isEligableRefCountingInst(I)) {
+        Changes = StateChanges(Changes | tryNonAtomicRC(I));
+      }
+    }
+  }
+  return Changes;
+}
+
+StateChanges NonAtomicRCTransformer::process() {
+  DEBUG(llvm::dbgs() << "\nAbout to process function:\n"; F->dump());
+  auto ChangesRefCounting = processNonEscapingRefCountingInsts();
+
+  if (ChangesRefCounting) {
+    DEBUG(llvm::dbgs() << "\n\nFunction after the transformation:"; F->dump());
+  }
+
+  return StateChanges(ChangesRefCounting);
+}
+
+//===----------------------------------------------------------------------===//
+//                              Top Level Driver
+//===----------------------------------------------------------------------===//
+
+class NonAtomicRC : public SILFunctionTransform {
+public:
+  NonAtomicRC() {}
+
+private:
+  /// The entry point to the transformation.
+  void run() override {
+    if (!PerformNonAtomicOpts)
+      return;
+
+    DEBUG(llvm::dbgs() << "** Start NonAtomicRC for " << getFunction()->getName()
+                       << " **\n");
+
+    auto *EA = PM->getAnalysis<EscapeAnalysis>();
+    auto *RCIA = PM->getAnalysis<RCIdentityAnalysis>();
+
+    SILFunction *F = getFunction();
+    auto *ConGraph = EA->getConnectionGraph(F);
+    if (ConGraph) {
+      NonAtomicRCTransformer Transformer(PM, F, ConGraph, EA, RCIA->get(F));
+      auto Changes = Transformer.process();
+      if (Changes) {
+        PM->invalidateAnalysis(F, Changes);
+      }
+    }
+    DEBUG(llvm::dbgs() << "** End NonAtomicRC for " << getFunction()->getName()
+                       << " **\n");
+
+  }
+
+  StringRef getName() override { return "NonAtomicRC"; }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createNonAtomicRC() { return new NonAtomicRC(); }

--- a/test/SILOptimizer/nonatomic_reference_counting_opt.sil
+++ b/test/SILOptimizer/nonatomic_reference_counting_opt.sil
@@ -1,0 +1,283 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -non-atomic-rc | FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+public class C {
+  deinit
+  init()
+}
+
+public struct S {
+  @sil_stored var c: C { get set }
+}
+
+sil_global @g : $C
+
+sil_global @s : $S
+
+sil [noinline] @non_escaping_foo : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : $C):
+  return %0 : $C
+}
+
+sil [noinline] @escaping_foo : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : $C):
+  %1 = global_addr @g : $*C
+  store %0 to %1 : $*C
+  return %0 : $C
+}
+
+sil [noinline] @non_escaping_struct_foo : $@convention(thin) (@owned S) -> @owned S {
+bb0(%0 : $S):
+  return %0 : $S
+}
+
+sil [noinline] @escaping_struct_foo : $@convention(thin) (@owned S) -> @owned S {
+bb0(%0 : $S):
+  %1 = global_addr @s : $*S
+  store %0 to %1 : $*S
+  return %0 : $S
+}
+
+
+// Test that RC operations on non-escaping references are converted into
+// non-atomic RC operations.
+
+// CHECK-LABEL: sil @test_strong_rr_positive
+// CHECK: strong_retain [nonatomic]
+// CHECK: strong_release [nonatomic]
+// CHECK: return
+sil @test_strong_rr_positive: $@convention(thin) () -> @owned C {
+bb0:
+  %1 = alloc_ref $C
+  strong_retain %1 : $C
+  %f = function_ref @non_escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%1) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %1 : $C
+  return %1 : $C
+}
+
+// CHECK-LABEL: sil @test_rr_value_positive
+// CHECK: retain_value [nonatomic]
+// CHECK: release_value [nonatomic]
+// CHECK: return
+sil @test_rr_value_positive: $@convention(thin) () -> @owned S {
+bb0:
+  %0 = alloc_ref $C
+  %2 = struct $S (%0 : $C)
+  %3 = alloc_stack $S
+  store %2 to %3 : $*S
+  retain_value %2 : $S
+  %f = function_ref @non_escaping_struct_foo : $@convention(thin) (@owned S) -> @owned S
+  %r = apply %f (%2) : $@convention(thin) (@owned S) -> @owned S
+  release_value %2 : $S
+  dealloc_stack %3 : $*S
+  return %2 : $S
+}
+
+// CHECK-LABEL: sil @test_strong_rrN_positive
+// CHECK: strong_retain [nonatomic]
+// CHECK: strong_retain [nonatomic]
+// CHECK: strong_release [nonatomic]
+// CHECK: strong_release [nonatomic]
+// CHECK: return
+sil @test_strong_rrN_positive: $@convention(thin) () -> @owned C {
+bb0:
+  %1 = alloc_ref $C
+  strong_retain %1 : $C
+  strong_retain %1 : $C
+  %f = function_ref @non_escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%1) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %1 : $C
+  strong_release %1 : $C
+  return %1 : $C
+}
+
+// CHECK-LABEL: sil @test_bridged_rr_positive
+// CHECK: strong_retain [nonatomic]
+// CHECK: strong_release [nonatomic]
+// CHECK: return
+sil @test_bridged_rr_positive: $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $C
+  %1 = integer_literal $Builtin.Word, 0
+  %2 = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
+  strong_retain %2 : $Builtin.BridgeObject
+  %f = function_ref @non_escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%0) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %2 : $Builtin.BridgeObject
+  %3 = tuple ()
+  %4 = return %3 : $()
+}
+
+// CHECK-LABEL: sil @test_pin_unpin_positive
+// CHECK: strong_pin [nonatomic]
+// CHECK: strong_unpin [nonatomic]
+// CHECK: return
+sil @test_pin_unpin_positive: $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $C
+  %1 = unchecked_ref_cast %0 : $C to  $Builtin.NativeObject
+  %2 = strong_pin %1 : $Builtin.NativeObject
+  %f = function_ref @non_escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%0) : $@convention(thin) (@owned C) -> @owned C
+  strong_unpin %2 : $Optional<Builtin.NativeObject>
+  %3 = tuple ()
+  %4 = return %3 : $()
+}
+
+// Test that RC operations on escaping references are not converted into
+// non-atomic RC operations.
+
+// The incoming reference is considered to be escaping.
+// CHECK-LABEL: sil @test_incoming_reference_negative
+// CHECK-NOT: strong_retain [nonatomic]
+// CHECK: strong_retain
+// CHECK-NOT: strong_release [nonatomic]
+// CHECK: strong_release
+// CHECK: return
+sil @test_incoming_reference_negative: $@convention(thin) (C) -> @owned C {
+bb0(%1 : $C):
+  strong_retain %1 : $C
+  %f = function_ref @non_escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%1) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %1 : $C
+  return %1 : $C
+}
+
+// CHECK-LABEL: sil @test_strong_rr_negative
+// CHECK-NOT: strong_retain [nonatomic]
+// CHECK: strong_retain
+// CHECK-NOT: strong_release [nonatomic]
+// CHECK: strong_release
+// CHECK: return
+sil @test_strong_rr_negative: $@convention(thin) () -> @owned C {
+bb0:
+  %1 = alloc_ref $C
+  strong_retain %1 : $C
+  %f = function_ref @escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%1) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %1 : $C
+  return %1 : $C
+}
+
+// CHECK-LABEL: sil @test_rr_value_negative
+// CHECK-NOT: retain_value [nonatomic]
+// CHECK: retain_value
+// CHECK-NOT: release_value [nonatomic]
+// CHECK: release_value
+// CHECK: return
+sil @test_rr_value_negative: $@convention(thin) () -> @owned S {
+bb0:
+  %0 = alloc_ref $C
+  %2 = struct $S (%0 : $C)
+  %3 = alloc_stack $S
+  store %2 to %3 : $*S
+  retain_value %2 : $S
+  %f = function_ref @escaping_struct_foo : $@convention(thin) (@owned S) -> @owned S
+  %r = apply %f (%2) : $@convention(thin) (@owned S) -> @owned S
+  release_value %2 : $S
+  dealloc_stack %3 : $*S
+  return %2 : $S
+}
+
+// Check that even if a property of a struct escapes, the whole struct
+// is considered escaped and thus non-atomic RC operations cannot be used.
+
+// CHECK-LABEL: sil @test_escaping_property_rr_value_negative
+// CHECK-NOT: retain_value [nonatomic]
+// CHECK: retain_value
+// CHECK-NOT: release_value [nonatomic]
+// CHECK: release_value
+// CHECK: return
+sil @test_escaping_property_rr_value_negative: $@convention(thin) () -> @owned S {
+bb0:
+  %0 = alloc_ref $C
+  %2 = struct $S (%0 : $C)
+  %3 = alloc_stack $S
+  store %2 to %3 : $*S
+  retain_value %2 : $S
+  %f = function_ref @escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%0) : $@convention(thin) (@owned C) -> @owned C
+  %f1 = function_ref @non_escaping_struct_foo : $@convention(thin) (@owned S) -> @owned S
+  %r1 = apply %f1 (%2) : $@convention(thin) (@owned S) -> @owned S
+  release_value %2 : $S
+  dealloc_stack %3 : $*S
+  return %2 : $S
+}
+
+// CHECK-LABEL: sil @test_strong_rrN_negative
+// CHECK-NOT: strong_retain [nonatomic]
+// CHECK: strong_retain
+// CHECK: strong_retain
+// CHECK-NOT: strong_release [nonatomic]
+// CHECK: strong_release
+// CHECK: strong_release
+// CHECK: return
+sil @test_strong_rrN_negative: $@convention(thin) () -> @owned C {
+bb0:
+  %1 = alloc_ref $C
+  strong_retain %1 : $C
+  strong_retain %1 : $C
+  %f = function_ref @escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%1) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %1 : $C
+  strong_release %1 : $C
+  return %1 : $C
+}
+
+// CHECK-LABEL: sil @test_bridged_rr_negative
+// CHECK-NOT: strong_retain [nonatomic]
+// CHECK: strong_retain
+// CHECK-NOT: strong_release [nonatomic]
+// CHECK: strong_release
+// CHECK: return
+sil @test_bridged_rr_negative: $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $C
+  %1 = integer_literal $Builtin.Word, 0
+  %2 = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
+  strong_retain %2 : $Builtin.BridgeObject
+  %f = function_ref @escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%0) : $@convention(thin) (@owned C) -> @owned C
+  strong_release %2 : $Builtin.BridgeObject
+  %3 = tuple ()
+  %4 = return %3 : $()
+}
+
+// CHECK-LABEL: sil @test_pin_unpin_negative
+// CHECK-NOT: strong_pin [nonatomic]
+// CHECK: strong_pin
+// CHECK-NOT: strong_unpin [nonatomic]
+// CHECK: strong_unpin
+// CHECK: return
+sil @test_pin_unpin_negative: $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $C
+  %1 = unchecked_ref_cast %0 : $C to  $Builtin.NativeObject
+  %2 = strong_pin %1 : $Builtin.NativeObject
+  %f = function_ref @escaping_foo : $@convention(thin) (@owned C) -> @owned C
+  %r = apply %f (%0) : $@convention(thin) (@owned C) -> @owned C
+  strong_unpin %2 : $Optional<Builtin.NativeObject>
+  %3 = tuple ()
+  %4 = return %3 : $()
+}
+
+
+
+// C.__deallocating_deinit
+sil @_TFC28nonatomic_reference_counting1CD : $@convention(method) (@owned C) -> () {
+bb0(%0 : $C):
+  dealloc_ref %0 : $C
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil_vtable C {
+  #C.deinit!deallocator: _TFC28nonatomic_reference_counting1CD  // C.__deallocating_deinit
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The initial version of the NonAtomicRC optimization pass.

Reference counting on non-escaping objects can be marked as non-atomic.

THIS IS A WORK IN PROGRESS. DON'T MERGE YET.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
