### PR TITLE
SwiftRemoteMirror C API, TypeRef memory management improvements

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -96,8 +96,10 @@ class ReflectionContext {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSize = typename Runtime::StoredSize;
 
+  std::vector<std::unique_ptr<TypeRef>> TypeRefPool;
+
   std::vector<ReflectionInfo> ReflectionInfos;
-  std::unordered_map<StoredPointer, TypeRefPointer> TypeRefCache;
+  std::unordered_map<StoredPointer, TypeRef *> TypeRefCache;
   std::unordered_map<StoredPointer, SharedTargetMetadataRef<Runtime>>
   MetadataCache;
 
@@ -109,12 +111,12 @@ class ReflectionContext {
   std::shared_ptr<MemoryReader> Reader;
 
   void dumpTypeRef(const std::string &MangledName,
-                   std::ostream &OS, bool printTypeName = false) const {
+                   std::ostream &OS, bool printTypeName = false) {
     auto TypeName = Demangle::demangleTypeAsString(MangledName);
     OS << TypeName << std::endl;
 
     auto DemangleTree = Demangle::demangleTypeAsNode(MangledName);
-    auto TR = TypeRef::fromDemangleNode(DemangleTree);
+    auto TR = decodeTypeRef(DemangleTree);
     if (!TR) {
       OS << "!!! Invalid typeref: " << MangledName << std::endl;
       return;
@@ -150,10 +152,10 @@ class ReflectionContext {
           continue;
         std::string ProtocolMangledName(AssocTyDescriptor.ProtocolTypeName);
         auto DemangledProto = Demangle::demangleTypeAsNode(ProtocolMangledName);
-        auto TR = TypeRef::fromDemangleNode(DemangledProto);
+        auto TR = decodeTypeRef(DemangledProto);
 
         auto &Conformance = *DependentMember->getProtocol();
-        if (auto Protocol = dyn_cast<ProtocolTypeRef>(TR.get())) {
+        if (auto Protocol = dyn_cast<ProtocolTypeRef>(TR)) {
           if (*Protocol != Conformance)
             continue;
           return &AssocTyDescriptor;
@@ -164,6 +166,7 @@ class ReflectionContext {
   }
 
 public:
+
   ReflectionContext(std::shared_ptr<MemoryReader> Reader)
     : Reader(Reader) {}
 
@@ -171,7 +174,157 @@ public:
     return *Reader;
   }
 
-  void dumpFieldSection(std::ostream &OS) const {
+  template <typename TypeRefTy, typename... Args>
+  TypeRefTy *make_typeref(Args... args) {
+    auto TR = new TypeRefTy(::std::forward<Args>(args)...);
+    TypeRefPool.push_back(std::unique_ptr<TypeRef>(TR));
+    return TR;
+  }
+
+  TypeRef *decodeTypeRef(Demangle::NodePointer Node) {
+    using NodeKind = Demangle::Node::Kind;
+    switch (Node->getKind()) {
+      case NodeKind::Global:
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::TypeMangling:
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::Type:
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::BoundGenericClass:
+      case NodeKind::BoundGenericEnum:
+      case NodeKind::BoundGenericStructure: {
+        auto mangledName = Demangle::mangleNode(Node->getChild(0));
+        auto genericArgs = Node->getChild(1);
+        std::vector<TypeRef *> Args;
+        for (auto genericArg : *genericArgs) {
+          auto paramTypeRef = decodeTypeRef(genericArg);
+          if (!paramTypeRef)
+            return nullptr;
+          Args.push_back(paramTypeRef);
+        }
+
+        return BoundGenericTypeRef::create(*this, mangledName, Args);
+      }
+      case NodeKind::Class:
+      case NodeKind::Enum:
+      case NodeKind::Structure: {
+        auto mangledName = Demangle::mangleNode(Node);
+        return NominalTypeRef::create(*this, mangledName);
+      }
+      case NodeKind::BuiltinTypeName: {
+        auto mangledName = Demangle::mangleNode(Node);
+        return BuiltinTypeRef::create(*this, mangledName);
+      }
+      case NodeKind::ExistentialMetatype: {
+        auto instance = decodeTypeRef(Node->getChild(0));
+        if (!instance)
+          return nullptr;
+        return ExistentialMetatypeTypeRef::create(*this, instance);
+      }
+      case NodeKind::Metatype: {
+        auto instance = decodeTypeRef(Node->getChild(0));
+        if (!instance)
+          return nullptr;
+        return MetatypeTypeRef::create(*this, instance);
+      }
+      case NodeKind::ProtocolList: {
+        std::vector<TypeRef *> Protocols;
+        auto TypeList = Node->getChild(0);
+        for (auto Type : *TypeList) {
+          if (auto Protocol = decodeTypeRef(Type))
+            Protocols.push_back(Protocol);
+          else
+            return nullptr;
+        }
+        if (Protocols.size() == 1)
+          return Protocols.front();
+        else
+          return ProtocolCompositionTypeRef::create(*this, Protocols);
+      }
+      case NodeKind::Protocol: {
+        auto moduleName = Node->getChild(0)->getText();
+        auto name = Node->getChild(1)->getText();
+        return ProtocolTypeRef::create(*this, moduleName, name);
+      }
+      case NodeKind::DependentGenericParamType: {
+        auto depth = Node->getChild(0)->getIndex();
+        auto index = Node->getChild(1)->getIndex();
+        return GenericTypeParameterTypeRef::create(*this, depth, index);
+      }
+      case NodeKind::FunctionType: {
+        std::vector<TypeRef *> arguments;
+        auto input = decodeTypeRef(Node->getChild(0));
+        if (!input)
+          return nullptr;
+        if (auto tuple = dyn_cast<TupleTypeRef>(input))
+          arguments = tuple->getElements();
+        else
+          arguments = { input };
+        auto result = decodeTypeRef(Node->getChild(1));
+        if (!result)
+          return nullptr;
+        return FunctionTypeRef::create(*this, arguments, result);
+      }
+      case NodeKind::ArgumentTuple:
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::ReturnType:
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::NonVariadicTuple:
+      case NodeKind::VariadicTuple: {
+        std::vector<TypeRef *> Elements;
+        for (auto element : *Node) {
+          auto elementType = decodeTypeRef(element);
+          if (!elementType)
+            return nullptr;
+          Elements.push_back(elementType);
+        }
+        bool Variadic = (Node->getKind() == NodeKind::VariadicTuple);
+        return TupleTypeRef::create(*this, Elements, Variadic);
+      }
+      case NodeKind::TupleElement:
+        if (Node->getChild(0)->getKind() == NodeKind::TupleElementName)
+          return decodeTypeRef(Node->getChild(1));
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::DependentGenericType: {
+        return decodeTypeRef(Node->getChild(1));
+      }
+      case NodeKind::DependentMemberType: {
+        auto base = decodeTypeRef(Node->getChild(0));
+        if (!base)
+          return nullptr;
+        auto member = Node->getChild(1)->getText();
+        auto protocol = decodeTypeRef(Node->getChild(1));
+        if (!protocol)
+          return nullptr;
+        assert(llvm::isa<ProtocolTypeRef>(protocol));
+        return DependentMemberTypeRef::create(*this, member, base, protocol);
+      }
+      case NodeKind::DependentAssociatedTypeRef:
+        return decodeTypeRef(Node->getChild(0));
+      case NodeKind::Unowned: {
+        auto base = decodeTypeRef(Node->getChild(0));
+        if (!base)
+          return nullptr;
+        return UnownedStorageTypeRef::create(*this, base);
+      }
+      case NodeKind::Unmanaged: {
+        auto base = decodeTypeRef(Node->getChild(0));
+        if (!base)
+          return nullptr;
+        return UnmanagedStorageTypeRef::create(*this, base);
+      }
+      case NodeKind::Weak: {
+        auto base = decodeTypeRef(Node->getChild(0));
+        if (!base)
+          return nullptr;
+        return WeakStorageTypeRef::create(*this, base);
+      }
+      default:
+        return nullptr;
+    }
+  }
+
+  void dumpFieldSection(std::ostream &OS) {
     for (const auto &sections : ReflectionInfos) {
       for (const auto &descriptor : sections.fieldmd) {
         auto TypeName
@@ -188,7 +341,7 @@ public:
     }
   }
 
-  void dumpAssociatedTypeSection(std::ostream &OS) const {
+  void dumpAssociatedTypeSection(std::ostream &OS) {
     for (const auto &sections : ReflectionInfos) {
       for (const auto &descriptor : sections.assocty) {
         auto conformingTypeName = Demangle::demangleTypeAsString(
@@ -207,7 +360,7 @@ public:
     }
   }
 
-  void dumpAllSections(std::ostream &OS) const {
+  void dumpAllSections(std::ostream &OS) {
     OS << "FIELDS:" << std::endl;
     for (size_t i = 0; i < 7; ++i) OS << '=';
     OS << std::endl;
@@ -219,7 +372,7 @@ public:
     OS << std::endl;
   }
 
-  TypeRefPointer
+  TypeRef *
   getDependentMemberTypeRef(const std::string &MangledTypeName,
                             const DependentMemberTypeRef *DependentMember) {
 
@@ -230,7 +383,7 @@ public:
 
         auto SubstitutedTypeName = AssocTy.getMangledSubstitutedTypeName();
         auto Demangled = Demangle::demangleTypeAsNode(SubstitutedTypeName);
-        return TypeRef::fromDemangleNode(Demangled);
+        return decodeTypeRef(Demangled);
       }
     }
     return nullptr;
@@ -406,7 +559,7 @@ public:
       SharedTargetNominalTypeDescriptorRef<Runtime> Descriptor;
       std::tie(Descriptor, DescriptorAddress)
         = readNominalTypeDescriptor(MetadataAddress);
-      TypeRefVector Substitutions;
+      std::vector<TypeRef *> Substitutions;
       auto OffsetToParent
         = sizeof(StoredPointer) * (Descriptor->GenericParams.Offset - 1);
       if (!Reader->readInteger(RemoteAddress(MetadataAddress + OffsetToParent),
@@ -422,12 +575,12 @@ public:
     return 0;
   }
 
-  TypeRefVector getGenericSubst(StoredPointer MetadataAddress) {
+  std::vector<TypeRef *> getGenericSubst(StoredPointer MetadataAddress) {
     StoredPointer DescriptorAddress;
     SharedTargetNominalTypeDescriptorRef<Runtime> Descriptor;
     std::tie(Descriptor, DescriptorAddress)
       = readNominalTypeDescriptor(MetadataAddress);
-    TypeRefVector Substitutions;
+    std::vector<TypeRef *> Substitutions;
     auto NumGenericParams = Descriptor->GenericParams.NumPrimaryParams;
     auto OffsetToGenericArgs
       = sizeof(StoredPointer) * (Descriptor->GenericParams.Offset);
@@ -448,7 +601,7 @@ public:
     return Substitutions;
   }
 
-  TypeRefPointer
+  TypeRef *
   getNominalTypeRef(StoredPointer MetadataAddress) {
     auto Meta = readMetadata(MetadataAddress);
 
@@ -470,19 +623,19 @@ public:
     if (!DemangleNode)
       return nullptr;
 
-    TypeRefPointer Parent;
+    TypeRef *Parent;
     if (auto ParentAddress = getParentAddress(MetadataAddress))
       Parent = getTypeRef(ParentAddress);
 
-    TypeRefPointer Nominal;
+    TypeRef *Nominal;
     if (Descriptor->GenericParams.NumPrimaryParams) {
       auto Args = getGenericSubst(MetadataAddress);
-      auto BG = BoundGenericTypeRef::create(MangledName, Args);
+      auto BG = BoundGenericTypeRef::create(*this, MangledName, Args);
       BG->setParent(Parent);
       Nominal = BG;
     } else {
-      auto TR = TypeRef::fromDemangleNode(DemangleNode);
-      auto N = cast<NominalTypeRef>(TR.get());
+      auto TR = decodeTypeRef(DemangleNode);
+      auto N = cast<NominalTypeRef>(TR);
       N->setParent(Parent);
       Nominal = TR;
     }
@@ -490,7 +643,7 @@ public:
     return Nominal;
   }
 
-  TypeRefPointer getTypeRef(StoredPointer MetadataAddress) {
+  TypeRef *getTypeRef(StoredPointer MetadataAddress) {
     auto Cached = TypeRefCache.find(MetadataAddress);
     if (Cached != TypeRefCache.end())
       return Cached->second;
@@ -508,7 +661,7 @@ public:
       return getNominalTypeRef(MetadataAddress);
     case MetadataKind::Tuple: {
       auto TupleMeta = cast<TargetTupleTypeMetadata<Runtime>>(Meta.get());
-      TypeRefVector Elements;
+      std::vector<TypeRef *> Elements;
       StoredPointer ElementAddress = MetadataAddress +
         sizeof(TargetTupleTypeMetadata<Runtime>);
       using Element = typename TargetTupleTypeMetadata<Runtime>::Element;
@@ -524,7 +677,7 @@ public:
         else
           return nullptr;
       }
-      return TupleTypeRef::create(Elements);
+      return TupleTypeRef::create(*this, Elements);
     }
     case MetadataKind::Function: {
       auto Function = cast<TargetFunctionTypeMetadata<Runtime>>(Meta.get());
@@ -534,7 +687,7 @@ public:
       if (!Reader->readBytes(RemoteAddress(FlagsAddress),
                              (uint8_t*)&Flags, sizeof(Flags)))
         return nullptr;
-      TypeRefVector Arguments;
+      std::vector<TypeRef *> Arguments;
       StoredPointer ArgumentAddress = MetadataAddress +
         sizeof(TargetFunctionTypeMetadata<Runtime>);
       for (StoredPointer i = 0; i < Function->getNumArguments(); ++i,
@@ -554,11 +707,11 @@ public:
       auto Result = getTypeRef(Function->ResultType);
       if (!Result)
         return nullptr;
-      return FunctionTypeRef::create(Arguments, Result);
+      return FunctionTypeRef::create(*this, Arguments, Result);
     }
     case MetadataKind::Existential: {
       auto Exist = cast<TargetExistentialTypeMetadata<Runtime>>(Meta.get());
-      TypeRefVector Protocols;
+      std::vector<TypeRef *> Protocols;
       for (size_t i = 0; i < Exist->Protocols.NumProtocols; ++i) {
         auto ProtocolAddress = Exist->Protocols[i];
         auto ProtocolDescriptor = readProtocolDescriptor(ProtocolAddress);
@@ -570,52 +723,52 @@ public:
                                 MangledName))
           return nullptr;
         auto Demangled = Demangle::demangleSymbolAsNode(MangledName);
-        auto Protocol = TypeRef::fromDemangleNode(Demangled);
-        if (!llvm::isa<ProtocolTypeRef>(Protocol.get()))
+        auto Protocol = decodeTypeRef(Demangled);
+        if (!llvm::isa<ProtocolTypeRef>(Protocol))
           return nullptr;
 
         Protocols.push_back(Protocol);
       }
-      return ProtocolCompositionTypeRef::create(Protocols);
+      return ProtocolCompositionTypeRef::create(*this, Protocols);
     }
     case MetadataKind::Metatype: {
       auto Metatype = cast<TargetMetatypeMetadata<Runtime>>(Meta.get());
       auto Instance = getTypeRef(Metatype->InstanceType);
-      return MetatypeTypeRef::create(Instance);
+      return MetatypeTypeRef::create(*this, Instance);
     }
     case MetadataKind::ObjCClassWrapper:
-      return ObjCClassTypeRef::Unnamed;
+      return ObjCClassTypeRef::getUnnamed();
     case MetadataKind::ExistentialMetatype: {
       auto Exist = cast<TargetExistentialMetatypeMetadata<Runtime>>(Meta.get());
       auto Instance = getTypeRef(Exist->InstanceType);
-      return ExistentialMetatypeTypeRef::create(Instance);
+      return ExistentialMetatypeTypeRef::create(*this, Instance);
     }
     case MetadataKind::ForeignClass:
-      return ForeignClassTypeRef::Unnamed;
+      return ForeignClassTypeRef::getUnnamed();
     case MetadataKind::HeapLocalVariable:
-      return ForeignClassTypeRef::Unnamed;
+      return ForeignClassTypeRef::getUnnamed();
     case MetadataKind::HeapGenericLocalVariable:
-      return ForeignClassTypeRef::Unnamed;
+      return ForeignClassTypeRef::getUnnamed();
     case MetadataKind::ErrorObject:
-      return ForeignClassTypeRef::Unnamed;
+      return ForeignClassTypeRef::getUnnamed();
     case MetadataKind::Opaque:
-      return OpaqueTypeRef::Opaque;
+      return OpaqueTypeRef::get();
     }
   }
 
-  std::vector<std::pair<std::string, ConstTypeRefPointer>>
-  getFieldTypeRefs(TypeRefPointer TR) {
+  std::vector<std::pair<std::string, TypeRef *>>
+  getFieldTypeRefs(TypeRef *TR) {
     std::string MangledName;
-    if (auto N = dyn_cast<NominalTypeRef>(TR.get()))
+    if (auto N = dyn_cast<NominalTypeRef>(TR))
       MangledName = N->getMangledName();
-    else if (auto BG = dyn_cast<BoundGenericTypeRef>(TR.get()))
+    else if (auto BG = dyn_cast<BoundGenericTypeRef>(TR))
       MangledName = BG->getMangledName();
     else
       return {};
 
     auto Subs = TR->getSubstMap();
 
-    std::vector<std::pair<std::string, ConstTypeRefPointer>> Fields;
+    std::vector<std::pair<std::string, TypeRef *>> Fields;
     for (auto Info : ReflectionInfos) {
       for (auto &FieldDescriptor : Info.fieldmd) {
         auto CandidateMangledName = FieldDescriptor.MangledTypeName.get();
@@ -626,7 +779,7 @@ public:
         for (auto &Field : FieldDescriptor) {
           auto Demangled
           = Demangle::demangleTypeAsNode(Field.getMangledTypeName());
-          auto Unsubstituted = TypeRef::fromDemangleNode(Demangled);
+          auto Unsubstituted = decodeTypeRef(Demangled);
           if (!Unsubstituted)
             return {};
           auto Substituted = Unsubstituted->subst(*this, Subs);
@@ -640,7 +793,7 @@ public:
     return Fields;
   }
 
-  std::vector<std::pair<std::string, ConstTypeRefPointer>>
+  std::vector<std::pair<std::string, TypeRef *>>
   getFieldTypeRefs(StoredPointer MetadataAddress) {
     auto Meta = readMetadata(MetadataAddress);
     if (!Meta)

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -680,18 +680,17 @@ public:
       SWIFT_UNKNOWN,
       NULL,
       0,
+      0,
       0
     };
   }
 
-  swift_fieldinfo_t getInfoForField(const TypeRef *TR, unsigned Index) {
+  swift_childinfo_t getInfoForChild(const TypeRef *TR, unsigned Index) {
     // TODO
     return {
-      NOTAPOINTER,
       0,
       NULL,
       0,
-      0
     };
   }
 };

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -56,9 +56,6 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
                                    swift_reflection_section_t assocty);
 
 
-/// Clear any caching of field type information for all known heap instances.
-void swift_reflection_clearCaches(SwiftReflectionContextRef Context);
-
 /// Returns an opaque type reference for a metadata pointer, or
 /// NULL if one can't be constructed.
 swift_typeref_t
@@ -70,8 +67,8 @@ swift_typeinfo_t
 swift_reflection_infoForTypeRef(SwiftReflectionContextRef ContextRef,
                                 swift_typeref_t OpaqueTypeRef);
 
-/// Returns the information about a stored property by index.
-swift_fieldinfo_t
+/// Returns the information about a child by index.
+swift_childinfo_t
 swift_reflection_infoForField(SwiftReflectionContextRef ContextRef,
                               swift_typeref_t OpaqueTypeRef,
                               unsigned Index);

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -39,14 +39,18 @@ typedef struct swift_reflection_section_t {
 } swift_reflection_section_t;
 
 /// The kind of a Swift type.
-typedef enum swift_typeref_kind_t {
-  SWIFT_CLASS,
+typedef enum swift_layout_kind_t {
+  SWIFT_STRONG_POINTER,
+  SWIFT_WEAK_POINTER,
+  SWIFT_UNOWNED_POINTER,
+  SWIFT_UNMANAGED_POINTER,
   SWIFT_STRUCT,
   SWIFT_TUPLE,
+  SWIFT_THICK_FUNCTION,
+  SWIFT_THIN_FUNCTION,
+  OBJC_BLOCK,
   SWIFT_CLOSURE_CONTEXT,
-  SWIFT_DICTIONARY_OWNER,
-  SWIFT_SET_OWNER,
-  SWIFT_ARRAY_OWNER,
+  SWIFT_BOX,
   SWIFT_UNKNOWN
 } swift_layout_kind_t;
 
@@ -54,33 +58,22 @@ typedef enum swift_typeref_kind_t {
 typedef struct swift_typeinfo_t {
   swift_layout_kind_t LayoutKind;
 
-  /// The demangled type name.
-  const char *TypeName;
+  const char *MangledTypeName;
 
   size_t Size;
-  size_t Stride;
+  size_t InstanceSize;
+  size_t Alignment;
 } swift_typeinfo_t;
 
-typedef enum swift_reference_kind_t {
-  STRONG,
-  WEAK,
-  UNOWNED,
-  UNMANAGED,
-  NOTAPOINTER
-} swift_reference_kind_t;
-
-typedef struct swift_fieldinfo_t {
-  swift_reference_kind_t ReferenceKind;
+typedef struct swift_childinfo_t {
   swift_typeref_t TypeRef;
-  const char *FieldName;
+  const char *Name;
   size_t Offset;
-  size_t Size;
-} swift_fieldinfo_t;
+} swift_childinfo_t;
 
 /// \brief An opaque pointer to a context which maintains state and
 /// caching of reflection structure for heap instances.
 typedef struct SwiftReflectionContext *SwiftReflectionContextRef;
-
 
 #ifdef __cplusplus
 } // extern "C"

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -2,4 +2,5 @@ add_swift_library(swiftReflection IS_STDLIB IS_HOST
   Demangle.cpp
   Remangle.cpp
   TypeRef.cpp
-  INSTALL_IN_COMPONENT dev)
+  INSTALL_IN_COMPONENT dev
+  COMPONENT_DEPENDS Support)

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -46,7 +46,7 @@ class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
     return OS;
   }
 
-  void printRec(const TypeRef *typeRef) {
+  void printRec(TypeRef *typeRef) {
     OS << "\n";
 
     Indent += 2;
@@ -58,14 +58,14 @@ public:
   PrintTypeRef(std::ostream &OS, unsigned Indent)
   : OS(OS), Indent(Indent) {}
 
-  void visitBuiltinTypeRef(const BuiltinTypeRef *B) {
+  void visitBuiltinTypeRef(BuiltinTypeRef *B) {
     printHeader("builtin");
     auto demangled = Demangle::demangleTypeAsString(B->getMangledName());
     printField("", demangled);
     OS << ')';
   }
 
-  void visitNominalTypeRef(const NominalTypeRef *N) {
+  void visitNominalTypeRef(NominalTypeRef *N) {
     if (N->isStruct())
       printHeader("struct");
     else if (N->isEnum())
@@ -77,11 +77,11 @@ public:
     auto demangled = Demangle::demangleTypeAsString(N->getMangledName());
     printField("", demangled);
     if (auto parent = N->getParent())
-      printRec(parent.get());
+      printRec(parent);
     OS << ')';
   }
 
-  void visitBoundGenericTypeRef(const BoundGenericTypeRef *BG) {
+  void visitBoundGenericTypeRef(BoundGenericTypeRef *BG) {
     if (BG->isStruct())
       printHeader("bound-generic struct");
     else if (BG->isEnum())
@@ -94,101 +94,101 @@ public:
     auto demangled = Demangle::demangleTypeAsString(BG->getMangledName());
     printField("", demangled);
     for (auto param : BG->getGenericParams())
-      printRec(param.get());
+      printRec(param);
     if (auto parent = BG->getParent())
-      printRec(parent.get());
+      printRec(parent);
     OS << ')';
   }
 
-  void visitTupleTypeRef(const TupleTypeRef *T) {
+  void visitTupleTypeRef(TupleTypeRef *T) {
     printHeader("tuple");
     for (auto element : T->getElements())
-      printRec(element.get());
+      printRec(element);
     OS << ')';
   }
 
-  void visitFunctionTypeRef(const FunctionTypeRef *F) {
+  void visitFunctionTypeRef(FunctionTypeRef *F) {
     printHeader("function");
     for (auto Arg : F->getArguments())
-      printRec(Arg.get());
-    printRec(F->getResult().get());
+      printRec(Arg);
+    printRec(F->getResult());
     OS << ')';
   }
 
-  void visitProtocolTypeRef(const ProtocolTypeRef *P) {
+  void visitProtocolTypeRef(ProtocolTypeRef *P) {
     printHeader("protocol");
     printField("module", P->getModuleName());
     printField("name", P->getName());
     OS << ')';
   }
 
-  void visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
+  void visitProtocolCompositionTypeRef(ProtocolCompositionTypeRef *PC) {
     printHeader("protocol-composition");
     for (auto protocol : PC->getProtocols())
-      printRec(protocol.get());
+      printRec(protocol);
     OS << ')';
   }
 
-  void visitMetatypeTypeRef(const MetatypeTypeRef *M) {
+  void visitMetatypeTypeRef(MetatypeTypeRef *M) {
     printHeader("metatype");
-    printRec(M->getInstanceType().get());
+    printRec(M->getInstanceType());
     OS << ')';
   }
 
-  void visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
+  void visitExistentialMetatypeTypeRef(ExistentialMetatypeTypeRef *EM) {
     printHeader("existential-metatype");
-    printRec(EM->getInstanceType().get());
+    printRec(EM->getInstanceType());
     OS << ')';
   }
 
-  void visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP){
+  void visitGenericTypeParameterTypeRef(GenericTypeParameterTypeRef *GTP){
     printHeader("generic-type-parameter");
     printField("depth", GTP->getDepth());
     printField("index", GTP->getIndex());
     OS << ')';
   }
 
-  void visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
+  void visitDependentMemberTypeRef(DependentMemberTypeRef *DM) {
     printHeader("dependent-member");
     printRec(DM->getProtocol());
-    printRec(DM->getBase().get());
+    printRec(DM->getBase());
     printField("member", DM->getMember());
     OS << ')';
   }
 
-  void visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
+  void visitForeignClassTypeRef(ForeignClassTypeRef *F) {
     printHeader("foreign");
     if (!F->getName().empty())
       printField("name", F->getName());
     OS << ')';
   }
 
-  void visitObjCClassTypeRef(const ObjCClassTypeRef *OC) {
+  void visitObjCClassTypeRef(ObjCClassTypeRef *OC) {
     printHeader("objective-c-class");
     if (!OC->getName().empty())
       printField("name", OC->getName());
     OS << ')';
   }
 
-  void visitUnownedStorageTypeRef(const UnownedStorageTypeRef *US) {
+  void visitUnownedStorageTypeRef(UnownedStorageTypeRef *US) {
     printHeader("unowned-storage");
-    printRec(US->getType().get());
+    printRec(US->getType());
     OS << ')';
   }
 
-  void visitWeakStorageTypeRef(const WeakStorageTypeRef *WS) {
+  void visitWeakStorageTypeRef(WeakStorageTypeRef *WS) {
     printHeader("weak-storage");
-    printRec(WS->getType().get());
+    printRec(WS->getType());
     OS << ')';
   }
 
-  void visitUnmanagedStorageTypeRef(const UnmanagedStorageTypeRef *US) {
+  void visitUnmanagedStorageTypeRef(UnmanagedStorageTypeRef *US) {
     printHeader("weak-storage");
-    printRec(US->getType().get());
+    printRec(US->getType());
     OS << ')';
   }
 
-  void visitOpaqueTypeRef(const OpaqueTypeRef *O) {
+  void visitOpaqueTypeRef(OpaqueTypeRef *O) {
     printHeader("opaque");
     OS << ')';
   }
@@ -196,261 +196,130 @@ public:
 
 struct TypeRefIsConcrete
   : public TypeRefVisitor<TypeRefIsConcrete, bool> {
-  bool visitBuiltinTypeRef(const BuiltinTypeRef *B) {
+  bool visitBuiltinTypeRef(BuiltinTypeRef *B) {
     return true;
   }
 
-  bool visitNominalTypeRef(const NominalTypeRef *N) {
+  bool visitNominalTypeRef(NominalTypeRef *N) {
     return true;
   }
 
-  bool visitBoundGenericTypeRef(const BoundGenericTypeRef *BG) {
-    TypeRefVector GenericParams;
+  bool visitBoundGenericTypeRef(BoundGenericTypeRef *BG) {
+    std::vector<TypeRef *> GenericParams;
     for (auto Param : BG->getGenericParams())
-      if (!visit(Param.get()))
+      if (!visit(Param))
         return false;
     return true;
   }
 
-  bool visitTupleTypeRef(const TupleTypeRef *T) {
+  bool visitTupleTypeRef(TupleTypeRef *T) {
     for (auto Element : T->getElements()) {
-      if (!visit(Element.get()))
+      if (!visit(Element))
         return false;
     }
     return true;
   }
 
-  bool visitFunctionTypeRef(const FunctionTypeRef *F) {
-    TypeRefVector SubstitutedArguments;
+  bool visitFunctionTypeRef(FunctionTypeRef *F) {
+    std::vector<TypeRef *> SubstitutedArguments;
     for (auto Argument : F->getArguments())
-      if (!visit(Argument.get()))
+      if (!visit(Argument))
         return false;
-    return visit(F->getResult().get());
+    return visit(F->getResult());
   }
 
-  bool visitProtocolTypeRef(const ProtocolTypeRef *P) {
+  bool visitProtocolTypeRef(ProtocolTypeRef *P) {
     return true;
   }
 
   bool
-  visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
+  visitProtocolCompositionTypeRef(ProtocolCompositionTypeRef *PC) {
     for (auto Protocol : PC->getProtocols())
-      if (!visit(Protocol.get()))
+      if (!visit(Protocol))
         return false;
     return true;
   }
 
-  bool visitMetatypeTypeRef(const MetatypeTypeRef *M) {
-    return visit(M->getInstanceType().get());
+  bool visitMetatypeTypeRef(MetatypeTypeRef *M) {
+    return visit(M->getInstanceType());
   }
 
   bool
-  visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
-    return visit(EM->getInstanceType().get());
+  visitExistentialMetatypeTypeRef(ExistentialMetatypeTypeRef *EM) {
+    return visit(EM->getInstanceType());
   }
 
   bool
-  visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP){
+  visitGenericTypeParameterTypeRef(GenericTypeParameterTypeRef *GTP){
     return false;
   }
 
   bool
-  visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
-    return visit(DM->getBase().get());
+  visitDependentMemberTypeRef(DependentMemberTypeRef *DM) {
+    return visit(DM->getBase());
   }
 
-  bool visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
+  bool visitForeignClassTypeRef(ForeignClassTypeRef *F) {
     return true;
   }
 
-  bool visitObjCClassTypeRef(const ObjCClassTypeRef *OC) {
+  bool visitObjCClassTypeRef(ObjCClassTypeRef *OC) {
     return true;
   }
   
-  bool visitOpaqueTypeRef(const OpaqueTypeRef *OP) {
+  bool visitOpaqueTypeRef(OpaqueTypeRef *Op) {
     return true;
   }
 
-  bool visitUnownedStorageTypeRef(const UnownedStorageTypeRef *US) {
-    return visit(US->getType().get());
+  bool visitUnownedStorageTypeRef(UnownedStorageTypeRef *US) {
+    return visit(US->getType());
   }
 
-  bool visitWeakStorageTypeRef(const WeakStorageTypeRef *WS) {
-    return visit(WS->getType().get());
+  bool visitWeakStorageTypeRef(WeakStorageTypeRef *WS) {
+    return visit(WS->getType());
   }
 
-  bool visitUnmanagedStorageTypeRef(const UnmanagedStorageTypeRef *US) {
-    return visit(US->getType().get());
+  bool visitUnmanagedStorageTypeRef(UnmanagedStorageTypeRef *US) {
+    return visit(US->getType());
   }
 };
 
-const std::shared_ptr<ForeignClassTypeRef>
-ForeignClassTypeRef::Unnamed = ForeignClassTypeRef::create("");
+ForeignClassTypeRef *
+ForeignClassTypeRef::UnnamedSingleton = new ForeignClassTypeRef("");
 
-const std::shared_ptr<ObjCClassTypeRef>
-ObjCClassTypeRef::Unnamed = ObjCClassTypeRef::create("");
+ForeignClassTypeRef *ForeignClassTypeRef::getUnnamed() {
+  return UnnamedSingleton;
+}
 
-const std::shared_ptr<OpaqueTypeRef>
-OpaqueTypeRef::Opaque = std::make_shared<OpaqueTypeRef>();
+ObjCClassTypeRef *
+ObjCClassTypeRef::UnnamedSingleton = new ObjCClassTypeRef("");
 
-void TypeRef::dump() const {
+ObjCClassTypeRef *ObjCClassTypeRef::getUnnamed() {
+  return UnnamedSingleton;
+}
+
+OpaqueTypeRef *
+OpaqueTypeRef::Singleton = new OpaqueTypeRef();
+
+OpaqueTypeRef *OpaqueTypeRef::get() {
+  return Singleton;
+}
+
+void TypeRef::dump() {
   dump(std::cerr);
 }
 
-void TypeRef::dump(std::ostream &OS, unsigned Indent) const {
+void TypeRef::dump(std::ostream &OS, unsigned Indent) {
   PrintTypeRef(OS, Indent).visit(this);
   OS << std::endl;
 }
 
-TypeRefPointer TypeRef::fromDemangleNode(Demangle::NodePointer Node) {
-  using NodeKind = Demangle::Node::Kind;
-  switch (Node->getKind()) {
-    case NodeKind::Global:
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::TypeMangling:
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::Type:
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::BoundGenericClass:
-    case NodeKind::BoundGenericEnum:
-    case NodeKind::BoundGenericStructure: {
-      auto mangledName = Demangle::mangleNode(Node->getChild(0));
-      auto genericArgs = Node->getChild(1);
-      TypeRefVector Args;
-      for (auto genericArg : *genericArgs) {
-        auto paramTypeRef = fromDemangleNode(genericArg);
-        if (!paramTypeRef)
-          return nullptr;
-        Args.push_back(paramTypeRef);
-      }
-
-      return BoundGenericTypeRef::create(mangledName, Args);
-    }
-    case NodeKind::Class:
-    case NodeKind::Enum:
-    case NodeKind::Structure: {
-      auto mangledName = Demangle::mangleNode(Node);
-      return NominalTypeRef::create(mangledName);
-    }
-    case NodeKind::BuiltinTypeName: {
-      auto mangledName = Demangle::mangleNode(Node);
-      return BuiltinTypeRef::create(mangledName);
-    }
-    case NodeKind::ExistentialMetatype: {
-      auto instance = fromDemangleNode(Node->getChild(0));
-      if (!instance)
-        return nullptr;
-      return ExistentialMetatypeTypeRef::create(instance);
-    }
-    case NodeKind::Metatype: {
-      auto instance = fromDemangleNode(Node->getChild(0));
-      if (!instance)
-        return nullptr;
-      return MetatypeTypeRef::create(instance);
-    }
-    case NodeKind::ProtocolList: {
-      TypeRefVector Protocols;
-      auto TypeList = Node->getChild(0);
-      for (auto Type : *TypeList) {
-        if (auto Protocol = fromDemangleNode(Type))
-          Protocols.push_back(Protocol);
-        else
-          return nullptr;
-      }
-      if (Protocols.size() == 1)
-        return Protocols.front();
-      else
-        return ProtocolCompositionTypeRef::create(Protocols);
-    }
-    case NodeKind::Protocol: {
-      auto moduleName = Node->getChild(0)->getText();
-      auto name = Node->getChild(1)->getText();
-      return ProtocolTypeRef::create(moduleName, name);
-    }
-    case NodeKind::DependentGenericParamType: {
-      auto depth = Node->getChild(0)->getIndex();
-      auto index = Node->getChild(1)->getIndex();
-      return GenericTypeParameterTypeRef::create(depth, index);
-    }
-    case NodeKind::FunctionType: {
-      TypeRefVector arguments;
-      auto input = fromDemangleNode(Node->getChild(0));
-      if (!input)
-        return nullptr;
-      if (auto tuple = dyn_cast<TupleTypeRef>(input.get()))
-        arguments = tuple->getElements();
-      else
-        arguments = { input };
-      auto result = fromDemangleNode(Node->getChild(1));
-      if (!result)
-        return nullptr;
-      return FunctionTypeRef::create(arguments, result);
-    }
-    case NodeKind::ArgumentTuple:
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::ReturnType:
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::NonVariadicTuple:
-    case NodeKind::VariadicTuple: {
-      TypeRefVector Elements;
-      for (auto element : *Node) {
-        auto elementType = fromDemangleNode(element);
-        if (!elementType)
-          return nullptr;
-        Elements.push_back(elementType);
-      }
-      bool Variadic = (Node->getKind() == NodeKind::VariadicTuple);
-      return TupleTypeRef::create(Elements, Variadic);
-    }
-    case NodeKind::TupleElement:
-      if (Node->getChild(0)->getKind() == NodeKind::TupleElementName)
-        return fromDemangleNode(Node->getChild(1));
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::DependentGenericType: {
-      return fromDemangleNode(Node->getChild(1));
-    }
-    case NodeKind::DependentMemberType: {
-      auto base = fromDemangleNode(Node->getChild(0));
-      if (!base)
-        return nullptr;
-      auto member = Node->getChild(1)->getText();
-      auto protocol = fromDemangleNode(Node->getChild(1));
-      if (!protocol)
-        return nullptr;
-      assert(llvm::isa<ProtocolTypeRef>(protocol.get()));
-      return DependentMemberTypeRef::create(member, base, protocol);
-    }
-    case NodeKind::DependentAssociatedTypeRef:
-      return fromDemangleNode(Node->getChild(0));
-    case NodeKind::Unowned: {
-      auto base = fromDemangleNode(Node->getChild(0));
-      if (!base)
-        return nullptr;
-      return UnownedStorageTypeRef::create(base);
-    }
-    case NodeKind::Unmanaged: {
-      auto base = fromDemangleNode(Node->getChild(0));
-      if (!base)
-        return nullptr;
-      return UnmanagedStorageTypeRef::create(base);
-    }
-    case NodeKind::Weak: {
-      auto base = fromDemangleNode(Node->getChild(0));
-      if (!base)
-        return nullptr;
-      return WeakStorageTypeRef::create(base);
-    }
-    default:
-      return nullptr;
-  }
-}
-
-bool TypeRef::isConcrete() const {
+bool TypeRef::isConcrete() {
   return TypeRefIsConcrete().visit(this);
 }
 
 unsigned NominalTypeTrait::getDepth() const {
-  if (auto P = Parent.get()) {
+  if (auto P = Parent) {
     switch (P->getKind()) {
     case TypeRefKind::Nominal:
       return 1 + cast<NominalTypeRef>(P)->getDepth();

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -52,11 +52,6 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
   Context->addReflectionInfo(Info);
 }
 
-void swift_reflection_clearCaches(SwiftReflectionContextRef ContextRef) {
-  auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
-  Context->clear();
-}
-
 swift_typeref_t
 swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
                                     uintptr_t metadata) {
@@ -87,12 +82,12 @@ swift_reflection_infoForTypeRef(SwiftReflectionContextRef ContextRef,
   return Context->getInfoForTypeRef(TR);
 }
 
-swift_fieldinfo_t
-swift_reflection_infoForField(SwiftReflectionContextRef ContextRef,
+swift_childinfo_t
+swift_reflection_infoForChild(SwiftReflectionContextRef ContextRef,
                               swift_typeref_t OpaqueTypeRef,
                               unsigned Index) {
   auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
   auto TR = reinterpret_cast<TypeRef *>(OpaqueTypeRef);
-  return Context->getInfoForField(TR, Index);
+  return Context->getInfoForChild(TR, Index);
 }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -57,7 +57,7 @@ swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
                                     uintptr_t metadata) {
   auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
   auto TR = Context->getTypeRef(metadata);
-  return reinterpret_cast<swift_typeref_t>(TR.get());
+  return reinterpret_cast<swift_typeref_t>(TR);
 }
 
 swift_typeref_t
@@ -68,7 +68,7 @@ swift_reflection_genericArgumentOfTypeRef(swift_typeref_t OpaqueTypeRef,
   if (auto BG = dyn_cast<BoundGenericTypeRef>(TR)) {
     auto &Params = BG->getGenericParams();
     if (Index < Params.size()) {
-      return reinterpret_cast<swift_typeref_t>(Params[Index].get());
+      return reinterpret_cast<swift_typeref_t>(Params[Index]);
     }
   }
   return 0;


### PR DESCRIPTION
- Some minor changes to the SwiftRemoteMirror C API, NFC yet.
- Tie lifetime of typerefs to the ReflectionContext  …
  We will be handing pointers to typerefs over the SwiftRemoteMirrors C
  API boundary, at which point it is unclear who will hold onto a shared
  pointer. The useful lifetime of a typeref is tied to the
  ReflectionContext for which they were created anyway so, when it goes
  away, all of those typerefs can go away anyway.

We can't use LLVM's bump-pointer allocator here because we only build
the Support library for the host. As a compromise, stuff new typeref
pointers into a vector pool, where they will be taken down during
ReflectionContext's destructor.
