### PR TITLE
[android] Guard spawn.h import

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.c
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Spawn is not available on Android.
+#if !defined(__ANDROID__)
+
 // NOTE: preprocess away the availability information to allow use of
 // unsupported APIs on certain targets (i.e. tvOS)
 #define availability(...)
@@ -19,7 +22,7 @@
 // NOTE: forward declare this rather than including crt_externs.h as not all
 // SDKs provide it
 extern char ***_NSGetEnviron(void);
-#endif
+#endif // defined(__APPLE__)
 
 int swift_posix_spawn_file_actions_init(
     posix_spawn_file_actions_t *file_actions) {
@@ -53,5 +56,6 @@ int swift_posix_spawn(pid_t *__restrict pid, const char * __restrict path,
 char ***swift_SwiftPrivateLibcExtras_NSGetEnviron(void) {
   return _NSGetEnviron();
 }
-#endif
+#endif // defined(__APPLE__)
+#endif // defined(__ANDROID__)
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

`spawn.h` isn't available on Android. Put its import behind an `#if defined(__ANDROID__)` in order to fix the Android build.

/cc @compnerd, who added the import in https://github.com/apple/swift/pull/2006. Does this modification work for you?
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
