### PR TITLE
[stdlib] Add Int.init(bitPattern: OpaquePointer?)

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -162,6 +162,20 @@ extension OpaquePointer : CustomDebugStringConvertible {
   }
 }
 
+extension Int {
+  @warn_unused_result
+  public init(bitPattern pointer: OpaquePointer?) {
+    self.init(bitPattern: UnsafePointer<Void>(pointer))
+  }
+}
+
+extension UInt {
+  @warn_unused_result
+  public init(bitPattern pointer: OpaquePointer?) {
+    self.init(bitPattern: UnsafePointer<Void>(pointer))
+  }
+}
+
 @warn_unused_result
 public func ==(lhs: OpaquePointer, rhs: OpaquePointer) -> Bool {
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -28,12 +28,11 @@ func _stdlib_atomicCompareExchangeStrongPtrImpl(
   expected: UnsafeMutablePointer<OpaquePointer?>,
   desired: OpaquePointer?) -> Bool {
 
-  // Bit-cast directly from 'OpaquePointer?' to 'Builtin.Word' because
-  // Builtin.RawPointer can't be nil.
+  // We use Builtin.Word here because Builtin.RawPointer can't be nil.
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
     target._rawValue,
-    unsafeBitCast(expected.pointee, to: Builtin.Word.self),
-    unsafeBitCast(desired, to: Builtin.Word.self))
+    UInt(bitPattern: expected.pointee)._builtinWordValue,
+    UInt(bitPattern: desired)._builtinWordValue)
   expected.pointee = OpaquePointer(bitPattern: Int(oldValue))
   return Bool(won)
 }

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -151,7 +151,6 @@ ${SelfName}TestSuite.test("Hashable") {
   }
 }
 
-% if SelfName != 'OpaquePointer':
 ${SelfName}TestSuite.test("toInteger") {
   do {
     let word: Int = 0x12345678
@@ -172,7 +171,6 @@ ${SelfName}TestSuite.test("toInteger") {
     expectEqual(UInt(0), UInt(bitPattern: ptr))
   }
 }
-% end
 
 % end
 


### PR DESCRIPTION
(and the same for UInt)

@gribozavr  and I consider this an oversight in [SE-0016](https://github.com/apple/swift-evolution/blob/master/proposals/0016-initializers-for-converting-unsafe-pointers-to-ints.md), particularly since OpaquePointer has the inverse operation `init?(bitPattern: Int)`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
