### PR TITLE
Fix up and re-enable test.

### DIFF
--- a/test/SILGen/objc_nonnull_lie_hack.swift
+++ b/test/SILGen/objc_nonnull_lie_hack.swift
@@ -5,7 +5,6 @@
 // RUN: %target-swift-frontend -emit-sil -O -sdk %S/Inputs -I %S/Inputs -I %t/APINotes -enable-source-import -primary-file %s | FileCheck -check-prefix=OPT %s
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar24894993
 
 import Foundation
 import gizmo
@@ -17,23 +16,9 @@ import gizmo
 
 // OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack10makeObjectFT_GSqCSo8NSObject_
 // OPT:         [[OPT:%.*]] = unchecked_ref_cast
-// OPT:         select_enum [[OPT]] : $Optional<NSObject>{{.*}} case #Optional.none!enumelt
+// OPT:         switch_enum [[OPT]] : $Optional<NSObject>, case #Optional.none!enumelt: [[NIL:bb[0-9]+]]
 func makeObject() -> NSObject? {
   let foo: NSObject? = NSObject()
-  if foo == nil {
-    print("nil")
-  }
-  return foo
-}
-
-// OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack18callInstanceMethod
-// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmo!1.foreign : Gizmo -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
-// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]]
-// OPT: select_enum [[OPTIONAL]] : $Optional<Gizmo>
-func callInstanceMethod(gizmo: Gizmo) -> Gizmo? {
-  let foo: Gizmo? = gizmo.nonNilGizmo()
-
   if foo == nil {
     print("nil")
   }
@@ -46,7 +31,7 @@ func callInstanceMethod(gizmo: Gizmo) -> Gizmo? {
 // OPT: [[OBJC_METATYPE:%[0-9]+]] = metatype $@objc_metatype Gizmo.Type
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJC_METATYPE]]) : $@convention(objc_method) (@objc_metatype Gizmo.Type) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
-// OPT: select_enum [[OPTIONAL]] : $Optional<Gizmo>
+// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
 func callClassMethod() -> Gizmo? {
   let foo: Gizmo? = Gizmo.nonNilGizmo()
   if foo == nil {
@@ -55,11 +40,25 @@ func callClassMethod() -> Gizmo? {
   return foo  
 }
 
-// OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack12loadPropertyFCSo5GizmoGSqS0__ : $@convention(thin) (@owned Gizmo) -> @owned Optional<Gizmo>
+// OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack18callInstanceMetho
+// OPT: [[METHOD:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmo!1.foreign : Gizmo -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
+// OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[METHOD]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
+// OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]]
+// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
+func callInstanceMethod(gizmo: Gizmo) -> Gizmo? {
+  let foo: Gizmo? = gizmo.nonNilGizmo()
+
+  if foo == nil {
+    print("nil")
+  }
+  return foo
+}
+
+// OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack12loadPropertyFT5gizmoCSo5Gizmo_GSqS0__
 // OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.nonNilGizmoProperty!getter.1.foreign : Gizmo -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
-// OPT: select_enum [[OPTIONAL]] : $Optional<Gizmo>,
+// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>,
 func loadProperty(gizmo: Gizmo) -> Gizmo? {
   let foo: Gizmo? = gizmo.nonNilGizmoProperty
   if foo == nil {
@@ -68,11 +67,11 @@ func loadProperty(gizmo: Gizmo) -> Gizmo? {
   return foo  
 }
 
-// OPT-LABEL: sil hidden @_TF21objc_nonnull_lie_hack19loadUnownedPropertyFCSo5GizmoGSqS0__
+// OPT-LABEL: sil hidden @_TTSf4g___TF21objc_nonnull_lie_hack19loadUnownedPropertyFT5gizmoCSo5Gizmo_GSqS0__
 // OPT: [[GETTER:%[0-9]+]] = class_method [volatile] [[OBJ:%[0-9]+]] : $Gizmo, #Gizmo.unownedNonNilGizmoProperty!getter.1.foreign : Gizmo -> () -> Gizmo , $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[NONOPTIONAL:%[0-9]+]] = apply [[GETTER]]([[OBJ]]) : $@convention(objc_method) (Gizmo) -> @autoreleased Gizmo
 // OPT: [[OPTIONAL:%[0-9]+]] = unchecked_ref_cast [[NONOPTIONAL]] : $Gizmo to $Optional<Gizmo>
-// OPT: select_enum [[OPTIONAL]] : $Optional<Gizmo>
+// OPT: switch_enum [[OPTIONAL]] : $Optional<Gizmo>
 func loadUnownedProperty(gizmo: Gizmo) -> Gizmo? {
   let foo: Gizmo? = gizmo.unownedNonNilGizmoProperty
   if foo == nil {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fix up a test that was disabled after a buildbot break.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This was disabled after one of the pass pipeline changes resulted in the
test failing only in certain configurations (unoptimized stdlib
build). Previously, the same test had been updated for other pipeline
changes, but the more recent pipeline changes made the previous updates
unnecessary.

This change reverts those previous updates, and adds new updates to deal
with changes that have happened since the test was
disabled (specifically signature optimization firing in some cases where it
wasn't before).
