### PR TITLE
swift-reflection-dump: fix -Wpessimizing-move warning

### DIFF
--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -98,7 +98,7 @@ static int doDumpReflectionSections(std::string binaryFilename,
   OwningBinary<Binary> binaryOwner;
   std::unique_ptr<llvm::object::ObjectFile> objectOwner;
 
-  auto Expected = std::move(llvm::object::createBinary(binaryFilename));
+  auto Expected = llvm::object::createBinary(binaryFilename);
   if (!Expected) {
     std::cerr << "Could not create binary for " << binaryFilename;
     return EXIT_FAILURE;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

  warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    auto Expected = std::move(llvm::object::createBinary(binaryFileName)
                    ^
  note: remove std::move call here
    auto Expected = std::move(llvm::object::createBinary(binaryFilename)
                    ^~~~~~~~~
