### PR TITLE
[Sema] Fixes infinite recursion when inheriting from a member of the same type

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/08008-swift-typechecker-typecheckexpression.swift
+++ b/validation-test/compiler_crashers_2_fixed/08008-swift-typechecker-typecheckexpression.swift
@@ -5,8 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// ASAN Output: stack-overflow on address 0x7ffe8def3f70 (pc 0x000001cf1268 bp 0x7ffe8def48f0 sp 0x7ffe8def3f00 T0)
-func b<T {
-class A : A.e {
-func e: T.e
+// RUN: not %target-swift-frontend %s -parse
+// ASAN Output: stack-overflow on address 0x7fffe2a98fd8 (pc 0x000001e12adb bp 0x7fffe2a992d0 sp 0x7fffe2a98f60 T0)
+class A:A.b{let b=Void{

--- a/validation-test/compiler_crashers_fixed/21765-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/21765-vtable.swift
@@ -5,6 +5,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// ASAN Output: stack-overflow on address 0x7fffe2a98fd8 (pc 0x000001e12adb bp 0x7fffe2a992d0 sp 0x7fffe2a98f60 T0)
-class A:A.b{let b=Void{
+// RUN: not %target-swift-frontend %s -parse
+// ASAN Output: stack-overflow on address 0x7ffe8def3f70 (pc 0x000001cf1268 bp 0x7ffe8def48f0 sp 0x7ffe8def3f00 T0)
+func b<T {
+class A : A.e {
+func e: T.e

--- a/validation-test/compiler_crashers_fixed/27939-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/27939-vtable.swift
@@ -5,7 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // ASAN Output: stack-overflow on address 0x7ffdad0b1cd0 (pc 0x000001cf1268 bp 0x7ffdad0b2650 sp 0x7ffdad0b1c60 T0)
 func b<T {
 class A : A.e {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fixes infinite recursion (stack overflow) in the compiler on code that looks like:

``` swift
    class Some: Some.SubType { }
```
#### Resolved bug number:
- [SR-84](https://bugs.swift.org/browse/SR-84)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
