### PR TITLE
[build-script] Use the correct build directory when building Darwin XCTest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1953,16 +1953,14 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     # result, we must copy swift-stdlib-tool ourselves.
                     copy_swift_stdlib_tool_substitute "$(build_directory_bin ${deployment_target} swift)/swift-stdlib-tool"
 
-                    # The Linux build places build products in the
-                    # XCTEST_BUILD_DIR. This, and installation of XCTest in
-                    # general, is not supported on OS X.
                     set -x
                     xcodebuild \
                         -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
                         -scheme SwiftXCTest \
                         SWIFT_EXEC="${SWIFTC_BIN}" \
                         SWIFT_LINK_OBJC_RUNTIME=YES \
-                        DSTROOT="${XCTEST_BUILD_DIR}"
+                        SYMROOT="${XCTEST_BUILD_DIR}" \
+                        OBJROOT="${XCTEST_BUILD_DIR}"
                     { set +x; } 2>/dev/null
                 else
                     FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
@@ -2252,7 +2250,9 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                         -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
                         -scheme SwiftXCTestFunctionalTests \
                         SWIFT_EXEC="${SWIFTC_BIN}" \
-                        SWIFT_LINK_OBJC_RUNTIME=YES
+                        SWIFT_LINK_OBJC_RUNTIME=YES \
+                        SYMROOT="${XCTEST_BUILD_DIR}" \
+                        OBJROOT="${XCTEST_BUILD_DIR}"
                     { set +x; } 2>/dev/null
                 else
                     FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Specify the XCTest build directory for both the `SYMROOT` and `OBJROOT` build settings when invoking `xcodebuild`. `DSTROOT`, which was previously being specified, is only used when performing an `install` action, which was disabled in https://github.com/apple/swift/pull/2036. With this change, all build intermediates and products end up in the correct XCTest build directory, with the system-wide `DerivedData` directory only receiving Xcode build logs.

This should resolve lingering issues related to leftover state from old builds causing CI failures. (See https://github.com/apple/swift-corelibs-xctest/pull/77 and https://github.com/apple/swift-corelibs-xctest/pull/95)

CC @modocache @shahmishal 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
