### PR TITLE
Add MetadataSourceBuilder, static creation and encoding methods

### DIFF
--- a/include/swift/Reflection/MetadataSource.h
+++ b/include/swift/Reflection/MetadataSource.h
@@ -22,6 +22,7 @@
 #ifndef SWIFT_REFLECTION_METADATASOURCE_H
 #define SWIFT_REFLECTION_METADATASOURCE_H
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/Support/Casting.h"
 
 using llvm::cast;
@@ -39,6 +40,111 @@ enum class MetadataSourceKind {
 
 class MetadataSource {
   MetadataSourceKind Kind;
+
+  static bool decodeNatural(std::string::const_iterator &it,
+                            const std::string::const_iterator &end,
+                            unsigned &result) {
+    auto begin = it;
+    while (it != end) {
+      if (*it >= '0' && *it <= '9')
+        ++it;
+      else
+        break;
+    }
+
+    std::string natural(begin, it);
+    if (natural.empty())
+      return false;
+
+    result = std::stoi(natural);
+    return true;
+  }
+
+  template <typename Allocator>
+  static const MetadataSource *
+  decodeClosureBinding(Allocator &A,
+                       std::string::const_iterator &it,
+                       const std::string::const_iterator &end) {
+    if (it == end)
+      return nullptr;
+
+    if (*it == 'M')
+      ++it;
+    else
+      return nullptr;
+
+    unsigned Index;
+    if (!decodeNatural(it, end, Index))
+      return nullptr;
+    return A.template createClosureBinding(Index);
+  }
+
+  template <typename Allocator>
+  static const MetadataSource *
+  decodeReferenceCapture(Allocator &A,
+                         std::string::const_iterator &it,
+                         const std::string::const_iterator &end) {
+    if (it == end)
+      return nullptr;
+
+    if (*it == 'R')
+      ++it;
+    else
+      return nullptr;
+
+    unsigned Index;
+    if (!decodeNatural(it, end, Index))
+      return nullptr;
+    return A.template createReferenceCapture(Index);
+  }
+
+  template <typename Allocator>
+  static const MetadataSource *
+  decodeGenericArgument(Allocator &A,
+                        std::string::const_iterator &it,
+                        const std::string::const_iterator &end) {
+    if (it == end)
+      return nullptr;
+
+    if (*it == 'G')
+      ++it;
+    else
+      return nullptr;
+
+    unsigned Index;
+    if (!decodeNatural(it, end, Index))
+      return nullptr;
+
+    auto Source = decode(A, it, end);
+    if (!Source)
+      return nullptr;
+
+    if (it == end || *it != '_')
+      return nullptr;
+
+    ++it;
+
+    return A.template createGenericArgument(Index, Source);
+  }
+
+  template <typename Allocator>
+  static const MetadataSource *decode(Allocator &A,
+                                      std::string::const_iterator &it,
+                                      const std::string::const_iterator &end) {
+    if (it == end) return nullptr;
+
+    switch (*it) {
+      case 'M':
+        return decodeClosureBinding(A, it, end);
+      case 'R':
+        return decodeReferenceCapture(A, it, end);
+      case 'G':
+        return decodeGenericArgument(A, it, end);
+      default:
+        return nullptr;
+    }
+  }
+
 public:
   MetadataSource(MetadataSourceKind Kind) : Kind(Kind) {}
 
@@ -48,6 +154,12 @@ public:
 
   void dump() const;
   void dump(std::ostream &OS, unsigned Indent = 0) const;
+  std::string encode() const;
+  template <typename Allocator>
+  static const MetadataSource *decode(Allocator &A, const std::string &str) {
+    auto begin = str.begin();
+    return MetadataSource::decode<Allocator>(A, begin, str.end());
+  }
 
   virtual ~MetadataSource() = default;
 };
@@ -59,8 +171,15 @@ class ClosureBindingMetadataSource final : public MetadataSource {
   unsigned Index;
 
 public:
-  ClosureBindingMetadataSource(unsigned Index) :
-    MetadataSource(MetadataSourceKind::ClosureBinding) {}
+
+  ClosureBindingMetadataSource(unsigned Index)
+    : MetadataSource(MetadataSourceKind::ClosureBinding), Index(Index) {}
+
+  template <typename Allocator>
+  static const ClosureBindingMetadataSource *
+  create(Allocator &A, unsigned Index) {
+    return A.template make_source<ClosureBindingMetadataSource>(Index);
+  }
 
   unsigned getIndex() const {
     return Index;
@@ -75,9 +194,16 @@ public:
 /// be followed to the heap instance's data, then its metadata pointer.
 class ReferenceCaptureMetadataSource final : public MetadataSource {
   unsigned Index;
+
 public:
-  ReferenceCaptureMetadataSource(unsigned Index):
-    MetadataSource(MetadataSourceKind::ReferenceCapture) {}
+  ReferenceCaptureMetadataSource(unsigned Index)
+    : MetadataSource(MetadataSourceKind::ReferenceCapture), Index(Index) {}
+
+  template <typename Allocator>
+  static const ReferenceCaptureMetadataSource *
+  create(Allocator &A, unsigned Index) {
+    return A.template make_source<ReferenceCaptureMetadataSource>(Index);
+  }
 
   unsigned getIndex() const {
     return Index;
@@ -105,6 +231,12 @@ public:
     : MetadataSource(MetadataSourceKind::GenericArgument),
       Index(Index),
       Source(Source) {}
+
+  template <typename Allocator>
+  static const GenericArgumentMetadataSource *
+  create(Allocator &A, unsigned Index, const MetadataSource *Source) {
+    return A.template make_source<GenericArgumentMetadataSource>(Index, Source);
+  }
 
   unsigned getIndex() const {
     return Index;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -45,6 +45,7 @@ if(SWIFT_BUILD_TOOLS)
   add_subdirectory(Driver)
   add_subdirectory(IDE)
   add_subdirectory(Parse)
+  add_subdirectory(Reflection)
   add_subdirectory(SwiftDemangle)
 
   if(SWIFT_BUILD_SDK_OVERLAY)

--- a/unittests/Reflection/CMakeLists.txt
+++ b/unittests/Reflection/CMakeLists.txt
@@ -1,0 +1,15 @@
+if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
+   ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
+  set(PLATFORM_TARGET_LINK_LIBRARIES)
+
+  list(APPEND PLATFORM_TARGET_LINK_LIBRARIES
+    swiftReflection${SWIFT_PRIMARY_VARIANT_SUFFIX})
+
+  add_swift_unittest(SwiftReflectionTests
+    MetadataSource.cpp)
+
+  target_link_libraries(SwiftReflectionTests
+    swiftReflection${SWIFT_PRIMARY_VARIANT_SUFFIX}
+    ${PLATFORM_TARGET_LINK_LIBRARIES})
+endif()
+

--- a/unittests/Reflection/MetadataSource.cpp
+++ b/unittests/Reflection/MetadataSource.cpp
@@ -1,0 +1,53 @@
+#include "swift/Reflection/ReflectionContext.h"
+#include "swift/Reflection/MetadataSource.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace reflection;
+
+TEST(Reflection, MetadataSourceEncodingRoundTrip) {
+  MetadataSourceBuilder Builder;
+
+  auto CB = Builder.createClosureBinding(123);
+  CB->dump();
+  auto CB_encoded = CB->encode();
+  std::cerr << "Encoded as: " << CB_encoded << std::endl;
+  auto CB_MS_decoded = MetadataSource::decode(Builder, CB_encoded);
+  CB_MS_decoded->dump();
+  auto CB_decoded = cast<ClosureBindingMetadataSource>(CB_MS_decoded);
+
+  EXPECT_EQ(CB->getIndex(), CB_decoded->getIndex());
+
+  std::cerr << std::endl;
+
+  auto RC = Builder.createReferenceCapture(123);
+  RC->dump();
+  auto RC_encoded = RC->encode();
+  std::cerr << "Encoded as: " <<  RC_encoded << std::endl;
+  auto RC_MS_decoded = MetadataSource::decode(Builder, RC_encoded);
+  RC_MS_decoded->dump();
+  auto RC_decoded = cast<ReferenceCaptureMetadataSource>(RC_MS_decoded);
+
+  EXPECT_EQ(RC->getIndex(), RC_decoded->getIndex());
+
+  std::cerr << std::endl;
+
+  auto GA_CB = Builder.createGenericArgument(0, CB);
+  GA_CB->dump();
+  auto GA_GA_CB = Builder.createGenericArgument(1, GA_CB);
+  auto GA_encoded = GA_GA_CB->encode();
+  std::cerr << "Encoded as: " << GA_encoded << std::endl;
+  auto GA_MS_decoded = MetadataSource::decode(Builder, GA_encoded);
+  GA_MS_decoded->dump();
+  auto GA_decoded = cast<GenericArgumentMetadataSource>(GA_MS_decoded);
+
+  EXPECT_EQ(GA_GA_CB->getIndex(), GA_decoded->getIndex());
+
+  std::cerr << std::endl;
+
+  auto GA_GA_decoded = cast<GenericArgumentMetadataSource>(GA_decoded->getSource());
+
+  EXPECT_EQ(GA_CB->getIndex(), GA_GA_decoded->getIndex());
+
+  std::cerr << std::endl;
+}


### PR DESCRIPTION
Create a builder divorced from the ReflectionContext so that
MetadataSources can be created in other contexts, such as emitting
private heap metadata during IRGen, where we'll have to record the
layout of captures and how to get metadata for generic arguments in
order to construct typerefs of the captures, etc.

Also add an encoder/decoder system for MetadataSources for when
we start serializing these into capture descriptors.
