### PR TITLE
Restore const-ness of TypeRefs

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -72,55 +72,58 @@ public:
 /// building TypeRefs.
 class TypeRefBuilder {
 public:
-  using Type = TypeRef*;
+  using Type = const TypeRef *;
 
 private:
-  std::vector<std::unique_ptr<TypeRef>> TypeRefPool;
+  std::vector<std::unique_ptr<const TypeRef>> TypeRefPool;
 
 public:
   template <typename TypeRefTy, typename... Args>
   TypeRefTy *make_typeref(Args... args) {
     auto TR = new TypeRefTy(::std::forward<Args>(args)...);
-    TypeRefPool.push_back(std::unique_ptr<TypeRef>(TR));
+    TypeRefPool.push_back(std::unique_ptr<const TypeRef>(TR));
     return TR;
   }
 
-  BuiltinTypeRef *createBuiltinType(const std::string &mangledName) {
+  const BuiltinTypeRef *createBuiltinType(const std::string &mangledName) {
     return BuiltinTypeRef::create(*this, mangledName);
   }
 
-  NominalTypeRef *createNominalType(const std::string &mangledName,
-                                    TypeRef *parent) {
+  const NominalTypeRef *createNominalType(const std::string &mangledName,
+                                    const TypeRef *parent) {
     return NominalTypeRef::create(*this, mangledName, parent);
   }
 
-  BoundGenericTypeRef *createBoundGenericType(const std::string &mangledName,
-                                        const std::vector<TypeRef *> &args,
-                                              TypeRef *parent) {
+  const BoundGenericTypeRef *
+  createBoundGenericType(const std::string &mangledName,
+                         const std::vector<const TypeRef *> &args,
+                         const TypeRef *parent) {
     return BoundGenericTypeRef::create(*this, mangledName, args, parent);
   }
 
-  TupleTypeRef *createTupleType(const std::vector<TypeRef *> &elements,
-                                bool isVariadic) {
+  const TupleTypeRef *
+  createTupleType(const std::vector<const TypeRef *> &elements,
+                  bool isVariadic) {
     return TupleTypeRef::create(*this, elements, isVariadic);
   }
 
-  FunctionTypeRef *createFunctionType(const std::vector<TypeRef *> &args,
-                                      const std::vector<bool> &inOutArgs,
-                                      TypeRef *result,
-                                      FunctionTypeFlags flags) {
+  const FunctionTypeRef *
+  createFunctionType(const std::vector<const TypeRef *> &args,
+                     const std::vector<bool> &inOutArgs,
+                     const TypeRef *result,
+                     FunctionTypeFlags flags) {
     // FIXME: don't ignore inOutArgs
     // FIXME: don't ignore flags
     return FunctionTypeRef::create(*this, args, result);
   }
 
-  ProtocolTypeRef *createProtocolType(const std::string &moduleName,
+  const ProtocolTypeRef *createProtocolType(const std::string &moduleName,
                                       const std::string &protocolName) {
     return ProtocolTypeRef::create(*this, moduleName, protocolName);
   }
 
-  ProtocolCompositionTypeRef *
-  createProtocolCompositionType(const std::vector<TypeRef*> &protocols) {
+  const ProtocolCompositionTypeRef *
+  createProtocolCompositionType(const std::vector<const TypeRef*> &protocols) {
     for (auto protocol : protocols) {
       if (!isa<ProtocolTypeRef>(protocol))
         return nullptr;
@@ -128,49 +131,51 @@ public:
     return ProtocolCompositionTypeRef::create(*this, protocols);
   }
 
-  ExistentialMetatypeTypeRef *
-  createExistentialMetatypeType(TypeRef *instance) {
+  const ExistentialMetatypeTypeRef *
+  createExistentialMetatypeType(const TypeRef *instance) {
     return ExistentialMetatypeTypeRef::create(*this, instance);
   }
 
-  MetatypeTypeRef *createMetatypeType(TypeRef *instance) {
+  const MetatypeTypeRef *createMetatypeType(const TypeRef *instance) {
     return MetatypeTypeRef::create(*this, instance);
   }
 
-  GenericTypeParameterTypeRef *
+  const GenericTypeParameterTypeRef *
   createGenericTypeParameterType(unsigned depth, unsigned index) {
     return GenericTypeParameterTypeRef::create(*this, depth, index);
   }
 
-  DependentMemberTypeRef *createDependentMemberType(const std::string &member,
-                                                    TypeRef *base,
-                                                    TypeRef *protocol) {
+  const DependentMemberTypeRef *
+  createDependentMemberType(const std::string &member,
+                            const TypeRef *base,
+                            const TypeRef *protocol) {
     if (!isa<ProtocolTypeRef>(protocol))
       return nullptr;
     return DependentMemberTypeRef::create(*this, member, base, protocol);
   }
 
-  UnownedStorageTypeRef *createUnownedStorageType(TypeRef *base) {
+  const UnownedStorageTypeRef *createUnownedStorageType(const TypeRef *base) {
     return UnownedStorageTypeRef::create(*this, base);
   }
 
-  UnmanagedStorageTypeRef *createUnmanagedStorageType(TypeRef *base) {
+  const UnmanagedStorageTypeRef *
+  createUnmanagedStorageType(const TypeRef *base) {
     return UnmanagedStorageTypeRef::create(*this, base);
   }
 
-  WeakStorageTypeRef *createWeakStorageType(TypeRef *base) {
+  const WeakStorageTypeRef *createWeakStorageType(const TypeRef *base) {
     return WeakStorageTypeRef::create(*this, base);
   }
 
-  ObjCClassTypeRef *getUnnamedObjCClassType() {
+  const ObjCClassTypeRef *getUnnamedObjCClassType() {
     return ObjCClassTypeRef::getUnnamed();
   }
 
-  ForeignClassTypeRef *getUnnamedForeignClassType() {
+  const ForeignClassTypeRef *getUnnamedForeignClassType() {
     return ForeignClassTypeRef::getUnnamed();
   }
 
-  OpaqueTypeRef *getOpaqueType() {
+  const OpaqueTypeRef *getOpaqueType() {
     return OpaqueTypeRef::get();
   }
 };
@@ -327,7 +332,7 @@ public:
     OS << '\n';
   }
 
-  TypeRef *
+  const TypeRef *
   getDependentMemberTypeRef(const std::string &MangledTypeName,
                             const DependentMemberTypeRef *DependentMember) {
 
@@ -344,8 +349,8 @@ public:
     return nullptr;
   }
 
-  std::vector<std::pair<std::string, TypeRef *>>
-  getFieldTypeRefs(TypeRef *TR) {
+  std::vector<std::pair<std::string, const TypeRef *>>
+  getFieldTypeRefs(const TypeRef *TR) {
     std::string MangledName;
     if (auto N = dyn_cast<NominalTypeRef>(TR))
       MangledName = N->getMangledName();
@@ -356,7 +361,7 @@ public:
 
     auto Subs = TR->getSubstMap();
 
-    std::vector<std::pair<std::string, TypeRef *>> Fields;
+    std::vector<std::pair<std::string, const TypeRef *>> Fields;
     for (auto Info : ReflectionInfos) {
       for (auto &FieldDescriptor : Info.fieldmd) {
         auto CandidateMangledName = FieldDescriptor.MangledTypeName.get();
@@ -389,7 +394,7 @@ public:
     return Fields;
   }
 
-  std::vector<std::pair<std::string, TypeRef *>>
+  std::vector<std::pair<std::string, const TypeRef *>>
   getFieldTypeRefs(StoredPointer MetadataAddress) {
     auto TR = readTypeFromMetadata(MetadataAddress);
     return getFieldTypeRefs(TR);

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -46,7 +46,7 @@ class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
     return OS;
   }
 
-  void printRec(TypeRef *typeRef) {
+  void printRec(const TypeRef *typeRef) {
     OS << "\n";
 
     Indent += 2;
@@ -58,14 +58,14 @@ public:
   PrintTypeRef(std::ostream &OS, unsigned Indent)
   : OS(OS), Indent(Indent) {}
 
-  void visitBuiltinTypeRef(BuiltinTypeRef *B) {
+  void visitBuiltinTypeRef(const BuiltinTypeRef *B) {
     printHeader("builtin");
     auto demangled = Demangle::demangleTypeAsString(B->getMangledName());
     printField("", demangled);
     OS << ')';
   }
 
-  void visitNominalTypeRef(NominalTypeRef *N) {
+  void visitNominalTypeRef(const NominalTypeRef *N) {
     if (N->isStruct())
       printHeader("struct");
     else if (N->isEnum())
@@ -81,7 +81,7 @@ public:
     OS << ')';
   }
 
-  void visitBoundGenericTypeRef(BoundGenericTypeRef *BG) {
+  void visitBoundGenericTypeRef(const BoundGenericTypeRef *BG) {
     if (BG->isStruct())
       printHeader("bound-generic struct");
     else if (BG->isEnum())
@@ -100,14 +100,14 @@ public:
     OS << ')';
   }
 
-  void visitTupleTypeRef(TupleTypeRef *T) {
+  void visitTupleTypeRef(const TupleTypeRef *T) {
     printHeader("tuple");
     for (auto element : T->getElements())
       printRec(element);
     OS << ')';
   }
 
-  void visitFunctionTypeRef(FunctionTypeRef *F) {
+  void visitFunctionTypeRef(const FunctionTypeRef *F) {
     printHeader("function");
     for (auto Arg : F->getArguments())
       printRec(Arg);
@@ -115,40 +115,40 @@ public:
     OS << ')';
   }
 
-  void visitProtocolTypeRef(ProtocolTypeRef *P) {
+  void visitProtocolTypeRef(const ProtocolTypeRef *P) {
     printHeader("protocol");
     printField("module", P->getModuleName());
     printField("name", P->getName());
     OS << ')';
   }
 
-  void visitProtocolCompositionTypeRef(ProtocolCompositionTypeRef *PC) {
+  void visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     printHeader("protocol-composition");
     for (auto protocol : PC->getProtocols())
       printRec(protocol);
     OS << ')';
   }
 
-  void visitMetatypeTypeRef(MetatypeTypeRef *M) {
+  void visitMetatypeTypeRef(const MetatypeTypeRef *M) {
     printHeader("metatype");
     printRec(M->getInstanceType());
     OS << ')';
   }
 
-  void visitExistentialMetatypeTypeRef(ExistentialMetatypeTypeRef *EM) {
+  void visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
     printHeader("existential-metatype");
     printRec(EM->getInstanceType());
     OS << ')';
   }
 
-  void visitGenericTypeParameterTypeRef(GenericTypeParameterTypeRef *GTP){
+  void visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP){
     printHeader("generic-type-parameter");
     printField("depth", GTP->getDepth());
     printField("index", GTP->getIndex());
     OS << ')';
   }
 
-  void visitDependentMemberTypeRef(DependentMemberTypeRef *DM) {
+  void visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
     printHeader("dependent-member");
     printRec(DM->getProtocol());
     printRec(DM->getBase());
@@ -156,39 +156,39 @@ public:
     OS << ')';
   }
 
-  void visitForeignClassTypeRef(ForeignClassTypeRef *F) {
+  void visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
     printHeader("foreign");
     if (!F->getName().empty())
       printField("name", F->getName());
     OS << ')';
   }
 
-  void visitObjCClassTypeRef(ObjCClassTypeRef *OC) {
+  void visitObjCClassTypeRef(const ObjCClassTypeRef *OC) {
     printHeader("objective-c-class");
     if (!OC->getName().empty())
       printField("name", OC->getName());
     OS << ')';
   }
 
-  void visitUnownedStorageTypeRef(UnownedStorageTypeRef *US) {
+  void visitUnownedStorageTypeRef(const UnownedStorageTypeRef *US) {
     printHeader("unowned-storage");
     printRec(US->getType());
     OS << ')';
   }
 
-  void visitWeakStorageTypeRef(WeakStorageTypeRef *WS) {
+  void visitWeakStorageTypeRef(const WeakStorageTypeRef *WS) {
     printHeader("weak-storage");
     printRec(WS->getType());
     OS << ')';
   }
 
-  void visitUnmanagedStorageTypeRef(UnmanagedStorageTypeRef *US) {
+  void visitUnmanagedStorageTypeRef(const UnmanagedStorageTypeRef *US) {
     printHeader("weak-storage");
     printRec(US->getType());
     OS << ')';
   }
 
-  void visitOpaqueTypeRef(OpaqueTypeRef *O) {
+  void visitOpaqueTypeRef(const OpaqueTypeRef *O) {
     printHeader("opaque");
     OS << ')';
   }
@@ -196,15 +196,15 @@ public:
 
 struct TypeRefIsConcrete
   : public TypeRefVisitor<TypeRefIsConcrete, bool> {
-  bool visitBuiltinTypeRef(BuiltinTypeRef *B) {
+  bool visitBuiltinTypeRef(const BuiltinTypeRef *B) {
     return true;
   }
 
-  bool visitNominalTypeRef(NominalTypeRef *N) {
+  bool visitNominalTypeRef(const NominalTypeRef *N) {
     return true;
   }
 
-  bool visitBoundGenericTypeRef(BoundGenericTypeRef *BG) {
+  bool visitBoundGenericTypeRef(const BoundGenericTypeRef *BG) {
     std::vector<TypeRef *> GenericParams;
     for (auto Param : BG->getGenericParams())
       if (!visit(Param))
@@ -212,7 +212,7 @@ struct TypeRefIsConcrete
     return true;
   }
 
-  bool visitTupleTypeRef(TupleTypeRef *T) {
+  bool visitTupleTypeRef(const TupleTypeRef *T) {
     for (auto Element : T->getElements()) {
       if (!visit(Element))
         return false;
@@ -220,7 +220,7 @@ struct TypeRefIsConcrete
     return true;
   }
 
-  bool visitFunctionTypeRef(FunctionTypeRef *F) {
+  bool visitFunctionTypeRef(const FunctionTypeRef *F) {
     std::vector<TypeRef *> SubstitutedArguments;
     for (auto Argument : F->getArguments())
       if (!visit(Argument))
@@ -228,93 +228,93 @@ struct TypeRefIsConcrete
     return visit(F->getResult());
   }
 
-  bool visitProtocolTypeRef(ProtocolTypeRef *P) {
+  bool visitProtocolTypeRef(const ProtocolTypeRef *P) {
     return true;
   }
 
   bool
-  visitProtocolCompositionTypeRef(ProtocolCompositionTypeRef *PC) {
+  visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     for (auto Protocol : PC->getProtocols())
       if (!visit(Protocol))
         return false;
     return true;
   }
 
-  bool visitMetatypeTypeRef(MetatypeTypeRef *M) {
+  bool visitMetatypeTypeRef(const MetatypeTypeRef *M) {
     return visit(M->getInstanceType());
   }
 
   bool
-  visitExistentialMetatypeTypeRef(ExistentialMetatypeTypeRef *EM) {
+  visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
     return visit(EM->getInstanceType());
   }
 
   bool
-  visitGenericTypeParameterTypeRef(GenericTypeParameterTypeRef *GTP){
+  visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP){
     return false;
   }
 
   bool
-  visitDependentMemberTypeRef(DependentMemberTypeRef *DM) {
+  visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
     return visit(DM->getBase());
   }
 
-  bool visitForeignClassTypeRef(ForeignClassTypeRef *F) {
+  bool visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
     return true;
   }
 
-  bool visitObjCClassTypeRef(ObjCClassTypeRef *OC) {
+  bool visitObjCClassTypeRef(const ObjCClassTypeRef *OC) {
     return true;
   }
   
-  bool visitOpaqueTypeRef(OpaqueTypeRef *Op) {
+  bool visitOpaqueTypeRef(const OpaqueTypeRef *Op) {
     return true;
   }
 
-  bool visitUnownedStorageTypeRef(UnownedStorageTypeRef *US) {
+  bool visitUnownedStorageTypeRef(const UnownedStorageTypeRef *US) {
     return visit(US->getType());
   }
 
-  bool visitWeakStorageTypeRef(WeakStorageTypeRef *WS) {
+  bool visitWeakStorageTypeRef(const WeakStorageTypeRef *WS) {
     return visit(WS->getType());
   }
 
-  bool visitUnmanagedStorageTypeRef(UnmanagedStorageTypeRef *US) {
+  bool visitUnmanagedStorageTypeRef(const UnmanagedStorageTypeRef *US) {
     return visit(US->getType());
   }
 };
 
-ForeignClassTypeRef *
+const ForeignClassTypeRef *
 ForeignClassTypeRef::UnnamedSingleton = new ForeignClassTypeRef("");
 
-ForeignClassTypeRef *ForeignClassTypeRef::getUnnamed() {
+const ForeignClassTypeRef *ForeignClassTypeRef::getUnnamed() {
   return UnnamedSingleton;
 }
 
-ObjCClassTypeRef *
+const ObjCClassTypeRef *
 ObjCClassTypeRef::UnnamedSingleton = new ObjCClassTypeRef("");
 
-ObjCClassTypeRef *ObjCClassTypeRef::getUnnamed() {
+const ObjCClassTypeRef *ObjCClassTypeRef::getUnnamed() {
   return UnnamedSingleton;
 }
 
-OpaqueTypeRef *
+const OpaqueTypeRef *
 OpaqueTypeRef::Singleton = new OpaqueTypeRef();
 
-OpaqueTypeRef *OpaqueTypeRef::get() {
+const OpaqueTypeRef *OpaqueTypeRef::get() {
   return Singleton;
 }
 
-void TypeRef::dump() {
+void TypeRef::dump() const {
   dump(std::cerr);
 }
 
-void TypeRef::dump(std::ostream &OS, unsigned Indent) {
+void TypeRef::dump(std::ostream &OS, unsigned Indent) const {
   PrintTypeRef(OS, Indent).visit(this);
   OS << std::endl;
 }
 
-bool TypeRef::isConcrete() {
+bool TypeRef::isConcrete() const {
   return TypeRefIsConcrete().visit(this);
 }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -65,7 +65,7 @@ swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
 swift_typeref_t
 swift_reflection_genericArgumentOfTypeRef(swift_typeref_t OpaqueTypeRef,
                                           unsigned Index) {
-  auto TR = reinterpret_cast<TypeRef *>(OpaqueTypeRef);
+  auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
 
   if (auto BG = dyn_cast<BoundGenericTypeRef>(TR)) {
     auto &Params = BG->getGenericParams();
@@ -80,7 +80,7 @@ swift_typeinfo_t
 swift_reflection_infoForTypeRef(SwiftReflectionContextRef ContextRef,
                                 swift_typeref_t OpaqueTypeRef) {
   auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
-  auto TR = reinterpret_cast<TypeRef *>(OpaqueTypeRef);
+  auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
   return Context->getInfoForTypeRef(TR);
 }
 
@@ -89,7 +89,7 @@ swift_reflection_infoForChild(SwiftReflectionContextRef ContextRef,
                               swift_typeref_t OpaqueTypeRef,
                               unsigned Index) {
   auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
-  auto TR = reinterpret_cast<TypeRef *>(OpaqueTypeRef);
+  auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
   return Context->getInfoForChild(TR, Index);
 }
 


### PR DESCRIPTION
We got rid of the last mutating methods on TypeRefs, so let's
make these all const again.
