### PR TITLE
[SR-237] Move stdlib deployment targets to Python

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -306,6 +306,12 @@ details of the setups of other systems or automated environments.""")
              "target. The built LLVM and Clang will be used to compile Swift "
              "for the cross-compilation targets.",
         default=swift_build_support.targets.host_target())
+    targets_group.add_argument(
+        "--stdlib-deployment-targets",
+        help="list of targets to compile or cross-compile the Swift standard "
+             "library for. %(default)s by default.",
+        nargs="*",
+        default=swift_build_support.targets.stdlib_deployment_targets())
 
     projects_group = parser.add_argument_group(
         title="Options to select projects")
@@ -756,6 +762,7 @@ the number of parallel build jobs to use""",
         '--darwin-xcrun-toolchain',
         '--cmake',
         '--host-target',
+        '--stdlib-deployment-targets',
         '--skip-build',
         '--show-sdks',
         '--install-prefix',
@@ -772,7 +779,7 @@ the number of parallel build jobs to use""",
         '--skip-test-watchos-host',
     ]))
 
-    if args.host_target is None:
+    if args.host_target is None or args.stdlib_deployment_targets is None:
         print_with_argv0("Unknown operating system.")
         return 1
 
@@ -1110,6 +1117,8 @@ the number of parallel build jobs to use""",
         "--build-dir", build_dir,
         "--install-prefix", os.path.abspath(args.install_prefix),
         "--host-target", args.host_target,
+        "--stdlib-deployment-targets",
+        " ".join(args.stdlib_deployment_targets),
         "--host-cc", host_clang.cc,
         "--host-cxx", host_clang.cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -186,6 +186,7 @@ KNOWN_SETTINGS=(
     install-libdispatch         ""               "whether to install libdispatch"
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
     host-target                 ""               "The host target. LLVM, Clang, and Swift will be built for this target. The built LLVM and Clang will be used to compile Swift for the cross-compilation targets. **This argument is required**"
+    stdlib-deployment-targets   ""               "space-separated list of targets to compile or cross-compile the Swift standard library for"
     cross-compile-tools-deployment-targets ""    "space-separated list of targets to cross-compile host Swift tools for"
     skip-merge-lipo-cross-compile-tools ""       "set to skip running merge-lipo after installing cross-compiled host Swift tools"
     darwin-deployment-version-osx     "10.9"     "minimum deployment target version for OS X"
@@ -897,76 +898,6 @@ function is_cross_tools_deployment_target() {
     done
 }
 
-# A list of deployment targets that we compile or cross-compile the
-# Swift standard library for.
-STDLIB_DEPLOYMENT_TARGETS=()
-case "$(uname -s -m)" in
-    Linux\ x86_64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-x86_64"
-            "android-armv7"
-        )
-        ;;
-    Linux\ armv6*)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-armv6"
-        )
-        ;;
-    Linux\ armv7*)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-armv7"
-        )
-        ;;
-    Linux\ aarch64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-aarch64"
-        )
-        ;;
-    Linux\ ppc64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-powerpc64"
-        )
-        ;;
-    Linux\ ppc64le)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "linux-powerpc64le"
-        )
-        ;;
-    Darwin\ x86_64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "macosx-x86_64"
-            "iphonesimulator-i386"
-            "iphonesimulator-x86_64"
-            "appletvsimulator-x86_64"
-            "watchsimulator-i386"
-
-            # Put iOS native targets last so that we test them last (it takes a
-            # long time).
-            "iphoneos-arm64"
-            "iphoneos-armv7"
-            "appletvos-arm64"
-            "watchos-armv7k"
-        )
-        ;;
-
-    FreeBSD\ amd64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "freebsd-x86_64"
-        )
-        ;;
-
-    CYGWIN_NT-10.0\ x86_64)
-        STDLIB_DEPLOYMENT_TARGETS=(
-            "cygwin-x86_64"
-        )
-        ;;
-
-    *)
-        echo "Unknown operating system"
-        exit 1
-        ;;
-esac
-
 #
 # Calculate source directories for each product.
 #
@@ -1058,6 +989,7 @@ SWIFT_STDLIB_TARGETS=()
 SWIFT_BENCHMARK_TARGETS=()
 SWIFT_RUN_BENCHMARK_TARGETS=()
 SWIFT_TEST_TARGETS=()
+STDLIB_DEPLOYMENT_TARGETS=($STDLIB_DEPLOYMENT_TARGETS)
 for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
     build_for_this_target=1
     test_this_target=1

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -51,6 +51,57 @@ def host_target():
     return None
 
 
+def stdlib_deployment_targets():
+    """
+    Return deployment targets for the Swift stdlib, based on the host machine.
+    If the host machine is not one of the recognized ones, return None.
+    """
+    system = platform.system()
+    machine = platform.machine()
+
+    if system == 'Linux':
+        if machine == 'x86_64':
+            return [
+                'linux-x86_64',
+                'android-armv7',
+            ]
+        elif machine.startswith('armv6'):
+            # linux-armv6* is canonicalized to 'linux-armv6'
+            return ['linux-armv6']
+        elif machine.startswith('armv7'):
+            # linux-armv7* is canonicalized to 'linux-armv7'
+            return ['linux-armv7']
+        elif machine == 'aarch64':
+            return ['linux-aarch64']
+        elif machine == 'ppc64':
+            return ['linux-ppc64']
+        elif machine == 'ppc64le':
+            return ['linux-ppc64le']
+    elif system == 'Darwin':
+        if machine == 'x86_64':
+            return [
+                'macosx-x86_64',
+                'iphonesimulator-i386',
+                'iphonesimulator-x86_64',
+                'appletvsimulator-x86_64',
+                'watchsimulator-i386',
+                # Put iOS native targets last so that we test them last
+                # (it takes a long time).
+                'iphoneos-arm64',
+                'iphoneos-armv7',
+                'appletvos-arm64',
+                'watchos-armv7k',
+            ]
+    elif system == 'FreeBSD':
+        if machine == 'amd64':
+            return ['freebsd-x86_64']
+    elif system == 'CYGWIN_NT-10.0':
+        if machine == 'x86_64':
+            return ['cygwin-x86_64']
+
+    return None
+
+
 def install_prefix():
     """
     Returns the default path at which built Swift products (like bin, lib,


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Migrate the logic that determines which platforms to build the stdlib for to Python. This applies both as an effort to migrate more of the build script to Python (https://bugs.swift.org/browse/SR-237), but also as a means of splitting up the work necessary to cross-compile the Swift stdlib from OS X to Linux (#1398).
#### Resolved bug number: ([SR-237](https://bugs.swift.org/browse/SR-237))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
