### PR TITLE
[doc] Fix broken links, permanent redirects and Rust-related inconsistencies

### DIFF
--- a/docs/Generics.rst
+++ b/docs/Generics.rst
@@ -208,7 +208,7 @@ interface, e.g. (in Java)::
 
 and then a class X that wants to be Comparable will inherit from
 Comparable<X>. This is ugly and has a number of pitfalls; see
-http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6479372 .
+http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6479372.
 
 Scala and Strongtalk have the notion of the 'Self' type, which effectively
 allows one to refer to the eventual type of 'self' (which we call

--- a/docs/GitWorkflows.rst
+++ b/docs/GitWorkflows.rst
@@ -30,7 +30,7 @@ This document will show how to translate these commands to Git and additionally
 how to configure Git. It assumes that one is attempting to manipulate a Git
 repository via bash in a terminal. A lot of information since this is supposed
 to be a short, actionable guide. For more information, please see the Git crash
-course guide for SVN users at <https://git-scm.com/course/SVN.html>
+course guide for SVN users at <https://git-scm.com/course/svn.html>
 
 *NOTE* Whenever we say the Swift repository, we mean any repository in the
 Swift project.
@@ -94,7 +94,7 @@ as follows::
 This will cause Git to clone the repository at 'repository url' and check out
 the 'master' branch. The 'master' branch corresponds to 'trunk' in SVN. For more
 information about branching in Git please see
-<https://git-scm.com/course/SVN.html#branch>
+<https://git-scm.com/course/svn.html#branch>
 
 Before beginning to commit though, we /must/ perform some default configuration
 of our repository to match the Swift repository default configuration by

--- a/docs/Modules.rst
+++ b/docs/Modules.rst
@@ -415,7 +415,7 @@ Glossary
     A module whose contents are generated from a C-family header or set of 
     headers. See Clang's Modules__ documentation for more information.
 
-    __ http://goto.apple.com/?http://clang.llvm.org/docs/Modules.html
+    __ http://clang.llvm.org/docs/Modules.html
 
   framework
     A mechanism for library distribution on OS X. Traditionally contains header
@@ -440,7 +440,7 @@ Glossary
     in C++; see Wikipedia__ for some examples. Swift's name mangling scheme is
     not the same as C++'s but serves a similar purpose.
 
-    __ http://goto.apple.com/?http://en.wikipedia.org/wiki/Name_mangling#Name_mangling_in_C.2B.2B
+    __ https://en.wikipedia.org/wiki/Name_mangling#C.2B.2B
 
   module
     An entity containing the API for a library, to be `imported <import>` into

--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -350,7 +350,7 @@ The compiler only automatically specializes generic code if the call
 site and the callee function are located in the same module. However,
 the programmer can provide hints to the compiler in the form of
 @_specialize attributes. For details see
-https://github.com/apple/swift/blob/master/docs/Generics.rst#specialization.
+:ref:`generics-specialization`.
 
 This attribute instructs the compiler to specialize on the specified
 concrete type list. The compiler inserts type checks and dispatches

--- a/docs/SequencesAndCollections.rst
+++ b/docs/SequencesAndCollections.rst
@@ -54,7 +54,7 @@ represented by the `SequenceType` protocol::
 
   .. |AnyIterator| replace:: `AnyIterator<T>`
 
-  __ http://swiftdoc.org/type/AnyIterator/
+  __ http://swiftdoc.org/v3.0/type/AnyIterator/
 
 As you can see, sequence does nothing more than deliver an iterator.
 To understand the need for iterators, it's important to distinguish
@@ -356,7 +356,7 @@ features such as `Comparable` conformance, index subtraction, and
 addition/subtraction of integers to/from indices.
 
 The indices of a `deque
-<http://en.wikipedia.org/wiki/Double-ended_queue>`_ can provide random
+<https://en.wikipedia.org/wiki/Double-ended_queue>`_ can provide random
 access, as do the indices into `String.UTF16View` (when Foundation is
 loaded) and, of course, array indices.  Many common sorting and
 selection algorithms, among others, depend on these capabilities.

--- a/docs/StringDesign.rst
+++ b/docs/StringDesign.rst
@@ -144,7 +144,7 @@ string usage while discovering its essential properties.
 ``String`` is a `First-Class Type`__
 ------------------------------------
 
-__ http://en.wikipedia.org/wiki/First-class_citizen
+__ https://en.wikipedia.org/wiki/First-class_citizen
 
 .. parsed-literal::
 
@@ -581,7 +581,7 @@ How Would You Design It?
     7. UTF-8 sequences sort in code point order.
     8. UTF-8 has no "byte order."
 
-    __ http://research.swtch.com/2010/03/utf-8-bits-bytes-and-benefits.html
+    __ http://research.swtch.com/utf8
 
 * It would be efficient, taking advantage of state-of-the-art
   optimizations, including:

--- a/docs/archive/Objective-CInteroperability.rst
+++ b/docs/archive/Objective-CInteroperability.rst
@@ -396,7 +396,7 @@ Attributes for Objective-C Support
    Maybe eventually [objc] will take an optional argument specifying the
    Objective-C-equivalent name.
 
-__ http://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/CocoaNibs/CocoaNibs.html#//apple_ref/doc/uid/10000051i-CH4-SW6
+__ https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/CocoaNibs/CocoaNibs.html#//apple_ref/doc/uid/10000051i-CH4-SW6
 
 
 Level 1: Message-passing

--- a/docs/proposals/archive/MemoryAndConcurrencyModel.rst
+++ b/docs/proposals/archive/MemoryAndConcurrencyModel.rst
@@ -94,7 +94,7 @@ definition. These kinds are:
    Not having mutable shared state also prevents race conditions from turning
    into safety violations. Here's a description of the go issue which causes
    them to be unsafe when running multiple threads:
-   `http://research.swtch.com/2010/02/off-to-races.html`_
+   <http://research.swtch.com/gorace>
 
    Note that a highly desirable feature of the language is the ability to take
    an instance of a mutable type and *make it immutable* somehow, allowing it to

--- a/docs/proposals/archive/UnifiedFunctionSyntax.rst
+++ b/docs/proposals/archive/UnifiedFunctionSyntax.rst
@@ -503,4 +503,4 @@ circumstances that affect inclusion or exclusion from the list.
 | Worth          | No      |         |                            |
 +----------------+---------+---------+----------------------------+
 
-.. _the english club: http://www.englishclub.com/grammar/prepositions-list.htm
+.. _the english club: https://www.englishclub.com/grammar/prepositions-list.htm

--- a/docs/proposals/valref.rst
+++ b/docs/proposals/valref.rst
@@ -432,16 +432,16 @@ How This Design Beats Rust/C++/C#/etc.
 
 * Simple programs stay simple.  Rust has a great low-level memory safety
   story, but it comes at the expense of ease-of-use.  You can't learn
-  to use that system effectively without confronting three `kinds`__
+  to use that system effectively without confronting two `kinds`__
   of pointer, `named lifetimes`__, `borrowing managed boxes and
   rooting`__, etc.  By contrast, there's a path to learning swift that
   postpones the ``val``\ /``ref`` distinction, and that's pretty much
   *all* one must learn to have a complete understanding of the object
   model in the "easy" and "safe" zones.
 
-__ http://static.rust-lang.org/doc/tutorial.html#boxes-and-pointers
-__ http://static.rust-lang.org/doc/tutorial-borrowed-ptr.html#named-lifetimes
-__ http://static.rust-lang.org/doc/tutorial-borrowed-ptr.html#borrowing-managed-boxes-and-rooting
+__ https://doc.rust-lang.org/reference.html#pointer-types
+__ https://doc.rust-lang.org/book/lifetimes.html
+__ https://doc.rust-lang.org/book/box-syntax-and-patterns.html
 
 * Simple programs stay safe.  C++ offers great control over
   everything, but the sharp edges are always exposed.  This design


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?
1. Fix almost every broken link and perm redirect:    
   - Fix cross-reference from `OptimizationTips.rst` to _Specialization_ section in `Generics.rst` to use Sphinx syntax instead of a direct link to GitHub
   - Fix over 12 broken links and permanent redirects in the documentation
   - **Note:** the only links left broken (to non-Apple devs) are the ones to _http://cocoa.apple.com/_
2. Fix Rust related inconsistencies and broken links in _Values and References_ proposal:
   - Reflect that the Rust language does NOT have three types of pointers anymore
   - Fix broken links to deprecated Rust documentation by replacing them with comparable references in the new Rust documentation

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
