### PR TITLE
[Sema] Warn unhanded errors in empty catch block

### DIFF
--- a/benchmark/single-source/ErrorHandling.swift
+++ b/benchmark/single-source/ErrorHandling.swift
@@ -34,7 +34,7 @@ public func run_ErrorHandling(_ N: Int) {
     do {
       try doSomething()
     } catch _ {
-
+        continue
     }
   }
 }

--- a/benchmark/single-source/SevenBoom.swift
+++ b/benchmark/single-source/SevenBoom.swift
@@ -29,6 +29,7 @@ public func run_SevenBoom(_ N: Int) {
       c += 1
     }
     catch _ {
+        continue
     }
   }
   CheckResults(c == 1, "IncorrectResults in SevenBoom")

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2345,6 +2345,8 @@ WARNING(no_throw_in_try,none,
 
 WARNING(no_throw_in_do_with_catch,none,
         "'catch' block is unreachable because no errors are thrown in 'do' block", ())
+WARNING(empty_catch_block,none,
+        "'catch' block is empty, errors thrown in 'do' block are unhandled", ())
 
 //------------------------------------------------------------------------------
 // Type Check Types

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -13,7 +13,8 @@ func opaque_error() -> ErrorProtocol { return MSV.Foo }
 func one() {
   do {
     true ? () : throw opaque_error() // expected-error {{expected expression after '? ... :' in ternary expression}}
-  } catch _ {
+  } catch {
+    _ = error
   }
 
   do {
@@ -26,6 +27,7 @@ func one() {
   } catch where true { // expected-warning {{'catch' block is unreachable because no errors are thrown in 'do' block}}
     let error2 = error
   } catch {
+    // discard
   }
   
   // <rdar://problem/20985280> QoI: improve diagnostic on improper pattern match on type
@@ -33,11 +35,13 @@ func one() {
     throw opaque_error()
   } catch MSV { // expected-error {{'is' keyword required to pattern match against type name}} {{11-11=is }}
   } catch {
+    // discard
   }
 
   do {
     throw opaque_error()
-  } catch is ErrorProtocol {  // expected-warning {{'is' test is always true}}
+  } catch is ErrorProtocol {  // expected-warning {{'is' test is always true}} expected-warning 2 {{catch' block is empty, errors thrown in 'do' block are unhandled}}
+    
   }
   
   func foo() throws {}
@@ -47,6 +51,7 @@ func one() {
     try foo()
 #endif
   } catch {    // don't warn, #if code should be scanned.
+    _ = error
   }
 
   do {
@@ -54,7 +59,23 @@ func one() {
     throw opaque_error()
 #endif
   } catch {    // don't warn, #if code should be scanned.
+    _ = error
   }
+  
+  // Catch block not handling error
+  do {
+  } catch {}    // expected-warning {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+
+  do {
+    #if false
+      throw opaque_error()
+    #endif
+  } catch {}  // expected-warning {{'catch' block is empty, errors thrown in 'do' block are unhandled}}
+  
+  do {
+    try genError()
+  } catch {} // expected-warning {{'catch' block is empty, errors thrown in 'do' block are unhandled}}
+  
 }
 
 func takesAutoclosure(@autoclosure _ fn : () -> Int) {}

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -87,6 +87,7 @@ func rethrowsDispatchError(handleError: ((ErrorProtocol) throws -> ()), body: ()
   do {
     body()   // expected-error {{call can throw but is not marked with 'try'}}
   } catch {
+    return
   }
 }
 

--- a/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_diagnostics.swift
@@ -48,13 +48,17 @@ class ErrantClass : ErrantBaseClass {
     y = 10
     do {
       try super.init()
-    } catch {}
+    } catch {
+      _ = error
+    }
   } // expected-error {{'self' used inside 'catch' block reachable from super.init call}}
 
   convenience init(invalidEscapeConvenience: ()) {
     do {
       try self.init()
-    } catch {}
+    } catch {
+      _ = error
+    }
   } // expected-error {{'self' used inside 'catch' block reachable from self.init call}}
 
   init(noEscapeDesignated: ()) throws {

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -27,7 +27,7 @@ func three() {
   do {
     throw opaque_error() // expected-error {{error is not handled because the enclosing catch is not exhaustive}}
   } catch let e as MSV {
-    _ = e
+    _ = e // discard
   }
 }
 
@@ -35,7 +35,7 @@ func four() {
   do {
     throw opaque_error()
   } catch let e {
-    _ = e
+    _ = e // discard
   }
 }
 
@@ -45,6 +45,7 @@ func five() {
   } catch let e as MSV {
     _ = e
   } catch _ {
+    // discard
   }
 }
 
@@ -56,6 +57,7 @@ func six() {
       _ = e
     }
   } catch _ {
+    return
   }
 }
 
@@ -130,6 +132,7 @@ func eleven_one() {
       try thrower()
     // FIXME: suppress the double-emission of the 'always true' warning
     } catch let e as ErrorProtocol { // expected-warning {{immutable value 'e' was never used}} {{17-18=_}} expected-warning 2 {{'as' test is always true}}
+      return // discard
     }
   }
 }


### PR DESCRIPTION
#### What's in this pull request?

This issue addresses [SR-978](https://bugs.swift.org/browse/SR-978). It warns when an empty, unguarded `catch` block is the only sink of an error. 

``` swift
do {
    try something()
} catch { // error: 'catch' block is empty, errors thrown in 'do' block are unhandled
}
```

It does not warn when there are more than 1 catch block, as in patterns like below, as the user is giving thought to handling errors.

``` swift
do {
    try something()
} catch let error as SomeError {
    // …
} catch {
    // discard
}
```

It emits a FIXIT to remove the catch block, this deviates from the initial design (to remove the `do`/`catch` pattern and replace all `try` expressions with `try!`)  for a few reasons:
- [I implemented it here](https://github.com/joewillsher/swift/commit/5a2641482a4144b81d5fc6d3774080b9adbad24c); I walk the subtree and transform`try` expressions to `try!`; removing the catch block; and replace `throw` expressions with `break`s. I decided against this in the end as it often does not produce code which is safer, or with more explicit error handling — even if limited to small blocks it seemed unreasonable.
- `try!` may not be the sensible behaviour to encourage; there is precedent for introducing traps in FIXITs (unexpected optionals offer to insert a `!` for example). However there are no cases where FIXITs promote `try!`, or introduce traps throughout a whole block stmt.
- A FIXIT offering to remove the `catch {}` highlights the need to handle the error, whilst making the user consider and implement the error handling.

Thanks for your help so far, what are your thoughts @jckarter?
#### Resolved bug number: ([SR-978](https://bugs.swift.org/browse/SR-978))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Implementation for https://bugs.swift.org/browse/SR-978
A warning is emitted when the only `catch` on a `do/catch` statement is
unguarded and has no body. A fixit is also offered to remove the catch
block. The tests were updated to fix new warnings and to add cases for
this new functionality.
