### PR TITLE
[build-script] Tests should fail if one of test commands failed.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2311,7 +2311,7 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                     # executing ninja directly, have it dump the commands it would
                     # run, strip Ninja's progress prefix with sed, and tell the
                     # shell to execute that.
-                    sh -c "set -x && $("${build_cmd[@]}" -n -v ${target} | sed -e 's/[^]]*] //')"
+                    sh -e -x -c "$("${build_cmd[@]}" -n -v ${target} | sed -e 's/[^]]*] //')"
                 else
                     set -x
                     "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${target}


### PR DESCRIPTION
#### What's in this pull request?

Test script:

``` sh
false
true
```

should be considered as _failed_, and `true` should never be executed.

Use `-e` option for test script execution: `sh -e -x -c "script.."`

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
