### PR TITLE
[Sema] Improved error message for static functions on existential metatypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -93,6 +93,9 @@ ERROR(could_not_use_type_member,none,
 ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
       (Type, DeclName))
+ERROR(could_not_use_type_member_on_existential,none,
+      "static member %1 cannot be used on protocol metatype %0",
+      (Type, DeclName))
 ERROR(could_not_use_instance_member_on_type,none,
       "instance member %1 cannot be used on type %0",
       (Type, DeclName))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2251,10 +2251,21 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
                instanceTy, memberName)
         .highlight(baseRange).highlight(nameLoc.getSourceRange());
       return;
+            
     case MemberLookupResult::UR_TypeMemberOnInstance:
-      diagnose(loc, diag::could_not_use_type_member_on_instance,
-               baseObjTy, memberName)
-        .highlight(baseRange).highlight(nameLoc.getSourceRange());
+      if (instanceTy->isExistentialType() && baseObjTy->is<AnyMetatypeType>()) {
+        // If the base of the lookup is an existential metatype, emit an
+        // error specific to that
+        diagnose(loc, diag::could_not_use_type_member_on_existential,
+                 baseObjTy, memberName)
+          .highlight(baseRange).highlight(nameLoc.getSourceRange());
+      } else {
+        // Otherwise the static member lookup was invalid because it was
+        // called on an instance
+        diagnose(loc, diag::could_not_use_type_member_on_instance,
+                 baseObjTy, memberName)
+          .highlight(baseRange).highlight(nameLoc.getSourceRange());
+      }
       return;
         
     case MemberLookupResult::UR_MutatingMemberOnRValue:

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -820,7 +820,7 @@ struct MemberLookupResult {
     /// Argument labels don't match.
     UR_LabelMismatch,
     
-    /// This uses a type like Self it its signature that cannot be used on an
+    /// This uses a type like Self in its signature that cannot be used on an
     /// existential box.
     UR_UnavailableInExistential,
     
@@ -828,7 +828,7 @@ struct MemberLookupResult {
     /// type.
     UR_InstanceMemberOnType,
     
-    /// This is a static/class member being access through an instance.
+    /// This is a static/class member being accessed through an instance.
     UR_TypeMemberOnInstance,
     
     /// This is a mutating member, being used on an rvalue.

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -294,8 +294,8 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
   _ = p.mut // expected-error{{instance member 'mut' cannot be used on type 'P'}}
 
   // Static member of metatype -- not allowed
-  _ = pp.tum // expected-error{{static member 'tum' cannot be used on instance of type 'P.Protocol'}}
-  _ = P.tum // expected-error{{static member 'tum' cannot be used on instance of type 'P.Protocol'}}
+  _ = pp.tum // expected-error{{static member 'tum' cannot be used on protocol metatype 'P.Protocol'}}
+  _ = P.tum // expected-error{{static member 'tum' cannot be used on protocol metatype 'P.Protocol'}}
 
   // Static member of extension returning Self)
   let _: () -> P = id(p.returnSelfStatic)

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -63,8 +63,8 @@ func testSelector(_ c1: C1, p1: P1, obj: AnyObject) {
   // Methods on a protocol.
   _ = #selector(P1.method4)
   _ = #selector(P1.method4(_:b:))
-  _ = #selector(P1.method5) // FIXME: expected-error{{static member 'method5' cannot be used on instance of type 'P1.Protocol'}}
-  _ = #selector(P1.method5(_:b:)) // FIXME: expected-error{{static member 'method5(_:b:)' cannot be used on instance of type 'P1.Protocol'}}
+  _ = #selector(P1.method5) // expected-error{{static member 'method5' cannot be used on protocol metatype 'P1.Protocol'}}
+  _ = #selector(P1.method5(_:b:)) // expected-error{{static member 'method5(_:b:)' cannot be used on protocol metatype 'P1.Protocol'}}
   _ = #selector(p1.method4)
   _ = #selector(p1.method4(_:b:))
   _ = #selector(p1.dynamicType.method5)


### PR DESCRIPTION
#### What's in this pull request?

This improves the error message produced when static members are looked up on existential metatypes.

```
protocol P { }
extension P {
    static func staticMethod(a:Int) { ... }
}

_ = P.staticMethod(a:) // error: static member 'staticMethod(a:)' cannot be used on instance of type 'P.Protocol'
```

Now the compiler emits the warning `error: static member 'staticMethod(a:)' cannot be used on protocol metatype 'P.Protocol'`. This better reflects why this is forbidden—the protocol cannot provide the static member.

This addresses some FIXMEs in test/expr/unary/selector/selector.swift. 

The compiler still emits the correct error messages for lookups on the `P.Type` and `P.Protocol` cases and no new cases are diagnosed as errors.

```
_ = P.Type.staticMethod(a:) // error: type 'P.Type' has no member 'staticMethod(a:)'
_ = P.Protocol.staticMethod(a:) // error: type 'P.Protocol' has no member 'staticMethod(a:)'
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are: 

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
