### PR TITLE
SE-0036: Requiring Leading Dot Prefixes for Enum Instance Member Implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Swift 3.0
     `NS[Mutable]Dictionary` are still imported as nongeneric classes for
     the time being.
 
+* [SE-0036](https://github.com/apple/swift-evolution/blob/master/proposals/0036-enum-dot.md): 
+  Enum elements can no longer be accessed like instance members in instance methods.
 * As part of the changes for SE-0055 (see below), the *pointee* types of
   imported pointers (e.g. the `id` in `id *`) are no longer assumed to always
   be `_Nullable` even if annotated otherwise. However, an implicit or explicit

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -93,6 +93,9 @@ ERROR(could_not_use_type_member,none,
 ERROR(could_not_use_type_member_on_instance,none,
       "static member %1 cannot be used on instance of type %0",
       (Type, DeclName))
+ERROR(could_not_use_enum_element_on_instance,none,
+      "enum element %0 cannot be referenced as an instance member",
+      (DeclName))
 ERROR(could_not_use_type_member_on_existential,none,
       "static member %1 cannot be used on protocol metatype %0",
       (Type, DeclName))

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1733,7 +1733,7 @@ public:
       OS << '\n';
       printRec(E->getArgument());
     }
-    OS << "')";
+    OS << ")";
   }
   void visitDotSelfExpr(DotSelfExpr *E) {
     printCommon(E, "dot_self_expr");

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -557,7 +557,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             if (FD->isStatic() && !isMetatypeType)
               continue;
           } else if (isa<EnumElementDecl>(Result)) {
-            Results.push_back(UnqualifiedLookupResult(MetaBaseDecl, Result));
+            Results.push_back(UnqualifiedLookupResult(BaseDecl, Result));
             continue;
           }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2278,6 +2278,22 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
       } else {
         // Otherwise the static member lookup was invalid because it was
         // called on an instance
+        
+        // Handle enum element lookup on instance type
+        auto lookThroughBaseObjTy = baseObjTy->lookThroughAllAnyOptionalTypes();
+        if (lookThroughBaseObjTy->is<EnumType>()
+            || lookThroughBaseObjTy->is<BoundGenericEnumType>()) {
+          for (auto cand : result.UnviableCandidates) {
+            ValueDecl *decl = cand.first;
+            if (isa<EnumElementDecl>(decl)) {
+              diagnose(loc, diag::could_not_use_enum_element_on_instance,
+                       memberName);
+              return;
+            }
+          }
+        }
+        
+        // Provide diagnostic other static member lookups on instance type
         diagnose(loc, diag::could_not_use_type_member_on_instance,
                  baseObjTy, memberName)
           .highlight(baseRange).highlight(nameLoc.getSourceRange());

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -65,9 +65,14 @@ filterForEnumElement(LookupResult foundElements) {
   EnumElementDecl *foundElement = nullptr;
   VarDecl *foundConstant = nullptr;
 
-  for (ValueDecl *e : foundElements) {
+  for (swift::LookupResult::Result result : foundElements) {
+    ValueDecl *e = result.Decl;
     assert(e);
     if (e->isInvalid()) {
+      continue;
+    }
+    // Skip if the enum element was referenced as an instance member
+    if (!result.Base || !result.Base->getType()->is<MetatypeType>()) {
       continue;
     }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -332,7 +332,7 @@ public:
   template<typename StmtTy>
   bool typeCheckStmt(StmtTy *&S) {
     StmtTy *S2 = cast_or_null<StmtTy>(visit(S));
-    if (S2 == 0) return true;
+    if (S2 == nullptr) return true;
     S = S2;
     performStmtDiagnostics(TC, S);
     return false;

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -180,23 +180,23 @@ internal enum _CollectionOperation : Equatable {
     var newElementsIds = elementsLastMutatedStateIds
     var newEndIndexId = endIndexLastMutatedStateId
     switch self {
-    case reserveCapacity:
+    case .reserveCapacity:
       let invalidIndices = newElementsIds.indices
       newElementsIds.replaceSubrange(
         Range(invalidIndices),
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
-    case append:
+    case .append:
       newElementsIds.append(nextStateId)
       newEndIndexId = nextStateId
 
-    case appendContentsOf(let count):
+    case .appendContentsOf(let count):
       newElementsIds.append(contentsOf:
         repeatElement(nextStateId, count: count))
       newEndIndexId = nextStateId
 
-    case replaceRange(let subRange, let replacementCount):
+    case .replaceRange(let subRange, let replacementCount):
       newElementsIds.replaceSubrange(
         subRange,
         with: repeatElement(nextStateId, count: replacementCount))
@@ -207,7 +207,7 @@ internal enum _CollectionOperation : Equatable {
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
-    case insert(let atIndex):
+    case .insert(let atIndex):
       newElementsIds.insert(nextStateId, at: atIndex)
 
       let invalidIndices = atIndex..<newElementsIds.endIndex
@@ -216,7 +216,7 @@ internal enum _CollectionOperation : Equatable {
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
-    case insertContentsOf(let atIndex, let count):
+    case .insertContentsOf(let atIndex, let count):
       newElementsIds.insert(
         contentsOf: repeatElement(nextStateId, count: count),
         at: atIndex)
@@ -227,7 +227,7 @@ internal enum _CollectionOperation : Equatable {
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
-    case removeAtIndex(let index):
+    case .removeAtIndex(let index):
       newElementsIds.remove(at: index)
 
       let invalidIndices = index..<newElementsIds.endIndex
@@ -236,11 +236,11 @@ internal enum _CollectionOperation : Equatable {
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
-    case removeLast:
+    case .removeLast:
       newElementsIds.removeLast()
       newEndIndexId = nextStateId
 
-    case removeRange(let subRange):
+    case .removeRange(let subRange):
       newElementsIds.removeSubrange(subRange)
 
       let invalidIndices = subRange.lowerBound..<newElementsIds.endIndex
@@ -249,7 +249,7 @@ internal enum _CollectionOperation : Equatable {
         with: repeatElement(nextStateId, count: invalidIndices.count))
       newEndIndexId = nextStateId
 
-    case removeAll(let keepCapacity):
+    case .removeAll(let keepCapacity):
       newElementsIds.removeAll(keepingCapacity: keepCapacity)
       newEndIndexId = nextStateId
     }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -1332,25 +1332,25 @@ public enum OSVersion : CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case osx(let major, let minor, let bugFix):
+    case .osx(let major, let minor, let bugFix):
       return "OS X \(major).\(minor).\(bugFix)"
-    case iOS(let major, let minor, let bugFix):
+    case .iOS(let major, let minor, let bugFix):
       return "iOS \(major).\(minor).\(bugFix)"
-    case tvOS(let major, let minor, let bugFix):
+    case .tvOS(let major, let minor, let bugFix):
       return "TVOS \(major).\(minor).\(bugFix)"
-    case watchOS(let major, let minor, let bugFix):
+    case .watchOS(let major, let minor, let bugFix):
       return "watchOS \(major).\(minor).\(bugFix)"
-    case iOSSimulator:
+    case .iOSSimulator:
       return "iOSSimulator"
-    case tvOSSimulator:
+    case .tvOSSimulator:
       return "TVOSSimulator"
-    case watchOSSimulator:
+    case .watchOSSimulator:
       return "watchOSSimulator"
-    case linux:
+    case .linux:
       return "Linux"
-    case freeBSD:
+    case .freeBSD:
       return "FreeBSD"
-    case android:
+    case .android:
       return "Android"
     }
   }
@@ -1469,102 +1469,102 @@ public enum TestRunPredicate : CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case custom(_, let reason):
+    case .custom(_, let reason):
       return "Custom(reason: \(reason))"
 
-    case always(let reason):
+    case .always(let reason):
       return "Always(reason: \(reason))"
-    case never:
+    case .never:
       return ""
 
-    case osxAny(let reason):
+    case .osxAny(let reason):
       return "osx(*, reason: \(reason))"
-    case osxMajor(let major, let reason):
+    case .osxMajor(let major, let reason):
       return "osx(\(major).*, reason: \(reason))"
-    case osxMinor(let major, let minor, let reason):
+    case .osxMinor(let major, let minor, let reason):
       return "osx(\(major).\(minor), reason: \(reason))"
-    case osxMinorRange(let major, let minorRange, let reason):
+    case .osxMinorRange(let major, let minorRange, let reason):
       return "osx(\(major).[\(minorRange)], reason: \(reason))"
-    case osxBugFix(let major, let minor, let bugFix, let reason):
+    case .osxBugFix(let major, let minor, let bugFix, let reason):
       return "osx(\(major).\(minor).\(bugFix), reason: \(reason))"
-    case osxBugFixRange(let major, let minor, let bugFixRange, let reason):
+    case .osxBugFixRange(let major, let minor, let bugFixRange, let reason):
       return "osx(\(major).\(minor).[\(bugFixRange)], reason: \(reason))"
 
-    case iOSAny(let reason):
+    case .iOSAny(let reason):
       return "iOS(*, reason: \(reason))"
-    case iOSMajor(let major, let reason):
+    case .iOSMajor(let major, let reason):
       return "iOS(\(major).*, reason: \(reason))"
-    case iOSMinor(let major, let minor, let reason):
+    case .iOSMinor(let major, let minor, let reason):
       return "iOS(\(major).\(minor), reason: \(reason))"
-    case iOSMinorRange(let major, let minorRange, let reason):
+    case .iOSMinorRange(let major, let minorRange, let reason):
       return "iOS(\(major).[\(minorRange)], reason: \(reason))"
-    case iOSBugFix(let major, let minor, let bugFix, let reason):
+    case .iOSBugFix(let major, let minor, let bugFix, let reason):
       return "iOS(\(major).\(minor).\(bugFix), reason: \(reason))"
-    case iOSBugFixRange(let major, let minor, let bugFixRange, let reason):
+    case .iOSBugFixRange(let major, let minor, let bugFixRange, let reason):
       return "iOS(\(major).\(minor).[\(bugFixRange)], reason: \(reason))"
 
-    case iOSSimulatorAny(let reason):
+    case .iOSSimulatorAny(let reason):
       return "iOSSimulatorAny(*, reason: \(reason))"
 
-    case tvOSAny(let reason):
+    case .tvOSAny(let reason):
       return "tvOS(*, reason: \(reason))"
-    case tvOSMajor(let major, let reason):
+    case .tvOSMajor(let major, let reason):
       return "tvOS(\(major).*, reason: \(reason))"
-    case tvOSMinor(let major, let minor, let reason):
+    case .tvOSMinor(let major, let minor, let reason):
       return "tvOS(\(major).\(minor), reason: \(reason))"
-    case tvOSMinorRange(let major, let minorRange, let reason):
+    case .tvOSMinorRange(let major, let minorRange, let reason):
       return "tvOS(\(major).[\(minorRange)], reason: \(reason))"
-    case tvOSBugFix(let major, let minor, let bugFix, let reason):
+    case .tvOSBugFix(let major, let minor, let bugFix, let reason):
       return "tvOS(\(major).\(minor).\(bugFix), reason: \(reason))"
-    case tvOSBugFixRange(let major, let minor, let bugFixRange, let reason):
+    case .tvOSBugFixRange(let major, let minor, let bugFixRange, let reason):
       return "tvOS(\(major).\(minor).[\(bugFixRange)], reason: \(reason))"
 
-    case tvOSSimulatorAny(let reason):
+    case .tvOSSimulatorAny(let reason):
       return "tvOSSimulatorAny(*, reason: \(reason))"
 
-    case watchOSAny(let reason):
+    case .watchOSAny(let reason):
       return "watchOS(*, reason: \(reason))"
-    case watchOSMajor(let major, let reason):
+    case .watchOSMajor(let major, let reason):
       return "watchOS(\(major).*, reason: \(reason))"
-    case watchOSMinor(let major, let minor, let reason):
+    case .watchOSMinor(let major, let minor, let reason):
       return "watchOS(\(major).\(minor), reason: \(reason))"
-    case watchOSMinorRange(let major, let minorRange, let reason):
+    case .watchOSMinorRange(let major, let minorRange, let reason):
       return "watchOS(\(major).[\(minorRange)], reason: \(reason))"
-    case watchOSBugFix(let major, let minor, let bugFix, let reason):
+    case .watchOSBugFix(let major, let minor, let bugFix, let reason):
       return "watchOS(\(major).\(minor).\(bugFix), reason: \(reason))"
-    case watchOSBugFixRange(let major, let minor, let bugFixRange, let reason):
+    case .watchOSBugFixRange(let major, let minor, let bugFixRange, let reason):
       return "watchOS(\(major).\(minor).[\(bugFixRange)], reason: \(reason))"
 
-    case watchOSSimulatorAny(let reason):
+    case .watchOSSimulatorAny(let reason):
       return "watchOSSimulatorAny(*, reason: \(reason))"
 
-    case linuxAny(reason: let reason):
+    case .linuxAny(reason: let reason):
       return "linuxAny(*, reason: \(reason))"
 
-    case androidAny(reason: let reason):
+    case .androidAny(reason: let reason):
       return "androidAny(*, reason: \(reason))"
 
-    case freeBSDAny(reason: let reason):
+    case .freeBSDAny(reason: let reason):
       return "freeBSDAny(*, reason: \(reason))"
 
-    case objCRuntime(let reason):
+    case .objCRuntime(let reason):
       return "Objective-C runtime, reason: \(reason))"
-    case nativeRuntime(let reason):
+    case .nativeRuntime(let reason):
       return "Native runtime (no ObjC), reason: \(reason))"
     }
   }
 
   public func evaluate() -> Bool {
     switch self {
-    case custom(let predicate, _):
+    case .custom(let predicate, _):
       return predicate()
 
-    case always:
+    case .always:
       return true
-    case never:
+    case .never:
       return false
 
-    case osxAny:
+    case .osxAny:
       switch _getRunningOSVersion() {
       case .osx:
         return true
@@ -1572,7 +1572,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case osxMajor(let major, _):
+    case .osxMajor(let major, _):
       switch _getRunningOSVersion() {
       case .osx(major, _, _):
         return true
@@ -1580,7 +1580,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case osxMinor(let major, let minor, _):
+    case .osxMinor(let major, let minor, _):
       switch _getRunningOSVersion() {
       case .osx(major, minor, _):
         return true
@@ -1588,7 +1588,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case osxMinorRange(let major, let minorRange, _):
+    case .osxMinorRange(let major, let minorRange, _):
       switch _getRunningOSVersion() {
       case .osx(major, let runningMinor, _):
         return minorRange.contains(runningMinor)
@@ -1596,7 +1596,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case osxBugFix(let major, let minor, let bugFix, _):
+    case .osxBugFix(let major, let minor, let bugFix, _):
       switch _getRunningOSVersion() {
       case .osx(major, minor, bugFix):
         return true
@@ -1604,7 +1604,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case osxBugFixRange(let major, let minor, let bugFixRange, _):
+    case .osxBugFixRange(let major, let minor, let bugFixRange, _):
       switch _getRunningOSVersion() {
       case .osx(major, minor, let runningBugFix):
         return bugFixRange.contains(runningBugFix)
@@ -1612,7 +1612,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSAny:
+    case .iOSAny:
       switch _getRunningOSVersion() {
       case .iOS:
         return true
@@ -1620,7 +1620,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSMajor(let major, _):
+    case .iOSMajor(let major, _):
       switch _getRunningOSVersion() {
       case .iOS(major, _, _):
         return true
@@ -1628,7 +1628,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSMinor(let major, let minor, _):
+    case .iOSMinor(let major, let minor, _):
       switch _getRunningOSVersion() {
       case .iOS(major, minor, _):
         return true
@@ -1636,7 +1636,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSMinorRange(let major, let minorRange, _):
+    case .iOSMinorRange(let major, let minorRange, _):
       switch _getRunningOSVersion() {
       case .iOS(major, let runningMinor, _):
         return minorRange.contains(runningMinor)
@@ -1644,7 +1644,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSBugFix(let major, let minor, let bugFix, _):
+    case .iOSBugFix(let major, let minor, let bugFix, _):
       switch _getRunningOSVersion() {
       case .iOS(major, minor, bugFix):
         return true
@@ -1652,7 +1652,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSBugFixRange(let major, let minor, let bugFixRange, _):
+    case .iOSBugFixRange(let major, let minor, let bugFixRange, _):
       switch _getRunningOSVersion() {
       case .iOS(major, minor, let runningBugFix):
         return bugFixRange.contains(runningBugFix)
@@ -1660,7 +1660,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case iOSSimulatorAny:
+    case .iOSSimulatorAny:
       switch _getRunningOSVersion() {
       case .iOSSimulator:
         return true
@@ -1668,7 +1668,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSAny:
+    case .tvOSAny:
       switch _getRunningOSVersion() {
       case .tvOS:
         return true
@@ -1676,7 +1676,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSMajor(let major, _):
+    case .tvOSMajor(let major, _):
       switch _getRunningOSVersion() {
       case .tvOS(major, _, _):
         return true
@@ -1684,7 +1684,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSMinor(let major, let minor, _):
+    case .tvOSMinor(let major, let minor, _):
       switch _getRunningOSVersion() {
       case .tvOS(major, minor, _):
         return true
@@ -1692,7 +1692,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSMinorRange(let major, let minorRange, _):
+    case .tvOSMinorRange(let major, let minorRange, _):
       switch _getRunningOSVersion() {
       case .tvOS(major, let runningMinor, _):
         return minorRange.contains(runningMinor)
@@ -1700,7 +1700,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSBugFix(let major, let minor, let bugFix, _):
+    case .tvOSBugFix(let major, let minor, let bugFix, _):
       switch _getRunningOSVersion() {
       case .tvOS(major, minor, bugFix):
         return true
@@ -1708,7 +1708,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSBugFixRange(let major, let minor, let bugFixRange, _):
+    case .tvOSBugFixRange(let major, let minor, let bugFixRange, _):
       switch _getRunningOSVersion() {
       case .tvOS(major, minor, let runningBugFix):
         return bugFixRange.contains(runningBugFix)
@@ -1716,7 +1716,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case tvOSSimulatorAny:
+    case .tvOSSimulatorAny:
       switch _getRunningOSVersion() {
       case .tvOSSimulator:
         return true
@@ -1724,7 +1724,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSAny:
+    case .watchOSAny:
       switch _getRunningOSVersion() {
       case .watchOS:
         return true
@@ -1732,7 +1732,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSMajor(let major, _):
+    case .watchOSMajor(let major, _):
       switch _getRunningOSVersion() {
       case .watchOS(major, _, _):
         return true
@@ -1740,7 +1740,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSMinor(let major, let minor, _):
+    case .watchOSMinor(let major, let minor, _):
       switch _getRunningOSVersion() {
       case .watchOS(major, minor, _):
         return true
@@ -1748,7 +1748,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSMinorRange(let major, let minorRange, _):
+    case .watchOSMinorRange(let major, let minorRange, _):
       switch _getRunningOSVersion() {
       case .watchOS(major, let runningMinor, _):
         return minorRange.contains(runningMinor)
@@ -1756,7 +1756,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSBugFix(let major, let minor, let bugFix, _):
+    case .watchOSBugFix(let major, let minor, let bugFix, _):
       switch _getRunningOSVersion() {
       case .watchOS(major, minor, bugFix):
         return true
@@ -1764,7 +1764,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSBugFixRange(let major, let minor, let bugFixRange, _):
+    case .watchOSBugFixRange(let major, let minor, let bugFixRange, _):
       switch _getRunningOSVersion() {
       case .watchOS(major, minor, let runningBugFix):
         return bugFixRange.contains(runningBugFix)
@@ -1772,7 +1772,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case watchOSSimulatorAny:
+    case .watchOSSimulatorAny:
       switch _getRunningOSVersion() {
       case .watchOSSimulator:
         return true
@@ -1780,7 +1780,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case linuxAny:
+    case .linuxAny:
       switch _getRunningOSVersion() {
       case .linux:
         return true
@@ -1788,7 +1788,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case androidAny:
+    case .androidAny:
       switch _getRunningOSVersion() {
       case .android:
         return true
@@ -1796,7 +1796,7 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case freeBSDAny:
+    case .freeBSDAny:
       switch _getRunningOSVersion() {
       case .freeBSD:
         return true
@@ -1804,14 +1804,14 @@ public enum TestRunPredicate : CustomStringConvertible {
         return false
       }
 
-    case objCRuntime:
+    case .objCRuntime:
 #if _runtime(_ObjC)
       return true
 #else
       return false
 #endif
 
-    case nativeRuntime:
+    case .nativeRuntime:
 #if _runtime(_ObjC)
       return false
 #else

--- a/test/ClangModules/enum.swift
+++ b/test/ClangModules/enum.swift
@@ -98,9 +98,9 @@ case NSAliasesEnum.differentValue:
 extension NSAliasesEnum {
   func test() {
     switch aliasOriginal {
-    case bySameValue:
+    case .bySameValue:
       break
-    case differentValue:
+    case .differentValue:
       break
     }
   }

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -433,3 +433,88 @@ enum RawValueBTest: Double, RawValueB {
 enum foo : String {
   case bar = nil // expected-error {{cannot convert nil to raw type 'String'}}
 }
+
+// Static member lookup from instance methods
+
+struct EmptyStruct {}
+
+enum EnumWithStaticMember {
+  static let staticVar = EmptyStruct()
+  
+  func foo() {
+    let _ = staticVar // expected-error {{static member 'staticVar' cannot be used on instance of type 'EnumWithStaticMember'}}
+  }
+}
+
+// SE-0036:
+
+struct SE0036_Auxiliary {}
+
+enum SE0036 {
+  case A
+  case B(SE0036_Auxiliary)
+  
+  static func staticReference() {
+    let _ = A
+    let _ = SE0036.A
+  }
+  
+  func staticReferencInInstanceMethod() {
+    let _ = A // expected-error {{enum element 'A' cannot be referenced as an instance member}}
+    let _ = SE0036.A
+  }
+  
+  static func staticReferencInSwitchInStaticMethod() {
+    switch SE0036.A {
+    case A: break
+    case B(_): break
+    }
+  }
+  
+  func staticReferencInSwitchInInstanceMethod() {
+    switch self {
+    case A: break // expected-error {{enum element 'A' cannot be referenced as an instance member}}
+    case B(_): break // expected-error {{enum element 'B' cannot be referenced as an instance member}}
+    }
+  }
+  
+  func explicitReferencInSwitch() {
+    switch SE0036.A {
+    case SE0036.A: break
+    case SE0036.B(_): break
+    }
+  }
+  
+  func dotReferencInSwitchInInstanceMethod() {
+    switch self {
+    case .A: break
+    case .B(_): break
+    }
+  }
+  
+  static func dotReferencInSwitchInStaticMethod() {
+    switch SE0036.A {
+    case .A: break
+    case .B(_): break
+    }
+  }
+  
+  init() {
+    self = .A
+    self = A // expected-error {{enum element 'A' cannot be referenced as an instance member}}
+    self = SE0036.A
+    self = .B(SE0036_Auxiliary())
+    self = B(SE0036_Auxiliary()) // expected-error {{enum element 'B' cannot be referenced as an instance member}}
+    self = SE0036.B(SE0036_Auxiliary())
+  }
+}
+
+enum SE0036_Generic<T> {
+  case A
+  
+  func foo() {
+    switch self {
+    case A: break // expected-error {{enum element 'A' cannot be referenced as an instance member}}
+    }
+  }
+}

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -82,26 +82,26 @@ enum Voluntary<T> : Equatable {
     case other:
       ()
 
-    case Naught,
-         Naught(),
-         Naught(_, _): // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
+    case .Naught,
+         .Naught(),
+         .Naught(_, _): // expected-error{{tuple pattern has the wrong length for tuple type '()'}}
       ()
 
-    case Mere,
-         Mere(), // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}}
-         Mere(_),
-         Mere(_, _): // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}}
+    case .Mere,
+         .Mere(), // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}}
+         .Mere(_),
+         .Mere(_, _): // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}}
       ()
 
-    case Twain(), // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
-         Twain(_),
-         Twain(_, _),
-         Twain(_, _, _): // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
+    case .Twain(), // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
+         .Twain(_),
+         .Twain(_, _),
+         .Twain(_, _, _): // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
       ()
     }
 
     switch foo {
-    case Naught: // expected-error{{enum case 'Naught' is not a member of type 'Foo'}}
+    case .Naught: // expected-error{{enum case 'Naught' not found in type 'Foo'}}
       ()
     case .A, .B, .C:
       ()

--- a/test/Prototypes/Result.swift
+++ b/test/Prototypes/Result.swift
@@ -17,45 +17,45 @@ case Success(Value)
 case Error(ErrorProtocol)
 
   init(success x: Value) {
-    self = Success(x)
+    self = .Success(x)
   }
   
   init(error: ErrorProtocol) {
-    self = Error(error)
+    self = .Error(error)
   }
   
   func map<U>(_ transform: @noescape (Value) -> U) -> Result<U> {
     switch self {
-    case Success(let x): return .Success(transform(x))
-    case Error(let e): return .Error(e)
+    case .Success(let x): return .Success(transform(x))
+    case .Error(let e): return .Error(e)
     }
   }
 
   func flatMap<U>(_ transform: @noescape (Value) -> Result<U>) -> Result<U> {
     switch self {
-    case Success(let x): return transform(x)
-    case Error(let e): return .Error(e)
+    case .Success(let x): return transform(x)
+    case .Error(let e): return .Error(e)
     }
   }
 
   func get() throws -> Value {
     switch self {
-    case Success(let x): return x
-    case Error(let e): throw e
+    case .Success(let x): return x
+    case .Error(let e): throw e
     }
   }
 
   var success: Value? {
     switch self {
-    case Success(let x): return x
-    case Error: return nil
+    case .Success(let x): return x
+    case .Error: return nil
     }
   }
 
   var error: ErrorProtocol? {
     switch self {
-    case Success: return nil
-    case Error(let x): return x
+    case .Success: return nil
+    case .Error(let x): return x
     }
   }
 }

--- a/test/SILGen/coverage_class.swift
+++ b/test/SILGen/coverage_class.swift
@@ -26,5 +26,5 @@ enum E {
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.foo
   func foo() {}
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.init
-  init() { self = Y }
+  init() { self = .Y }
 }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -565,7 +565,7 @@ enum TrivialEnum : TriviallyConstructible {
   case NotSoTrivial
 
   init() {
-    self = NotSoTrivial
+    self = .NotSoTrivial
   }
 
   func go(_ x: Int) {}

--- a/test/Sema/enum_equatable_hashable.swift
+++ b/test/Sema/enum_equatable_hashable.swift
@@ -12,9 +12,9 @@ var aHash: Int = Foo.A.hashValue
 enum Generic<T> {
   case A, B
 
-  func method() -> Int {
+  static func method() -> Int {
     if A == B { }
-    return A.hashValue
+    return Generic.A.hashValue
   }
 }
 

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -282,11 +282,11 @@ enum r19997577Type {
   func reduce<Result>(_ initial: Result, _ combine: @noescape (Result, r19997577Type) -> Result) -> Result {
     let binary: @noescape (r19997577Type, r19997577Type) -> Result = { combine(combine(combine(initial, self), $0), $1) }
     switch self {
-    case Unit:
+    case .Unit:
       return combine(initial, self)
-    case let Function(t1, t2):
+    case let .Function(t1, t2):
       return binary(t1(), t2())
-    case let Sum(t1, t2):
+    case let .Sum(t1, t2):
       return binary(t1(), t2())
     }
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Implemented [SE-0036](https://github.com/apple/swift-evolution/blob/master/proposals/0036-enum-dot.md): Requiring Leading Dot Prefixes for Enum Instance Member Implementations
#### Resolved bug number: [SR-1236](https://bugs.swift.org/browse/SR-1236)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
