### PR TITLE
[gardening] "[ a, b ]" → "[a, b]", "\t" → " ", "are are" → "are"

### DIFF
--- a/benchmark/single-source/UTF8Decode.swift
+++ b/benchmark/single-source/UTF8Decode.swift
@@ -25,7 +25,7 @@ public func run_UTF8Decode(_ N: Int) {
   // Most commonly emoji, which are usually mixed with other text.
   let emoji = "Panda 🐼, Dog 🐶, Cat 🐱, Mouse 🐭."
 
-  let strings = [ ascii, russian, japanese, emoji ].map { Array($0.utf8) }
+  let strings = [ascii, russian, japanese, emoji].map { Array($0.utf8) }
 
   func isEmpty(_ result: UnicodeDecodingResult) -> Bool {
     switch result {

--- a/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
+++ b/benchmark/single-source/unit-tests/ObjectiveCBridging.swift
@@ -27,7 +27,7 @@ public func conditionalCast<NS, T>(_ ns: NS) -> T? {
 // === String === //
 
 func createNSString() -> NSString {
-	return NSString(cString: "NSString that does not fit in tagged pointer", encoding: NSUTF8StringEncoding)!
+  return NSString(cString: "NSString that does not fit in tagged pointer", encoding: NSUTF8StringEncoding)!
 }
 
 @inline(never)
@@ -178,7 +178,7 @@ func testObjectiveCBridgeFromNSArrayAnyObjectToString() {
       nativeString = nativeArray[0]
     }
   }
-	CheckResults(nativeString != nil && nativeString == "NSString that does not fit in tagged pointer", "Expected results did not match")
+  CheckResults(nativeString != nil && nativeString == "NSString that does not fit in tagged pointer", "Expected results did not match")
 }
 
 @inline(never)
@@ -404,7 +404,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectForced() {
        result = nativeSet.contains(nsString)
     }
   }
-	CheckResults(result != nil && result!, "Expected results did not match")
+  CheckResults(result != nil && result!, "Expected results did not match")
 }
 
 @inline(never)
@@ -447,7 +447,7 @@ func testObjectiveCBridgeFromNSSetAnyObjectToString() {
        result = nativeSet.contains(nativeString)
     }
   }
-	CheckResults(result != nil && result!, "Expected results did not match")
+  CheckResults(result != nil && result!, "Expected results did not match")
 }
 
 @inline(never)

--- a/benchmark/single-source/unit-tests/ObjectiveCBridgingStubs.swift
+++ b/benchmark/single-source/unit-tests/ObjectiveCBridgingStubs.swift
@@ -75,8 +75,7 @@ public func run_ObjectiveCBridgeStubFromArrayOfNSString(_ N: Int) {
 func testObjectiveCBridgeStubToArrayOfNSString() {
    let b = BridgeTester()
    let str = "hello world"
-   let arr = [ str, str, str, str, str,
-               str, str, str, str, str ]
+   let arr = [str, str, str, str, str, str, str, str, str, str]
    for _ in 0 ..< 10_000 {
      b.test(fromArrayOf: arr)
    }

--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -446,7 +446,7 @@ argument drops from being O(n), depending on the size of the tree to O(1).
   struct Tree : P {
     var node : [P?]
     init() {
-      node = [ thing ]
+      node = [thing]
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6427,7 +6427,7 @@ void TypeChecker::validateDecl(ValueDecl *D, bool resolveTypeParams) {
     if (typeAlias->hasType()) {
       
       // If we have are recursing into validation and already have a type set...
-      // but also don't have the underlying type computed, then we are are
+      // but also don't have the underlying type computed, then we are
       // recursing into interface validation while checking the body of the
       // type.  Reject this with a circularity diagnostic.
       if (!typeAlias->hasUnderlyingType()) {

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -275,7 +275,7 @@ self.test("\(testNamePrefix)._withUnsafeMutableBufferPointerIfSupported()/semant
 // sort()
 //===----------------------------------------------------------------------===//
 
-% for predicate in [ False, True ]:
+% for predicate in [False, True]:
 
 self.test("\(testNamePrefix).sorted/DispatchesThrough_withUnsafeMutableBufferPointerIfSupported/${'Predicate' if predicate else 'WhereElementIsComparable'}") {
   let sequence = [ 5, 4, 3, 2, 1 ]
@@ -615,7 +615,7 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
 // sort()
 //===----------------------------------------------------------------------===//
 
-% for predicate in [ False, True ]:
+% for predicate in [False, True]:
 
 func checkSortInPlace_${'Predicate' if predicate else 'WhereElementIsComparable'}(
   sequence: [Int],
@@ -705,7 +705,7 @@ self.test("\(testNamePrefix).sort/${'Predicate' if predicate else 'WhereElementI
 // partition()
 //===----------------------------------------------------------------------===//
 
-% for predicate in [ False, True ]:
+% for predicate in [False, True]:
 
 func checkPartition_${'Predicate' if predicate else 'WhereElementIsComparable'}(
   sequence: [Int],

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -50,7 +50,7 @@ public struct SourceLocStack {
   }
 
   public init(_ loc: SourceLoc) {
-    locs = [ loc ]
+    locs = [loc]
   }
 
   init(_locs: [SourceLoc]) {
@@ -2613,8 +2613,8 @@ func == <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
 }
 
 func < <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
-  return [ lhs.first, lhs.second ].lexicographicallyPrecedes(
-    [ rhs.first, rhs.second ])
+  return [lhs.first, lhs.second].lexicographicallyPrecedes(
+    [rhs.first, rhs.second])
 }
 
 public func expectEqualsUnordered<
@@ -2628,7 +2628,7 @@ public func expectEqualsUnordered<
     _ expected: Expected, _ actual: Actual, ${TRACE}
 ) {
   func comparePairLess(_ lhs: (T, T), rhs: (T, T)) -> Bool {
-    return [ lhs.0, lhs.1 ].lexicographicallyPrecedes([ rhs.0, rhs.1 ])
+    return [lhs.0, lhs.1].lexicographicallyPrecedes([rhs.0, rhs.1])
   }
 
   let x: [(T, T)] =

--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -21,7 +21,7 @@ struct _Prespecialize {
   static internal func _specializeArrays() {
     func _createArrayUser<Element : Comparable>(_ sampleValue: Element) {
       // Initializers.
-      let _: [Element] = [ sampleValue ]
+      let _: [Element] = [sampleValue]
       var a = [Element](repeating: sampleValue, count: 1)
 
       // Read array element
@@ -70,7 +70,7 @@ struct _Prespecialize {
 
     func _createArrayUserWithoutSorting<Element>(_ sampleValue: Element) {
       // Initializers.
-      let _: [Element] = [ sampleValue ]
+      let _: [Element] = [sampleValue]
       var a = [Element](repeating: sampleValue, count: 1)
 
       // Read array element

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -133,7 +133,7 @@ extension _ArrayBuffer {
   /// Otherwise, returns `nil`.
   @warn_unused_result
   public mutating func requestUniqueMutableBackingBuffer(minimumCapacity: Int)
-	-> NativeBuffer? {
+  -> NativeBuffer? {
     if _fastPath(isUniquelyReferenced()) {
       let b = _native
       if _fastPath(b.capacity >= minimumCapacity) {

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -119,7 +119,7 @@ orderingRequirementForComparable = """\
 
 % # Generate two versions: with explicit predicates and with
 % # a Comparable requirement.
-% for preds in [ True, False ]:
+% for preds in [True, False]:
 
 %   if preds:
 extension MutableCollection where Index : RandomAccessIndex {

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -46,7 +46,7 @@ extension Sequence {
 
 % # Generate two versions: with explicit predicates and with
 % # a Comparable requirement.
-% for preds in [ True, False ]:
+% for preds in [True, False]:
 
 %{
 if preds:
@@ -116,7 +116,7 @@ extension Sequence ${"" if preds else "where Iterator.Element : Comparable"} {
 
 % # Generate two versions: with explicit predicates and with
 % # an Equatable requirement.
-% for preds in [ True, False ]:
+% for preds in [True, False]:
 
 extension Sequence ${"" if preds else "where Iterator.Element : Equatable"} {
 
@@ -170,7 +170,7 @@ else:
 
 % # Generate two versions: with explicit predicates and with
 % # an Equatable requirement.
-% for preds in [ True, False ]:
+% for preds in [True, False]:
 
 extension Sequence ${"" if preds else "where Iterator.Element : Equatable"} {
 
@@ -226,7 +226,7 @@ else:
 
 % # Generate two versions: with explicit predicates and with
 % # Comparable requirement.
-% for preds in [ True, False ]:
+% for preds in [True, False]:
 
 extension Sequence ${"" if preds else "where Iterator.Element : Comparable"} {
 

--- a/test/1_stdlib/HeapBuffer.swift
+++ b/test/1_stdlib/HeapBuffer.swift
@@ -30,7 +30,7 @@ func testUnique() {
   print("buffer is unique: \(a.isUniquelyReferenced())")
   // CHECK-NEXT: buffer is unique: true
   
-  var addRef = [ a ]
+  var addRef = [a]
   print("copied buffer is unique: \(a.isUniquelyReferenced())")
   // CHECK-NEXT: copied buffer is unique: false
 }

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -417,7 +417,7 @@ NSStringAPIs.test("completePath(into:caseSensitive:matchesInto:filterTypes)") {
 
     expectEqual(1, count)
     expectEqual(existingPath, outputName)
-    expectEqual([ existingPath ], outputArray)
+    expectEqual([existingPath], outputArray)
   }
 
   do {
@@ -545,12 +545,11 @@ NSStringAPIs.test("enumerateLinguisticTagsIn(_:scheme:options:orthography:_:") {
     }
   }
   expectEqual(
-      [ NSLinguisticTagWord, NSLinguisticTagWhitespace,
-        NSLinguisticTagWord ],
-      tags)
+    [NSLinguisticTagWord, NSLinguisticTagWhitespace, NSLinguisticTagWord],
+    tags)
   expectEqual(["Глокая", " ", "куздра"], tokens)
   let sentence = s[startIndex..<endIndex]
-  expectEqual([ sentence, sentence, sentence ], sentences)
+  expectEqual([sentence, sentence, sentence], sentences)
 }
 
 NSStringAPIs.test("enumerateSubstringsIn(_:options:_:)") {
@@ -888,9 +887,8 @@ NSStringAPIs.test("linguisticTagsIn(_:scheme:options:orthography:tokenRanges:)")
       options: [],
       orthography: nil, tokenRanges: &tokenRanges)
   expectEqual(
-      [ NSLinguisticTagWord, NSLinguisticTagWhitespace,
-        NSLinguisticTagWord ],
-      tags)
+    [NSLinguisticTagWord, NSLinguisticTagWhitespace, NSLinguisticTagWord],
+    tags)
   expectEqual(["Глокая", " ", "куздра"],
       tokenRanges.map { s[$0] } )
 }

--- a/test/1_stdlib/PrintClass.swift
+++ b/test/1_stdlib/PrintClass.swift
@@ -24,8 +24,8 @@ PrintTests.test("ClassPrintable") {
   let classMetatype = ClassPrintable.self
   expectPrinted("ClassPrintable", classMetatype)
   expectDebugPrinted("PrintTestTypes.ClassPrintable", classMetatype)
-  expectPrinted("[PrintTestTypes.ClassPrintable]", [ classMetatype ])
-  expectDebugPrinted("[PrintTestTypes.ClassPrintable]", [ classMetatype ])
+  expectPrinted("[PrintTestTypes.ClassPrintable]", [classMetatype])
+  expectDebugPrinted("[PrintTestTypes.ClassPrintable]", [classMetatype])
 }
 
 PrintTests.test("ClassVeryPrintable") {

--- a/test/1_stdlib/PrintStruct.swift
+++ b/test/1_stdlib/PrintStruct.swift
@@ -53,9 +53,9 @@ func test_ThickMetatypePrintingImpl<T>(
   _ expectedDebug: String
   ) {
     expectPrinted(expectedPrint, thickMetatype)
-    expectPrinted("[\(expectedDebug)]", [ thickMetatype ])
+    expectPrinted("[\(expectedDebug)]", [thickMetatype])
     expectDebugPrinted(expectedDebug, thickMetatype)
-    expectDebugPrinted("[\(expectedDebug)]", [ thickMetatype ])
+    expectDebugPrinted("[\(expectedDebug)]", [thickMetatype])
 }
 
 PrintTests.test("StructPrintable") {
@@ -72,8 +72,8 @@ PrintTests.test("StructPrintable") {
   let structMetatype = StructPrintable.self
   expectPrinted("StructPrintable", structMetatype)
   expectDebugPrinted("PrintTestTypes.StructPrintable", structMetatype)
-  expectPrinted("[PrintTestTypes.StructPrintable]", [ structMetatype ])
-  expectDebugPrinted("[PrintTestTypes.StructPrintable]", [ structMetatype ])
+  expectPrinted("[PrintTestTypes.StructPrintable]", [structMetatype])
+  expectDebugPrinted("[PrintTestTypes.StructPrintable]", [structMetatype])
   test_ThickMetatypePrintingImpl(structMetatype, "StructPrintable",
     "PrintTestTypes.StructPrintable")
 }

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -144,7 +144,7 @@ class ClassConformsToP1 : Boolean, Q1 {
 
 class Class2ConformsToP1<T : Boolean> : Boolean, Q1 {
   init(_ value: T) {
-    self.value = [ value ]
+    self.value = [value]
   }
   var boolValue: Bool {
     return value[0].boolValue

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -56,7 +56,7 @@ internal func _splitRandomAccessIndexRange<Index : RandomAccessIndex>(
   let endIndex = range.endIndex
   let length = startIndex.distance(to: endIndex).toIntMax()
   if length < 2 {
-    return [ range ]
+    return [range]
   }
   let middle = startIndex.advanced(by: Index.Distance(length / 2))
   return [startIndex ..< middle, middle ..< endIndex]

--- a/test/SourceKit/CodeComplete/Inputs/custom-completion/custom.json
+++ b/test/SourceKit/CodeComplete/Inputs/custom-completion/custom.json
@@ -4,17 +4,17 @@
     {
       key.name: "customExpr",
       key.kind: myuid.customExpr,
-      key.context: [ source.lang.swift.expr ]
+      key.context: [source.lang.swift.expr]
     },
     {
       key.name: "customStmt",
       key.kind: myuid.customStmt,
-      key.context: [ source.lang.swift.stmt ]
+      key.context: [source.lang.swift.stmt]
     },
     {
       key.name: "customType",
       key.kind: myuid.customType,
-      key.context: [ source.lang.swift.type ]
+      key.context: [source.lang.swift.type]
     },
     {
       key.name: "customExprOrStmtOrType",

--- a/test/SourceKit/CodeComplete/Inputs/filter-rules/showSpecific.json
+++ b/test/SourceKit/CodeComplete/Inputs/filter-rules/showSpecific.json
@@ -11,6 +11,6 @@
   {
     key.kind: source.codecompletion.keyword,
     key.hide: 0,
-    key.uids: [ source.lang.swift.keyword.func ]
+    key.uids: [source.lang.swift.keyword.func]
   }
 ]

--- a/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
+++ b/unittests/Basic/UnicodeGraphemeBreakTest.cpp.gyb
@@ -46,7 +46,7 @@ static std::vector<unsigned> FindGraphemeClusterBoundaries(StringRef Str) {
 
 TEST(ExtractExtendedGraphemeCluster, TestsFromUnicodeSpec) {
 % for subject_string, expected_boundaries in grapheme_cluster_break_tests:
-  EXPECT_EQ((std::vector<unsigned>{ ${', '.join([ str(x) for x in expected_boundaries ])} }),
+  EXPECT_EQ((std::vector<unsigned>{ ${', '.join([str(x) for x in expected_boundaries])} }),
       FindGraphemeClusterBoundaries("${subject_string}"));
 % end
 }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1162,7 +1162,7 @@ func getAsNSMutableDictionary(_ d: Dictionary<Int, Int>) -> NSMutableDictionary 
 }
 
 func getBridgedVerbatimDictionary() -> Dictionary<NSObject, AnyObject> {
-  let nsd = getAsNSDictionary([ 10: 1010, 20: 1020, 30: 1030 ])
+  let nsd = getAsNSDictionary([10: 1010, 20: 1020, 30: 1030])
   return convertNSDictionaryToDictionary(nsd)
 }
 
@@ -1173,12 +1173,12 @@ func getBridgedVerbatimDictionary(_ d: Dictionary<Int, Int>) -> Dictionary<NSObj
 
 func getBridgedVerbatimDictionaryAndNSMutableDictionary()
     -> (Dictionary<NSObject, AnyObject>, NSMutableDictionary) {
-  let nsd = getAsNSMutableDictionary([ 10: 1010, 20: 1020, 30: 1030 ])
+  let nsd = getAsNSMutableDictionary([10: 1010, 20: 1020, 30: 1030])
   return (convertNSDictionaryToDictionary(nsd), nsd)
 }
 
 func getBridgedNonverbatimDictionary() -> Dictionary<TestBridgedKeyTy, TestBridgedValueTy> {
-  let nsd = getAsNSDictionary([ 10: 1010, 20: 1020, 30: 1030 ])
+  let nsd = getAsNSDictionary([10: 1010, 20: 1020, 30: 1030 ])
   return Swift._forceBridgeFromObjectiveC(nsd, Dictionary.self)
 }
 
@@ -1189,7 +1189,7 @@ func getBridgedNonverbatimDictionary(_ d: Dictionary<Int, Int>) -> Dictionary<Te
 
 func getBridgedNonverbatimDictionaryAndNSMutableDictionary()
     -> (Dictionary<TestBridgedKeyTy, TestBridgedValueTy>, NSMutableDictionary) {
-  let nsd = getAsNSMutableDictionary([ 10: 1010, 20: 1020, 30: 1030 ])
+  let nsd = getAsNSMutableDictionary([10: 1010, 20: 1020, 30: 1030])
   return (Swift._forceBridgeFromObjectiveC(nsd, Dictionary.self), nsd)
 }
 
@@ -1319,12 +1319,12 @@ class CustomImmutableNSDictionary : NSDictionary {
 
   override func object(forKey aKey: AnyObject) -> AnyObject? {
     CustomImmutableNSDictionary.timesObjectForKeyWasCalled += 1
-    return getAsNSDictionary([ 10: 1010, 20: 1020, 30: 1030 ]).object(forKey: aKey)
+    return getAsNSDictionary([10: 1010, 20: 1020, 30: 1030]).object(forKey: aKey)
   }
 
   override func keyEnumerator() -> NSEnumerator {
     CustomImmutableNSDictionary.timesKeyEnumeratorWasCalled += 1
-    return getAsNSDictionary([ 10: 1010, 20: 1020, 30: 1030 ]).keyEnumerator()
+    return getAsNSDictionary([10: 1010, 20: 1020, 30: 1030]).keyEnumerator()
   }
 
   override var count: Int {
@@ -1391,7 +1391,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.DictionaryIsCopied") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Verbatim.NSDictionaryIsRetained") {
   var nsd: NSDictionary = NSDictionary(dictionary:
-    getAsNSDictionary([ 10: 1010, 20: 1020, 30: 1030 ]))
+    getAsNSDictionary([10: 1010, 20: 1020, 30: 1030]))
 
   var d: [NSObject : AnyObject] = convertNSDictionaryToDictionary(nsd)
 
@@ -1408,7 +1408,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.NSDictionaryIsRetained") {
 
 DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.NSDictionaryIsCopied") {
   var nsd: NSDictionary = NSDictionary(dictionary:
-    getAsNSDictionary([ 10: 1010, 20: 1020, 30: 1030 ]))
+    getAsNSDictionary([10: 1010, 20: 1020, 30: 1030]))
 
   var d: [TestBridgedKeyTy : TestBridgedValueTy] =
     convertNSDictionaryToDictionary(nsd)
@@ -2438,40 +2438,40 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
 
   helper([:], [:], true)
 
-  helper([ 10: 1010 ],
-         [ 10: 1010 ],
+  helper([10: 1010],
+         [10: 1010],
          true)
 
-  helper([ 10: 1010, 20: 1020 ],
-         [ 10: 1010, 20: 1020 ],
+  helper([10: 1010, 20: 1020],
+         [10: 1010, 20: 1020],
          true)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
-         [ 10: 1010, 20: 1020, 30: 1030 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
+         [10: 1010, 20: 1020, 30: 1030],
          true)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
-         [ 10: 1010, 20: 1020, 1111: 1030 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
+         [10: 1010, 20: 1020, 1111: 1030],
          false)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
-         [ 10: 1010, 20: 1020, 30: 1111 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
+         [10: 1010, 20: 1020, 30: 1111],
          false)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
-         [ 10: 1010, 20: 1020 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
+         [10: 1010, 20: 1020],
          false)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
-         [ 10: 1010 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
+         [10: 1010],
          false)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
          [:],
          false)
 
-  helper([ 10: 1010, 20: 1020, 30: 1030 ],
-         [ 10: 1010, 20: 1020, 30: 1030, 40: 1040 ],
+  helper([10: 1010, 20: 1020, 30: 1030],
+         [10: 1010, 20: 1020, 30: 1030, 40: 1040],
          false)
 }
 
@@ -2480,7 +2480,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Verbatim.ArrayOfDictionaries") {
   var nsa = NSMutableArray()
   for i in 0..<3 {
     nsa.add(
-        getAsNSDictionary([ 10: 1010 + i, 20: 1020 + i, 30: 1030 + i ]))
+        getAsNSDictionary([10: 1010 + i, 20: 1020 + i, 30: 1030 + i]))
   }
 
   var a = nsa as [AnyObject] as! [Dictionary<NSObject, AnyObject>]
@@ -2501,7 +2501,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayOfDictionaries") {
   var nsa = NSMutableArray()
   for i in 0..<3 {
     nsa.add(
-        getAsNSDictionary([ 10: 1010 + i, 20: 1020 + i, 30: 1030 + i ]))
+        getAsNSDictionary([10: 1010 + i, 20: 1020 + i, 30: 1030 + i]))
   }
 
   var a = nsa as [AnyObject] as! [Dictionary<TestBridgedKeyTy, TestBridgedValueTy>]

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -665,7 +665,7 @@ SequenceTypeTests.test("reduce") {
       (partialResult: OpaqueValue<[Int]>, element: OpaqueValue<Int>)
         -> OpaqueValue<[Int]> in
       timesClosureWasCalled += 1
-      return OpaqueValue<[Int]>(partialResult.value + [ element.value ])
+      return OpaqueValue<[Int]>(partialResult.value + [element.value])
     }
     expectEqual(test.sequence, result.value)
     expectEqual([], s.map { $0.value }, "sequence should be consumed")

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2092,7 +2092,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.ArrayOfSets") {
   var nsa = NSMutableArray()
   for i in 0..<3 {
     nsa.add(
-        getAsNSSet([ 1 + i,  2 + i, 3 + i ]))
+        getAsNSSet([1 + i,  2 + i, 3 + i]))
   }
 
   var a = nsa as [AnyObject] as! [Set<NSObject>]
@@ -2104,7 +2104,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.ArrayOfSets") {
       let v = (value as! TestObjCKeyTy).value
       items.append(v)
     }
-    var expectedItems = [ 1 + i, 2 + i, 3 + i ]
+    var expectedItems = [1 + i, 2 + i, 3 + i]
     expectTrue(equalsUnordered(items, expectedItems))
   }
 }
@@ -2113,7 +2113,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayOfSets") {
   var nsa = NSMutableArray()
   for i in 0..<3 {
     nsa.add(
-        getAsNSSet([ 1 + i, 2 + i, 3 + i ]))
+        getAsNSSet([1 + i, 2 + i, 3 + i]))
   }
 
   var a = nsa as [AnyObject] as! [Set<TestBridgedKeyTy>]
@@ -2124,7 +2124,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayOfSets") {
     while let value = iter.next() {
       items.append(value.value)
     }
-    var expectedItems = [ 1 + i, 2 + i, 3 + i ]
+    var expectedItems = [1 + i, 2 + i, 3 + i]
     expectTrue(equalsUnordered(items, expectedItems))
   }
 }
@@ -2162,7 +2162,7 @@ SetTestSuite.test("BridgingRoundtrip") {
     let v = (value as! TestObjCKeyTy).value
     items.append(v)
   }
-  expectTrue(equalsUnordered([ 1010, 2020, 3030 ], items))
+  expectTrue(equalsUnordered([1010, 2020, 3030], items))
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.ObjectEnumerator.FastEnumeration.UseFromSwift") {
@@ -2325,7 +2325,7 @@ SetTestSuite.test("BridgedToObjC.MemberTypesCustomBridged") {
   while let nextObject = enumerator.nextObject() {
     members.append((nextObject as! TestObjCKeyTy).value)
   }
-  expectTrue(equalsUnordered([ 1010, 2020, 3030 ], members))
+  expectTrue(equalsUnordered([1010, 2020, 3030], members))
 
   expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }
@@ -3437,7 +3437,7 @@ class MockSetWithCustomCount : NSSet {
 
   override func objectEnumerator() -> NSEnumerator {
     expectUnreachable()
-    return getAsNSSet([ 1010, 1020, 1030 ]).objectEnumerator()
+    return getAsNSSet([1010, 1020, 1030]).objectEnumerator()
   }
 
   override var count: Int {
@@ -3686,37 +3686,37 @@ SetTestSuite.test("Operator.Precedence") {
 //===---
 
 SetTestSuite.test("mutationDoesNotAffectIterator/remove,1") {
-  var set = Set([ 1010, 1020, 1030 ])
+  var set = Set([1010, 1020, 1030])
   var iter = set.makeIterator()
   expectOptionalEqual(1010, set.remove(1010))
 
-  expectEqualsUnordered([ 1010, 1020, 1030 ], Array(IteratorSequence(iter)))
+  expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))
 }
 
 SetTestSuite.test("mutationDoesNotAffectIterator/remove,all") {
-  var set = Set([ 1010, 1020, 1030 ])
+  var set = Set([1010, 1020, 1030])
   var iter = set.makeIterator()
   expectOptionalEqual(1010, set.remove(1010))
   expectOptionalEqual(1020, set.remove(1020))
   expectOptionalEqual(1030, set.remove(1030))
 
-  expectEqualsUnordered([ 1010, 1020, 1030 ], Array(IteratorSequence(iter)))
+  expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))
 }
 
 SetTestSuite.test("mutationDoesNotAffectIterator/removeAll,keepingCapacity=false") {
-  var set = Set([ 1010, 1020, 1030 ])
+  var set = Set([1010, 1020, 1030])
   var iter = set.makeIterator()
   set.removeAll(keepingCapacity: false)
 
-  expectEqualsUnordered([ 1010, 1020, 1030 ], Array(IteratorSequence(iter)))
+  expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))
 }
 
 SetTestSuite.test("mutationDoesNotAffectIterator/removeAll,keepingCapacity=true") {
-  var set = Set([ 1010, 1020, 1030 ])
+  var set = Set([1010, 1020, 1030])
   var iter = set.makeIterator()
   set.removeAll(keepingCapacity: true)
 
-  expectEqualsUnordered([ 1010, 1020, 1030 ], Array(IteratorSequence(iter)))
+  expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))
 }
 
 runAllTests()

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -317,8 +317,8 @@ StringTests.test("literalConcatenation") {
 
 StringTests.test("appendToSubstring") {
   for initialSize in 1..<16 {
-    for sliceStart in [ 0, 2, 8, initialSize ] {
-      for sliceEnd in [ 0, 2, 8, sliceStart + 1 ] {
+    for sliceStart in [0, 2, 8, initialSize] {
+      for sliceEnd in [0, 2, 8, sliceStart + 1] {
         if sliceStart > initialSize || sliceEnd > initialSize ||
           sliceEnd < sliceStart {
           continue

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -133,7 +133,7 @@ func checkGraphemeClusterSegmentation(
   for c in subject.characters {
     let currentClusterSize = String(c).unicodeScalars.count
     unicodeScalarCount += currentClusterSize
-    actualBoundaries += [ unicodeScalarCount ]
+    actualBoundaries += [unicodeScalarCount]
   }
   expectEqual(
     expectedBoundaries, actualBoundaries,
@@ -167,9 +167,9 @@ UnicodeTrie.test("GraphemeClusterSegmentation/UnicodeSpec") {
 % for code_points, expected_boundaries in grapheme_cluster_break_tests:
   do {
     let scalars: [UInt32] =
-        [ ${", ".join([ str(cp) for cp in code_points ])} ]
+        [ ${", ".join([str(cp) for cp in code_points])} ]
     let expectedBoundaries: [Int] =
-        [ ${", ".join([ str(x) for x in expected_boundaries ])} ]
+        [ ${", ".join([str(x) for x in expected_boundaries])} ]
     checkGraphemeClusterSegmentation(expectedBoundaries, scalars: scalars,
         SourceLocStack().withCurrentLoc())
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

`[ a, b ]` → `[a, b]`, `\t` → ` `,`are are`→`are`
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
