### PR TITLE
[gardening] Add whitespace: "foo,bar" → "foo, bar"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,23 +26,23 @@ Swift 3.0
   unsafeBitCast(nullablePointer, to: Int.self)
   ```
 
-* [SE-0046] (https://github.com/apple/swift-evolution/blob/master/proposals/0046-first-label.md) Function parameters now have consistent labelling across all function parameters. With this update the first parameter declarations will now match the existing behavior of the second and later parameters. This change makes the language simpler. 
+* [SE-0046] (https://github.com/apple/swift-evolution/blob/master/proposals/0046-first-label.md) Function parameters now have consistent labelling across all function parameters. With this update the first parameter declarations will now match the existing behavior of the second and later parameters. This change makes the language simpler.
 
-    Functions that were written and called as follows 
+    Functions that were written and called as follows
     ```swift
       func foo(x: Int, y: Int) {
       }
       foo(1, y: 2)
-      
+
       func bar(a a: Int, b: Int) {
-      } 
+      }
       bar(a: 3, b: 4)
     ```
     will now be written as (to achieve the same behavior):
     ```swift
         func foo(_ x: Int, y: Int) {}
         foo(1, y: 2)
-        func bar(a: Int, b: Int) {} 
+        func bar(a: Int, b: Int) {}
         bar(a: 3, b: 4)
     ```
 
@@ -106,7 +106,7 @@ Swift 3.0
     typealias StringDictionary<T> = Dictionary<String, T>
     typealias IntFunction<T> = (T) -> Int
     typealias MatchingTriple<T> = (T, T, T)
-    typealias BackwardTriple<T1,T2,T3> = (T3, T2, T1)
+    typealias BackwardTriple<T1, T2, T3> = (T3, T2, T1)
 ```
   etc.
 
@@ -176,7 +176,7 @@ Swift 2.2
   The `typealias` keyword is still allowed (but deprecated and produces a warning)
   in Swift 2.2. This warning will become an error in Swift 3.0.
 
-* Curried function syntax has been deprecated, and is slated to be removed in 
+* Curried function syntax has been deprecated, and is slated to be removed in
   Swift 3.0.
 
 * The `++` and `--` operators have been deprecated, and are slated to be removed in
@@ -193,12 +193,12 @@ Swift 2.2
     ```
 
   should move to being written as:
-  
+
     ```swift
     foo(x.0, x.b)
     ```
 
-  For more information and rationale, see 
+  For more information and rationale, see
   [SE-0029](https://github.com/apple/swift-evolution/blob/master/proposals/0029-remove-implicit-tuple-splat.md).
 
 * New `#file`, `#line`, `#column`, and `#function` expressions have been introduced to
@@ -316,7 +316,7 @@ Swift 2.2
 
       let buttonFactory = UIButton.init(type:)
    ```
-   
+
   For more information, see [SE-0021](https://github.com/apple/swift-evolution/blob/master/proposals/0021-generalized-naming.md).
 
 * There is a new build configuration function, `#if swift(>=x.y)`, which
@@ -343,14 +343,14 @@ Swift 2.2
    ```swift
       let sel = #selector(insertSubview(_:aboveSubview:)) // sel has type Selector
    ```
-   
+
   Along with this change, the use of string literals as selectors has
   been deprecated, e.g.,
 
   ```swift
       let sel: Selector = "insertSubview:aboveSubview:"
   ```
-   
+
   Generally, such string literals should be replaced with uses of
   `#selector`, and the compiler will provide Fix-Its that use
   `#selector`. In cases where this is not possible (e.g., when referring
@@ -360,7 +360,7 @@ Swift 2.2
   ```swift
       let sel = Selector("propertyName")
   ```
-   
+
   Note that the compiler is now checking the string literals used to
   construct Selectors to ensure that they are well-formed Objective-C
   selectors and that there is an `@objc` method with that selector.
@@ -889,8 +889,8 @@ Swift 2.2
   value for the enum to be stored indirectly, allowing for recursive data
   structures to be defined. For example:
 
-  ```swift  
-  enum List<T> {
+  ```swift
+    enum List<T> {
     case Nil
     indirect case Cons(head: T, tail: List<T>)
   }
@@ -1138,7 +1138,7 @@ Swift 2.2
   needs to be written as:
 
   ```swift
-  var (a,b) : (Int, Float) = foo()
+  var (a, b) : (Int, Float) = foo()
   ```
 
   if an explicit type annotation is needed. The former syntax was ambiguous
@@ -1934,10 +1934,10 @@ Swift 2.2
 2014-10-09 [Roughly Xcode 6.1, and Swift 1.1]
 ----------
 
-* `HeapBuffer<Value,Element>`, `HeapBufferStorage<Value,Element>`, and
+* `HeapBuffer<Value, Element>`, `HeapBufferStorage<Value, Element>`, and
   `OnHeap<Value>` were never really useful, because their APIs were
   insufficiently public.  They have been replaced with a single class,
-  `ManagedBuffer<Value,Element>`.  See also the new function
+  `ManagedBuffer<Value, Element>`.  See also the new function
   `isUniquelyReferenced(x)` which is often useful in conjunction with
   `ManagedBuffer`.
 
@@ -3974,7 +3974,7 @@ Swift 2.2
 
     ```swift
     func swap<T>(a : @inout T, b : @inout T) {
-      (a,b) = (b,a)
+      (a, b) = (b, a)
     }
     ```
 
@@ -3982,7 +3982,7 @@ Swift 2.2
 
     ```swift
     func swap<T>(inout a : T, inout b : T) {
-      (a,b) = (b,a)
+      (a, b) = (b, a)
     }
     ```
 

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -53,7 +53,7 @@ struct S<T> {
 }
 @inline(never)
 func genStructArray() {
-  _ = RefArray<S<Int>>(S(x:3,y:4))
+  _ = RefArray<S<Int>>(S(x:3, y:4))
   // should be a nop
 }
 

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -183,7 +183,7 @@ extension Edge : Hashable {
   }
 }
 
-func Prims(_ graph : Array<GraphNode>, _ fun : (Int,Int)->Double) -> Array<Int?> {
+func Prims(_ graph : Array<GraphNode>, _ fun : (Int, Int)->Double) -> Array<Int?> {
   var treeEdges = Array<Int?>(repeating:nil, count:graph.count)
 
   let queue = PriorityQueue(Num:graph.count)
@@ -226,7 +226,7 @@ public func run_Prims(_ N: Int) {
 
     // Prim's algorithm is designed for undirected graphs.
     // Due to that, in our set all the edges are paired, i.e. for any
-    // edge (start,end,C) there is also an edge (end,start,C).
+    // edge (start, end, C) there is also an edge (end, start, C).
     let edges : [(Int, Int, Double)] = [
       (26, 47, 921),
       (20, 25, 971),

--- a/docs/ARCOptimization.rst
+++ b/docs/ARCOptimization.rst
@@ -91,7 +91,7 @@ Definitions
 -----------
 
 Let ``I`` be a SIL instruction with n operands and m results. We say that ``I``
-is a (i,j) RC Identity preserving instruction if performing a ``retain_value``
+is a (i, j) RC Identity preserving instruction if performing a ``retain_value``
 on the ith SSA argument immediately before ``I`` is executed is equivalent to
 performing a ``retain_value`` on the jth SSA result of ``I`` immediately
 following the execution of ``I``. For example in the following, if::
@@ -118,7 +118,7 @@ such that:
 
 - ``%a`` is the jth result of ``I``.
 - ``%b`` is the ith argument of ``I``.
-- ``I`` is (i,j) RC identity preserving.
+- ``I`` is (i, j) RC identity preserving.
 
 Due to the nature of SSA form, we can not even speak of symmetry or
 reflexivity. But we do get transitivity! Easily if ``%b ~rci %a`` and ``%c ~rci

--- a/docs/ErrorHandling.rst
+++ b/docs/ErrorHandling.rst
@@ -637,7 +637,7 @@ can be done in a fairly simple way: a function can declare that it
 throws if any of a set of named arguments do.  As an example (using
 strawman syntax)::
 
-  func map<T,U>(_ array: [T], fn: T -> U) throwsIf(fn) -> [U] {
+  func map<T, U>(_ array: [T], fn: T -> U) throwsIf(fn) -> [U] {
     ...
   }
 

--- a/docs/ErrorHandlingRationale.rst
+++ b/docs/ErrorHandlingRationale.rst
@@ -1458,7 +1458,7 @@ done in a fairly simple way: a function can declare that it throws if
 any of a set of named arguments do.  As an example (using strawman
 syntax)::
 
-  func map<T,U>(_ array: [T], fn: T throws -> U) throwsIf(fn) -> [U] {
+  func map<T, U>(_ array: [T], fn: T throws -> U) throwsIf(fn) -> [U] {
     ...
   }
 

--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -249,7 +249,7 @@ interferes-with
 guards
 
   If ``OpA`` guards ``OpB``, then the sequence of operations
-  ``OpA,OpB`` must be preserved on any control flow path on which the
+  ``OpA, OpB`` must be preserved on any control flow path on which the
   sequence originally appears.
 
 An operation can only interfere-with or guard another if they may operate on the same Array.

--- a/docs/PatternMatching.rst
+++ b/docs/PatternMatching.rst
@@ -206,7 +206,7 @@ see the pattern grammar)::
   case (0, var y):
     return 1
   case (var x, var y)
-    return foo(x-1,y) + foo(x,y-1)
+    return foo(x - 1, y) + foo(x, y - 1)
   }
 
 It's tempting to just say that an unsound name binding (i.e. a name
@@ -401,7 +401,7 @@ The current Swift approximation is::
   func length(_ list : List) : Int {
     switch list {
       case .nil: return 0
-      case .cons(_,var tail): return 1 + length(tail)
+      case .cons(_, var tail): return 1 + length(tail)
     }
   }
 
@@ -410,7 +410,7 @@ function body. We could remove those with something like this::
 
   func length(_ list : List) : Int = switch list {
     case .nil: return 0
-    case .cons(_,var tail): return 1 + length(tail)
+    case .cons(_, var tail): return 1 + length(tail)
   }
 
 Anyway, that's easy to add later if we see the need.

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -306,13 +306,13 @@ unrestricted type, it is lowered as if the pattern were replaced with
 a type sharing the same structure but replacing all materializable
 types with fresh type variables.
 
-For example, if ``g`` has type ``Generator<(Int,Int) -> Float>``, ``g.fn`` is
-lowered using the pattern ``() -> T``, which eventually causes ``(Int,Int)
+For example, if ``g`` has type ``Generator<(Int, Int) -> Float>``, ``g.fn`` is
+lowered using the pattern ``() -> T``, which eventually causes ``(Int, Int)
 -> Float`` to be lowered using the pattern ``T``, which is the same as
 lowering it with the pattern ``U -> V``; the result is that ``g.fn``
 has the following lowered type::
 
-  @callee_owned () -> @owned @callee_owned (@in (Int,Int)) -> @out Float.
+  @callee_owned () -> @owned @callee_owned (@in (Int, Int)) -> @out Float.
 
 As another example, suppose that ``h`` has type
 ``Generator<(Int, inout Int) -> Float>``.  Neither ``(Int, inout Int)``

--- a/docs/StringDesign.rst
+++ b/docs/StringDesign.rst
@@ -744,7 +744,7 @@ Indexing
          doSomethingWith(\ **someString[i]**\ )
        }
 
-       var (i,j) = **someString.indices().bounds**
+       var (i, j) = **someString.indices().bounds**
        while (i != j) {
          doSomethingElseWith(\ **someString[i]**\ )
          ++i
@@ -981,7 +981,7 @@ Building
 :Swift:
   .. parsed-literal::
         func **+** (lhs: String, rhs: String) -> String
-        func [infix,assignment] **+=** (lhs: [inout] String, rhs: String)
+        func [infix, assignment] **+=** (lhs: [inout] String, rhs: String)
         func **append**\ (_ suffix: String)
 
 

--- a/docs/proposals/Accessors.rst
+++ b/docs/proposals/Accessors.rst
@@ -168,7 +168,7 @@ Unnecessary subobject accesses
 
 The first is that they may load or store more than is necessary.
 
-As an obvious example, imagine a variable of type ``(Int,Int)``; even
+As an obvious example, imagine a variable of type ``(Int, Int)``; even
 if my code only accesses the first element of the tuple, full-value
 accesses force me to read or write the second element as well.  That
 means that, even if I'm purely overwriting the first element, I
@@ -177,7 +177,7 @@ value to use for the second element when performing the full-value
 store.
 
 Additionally, while unnecessarily loading the second element of an
-``(Int,Int)`` pair might seem trivial, consider that the tuple could
+``(Int, Int)`` pair might seem trivial, consider that the tuple could
 actually have twenty elements, or that the second element might be
 non-trivial to copy (e.g. if it's a retainable pointer).
 

--- a/docs/proposals/Concurrency.rst
+++ b/docs/proposals/Concurrency.rst
@@ -584,14 +584,14 @@ code runs significantly faster.
     var product = Matrix(A.size)
     // Extract 4 quarters from matrices A and B.
     let half = A.size/2
-    let A11 = A.slice(half ,0   , 0)
-    let A12 = A.slice(half ,0   , half)
-    let A21 = A.slice(half ,half, 0)
-    let A22 = A.slice(half ,half, half)
-    let B11 = B.slice(half ,0   , 0)
-    let B12 = B.slice(half ,0   , half)
-    let B21 = B.slice(half ,half, 0)
-    let B22 = B.slice(half ,half, half)
+    let A11 = A.slice(half, 0,    0)
+    let A12 = A.slice(half, 0,    half)
+    let A21 = A.slice(half, half, 0)
+    let A22 = A.slice(half, half, half)
+    let B11 = B.slice(half, 0,    0)
+    let B12 = B.slice(half, 0,    half)
+    let B21 = B.slice(half, half, 0)
+    let B22 = B.slice(half, half, half)
 
     // Multiply each of the sub blocks.
     let C11_1 = async((A11, B11), callback: ParallelMatMul)
@@ -610,8 +610,8 @@ code runs significantly faster.
     let C22 = C22_1.await() +  C22_2.await()
 
     // Save the matrix slices into the correct locations.
-    product.update(C11, 0   , 0)
-    product.update(C12, 0   , half)
+    product.update(C11, 0,    0)
+    product.update(C12, 0,    half)
     product.update(C21, half, 0)
     product.update(C22, half, half)
     return product

--- a/docs/proposals/InoutCOWOptimization.rst
+++ b/docs/proposals/InoutCOWOptimization.rst
@@ -52,7 +52,7 @@ could be written as follows:
     ...
     @mutating
     func quickSort(_ compare: (StreamType.Element, StreamType.Element) -> Bool) {
-      let (start,end) = (startIndex, endIndex)
+      let (start, end) = (startIndex, endIndex)
       if start != end && start.succ() != end {
         let pivot = self[start]
         let mid = partition({compare($0, pivot)})

--- a/docs/proposals/archive/MemoryAndConcurrencyModel.rst
+++ b/docs/proposals/archive/MemoryAndConcurrencyModel.rst
@@ -54,7 +54,7 @@ definition. These kinds are:
    compiler rejects) immutable data that is pointing to mutable data. For
    example::
 
-     struct [immutable,inout] IList { data : int, next : List }
+     struct [immutable, inout] IList { data : int, next : List }
      ...
      var a = IList(1, IList(2, IList(3, nil)))
      ...

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -788,7 +788,7 @@ class ApplyInstBase<Impl, Base, true>
 protected:
   template <class... As>
   ApplyInstBase(As &&...args)
-    : ApplyInstBase<Impl,Base,false>(std::forward<As>(args)...) {}
+    : ApplyInstBase<Impl, Base, false>(std::forward<As>(args)...) {}
 
 public:
   using super::getCallee;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2142,7 +2142,7 @@ void TypeChecker::addImplicitDestructor(ClassDecl *CD) {
   typeCheckDecl(DD, /*isFirstPass=*/true);
 
   // Create an empty body for the destructor.
-  DD->setBody(BraceStmt::create(Context, CD->getLoc(), { }, CD->getLoc(),true));
+  DD->setBody(BraceStmt::create(Context, CD->getLoc(), { }, CD->getLoc(), true));
   CD->addMember(DD);
   CD->setHasDestructor();
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4050,7 +4050,7 @@ public:
 
           // If we found both, point at them.
           if (prefixOp) {
-            TC.diagnose(prefixOp, diag::unary_operator_declaration_here,false)
+            TC.diagnose(prefixOp, diag::unary_operator_declaration_here, false)
               .fixItInsert(FD->getLoc(), "prefix ");
             TC.diagnose(postfixOp, diag::unary_operator_declaration_here, true)
               .fixItInsert(FD->getLoc(), "postfix ");

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -50,7 +50,7 @@ public let partitionExhaustiveTests = [
   PartitionExhaustiveTest([ 10, 20, 30, 40, 50, 60, 70 ]),
 ]
 
-public func withInvalidOrderings(_ body: ((Int,Int) -> Bool) -> Void) {
+public func withInvalidOrderings(_ body: ((Int, Int) -> Bool) -> Void) {
   // Test some ordering predicates that don't create strict weak orderings
   body { (_,_) in true }
   body { (_,_) in false }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -161,7 +161,7 @@ public func expectationFailure(
 }
 
 public func expectEqual<T>(
-  _ expected: T, _ actual: T, ${TRACE}, sameValue equal: (T,T) -> Bool
+  _ expected: T, _ actual: T, ${TRACE}, sameValue equal: (T, T) -> Bool
 ) {
   if !equal(expected, actual) {
     expectationFailure(
@@ -190,7 +190,7 @@ public func expectOptionalEqual<T : Equatable>(
 }
 
 public func expectOptionalEqual<T>(
-  _ expected: T, _ actual: T?, ${TRACE}, sameValue equal: (T,T) -> Bool
+  _ expected: T, _ actual: T?, ${TRACE}, sameValue equal: (T, T) -> Bool
 ) {
   if (actual == nil) || !equal(expected, actual!) {
     expectationFailure(
@@ -2265,8 +2265,8 @@ public func check${traversal}Collection<
   checkRandomAccessIndex(
     instances,
     distances: distances,
-    distanceOracle: { (x:Int,y:Int) in Distance(IntMax(y - x)) },
-    advanceOracle: { x,y in nextN(distances[y], instances[x]) },
+    distanceOracle: { (x: Int, y: Int) in Distance(IntMax(y - x)) },
+    advanceOracle: { x, y in nextN(distances[y], instances[x]) },
     startIndex: collection.startIndex,
     endIndex: next5(partWay1), ${trace})
 % end

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -1686,7 +1686,7 @@ extension String {
   ///
   /// Locale-independent case-insensitive operation, and other needs,
   /// can be achieved by calling
-  /// `rangeOfString(_:options:_,range:_locale:_)`.
+  /// `rangeOfString(_:options:_, range:_locale:_)`.
   ///
   /// Equivalent to
   ///

--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -280,7 +280,7 @@ public func abs(_ x: ${vectype}) -> ${vectype} {
 @warn_unused_result
 public func min(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:             \
-                    'min(x.' + c + ',y.' + c + ')', \
+                    'min(x.' + c + ', y.' + c + ')', \
                     component[:size]))})
 }
 
@@ -290,7 +290,7 @@ public func min(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
 @warn_unused_result
 public func max(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:             \
-                    'max(x.' + c + ',y.' + c + ')', \
+                    'max(x.' + c + ', y.' + c + ')', \
                     component[:size]))})
 }
 
@@ -472,21 +472,21 @@ public func smoothstep(_ x: ${vectype},
                               edge1: ${vectype})
                                 -> ${vectype} {
   let t = clamp((x-edge0)/(edge1-edge0), min: 0, max: 1)
-  return t*t*(${vectype}(3) - 2*t)
+  return t * t * (${vectype}(3) - 2 * t)
 }
 
 /// Dot product of `x` and `y`.
 @inline(__always)
 @warn_unused_result
 public func dot(_ x: ${vectype}, _ y: ${vectype}) -> ${type} {
-  return reduce_add(x*y)
+  return reduce_add(x * y)
 }
 
 /// Projection of `x` onto `y`.
 @inline(__always)
 @warn_unused_result
 public func project(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
-  return dot(x,y)/dot(y,y)*y
+  return dot(x, y) / dot(y, y) * y
 }
 
 /// Length of `x`, squared.  This is more efficient to compute than the length,
@@ -504,7 +504,7 @@ public func project(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
 @inline(__always)
 @warn_unused_result
 public func length_squared(_ x: ${vectype}) -> ${type} {
-  return dot(x,x)
+  return dot(x, x)
 }
 
 /// Length (two-norm or "Euclidean norm") of `x`.
@@ -555,7 +555,7 @@ public func normalize(_ x: ${vectype}) -> ${vectype} {
 @inline(__always)
 @warn_unused_result
 public func reflect(_ x: ${vectype}, n: ${vectype}) -> ${vectype} {
-  return x - 2*dot(x,n)*n
+  return x - 2 * dot(x, n) * n
 }
 
 /// The refraction direction given unit incident vector `x`, unit surface
@@ -568,8 +568,8 @@ public func refract(_ x: ${vectype},
                            n: ${vectype},
                            eta: ${type})
                              -> ${vectype} {
-  let k = 1 - eta*eta*(1 - dot(x,n)*dot(x,n))
-  if k >= 0 { return eta*x - (eta*dot(x,n) + sqrt(k))*n }
+  let k = 1 - eta * eta * (1 - dot(x, n) * dot(x, n))
+  if k >= 0 { return eta * x - (eta * dot(x, n) + sqrt(k)) * n }
   return ${vectype}(0)
 }
 

--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -409,7 +409,7 @@ extension ${Self} : RandomAccessIndex {
 // Operations that return an overflow bit in addition to a partial result,
 // helpful for checking for overflow when you want to handle it.
 extension ${Self} {
-% for Method,op in [('add', 'add'), ('subtract', 'sub'), ('multiply', 'mul')]:
+% for Method, op in [('add', 'add'), ('subtract', 'sub'), ('multiply', 'mul')]:
   /// ${Method.capitalize()} `lhs` and `rhs`, returning a result and a
   /// `Bool` that is `true` iff the operation caused an arithmetic
   /// overflow.
@@ -420,7 +420,7 @@ extension ${Self} {
   }
 % end
 
-% for Method,op in [('divide', 'div'), ('remainder', 'rem')]:
+% for Method, op in [('divide', 'div'), ('remainder', 'rem')]:
   /// Divide `lhs` and `rhs`, returning
   /// ${'a result' if op == 'div' else 'the remainder'} and a `Bool`
   /// that is `true` iff the operation caused an arithmetic overflow.
@@ -539,7 +539,7 @@ extension ${Self} {
 // FIXME: must use condfail in these operators, rather than
 // overflowChecked, pending <rdar://problem/16271923> so that we don't
 // foil static checking for numeric overflows.
-% for op,method in ('+','add'), ('*','mul'), ('-','sub'):
+% for op, method in ('+','add'), ('*','mul'), ('-','sub'):
 @_transparent
 public func ${op} (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
   let (result, error) = Builtin.${sign}${method}_with_overflow_${BuiltinName}(
@@ -550,7 +550,7 @@ public func ${op} (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
 }
 % end
 
-% for op,inst in [('/', 'div'), ('%', 'rem')]:
+% for op, inst in [('/', 'div'), ('%', 'rem')]:
 @_transparent
 public func ${op}(lhs: ${Self}, rhs: ${Self}) -> ${Self} {
   Builtin.condfail((rhs == 0)._value)
@@ -573,8 +573,8 @@ public prefix func ~(rhs: ${Self}) -> ${Self} {
 
 % for op, name in (
 %  ('==','eq'), ('!=','ne'),
-%  ('<',sign+'lt'), ('<=',sign+'le'),
-%  ('>',sign+'gt'), ('>=',sign+'ge')):
+%  ('<', sign + 'lt'), ('<=', sign + 'le'),
+%  ('>', sign + 'gt'), ('>=', sign + 'ge')):
 @_transparent
 public func ${op} (lhs: ${Self}, rhs: ${Self}) -> Bool {
   return Bool(Builtin.cmp_${name}_${BuiltinName}(lhs._value, rhs._value))

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -33,7 +33,7 @@ builtinIntLiteralBits = 2048
 def allInts():
     for bits in allIntBits:
         for signed in False, True:
-            yield bits,signed
+            yield bits, signed
 
 def baseIntName(name):
     return 'Int' if name == 'Int' else 'Int' + str(name)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3383,7 +3383,7 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
         let idealBucket = nativeStorage._bucket(nativeStorage.key(at: b))
 
         // Does this element belong between start and hole?  We need
-        // two separate tests depending on whether [start,hole] wraps
+        // two separate tests depending on whether [start, hole] wraps
         // around the end of the buffer
         let c0 = idealBucket >= start
         let c1 = idealBucket <= hole
@@ -3772,7 +3772,7 @@ elif Self == 'Dictionary':
 ///
 /// 2. Subscripting with an index, yielding a key-value pair:
 ///
-///        (k,v) = d[i]"""
+///        (k, v) = d[i]"""
 }%
 
 ${SubscriptingWithIndexDoc}

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -45,14 +45,14 @@ class _HeapBufferStorage<Value, Element> : NonObjectiveCBase {
   public override init() {}
 
   /// The type used to actually manage instances of
-  /// `_HeapBufferStorage<Value,Element>`.
+  /// `_HeapBufferStorage<Value, Element>`.
   typealias Buffer = _HeapBuffer<Value, Element>
   deinit {
     Buffer(self)._value.deinitialize()
   }
 
   @warn_unused_result
-  final func __getInstanceSizeAndAlignMask() -> (Int,Int) {
+  final func __getInstanceSizeAndAlignMask() -> (Int, Int) {
     return Buffer(self)._allocatedSizeAndAlignMask()
   }
 }
@@ -139,7 +139,7 @@ struct _HeapBuffer<Value, Element> : Equatable {
   }
 
   public // @testable
-  init(_ storage: _HeapBufferStorage<Value,Element>) {
+  init(_ storage: _HeapBufferStorage<Value, Element>) {
     self._storage = Builtin.castToNativeObject(storage)
   }
 

--- a/stdlib/public/core/IntegerArithmetic.swift.gyb
+++ b/stdlib/public/core/IntegerArithmetic.swift.gyb
@@ -31,7 +31,7 @@ integerBinaryOps = [
 /// be satisfied by types conforming to that protocol.
 @_show_in_interface
 public protocol _IntegerArithmetic {
-% for name,_,Action,result in integerBinaryOps:
+% for name, _, Action, result in integerBinaryOps:
   /// ${Action} `lhs` and `rhs`, returning ${result} and a `Bool` that is
   /// `true` iff the operation caused an arithmetic overflow.
   static func ${name}WithOverflow(_ lhs: Self, _ rhs: Self) -> (Self, overflow: Bool)
@@ -42,7 +42,7 @@ public protocol _IntegerArithmetic {
 public protocol IntegerArithmetic : _IntegerArithmetic, Comparable {
   // Checked arithmetic functions.  Specific implementations in
   // FixedPoint.swift.gyb support static checking for integer types.
-% for name,op,Action,result in integerBinaryOps:
+% for name, op, Action, result in integerBinaryOps:
   /// ${Action} `lhs` and `rhs`, returning ${result} and trapping in case of
   /// arithmetic overflow (except in -Ounchecked builds).
   @warn_unused_result
@@ -55,7 +55,7 @@ public protocol IntegerArithmetic : _IntegerArithmetic, Comparable {
   func toIntMax() -> IntMax
 }
 
-% for name,op,Action,result in integerBinaryOps:
+% for name, op, Action, result in integerBinaryOps:
 /// ${Action} `lhs` and `rhs`, returning ${result} and trapping in case of
 /// arithmetic overflow (except in -Ounchecked builds).
 @_transparent

--- a/stdlib/public/core/IntegerParsing.swift.gyb
+++ b/stdlib/public/core/IntegerParsing.swift.gyb
@@ -132,7 +132,7 @@ extension ${Self} {
     if let value = _parseAsciiAs${'' if signed else 'U'}IntMax(
       text.utf16, radix, ${'' if signed else 'U'}IntMax(${Self}.max)) {
       self.init(
-        ${'' if Self in (IntMax,UIntMax) else 'truncatingBitPattern:'} value)
+        ${'' if Self in (IntMax, UIntMax) else 'truncatingBitPattern:'} value)
     }
     else {
       return nil

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -20,7 +20,7 @@ public class NonObjectiveCBase {
   public init() {}
 }
 
-/// A base class of `ManagedBuffer<Value,Element>`, used during
+/// A base class of `ManagedBuffer<Value, Element>`, used during
 /// instance creation.
 ///
 /// During instance creation, in particular during
@@ -35,7 +35,7 @@ public class ManagedProtoBuffer<Value, Element> : NonObjectiveCBase {
   /// idea to store this information in the "value" area when
   /// an instance is created.
   public final var capacity: Int {
-    let p = ManagedBufferPointer<Value,Element>(self)
+    let p = ManagedBufferPointer<Value, Element>(self)
     return p.capacity
   }
 
@@ -102,7 +102,7 @@ public class ManagedBuffer<Value, Element>
     initialValue: (ManagedProtoBuffer<Value, Element>) -> Value
   ) -> ManagedBuffer<Value, Element> {
 
-    let p = ManagedBufferPointer<Value,Element>(
+    let p = ManagedBufferPointer<Value, Element>(
       bufferClass: self,
       minimumCapacity: minimumCapacity,
       initialValue: { buffer, _ in
@@ -146,7 +146,7 @@ public class ManagedBuffer<Value, Element>
 /// --------------------
 ///
 ///      class MyBuffer<Element> { // non-@objc
-///        typealias Manager = ManagedBufferPointer<(Int,String), Element>
+///        typealias Manager = ManagedBufferPointer<(Int, String), Element>
 ///        deinit {
 ///          Manager(unsafeBufferObject: self).withUnsafeMutablePointers {
 ///            (pointerToValue, pointerToElements) -> Void in

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -701,7 +701,7 @@ public protocol CustomPlaygroundQuickLookable {
 ///
 ///     struct IntPairs {
 ///       var elements: [(Int, Int)]
-///       init(_ pairs: DictionaryLiteral<Int,Int>) {
+///       init(_ pairs: DictionaryLiteral<Int, Int>) {
 ///         elements = Array(pairs)
 ///       }
 ///     }

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -43,7 +43,7 @@ struct _StringBufferIVars {
 }
 
 // FIXME: Wanted this to be a subclass of
-// _HeapBuffer<_StringBufferIVars,UTF16.CodeUnit>, but
+// _HeapBuffer<_StringBufferIVars, UTF16.CodeUnit>, but
 // <rdar://problem/15520519> (Can't call static method of derived
 // class of generic class with dependent argument type) prevents it.
 public struct _StringBuffer {

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -933,9 +933,9 @@ extern "C" bool swift_isKind(id object, NSString *className) {
 #error __USER_LABEL_PREFIX__ is undefined
 #endif
 
-#define GLUE_EXPANDED(a,b) a##b
-#define GLUE(a,b) GLUE_EXPANDED(a,b)
-#define SYMBOL_NAME(name) GLUE(__USER_LABEL_PREFIX__,name)
+#define GLUE_EXPANDED(a, b) a##b
+#define GLUE(a, b) GLUE_EXPANDED(a, b)
+#define SYMBOL_NAME(name) GLUE(__USER_LABEL_PREFIX__, name)
 
 #define QUOTE_EXPANDED(literal) #literal
 #define QUOTE(literal) QUOTE_EXPANDED(literal)

--- a/test/1_stdlib/BridgeStorage.swift.gyb
+++ b/test/1_stdlib/BridgeStorage.swift.gyb
@@ -120,7 +120,7 @@ var unTaggedNSString : NSString {
 
 % for Self in ['_BridgeStorage']:
 allTests.test("${Self}") {
-  typealias B = ${Self}<C,NSString>
+  typealias B = ${Self}<C, NSString>
   
   let oy: NSString = "oy"
   expectTrue(B(objC: oy).objCInstance == oy)

--- a/test/1_stdlib/Tuple.swift.gyb
+++ b/test/1_stdlib/Tuple.swift.gyb
@@ -18,7 +18,7 @@ var TupleTestSuite = TestSuite("Tuple")
 % maxArity = 6 # the highest arity the operators are defined for
 
 func testEquality<A : Equatable, B : Equatable, C : Equatable>(
-  _ lhs: (A,B,C), equal: Bool, to rhs: (A,B,C),
+  _ lhs: (A, B, C), equal: Bool, to rhs: (A, B, C),
   //===--- TRACE boilerplate ----------------------------------------------===//
   @autoclosure _ message: ()->String = "",
   showFrame: Bool = true,
@@ -92,7 +92,7 @@ enum Ordering : Equatable {
 }
 
 func testOrdering<A : Comparable, B : Comparable, C : Comparable>(
-  _ lhs: (A,B,C), _ ordering: Ordering, _ rhs: (A, B, C),
+  _ lhs: (A, B, C), _ ordering: Ordering, _ rhs: (A, B, C),
   //===--- TRACE boilerplate ----------------------------------------------===//
   @autoclosure _ message: ()->String = "",
   showFrame: Bool = true,

--- a/test/1_stdlib/simd.swift.gyb
+++ b/test/1_stdlib/simd.swift.gyb
@@ -316,9 +316,9 @@ simdTestSuite.test("matrix elements") {
     ${mat}[i] = ${type}(i+1)*${basis}[i]
   }
   expectEqual(
-    ${mat}, ${mattype}(diagonal:${range(1,diagsize+1)}), sameValue: same)
+    ${mat}, ${mattype}(diagonal:${range(1, diagsize + 1)}), sameValue: same)
   for i in 0..<${cols} {
-    expectEqual(${mat}[i], ${type}(i+1)*${basis}[i], sameValue: same)
+    expectEqual(${mat}[i], ${type}(i + 1)*${basis}[i], sameValue: same)
   }
 
   //  Check getting and setting elements (and transpose).

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -2,7 +2,7 @@
 
 import Builtin
 
-struct Huge { var x,y,z,w,a,b,c,d: Builtin.Int32 }
+struct Huge { var x, y, z, w, a, b, c, d: Builtin.Int32 }
 
 // CHECK-LABEL: define{{( protected)?}} void @arguments_in_def(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %V14argument_attrs4Huge* noalias nocapture dereferenceable(32), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> () {

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -163,7 +163,7 @@ class GenericInheritsGeneric<A, B> : RootGeneric<A> {
 
   override init()
 }
-sil @_TFC15generic_classes22GenericInheritsGenericD : $@convention(method) <T,U> (GenericInheritsGeneric<T,U>) -> ()
+sil @_TFC15generic_classes22GenericInheritsGenericD : $@convention(method) <T, U> (GenericInheritsGeneric<T, U>) -> ()
 
 sil @_TFC15generic_classes22GenericInheritsGeneric7zippityU___fGS0_Q_Q0__FT_T_ : $@convention(method) <A, B> (@guaranteed GenericInheritsGeneric<A, B>) -> ()
 
@@ -200,7 +200,7 @@ class RecursiveGenericInheritsGeneric<A, B> : RootGeneric<A> {
   override init()
 }
 sil_vtable RecursiveGenericInheritsGeneric {}
-sil @_TFC15generic_classes31RecursiveGenericInheritsGenericD : $@convention(method) <T,U> (RecursiveGenericInheritsGeneric<T,U>) -> ()
+sil @_TFC15generic_classes31RecursiveGenericInheritsGenericD : $@convention(method) <T, U> (RecursiveGenericInheritsGeneric<T, U>) -> ()
 
 
 // CHECK: define{{( protected)?}} [[ROOTGENERIC]]* @RootGeneric_fragile_dependent_alloc

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -5,7 +5,7 @@ import simd
 
 // Work around rdar://problem/20577079 with a Swift function that touches all
 // the fields of float4, forcing it to be validated.
-func forceStuff(x: float4, y: float3) -> (Float,Float,Float,Float) {
+func forceStuff(x: float4, y: float3) -> (Float, Float, Float, Float) {
   if true {
     return (y.x, y.y, y.z, y.x)
   } else {

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -7,7 +7,7 @@ sil_stage canonical
 struct Foo {}
 class Bar<T, U, V> {}
 sil_vtable Bar {}
-sil @_TFC19sil_witness_methods3BarD : $@convention(method) <T,U,V> (Bar<T,U,V>) -> ()
+sil @_TFC19sil_witness_methods3BarD : $@convention(method) <T, U, V> (Bar<T, U, V>) -> ()
 
 struct X {}
 struct Y {}

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -38,7 +38,7 @@ entry:
 
 @_alignment(32)
 struct OverAligned {
-  var x,y,z,w: Builtin.Int64
+  var x, y, z, w: Builtin.Int64
 }
 
 // CHECK-LABEL: define{{( protected)?}} void @pod_box_32_32

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -357,16 +357,16 @@ public func > <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
 // These two versions of the operators are not ordered with respect to
 // one another:
 //
-//     <T : Comparable>(T,T) -> Bool
-//     <T : Integer, U : Integer>(T,U) -> Bool
+//     <T : Comparable>(T, T) -> Bool
+//     <T : Integer, U : Integer>(T, U) -> Bool
 //
 // so we define:
 //
-//     <T : Integer>(T,T) -> Bool
+//     <T : Integer>(T, T) -> Bool
 
 @_transparent
 @warn_unused_result
-public func != <T : Integer>(lhs:T, rhs: T) -> Bool {
+public func != <T : Integer>(lhs: T, rhs: T) -> Bool {
   return !(lhs == rhs)
 }
 

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -727,7 +727,7 @@ bb2:
 // CHECK-NOT: value_metatype $@objc_metatype
 // CHECK: strong_release
 // CHECK: return
-sil @cse_value_metatype : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned (AnyObject,AnyObject) {
+sil @cse_value_metatype : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned (AnyObject, AnyObject) {
 bb0(%0 : $T):
   %2 = value_metatype $@objc_metatype T.Type, %0 : $T
   %4 = objc_metatype_to_object %2 : $@objc_metatype T.Type to $AnyObject
@@ -788,7 +788,7 @@ bb0(%0 : $B, %1 : $B):
 // CHECK-NOT: objc_metatype_to_object
 // CHECK: strong_release
 // CHECK: return
-sil @cse_objc_metatype_to_object : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned (AnyObject,AnyObject) {
+sil @cse_objc_metatype_to_object : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned (AnyObject, AnyObject) {
 bb0(%0 : $T):
   %2 = value_metatype $@objc_metatype T.Type, %0 : $T
   %4 = objc_metatype_to_object %2 : $@objc_metatype T.Type to $AnyObject
@@ -824,7 +824,7 @@ bb0(%0 : $XX):
 // CHECK-NOT: raw_pointer_to_ref
 // CHECK: tuple
 // CHECK: return
-sil @cse_raw_pointer_to_ref : $@convention(thin) (Builtin.RawPointer) -> @owned(C,C) {
+sil @cse_raw_pointer_to_ref : $@convention(thin) (Builtin.RawPointer) -> @owned(C, C) {
 bb0(%0 : $Builtin.RawPointer):
   %1 = raw_pointer_to_ref %0 : $Builtin.RawPointer to $C
   %2 = raw_pointer_to_ref %0 : $Builtin.RawPointer to $C

--- a/test/SILOptimizer/definite_init.sil
+++ b/test/SILOptimizer/definite_init.sil
@@ -44,7 +44,7 @@ bb0:
 // func used_by_inout(a : Int) -> (Int, Int) {
 //  var t = a
 //  takes_Int_inout(&a)
-//  return (t,a)
+//  return (t, a)
 //}
 // CHECK-LABEL: sil @used_by_inout
 sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {

--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -59,7 +59,7 @@ sil @takes_Int_inout : $@convention(thin) (@inout Int) -> ()
 // func used_by_inout(a : Int) -> (Int, Int) {
 //  var t = a
 //  takes_Int_inout(&a)
-//  return (t,a)
+//  return (t, a)
 //}
 // CHECK-LABEL: sil @used_by_inout
 sil @used_by_inout : $@convention(thin) (Int) -> (Int, Int) {

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -6,7 +6,7 @@ import Builtin
 import Swift
 
 class RawBuffer {}
-class HeapBufferStorage<T,U> : RawBuffer {}
+class HeapBufferStorage<T, U> : RawBuffer {}
 
 enum FakeOptional<T> {
   case none
@@ -2604,7 +2604,7 @@ class CC4 {
 // Function that takes different kinds of arguments: @in, @guaranteed, @owned, 
 sil @closure_with_in_guaranteed_owned_in_args : $@convention(method) (@in CC2, @guaranteed CC1, @owned CC3, @in CC4) -> Optional<Int>
 
-// Test the peephole performing apply{partial_apply(x,y,z)}(a) -> apply(a,x,y,z)
+// Test the peephole performing apply{partial_apply(x, y, z)}(a) -> apply(a, x, y, z)
 // We need to check the following:
 // - all arguments of a partial_apply, which are either results of a stack_alloc or consumed indirect arguments
 //  should be copied into temporaries. This should happen just before that partial_apply instruction.

--- a/test/SILOptimizer/sil_combine_uncheck.sil
+++ b/test/SILOptimizer/sil_combine_uncheck.sil
@@ -6,7 +6,7 @@ import Builtin
 import Swift
 
 class RawBuffer {}
-class HeapBufferStorage<T,U> : RawBuffer {}
+class HeapBufferStorage<T, U> : RawBuffer {}
 
 class C {
 }

--- a/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
+++ b/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
@@ -45,7 +45,7 @@ static std::vector<unsigned> FindGraphemeClusterBoundaries(StringRef Str) {
 }
 
 TEST(ExtractExtendedGraphemeCluster, TestsFromUnicodeSpec) {
-% for subject_string,expected_boundaries in grapheme_cluster_break_tests:
+% for subject_string, expected_boundaries in grapheme_cluster_break_tests:
   EXPECT_EQ((std::vector<unsigned>{ ${', '.join([ str(x) for x in expected_boundaries ])} }),
       FindGraphemeClusterBoundaries("${subject_string}"));
 % end

--- a/utils/analyze_deps.rb
+++ b/utils/analyze_deps.rb
@@ -27,7 +27,7 @@ YAML::dump(files)
 
 # We cheat here and dump everything into the same bucket.
 names = {}
-files.each do |k,v|
+files.each do |k, v|
   v['provides'].each do |name|
     names[name] ||= []
     names[name] << k
@@ -44,7 +44,7 @@ end
 
 all_deps = {}
 all_private_deps = {}
-files.each do |k,v|
+files.each do |k, v|
   deps = Set.new()
   private_deps = Set.new()
   v['top-level'].each do |name|
@@ -80,7 +80,7 @@ end
 
 # Graphviz output!
 puts 'digraph dependencies {'
-all_deps.each do |k,v|
+all_deps.each do |k, v|
   v.each do |dep|
     puts "\t\"#{dep}\" -> \"#{k}\""
   end
@@ -88,7 +88,7 @@ all_deps.each do |k,v|
     puts "\t\"#{k}\""
   end
 end
-all_private_deps.each do |k,v|
+all_private_deps.each do |k, v|
   v.each do |dep|
     puts "\t\"#{dep}\" -> \"#{k}\" [style=dotted]"
   end

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -152,7 +152,7 @@ def tokenize_python_to_unmatched_close_curly(source_text, start, line_starts):
 
 def tokenize_template(template_text):
     r"""Given the text of a template, returns an iterator over
-    (tokenType,token,match) tuples.
+    (tokenType, token, match) tuples.
 
     **Note**: this is template syntax tokenization, not Python
     tokenization.
@@ -165,13 +165,13 @@ def tokenize_template(template_text):
     then refined by ParseContext.token_generator.
 
     >>> from pprint import *
-    >>> pprint(list((kind, text) for kind,text,_ in tokenize_template(
+    >>> pprint(list((kind, text) for kind, text, _ in tokenize_template(
     ...   '%for x in range(10):\n%  print x\n%end\njuicebox')))
     [('gybLines', '%for x in range(10):\n%  print x'),
      ('gybLinesClose', '%end'),
      ('literal', 'juicebox')]
 
-    >>> pprint(list((kind, text) for kind,text,_ in tokenize_template(
+    >>> pprint(list((kind, text) for kind, text, _ in tokenize_template(
     ... '''Nothing
     ... % if x:
     ... %    for i in range(3):

--- a/validation-test/stdlib/NumericDiagnostics.swift.gyb
+++ b/validation-test/stdlib/NumericDiagnostics.swift.gyb
@@ -3,7 +3,7 @@
 // REQUIRES: executable_test
 
 % from SwiftIntTypes import all_numeric_type_names, numeric_type_names_macintosh_only, \
-%   all_integer_type_names,all_integer_binary_operator_names, all_integer_or_real_binary_operator_names, \
+%   all_integer_type_names, all_integer_binary_operator_names, all_integer_or_real_binary_operator_names, \
 %   all_arithmetic_comparison_operator_names, all_integer_assignment_operator_names, \
 %   all_integer_or_real_assignment_operator_names
 

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -35,7 +35,7 @@ import Foundation
 var graphemeBreakPropertyTable = [
 // 'as Int' annotations are needed to help prevent the type-checker from
 // blowing the stack. <rdar://problem/17539704>
-% for start_code_point,end_code_point,value in grapheme_cluster_break_property_table.property_value_ranges:
+% for start_code_point, end_code_point, value in grapheme_cluster_break_property_table.property_value_ranges:
   (${start_code_point} as Int, ${end_code_point} as Int, _GraphemeClusterBreakPropertyValue.${value}),
 % end
 ]
@@ -164,7 +164,7 @@ UnicodeTrie.test("GraphemeClusterSegmentation/UnicodeSpec") {
   // Test segmentation algorithm using test data from the Unicode
   // specification.
 
-% for code_points,expected_boundaries in grapheme_cluster_break_tests:
+% for code_points, expected_boundaries in grapheme_cluster_break_tests:
   do {
     let scalars: [UInt32] =
         [ ${", ".join([ str(cp) for cp in code_points ])} ]


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Add whitespace: `foo,bar` → `foo, bar`
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
