### PR TITLE
[coverage] Ignore compiler_crashers for coverage tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -139,7 +139,7 @@ class SwiftTest(lit.formats.ShTest, object):
             self.coverage_mode = None
         else:
             self.coverage_mode = coverage_mode
-        self.skip_merge_next_test = False
+        self.skipped_tests = set()
 
     def profdir_for_test(self, test):
         _, tmp_base = lit.TestRunner.getTempPaths(test)
@@ -147,13 +147,13 @@ class SwiftTest(lit.formats.ShTest, object):
 
     def before_test(self, test, litConfig):
         if self.coverage_mode:
-            profdir = self.profdir_for_test(test)
             # FIXME: The compiler crashers run so fast they fill up the
             # merger's queue (and therefore the build bot's disk)
-            if 'compiler_crashers' in profdir:
+            if 'crasher' in test.getSourcePath():
                 test.config.environment["LLVM_PROFILE_FILE"] = os.devnull
-                self.skip_merge_next_test = True
+                self.skipped_tests.add(test.getSourcePath())
                 return
+            profdir = self.profdir_for_test(test)
             if not os.path.exists(profdir):
                 os.makedirs(profdir)
 
@@ -161,14 +161,15 @@ class SwiftTest(lit.formats.ShTest, object):
                 os.path.join(profdir, "swift-%p.profraw")
 
     def after_test(self, test, litConfig, result):
-        if self.coverage_mode == "MERGED" and not self.skip_merge_next_test:
+        if test.getSourcePath() in self.skipped_tests:
+            return result
+        if self.coverage_mode == "MERGED":
             profdir = self.profdir_for_test(test)
             files = glob.glob(os.path.join(profdir, "swift-*.profraw"))
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('localhost', 12400))
             sock.send("\n".join(files))
             sock.close()
-        self.skip_merge_next_test = False
         return result
 
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -162,6 +162,7 @@ class SwiftTest(lit.formats.ShTest, object):
 
     def after_test(self, test, litConfig, result):
         if test.getSourcePath() in self.skipped_tests:
+            self.skipped_tests.remove(test.getSourcePath())
             return result
         if self.coverage_mode == "MERGED":
             profdir = self.profdir_for_test(test)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -139,6 +139,7 @@ class SwiftTest(lit.formats.ShTest, object):
             self.coverage_mode = None
         else:
             self.coverage_mode = coverage_mode
+        self.skip_merge_next_test = False
 
     def profdir_for_test(self, test):
         _, tmp_base = lit.TestRunner.getTempPaths(test)
@@ -147,6 +148,12 @@ class SwiftTest(lit.formats.ShTest, object):
     def before_test(self, test, litConfig):
         if self.coverage_mode:
             profdir = self.profdir_for_test(test)
+            # FIXME: The compiler crashers run so fast they fill up the
+            # merger's queue (and therefore the build bot's disk)
+            if 'compiler_crashers' in profdir:
+                test.config.environment["LLVM_PROFILE_FILE"] = os.devnull
+                self.skip_merge_next_test = True
+                return
             if not os.path.exists(profdir):
                 os.makedirs(profdir)
 
@@ -154,13 +161,14 @@ class SwiftTest(lit.formats.ShTest, object):
                 os.path.join(profdir, "swift-%p.profraw")
 
     def after_test(self, test, litConfig, result):
-        if self.coverage_mode == "MERGED":
+        if self.coverage_mode == "MERGED" and not self.skip_merge_next_test:
             profdir = self.profdir_for_test(test)
             files = glob.glob(os.path.join(profdir, "swift-*.profraw"))
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('localhost', 12400))
             sock.send("\n".join(files))
             sock.close()
+        self.skip_merge_next_test = False
         return result
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Ignores `compiler_crashers` when profiling coverage.
1) Compiler crashers should not count for coverage; it's not well known which parts of the compiler each of them touches, nor do we intend to use those tests to find that out.
2) The compiler crashers run very quickly and fill up disk space before the merger has time to merge them. This is a stopgap solution until we can have `lit` communicate with the merger better, or until LLVM can handle in-process merging.

<!-- Description about pull request. -->
#### Resolved bug number: N/A

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
