### PR TITLE
[GenReflection] Emit associated type reflection metadata via extensions

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2762,6 +2762,8 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 }
 
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
+  ExtensionDecls.push_back(ext);
+
   emitNestedTypeDecls(ext->getMembers());
 
   // Generate a category if the extension either introduces a

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -671,6 +671,9 @@ private:
   SmallVector<CanType, 4> RuntimeResolvableTypes;
   /// Collection of nominal types to generate field metadata records.
   SmallVector<const NominalTypeDecl *, 4> NominalTypeDecls;
+  /// Collection of extensions to generate associated type metadata records
+  /// if they added conformance to a protocol with associated type requirements.
+  SmallVector<const ExtensionDecl *, 4> ExtensionDecls;
   /// List of ExtensionDecls corresponding to the generated
   /// categories.
   SmallVector<ExtensionDecl*, 4> ObjCCategoryDecls;

--- a/test/Reflection/Inputs/Extensions.swift
+++ b/test/Reflection/Inputs/Extensions.swift
@@ -1,0 +1,6 @@
+extension S : P4 {
+  public typealias Result = Int
+  public func getResult() -> Result {
+    return 888
+  }
+}

--- a/test/Reflection/Inputs/Protocols.swift
+++ b/test/Reflection/Inputs/Protocols.swift
@@ -11,6 +11,11 @@ public protocol P3 {
   associatedtype Second
 }
 
+public protocol P4 {
+  associatedtype Result
+  func getResult() -> Result
+}
+
 public protocol ClassBoundP: class {
   associatedtype Inner
 }

--- a/test/Reflection/typeref_decoding.result.txt
+++ b/test/Reflection/typeref_decoding.result.txt
@@ -596,6 +596,41 @@ typealias First = A
 typealias Second = B
 (generic-type-parameter depth=0 index=1)
 
+- TypesToReflect.C4 : TypesToReflect.P1
+typealias Inner = A
+(generic-type-parameter depth=0 index=0)
+
+- TypesToReflect.C4 : TypesToReflect.P2
+typealias Outer = A
+(generic-type-parameter depth=0 index=0)
+
+- TypesToReflect.S4 : TypesToReflect.P1
+typealias Inner = A
+(generic-type-parameter depth=0 index=0)
+
+- TypesToReflect.S4 : TypesToReflect.P2
+typealias Outer = A
+(generic-type-parameter depth=0 index=0)
+
+- TypesToReflect.E4 : TypesToReflect.P1
+typealias Inner = A
+(generic-type-parameter depth=0 index=0)
+
+- TypesToReflect.E4 : TypesToReflect.P2
+typealias Outer = B
+(generic-type-parameter depth=0 index=1)
+
+- TypesToReflect.E4 : TypesToReflect.P3
+typealias First = A
+(generic-type-parameter depth=0 index=0)
+
+typealias Second = B
+(generic-type-parameter depth=0 index=1)
+
+- TypesToReflect.S : TypesToReflect.P4
+typealias Result = Swift.Int
+(struct Swift.Int)
+
 
 BUILTIN TYPES:
 ==============

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,4 +1,4 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift -emit-module -emit-library -module-name TypesToReflect -Xfrontend -enable-reflection-metadata -o %t/libTypesToReflect
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift -emit-module -emit-library -module-name TypesToReflect -Xfrontend -enable-reflection-metadata -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect > %t/typeref_decoding.txt
 // RUN: diff -u %S/typeref_decoding.result.txt %t/typeref_decoding.txt


### PR DESCRIPTION
Don't leave behind conformances gotten through extensions when
emitting associated type reflection metadata.
