### PR TITLE
[SILGen] Use the signature of the real UIApplicationMain

### DIFF
--- a/test/Interpreter/SDK/UIApplicationMain.swift
+++ b/test/Interpreter/SDK/UIApplicationMain.swift
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: %target-build-swift %s -o %t/main -parse-as-library
+
+// We aren't yet able to run tests that require a UI context, so just try
+// building with the real SDK for now.
+// DISABLED: %target-run %t/main | FileCheck %s
+
+// REQUIRES: OS=ios
+
+import UIKit
+
+@UIApplicationMain
+class MyDelegate : NSObject, UIApplicationDelegate {
+  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    // CHECK: launched
+    print("launched")
+    exit(EXIT_SUCCESS)
+  }
+}

--- a/test/SILGen/Inputs/UIApplicationMain-helper.swift
+++ b/test/SILGen/Inputs/UIApplicationMain-helper.swift
@@ -1,0 +1,12 @@
+import Foundation
+import UIKit
+
+public func publicFoo(x: AnyObject.Type) -> String {
+  return NSStringFromClass(x)
+}
+
+public func publicBar() {
+  UIApplicationMain(0, nil, nil, nil)
+}
+
+

--- a/test/SILGen/NSApplicationMain.swift
+++ b/test/SILGen/NSApplicationMain.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend -emit-silgen -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s | FileCheck %s -check-prefix=IR
 
+// RUN: %target-swift-frontend -emit-silgen -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -D REFERENCE | FileCheck %s -check-prefix=IR
+
 // REQUIRES: OS=macosx
 
 import Foundation
@@ -14,8 +17,10 @@ class MyDelegate: NSApplicationDelegate {}
 // IR-LABEL: define{{( protected)?}} i32 @main
 // IR:            call i32 @NSApplicationMain
 
+#if REFERENCE
 // Ensure that we coexist with normal references to the functions we
 // implicitly reference in the synthesized main.
 func bar() {
   NSApplicationMain(Process.argc, Process.unsafeArgv)
 }
+#endif

--- a/test/SILGen/UIApplicationMain.swift
+++ b/test/SILGen/UIApplicationMain.swift
@@ -4,6 +4,18 @@
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s | FileCheck %s
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %s | FileCheck %s -check-prefix=IR
 
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s -D REFERENCE | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %s -D REFERENCE | FileCheck %s -check-prefix=IR
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library -primary-file %s %S/Inputs/UIApplicationMain-helper.swift -module-name test | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library -primary-file %s %S/Inputs/UIApplicationMain-helper.swift -module-name test | FileCheck %s -check-prefix=IR
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s %S/Inputs/UIApplicationMain-helper.swift -module-name test | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %s %S/Inputs/UIApplicationMain-helper.swift -module-name test | FileCheck %s -check-prefix=IR
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %S/Inputs/UIApplicationMain-helper.swift %s -module-name test | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %S/Inputs/UIApplicationMain-helper.swift %s -module-name test | FileCheck %s -check-prefix=IR
+
 // REQUIRES: OS=ios
 // REQUIRES: objc_interop
 
@@ -20,9 +32,12 @@ class MyDelegate : UIApplicationDelegate {}
 
 // Ensure that we coexist with normal references to the functions we
 // implicitly reference in the synthesized main.
+#if REFERENCE
 func foo(x: AnyObject.Type) -> String {
   return NSStringFromClass(x)
 }
+
 func bar() {
   UIApplicationMain(0, nil, nil, nil)
 }
+#endif


### PR DESCRIPTION
...instead of trying to guess it ourselves.

My previous attempt at this (part of the optional pointers work, bc83940) made a critical mistake because our only test case _also_ referenced UIApplicationMain directly. I've made the test case test several more situations, and also added what _would_ be an execution test if our simulator testing handled UI-based tests.

rdar://problem/25712303

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
