### PR TITLE
[utils/build-script] Introduce '--extra-cmake-vars' option

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -701,11 +701,11 @@ the number of parallel build jobs to use""",
         action="append", dest="extra_swift_args", default=[])
 
     parser.add_argument(
-        "--extra-cmake-vars", help=textwrap.dedent("""
-    Pass through extra variables to CMake in the form of comma separated vars
-    'CMAKE_VAR1=YES,CMAKE_VAR2=/tmp'. Can be called multiple times to add
-    multiple such vars."""),
-        action="append", dest="extra_cmake_vars", default=[])
+        "--extra-cmake-options", help=textwrap.dedent("""
+    Pass through extra options to CMake in the form of comma separated options
+    '-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp'. Can be called multiple times to add
+    multiple such options."""),
+        action="append", dest="extra_cmake_options", default=[])
 
     parser.add_argument(
         "build_script_impl_args",
@@ -1117,10 +1117,10 @@ the number of parallel build jobs to use""",
 
     # If we have extra_cmake_args, combine all of them together and then add
     # them as one command.
-    if args.extra_cmake_vars:
+    if args.extra_cmake_options:
         build_script_impl_args += [
-            "--extra-cmake-vars",
-            ",".join(args.extra_cmake_vars)]
+            "--extra-cmake-options",
+            ",".join(args.extra_cmake_options)]
 
     build_script_impl_args += args.build_script_impl_args
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -701,6 +701,13 @@ the number of parallel build jobs to use""",
         action="append", dest="extra_swift_args", default=[])
 
     parser.add_argument(
+        "--extra-cmake-vars", help=textwrap.dedent("""
+    Pass through extra variables to CMake in the form of comma separated vars
+    'CMAKE_VAR1=YES,CMAKE_VAR2=/tmp'. Can be called multiple times to add
+    multiple such vars."""),
+        action="append", dest="extra_cmake_vars", default=[])
+
+    parser.add_argument(
         "build_script_impl_args",
         help="",
         nargs="*")
@@ -1107,6 +1114,13 @@ the number of parallel build jobs to use""",
         build_script_impl_args += [
             "--extra-swift-args",
             ";".join(args.extra_swift_args)]
+
+    # If we have extra_cmake_args, combine all of them together and then add
+    # them as one command.
+    if args.extra_cmake_vars:
+        build_script_impl_args += [
+            "--extra-cmake-vars",
+            ",".join(args.extra_cmake_vars)]
 
     build_script_impl_args += args.build_script_impl_args
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -190,7 +190,7 @@ KNOWN_SETTINGS=(
     darwin-deployment-version-tvos    "9.0"      "minimum deployment target version for tvOS"
     darwin-deployment-version-watchos "2.0"      "minimum deployment target version for watchOS"
 
-    extra-cmake-vars            ""               "Extra variables to pass to CMake for all targets"
+    extra-cmake-options         ""               "Extra options to pass to CMake for all targets"
     extra-swift-args            ""               "Extra arguments to pass to swift modules which match regex. Assumed to be a flattened cmake list consisting of [module_regexp, args, module_regexp, args, ...]"
     sil-verify-all              "0"              "If enabled, run the SIL verifier after each transform when building Swift files during this build process"
     swift-enable-ast-verifier   "1"              "If enabled, and the assertions are enabled, the built Swift compiler will run the AST verifier every time it is invoked"
@@ -1198,12 +1198,12 @@ if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
     )
 fi
 
-if [[ "${EXTRA_CMAKE_VARS}" ]] ; then
-    for cmake_var in $(echo "${EXTRA_CMAKE_VARS}" | tr "," "\n")
+if [[ "${EXTRA_CMAKE_OPTIONS}" ]] ; then
+    for cmake_opt in $(echo "${EXTRA_CMAKE_OPTIONS}" | tr "," "\n")
     do
         COMMON_CMAKE_OPTIONS=(
             "${COMMON_CMAKE_OPTIONS[@]}"
-            "-D${cmake_var}"
+            "${cmake_opt}"
         )
     done
 fi

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -190,6 +190,7 @@ KNOWN_SETTINGS=(
     darwin-deployment-version-tvos    "9.0"      "minimum deployment target version for tvOS"
     darwin-deployment-version-watchos "2.0"      "minimum deployment target version for watchOS"
 
+    extra-cmake-vars            ""               "Extra variables to pass to CMake for all targets"
     extra-swift-args            ""               "Extra arguments to pass to swift modules which match regex. Assumed to be a flattened cmake list consisting of [module_regexp, args, module_regexp, args, ...]"
     sil-verify-all              "0"              "If enabled, run the SIL verifier after each transform when building Swift files during this build process"
     swift-enable-ast-verifier   "1"              "If enabled, and the assertions are enabled, the built Swift compiler will run the AST verifier every time it is invoked"
@@ -1195,6 +1196,16 @@ if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
         "${COMMON_CMAKE_OPTIONS[@]}"
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     )
+fi
+
+if [[ "${EXTRA_CMAKE_VARS}" ]] ; then
+    for cmake_var in $(echo "${EXTRA_CMAKE_VARS}" | tr "," "\n")
+    do
+        COMMON_CMAKE_OPTIONS=(
+            "${COMMON_CMAKE_OPTIONS[@]}"
+            "-D${cmake_var}"
+        )
+    done
 fi
 
 if [[ "${DISTCC}" ]] ; then


### PR DESCRIPTION
Introduce '--extra-cmake-vars' to allow setting any CMake veriables when configuring the targets.
