### PR TITLE
Fix demangle that failed to process stdlib protocol return type

### DIFF
--- a/lib/Basic/Demangle.cpp
+++ b/lib/Basic/Demangle.cpp
@@ -1123,6 +1123,13 @@ private:
     // we have to duplicate some of the logic from
     // demangleDeclarationName.
     if (Mangled.nextIf('S')) {
+
+      if (Mangled.nextIf('s')) {
+        NodePointer stdlib = NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
+        
+        return demangleProtocolNameGivenContext(stdlib);
+      }
+      
       NodePointer sub = demangleSubstitutionIndex();
       if (!sub) return nullptr;
       if (sub->getKind() == Node::Kind::Protocol)
@@ -1132,12 +1139,6 @@ private:
         return nullptr;
 
       return demangleProtocolNameGivenContext(sub);
-    }
-
-    if (Mangled.nextIf('s')) {
-      NodePointer stdlib = NodeFactory::create(Node::Kind::Module, STDLIB_NAME);
-
-      return demangleProtocolNameGivenContext(stdlib);
     }
 
     return demangleDeclarationName(Node::Kind::Protocol);


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Fix demangle that failed to process return type that is protocol declared in stdlib. Sample mangled call:
_TPA__TTRXFo_dO8MyModule5MyArg_dSbzoPSs9ErrorType__XFo_iS0__dSbzoPS1___

<!-- Description about pull request. -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
