### PR TITLE
[WIP] [New indexing model] Fix index sharing and moving on String views

### DIFF
--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -78,7 +78,8 @@ extension String {
   /// representation.
   @warn_unused_result
   func _index(utf16Index: Int) -> Index {
-    return Index(_base: String.UnicodeScalarView.Index(utf16Index, _core))
+    return Index(_base: String.UnicodeScalarView.Index(utf16Index),
+                 _characters: characters)
   }
 
   /// Return a `Range<Index>` corresponding to the given `NSRange` of

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -953,10 +953,11 @@ extension String.Index {
     _ unicodeScalarIndex: String.UnicodeScalarIndex,
     within characters: String
   ) {
-    if !unicodeScalarIndex._isOnGraphemeClusterBoundary {
+    if !characters.unicodeScalars._isOnGraphemeClusterBoundary(
+      unicodeScalarIndex) {
       return nil
     }
-    self.init(_base: unicodeScalarIndex)
+    self.init(_base: unicodeScalarIndex, _characters: characters.characters)
   }
 
   /// Construct the position in `characters` that corresponds exactly to

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -269,6 +269,11 @@ public struct _StringCore {
   // slicing
 
   /// Returns the given sub-`_StringCore`.
+  /// 
+  /// - Important: This ranged subscript violates the expectation that a
+  ///   slice of a collection shares indices with its parent collection.
+  ///   All `_StringCore` slices have zero-based indices; it is up to
+  ///   string view implementations to handle offsets correctly.
   public subscript(bounds: Range<Int>) -> _StringCore {
     _precondition(
       bounds.lowerBound >= 0,

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -136,7 +136,7 @@ extension String {
     for i in rng.indices {
       if rng[i] == delim {
         return (String(rng[rng.startIndex..<i]), 
-                String(rng[i.successor()..<rng.endIndex]), 
+                String(rng[rng.successor(of: i)..<rng.endIndex]),
                 true)
       }
     }
@@ -155,7 +155,7 @@ extension String {
       if predicate(rng[i]) {
         return (String(rng[rng.startIndex..<i]),
                 rng[i], 
-                String(rng[i.successor()..<rng.endIndex]), 
+                String(rng[rng.successor(of: i)..<rng.endIndex]), 
                 true)
       }
     }

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -32,7 +32,7 @@ extension String {
     /// The position of the first code unit if the `String` is
     /// non-empty; identical to `endIndex` otherwise.
     public var startIndex: Index {
-      return Index(_offset: 0)
+      return Index(_offset: _offset)
     }
 
     /// The "past the end" position.
@@ -41,7 +41,7 @@ extension String {
     /// reachable from `startIndex` by zero or more applications of
     /// `successor(of:)`.
     public var endIndex: Index {
-      return Index(_offset: _length)
+      return Index(_offset: _offset + _length)
     }
 
     public struct Indices {
@@ -96,7 +96,7 @@ extension String {
 
     @warn_unused_result
     func _internalIndex(at i: Int) -> Int {
-      return _core.startIndex + _offset + i
+      return _core.startIndex + i
     }
 
     /// Access the element at `position`.
@@ -105,7 +105,7 @@ extension String {
     ///   `position != endIndex`.
     public subscript(i: Index) -> UTF16.CodeUnit {
       let position = i._offset
-      _precondition(position >= 0 && position < _length,
+      _precondition(position >= _offset && position < _offset + _length,
           "out-of-range access on a UTF16View")
 
       let index = _internalIndex(at: position)
@@ -177,8 +177,8 @@ extension String {
     }
 
     public var description: String {
-      let start = _internalIndex(at: 0)
-      let end = _internalIndex(at: _length)
+      let start = _internalIndex(at: _offset)
+      let end = _internalIndex(at: _offset + _length)
       return String(_core[start..<end])
     }
 

--- a/test/1_stdlib/subString.swift
+++ b/test/1_stdlib/subString.swift
@@ -1,16 +1,93 @@
-// RUN: %target-run-simple-swift | FileCheck %s
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
-func test(s: String)
-{
-  print(s)
-  var s2 = s[s.index(2, stepsFrom: s.startIndex)..<s.index(4, stepsFrom: s.startIndex)]
-  print(s2)
-  var s3 = s2[s2.startIndex..<s2.startIndex]
-  var s4 = s3[s2.startIndex..<s2.startIndex]
+import StdlibUnittest
+
+var SubstringTests = TestSuite("SubstringTests")
+
+func checkMatch<S: Collection, T: Collection
+  where S.Index == T.Index, S.Iterator.Element == T.Iterator.Element,
+  S.Iterator.Element: Equatable>(
+    x: S, _ y: T, _ i: S.Index) {
+  
+  expectEqual(x[i], y[i])
 }
 
-test("some text")
+let s = "abcdefg"
 
-// CHECK: some text
-// CHECK: me
+SubstringTests.test("CharacterView") {
+  var t = s.characters.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.characters, t, t.startIndex)
+  checkMatch(s.characters, t, t.successor(of: t.startIndex))
+  checkMatch(s.characters, t, t.predecessor(of: t.endIndex))
+  
+  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+  
+  checkMatch(s.characters, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.successor(of: u.startIndex))
+  checkMatch(t, u, u.predecessor(of: u.endIndex))
+  
+  u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
+  expectEqual(String(u), "Efg")
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+}
+
+SubstringTests.test("UnicodeScalars") {
+  var t = s.unicodeScalars.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.unicodeScalars, t, t.startIndex)
+  checkMatch(s.unicodeScalars, t, t.successor(of: t.startIndex))
+  checkMatch(s.unicodeScalars, t, t.predecessor(of: t.endIndex))
+  
+  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+  
+  checkMatch(s.unicodeScalars, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.successor(of: u.startIndex))
+  checkMatch(t, u, u.predecessor(of: u.endIndex))
+  
+  u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
+  expectEqual(String(u), "Efg")
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+}
+
+SubstringTests.test("UTF16View") {
+  var t = s.utf16.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.utf16, t, t.startIndex)
+  checkMatch(s.utf16, t, t.successor(of: t.startIndex))
+  checkMatch(s.utf16, t, t.predecessor(of: t.endIndex))
+  
+  checkMatch(s.utf16, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.successor(of: u.startIndex))
+  checkMatch(t, u, u.predecessor(of: u.endIndex))
+}
+
+SubstringTests.test("UTF8View") {
+  var t = s.utf8.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.utf8, t, t.startIndex)
+  checkMatch(s.utf8, t, t.successor(of: t.startIndex))
+  
+  checkMatch(s.utf8, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.successor(of: u.startIndex))
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This pulls `_StringCore` references out of string indices and fixes the index sharing bugs on `UTF16View`, `UnicodeScalarView`, and `CharacterView`. There are other approaches to resolving this, so I wanted to get feedback on whether this is the right way to go. If not, hopefully it can help identify where the current issues are. This modified version passes the string tests in `test/1_stdlib`, including a new one.

An example of the index sharing problems:

``` swift
let s = "abcdefg"
let c = s.characters.dropFirst(2)
c[c.startIndex]    // "c": ok
s[c.startIndex]    // "a": should be "c"
```
- The `UTF16View` problem was simple to resolve, as it already tracks its offset. The change just uses that offset as the `startIndex` of a view and updates the related APIs accordingly.
- In `UnicodeScalarView`, this adds a `_coreOffset` property that tracks the offset of that particular instance's `_core` reference from its "parent", necessary since `_StringCore` is _always_ zero-based. A `UnicodeScalarView.Index` instance now holds a position in the original `_core`, and any particular `UnicodeScalarView` instance can use that position combined with its `_coreOffset` to arrive at the correct "local" position.
- The changes in `CharacterView` are similar to `UnicodeScalarView`, but a bit messier. Because indices don't have a reference to the actual string data anymore, methods like `_measureExtendedGraphemeClusterForward` need to move from the index up to the view. That, in turn, requires the presence of a `CharacterView` when creating a new `String.Index`, which looks a little weird.

Approaches not taken:
- _Making `_StringCore` non-zero-based:_ I couldn't rule out the `NSString` APIs needing this to still be zero-based, so I left it alone and just documented the variance.
- _Basing `CharacterView` on `UnicodeScalarView`:_ It looks to me like this would work—wrapping a `_unicodeScalars` instance seems like it would simplify some of the index moving and de-duplicate the offset tracking (I think), but it's a larger architectural change.

cc @gribozavr @shawnce 
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
