### PR TITLE
Stride should allow zero size.

### DIFF
--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -150,7 +150,6 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
   }
 
   internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "stride size must not be zero")
     // Unreachable endpoints are allowed; they just make for an
     // already-empty Sequence.
     self._start = _start
@@ -218,7 +217,6 @@ public struct StrideThrough<
   }
 
   internal init(_start: Element, end: Element, stride: Element.Stride) {
-    _precondition(stride != 0, "stride size must not be zero")
     self._start = _start
     self._end = end
     self._stride = stride


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

People expect strides to allow zero size - like any traditional `for` loop that would have just skipped.
Adding an additional condition just for that makes the code messier.

But moreover - Xcode itself expects it to allow `0` length stride.
As Xcode automatically converts old `for` loops to strides, it actually **breaks** code that may in some cases have zero-length strides.

Example case:
https://github.com/danielgindi/Charts/issues/931

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
