### PR TITLE
Reorder and remove some passes to reduce compile time.

### DIFF
--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -219,24 +219,24 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
   // Promote stack allocations to values and eliminate redundant
   // loads.
   PM.addMem2Reg();
-  PM.addRedundantLoadElimination();
+  PM.addPerformanceConstantPropagation();
   //  Do a round of CFG simplification, followed by peepholes, then
   //  more CFG simplification.
-  AddSimplifyCFGSILCombine(PM);
 
-  PM.addPerformanceConstantPropagation();
-  PM.addCSE();
-  PM.addSILCombine();
-  PM.addJumpThreadSimplifyCFG();
-  // Jump threading can expose opportunity for silcombine (enum -> is_enum_tag->
+  // Jump threading can expose opportunity for SILCombine (enum -> is_enum_tag->
   // cond_br).
+  PM.addJumpThreadSimplifyCFG();
   PM.addSILCombine();
-  // Which can expose opportunity for simplifcfg.
+  // SILCombine can expose further opportunities for SimplifyCFG.
   PM.addSimplifyCFG();
+
+  PM.addCSE();
+  PM.addRedundantLoadElimination();
 
   // Perform retain/release code motion and run the first ARC optimizer.
   PM.addCSE();
   PM.addDCE();
+
   PM.addEarlyCodeMotion();
   PM.addARCSequenceOpts();
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Reduce compile time by reordering and eliminating some optimization passes.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

I'm measuring around a 1% reduciton in compile time for the stdlib, with
a handful of improvements on the benchmarks when compiled at -O, and one
small regression on one benchmark.
