### PR TITLE
[build-script] Handle presets with only build-script-impl args

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -186,7 +186,7 @@ def get_preset_options(substitutions, preset_file_names, preset_name):
 
     (build_script_opts, build_script_impl_opts, missing_opts) = \
         _get_preset_options_impl(config, substitutions, preset_name)
-    if not build_script_opts:
+    if not build_script_opts and not build_script_impl_opts:
         print_with_argv0("preset '" + preset_name + "' not found")
         sys.exit(1)
     if missing_opts:


### PR DESCRIPTION
#### What's in this pull request?

This change allows presets to specify no `build-script` arguments if it still provides `build-script-impl` args.

Given the preset below, without this change `utils/build-script --preset=foo` would result in `utils/build-script: preset 'foo' not found`.

```
[preset: foo]
dash-dash
optionA
optionB=bar
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
