### PR TITLE
[build-script] Clear CMakeCache.txt before (re)configuration.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2037,10 +2037,12 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
         fi
 
         # Configure if necessary.
-        if [[  "${RECONFIGURE}" || ! -f "${build_dir}/CMakeCache.txt" || \
+        cmake_cache_path="${build_dir}/CMakeCache.txt"
+        if [[  "${RECONFIGURE}" || ! -f "${cmake_cache_path}" || \
                     ( ! -z "${generator_output_path}" && ! -f "${generator_output_path}" ) ]] ; then
-            mkdir -p "${build_dir}"
             set -x
+            mkdir -p "${build_dir}"
+            rm -f "${cmake_cache_path}"
             (cd "${build_dir}" && "${CMAKE}" "${cmake_options[@]}" ${USER_CONFIG_ARGS})
             { set +x; } 2>/dev/null
         fi


### PR DESCRIPTION
#### What's in this pull request?

Since `cmake` doesn't clear the cached values,
We should remove `CMakeCache.txt` before re-configuration.
(or explicitly unset cached values using `-U`)

For example:

``` sh
build$ cat ../CMakeLists.txt

set(MY_OPTION "==DEFAULT==" CACHE STRING "My Option Value")
message("MyOption: ${MY_OPTION}")

build$ cmake -G Ninja ../ -DMY_OPTION=FOOBAR
...
MyOption: FOOBAR
...

build$ cmake -G Ninja ../  # <- This is the problem
...
MyOption: FOOBAR
...

build$ cmake -G Ninja ../ -UMY_OPTION
...
MyOption: ==DEFAULT==
...
```

In `build-script-impl`, compare:

```
# OK
cmake_options+=(
    -DSWIFT_MY_FLAG:BOOL=$(true_false "${MY_FLAG}")
)

# NOT OK
if [[ "${MY_VALUE}" ]]; then
    cmake_options+=(
        -DSWIFT_MY_VALUE:STRING="${MY_VALUE}"
    )
fi
```

In the latter case, we should explicitly specify `-USWIFT_MY_VALUE`  in `else` branch to use the default value.
But it's very annoying to apply that for every options.
More easy solution is to clear the cache by deleting `CMakeCache.txt`

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
