### PR TITLE
Fix two validation tests that require asserts.

### DIFF
--- a/validation-test/IDE/crashers/037-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/IDE/crashers/037-swift-typechecker-resolvetypeincontext.swift
@@ -1,4 +1,7 @@
 // RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+// REQUIRES: asserts
+
 A{extension{
 class A{func c
 var d=c let t{#^A^#

--- a/validation-test/compiler_crashers_2/0038-lowering-CheckedCastEmitter-emitConditional.swift
+++ b/validation-test/compiler_crashers_2/0038-lowering-CheckedCastEmitter-emitConditional.swift
@@ -1,4 +1,6 @@
 // RUN: not --crash %target-swift-frontend %s -emit-silgen
 
+// REQUIRES: asserts
+
 let a: () -> Int? = { return nil }
 a as? Int


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Add 'REQUIRES: asserts' to two crasher tests that need them.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
