### PR TITLE
[runtime] Fortify the swift_demangle API.

### DIFF
--- a/include/swift/Runtime/Portability.h
+++ b/include/swift/Runtime/Portability.h
@@ -1,0 +1,23 @@
+//===--- Portability.h -----------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Includes stub APIs that make the portable runtime easier to write.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_PORTABILITY_H
+#define SWIFT_RUNTIME_PORTABILITY_H
+#include <stddef.h>
+
+size_t _swift_strlcpy(char *dst, const char *src, size_t maxlen);
+
+#endif

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -121,30 +121,6 @@ func _typeByName(_ name: String) -> Any.Type? {
     return type
   }
 }
- 
-@warn_unused_result
-@_silgen_name("swift_stdlib_demangleName")
-func _stdlib_demangleNameImpl(
-  _ mangledName: UnsafePointer<UInt8>,
-  _ mangledNameLength: UInt,
-  _ demangledName: UnsafeMutablePointer<String>)
-
-// NB: This function is not used directly in the Swift codebase, but is
-// exported for Xcode support. Please coordinate before changing.
-@warn_unused_result
-public // @testable
-func _stdlib_demangleName(_ mangledName: String) -> String {
-  let mangledNameUTF8 = Array(mangledName.utf8)
-  return mangledNameUTF8.withUnsafeBufferPointer {
-    (mangledNameUTF8) in
-    let (_, demangledName) = _withUninitializedString {
-      _stdlib_demangleNameImpl(
-        mangledNameUTF8.baseAddress!, UInt(mangledNameUTF8.endIndex),
-        $0)
-    }
-    return demangledName
-  }
-}
 
 /// Returns `floor(log(x))`.  This equals to the position of the most
 /// significant non-zero bit, or 63 - number-of-zeros before it.

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -47,6 +47,7 @@ set(swift_runtime_sources
     MetadataLookup.cpp
     Mutex.cpp
     Once.cpp
+    Portability.cpp
     ProtocolConformance.cpp
     Reflection.cpp
     RuntimeEntrySymbols.cpp

--- a/stdlib/public/runtime/Portability.cpp
+++ b/stdlib/public/runtime/Portability.cpp
@@ -1,0 +1,29 @@
+//===--- Portability.cpp - -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===---------------------------------------------------------------------===//
+//
+// Implementations of the stub APIs that make portable runtime easier to write.
+//
+//===---------------------------------------------------------------------===//
+
+#include "swift/Runtime/Portability.h"
+#include <cstring>
+
+size_t _swift_strlcpy(char *dst, const char *src, size_t maxlen) {
+  const size_t srclen = std::strlen(src);
+  if (srclen < maxlen) {
+    std::memmove(dst, src, srclen + 1);
+  } else if (maxlen != 0) {
+    std::memmove(dst, src, maxlen - 1);
+    dst[maxlen - 1] = '\0';
+  }
+  return srclen;
+}

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -17,6 +17,7 @@
 #include "swift/Runtime/Enum.h"
 #include "swift/Basic/Demangle.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Portability.h"
 #include "Private.h"
 #include <cassert>
 #include <cstdio>
@@ -1247,6 +1248,6 @@ extern "C" char *swift_demangle(const char *mangledName,
   }
 
   // Copy into the provided buffer.
-  strlcpy(outputBuffer, result.c_str(), *outputBufferSize);
+  _swift_strlcpy(outputBuffer, result.c_str(), *outputBufferSize);
   return outputBuffer;
 }

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -9,6 +9,37 @@ import StdlibUnittest
 import SwiftShims
 
 
+@warn_unused_result
+@_silgen_name("swift_demangle")
+public
+func _stdlib_demangleImpl(
+  mangledName: UnsafePointer<UInt8>?,
+  mangledNameLength: UInt,
+  outputBuffer: UnsafeMutablePointer<UInt8>?,
+  outputBufferSize: UnsafeMutablePointer<UInt>?,
+  flags: UInt32
+) -> UnsafeMutablePointer<CChar>?
+
+@warn_unused_result
+func _stdlib_demangleName(_ mangledName: String) -> String {
+  return mangledName.nulTerminatedUTF8.withUnsafeBufferPointer {
+    (mangledNameUTF8) in
+
+    let demangledNamePtr = _stdlib_demangleImpl(
+      mangledName: mangledNameUTF8.baseAddress,
+      mangledNameLength: UInt(mangledNameUTF8.count - 1),
+      outputBuffer: nil,
+      outputBufferSize: nil,
+      flags: 0)
+
+    if let demangledNamePtr = demangledNamePtr {
+      let demangledName = String(cString: demangledNamePtr)
+      _swift_stdlib_free(demangledNamePtr)
+      return demangledName
+    }
+    return mangledName
+  }
+}
 
 var swiftObjectCanaryCount = 0
 class SwiftObjectCanary {


### PR DESCRIPTION
Remove the reference to String, which leaks internal implementation details,
check for invalid inputs, and make the API more flexible. Remove the similar
Swift API, since it provides no additional value.
