### PR TITLE
[gardening] Remove unused function swift_reflection_infoForChild(…)

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -81,13 +81,3 @@ swift_reflection_infoForTypeRef(SwiftReflectionContextRef ContextRef,
   auto TR = reinterpret_cast<TypeRef *>(OpaqueTypeRef);
   return Context->getInfoForTypeRef(TR);
 }
-
-swift_childinfo_t
-swift_reflection_infoForChild(SwiftReflectionContextRef ContextRef,
-                              swift_typeref_t OpaqueTypeRef,
-                              unsigned Index) {
-  auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
-  auto TR = reinterpret_cast<TypeRef *>(OpaqueTypeRef);
-  return Context->getInfoForChild(TR, Index);
-}
-


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

`swift_reflection_infoForChild` appears to be unused. @bitjammer - please review, I might be mistaken here :-)

Before this commit:

```
$ git grep infoForChild
stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp:swift_reflection_infoForChild(SwiftReflectionContextRef ContextRef,
$
```

After this commit:

```
$ git grep infoForChild
$
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
