### PR TITLE
Disable foundation till PR 304 has been merged

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -602,11 +602,16 @@ lldb
 release
 test
 validation-test
-foundation
+
+# Remove foundation till this PR is merged
+# https://github.com/apple/swift-corelibs-foundation/pull/304
+# foundation
 
 dash-dash
 
-install-foundation
+# Remove foundation till this PR is merged
+# https://github.com/apple/swift-corelibs-foundation/pull/304
+# install-foundation
 reconfigure
 
 # Ubuntu 15.10 preset for backwards compat and future customizations.
@@ -623,7 +628,10 @@ llbuild
 lldb
 # Not all tests pass, currently
 #test
-foundation
+
+# Remove foundation till this PR is merged
+# https://github.com/apple/swift-corelibs-foundation/pull/304
+# foundation
 swiftpm
 xctest
 
@@ -634,7 +642,9 @@ dash-dash
 install-swift
 install-lldb
 install-llbuild
-install-foundation
+# Remove foundation till this PR is merged
+# https://github.com/apple/swift-corelibs-foundation/pull/304
+# install-foundation
 install-swiftpm
 install-xctest
 install-prefix=/usr

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -574,6 +574,10 @@ swiftpm
 xctest
 dash-dash
 
+# Remove foundation till this PR is merged
+# https://github.com/apple/swift-corelibs-foundation/pull/304
+skip-build-foundation
+
 install-swift
 install-lldb
 install-llbuild

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -571,18 +571,24 @@ mixin-preset=mixin_lightweight_assertions
 
 llbuild
 swiftpm
-xctest
+
+# Remove foundation till this PR is merged
+# https://github.com/apple/swift-corelibs-foundation/pull/304
+# xctest
+
 dash-dash
 
 # Remove foundation till this PR is merged
 # https://github.com/apple/swift-corelibs-foundation/pull/304
+# install-xctest
 skip-build-foundation
+skip-build-xctest
 
 install-swift
 install-lldb
 install-llbuild
 install-swiftpm
-install-xctest
+
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;license
 build-swift-static-stdlib
@@ -636,8 +642,9 @@ lldb
 # Remove foundation till this PR is merged
 # https://github.com/apple/swift-corelibs-foundation/pull/304
 # foundation
+# xctest
 swiftpm
-xctest
+
 
 build-subdir=buildbot_linux
 
@@ -646,11 +653,13 @@ dash-dash
 install-swift
 install-lldb
 install-llbuild
+
 # Remove foundation till this PR is merged
 # https://github.com/apple/swift-corelibs-foundation/pull/304
 # install-foundation
+# install-xctest
+
 install-swiftpm
-install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;dev
 build-swift-static-stdlib


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Disable foundation in build preset, because CI will fail till PR 304 has been merged into apple/swift-corelibs-foundation.git
https://github.com/apple/swift-corelibs-foundation/pull/304
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
