### PR TITLE
Make getSourceRange/Impl spacing consistent with getStartLoc/Impl and…

### DIFF
--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -91,7 +91,6 @@ template <class T> static SourceRange getSourceRangeImpl(const T *S) {
                 "or getStartLoc()/getEndLoc()");
   return Dispatch<isOverriddenFromStmt(&T::getSourceRange)>::getSourceRange(S);
 }
-
 SourceRange Stmt::getSourceRange() const {
   switch (getKind()) {
 #define STMT(ID, PARENT)                                           \


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… getEndLoc/Impl (NFC)
