### PR TITLE
Added the -frontend parameter to the documentation 

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -171,7 +171,7 @@ Substitutions that start with ``%target`` configure the compiler for building
 code for the target that is not the build machine:
 
 * ``%target-parse-verify-swift``: parse and type check the current Swift file
-  for the target platform and verify diagnostics, like ``swift -parse -verify
+  for the target platform and verify diagnostics, like ``swift -frontend -parse -verify
   %s``.
 
   Use this substitution for testing semantic analysis in the compiler.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

It seems like the testing documentation was out of sync with the actual implementation. 
To run the test started by the `%target-parse-verify-swift` manually you need to add the `-frontend` option to `swift -parse -verify`. This updates the documentation to include the parameter.
