### PR TITLE
[build-script] Remove unused cmake options from Swift configuration.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1564,32 +1564,8 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             echo "${product}: using standard linker"
         fi
 
-        PRODUCT=$(toupper ${product})
         llvm_build_dir=$(build_directory ${deployment_target} llvm)
         module_cache="${build_dir}/module-cache"
-        swift_cmake_options=(
-            "${swift_cmake_options[@]}"
-            -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}"
-            -DLLVM_CONFIG:PATH="$(build_directory_bin ${deployment_target} llvm)/llvm-config"
-            -D${PRODUCT}_PATH_TO_CLANG_SOURCE:PATH="${CLANG_SOURCE_DIR}"
-            -D${PRODUCT}_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
-            -D${PRODUCT}_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SOURCE_DIR}"
-            -D${PRODUCT}_PATH_TO_LLVM_BUILD:PATH="${llvm_build_dir}"
-            -D${PRODUCT}_PATH_TO_CMARK_SOURCE:PATH="${CMARK_SOURCE_DIR}"
-            -D${PRODUCT}_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${deployment_target} cmark)"
-        )
-
-        if [[ "${CMAKE_GENERATOR}" == "Xcode" ]] ; then
-            swift_cmake_options=(
-                "${swift_cmake_options[@]-}"
-                -D${PRODUCT}_CMARK_LIBRARY_DIR:PATH=$(build_directory ${deployment_target} cmark)/src/${CMARK_BUILD_TYPE}
-            )
-        else
-            swift_cmake_options=(
-                "${swift_cmake_options[@]-}"
-                -D${PRODUCT}_CMARK_LIBRARY_DIR:PATH=$(build_directory ${deployment_target} cmark)/src
-            )
-        fi
 
         case ${product} in
             cmark)
@@ -1747,8 +1723,32 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     -DSWIFT_ENABLE_LTO:BOOL=$(true_false "${SWIFT_ENABLE_LTO}")
                     -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=$(true_false "${BUILD_RUNTIME_WITH_HOST_COMPILER}")
                     "${swift_cmake_options[@]}"
-                    "${SWIFT_SOURCE_DIR}"
                 )
+
+                cmake_options=(
+                    "${cmake_options[@]}"
+                    -DCMAKE_INSTALL_PREFIX:PATH="${INSTALL_PREFIX}"
+                    -DLLVM_CONFIG:PATH="$(build_directory_bin ${deployment_target} llvm)/llvm-config"
+                    -DSWIFT_PATH_TO_CLANG_SOURCE:PATH="${CLANG_SOURCE_DIR}"
+                    -DSWIFT_PATH_TO_CLANG_BUILD:PATH="${llvm_build_dir}"
+                    -DSWIFT_PATH_TO_LLVM_SOURCE:PATH="${LLVM_SOURCE_DIR}"
+                    -DSWIFT_PATH_TO_LLVM_BUILD:PATH="${llvm_build_dir}"
+                    -DSWIFT_PATH_TO_CMARK_SOURCE:PATH="${CMARK_SOURCE_DIR}"
+                    -DSWIFT_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${deployment_target} cmark)"
+                )
+
+                if [[ "${CMAKE_GENERATOR}" == "Xcode" ]] ; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_CMARK_LIBRARY_DIR:PATH=$(build_directory ${deployment_target} cmark)/src/${CMARK_BUILD_TYPE}
+                    )
+                else
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_CMARK_LIBRARY_DIR:PATH=$(build_directory ${deployment_target} cmark)/src
+                    )
+                fi
+
                 if [[ "${SWIFT_SDKS}" ]] ; then
                     cmake_options=(
                         "${cmake_options[@]}"
@@ -1773,6 +1773,12 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     build_targets=("${build_targets[@]}"
                                    "${SWIFT_BENCHMARK_TARGETS[@]}")
                 fi
+
+                cmake_options=(
+                    "${cmake_options[@]}"
+                    "${SWIFT_SOURCE_DIR}"
+                )
+
                 skip_build=${SKIP_BUILD_SWIFT}
                 ;;
             lldb)


### PR DESCRIPTION
#### What's in this pull request?

Before, `build-script-impl` emitted some unused or duplicated `-D` definitions.

Like:

```
-DCMAKE_INSTALL_PREFIX:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr \
-DLLVM_CONFIG:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/llvm-config \
-DCMARK_PATH_TO_CLANG_SOURCE:PATH=/Users/rintaro/git/swift-oss/llvm/tools/clang \
-DCMARK_PATH_TO_CLANG_BUILD:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64 \
-DCMARK_PATH_TO_LLVM_SOURCE:PATH=/Users/rintaro/git/swift-oss/llvm \
-DCMARK_PATH_TO_LLVM_BUILD:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64 \
-DCMARK_PATH_TO_CMARK_SOURCE:PATH=/Users/rintaro/git/swift-oss/cmark \
-DCMARK_PATH_TO_CMARK_BUILD:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/cmark-macosx-x86_64 \
-DCMARK_CMARK_LIBRARY_DIR:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/cmark-macosx-x86_64/src \
-DCMAKE_INSTALL_PREFIX:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr \
-DLLVM_CONFIG:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/llvm-config \
-DLLVM_PATH_TO_CLANG_SOURCE:PATH=/Users/rintaro/git/swift-oss/llvm/tools/clang \
-DLLVM_PATH_TO_CLANG_BUILD:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64 \
-DLLVM_PATH_TO_LLVM_SOURCE:PATH=/Users/rintaro/git/swift-oss/llvm \
-DLLVM_PATH_TO_LLVM_BUILD:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64 \
-DLLVM_PATH_TO_CMARK_SOURCE:PATH=/Users/rintaro/git/swift-oss/cmark \
-DLLVM_PATH_TO_CMARK_BUILD:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/cmark-macosx-x86_64 \
-DLLVM_CMARK_LIBRARY_DIR:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/cmark-macosx-x86_64/src \
-DCMAKE_INSTALL_PREFIX:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr \
-DLLVM_CONFIG:PATH=/Users/rintaro/git/swift-oss/build/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/llvm-config \
```

This PR removes unused `LLVM_` or `CMARK_` prefixed options, and duplicated `-DCMAKE_INSTALL_PREFIX` and `-DLLVM_CONFIG`.

Fixes this cmake warnings:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMARK_CMARK_LIBRARY_DIR
    CMARK_PATH_TO_CLANG_BUILD
    CMARK_PATH_TO_CLANG_SOURCE
    CMARK_PATH_TO_CMARK_BUILD
    CMARK_PATH_TO_CMARK_SOURCE
    CMARK_PATH_TO_LLVM_BUILD
    CMARK_PATH_TO_LLVM_SOURCE
    LLVM_CMARK_LIBRARY_DIR
    LLVM_PATH_TO_CLANG_BUILD
    LLVM_PATH_TO_CLANG_SOURCE
    LLVM_PATH_TO_CMARK_BUILD
    LLVM_PATH_TO_CMARK_SOURCE
    LLVM_PATH_TO_LLVM_BUILD
    LLVM_PATH_TO_LLVM_SOURCE
```

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
