### PR TITLE
[gardening] "Type->Type" → "Type -> Type" in Swift code

### DIFF
--- a/benchmark/single-source/CaptureProp.swift
+++ b/benchmark/single-source/CaptureProp.swift
@@ -17,7 +17,7 @@ func sum(_ x:Int, y:Int) -> Int {
 @inline(never)
 func benchCaptureProp<S : Sequence
 >(
-  _ s: S, _ f:(S.Iterator.Element, S.Iterator.Element)->S.Iterator.Element) -> S.Iterator.Element {
+  _ s: S, _ f: (S.Iterator.Element, S.Iterator.Element) -> S.Iterator.Element) -> S.Iterator.Element {
 
   var it = s.makeIterator()
   let initial = it.next()!

--- a/benchmark/single-source/Integrate.swift
+++ b/benchmark/single-source/Integrate.swift
@@ -18,13 +18,13 @@ import TestsUtils
 class Integrate {
   static let epsilon = 1.0e-9;
 
-  let fun:(Double)->Double;
+  let fun: (Double) -> Double;
 
-  init (f:(Double)->Double) {
+  init (f: (Double) -> Double) {
     fun = f;
   }
     
-  private func recEval(_ l:Double, fl:Double, r:Double, fr:Double, a:Double)->Double {
+  private func recEval(_ l: Double, fl: Double, r: Double, fr: Double, a: Double) -> Double {
     let h = (r - l) / 2
     let hh = h / 2
     let c = l + h
@@ -43,7 +43,7 @@ class Integrate {
   }
 
   @inline(never)
-  func computeArea(_ left: Double, right:Double)->Double {
+  func computeArea(_ left: Double, right: Double) -> Double {
     return recEval(left, fl:fun(left), r:right, fr:fun(right), a:0)
   }
 }

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -183,7 +183,7 @@ extension Edge : Hashable {
   }
 }
 
-func Prims(_ graph : Array<GraphNode>, _ fun : (Int, Int)->Double) -> Array<Int?> {
+func Prims(_ graph : Array<GraphNode>, _ fun : (Int, Int) -> Double) -> Array<Int?> {
   var treeEdges = Array<Int?>(repeating:nil, count:graph.count)
 
   let queue = PriorityQueue(Num:graph.count)

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -48,9 +48,9 @@ extension BenchResults : CustomStringConvertible {
 struct Test {
   let name: String
   let index: Int
-  let f: (Int)->()
+  let f: (Int) -> ()
   var run: Bool
-  init(name: String, n: Int, f: (Int)->()) {
+  init(name: String, n: Int, f: (Int) -> ()) {
     self.name = name
     self.index = n
     self.f = f
@@ -58,8 +58,8 @@ struct Test {
   }
 }
 
-public var precommitTests: [String : (Int)->()] = [:]
-public var otherTests: [String : (Int)->()] = [:]
+public var precommitTests: [String : (Int) -> ()] = [:]
+public var otherTests: [String : (Int) -> ()] = [:]
 
 enum TestAction {
   case Run

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -182,7 +182,7 @@ public func expectNotEqual<T : Equatable>(_ expected: T, _ actual: T, ${TRACE}) 
 }
 
 // Cannot write a sane set of overloads using generics because of:
-// <rdar://problem/17015923> Array->NSArray implicit conversion insanity
+// <rdar://problem/17015923> Array -> NSArray implicit conversion insanity
 public func expectOptionalEqual<T : Equatable>(
   _ expected: T, _ actual: T?, ${TRACE}
 ) {

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -31,7 +31,7 @@ public func print(
 #if os(Windows)
   // FIXME: This fix is for 'crash at hook(output.left)' in cygwin.
   //        Proper fix is needed. see: https://bugs.swift.org/browse/SR-612
-  let _playgroundPrintHook: ((String)->Void)? = nil
+  let _playgroundPrintHook: ((String) -> Void)? = nil
 #endif
   if let hook = _playgroundPrintHook {
     var output = _TeeStream(left: "", right: _Stdout())

--- a/test/1_stdlib/NewArray.swift.gyb
+++ b/test/1_stdlib/NewArray.swift.gyb
@@ -144,7 +144,7 @@ func test<
   checkEqual(x, y, false)
 
   func checkReallocations(
-    _ a: T, _ growthDescription: String, _ growBy1: (_: inout T)->()
+    _ a: T, _ growthDescription: String, _ growBy1: (_: inout T) -> ()
   ) {
     var a = a
     var reallocations = 0

--- a/test/1_stdlib/Tuple.swift.gyb
+++ b/test/1_stdlib/Tuple.swift.gyb
@@ -20,7 +20,7 @@ var TupleTestSuite = TestSuite("Tuple")
 func testEquality<A : Equatable, B : Equatable, C : Equatable>(
   _ lhs: (A, B, C), equal: Bool, to rhs: (A, B, C),
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = #file, line: UInt = #line
@@ -94,7 +94,7 @@ enum Ordering : Equatable {
 func testOrdering<A : Comparable, B : Comparable, C : Comparable>(
   _ lhs: (A, B, C), _ ordering: Ordering, _ rhs: (A, B, C),
   //===--- TRACE boilerplate ----------------------------------------------===//
-  @autoclosure _ message: ()->String = "",
+  @autoclosure _ message: () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = #file, line: UInt = #line

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -147,7 +147,7 @@ public func myMap<C : Collection, T>(
 }
 
 @available(*, unavailable, message: "call the 'map()' method on the optional value")
-public func myMap<T, U>(_ x: T?, @noescape _ f: (T)->U) -> U? {
+public func myMap<T, U>(_ x: T?, @noescape _ f: (T) -> U) -> U? {
   fatalError("unavailable function can't be called")
 }
 

--- a/test/Prototypes/CollectionsMoveIndices.swift
+++ b/test/Prototypes/CollectionsMoveIndices.swift
@@ -324,7 +324,7 @@
 // a small number of commonly used algorithms that require that
 // property, and they can be provided as methods on the collection,
 // for example removeAll(in: Range<Index>) and
-// removeAll(_: (Element)->Bool).
+// removeAll(_: (Element) -> Bool).
 //
 // If we were to allow reference-counted indices (basically, the
 // current collections model), then an additional design is possible

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -126,7 +126,7 @@ public func _assertCond(
 /// Prints the message if the body is uncommented; used for
 /// diagnostics.
 @_transparent
-public func _log(@autoclosure _ message: ()->String) {
+public func _log(@autoclosure _ message: () -> String) {
   print(message())
 }
 

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
 
-func foo(f f: (()->())!) {
+func foo(f f: (() -> ())!) {
   var f = f
   f?()
 }

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -23,7 +23,7 @@ func testCall(_ f: (() -> ())?) {
 // CHECK-NEXT: enum $Optional<()>, #Optional.none!enumelt
 // CHECK-NEXT: br bb2
 
-func testAddrOnlyCallResult<T>(_ f: (()->T)?) {
+func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
   var f = f
   var x = f?()
 }

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -72,7 +72,7 @@ typealias D<T1, T2, T3> = MyType<T2, T1>  // expected-note {{'T3' declared as pa
 
 typealias E<T1, T2> = Int  // expected-note {{generic type 'E' declared here}}
 
-typealias F<T1, T2> = T1->T2
+typealias F<T1, T2> = T1 -> T2
 
 // Type alias of type alias.
 typealias G<S1, S2> = A<S1, S2>

--- a/validation-test/stdlib/OpenCLSDKOverlay.swift
+++ b/validation-test/stdlib/OpenCLSDKOverlay.swift
@@ -130,7 +130,7 @@ tests.test("clSetKernelArgsListAPPLE") {
   // Create the compute program from the source buffer
   //
   program = KernelSource.withCString {
-    (p: UnsafePointer<CChar>)->cl_program in
+    (p: UnsafePointer<CChar>) -> cl_program in
     var s: UnsafePointer? = p
     return withUnsafeMutablePointer(&s) {
       return clCreateProgramWithSource(context, 1, $0, nil, &err)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?
- `Type->Type` → `Type -> Type`
- `(t: Type)->Type` → `(t: Type) -> Type`

This is a follow-up to #2166.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
