### PR TITLE
[build-script] Introduce --dry-run mode

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -67,6 +67,7 @@ SWIFT_BUILD_ROOT = os.environ.get(
 
 def print_with_argv0(message):
     print(sys.argv[0] + ": " + message)
+    sys.stdout.flush()
 
 
 def quote_shell_command(args):
@@ -82,6 +83,7 @@ def check_call(args, print_command=False, verbose=False, disable_sleep=False):
 
     if print_command:
         print(os.getcwd() + "$ " + quote_shell_command(args))
+        sys.stdout.flush()
     try:
         return subprocess.check_call(args)
     except subprocess.CalledProcessError as e:
@@ -101,6 +103,7 @@ def check_call(args, print_command=False, verbose=False, disable_sleep=False):
 def check_output(args, print_command=False, verbose=False):
     if print_command:
         print(os.getcwd() + "$ " + quote_shell_command(args))
+        sys.stdout.flush()
     try:
         return subprocess.check_output(args)
     except subprocess.CalledProcessError as e:

--- a/utils/build-script
+++ b/utils/build-script
@@ -58,6 +58,12 @@ def main_preset():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""Builds Swift using a preset.""")
     parser.add_argument(
+        "-n", "--dry-run",
+        help="print the commands that would be executed, but do not execute "
+             "them",
+        action="store_true",
+        default=False)
+    parser.add_argument(
         "--preset-file",
         help="load presets from the specified file",
         metavar="PATH",
@@ -110,6 +116,8 @@ def main_preset():
         args.preset_substitutions, args.preset_file_names, args.preset)
 
     build_script_args = [sys.argv[0]]
+    if args.dry_run:
+        build_script_args += ["--dry-run"]
     build_script_args += preset_args
     if args.distcc:
         build_script_args += ["--distcc"]
@@ -305,6 +313,13 @@ to build Swift.  This is not a technical limitation of the Swift build system.
 It is a policy decision aimed at making the builds uniform across all
 environments and easily reproducible by engineers who are not familiar with the
 details of the setups of other systems or automated environments.""")
+
+    parser.add_argument(
+        "-n", "--dry-run",
+        help="print the commands that would be executed, but do not execute "
+             "them",
+        action="store_true",
+        default=False)
 
     targets_group = parser.add_argument_group(
         title="Host and cross-compilation targets")
@@ -968,6 +983,8 @@ details of the setups of other systems or automated environments.""")
         if '--check-args-only' in args.build_script_impl_args:
             return 0
 
+    shell.dry_run = args.dry_run
+
     # Prepare and validate toolchain
     toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
 
@@ -1418,6 +1435,9 @@ details of the setups of other systems or automated environments.""")
         ]
 
     build_script_impl_args += args.build_script_impl_args
+
+    if args.dry_run:
+        build_script_impl_args += ["--dry-run"]
 
     check_call([build_script_impl] + build_script_impl_args,
                disable_sleep=True)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -219,6 +219,26 @@ KNOWN_SETTINGS=(
     user-config-args            ""               "**Renamed to --extra-cmake-options**: User-supplied arguments to cmake when used to do configuration."
 )
 
+# Centalized access point for traced command invocation.
+# Every operation that might mutates file system should be called via
+# these functions.
+function call() {
+    { set -x; } 2>/dev/null
+    "$@"
+    { set +x; } 2>/dev/null
+}
+
+function with_pushd() {
+    local dir=$1
+    shift
+    set -x
+    pushd "${dir}"
+    "$@"
+    { set -x; } 2>/dev/null # because $@ might includes { set +x; }
+    popd
+    { set +x; } 2>/dev/null
+}
+
 function toupper() {
     echo "$@" | tr '[:lower:]' '[:upper:]'
 }
@@ -829,9 +849,7 @@ function cmake_needs_to_specify_standard_computed_defaults() {
 function copy_swift_stdlib_tool_substitute() {
     if [ ! -f "$1" ] ; then
         echo "--- Copy swift-stdlib-tool ---"
-        set -x
-        cp "${SWIFT_SOURCE_DIR}/utils/swift-stdlib-tool-substitute" "$1"
-        { set +x; } 2>/dev/null
+        call cp "${SWIFT_SOURCE_DIR}/utils/swift-stdlib-tool-substitute" "$1"
     fi
 }
 
@@ -840,7 +858,7 @@ function make_relative_symlink() {
     local TARGET=$2
     local TARGET_DIR=$(dirname $2)
     local RELATIVE_SOURCE=$(python -c "import os.path; print(os.path.relpath(\""${SOURCE}"\", \""${TARGET_DIR}"\"))")
-    ln -sf "${RELATIVE_SOURCE}" "${TARGET}"
+    call ln -sf "${RELATIVE_SOURCE}" "${TARGET}"
 }
 
 # Sanitize the list of cross-compilation targets.
@@ -1934,9 +1952,8 @@ for host in "${ALL_HOSTS[@]}"; do
                             )
                         fi
                         set_lldb_build_mode
-                        pushd ${source_dir}
-                        xcodebuild -target desktop -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
-                        popd
+                        with_pushd ${source_dir} \
+                            call xcodebuild -target desktop -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
                         continue
                         ;;
                 esac
@@ -1956,9 +1973,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
             swiftpm)
                 set_swiftpm_bootstrap_command
-                set -x
-                "${swiftpm_bootstrap_command[@]}"
-                { set +x; } 2>/dev/null
+                call "${swiftpm_bootstrap_command[@]}"
                 
                 # swiftpm installs itself with a bootstrap method. No further cmake building is performed.
                 continue
@@ -1976,14 +1991,12 @@ for host in "${ALL_HOSTS[@]}"; do
                     copy_swift_stdlib_tool_substitute "$(build_directory_bin ${host} swift)/swift-stdlib-tool"
                 fi
 
-                set -x
                 # FIXME: Use XCTEST_BUILD_TYPE (which is never properly
                 #        set) to build either --debug or --release.
-                "${XCTEST_SOURCE_DIR}"/build_script.py \
+                call "${XCTEST_SOURCE_DIR}"/build_script.py \
                     --swiftc="${SWIFTC_BIN}" \
                     --build-dir="${XCTEST_BUILD_DIR}" \
                     --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation"
-                { set +x; } 2>/dev/null
 
                 # XCTest builds itself and doesn't rely on cmake
                 continue
@@ -2026,13 +2039,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
     
-                set -x
-                pushd "${FOUNDATION_SOURCE_DIR}"
-                SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
+                with_pushd "${FOUNDATION_SOURCE_DIR}" \
+                    call env SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \
                       SDKROOT="${SWIFT_BUILD_PATH}" BUILD_DIR="${build_dir}" DSTROOT="$(get_host_install_destdir ${host})" PREFIX="$(get_host_install_prefix ${host})" ./configure "${FOUNDATION_BUILD_TYPE}" ${FOUNDATION_BUILD_ARGS[@]} -DXCTEST_BUILD_DIR=${XCTEST_BUILD_DIR} $LIBDISPATCH_BUILD_ARGS
-                ${NINJA_BIN}
-                popd
-                { set +x; } 2>/dev/null
+                with_pushd "${FOUNDATION_SOURCE_DIR}" \
+                    call ${NINJA_BIN}
 
                 # Foundation builds itself and doesn't use cmake
                 continue
@@ -2041,23 +2052,18 @@ for host in "${ALL_HOSTS[@]}"; do
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                 SWIFT_BUILD_PATH="$(build_directory ${host} swift)"
 
-                set -x
                 if [[ ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
                     # First time building; need to run autotools and configure
-                    mkdir -p "${LIBDISPATCH_BUILD_DIR}"
-                    pushd "${LIBDISPATCH_SOURCE_DIR}"
-                    autoreconf -fvi
-                    popd
-                    pushd "${LIBDISPATCH_BUILD_DIR}"
-                    "${LIBDISPATCH_SOURCE_DIR}"/configure --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})" --with-swift-toolchain="${SWIFT_BUILD_PATH}"
-                    popd
+                    call mkdir -p "${LIBDISPATCH_BUILD_DIR}"
+                    with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
+                        call autoreconf -fvi
+                    with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                        call "${LIBDISPATCH_SOURCE_DIR}"/configure --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})" --with-swift-toolchain="${SWIFT_BUILD_PATH}"
                 fi
-                pushd "${LIBDISPATCH_BUILD_DIR}"
-                make
-                cd tests
-                make build-tests
-                popd
-                { set +x; } 2>/dev/null
+                with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                    call make
+                with_pushd "${LIBDISPATCH_BUILD_DIR}/tests" \
+                    call make build-tests
 
                 # libdispatch builds itself and doesn't use cmake
                 continue
@@ -2069,8 +2075,8 @@ for host in "${ALL_HOSTS[@]}"; do
         esac
 
         # Clean the product-local module cache.
-        rm -rf "${module_cache}"
-        mkdir -p "${module_cache}"
+        call rm -rf "${module_cache}"
+        call mkdir -p "${module_cache}"
 
         # Compute the generator output file to check for, to determine if we
         # must reconfigure. We only handle Ninja for now.
@@ -2086,13 +2092,12 @@ for host in "${ALL_HOSTS[@]}"; do
         cmake_cache_path="${build_dir}/CMakeCache.txt"
         if [[  "${RECONFIGURE}" || ! -f "${cmake_cache_path}" || \
                     ( ! -z "${generator_output_path}" && ! -f "${generator_output_path}" ) ]] ; then
-            set -x
-            mkdir -p "${build_dir}"
+            call mkdir -p "${build_dir}"
             if [[ -n "${DISTCC}" ]]; then
                 EXTRA_DISTCC_OPTIONS=("DISTCC_HOSTS=localhost,lzo,cpp")
             fi
-            (cd "${build_dir}" && env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}")
-            { set +x; } 2>/dev/null
+            with_pushd "${build_dir}" \
+                call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
         fi
 
         # When we are building LLVM create symlinks to the c++ headers. We need
@@ -2115,9 +2120,7 @@ for host in "${ALL_HOSTS[@]}"; do
             BUILT_CXX_INCLUDE_DIR="$llvm_build_dir/include"
 
             echo "symlinking the system headers ($HOST_CXX_HEADERS_DIR) into the local clang build directory ($BUILT_CXX_INCLUDE_DIR)."
-            set -x
-            ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR"
-            { set +x; } 2>/dev/null
+            call ln -s -f "$HOST_CXX_HEADERS_DIR" "$BUILT_CXX_INCLUDE_DIR"
         fi
 
         # Build.
@@ -2130,14 +2133,10 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 # Xcode can't restart itself if it turns out we need to reconfigure.
                 # Do an advance build to handle that.
-                set -x
-                ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product})
-                { set +x; } 2>/dev/null
+                call ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product})
             fi
 
-            set -x
-            ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product}) -- "${BUILD_ARGS[@]}" ${build_targets[@]}
-            { set +x; } 2>/dev/null
+            call ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product}) -- "${BUILD_ARGS[@]}" ${build_targets[@]}
         fi
     done
 done
@@ -2210,8 +2209,6 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
 
                 results_dir="${lldb_build_dir}/test-results"
-                mkdir -p "${results_dir}"
-                pushd "${results_dir}"
 
                 # Handle test results formatter
                 if [[ "${LLDB_TEST_WITH_CURSES}" ]]; then
@@ -2245,8 +2242,9 @@ for host in "${ALL_HOSTS[@]}"; do
                     LLDB_DOTEST_CC_OPTS="-C $(build_directory $LOCAL_HOST llvm)"/bin/clang
                 fi
                 
-                SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" SWIFTLIBS="${swift_build_dir}/lib/swift" "${LLDB_SOURCE_DIR}"/test/dotest.py --executable "${lldb_executable}" --rerun-all-issues ${LLDB_DOTEST_CC_OPTS} ${LLDB_FORMATTER_OPTS}
-                popd
+                call mkdir -p "${results_dir}"
+                with_pushd "${results_dir}" \
+                    call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" SWIFTLIBS="${swift_build_dir}/lib/swift" "${LLDB_SOURCE_DIR}"/test/dotest.py --executable "${lldb_executable}" --rerun-all-issues ${LLDB_DOTEST_CC_OPTS} ${LLDB_FORMATTER_OPTS}
                 continue
                 ;;
             llbuild)
@@ -2261,9 +2259,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
                 echo "--- Running tests for ${product} ---"
-                set -x
-                "${swiftpm_bootstrap_command[@]}" test
-                { set +x; } 2>/dev/null
+                call "${swiftpm_bootstrap_command[@]}" test
                 # As swiftpm tests itself, we break early here.
                 continue
                 ;;
@@ -2275,12 +2271,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-                set -x
-                "${XCTEST_SOURCE_DIR}"/build_script.py test \
+                call "${XCTEST_SOURCE_DIR}"/build_script.py test \
                     --swiftc="${SWIFTC_BIN}" \
                     --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
                     "${XCTEST_BUILD_DIR}"
-                { set +x; } 2>/dev/null
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
@@ -2294,14 +2288,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
                 echo "--- Running tests for ${product} ---"
-                set -x
                 build_dir=$(build_directory ${host} ${product})
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-                pushd "${FOUNDATION_SOURCE_DIR}"
-                ${NINJA_BIN} TestFoundation
-                LD_LIBRARY_PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}":${LD_LIBRARY_PATH} "${build_dir}"/TestFoundation/TestFoundation
-                popd
-                { set +x; } 2>/dev/null
+                with_pushd "${FOUNDATION_SOURCE_DIR}" \
+                    call ${NINJA_BIN} TestFoundation
+                call env LD_LIBRARY_PATH="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}":${LD_LIBRARY_PATH} "${build_dir}"/TestFoundation/TestFoundation
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
@@ -2311,11 +2302,8 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                 echo "--- Running tests for ${product} ---"
-                set -x
-                pushd "${LIBDISPATCH_BUILD_DIR}"
-                make check
-                popd
-                { set +x; } 2>/dev/null
+                with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                    call make check
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;
@@ -2331,9 +2319,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
         if [[ "${executable_target}" != "" ]]; then
             echo "--- Building tests for ${product} ---"
-            set -x
-            ${DISTCC_PUMP} "${build_cmd[@]}" ${BUILD_TARGET_FLAG} "${executable_target}"
-            { set +x; } 2>/dev/null
+            call ${DISTCC_PUMP} "${build_cmd[@]}" ${BUILD_TARGET_FLAG} "${executable_target}"
         fi
 
         # We can only run tests built for the host machine, because
@@ -2357,9 +2343,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     # shell to execute that.
                     sh -e -x -c "$("${build_cmd[@]}" -n -v ${target} | sed -e 's/[^]]*] //')"
                 else
-                    set -x
-                    "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${target}
-                    { set +x; } 2>/dev/null
+                    call "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${target}
                 fi
                 echo "-- ${target} finished --"
             fi
@@ -2433,9 +2417,8 @@ for host in "${ALL_HOSTS[@]}"; do
                         ;;
                     macosx-*)
                         set_lldb_build_mode
-                        pushd ${LLDB_SOURCE_DIR}
-                        xcodebuild -target toolchain -configuration ${LLDB_BUILD_MODE} install ${lldb_xcodebuild_options[@]} DSTROOT="${host_install_destdir}" LLDB_TOOLCHAIN_PREFIX="${TOOLCHAIN_PREFIX}"
-                        popd
+                        with_pushd ${LLDB_SOURCE_DIR} \
+                            call xcodebuild -target toolchain -configuration ${LLDB_BUILD_MODE} install ${lldb_xcodebuild_options[@]} DSTROOT="${host_install_destdir}" LLDB_TOOLCHAIN_PREFIX="${TOOLCHAIN_PREFIX}"
                         continue
                         ;;
                 esac
@@ -2450,9 +2433,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
 
                 echo "--- Installing ${product} ---"
-                set -x
-                "${swiftpm_bootstrap_command[@]}" --prefix="${host_install_destdir}${host_install_prefix}" install
-                { set +x; } 2>/dev/null
+                call "${swiftpm_bootstrap_command[@]}" --prefix="${host_install_destdir}${host_install_prefix}" install
                 # As swiftpm bootstraps the installation itself, we break early here.
                 continue
                 ;;
@@ -2486,12 +2467,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 XCTEST_INSTALL_PREFIX="${host_install_destdir}${host_install_prefix}/lib/swift/${LIB_TARGET}"
                 # Note that installing directly to /usr/lib/swift usually
                 # requires root permissions.
-                set -x
-                "${XCTEST_SOURCE_DIR}"/build_script.py install \
+                call "${XCTEST_SOURCE_DIR}"/build_script.py install \
                     --library-install-path="${XCTEST_INSTALL_PREFIX}" \
                     --module-install-path="${XCTEST_INSTALL_PREFIX}"/"${SWIFT_HOST_VARIANT_ARCH}" \
                     "${XCTEST_BUILD_DIR}"
-                { set +x; } 2>/dev/null
 
                 # As XCTest installation is self-contained, we break early here.
                 continue
@@ -2511,11 +2490,8 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 echo "--- Installing ${product} ---"
                 build_dir=$(build_directory ${host} ${product})
-                set -x
-                pushd "${FOUNDATION_SOURCE_DIR}"
-                ${NINJA_BIN} install
-                popd
-                { set +x; } 2>/dev/null
+                with_pushd "${FOUNDATION_SOURCE_DIR}" \
+                    call ${NINJA_BIN} install
 
                 # As foundation installation is self-contained, we break early here.
                 continue
@@ -2530,11 +2506,8 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 echo "--- Installing ${product} ---"
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
-                set -x
-                pushd "${LIBDISPATCH_BUILD_DIR}"
-                make install
-                popd
-                { set +x; } 2>/dev/null
+                with_pushd "${LIBDISPATCH_BUILD_DIR}" \
+                    call make install
 
                 # As libdispatch installation is self-contained, we break early here.
                 continue
@@ -2553,10 +2526,7 @@ for host in "${ALL_HOSTS[@]}"; do
         echo "--- Installing ${product} ---"
         build_dir=$(build_directory ${host} ${product})
 
-        set -x
-
-        DESTDIR="${host_install_destdir}" "${CMAKE}" --build "${build_dir}" -- ${INSTALL_TARGETS}
-        { set +x; } 2>/dev/null
+        call env DESTDIR="${host_install_destdir}" "${CMAKE}" --build "${build_dir}" -- ${INSTALL_TARGETS}
     done
 
     if [[ "${DARWIN_INSTALL_EXTRACT_SYMBOLS}" ]] && [[ $(host_has_darwin_symbols ${host}) ]]; then
@@ -2628,47 +2598,47 @@ function build_and_test_installable_package() {
           DARWIN_TOOLCHAIN_CREATED_DATE="$(date -u +'%a %b %d %T GMT %Y')"
 
           echo "-- Removing: ${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          rm -f ${DARWIN_TOOLCHAIN_INFO_PLIST}
+          call rm -f ${DARWIN_TOOLCHAIN_INFO_PLIST}
 
-          ${PLISTBUDDY_BIN} -c "Add DisplayName string '${DARWIN_TOOLCHAIN_DISPLAY_NAME}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add ShortDisplayName string '${DARWIN_TOOLCHAIN_DISPLAY_NAME_SHORT}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add CreatedDate date '${DARWIN_TOOLCHAIN_CREATED_DATE}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add CompatibilityVersion integer ${COMPATIBILITY_VERSION}" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add Version string '${DARWIN_TOOLCHAIN_VERSION}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add CFBundleIdentifier string '${DARWIN_TOOLCHAIN_BUNDLE_IDENTIFIER}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add ReportProblemURL string '${DARWIN_TOOLCHAIN_REPORT_URL}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add Aliases array" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add Aliases:0 string '${DARWIN_TOOLCHAIN_ALIAS}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings dict" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:ENABLE_BITCODE string 'NO'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DISABLE_REQUIRED_ARCLITE string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
-          ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_LINK_OBJC_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add DisplayName string '${DARWIN_TOOLCHAIN_DISPLAY_NAME}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add ShortDisplayName string '${DARWIN_TOOLCHAIN_DISPLAY_NAME_SHORT}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add CreatedDate date '${DARWIN_TOOLCHAIN_CREATED_DATE}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add CompatibilityVersion integer ${COMPATIBILITY_VERSION}" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add Version string '${DARWIN_TOOLCHAIN_VERSION}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add CFBundleIdentifier string '${DARWIN_TOOLCHAIN_BUNDLE_IDENTIFIER}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add ReportProblemURL string '${DARWIN_TOOLCHAIN_REPORT_URL}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add Aliases array" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add Aliases:0 string '${DARWIN_TOOLCHAIN_ALIAS}'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings dict" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:ENABLE_BITCODE string 'NO'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_DISABLE_REQUIRED_ARCLITE string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call ${PLISTBUDDY_BIN} -c "Add OverrideBuildSettings:SWIFT_LINK_OBJC_RUNTIME string 'YES'" "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 
-          chmod a+r "${DARWIN_TOOLCHAIN_INFO_PLIST}"
+          call chmod a+r "${DARWIN_TOOLCHAIN_INFO_PLIST}"
 
           if [[ "${DARWIN_TOOLCHAIN_APPLICATION_CERT}" ]] ; then
             echo "-- Codesign xctoolchain --"
-            "${SWIFT_SOURCE_DIR}/utils/toolchain-codesign" "${DARWIN_TOOLCHAIN_APPLICATION_CERT}" "${host_install_destdir}${TOOLCHAIN_PREFIX}/" 
+            call "${SWIFT_SOURCE_DIR}/utils/toolchain-codesign" "${DARWIN_TOOLCHAIN_APPLICATION_CERT}" "${host_install_destdir}${TOOLCHAIN_PREFIX}/" 
           fi
           if [[ "${DARWIN_TOOLCHAIN_INSTALLER_PACKAGE}" ]] ; then
             echo "-- Create Installer --"
-            "${SWIFT_SOURCE_DIR}/utils/toolchain-installer" "${host_install_destdir}${TOOLCHAIN_PREFIX}/" "${DARWIN_TOOLCHAIN_BUNDLE_IDENTIFIER}" \
-            "${DARWIN_TOOLCHAIN_INSTALLER_CERT}" "${DARWIN_TOOLCHAIN_INSTALLER_PACKAGE}" "${DARWIN_TOOLCHAIN_INSTALL_LOCATION}" \
-            "${DARWIN_TOOLCHAIN_VERSION}" "${SWIFT_SOURCE_DIR}/utils/darwin-installer-scripts"
+            call "${SWIFT_SOURCE_DIR}/utils/toolchain-installer" "${host_install_destdir}${TOOLCHAIN_PREFIX}/" "${DARWIN_TOOLCHAIN_BUNDLE_IDENTIFIER}" \
+                "${DARWIN_TOOLCHAIN_INSTALLER_CERT}" "${DARWIN_TOOLCHAIN_INSTALLER_PACKAGE}" "${DARWIN_TOOLCHAIN_INSTALL_LOCATION}" \
+                "${DARWIN_TOOLCHAIN_VERSION}" "${SWIFT_SOURCE_DIR}/utils/darwin-installer-scripts"
           fi 
 
           # host_install_destdir contains the toolchain prefix.
           # We want to create the package in host_install_destdir_nonprefixed.
-          (cd "${host_install_destdir}" &&
-            tar -c -z -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}")
+          with_pushd "${host_install_destdir}" \
+              call tar -c -z -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}"
         else
             # tar on OSX doesn't support --owner/--group.
             if [[ "$(uname -s)" == "Darwin" ]] ; then
-                (cd "${host_install_destdir}" &&
-                        tar -c -z -f "${package_for_host}" "${host_install_prefix/#\/}")
+                with_pushd "${host_install_destdir}" \
+                    tar -c -z -f "${package_for_host}" "${host_install_prefix/#\/}"
             else
-                (cd "${host_install_destdir}" &&
-                        tar -c -z -f "${package_for_host}" --owner=0 --group=0 "${host_install_prefix/#\/}")
+                with_pushd "${host_install_destdir}" \
+                    tar -c -z -f "${package_for_host}" --owner=0 --group=0 "${host_install_prefix/#\/}"
             fi
         fi
         if [[ "${TEST_INSTALLABLE_PACKAGE}" ]] ; then
@@ -2685,16 +2655,13 @@ function build_and_test_installable_package() {
             LIT_EXECUTABLE_PATH="${LLVM_SOURCE_DIR}/utils/lit/lit.py"
             FILECHECK_EXECUTABLE_PATH="$(build_directory_bin ${LOCAL_HOST} llvm)/FileCheck"
             echo "-- Test Installable Package --"
-            set -x
-            rm -rf "${PKG_TESTS_SANDBOX_PARENT}"
-            mkdir -p "${PKG_TESTS_SANDBOX}"
-            pushd "${PKG_TESTS_SANDBOX_PARENT}"
-            tar xzf "${package_for_host}"
-            popd
+            call rm -rf "${PKG_TESTS_SANDBOX_PARENT}"
+            call mkdir -p "${PKG_TESTS_SANDBOX}"
+            with_pushd "${PKG_TESTS_SANDBOX_PARENT}" \
+                call tar xzf "${package_for_host}"
 
-            (cd "${PKG_TESTS_SOURCE_DIR}" &&
-                    python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param filecheck="${FILECHECK_EXECUTABLE_PATH}" --param test-exec-root="${PKG_TESTS_TEMPS}")
-            { set +x; } 2>/dev/null
+            with_pushd "${PKG_TESTS_SOURCE_DIR}" \
+                call python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param filecheck="${FILECHECK_EXECUTABLE_PATH}" --param test-exec-root="${PKG_TESTS_TEMPS}"
         fi
     fi
 }
@@ -2716,7 +2683,7 @@ if [[ ${#LIPO_SRC_DIRS[@]} -gt 0 ]]; then
     # This is from multiple hosts; Which host should we say it is? 
     # Let's call it 'merged-hosts' so that we can identify it.
     mergedHost="merged-hosts"
-    "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=$(xcrun_find_tool lipo) --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
+    call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=$(xcrun_find_tool lipo) --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
 
     # Build and test the lipo-ed package.
     build_and_test_installable_package ${mergedHost}

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -55,6 +55,7 @@ LLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;PowerPC;SystemZ"
 # referred to as `SWIFT_INSTALL_COMPONENTS` in the remainder of this script.
 KNOWN_SETTINGS=(
     # name                      default          description
+    dry-run                     ""               "print the commands that would be executed, but do not execute them"
     build-args                  ""               "arguments to the build tool; defaults to -j8 when CMake generator is \"Unix Makefiles\""
     build-dir                   ""               "out-of-tree build directory; default is in-tree. **This argument is required**"
     host-cc                     ""               "the path to CC, the 'clang' compiler for the host platform. **This argument is required**"
@@ -222,22 +223,41 @@ KNOWN_SETTINGS=(
 # Centalized access point for traced command invocation.
 # Every operation that might mutates file system should be called via
 # these functions.
+
 function call() {
-    { set -x; } 2>/dev/null
-    "$@"
-    { set +x; } 2>/dev/null
+    if [[ ${DRY_RUN} ]]; then
+        echo "${PS4}"$(quoted_print "$@")
+    else
+        { set -x; } 2>/dev/null
+        "$@"
+        { set +x; } 2>/dev/null
+    fi
 }
 
 function with_pushd() {
     local dir=$1
     shift
-    set -x
-    pushd "${dir}"
-    "$@"
-    { set -x; } 2>/dev/null # because $@ might includes { set +x; }
-    popd
-    { set +x; } 2>/dev/null
+    if [[ "$1" == "call" ]]; then
+        shift
+    fi
+    if [[ ${DRY_RUN} ]]; then
+        echo ${PS4}pushd "${dir}"
+        echo "${PS4}"$(quoted_print "$@")
+        echo ${PS4}popd
+    else
+        set -x
+        pushd "${dir}"
+        "$@"
+        { set -x; } 2>/dev/null # because $@ might includes { set +x; }
+        popd
+        { set +x; } 2>/dev/null
+    fi
 }
+
+function quoted_print() {
+    python -c 'import pipes; import sys; print(" ".join(pipes.quote(arg) for arg in sys.argv[1:]))' "$@"
+}
+
 
 function toupper() {
     echo "$@" | tr '[:lower:]' '[:upper:]'
@@ -1434,7 +1454,7 @@ function set_swiftpm_bootstrap_command() {
             XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
         fi
     fi
-    if [ ! -e "${LLBUILD_BIN}" ]; then
+    if [ "${SKIP_BUILD_LLBUILD}" ]; then
         echo "Error: Cannot build swiftpm without llbuild (swift-build-tool)."
         exit 1
     fi
@@ -2334,7 +2354,11 @@ for host in "${ALL_HOSTS[@]}"; do
             if [[ "${target}" != "" ]]; then
                 echo "--- ${target} ---"
                 trap "tests_busted ${product} '(${target})'" ERR
-                if [[ "${CMAKE_GENERATOR}" == Ninja ]] && !( "${build_cmd[@]}" --version 2>&1 | grep -i -q llbuild ); then
+
+                # NOTE: In dry-run mode, build_dir might not exist yet. In that
+                #       case, -n query will fail. So, in dry-run mode,
+                #       we don't expand test script.
+                if [[ ! "${DRY_RUN}" && "${CMAKE_GENERATOR}" == Ninja ]] && !( "${build_cmd[@]}" --version 2>&1 | grep -i -q llbuild ); then
                     # Ninja buffers command output to avoid scrambling the output
                     # of parallel jobs, which is awesome... except that it
                     # interferes with the progress meter when testing.  Instead of
@@ -2530,29 +2554,38 @@ for host in "${ALL_HOSTS[@]}"; do
     done
 
     if [[ "${DARWIN_INSTALL_EXTRACT_SYMBOLS}" ]] && [[ $(host_has_darwin_symbols ${host}) ]]; then
-        set -x
-        # Copy executables and shared libraries from the `host_install_destdir` to
-        # INSTALL_SYMROOT and run dsymutil on them.
-        (cd "${host_install_destdir}" &&
-         find ./"${TOOLCHAIN_PREFIX}" -perm -0111 -type f -print | cpio -pdm "${INSTALL_SYMROOT}")
+        echo "--- Extracting symbols ---"
 
-        # Run dsymutil on executables and shared libraries.
-        #
-        # Exclude shell scripts.
-        (cd "${INSTALL_SYMROOT}" &&
-         find ./"${TOOLCHAIN_PREFIX}" -perm -0111 -type f -print | \
-           grep -v swift-stdlib-tool | \
-           grep -v crashlog.py | \
-           grep -v symbolication.py | \
-           xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))
+        # FIXME: Since it's hard to trace output pipe call,
+        #        For now, We don't support dry-run trace for this block
+        #        Instead, just echo we do "darwin_intall_extract_symbols".
+        if [[ "${DRY_RUN}" ]]; then
+            call darwin_install_extract_symbols
+        else
+            set -x
+            # Copy executables and shared libraries from the `host_install_destdir` to
+            # INSTALL_SYMROOT and run dsymutil on them.
+            (cd "${host_install_destdir}" &&
+             find ./"${TOOLCHAIN_PREFIX}" -perm -0111 -type f -print | cpio -pdm "${INSTALL_SYMROOT}")
 
-        # Strip executables, shared libraries and static libraries in
-        # `host_install_destdir`.
-        find "${host_install_destdir}${TOOLCHAIN_PREFIX}/" \
-          -perm -0111 -or -name "*.a" -type f -print | \
-          xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+            # Run dsymutil on executables and shared libraries.
+            #
+            # Exclude shell scripts.
+            (cd "${INSTALL_SYMROOT}" &&
+             find ./"${TOOLCHAIN_PREFIX}" -perm -0111 -type f -print | \
+               grep -v swift-stdlib-tool | \
+               grep -v crashlog.py | \
+               grep -v symbolication.py | \
+               xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool dsymutil))
 
-        { set +x; } 2>/dev/null
+            # Strip executables, shared libraries and static libraries in
+            # `host_install_destdir`.
+            find "${host_install_destdir}${TOOLCHAIN_PREFIX}/" \
+              -perm -0111 -or -name "*.a" -type f -print | \
+              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+
+            { set +x; } 2>/dev/null
+        fi
     fi
 done
 # Everything is 'installed', but some products may be awaiting lipo.

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -13,6 +13,12 @@
 cd "$(dirname $0)/.." || exit
 SRC_DIR=$PWD
 
+DRY_RUN=
+if [[ "$1" == "-n" || "$1" == "--dry-run" ]] ; then
+    DRY_RUN="-n"
+    shift
+fi
+
 YEAR=$(date +"%Y")
 MONTH=$(date +"%m")
 DAY=$(date +"%d")
@@ -37,7 +43,7 @@ else
     SWIFT_PACKAGE=buildbot_linux
 fi
 
-./utils/build-script --preset="${SWIFT_PACKAGE}" \
+./utils/build-script ${DRY_RUN} --preset="${SWIFT_PACKAGE}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \

--- a/utils/swift_build_support/swift_build_support/debug.py
+++ b/utils/swift_build_support/swift_build_support/debug.py
@@ -37,5 +37,6 @@ def print_xcodebuild_versions(file=sys.stdout):
     print(u'--- SDK versions ---', file=file)
     print(u'{}\n'.format(_output(['xcodebuild', '-version', '-sdk'])),
           file=file)
+    file.flush()
     # You can't test beyond this because each developer's machines may have
     # a different set of SDKs installed.

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -41,10 +41,11 @@ def _print_command(dry_run, command, env=None, prompt="+ "):
     if env is not None:
         output += ['env'] + [_quote("%s=%s" % (k, v)) for k, v in env]
     output += [_quote(arg) for arg in command]
-    file = None
-    if not dry_run:
-        file = sys.stderr
+    file = sys.stderr
+    if dry_run:
+        file = sys.stdout
     print(prompt + ' '.join(output), file=file)
+    file.flush()
 
 
 def call(command, stderr=None, env=None, dry_run=None):


### PR DESCRIPTION
#### What's in this pull request?

If `-n` or `--dry-run` is specified in command line arguments, print the commands that would be executed to _stdout_, but do not execute them.
Using this, you can safely know such as exact cmake options, build targets, or directories to be created, without actual build.
Supported in `build-script` (both preset and normal) and `build-toolchain`.

```
utils/build-script -n -RT
utils/build-script -n --preset=buildbot_incremental,tools=RA,stdlib=RA
utils/build-toolchain -n local.swift
```

Example dry-run output by `utils/build-toolchain -n local.swift`
<details>
<summary>

Mac OS X</summary>



```
./utils/build-script: using preset 'buildbot_osx_package', which expands to ./utils/build-script --dry-run --ios --tvos --watchos --lldb --llbuild --swiftpm --release-debuginfo --build-subdir=buildbot_osx --ios --tvos --watchos --test --validation-test --long-test --assertions --no-swift-stdlib-assertions -- --lldb-no-debugserver --lldb-use-system-debugserver --lldb-build-type=Release --verbose-build --build-ninja --build-swift-static-stdlib --build-swift-stdlib-unittest-extra --compiler-vendor=apple '--swift-sdks=OSX;IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR' --install-swift --install-lldb --install-llbuild --install-swiftpm --install-destdir=/Users/rintaro/git/swift-oss/swift/swift-nightly-install --darwin-install-extract-symbols --install-symroot=/Users/rintaro/git/swift-oss/swift/swift-nightly-symroot --install-prefix=/Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/usr --test-installable-package --reconfigure --installable-package=/Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz --swift-enable-ast-verifier=0 '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service' '--llvm-install-components=libclang;libclang-headers' --installable-package=/Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz --symbols-package=/Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx-symbols.tar.gz --darwin-toolchain-bundle-identifier=local.swift.20160419 '--darwin-toolchain-display-name=Local Swift Development Snapshot 2016-04-19' --darwin-toolchain-name=swift-LOCAL-2016-04-19-a --darwin-toolchain-version=swift-LOCAL-2016-04-19-a --darwin-toolchain-alias=Local
Building the standard library for: swift-stdlib-macosx-x86_64 swift-stdlib-iphonesimulator-i386 swift-stdlib-iphonesimulator-x86_64 swift-stdlib-appletvsimulator-x86_64 swift-stdlib-watchsimulator-i386 swift-stdlib-iphoneos-arm64 swift-stdlib-iphoneos-armv7 swift-stdlib-appletvos-arm64 swift-stdlib-watchos-armv7k
Running Swift tests for: check-swift-all-macosx-x86_64 check-swift-all-iphonesimulator-i386 check-swift-all-iphonesimulator-x86_64 check-swift-all-appletvsimulator-x86_64 check-swift-all-watchsimulator-i386

+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx
cmark: using standard linker
+ rm -rf /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64
+ rm -f /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64/CMakeCache.txt
+ pushd /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64
+ /usr/local/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DCMAKE_MAKE_PROGRAM=/Users/rintaro/git/swift-oss/build/buildbot_osx/ninja-build/ninja -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo '-DCMAKE_C_FLAGS= -fno-stack-protector' '-DCMAKE_CXX_FLAGS= -fno-stack-protector' -DCMAKE_OSX_SYSROOT:PATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 /Users/rintaro/git/swift-oss/cmark
+ popd
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64 -- -j4 -v all
llvm: using standard linker
+ rm -rf /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64
+ rm -f /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/CMakeCache.txt
+ pushd /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64
+ /usr/local/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DCMAKE_MAKE_PROGRAM=/Users/rintaro/git/swift-oss/build/buildbot_osx/ninja-build/ninja '-DCMAKE_C_FLAGS= -fno-stack-protector' '-DCMAKE_CXX_FLAGS= -fno-stack-protector' -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO '-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;PowerPC' -DLLVM_INCLUDE_TESTS:BOOL=TRUE -LLVM_INCLUDE_DOCS:BOOL=TRUE -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9 -DCMAKE_OSX_SYSROOT:PATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -DLLVM_HOST_TRIPLE:STRING=x86_64-apple-macosx10.9 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL=TRUE -DCOMPILER_RT_ENABLE_IOS:BOOL=TRUE -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE -DCLANG_VENDOR=Apple -DCLANG_VENDOR_UTI=com.apple.compilers.llvm.clang -DPACKAGE_VERSION=3.8.0 -DCMAKE_INSTALL_PREFIX:PATH=/Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/usr -DINTERNAL_INSTALL_PREFIX=local /Users/rintaro/git/swift-oss/llvm
+ popd
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 -- -j4 -v all
symlinking the system headers (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../../usr/include/c++) into the local clang build directory (/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/include).
+ ln -s -f /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../../usr/include/c++ /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/include
swift: using standard linker
+ rm -rf /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64
+ rm -f /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/CMakeCache.txt
+ pushd /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64
+ /usr/local/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DCMAKE_MAKE_PROGRAM=/Users/rintaro/git/swift-oss/build/buildbot_osx/ninja-build/ninja '-DCMAKE_C_FLAGS= -fno-stack-protector' '-DCMAKE_CXX_FLAGS= -fno-stack-protector' -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=FALSE -DSWIFT_STDLIB_BUILD_TYPE:STRING=RelWithDebInfo -DSWIFT_STDLIB_ASSERTIONS:BOOL=FALSE -DSWIFT_STDLIB_ENABLE_REFLECTION_METADATA:BOOL=FALSE -DSWIFT_STDLIB_ENABLE_RESILIENCE:BOOL=FALSE -DSWIFT_STDLIB_SIL_SERIALIZE_ALL:BOOL=TRUE -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING= -DSWIFT_NATIVE_CLANG_TOOLS_PATH:STRING= -DSWIFT_NATIVE_SWIFT_TOOLS_PATH:STRING= -DSWIFT_BUILD_TOOLS:BOOL=TRUE -DSWIFT_BUILD_STDLIB:BOOL=TRUE -DSWIFT_SERIALIZE_STDLIB_UNITTEST:BOOL=FALSE -DSWIFT_STDLIB_SIL_DEBUGGING:BOOL=FALSE -DSWIFT_BUILD_SDK_OVERLAY:BOOL=TRUE -DSWIFT_BUILD_STATIC_STDLIB:BOOL=TRUE -DSWIFT_BUILD_PERF_TESTSUITE:BOOL=TRUE -DSWIFT_BUILD_EXAMPLES:BOOL=TRUE -DSWIFT_INCLUDE_TESTS:BOOL=TRUE '-DSWIFT_INSTALL_COMPONENTS:STRING=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service' -DSWIFT_EMBED_BITCODE_SECTION:BOOL=FALSE -DSWIFT_ENABLE_LTO:BOOL=FALSE -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=TRUE -DSWIFT_DARWIN_DEPLOYMENT_VERSION_OSX=10.9 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_IOS=7.0 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS=9.0 -DSWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS=2.0 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE -DSWIFT_VENDOR=Apple -DSWIFT_VENDOR_UTI=com.apple.compilers.llvm.swift -DSWIFT_VERSION=3.0 -DSWIFT_COMPILER_VERSION= -DDARWIN_TOOLCHAIN_VERSION=swift-LOCAL-2016-04-19-a -DSWIFT_DARWIN_XCRUN_TOOLCHAIN:STRING=default -DSWIFT_AST_VERIFIER:BOOL=FALSE -DSWIFT_SIL_VERIFY_ALL:BOOL=FALSE -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=FALSE -DCMAKE_INSTALL_PREFIX:PATH=/Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/usr -DLLVM_CONFIG:PATH=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/bin/llvm-config -DSWIFT_PATH_TO_CLANG_SOURCE:PATH=/Users/rintaro/git/swift-oss/llvm/tools/clang -DSWIFT_PATH_TO_CLANG_BUILD:PATH=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 -DSWIFT_PATH_TO_LLVM_SOURCE:PATH=/Users/rintaro/git/swift-oss/llvm -DSWIFT_PATH_TO_LLVM_BUILD:PATH=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 -DSWIFT_PATH_TO_CMARK_SOURCE:PATH=/Users/rintaro/git/swift-oss/cmark -DSWIFT_PATH_TO_CMARK_BUILD:PATH=/Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64 -DSWIFT_CMARK_LIBRARY_DIR:PATH=/Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64/src '-DSWIFT_SDKS:STRING=OSX;IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR' -DSWIFT_EXEC:STRING=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc /Users/rintaro/git/swift-oss/swift
+ popd
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v all swift-stdlib-macosx-x86_64 swift-stdlib-iphonesimulator-i386 swift-stdlib-iphonesimulator-x86_64 swift-stdlib-appletvsimulator-x86_64 swift-stdlib-watchsimulator-i386 swift-stdlib-iphoneos-arm64 swift-stdlib-iphoneos-armv7 swift-stdlib-appletvos-arm64 swift-stdlib-watchos-armv7k swift-benchmark-macosx-x86_64 swift-benchmark-iphoneos-arm64 swift-benchmark-iphoneos-armv7 swift-benchmark-appletvos-arm64 swift-benchmark-watchos-armv7k
lldb: using standard linker
+ pushd /Users/rintaro/git/swift-oss/lldb
+ xcodebuild -target desktop -configuration CustomSwift-Release LLDB_PATH_TO_LLVM_SOURCE=/Users/rintaro/git/swift-oss/llvm LLDB_PATH_TO_CLANG_SOURCE=/Users/rintaro/git/swift-oss/llvm/tools/clang LLDB_PATH_TO_SWIFT_SOURCE=/Users/rintaro/git/swift-oss/swift LLDB_PATH_TO_LLVM_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 LLDB_PATH_TO_CLANG_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 LLDB_PATH_TO_SWIFT_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 LLDB_PATH_TO_CMARK_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64 LLDB_IS_BUILDBOT_BUILD=0 'LLDB_BUILD_DATE="2016-04-19"' SYMROOT=/Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64 OBJROOT=/Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64 DEBUGSERVER_DISABLE_CODESIGN=1 DEBUGSERVER_DELETE_AFTER_BUILD=1 DEBUGSERVER_USE_FROM_SYSTEM=1
+ popd
llbuild: using standard linker
+ rm -rf /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64/module-cache
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64
+ rm -f /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64/CMakeCache.txt
+ pushd /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64
+ /usr/local/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -DCMAKE_MAKE_PROGRAM=/Users/rintaro/git/swift-oss/build/buildbot_osx/ninja-build/ninja -DCMAKE_INSTALL_PREFIX:PATH=/Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/usr -DLIT_EXECUTABLE:PATH=/Users/rintaro/git/swift-oss/llvm/utils/lit/lit.py -DFILECHECK_EXECUTABLE:PATH=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/bin/FileCheck -DCMAKE_BUILD_TYPE:STRING=Debug -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE /Users/rintaro/git/swift-oss/llbuild
+ popd
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64 -- -j4 -v all
swiftpm: using standard linker
+ /Users/rintaro/git/swift-oss/swiftpm/Utilities/bootstrap --sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -v --swiftc=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc --sbt=/Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64/bin/swift-build-tool --build=/Users/rintaro/git/swift-oss/build/buildbot_osx/swiftpm-macosx-x86_64
--- Building tests for cmark ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64 -- -j4 -v api_test
--- Running tests for cmark ---
--- test ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64 -- -j4 -v test
-- test finished --
--- Finished tests for cmark ---
--- Building tests for swift ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v SwiftUnitTests
--- Running tests for swift ---
--- check-swift-all-macosx-x86_64 ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v check-swift-all-macosx-x86_64
-- check-swift-all-macosx-x86_64 finished --
--- check-swift-all-iphonesimulator-i386 ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v check-swift-all-iphonesimulator-i386
-- check-swift-all-iphonesimulator-i386 finished --
--- check-swift-all-iphonesimulator-x86_64 ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v check-swift-all-iphonesimulator-x86_64
-- check-swift-all-iphonesimulator-x86_64 finished --
--- check-swift-all-appletvsimulator-x86_64 ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v check-swift-all-appletvsimulator-x86_64
-- check-swift-all-appletvsimulator-x86_64 finished --
--- check-swift-all-watchsimulator-i386 ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- -j4 -v check-swift-all-watchsimulator-i386
-- check-swift-all-watchsimulator-i386 finished --
--- Finished tests for swift ---
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64/test-results
+ pushd /Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64/test-results
+ env SWIFTCC=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc SWIFTLIBS=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/lib/swift /Users/rintaro/git/swift-oss/lldb/test/dotest.py --executable /Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64/CustomSwift-Release/lldb --rerun-all-issues -C /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/bin/clang --results-formatter lldbsuite.test.xunit_formatter.XunitFormatter --results-file /Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64/test-results/results.xml -O--xpass=ignore
+ popd
--- Running tests for llbuild ---
--- test ---
+ /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64 -- -j4 -v test
-- test finished --
--- Finished tests for llbuild ---
--- Running tests for swiftpm ---
+ /Users/rintaro/git/swift-oss/swiftpm/Utilities/bootstrap --sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -v --swiftc=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc --sbt=/Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64/bin/swift-build-tool --build=/Users/rintaro/git/swift-oss/build/buildbot_osx/swiftpm-macosx-x86_64 test
--- Installing llvm ---
+ env DESTDIR=/Users/rintaro/git/swift-oss/swift/swift-nightly-install /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 -- install-libclang install-libclang-headers
--- Installing swift ---
+ env DESTDIR=/Users/rintaro/git/swift-oss/swift/swift-nightly-install /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 -- install
+ pushd /Users/rintaro/git/swift-oss/lldb
+ xcodebuild -target toolchain -configuration CustomSwift-Release install LLDB_PATH_TO_LLVM_SOURCE=/Users/rintaro/git/swift-oss/llvm LLDB_PATH_TO_CLANG_SOURCE=/Users/rintaro/git/swift-oss/llvm/tools/clang LLDB_PATH_TO_SWIFT_SOURCE=/Users/rintaro/git/swift-oss/swift LLDB_PATH_TO_LLVM_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 LLDB_PATH_TO_CLANG_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64 LLDB_PATH_TO_SWIFT_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64 LLDB_PATH_TO_CMARK_BUILD=/Users/rintaro/git/swift-oss/build/buildbot_osx/cmark-macosx-x86_64 LLDB_IS_BUILDBOT_BUILD=0 'LLDB_BUILD_DATE="2016-04-19"' SYMROOT=/Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64 OBJROOT=/Users/rintaro/git/swift-oss/build/buildbot_osx/lldb-macosx-x86_64 DEBUGSERVER_DISABLE_CODESIGN=1 DEBUGSERVER_DELETE_AFTER_BUILD=1 DEBUGSERVER_USE_FROM_SYSTEM=1 DSTROOT=/Users/rintaro/git/swift-oss/swift/swift-nightly-install LLDB_TOOLCHAIN_PREFIX=/Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain
+ popd
--- Installing llbuild ---
+ env DESTDIR=/Users/rintaro/git/swift-oss/swift/swift-nightly-install /usr/local/bin/cmake --build /Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64 -- install-swift-build-tool
--- Installing swiftpm ---
+ /Users/rintaro/git/swift-oss/swiftpm/Utilities/bootstrap --sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -v --swiftc=/Users/rintaro/git/swift-oss/build/buildbot_osx/swift-macosx-x86_64/bin/swiftc --sbt=/Users/rintaro/git/swift-oss/build/buildbot_osx/llbuild-macosx-x86_64/bin/swift-build-tool --build=/Users/rintaro/git/swift-oss/build/buildbot_osx/swiftpm-macosx-x86_64 --prefix=/Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/usr install
--- Extracting symbols ---
+ darwin_install_extract_symbols
--- Creating installable package ---
-- Package file: /Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz --
-- Create Info.plist --
-- Removing: /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ rm -f /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ /usr/libexec/PlistBuddy -c 'Add DisplayName string '"'"'Local Swift Development Snapshot 2016-04-19'"'"'' /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ /usr/libexec/PlistBuddy -c 'Add Version string '"'"'swift-LOCAL-2016-04-19-a'"'"'' /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ /usr/libexec/PlistBuddy -c 'Add CFBundleIdentifier string '"'"'local.swift.20160419'"'"'' /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ /usr/libexec/PlistBuddy -c 'Add ReportProblemURL string '"'"'https://bugs.swift.org/'"'"'' /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ /usr/libexec/PlistBuddy -c 'Add Aliases array' /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ /usr/libexec/PlistBuddy -c 'Add Aliases:0 string '"'"'Local'"'"'' /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ chmod a+r /Users/rintaro/git/swift-oss/swift/swift-nightly-install//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain/Info.plist
+ pushd /Users/rintaro/git/swift-oss/swift/swift-nightly-install
+ tar -c -z -f /Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain
+ popd
-- Test Installable Package --
+ rm -rf /Users/rintaro/git/swift-oss/build/buildbot_osx/none-swift_package_sandbox
+ mkdir -p /Users/rintaro/git/swift-oss/build/buildbot_osx/none-swift_package_sandbox//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain
+ pushd /Users/rintaro/git/swift-oss/build/buildbot_osx/none-swift_package_sandbox
+ tar xzf /Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz
+ popd
+ pushd /Users/rintaro/git/swift-oss/swift-integration-tests
+ python /Users/rintaro/git/swift-oss/llvm/utils/lit/lit.py . -sv --param package-path=/Users/rintaro/git/swift-oss/build/buildbot_osx/none-swift_package_sandbox//Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain --param filecheck=/Users/rintaro/git/swift-oss/build/buildbot_osx/llvm-macosx-x86_64/bin/FileCheck
+ popd
--- Creating symbols package ---
-- Package file: /Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx-symbols.tar.gz --
+ pushd /Users/rintaro/git/swift-oss/swift/swift-nightly-symroot
+ tar -c -z -f /Users/rintaro/git/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx-symbols.tar.gz Library/Developer/Toolchains/swift-LOCAL-2016-04-19-a.xctoolchain
+ popd
```

</details>
<details>
<summary>

Linux</summary>



```
./utils/build-script: using preset 'buildbot_linux', which expands to ./utils/build-script --dry-run --assertions --no-swift-stdlib-assertions --llbuild --swiftpm --xctest --build-subdir=buildbot_linux --lldb --release --test --validation-test --long-test --foundation -- --swift-enable-ast-verifier=0 --install-swift --install-lldb --install-llbuild --install-swiftpm --install-xctest --install-prefix=/usr '--swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;license' --build-swift-static-stdlib --build-swift-stdlib-unittest-extra --skip-test-lldb --test-installable-package --install-destdir=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install --installable-package=/home/rintaro/Documents/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz --install-foundation --reconfigure
Building the standard library for: swift-stdlib-linux-x86_64
Running Swift tests for: check-swift-all-linux-x86_64

+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux
cmark: using standard linker
+ rm -rf /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64
+ rm -f /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64/CMakeCache.txt
+ pushd /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64
+ /usr/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/usr/bin/clang++ -DCMAKE_BUILD_TYPE:STRING=Release /home/rintaro/Documents/swift-oss/cmark
+ popd
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64 -- -j8 all
llvm: using standard linker
+ rm -rf /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64
+ rm -f /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/CMakeCache.txt
+ pushd /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64
+ /usr/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/usr/bin/clang++ '-DCMAKE_C_FLAGS= -fno-stack-protector' '-DCMAKE_CXX_FLAGS= -fno-stack-protector' -DCMAKE_BUILD_TYPE:STRING=Release -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO '-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;PowerPC' -DLLVM_INCLUDE_TESTS:BOOL=TRUE -LLVM_INCLUDE_DOCS:BOOL=TRUE -DCMAKE_INSTALL_PREFIX:PATH=/usr -DINTERNAL_INSTALL_PREFIX=local /home/rintaro/Documents/swift-oss/llvm
+ popd
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64 -- -j8 all
symlinking the system headers (/usr/include/c++) into the local clang build directory (/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/include).
+ ln -s -f /usr/include/c++ /home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/include
swift: using standard linker
+ rm -rf /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64
+ rm -f /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/CMakeCache.txt
+ pushd /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64
+ /usr/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/usr/bin/clang++ '-DCMAKE_C_FLAGS= -fno-stack-protector' '-DCMAKE_CXX_FLAGS= -fno-stack-protector' -DCMAKE_BUILD_TYPE:STRING=Release -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=FALSE -DSWIFT_STDLIB_BUILD_TYPE:STRING=Release -DSWIFT_STDLIB_ASSERTIONS:BOOL=FALSE -DSWIFT_STDLIB_ENABLE_REFLECTION_METADATA:BOOL=FALSE -DSWIFT_STDLIB_ENABLE_RESILIENCE:BOOL=FALSE -DSWIFT_STDLIB_SIL_SERIALIZE_ALL:BOOL=TRUE -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING= -DSWIFT_NATIVE_CLANG_TOOLS_PATH:STRING= -DSWIFT_NATIVE_SWIFT_TOOLS_PATH:STRING= -DSWIFT_BUILD_TOOLS:BOOL=TRUE -DSWIFT_BUILD_STDLIB:BOOL=TRUE -DSWIFT_SERIALIZE_STDLIB_UNITTEST:BOOL=FALSE -DSWIFT_STDLIB_SIL_DEBUGGING:BOOL=FALSE -DSWIFT_BUILD_SDK_OVERLAY:BOOL=TRUE -DSWIFT_BUILD_STATIC_STDLIB:BOOL=TRUE -DSWIFT_BUILD_PERF_TESTSUITE:BOOL=TRUE -DSWIFT_BUILD_EXAMPLES:BOOL=TRUE -DSWIFT_INCLUDE_TESTS:BOOL=TRUE '-DSWIFT_INSTALL_COMPONENTS:STRING=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;license' -DSWIFT_EMBED_BITCODE_SECTION:BOOL=FALSE -DSWIFT_ENABLE_LTO:BOOL=FALSE -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=TRUE -DSWIFT_DARWIN_XCRUN_TOOLCHAIN:STRING=default -DSWIFT_AST_VERIFIER:BOOL=FALSE -DSWIFT_SIL_VERIFY_ALL:BOOL=FALSE -DSWIFT_RUNTIME_ENABLE_LEAK_CHECKER:BOOL=FALSE -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLLVM_CONFIG:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/bin/llvm-config -DSWIFT_PATH_TO_CLANG_SOURCE:PATH=/home/rintaro/Documents/swift-oss/llvm/tools/clang -DSWIFT_PATH_TO_CLANG_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64 -DSWIFT_PATH_TO_LLVM_SOURCE:PATH=/home/rintaro/Documents/swift-oss/llvm -DSWIFT_PATH_TO_LLVM_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64 -DSWIFT_PATH_TO_CMARK_SOURCE:PATH=/home/rintaro/Documents/swift-oss/cmark -DSWIFT_PATH_TO_CMARK_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64 -DSWIFT_CMARK_LIBRARY_DIR:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64/src -DSWIFT_EXEC:STRING=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-macosx-x86_64/bin/swiftc /home/rintaro/Documents/swift-oss/swift
+ popd
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64 -- -j8 all swift-stdlib-linux-x86_64
lldb: using standard linker
+ rm -rf /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64
+ rm -f /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64/CMakeCache.txt
+ pushd /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64
+ /usr/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/usr/bin/clang++ -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLLDB_PATH_TO_LLVM_SOURCE:PATH=/home/rintaro/Documents/swift-oss/llvm -DLLDB_PATH_TO_CLANG_SOURCE:PATH=/home/rintaro/Documents/swift-oss/llvm/tools/clang -DLLDB_PATH_TO_SWIFT_SOURCE:PATH=/home/rintaro/Documents/swift-oss/swift -DLLDB_PATH_TO_LLVM_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64 -DLLDB_PATH_TO_CLANG_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64 -DLLDB_PATH_TO_SWIFT_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64 -DLLDB_PATH_TO_CMARK_BUILD:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64 -DLLDB_IS_BUILDBOT_BUILD=0 '-DLLDB_BUILD_DATE:STRING="2016-04-19"' -DLLDB_ALLOW_STATIC_BINDINGS=1 /home/rintaro/Documents/swift-oss/lldb
+ popd
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64 -- -j8 all
llbuild: using standard linker
+ rm -rf /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64/module-cache
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64
+ rm -f /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64/CMakeCache.txt
+ pushd /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64
+ /usr/bin/cmake -G Ninja -DCMAKE_C_COMPILER:PATH=/usr/bin/clang -DCMAKE_CXX_COMPILER:PATH=/usr/bin/clang++ -DCMAKE_INSTALL_PREFIX:PATH=/usr -DLIT_EXECUTABLE:PATH=/home/rintaro/Documents/swift-oss/llvm/utils/lit/lit.py -DFILECHECK_EXECUTABLE:PATH=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/bin/FileCheck -DCMAKE_BUILD_TYPE:STRING=Debug -DLLVM_ENABLE_ASSERTIONS:BOOL=TRUE /home/rintaro/Documents/swift-oss/llbuild
+ popd
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64 -- -j8 all
swiftpm: using standard linker
+ /home/rintaro/Documents/swift-oss/swiftpm/Utilities/bootstrap --swiftc=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swiftc --sbt=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64/bin/swift-build-tool --build=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swiftpm-linux-x86_64 --foundation=/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/Foundation --xctest=/home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64
foundation: using standard linker
+ pushd /home/rintaro/Documents/swift-oss/swift-corelibs-foundation
+ env SWIFTC=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swiftc CLANG=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/bin/clang SWIFT=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swift SDKROOT=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64 BUILD_DIR=/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64 DSTROOT=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install PREFIX=/usr ./configure Release -DXCTEST_BUILD_DIR=/home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64
+ ninja
+ popd
xctest: using standard linker
+ /home/rintaro/Documents/swift-oss/swift-corelibs-xctest/build_script.py --swiftc=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swiftc --build-dir=/home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64 --foundation-build-dir=/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/Foundation
--- Building tests for cmark ---
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64 -- -j8 api_test
--- Running tests for cmark ---
--- test ---
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/cmark-linux-x86_64 -- -j8 test
-- test finished --
--- Finished tests for cmark ---
--- Building tests for swift ---
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64 -- -j8 SwiftUnitTests
--- Running tests for swift ---
--- check-swift-all-linux-x86_64 ---
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64 -- -j8 check-swift-all-linux-x86_64
-- check-swift-all-linux-x86_64 finished --
--- Finished tests for swift ---
--- Running tests for llbuild ---
--- test ---
+ /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64 -- -j8 test
-- test finished --
--- Finished tests for llbuild ---
--- Running tests for swiftpm ---
+ /home/rintaro/Documents/swift-oss/swiftpm/Utilities/bootstrap --swiftc=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swiftc --sbt=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64/bin/swift-build-tool --build=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swiftpm-linux-x86_64 --foundation=/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/Foundation --xctest=/home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64 test
--- Running tests for foundation ---
+ pushd /home/rintaro/Documents/swift-oss/swift-corelibs-foundation
+ ninja TestFoundation
+ env LD_LIBRARY_PATH=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install//usr/lib/swift/:/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/Foundation:/home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64: /home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/TestFoundation/TestFoundation
+ popd
--- Finished tests for foundation ---
--- Running tests for xctest ---
+ /home/rintaro/Documents/swift-oss/swift-corelibs-xctest/build_script.py test --swiftc=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swiftc --foundation-build-dir=/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/Foundation /home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64
--- Finished tests for xctest ---
--- Installing swift ---
+ env DESTDIR=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64 -- install
--- Installing lldb ---
+ env DESTDIR=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/lldb-linux-x86_64 -- install
--- Installing llbuild ---
+ env DESTDIR=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install /usr/bin/cmake --build /home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64 -- install-swift-build-tool
--- Installing swiftpm ---
+ /home/rintaro/Documents/swift-oss/swiftpm/Utilities/bootstrap --swiftc=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swift-linux-x86_64/bin/swiftc --sbt=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llbuild-linux-x86_64/bin/swift-build-tool --build=/home/rintaro/Documents/swift-oss/build/buildbot_linux/swiftpm-linux-x86_64 --foundation=/home/rintaro/Documents/swift-oss/build/buildbot_linux/foundation-linux-x86_64/Foundation --xctest=/home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64 --prefix=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install//usr install
--- Installing foundation ---
+ pushd /home/rintaro/Documents/swift-oss/swift-corelibs-foundation
+ ninja install
+ popd
--- Installing xctest ---
+ /home/rintaro/Documents/swift-oss/swift-corelibs-xctest/build_script.py install --library-install-path=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install//usr/lib/swift/linux --module-install-path=/home/rintaro/Documents/swift-oss/swift/swift-nightly-install//usr/lib/swift/linux/x86_64 /home/rintaro/Documents/swift-oss/build/buildbot_linux/xctest-linux-x86_64
--- Creating installable package ---
-- Package file: /home/rintaro/Documents/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz --
+ pushd /home/rintaro/Documents/swift-oss/swift/swift-nightly-install
+ tar -c -z -f /home/rintaro/Documents/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz --owner=0 --group=0 usr
+ popd
-- Test Installable Package --
+ rm -rf /home/rintaro/Documents/swift-oss/build/buildbot_linux/none-swift_package_sandbox
+ mkdir -p /home/rintaro/Documents/swift-oss/build/buildbot_linux/none-swift_package_sandbox
+ pushd /home/rintaro/Documents/swift-oss/build/buildbot_linux/none-swift_package_sandbox
+ tar xzf /home/rintaro/Documents/swift-oss/swift/swift-LOCAL-2016-04-19-a-osx.tar.gz
+ popd
+ pushd /home/rintaro/Documents/swift-oss/swift-integration-tests
+ python /home/rintaro/Documents/swift-oss/llvm/utils/lit/lit.py . -sv --param package-path=/home/rintaro/Documents/swift-oss/build/buildbot_linux/none-swift_package_sandbox --param filecheck=/home/rintaro/Documents/swift-oss/build/buildbot_linux/llvm-linux-x86_64/bin/FileCheck
+ popd
```

</details>
#### Things to consider
- `dry-run` mode doesn't invoke actual build command in dry-run mode. i.e. `ninja -n`
- To prevent buffering issue, added `.flush()` right after every `print()` in Python code. Currently, because of buffering, `build-script: using preset 'buildbot_linux_1404', which expands to ...` message was [printed at last](https://ci.swift.org/view/Pull%20Request/job/swift-PR-Linux/1180/console#console-section-9).
- Because of the nature of shell-script, we can't transparently implement dry-run mode.
  In `build-script-impl`, we have to use `call` utility function: e.g. `call cmake -G Ninja`.
  However, I think, this is not necessarily a regression. Since we use `call` for all traced commands,
  we can easily visually distinguish potentially "dangerous" commands from control flow code.
  And, as a side effect, `build-script` doesn't emit confusing trace output like:
  
  ```
  ++ uname -s
  + [[ Linux == \D\a\r\w\i\n ]]
  ...
  ++ cmake_config_opt cmark
  ++ product=cmark
  ++ [[ Ninja == \X\c\o\d\e ]]
  ```
  
  anymore.
  And we don't have to write `set -x;` and `{ set +x; } 2>/dev/null` block manually.
- As above, this `build-script-impl` outputs relatively ~~simple~~ clean trace than current one. If it lacks any necessary information, please tell me. 
- `call` can only support simple command and arguments construct. To support commands that includes pipes(`|`) or redirects(`<`, `>`, `>>`, etc.), we have to do something special like:
  
  ```
  runscript() {                                                                     
      if [[ "${DRY_RUN}" ]]; then                                                   
          echo "$@"                                                                 
      else                                                                          
          set -x                                                                    
          eval "$@"                                                                 
      fi                                                                            
  }                                                                          
  runscript "find '${DIR}' -name '*.a' | xargs -n 1 strip"
  ```
  
  Because we need special care about complicated quoting for this, it's not included in this PR.
  Luckly, we have [only one block using pipes](https://github.com/rintaro/swift/blob/a8aeb890b700d2b985517d70dd3fbe71a4c8e602/utils/build-script-impl#L2515-L2550).
- To set environment variables in child process, you need `call env FOO=VAL command` instead of `FOO=VAL command` or `call FOO=VAL command`.
- To simulate `set -x` trace as exact as possible, command dump in dry-run mode [uses Python `pipes.quote()`](https://github.com/rintaro/swift/blob/a8aeb890b700d2b985517d70dd3fbe71a4c8e602/utils/build-script-impl#L259). Since it significantly slows down serialization, please someone tell me better way!
  Moreover, `pipes.quote()` emits inaccurate result for argument like  `"foo 'bar'"`. `pipes.quote()` emits `'foo '"'"'bar'"'"''`, whereas `set -x` emits `'foo '\''bar'\'''`

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
