### PR TITLE
Add nested parameter/returns/throws comment recognition

### DIFF
--- a/bindings/xml/comment-xml-schema.rng
+++ b/bindings/xml/comment-xml-schema.rng
@@ -650,9 +650,28 @@
           <!-- In general, template parameters with whitespace discussion
                should not be emitted, unless direction is explicitly specified.
                Schema might be more strict here. -->
-          <element name="Discussion">
-            <ref name="BlockContent" />
-          </element>
+          <choice>
+            <element name="ClosureParameter">
+              <optional>
+                <ref name="Abstract" />
+              </optional>
+              <optional>
+                <ref name="Parameters" />
+              </optional>
+              <optional>
+                <ref name="ResultDiscussion" />
+              </optional>
+              <optional>
+                <ref name="ThrowsDiscussion" />
+              </optional>
+              <optional>
+                <ref name="Discussion" />
+              </optional>
+            </element>
+            <element name="Discussion">
+              <ref name="BlockContent" />
+            </element>
+          </choice>
         </element>
       </oneOrMore>
     </element>

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -24,11 +24,11 @@ struct RawComment;
 class DocComment {
 public:
   struct CommentParts {
-    Optional<const llvm::markup::Paragraph *>Brief;
-    ArrayRef<const llvm::markup::MarkupASTNode *> BodyNodes;
-    ArrayRef<const llvm::markup::ParamField *> ParamFields;
-    Optional<const llvm::markup::ReturnsField *> ReturnsField;
-    Optional<const llvm::markup::ThrowsField *> ThrowsField;
+    Optional<const swift::markup::Paragraph *>Brief;
+    ArrayRef<const swift::markup::MarkupASTNode *> BodyNodes;
+    ArrayRef<const swift::markup::ParamField *> ParamFields;
+    Optional<const swift::markup::ReturnsField *> ReturnsField;
+    Optional<const swift::markup::ThrowsField *> ThrowsField;
 
     bool isEmpty() const {
       return !Brief.hasValue() && !ReturnsField.hasValue() && !ThrowsField.hasValue() && BodyNodes.empty() && ParamFields.empty();
@@ -37,39 +37,39 @@ public:
 
 private:
   const Decl *D;
-  const llvm::markup::Document *Doc = nullptr;
+  const swift::markup::Document *Doc = nullptr;
   const CommentParts Parts;
 
 public:
-  DocComment(const Decl *D, llvm::markup::Document *Doc,
+  DocComment(const Decl *D, swift::markup::Document *Doc,
              CommentParts Parts)
       : D(D), Doc(Doc), Parts(Parts) {}
 
   const Decl *getDecl() const { return D; }
 
-  const llvm::markup::Document *getDocument() const { return Doc; }
+  const swift::markup::Document *getDocument() const { return Doc; }
 
   CommentParts getParts() const {
     return Parts;
   }
 
-  Optional<const llvm::markup::Paragraph *> getBrief() const {
+  Optional<const swift::markup::Paragraph *> getBrief() const {
     return Parts.Brief;
   }
 
-  Optional<const llvm::markup::ReturnsField * >getReturnsField() const {
+  Optional<const swift::markup::ReturnsField * >getReturnsField() const {
     return Parts.ReturnsField;
   }
 
-  Optional<const llvm::markup::ThrowsField*> getThrowsField() const {
+  Optional<const swift::markup::ThrowsField*> getThrowsField() const {
     return Parts.ThrowsField;
   }
 
-  ArrayRef<const llvm::markup::ParamField *> getParamFields() const {
+  ArrayRef<const swift::markup::ParamField *> getParamFields() const {
     return Parts.ParamFields;
   }
 
-  ArrayRef<const llvm::markup::MarkupASTNode *> getBodyNodes() const {
+  ArrayRef<const swift::markup::MarkupASTNode *> getBodyNodes() const {
     return Parts.BodyNodes;
   }
 
@@ -79,7 +79,7 @@ public:
 
   // Only allow allocation using the allocator in MarkupContext or by
   // placement new.
-  void *operator new(size_t Bytes, llvm::markup::MarkupContext &MC,
+  void *operator new(size_t Bytes, swift::markup::MarkupContext &MC,
                      unsigned Alignment = alignof(DocComment));
   void *operator new(size_t Bytes, void *Mem) {
     assert(Mem);
@@ -91,7 +91,7 @@ public:
   void operator delete(void *Data) = delete;
 };
 
-Optional<DocComment *>getDocComment(llvm::markup::MarkupContext &Context,
+Optional<DocComment *>getDocComment(swift::markup::MarkupContext &Context,
                                     const Decl *D);
 
 } // namespace swift

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -22,34 +22,20 @@ class DocComment;
 struct RawComment;
 
 class DocComment {
-public:
-  struct CommentParts {
-    Optional<const swift::markup::Paragraph *>Brief;
-    ArrayRef<const swift::markup::MarkupASTNode *> BodyNodes;
-    ArrayRef<const swift::markup::ParamField *> ParamFields;
-    Optional<const swift::markup::ReturnsField *> ReturnsField;
-    Optional<const swift::markup::ThrowsField *> ThrowsField;
-
-    bool isEmpty() const {
-      return !Brief.hasValue() && !ReturnsField.hasValue() && !ThrowsField.hasValue() && BodyNodes.empty() && ParamFields.empty();
-    }
-  };
-
-private:
   const Decl *D;
   const swift::markup::Document *Doc = nullptr;
-  const CommentParts Parts;
+  const swift::markup::CommentParts Parts;
 
 public:
   DocComment(const Decl *D, swift::markup::Document *Doc,
-             CommentParts Parts)
+             swift::markup::CommentParts Parts)
       : D(D), Doc(Doc), Parts(Parts) {}
 
   const Decl *getDecl() const { return D; }
 
   const swift::markup::Document *getDocument() const { return Doc; }
 
-  CommentParts getParts() const {
+  swift::markup::CommentParts getParts() const {
     return Parts;
   }
 

--- a/include/swift/Markup/AST.h
+++ b/include/swift/Markup/AST.h
@@ -10,15 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 //
-#ifndef LLVM_MARKUP_AST_H
-#define LLVM_MARKUP_AST_H
+#ifndef SWIFT_MARKUP_AST_H
+#define SWIFT_MARKUP_AST_H
 
 #include "swift/Markup/LineList.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TrailingObjects.h"
 
-namespace llvm {
+namespace swift {
 namespace markup {
 
 class MarkupContext;
@@ -682,6 +682,6 @@ void dump(const MarkupASTNode *Node, llvm::raw_ostream &OS, unsigned indent = 0)
 void printInlinesUnder(const MarkupASTNode *Node, llvm::raw_ostream &OS,
                        bool PrintDecorators = false);
 } // namespace markup
-} // namespace llvm
+} // namespace swift
 
-#endif // LLVM_MARKUP_AST_H
+#endif // SWIFT_MARKUP_AST_H

--- a/include/swift/Markup/LineList.h
+++ b/include/swift/Markup/LineList.h
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_MARKUP_LINELIST_H
-#define LLVM_MARKUP_LINELIST_H
+#ifndef SWIFT_MARKUP_LINELIST_H
+#define SWIFT_MARKUP_LINELIST_H
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "swift/Basic/SourceLoc.h"
 
-namespace llvm {
+namespace swift {
 namespace markup {
 
 class MarkupContext;
@@ -76,6 +76,6 @@ public:
 };
 
 } // namespace markup
-} // namespace llvm
+} // namespace swift
 
-#endif // LLVM_MARKUP_LINELIST_H
+#endif // SWIFT_MARKUP_LINELIST_H

--- a/include/swift/Markup/Markup.h
+++ b/include/swift/Markup/Markup.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_MARKUP_MARKUP_H
-#define LLVM_MARKUP_MARKUP_H
+#ifndef SWIFT_MARKUP_MARKUP_H
+#define SWIFT_MARKUP_MARKUP_H
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Allocator.h"
@@ -20,12 +20,10 @@
 #include "swift/Markup/AST.h"
 #include "swift/Markup/LineList.h"
 
-
 namespace swift {
-  struct RawComment;
-}
 
-namespace llvm {
+struct RawComment;
+
 namespace markup {
 
 class LineList;
@@ -65,6 +63,6 @@ public:
 Document *parseDocument(MarkupContext &MC, LineList &LL);
 
 } // namespace markup
-} // namespace llvm
+} // namespace swift
 
-#endif // LLVM_MARKUP_MARKUP_H
+#endif // SWIFT_MARKUP_MARKUP_H

--- a/include/swift/Markup/SourceLoc.h
+++ b/include/swift/Markup/SourceLoc.h
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 
-#ifndef LLVM_REST_SOURCELOC_H
-#define LLVM_REST_SOURCELOC_H
+#ifndef SWIFT_MARKUP_SOURCELOC_H
+#define SWIFT_MARKUP_SOURCELOC_H
 
 #include "llvm/ADT/StringRef.h"
 #include <algorithm>
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-namespace llvm {
+namespace swift {
 namespace markup {
 
 class SourceLoc {
@@ -147,7 +147,7 @@ SourceManager<ExternalSourceLocTy>::toExternalSourceLoc(SourceLoc Loc) const {
 }
 
 } // namespace markup
-} // namespace llvm
+} // namespace swift
 
-#endif // LLVM_REST_SOURCELOC_H
+#endif // SWIFT_MARKUP_SOURCELOC_H
 

--- a/include/swift/Markup/XMLUtils.h
+++ b/include/swift/Markup/XMLUtils.h
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_MARKUP_XML_UTILS_H
-#define LLVM_MARKUP_XML_UTILS_H
+#ifndef SWIFT_MARKUP_XML_UTILS_H
+#define SWIFT_MARKUP_XML_UTILS_H
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace swift {
 namespace markup {
 
 // FIXME: copied from Clang's
@@ -71,7 +71,7 @@ static inline void appendWithCDATAEscaping(raw_ostream &OS, StringRef S) {
 }
 
 } // namespace markup
-} // namespace llvm
+} // namespace swift
 
-#endif // LLVM_MARKUP_XML_UTILS_H
+#endif // SWIFT_MARKUP_XML_UTILS_H
 

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -24,16 +24,16 @@
 
 using namespace swift;
 
-void *DocComment::operator new(size_t Bytes, llvm::markup::MarkupContext &MC,
+void *DocComment::operator new(size_t Bytes, swift::markup::MarkupContext &MC,
                                unsigned Alignment) {
   return MC.allocate(Bytes, Alignment);
 }
 
-Optional<llvm::markup::ParamField *> extractParamOutlineItem(
-    llvm::markup::MarkupContext &MC,
-    llvm::markup::MarkupASTNode *Node) {
+Optional<swift::markup::ParamField *> extractParamOutlineItem(
+    swift::markup::MarkupContext &MC,
+    swift::markup::MarkupASTNode *Node) {
 
-  auto Item = dyn_cast<llvm::markup::Item>(Node);
+  auto Item = dyn_cast<swift::markup::Item>(Node);
   if (!Item)
     return None;
 
@@ -42,7 +42,7 @@ Optional<llvm::markup::ParamField *> extractParamOutlineItem(
     return None;
 
   auto FirstChild = Children.front();
-  auto FirstParagraph = dyn_cast<llvm::markup::Paragraph>(FirstChild);
+  auto FirstParagraph = dyn_cast<swift::markup::Paragraph>(FirstChild);
   if (!FirstParagraph)
     return None;
 
@@ -51,7 +51,7 @@ Optional<llvm::markup::ParamField *> extractParamOutlineItem(
     return None;
 
   auto ParagraphText =
-      dyn_cast<llvm::markup::Text>(FirstParagraphChildren.front());
+      dyn_cast<swift::markup::Text>(FirstParagraphChildren.front());
   if (!ParagraphText)
     return None;
 
@@ -65,19 +65,19 @@ Optional<llvm::markup::ParamField *> extractParamOutlineItem(
 
   ParagraphText->setLiteralContent(Remainder.ltrim());
 
-  return llvm::markup::ParamField::create(MC, Name, Children);
+  return swift::markup::ParamField::create(MC, Name, Children);
 }
 
 bool extractParameterOutline(
-    llvm::markup::MarkupContext &MC, llvm::markup::List *L,
-    SmallVectorImpl<const llvm::markup::ParamField *> &ParamFields) {
-  SmallVector<llvm::markup::MarkupASTNode *, 8> NormalItems;
+    swift::markup::MarkupContext &MC, swift::markup::List *L,
+    SmallVectorImpl<const swift::markup::ParamField *> &ParamFields) {
+  SmallVector<swift::markup::MarkupASTNode *, 8> NormalItems;
   auto Children = L->getChildren();
   if (Children.empty())
     return false;
 
   for (auto Child : Children) {
-    auto I = dyn_cast<llvm::markup::Item>(Child);
+    auto I = dyn_cast<swift::markup::Item>(Child);
     if (!I) {
       NormalItems.push_back(Child);
       continue;
@@ -90,7 +90,7 @@ bool extractParameterOutline(
     }
 
     auto FirstChild = ItemChildren.front();
-    auto FirstParagraph = dyn_cast<llvm::markup::Paragraph>(FirstChild);
+    auto FirstParagraph = dyn_cast<swift::markup::Paragraph>(FirstChild);
     if (!FirstParagraph) {
       NormalItems.push_back(Child);
       continue;
@@ -103,7 +103,7 @@ bool extractParameterOutline(
     }
 
     auto HeadingText
-        = dyn_cast<llvm::markup::Text>(FirstParagraphChildren.front());
+        = dyn_cast<swift::markup::Text>(FirstParagraphChildren.front());
     if (!HeadingText) {
       NormalItems.push_back(Child);
       continue;
@@ -115,7 +115,7 @@ bool extractParameterOutline(
       continue;
     }
 
-    auto Rest = ArrayRef<llvm::markup::MarkupASTNode *>(
+    auto Rest = ArrayRef<swift::markup::MarkupASTNode *>(
         ItemChildren.begin() + 1, ItemChildren.end());
     if (Rest.empty()) {
       NormalItems.push_back(Child);
@@ -123,7 +123,7 @@ bool extractParameterOutline(
     }
 
     for (auto Child : Rest) {
-      auto SubList = dyn_cast<llvm::markup::List>(Child);
+      auto SubList = dyn_cast<swift::markup::List>(Child);
       if (!SubList)
         continue;
 
@@ -144,13 +144,13 @@ bool extractParameterOutline(
 }
 
 bool extractSeparatedParams(
-    llvm::markup::MarkupContext &MC, llvm::markup::List *L,
-    SmallVectorImpl<const llvm::markup::ParamField *> &ParamFields) {
-  SmallVector<llvm::markup::MarkupASTNode *, 8> NormalItems;
+    swift::markup::MarkupContext &MC, swift::markup::List *L,
+    SmallVectorImpl<const swift::markup::ParamField *> &ParamFields) {
+  SmallVector<swift::markup::MarkupASTNode *, 8> NormalItems;
   auto Children = L->getChildren();
 
   for (auto Child : Children) {
-    auto I = dyn_cast<llvm::markup::Item>(Child);
+    auto I = dyn_cast<swift::markup::Item>(Child);
     if (!I) {
       NormalItems.push_back(Child);
       continue;
@@ -163,7 +163,7 @@ bool extractSeparatedParams(
     }
 
     auto FirstChild = ItemChildren.front();
-    auto FirstParagraph = dyn_cast<llvm::markup::Paragraph>(FirstChild);
+    auto FirstParagraph = dyn_cast<swift::markup::Paragraph>(FirstChild);
     if (!FirstParagraph) {
       NormalItems.push_back(Child);
       continue;
@@ -176,7 +176,7 @@ bool extractSeparatedParams(
     }
 
     auto ParagraphText
-        = dyn_cast<llvm::markup::Text>(FirstParagraphChildren.front());
+        = dyn_cast<swift::markup::Text>(FirstParagraphChildren.front());
     if (!ParagraphText) {
       NormalItems.push_back(Child);
       continue;
@@ -208,13 +208,13 @@ bool extractSeparatedParams(
 }
 
 bool extractSimpleField(
-    llvm::markup::MarkupContext &MC, llvm::markup::List *L,
+    swift::markup::MarkupContext &MC, swift::markup::List *L,
     DocComment::CommentParts &Parts,
-    SmallVectorImpl<const llvm::markup::MarkupASTNode *> &BodyNodes) {
+    SmallVectorImpl<const swift::markup::MarkupASTNode *> &BodyNodes) {
   auto Children = L->getChildren();
-  SmallVector<llvm::markup::MarkupASTNode *, 8> NormalItems;
+  SmallVector<swift::markup::MarkupASTNode *, 8> NormalItems;
   for (auto Child : Children) {
-    auto I = dyn_cast<llvm::markup::Item>(Child);
+    auto I = dyn_cast<swift::markup::Item>(Child);
     if (!I) {
       NormalItems.push_back(Child);
       continue;
@@ -227,7 +227,7 @@ bool extractSimpleField(
     }
 
     auto FirstParagraph
-        = dyn_cast<llvm::markup::Paragraph>(ItemChildren.front());
+        = dyn_cast<swift::markup::Paragraph>(ItemChildren.front());
     if (!FirstParagraph) {
       NormalItems.push_back(Child);
       continue;
@@ -240,7 +240,7 @@ bool extractSimpleField(
     }
 
     auto ParagraphText
-        = dyn_cast<llvm::markup::Text>(ParagraphChildren.front());
+        = dyn_cast<swift::markup::Text>(ParagraphChildren.front());
     if (!ParagraphText) {
       NormalItems.push_back(Child);
       continue;
@@ -252,17 +252,17 @@ bool extractSimpleField(
     Tag = Tag.ltrim().rtrim();
     Remainder = Remainder.ltrim();
 
-    if (!llvm::markup::isAFieldTag(Tag)) {
+    if (!swift::markup::isAFieldTag(Tag)) {
       NormalItems.push_back(Child);
       continue;
     }
 
     ParagraphText->setLiteralContent(Remainder);
-    auto Field = llvm::markup::createSimpleField(MC, Tag, ItemChildren);
+    auto Field = swift::markup::createSimpleField(MC, Tag, ItemChildren);
 
-    if (auto RF = dyn_cast<llvm::markup::ReturnsField>(Field))
+    if (auto RF = dyn_cast<swift::markup::ReturnsField>(Field))
       Parts.ReturnsField = RF;
-    else if (auto TF = dyn_cast<llvm::markup::ThrowsField>(Field))
+    else if (auto TF = dyn_cast<swift::markup::ThrowsField>(Field))
       Parts.ThrowsField = TF;
     else
       BodyNodes.push_back(Field);
@@ -275,8 +275,8 @@ bool extractSimpleField(
 }
 
 static DocComment::CommentParts
-extractCommentParts(llvm::markup::MarkupContext &MC,
-                    llvm::markup::MarkupASTNode *Node) {
+extractCommentParts(swift::markup::MarkupContext &MC,
+                    swift::markup::MarkupASTNode *Node) {
 
   DocComment::CommentParts Parts;
   auto Children = Node->getChildren();
@@ -284,17 +284,17 @@ extractCommentParts(llvm::markup::MarkupContext &MC,
     return Parts;
 
   auto FirstParagraph
-      = dyn_cast<llvm::markup::Paragraph>(Node->getChildren().front());
+      = dyn_cast<swift::markup::Paragraph>(Node->getChildren().front());
   if (FirstParagraph)
     Parts.Brief = FirstParagraph;
 
-  SmallVector<const llvm::markup::MarkupASTNode *, 4> BodyNodes;
-  SmallVector<const llvm::markup::ParamField *, 8> ParamFields;
+  SmallVector<const swift::markup::MarkupASTNode *, 4> BodyNodes;
+  SmallVector<const swift::markup::ParamField *, 8> ParamFields;
 
   // Look for special top-level lists
   size_t StartOffset = FirstParagraph == nullptr ? 0 : 1;
   for (auto C = Children.begin() + StartOffset; C != Children.end(); ++C) {
-    if (auto L = dyn_cast<llvm::markup::List>(*C)) {
+    if (auto L = dyn_cast<swift::markup::List>(*C)) {
       // Could be one of the following:
       // 1. A parameter outline:
       //    - Parameters:
@@ -320,7 +320,7 @@ extractCommentParts(llvm::markup::MarkupContext &MC,
   return Parts;
 }
 
-Optional<DocComment *> swift::getDocComment(llvm::markup::MarkupContext &MC,
+Optional<DocComment *> swift::getDocComment(swift::markup::MarkupContext &MC,
                                             const Decl *D) {
   auto RC = D->getRawComment();
   if (RC.isEmpty())
@@ -328,8 +328,8 @@ Optional<DocComment *> swift::getDocComment(llvm::markup::MarkupContext &MC,
 
   PrettyStackTraceDecl StackTrace("parsing comment for", D);
 
-  llvm::markup::LineList LL = MC.getLineList(RC);
-  auto *Doc = llvm::markup::parseDocument(MC, LL);
+  swift::markup::LineList LL = MC.getLineList(RC);
+  auto *Doc = swift::markup::parseDocument(MC, LL);
   auto Parts = extractCommentParts(MC, Doc);
   return new (MC) DocComment(D, Doc, Parts);
 }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -70,7 +70,7 @@ Optional<swift::markup::ParamField *> extractParamOutlineItem(
 
 bool extractParameterOutline(
     swift::markup::MarkupContext &MC, swift::markup::List *L,
-    SmallVectorImpl<const swift::markup::ParamField *> &ParamFields) {
+    SmallVectorImpl<swift::markup::ParamField *> &ParamFields) {
   SmallVector<swift::markup::MarkupASTNode *, 8> NormalItems;
   auto Children = L->getChildren();
   if (Children.empty())
@@ -145,7 +145,7 @@ bool extractParameterOutline(
 
 bool extractSeparatedParams(
     swift::markup::MarkupContext &MC, swift::markup::List *L,
-    SmallVectorImpl<const swift::markup::ParamField *> &ParamFields) {
+    SmallVectorImpl<swift::markup::ParamField *> &ParamFields) {
   SmallVector<swift::markup::MarkupASTNode *, 8> NormalItems;
   auto Children = L->getChildren();
 
@@ -209,7 +209,7 @@ bool extractSeparatedParams(
 
 bool extractSimpleField(
     swift::markup::MarkupContext &MC, swift::markup::List *L,
-    DocComment::CommentParts &Parts,
+    swift::markup::CommentParts &Parts,
     SmallVectorImpl<const swift::markup::MarkupASTNode *> &BodyNodes) {
   auto Children = L->getChildren();
   SmallVector<swift::markup::MarkupASTNode *, 8> NormalItems;
@@ -274,11 +274,11 @@ bool extractSimpleField(
   return NormalItems.size() == 0;
 }
 
-static DocComment::CommentParts
+static swift::markup::CommentParts
 extractCommentParts(swift::markup::MarkupContext &MC,
                     swift::markup::MarkupASTNode *Node) {
 
-  DocComment::CommentParts Parts;
+  swift::markup::CommentParts Parts;
   auto Children = Node->getChildren();
   if (Children.empty())
     return Parts;
@@ -289,7 +289,7 @@ extractCommentParts(swift::markup::MarkupContext &MC,
     Parts.Brief = FirstParagraph;
 
   SmallVector<const swift::markup::MarkupASTNode *, 4> BodyNodes;
-  SmallVector<const swift::markup::ParamField *, 8> ParamFields;
+  SmallVector<swift::markup::ParamField *, 8> ParamFields;
 
   // Look for special top-level lists
   size_t StartOffset = FirstParagraph == nullptr ? 0 : 1;
@@ -316,6 +316,11 @@ extractCommentParts(swift::markup::MarkupContext &MC,
   // Copy BodyNodes and ParamFields into the MarkupContext.
   Parts.BodyNodes = MC.allocateCopy(llvm::makeArrayRef(BodyNodes));
   Parts.ParamFields = MC.allocateCopy(llvm::makeArrayRef(ParamFields));
+
+  for (auto Param : Parts.ParamFields) {
+    auto ParamParts = extractCommentParts(MC, Param);
+    Param->setParts(ParamParts);
+  }
 
   return Parts;
 }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -276,15 +276,15 @@ bool extractSimpleField(
 
 static DocComment::CommentParts
 extractCommentParts(llvm::markup::MarkupContext &MC,
-                    llvm::markup::Document *Doc) {
+                    llvm::markup::MarkupASTNode *Node) {
 
   DocComment::CommentParts Parts;
-  auto Children = Doc->getChildren();
+  auto Children = Node->getChildren();
   if (Children.empty())
     return Parts;
 
   auto FirstParagraph
-      = dyn_cast<llvm::markup::Paragraph>(Doc->getChildren().front());
+      = dyn_cast<llvm::markup::Paragraph>(Node->getChildren().front());
   if (FirstParagraph)
     Parts.Brief = FirstParagraph;
 

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -143,7 +143,7 @@ RawComment Decl::getRawComment() const {
   if (auto *Unit =
           dyn_cast<FileUnit>(this->getDeclContext()->getModuleScopeContext())) {
     if (Optional<CommentInfo> C = Unit->getCommentForDecl(this)) {
-      llvm::markup::MarkupContext MC;
+      swift::markup::MarkupContext MC;
       Context.setBriefComment(this, C->Brief);
       Context.setRawComment(this, C->Raw);
       return C->Raw;
@@ -191,7 +191,7 @@ static StringRef extractBriefComment(ASTContext &Context, RawComment RC,
   if (!D->canHaveComment())
     return StringRef();
 
-  llvm::markup::MarkupContext MC;
+  swift::markup::MarkupContext MC;
   auto DC = getDocComment(MC, D);
   if (!DC.hasValue())
     return StringRef();
@@ -202,7 +202,7 @@ static StringRef extractBriefComment(ASTContext &Context, RawComment RC,
 
   SmallString<256> BriefStr("");
   llvm::raw_svector_ostream OS(BriefStr);
-  llvm::markup::printInlinesUnder(Brief.getValue(), OS);
+  swift::markup::printInlinesUnder(Brief.getValue(), OS);
   if (OS.str().empty())
     return StringRef();
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -204,7 +204,7 @@ void getClangDocKeyword(ClangImporter &Importer, const Decl *D,
 } // end namespace comments
 } // end namespace clang
 
-namespace llvm {
+namespace swift {
 namespace markup {
 class SwiftDocWordExtractor : public MarkupASTWalker {
   CommandWordsPairs &Pairs;
@@ -242,7 +242,7 @@ void getSwiftDocKeyword(const Decl* D, CommandWordsPairs &Words) {
   }
   if (!Interested)
     return;
-  static llvm::markup::MarkupContext MC;
+  static swift::markup::MarkupContext MC;
   auto DC = getDocComment(MC, D);
   if (!DC.hasValue())
     return;
@@ -260,7 +260,7 @@ void getSwiftDocKeyword(const Decl* D, CommandWordsPairs &Words) {
   }
 }
 } // end namespace markup
-} // end namespace llvm
+} // end namespace swift
 
 typedef llvm::function_ref<bool(ValueDecl*, DeclVisibilityKind)> DeclFilter;
 DeclFilter DefaultFilter = [] (ValueDecl* VD, DeclVisibilityKind Kind) {return true;};
@@ -1496,7 +1496,7 @@ private:
     if (auto *CD = VD->getClangDecl()) {
       clang::comments::getClangDocKeyword(*Importer, CD, Pairs);
     } else {
-      llvm::markup::getSwiftDocKeyword(VD, Pairs);
+      swift::markup::getSwiftDocKeyword(VD, Pairs);
     }
     Builder.addDeclDocCommentWords(llvm::makeArrayRef(Pairs));
   }

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -27,7 +27,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/Index/CommentToXML.h"
 
-using namespace llvm::markup;
+using namespace swift::markup;
 using namespace swift;
 
 //===----------------------------------------------------------------------===//
@@ -69,7 +69,7 @@ struct CommentToXMLConverter {
 #include "swift/Markup/SimpleFields.def"
 
   void printDocument(const Document *D) {
-    llvm_unreachable("Can't print an llvm::markup::Document as XML directly");
+    llvm_unreachable("Can't print an swift::markup::Document as XML directly");
   }
 
   void printBlockQuote(const BlockQuote *BQ) {
@@ -400,7 +400,7 @@ std::string ide::extractPlainTextFromComment(const StringRef Text) {
     return {};
 
   RawComment Comment(Comments);
-  llvm::markup::MarkupContext MC;
+  swift::markup::MarkupContext MC;
   return MC.getLineList(Comment).str();
 }
 
@@ -418,7 +418,7 @@ bool ide::getDocumentationCommentAsXML(const Decl *D, raw_ostream &OS) {
     return false;
   }
 
-  llvm::markup::MarkupContext MC;
+  swift::markup::MarkupContext MC;
   auto DC = getDocComment(MC, D);
   if (!DC.hasValue())
     return false;
@@ -478,7 +478,7 @@ break;
 
   void printDocument(const Document *D) {
     // FIXME: Why keep doing this?
-    llvm_unreachable("Can't print an llvm::markup::Document as XML directly");
+    llvm_unreachable("Can't print an swift::markup::Document as XML directly");
   }
 
   void printBlockQuote(const BlockQuote *BQ) {
@@ -656,7 +656,7 @@ void ide::getDocumentationCommentAsDoxygen(const DocComment *DC,
   if (Brief.hasValue()) {
     SmallString<256> BriefStr;
     llvm::raw_svector_ostream OS(BriefStr);
-    llvm::markup::printInlinesUnder(Brief.getValue(), OS);
+    swift::markup::printInlinesUnder(Brief.getValue(), OS);
     Converter.print(OS.str());
     Converter.printNewline();
     Converter.printNewline();

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -44,7 +44,7 @@ Optional<std::pair<unsigned, unsigned>> swift::ide::parseLineCol(StringRef LineC
 }
 
 void XMLEscapingPrinter::printText(StringRef Text) {
-  llvm::markup::appendWithXMLEscaping(OS, Text);
+  swift::markup::appendWithXMLEscaping(OS, Text);
 }
 
 void XMLEscapingPrinter::printXML(StringRef Text) {

--- a/lib/Markup/AST.cpp
+++ b/lib/Markup/AST.cpp
@@ -19,7 +19,7 @@
 #include "swift/Markup/AST.h"
 #include "llvm/ADT/Optional.h"
 
-using namespace llvm;
+using namespace swift;
 using namespace markup;
 
 Document::Document(ArrayRef<MarkupASTNode*> Children)
@@ -29,7 +29,7 @@ Document::Document(ArrayRef<MarkupASTNode*> Children)
 }
 
 Document *Document::create(MarkupContext &MC,
-                           ArrayRef<llvm::markup::MarkupASTNode *> Children) {
+                           ArrayRef<swift::markup::MarkupASTNode *> Children) {
   void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
                           alignof(Document));
   return new (Mem) Document(Children);
@@ -151,7 +151,7 @@ Paragraph::Paragraph(ArrayRef<MarkupASTNode *> Children)
 }
 
 Paragraph *Paragraph::create(MarkupContext &MC,
-                             ArrayRef<llvm::markup::MarkupASTNode *> Children) {
+                             ArrayRef<swift::markup::MarkupASTNode *> Children) {
   void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
                           alignof(Paragraph));
   return new (Mem) Paragraph(Children);
@@ -184,7 +184,7 @@ Emphasis::Emphasis(ArrayRef<MarkupASTNode *> Children)
 }
 
 Emphasis *Emphasis::create(MarkupContext &MC,
-                           ArrayRef<llvm::markup::MarkupASTNode *> Children) {
+                           ArrayRef<swift::markup::MarkupASTNode *> Children) {
   void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
                           alignof(Emphasis));
   return new (Mem) Emphasis(Children);
@@ -197,7 +197,7 @@ Strong::Strong(ArrayRef<MarkupASTNode *> Children)
 }
 
 Strong *Strong::create(MarkupContext &MC,
-                       ArrayRef<llvm::markup::MarkupASTNode *> Children) {
+                       ArrayRef<swift::markup::MarkupASTNode *> Children) {
   void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()),
                           alignof(Strong));
   return new (Mem) Strong(Children);
@@ -253,41 +253,41 @@ return cast<Id>(this)->getChildren();
   }
 }
 
-void llvm::markup::printInlinesUnder(const MarkupASTNode *Node,
+void swift::markup::printInlinesUnder(const MarkupASTNode *Node,
                                      llvm::raw_ostream &OS,
                                      bool PrintDecorators) {
   auto printChildren = [](const ArrayRef<const MarkupASTNode *> Children,
                           llvm::raw_ostream &OS) {
     for (auto Child = Children.begin(); Child != Children.end(); Child++)
-      llvm::markup::printInlinesUnder(*Child, OS);
+      swift::markup::printInlinesUnder(*Child, OS);
   };
 
   switch (Node->getKind()) {
-  case llvm::markup::ASTNodeKind::HTML: {
+  case swift::markup::ASTNodeKind::HTML: {
     auto H = cast<HTML>(Node);
     OS << H->getLiteralContent();
     break;
   }
-  case llvm::markup::ASTNodeKind::InlineHTML: {
+  case swift::markup::ASTNodeKind::InlineHTML: {
     auto IH = cast<InlineHTML>(Node);
     OS << IH->getLiteralContent();
     break;
   }
-  case llvm::markup::ASTNodeKind::HRule:
+  case swift::markup::ASTNodeKind::HRule:
     OS << '\n';
     break;
-  case llvm::markup::ASTNodeKind::Text: {
+  case swift::markup::ASTNodeKind::Text: {
     auto T = cast<Text>(Node);
     OS << T->getLiteralContent();
     break;
   }
-  case llvm::markup::ASTNodeKind::SoftBreak:
+  case swift::markup::ASTNodeKind::SoftBreak:
     OS << ' ';
     break;
-  case llvm::markup::ASTNodeKind::LineBreak:
+  case swift::markup::ASTNodeKind::LineBreak:
     OS << '\n';
     break;
-  case llvm::markup::ASTNodeKind::Code: {
+  case swift::markup::ASTNodeKind::Code: {
     auto C = cast<Code>(Node);
     if (PrintDecorators)
       OS << '`';
@@ -299,7 +299,7 @@ void llvm::markup::printInlinesUnder(const MarkupASTNode *Node,
 
     break;
   }
-  case llvm::markup::ASTNodeKind::CodeBlock: {
+  case swift::markup::ASTNodeKind::CodeBlock: {
     auto CB = cast<CodeBlock>(Node);
     if (PrintDecorators) OS << "``";
 
@@ -309,14 +309,14 @@ void llvm::markup::printInlinesUnder(const MarkupASTNode *Node,
 
     break;
   }
-  case llvm::markup::ASTNodeKind::Emphasis: {
+  case swift::markup::ASTNodeKind::Emphasis: {
     auto E = cast<Emphasis>(Node);
     if (PrintDecorators) OS << '*';
     printChildren(E->getChildren(), OS);
     if (PrintDecorators) OS << '*';
     break;
   }
-  case llvm::markup::ASTNodeKind::Strong: {
+  case swift::markup::ASTNodeKind::Strong: {
     auto S = cast<Strong>(Node);
     if (PrintDecorators) OS << "**";
     printChildren(S->getChildren(), OS);
@@ -329,10 +329,10 @@ void llvm::markup::printInlinesUnder(const MarkupASTNode *Node,
   OS.flush();
 }
 
-llvm::markup::MarkupASTNode *llvm::markup::createSimpleField(
+swift::markup::MarkupASTNode *swift::markup::createSimpleField(
     MarkupContext &MC,
     StringRef Tag,
-    ArrayRef<llvm::markup::MarkupASTNode *> Children) {
+    ArrayRef<swift::markup::MarkupASTNode *> Children) {
   if (false) {
 
   }
@@ -344,7 +344,7 @@ llvm::markup::MarkupASTNode *llvm::markup::createSimpleField(
   llvm_unreachable("Given tag not for any simple markup field");
 }
 
-bool llvm::markup::isAFieldTag(StringRef Tag) {
+bool swift::markup::isAFieldTag(StringRef Tag) {
   if (false) {
 
   }
@@ -356,13 +356,13 @@ bool llvm::markup::isAFieldTag(StringRef Tag) {
   return false;
 }
 
-void llvm::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
+void swift::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
                         unsigned indent) {
   auto dumpChildren = [](const ArrayRef<const MarkupASTNode *> Children,
                          llvm::raw_ostream &OS, unsigned indent) {
     OS << '\n';
     for (auto Child = Children.begin(); Child != Children.end(); Child++) {
-      llvm::markup::dump(*Child, OS, indent + 1);
+      swift::markup::dump(*Child, OS, indent + 1);
       if (Child != Children.end() - 1)
         OS << '\n';
     }
@@ -398,70 +398,70 @@ void llvm::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
 
   OS << '(';
   switch (Node->getKind()) {
-  case llvm::markup::ASTNodeKind::Document: {
+  case swift::markup::ASTNodeKind::Document: {
     OS << "Document: Children=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::BlockQuote: {
+  case swift::markup::ASTNodeKind::BlockQuote: {
     OS << "BlockQuote: Children=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::List: {
+  case swift::markup::ASTNodeKind::List: {
     auto L = cast<List>(Node);
     OS << "List: " << (L->isOrdered() ? "Ordered " : "Unordered ");
     OS << "Items=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::Item: {
+  case swift::markup::ASTNodeKind::Item: {
     OS << "Item: Children=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::HTML: {
+  case swift::markup::ASTNodeKind::HTML: {
     auto H = cast<HTML>(Node);
     OS << "HTML: Content=";
     simpleEscapingPrint(H->getLiteralContent(), OS);
     break;
   }
-  case llvm::markup::ASTNodeKind::InlineHTML: {
+  case swift::markup::ASTNodeKind::InlineHTML: {
     auto IH = cast<InlineHTML>(Node);
     OS << "InlineHTML: Content=";
     simpleEscapingPrint(IH->getLiteralContent(), OS);
     break;
   }
-  case llvm::markup::ASTNodeKind::Paragraph: {
+  case swift::markup::ASTNodeKind::Paragraph: {
     OS << "Paragraph: Children=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::Header: {
+  case swift::markup::ASTNodeKind::Header: {
     auto H = cast<Header>(Node);
     OS << "Header: Level=" << H->getLevel();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::HRule: {
+  case swift::markup::ASTNodeKind::HRule: {
     OS << "HRule";
     break;
   }
-  case llvm::markup::ASTNodeKind::Text: {
+  case swift::markup::ASTNodeKind::Text: {
     auto T = cast<Text>(Node);
     OS << "Text: Content=";
     simpleEscapingPrint(T->getLiteralContent(), OS);
     break;
   }
-  case llvm::markup::ASTNodeKind::SoftBreak: {
+  case swift::markup::ASTNodeKind::SoftBreak: {
     OS << "SoftBreak";
     break;
   }
-  case llvm::markup::ASTNodeKind::LineBreak: {
+  case swift::markup::ASTNodeKind::LineBreak: {
     OS << "LineBreak";
     break;
   }
-  case llvm::markup::ASTNodeKind::CodeBlock: {
+  case swift::markup::ASTNodeKind::CodeBlock: {
     auto CB = cast<CodeBlock>(Node);
     OS << "CodeBlock: ";
     OS << "Language=";
@@ -470,24 +470,24 @@ void llvm::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
     simpleEscapingPrint(CB->getLiteralContent(), OS);
     break;
   }
-  case llvm::markup::ASTNodeKind::Code: {
+  case swift::markup::ASTNodeKind::Code: {
     auto C = cast<Code>(Node);
     OS << "Code: Content=\"";
     simpleEscapingPrint(C->getLiteralContent(), OS);
     OS << "\"";
     break;
   }
-  case llvm::markup::ASTNodeKind::Strong: {
+  case swift::markup::ASTNodeKind::Strong: {
     OS << "Strong: Children=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::Emphasis: {
+  case swift::markup::ASTNodeKind::Emphasis: {
     OS << "Emphasis: Children=" << Node->getChildren().size();
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::Link: {
+  case swift::markup::ASTNodeKind::Link: {
     auto L = cast<Link>(Node);
     OS << "Link: Destination=";
     simpleEscapingPrint(L->getDestination(), OS);
@@ -495,7 +495,7 @@ void llvm::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::Image: {
+  case swift::markup::ASTNodeKind::Image: {
     auto I = cast<Image>(Node);
     OS << "Image: Destination=";
     simpleEscapingPrint(I->getDestination(), OS);
@@ -503,7 +503,7 @@ void llvm::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case llvm::markup::ASTNodeKind::ParamField: {
+  case swift::markup::ASTNodeKind::ParamField: {
     auto PF = cast<ParamField>(Node);
     OS << "ParamField: Name=";
     simpleEscapingPrint(PF->getName(), OS);
@@ -513,7 +513,7 @@ void llvm::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
   }
 
 #define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind) \
-  case llvm::markup::ASTNodeKind::Id: { \
+  case swift::markup::ASTNodeKind::Id: { \
     auto Field = cast<Id>(Node); \
     OS << #Id << ": Children=" << Field->getChildren().size(); \
     dumpChildren(Node->getChildren(), OS, indent + 1); \

--- a/lib/Markup/AST.cpp
+++ b/lib/Markup/AST.cpp
@@ -205,7 +205,8 @@ Strong *Strong::create(MarkupContext &MC,
 
 ParamField::ParamField(StringRef Name, ArrayRef<MarkupASTNode *> Children)
     : PrivateExtension(ASTNodeKind::ParamField), NumChildren(Children.size()),
-      Name(Name) {
+      Name(Name),
+      Parts(None) {
   std::uninitialized_copy(Children.begin(), Children.end(),
                           getTrailingObjects<MarkupASTNode *>());
 }

--- a/lib/Markup/LineList.cpp
+++ b/lib/Markup/LineList.cpp
@@ -15,12 +15,12 @@
 #include "swift/Markup/LineList.h"
 #include "swift/Markup/Markup.h"
 
-using namespace llvm;
+using namespace swift;
 using namespace markup;
 
 std::string LineList::str() const {
   std::string Result;
-  raw_string_ostream Stream(Result);
+  llvm::raw_string_ostream Stream(Result);
   if (Lines.empty())
     return "";
 
@@ -42,7 +42,7 @@ std::string LineList::str() const {
   return Result;
 }
 
-size_t llvm::markup::measureIndentation(StringRef Text) {
+size_t swift::markup::measureIndentation(StringRef Text) {
   size_t Col = 0;
   for (size_t i = 0, e = Text.size(); i != e; ++i) {
     if (Text[i] == ' ' || Text[i] == '\v' || Text[i] == '\f') {

--- a/lib/Markup/Markup.cpp
+++ b/lib/Markup/Markup.cpp
@@ -17,8 +17,9 @@
 #include "swift/Markup/Markup.h"
 #include "cmark.h"
 
-using namespace llvm;
+using namespace swift;
 using namespace markup;
+
 struct ParseState {
   cmark_iter *Iter = nullptr;
   cmark_event_type Event = CMARK_EVENT_NONE;
@@ -317,7 +318,7 @@ parseElement(MarkupContext &MC, LineList &LL, ParseState State) {
   }
 }
 
-Document *llvm::markup::parseDocument(MarkupContext &MC, LineList &LL) {
+Document *swift::markup::parseDocument(MarkupContext &MC, LineList &LL) {
   auto Comment = LL.str();
   auto CMarkDoc = cmark_parse_document(Comment.c_str(), Comment.size(),
                                        CMARK_OPT_DEFAULT);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -175,7 +175,7 @@ private:
   }
 
   void printDocumentationComment(Decl *D) {
-    llvm::markup::MarkupContext MC;
+    swift::markup::MarkupContext MC;
     auto DC = getDocComment(MC, D);
     if (DC.hasValue())
       ide::getDocumentationCommentAsDoxygen(DC.getValue(), os);

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -422,3 +422,39 @@ public func codeListingWithDefaultLanguage() {}
 /// ```
 public func codeListingWithOtherLanguage() {}
 // CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>codeListingWithOtherLanguage()</Name><USR>s:F14swift_ide_test28codeListingWithOtherLanguageFT_T_</USR><Declaration>public func codeListingWithOtherLanguage()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><CodeListing language="c++"><zCodeLineNumbered><![CDATA[Something::Something::create();]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
+
+/// Partially applies a binary operator.
+///
+/// - Parameter a: The left-hand side to partially apply.
+/// - Parameter combine: A binary operator.
+///   - Parameter lhs: The left-hand side of the operator
+///   - Parameter rhs: The right-hand side of the operator
+///   - Returns: A result.
+///   - Throws: Nothing.
+public func closureParameterExplodedExploded<T>(a: T, combine: (lhs: T, rhs: T) -> T) {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}} line="{{.*}}" column="{{.*}}"><Name>closureParameterExplodedExploded(a:combine:)</Name><USR>s:F14swift_ide_test32closureParameterExplodedExplodedurFT1ax7combineFT3lhsx3rhsx_x_T_</USR><Declaration>public func closureParameterExplodedExploded&lt;T&gt;(a: T, combine: (lhs: T, rhs: T) -&gt; T)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>] CommentXMLValid
+
+/// Partially applies a binary operator.
+///
+/// - Parameters:
+///   - a: The left-hand side to partially apply.
+///   - combine: A binary operator.
+///     - Parameter lhs: The left-hand side of the operator
+///     - Parameter rhs: The right-hand side of the operator
+///     - Returns: A result.
+///     - Throws: Nothing.
+public func closureParameterOutlineExploded<T>(a: T, combine: (lhs: T, rhs: T) -> T) {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}} line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineExploded(a:combine:)</Name><USR>s:F14swift_ide_test31closureParameterOutlineExplodedurFT1ax7combineFT3lhsx3rhsx_x_T_</USR><Declaration>public func closureParameterOutlineExploded&lt;T&gt;(a: T, combine: (lhs: T, rhs: T) -&gt; T)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>] CommentXMLValid
+
+/// Partially applies a binary operator.
+///
+/// - Parameters:
+///   - a: The left-hand side to partially apply.
+///   - combine: A binary operator.
+///     - Parameters:
+///       - lhs: The left-hand side of the operator
+///       - rhs: The right-hand side of the operator
+///     - Returns: A result.
+///     - Throws: Nothing.
+public func closureParameterOutlineOutline<T>(a: T, combine: (lhs: T, rhs: T) -> T) {}
+// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineOutline(a:combine:)</Name><USR>s:F14swift_ide_test30closureParameterOutlineOutlineurFT1ax7combineFT3lhsx3rhsx_x_T_</USR><Declaration>public func closureParameterOutlineOutline&lt;T&gt;(a: T, combine: (lhs: T, rhs: T) -&gt; T)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -743,7 +743,7 @@ static bool passCursorInfoForDecl(const ValueDecl *VD,
           llvm::raw_svector_ostream OSBuf(Buf);
           SwiftLangSupport::printDisplayName(RelatedDecl, OSBuf);
         }
-        llvm::markup::appendWithXMLEscaping(OS, Buf);
+        swift::markup::appendWithXMLEscaping(OS, Buf);
       }
       OS<<"</RelatedName>";
     }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1970,10 +1970,10 @@ public:
     if (D->isImplicit())
       return true;
 
-    llvm::markup::MarkupContext MC;
+    swift::markup::MarkupContext MC;
     auto DC = getDocComment(MC, D);
     if (DC.hasValue())
-      llvm::markup::dump(DC.getValue()->getDocument(), OS);
+      swift::markup::dump(DC.getValue()->getDocument(), OS);
 
     return true;
   }


### PR DESCRIPTION
This adds the capability to add further documentation underneath parameter list items so as to document the meaning of closure parameters for APIs that take a function as an argument. For example:

``` swift
/// Brief.
///
/// - Parameter combine: A combining function
///   - Parameters:
///    - lhs: The left-hand side of the operator
///    - rhs: The right-hand side of the operator
///    - Returns: The result of the operator.
/// - Parameter lhs: The left-hand side to partially apply
func partial<T>(combine: (lhs: T, rhs: T) -> T, a: T) -> (T -> T) {
  // ...
}
```

rdar://problem/24794725
