### PR TITLE
Revert "Clang importer: Global vars imported as static member properties are final."

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2797,11 +2797,6 @@ namespace {
                        Impl.importSourceLoc(decl->getLocation()),
                        name, type, dc);
 
-      // If imported as member, the member should be final.
-      if (dc->getAsClassOrClassExtensionContext())
-        result->getAttrs().add(new (Impl.SwiftContext)
-                                 FinalAttr(/*IsImplicit=*/true));
-
       if (!decl->hasExternalStorage())
         Impl.registerExternalDecl(result);
 

--- a/test/IDE/Inputs/custom-modules/ImportAsMemberC.h
+++ b/test/IDE/Inputs/custom-modules/ImportAsMemberC.h
@@ -29,11 +29,3 @@ extern const CCPowerSupplyRef kCCPowerSupplySemiModular
 
 #pragma clang arc_cf_code_audited end
 
-extern const double kCCPowerSupplyDefaultPower
-  __attribute__((swift_name("CCPowerSupply.defaultPower")));
-
-extern const _Nonnull CCPowerSupplyRef kCCPowerSupplyAC
-  __attribute__((swift_name("CCPowerSupply.AC")));
-
-extern const _Nullable CCPowerSupplyRef kCCPowerSupplyDC
-  __attribute__((swift_name("CCPowerSupply.DC")));

--- a/test/IDE/import_as_member_cf.swift
+++ b/test/IDE/import_as_member_cf.swift
@@ -7,9 +7,6 @@
 // PRINTC:      extension CCPowerSupply {
 // PRINTC-NEXT:   /*not inherited*/ init(watts watts: Double)
 // PRINTC-NEXT:   class let semiModular: CCPowerSupply!
-// PRINTC-NEXT:   class let defaultPower: Double
-// PRINTC-NEXT:   class let AC: CCPowerSupply
-// PRINTC-NEXT:   class let DC: CCPowerSupply?
 // PRINTC-NEXT: }
 
 // PRINTC:      extension CCRefrigerator {

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -251,12 +251,3 @@ public func importAsProtocol(_ x: IAMProto_t) {
   // CHECK: function_ref @setSomeValue : $@convention(c) <τ_0_0 where τ_0_0 : IAMProto> (τ_0_0, Int32) -> Int32
   x.someValue = y
 }
-
-// CHECK-LABEL: sil @_TF10cf_members28importGlobalVarsAsProperties
-public func importGlobalVarsAsProperties()
-    -> (Double, CCPowerSupply, CCPowerSupply?) {
-  // CHECK: global_addr @kCCPowerSupplyDC
-  // CHECK: global_addr @kCCPowerSupplyAC
-  // CHECK: global_addr @kCCPowerSupplyDefaultPower
-  return (CCPowerSupply.defaultPower, CCPowerSupply.AC, CCPowerSupply.DC)
-}


### PR DESCRIPTION
Reverts apple/swift#2149

Reverting because this change apparently broke the OS X build:

https://ci.swift.org/job/oss-swift-incremental-RA-osx/3328/
