### PR TITLE
[PrivateLibcExtras] Remove unused methods

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -167,29 +167,6 @@ internal func _make_posix_spawn_file_actions_t()
 }
 #endif
 
-internal func _readAll(_ fd: CInt) -> String {
-  var buffer = [UInt8](repeating: 0, count: 1024)
-  var usedBytes = 0
-  while true {
-    let readResult: ssize_t = buffer.withUnsafeMutableBufferPointer {
-      (buffer) in
-      let ptr = UnsafeMutablePointer<Void>(buffer.baseAddress! + usedBytes)
-      return read(fd, ptr, size_t(buffer.count - usedBytes))
-    }
-    if readResult > 0 {
-      usedBytes += readResult
-      continue
-    }
-    if readResult == 0 {
-      break
-    }
-    preconditionFailure("read() failed")
-  }
-  return String._fromCodeUnitSequenceWithRepair(
-    UTF8.self, input: buffer[0..<usedBytes]).0
-}
-
-
 internal func _signalToString(_ signal: Int) -> String {
   switch CInt(signal) {
   case SIGILL:  return "SIGILL"
@@ -229,26 +206,6 @@ public func posixWaitpid(_ pid: pid_t) -> ProcessTerminationStatus {
     return .signal(Int(WTERMSIG(status)))
   }
   preconditionFailure("did not understand what happened to child process")
-}
-
-public func runChild(_ args: [String])
-  -> (stdout: String, stderr: String, status: ProcessTerminationStatus) {
-  let (pid, _, stdoutFD, stderrFD) = spawnChild(args)
-
-  // FIXME: reading stdout and stderr sequentially can block.  Should use
-  // select().  This is not so simple to implement because of:
-  // <rdar://problem/17828358> Darwin module is missing fd_set-related macros
-  let stdout = _readAll(stdoutFD)
-  let stderr = _readAll(stderrFD)
-
-  if close(stdoutFD) != 0 {
-    preconditionFailure("close() failed")
-  }
-  if close(stderrFD) != 0 {
-    preconditionFailure("close() failed")
-  }
-  let status = posixWaitpid(pid)
-  return (stdout, stderr, status)
 }
 
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Remove `runChild()`, which is no longer used anywhere in the codebase. Also remove `_readAll()`, which was only used within `runChild()`.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
