### PR TITLE
[build-script] Create relative symlinks into the llvm tree.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -846,6 +846,14 @@ function copy_swift_stdlib_tool_substitute() {
     fi
 }
 
+function make_relative_symlink() {
+    local SOURCE=$1
+    local TARGET=$2
+    local TARGET_DIR=$(dirname $2)
+    local RELATIVE_SOURCE=$(python -c "import os.path; print(os.path.relpath(\""${SOURCE}"\", \""${TARGET_DIR}"\"))")
+    ln -sf "${RELATIVE_SOURCE}" "${TARGET}"
+}
+
 # A list of deployment targets to cross-compile the Swift host tools for.
 # We can't run the resulting binaries on the build machine.
 CROSS_TOOLS_DEPLOYMENT_TARGETS=()
@@ -1001,14 +1009,14 @@ if [ ! -e "${WORKSPACE}/clang" ] ; then
     fi
 fi
 if [ ! -d "${CLANG_SOURCE_DIR}" ] ; then
-    ln -sf "${WORKSPACE}/clang" "${CLANG_SOURCE_DIR}"
+    make_relative_symlink "${WORKSPACE}/clang" "${CLANG_SOURCE_DIR}"
 fi
 
 # Symlink compiler-rt into the llvm tree, if it exists.
 COMPILER_RT_SOURCE_DIR="${LLVM_SOURCE_DIR}/projects/compiler-rt"
 if [ -e "${WORKSPACE}/compiler-rt" ] ; then
     if [ ! -d "${COMPILER_RT_SOURCE_DIR}" ] ; then
-        ln -sf "${WORKSPACE}/compiler-rt" "${COMPILER_RT_SOURCE_DIR}"
+        make_relative_symlink "${WORKSPACE}/compiler-rt" "${COMPILER_RT_SOURCE_DIR}"
     fi
 fi
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

On several occasions I have run into build failures related to missing headers after running `update-checkout`. I've discovered that one way to trigger this issue is to run the build script simultaneously from my OS X desktop and from within a virtualized Linux environment which has the same source source tree mounted as a volume at a different location. The build script symlinks `clang` and `compiler-rt` into the LLVM tree, but because the symlinks are created with absolute paths, the symlinks are specific to the environment where the build script is currently executing.

For example, when the build script is run from OS X, the generated symlink looks like:

`./llvm/tools/clang -> /Users/briancroom/Source/swift.org/clang`

whereas when run from Linux, it looks like:

`./llvm/tools/clang -> /src/swift.org/clang`

This PR changes these symlinks to be created with a relative path, looking like:

`./llvm/tools/clang -> ../../clang`

which is valid in both environments. Note that I'm using Python's `os.path.relpath` function to generate the path because I was unable to find a reasonable Bash solution for doing so.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
