### PR TITLE
[Import as member] Don't pair up get/set pairs from other modules

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2478,7 +2478,7 @@ namespace {
         auto function = dyn_cast<clang::FunctionDecl>(decl);
         if (!function) continue;
 
-        if (function == accessor) {
+        if (function->getCanonicalDecl() == accessor->getCanonicalDecl()) {
           foundAccessor = true;
           continue;
         }

--- a/test/IDE/Inputs/custom-modules/CollisionImportAsMember.h
+++ b/test/IDE/Inputs/custom-modules/CollisionImportAsMember.h
@@ -1,0 +1,5 @@
+// This is for exercising naming collisions with other modules
+
+#include "InferImportAsMember.h"
+
+extern double IAMStruct1GetNonPropertyExternalCollision(struct IAMStruct1 s);

--- a/test/IDE/Inputs/custom-modules/InferImportAsMember.h
+++ b/test/IDE/Inputs/custom-modules/InferImportAsMember.h
@@ -49,6 +49,7 @@ extern void IAMStruct1SetNonPropertyNoSelf(double x, double y);
 
 // No set only properties
 extern void IAMStruct1SetNonPropertyNoGet(struct IAMStruct1 s, double x);
+extern void IAMStruct1SetNonPropertyExternalCollision(struct IAMStruct1 s, double x);
 
 /// Various static functions that can't quite be imported as properties.
 // Too many parameters

--- a/test/IDE/infer_import_as_member.swift
+++ b/test/IDE/infer_import_as_member.swift
@@ -1,11 +1,12 @@
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=InferImportAsMember -always-argument-labels -enable-infer-import-as-member > %t.printed.A.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/custom-modules/CollisionImportAsMember.h -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=InferImportAsMember -always-argument-labels -enable-infer-import-as-member > %t.printed.A.txt
+// RUN: %target-swift-frontend -parse -import-objc-header %S/Inputs/custom-modules/CollisionImportAsMember.h -I %t -I %S/Inputs/custom-modules %s -enable-infer-import-as-member -verify
 // RUN: FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
 
 import InferImportAsMember
+let mine = IAMStruct1()
 
 // TODO: more cases, eventually exhaustive, as we start inferring the result we
 // want
-
 
 // PRINT-LABEL: struct IAMStruct1 {
 // PRINT-NEXT:    var x: Double
@@ -50,6 +51,7 @@ import InferImportAsMember
 // PRINT-NEXT:    func getNonPropertyNoSelf() -> Float
 // PRINT-NEXT:    static func setNonPropertyNoSelf(x x: Double, y y: Double)
 // PRINT-NEXT:    func setNonPropertyNoGet(x x: Double)
+// PRINT-NEXT:    func setNonPropertyExternalCollision(x x: Double)
 //
 // PRINT-LABEL:   /// Various static functions that can't quite be imported as properties.
 // PRINT-NEXT:    @discardableResult


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

While inferring get/set, we paired them up even when one of them was
available through a custom objc header (e.g. a private
header). Instead, fail to pair them up. Test case added.
