### PR TITLE
Sema: Allow ObjC generic extensions to perform @objc operations involving generics.

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -137,6 +137,26 @@ public:
     return CE->getType()->castTo<FunctionType>()->isNoEscape();
   }
 
+  bool isObjC() const {
+    if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      return afd->isObjC();
+    }
+    if (TheFunction.dyn_cast<AbstractClosureExpr *>()) {
+      // Closures are never @objc.
+      return false;
+    }
+    llvm_unreachable("unexpected AnyFunctionRef representation");
+  }
+  
+  SourceLoc getLoc() const {
+    if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      return afd->getLoc();
+    }
+    if (auto ce = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
+      return ce->getLoc();
+    }
+    llvm_unreachable("unexpected AnyFunctionRef representation");
+  }
 };
 
 } // namespace swift

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1061,8 +1061,10 @@ ERROR(extension_protocol_via_typealias,none,
 ERROR(extension_anyobject,none,
       "'AnyObject' protocol cannot be extended", ())
 ERROR(objc_generic_extension_using_type_parameter,none,
-      "Extension of a generic Objective-C class cannot access the class's "
-      "generic parameters", ())
+      "extension of a generic Objective-C class cannot access the class's "
+      "generic parameters at runtime", ())
+NOTE(objc_generic_extension_using_type_parameter_here,none,
+     "generic parameter used here", ())
 
 // Protocols
 ERROR(type_does_not_conform,none,

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -22,9 +22,36 @@ void takeGenericClass(__nullable GenericClass<NSString *> *thing);
 @end
 
 @protocol Pettable
+- (nonnull instancetype)initWithFur:(nonnull id)fur;
+- (nonnull instancetype)other;
++ (nonnull instancetype)adopt;
+- (void)pet;
+- (void)petWith:(nonnull id <Pettable>)other;
+
+@property (nonatomic, class) _Nonnull id<Pettable> needingMostPets;
+
 @end
 
 @interface Animal : NSObject
+- (nonnull instancetype)initWithNoise:(nonnull id)noise;
+- (nonnull instancetype)another;
++ (nonnull instancetype)create;
+
+- (void)eat:(Animal*)prey;
+
+@property (nonatomic, readonly) Animal *_Nonnull buddy;
+
+@property (nonatomic, class) Animal *_Nonnull apexPredator;
+
+- (Animal *_Nonnull)objectAtIndexedSubscript:(NSInteger)i;
+- (void)setObject:(Animal *_Nonnull)x atIndexedSubscript:(NSInteger)i;
+
+@end
+
+@protocol Fungible
+@end
+
+@interface FungibleContainer<T: id<Fungible>> : NSObject
 @end
 
 @interface PettableContainer<T: id<Pettable>> : NSObject

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -596,15 +596,14 @@ public class NonObjCClass { }
   init(fn: Int -> Int) throws { }
 }
 
-@objc class Pet: Pettable {}
-@objc protocol Runcible {}
+@objc class Spoon: Fungible {}
 
 // CHECK-LABEL: @interface UsesImportedGenerics
 @objc class UsesImportedGenerics {
   // CHECK: - (GenericClass<id> * _Nonnull)takeAndReturnGenericClass:(GenericClass<NSString *> * _Nullable)x;
   @objc func takeAndReturnGenericClass(_ x: GenericClass<NSString>?) -> GenericClass<AnyObject> { fatalError("") }
-  // CHECK: - (PettableContainer<id <Pettable>> * _Null_unspecified)takeAndReturnPettableContainer:(PettableContainer<Pet *> * _Nonnull)x;
-  @objc func takeAndReturnPettableContainer(_ x: PettableContainer<Pet>) -> PettableContainer<Pettable>! { fatalError("") }
+  // CHECK: - (FungibleContainer<id <Fungible>> * _Null_unspecified)takeAndReturnFungibleContainer:(FungibleContainer<Spoon *> * _Nonnull)x;
+  @objc func takeAndReturnFungibleContainer(_ x: FungibleContainer<Spoon>) -> FungibleContainer<Fungible>! { fatalError("") }
 }
 // CHECK: @end
 


### PR DESCRIPTION
Though the generic type information isn't present, it isn't necessary if we're just invoking other operations from Objective-C. This should allow an extension to use the generic class's own API to some degree, as it would if defined on the nongeneric form.
