### PR TITLE
[gardening] Fix comments not starting with "// " or "# "

### DIFF
--- a/benchmark/single-source/Walsh.swift
+++ b/benchmark/single-source/Walsh.swift
@@ -15,7 +15,7 @@ import Darwin
 
 func IsPowerOfTwo(_ x: Int) -> Bool { return (x & (x - 1)) == 0 }
 
-//Fast Walsh Hadamard Transform
+// Fast Walsh Hadamard Transform
 func WalshTransform(_ data: inout [Double]) {
   assert(IsPowerOfTwo(data.count), "Not a power of two")
   var temp = [Double](repeating: 0, count: data.count)

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -67,7 +67,7 @@ func g573() { f573(Starfish(), Salmon()) }
 func SR698(_ a: Int, b: Int) {}
 SR698(1, b: 2,) // expected-error {{unexpected ',' separator}}
 
-//SR-979 - Two inout crash compiler
+// SR-979 - Two inout crash compiler
 func SR979a(a : inout inout Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{17-23=}}
 func SR979b(inout inout b: Int) {}  // expected-error {{parameter may not have multiple 'inout', 'var', or 'let' specifiers}} {{19-25=}}
 // expected-error @-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{13-18=}} {{28-28=inout }}

--- a/test/SILOptimizer/specialize_ext.swift
+++ b/test/SILOptimizer/specialize_ext.swift
@@ -17,5 +17,5 @@ public func exp1() {
   var J = XXX<Int>(t: 4)
   J.bar(3)
 }
-//Make sure that we are able to specialize the extension 'bar'
+// Make sure that we are able to specialize the extension 'bar'
 //CHECK: sil shared [noinline] @_TTSg5Si___TFV14specialize_ext3XXX3bar


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix comments not starting with "// " or "# ".
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
