### PR TITLE
Add rudimentary nested closure param/return/throws support for Doxygen

### DIFF
--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -632,13 +632,78 @@ break;
     llvm_unreachable("Can't directly print Doxygen for a Swift Markup PrivateExtension");
   }
 
+  void printNestedParamField(const ParamField *PF) {
+    auto Parts = PF->getParts().getValue();
+    if (Parts.Brief.hasValue()) {
+      printASTNode(Parts.Brief.getValue());
+      printNewline();
+    }
+
+    if (!Parts.ParamFields.empty()) {
+      printNewline();
+      print("\\a ");
+      print(PF->getName());
+      print(" parameters:");
+      printNewline();
+
+      print("<ul>");
+      printNewline();
+      for (auto Param : Parts.ParamFields) {
+        print("<li>");
+        printNewline();
+        print(Param->getName());
+        print(": ");
+        printNestedParamField(Param);
+        print("</li>");
+        printNewline();
+      }
+      print("</ul>");
+      printNewline();
+      printNewline();
+    }
+
+    if (Parts.ReturnsField.hasValue()) {
+      printNewline();
+      print("\\a ");
+      print(PF->getName());
+      print(" returns: ");
+
+      for (auto Child : Parts.ReturnsField.getValue()->getChildren()) {
+        printASTNode(Child);
+        printNewline();
+      }
+    }
+
+    if (Parts.ThrowsField.hasValue()) {
+      printNewline();
+      print("\\a ");
+      print(PF->getName());
+      print(" error: ");
+
+      for (auto Child : Parts.ThrowsField.getValue()->getChildren()) {
+        printASTNode(Child);
+        printNewline();
+      }
+    }
+
+    for (auto BodyNode : Parts.BodyNodes) {
+      printASTNode(BodyNode);
+      printNewline();
+    }
+    printNewline();
+  }
+
   void printParamField(const ParamField *PF) {
     print("\\param ");
     print(PF->getName());
     print(" ");
-    for (auto Child : PF->getChildren())
-      printASTNode(Child);
-
+    if (PF->isClosureParameter()) {
+      printNestedParamField(PF);
+    } else {
+      for (auto Child : PF->getChildren()) {
+        printASTNode(Child);
+      }
+    }
     printNewline();
   }
 

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -107,6 +107,44 @@ public enum A012_AttachToEntities {
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f3()</Name><USR>s:FC14swift_ide_test5Brief2f3FT_T_</USR><Declaration>public func f3()</Declaration><Abstract><Para>Aaa.</Para></Abstract><Discussion><Para>Bbb.</Para></Discussion></Function>]
 }
 
+@objc public class ClosureContainer {
+/// Partially applies a binary operator.
+///
+/// - Parameter a: The left-hand side to partially apply.
+/// - Parameter combine: A binary operator.
+///   - Parameter lhs: The left-hand side of the operator
+///   - Parameter rhs: The right-hand side of the operator
+///   - Returns: A result.
+///   - Throws: Nothing.
+@objc public func closureParameterExplodedExploded(a: Int, combine: (lhs: Int, rhs: Int) -> Int) {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterExplodedExploded(a:combine:)</Name><USR>s:FC14swift_ide_test16ClosureContainer32closureParameterExplodedExplodedFT1aSi7combineFT3lhsSi3rhsSi_Si_T_</USR><Declaration>@objc public func closureParameterExplodedExploded(a: Int, combine: (lhs: Int, rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
+
+/// Partially applies a binary operator.
+///
+/// - Parameters:
+///   - a: The left-hand side to partially apply.
+///   - combine: A binary operator.
+///     - Parameter lhs: The left-hand side of the operator
+///     - Parameter rhs: The right-hand side of the operator
+///     - Returns: A result.
+///     - Throws: Nothing.
+@objc public func closureParameterOutlineExploded(a: Int, combine: (lhs: Int, rhs: Int) -> Int) {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineExploded(a:combine:)</Name><USR>s:FC14swift_ide_test16ClosureContainer31closureParameterOutlineExplodedFT1aSi7combineFT3lhsSi3rhsSi_Si_T_</USR><Declaration>@objc public func closureParameterOutlineExploded(a: Int, combine: (lhs: Int, rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
+
+/// Partially applies a binary operator.
+///
+/// - Parameters:
+///   - a: The left-hand side to partially apply.
+///   - combine: A binary operator.
+///     - Parameters:
+///       - lhs: The left-hand side of the operator
+///       - rhs: The right-hand side of the operator
+///     - Returns: A result.
+///     - Throws: Nothing.
+@objc public func closureParameterOutlineOutline(a: Int, combine: (lhs: Int, rhs: Int) -> Int) {}
+// CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineOutline(a:combine:)</Name><USR>s:FC14swift_ide_test16ClosureContainer30closureParameterOutlineOutlineFT1aSi7combineFT3lhsSi3rhsSi_Si_T_</USR><Declaration>@objc public func closureParameterOutlineOutline(a: Int, combine: (lhs: Int, rhs: Int) -&gt; Int)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]
+}
+
 @objc public class CodeBlock {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// This is how you use this code.
@@ -422,39 +460,3 @@ public func codeListingWithDefaultLanguage() {}
 /// ```
 public func codeListingWithOtherLanguage() {}
 // CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>codeListingWithOtherLanguage()</Name><USR>s:F14swift_ide_test28codeListingWithOtherLanguageFT_T_</USR><Declaration>public func codeListingWithOtherLanguage()</Declaration><Abstract><Para>Brief.</Para></Abstract><Discussion><CodeListing language="c++"><zCodeLineNumbered><![CDATA[Something::Something::create();]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></Function>]
-
-/// Partially applies a binary operator.
-///
-/// - Parameter a: The left-hand side to partially apply.
-/// - Parameter combine: A binary operator.
-///   - Parameter lhs: The left-hand side of the operator
-///   - Parameter rhs: The right-hand side of the operator
-///   - Returns: A result.
-///   - Throws: Nothing.
-public func closureParameterExplodedExploded<T>(a: T, combine: (lhs: T, rhs: T) -> T) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}} line="{{.*}}" column="{{.*}}"><Name>closureParameterExplodedExploded(a:combine:)</Name><USR>s:F14swift_ide_test32closureParameterExplodedExplodedurFT1ax7combineFT3lhsx3rhsx_x_T_</USR><Declaration>public func closureParameterExplodedExploded&lt;T&gt;(a: T, combine: (lhs: T, rhs: T) -&gt; T)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>] CommentXMLValid
-
-/// Partially applies a binary operator.
-///
-/// - Parameters:
-///   - a: The left-hand side to partially apply.
-///   - combine: A binary operator.
-///     - Parameter lhs: The left-hand side of the operator
-///     - Parameter rhs: The right-hand side of the operator
-///     - Returns: A result.
-///     - Throws: Nothing.
-public func closureParameterOutlineExploded<T>(a: T, combine: (lhs: T, rhs: T) -> T) {}
-// CHECK: DocCommentAsXML=[<Function file="{{.*}} line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineExploded(a:combine:)</Name><USR>s:F14swift_ide_test31closureParameterOutlineExplodedurFT1ax7combineFT3lhsx3rhsx_x_T_</USR><Declaration>public func closureParameterOutlineExploded&lt;T&gt;(a: T, combine: (lhs: T, rhs: T) -&gt; T)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>] CommentXMLValid
-
-/// Partially applies a binary operator.
-///
-/// - Parameters:
-///   - a: The left-hand side to partially apply.
-///   - combine: A binary operator.
-///     - Parameters:
-///       - lhs: The left-hand side of the operator
-///       - rhs: The right-hand side of the operator
-///     - Returns: A result.
-///     - Throws: Nothing.
-public func closureParameterOutlineOutline<T>(a: T, combine: (lhs: T, rhs: T) -> T) {}
-// CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>closureParameterOutlineOutline(a:combine:)</Name><USR>s:F14swift_ide_test30closureParameterOutlineOutlineurFT1ax7combineFT3lhsx3rhsx_x_T_</USR><Declaration>public func closureParameterOutlineOutline&lt;T&gt;(a: T, combine: (lhs: T, rhs: T) -&gt; T)</Declaration><Abstract><Para>Partially applies a binary operator.</Para></Abstract><Parameters><Parameter><Name>a</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side to partially apply.</Para></Discussion></Parameter><Parameter><Name>combine</Name><Direction isExplicit="0">in</Direction><ClosureParameter><Abstract><Para>A binary operator.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The left-hand side of the operator</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit="0">in</Direction><Discussion><Para>The right-hand side of the operator</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A result.</Para></ResultDiscussion><ThrowsDiscussion><Para>Nothing.</Para></ThrowsDiscussion></ClosureParameter></Parameter></Parameters></Function>]

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -86,6 +86,84 @@ SWIFT_CLASS("_TtC8comments5Brief")
 @end
 
 
+SWIFT_CLASS("_TtC8comments16ClosureContainer")
+@interface ClosureContainer
+
+/// Partially applies a binary operator.
+///
+/// \param a The left-hand side to partially apply.
+///
+/// \param combine A binary operator.
+///
+/// \a combine parameters:
+/// <ul>
+/// <li>
+/// lhs: The left-hand side of the operator
+///
+/// </li>
+/// <li>
+/// rhs: The right-hand side of the operator
+///
+/// </li>
+/// </ul>
+///
+///
+/// \a combine returns: A result.
+///
+/// \a combine error: Nothing.
+- (void)closureParameterExplodedExplodedWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger lhs, NSInteger rhs))combine;
+
+/// Partially applies a binary operator.
+///
+/// \param a The left-hand side to partially apply.
+///
+/// \param combine A binary operator.
+///
+/// \a combine parameters:
+/// <ul>
+/// <li>
+/// lhs: The left-hand side of the operator
+///
+/// </li>
+/// <li>
+/// rhs: The right-hand side of the operator
+///
+/// </li>
+/// </ul>
+///
+///
+/// \a combine returns: A result.
+///
+/// \a combine error: Nothing.
+- (void)closureParameterOutlineExplodedWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger lhs, NSInteger rhs))combine;
+
+/// Partially applies a binary operator.
+///
+/// \param a The left-hand side to partially apply.
+///
+/// \param combine A binary operator.
+///
+/// \a combine parameters:
+/// <ul>
+/// <li>
+/// lhs: The left-hand side of the operator
+///
+/// </li>
+/// <li>
+/// rhs: The right-hand side of the operator
+///
+/// </li>
+/// </ul>
+///
+///
+/// \a combine returns: A result.
+///
+/// \a combine error: Nothing.
+- (void)closureParameterOutlineOutlineWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger lhs, NSInteger rhs))combine;
+- (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+@end
+
+
 SWIFT_CLASS("_TtC8comments9CodeBlock")
 @interface CodeBlock
 


### PR DESCRIPTION
There isn't a great nested argument feature that we can use in our
Doxygen emitter but we can approximate it by nesting unordered lists
with labels.

rdar://problem/24794725
