### PR TITLE
Adding validation tests for LazyFilterCollection and LazyMapCollection

### DIFF
--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -1,0 +1,101 @@
+// -*- swift -*-
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %S/../../../utils/gyb %s -o %t/main.swift
+// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyFilterCollection.swift.a.out
+// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/LazyFilterCollection.swift.a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdlibCollectionUnittest
+
+var CollectionTests = TestSuite("Collection")
+
+%{
+variations = [('', 'Sequence'), ('', 'Collection'), ('Bidirectional', 'Collection')]
+}%
+
+// Test collections using value types as elements.
+% for (traversal, kind) in variations:
+CollectionTests.add${traversal}${kind}Tests(
+  make${kind}: { (elements: [OpaqueValue<Int>]) -> LazyFilter${kind}<Minimal${traversal}${kind}<OpaqueValue<Int>>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValue: identity,
+  extractValue: identity,
+  make${kind}OfEquatable: { (elements: [MinimalEquatableValue]) -> LazyFilter${kind}<Minimal${traversal}${kind}<MinimalEquatableValue>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValueIntoEquatable: identityEq,
+  extractValueFromEquatable: identityEq
+)
+% end
+
+// Test collections using reference types as elements.
+% for (traversal, kind) in variations:
+CollectionTests.add${traversal}${kind}Tests(
+  make${kind}: { (elements: [LifetimeTracked]) -> LazyFilter${kind}<Minimal${traversal}${kind}<LifetimeTracked]>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValue: { (element: OpaqueValue<Int>) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValue: { (element: LifetimeTracked) in
+    OpaqueValue(element.value, identity: element.identity)
+  },
+  make${kind}OfEquatable: { (elements: [LifetimeTracked]) -> LazyFilter${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValueIntoEquatable: { (element: MinimalEquatableValue) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValueFromEquatable: { (element: LifetimeTracked) in
+    MinimalEquatableValue(element.value, identity: element.identity)
+  }
+)
+% end
+
+// Test collection instances and iterators.
+CollectionTests.test("LazyFilterCollection instances") {
+% for (traversal, kind) in variations:
+  do {
+    let expected : [String] = []
+    let base = ["apple", "orange", "banana", "grapefruit", "lychee"]
+% if kind == 'Sequence':
+    checkSequence(expected, MinimalSequence(elements: base).lazy.filter { _ in return false })
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(expected, MinimalCollection(elements: base).lazy.filter { _ in return false }, sameValue: { $0 == $1 })
+% else:
+    check${traversal}${kind}(expected, Minimal${traversal}${kind}(elements: base).lazy.filter { _ in return false }, sameValue: { $0 == $1 })
+% end
+  }
+  do {
+    let expected = ["apple", "orange", "banana", "grapefruit", "lychee"]
+    let base = ["apple", "orange", "banana", "grapefruit", "lychee"]
+% if kind == 'Sequence':
+    checkSequence(expected, MinimalSequence(elements: base).lazy.filter { _ in return true })
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(expected, MinimalCollection(elements: base).lazy.filter { _ in return true }, sameValue: { $0 == $1 })
+% else:
+    check${traversal}${kind}(expected, Minimal${traversal}${kind}(elements: base).lazy.filter { _ in return true }, sameValue: { $0 == $1 })
+% end
+  }
+  do {
+    let expected = [2, 4, 6, 8, 10, 12, 14, 16]
+    let base = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+% if kind == 'Sequence':
+    checkSequence(expected, MinimalSequence(elements: base).lazy.filter { $0 % 2 == 0 })
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(expected, MinimalCollection(elements: base).lazy.filter { $0 % 2 == 0 }, sameValue: { $0 == $1 })
+% else:
+    check${traversal}${kind}(expected, Minimal${traversal}${kind}(elements: base).lazy.filter { $0 % 2 == 0 }, sameValue: { $0 == $1 })
+  }
+% end
+}
+
+runAllTests()

--- a/validation-test/stdlib/Collection/LazyMapCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyMapCollection.swift.gyb
@@ -1,0 +1,87 @@
+// -*- swift -*-
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %S/../../../utils/gyb %s -o %t/main.swift
+// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyMapCollection.swift.a.out
+// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/LazyMapCollection.swift.a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdlibCollectionUnittest
+
+var CollectionTests = TestSuite("Collection")
+
+%{
+variations = [('', 'Sequence'), ('', 'Collection'), ('Bidirectional', 'Collection'), ('RandomAccess', 'Collection')]
+}%
+
+// Test collections using value types as elements.
+% for (traversal, kind) in variations:
+CollectionTests.add${traversal}${kind}Tests(
+  make${kind}: { (elements: [OpaqueValue<Int>]) -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<OpaqueValue<Int>>, OpaqueValue<Int>> in
+    Minimal${traversal}${kind}(elements: elements).lazy.map(identity)
+  },
+  wrapValue: identity,
+  extractValue: identity,
+  make${kind}OfEquatable: { (elements: [MinimalEquatableValue]) -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<MinimalEquatableValue>, MinimalEquatableValue> in
+    Minimal${traversal}${kind}(elements: elements).lazy.map(identityEq)
+  },
+  wrapValueIntoEquatable: identityEq,
+  extractValueFromEquatable: identityEq
+)
+% end
+
+// Test collections using reference types as elements.
+% for (traversal, kind) in variations:
+CollectionTests.add${traversal}${kind}Tests(
+  make${kind}: { (elements: [LifetimeTracked]) -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>, LifetimeTracked> in
+    Minimal${traversal}${kind}(elements: elements).lazy.map { $0 }
+  },
+  wrapValue: { (element: OpaqueValue<Int>) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValue: { (element: LifetimeTracked) in
+    OpaqueValue(element.value, identity: element.identity)
+  },
+  make${kind}OfEquatable: { (elements: [LifetimeTracked]) -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>, LifetimeTracked> in
+    Minimal${traversal}${kind}(elements: elements).lazy.map { $0 }
+  },
+  wrapValueIntoEquatable: { (element: MinimalEquatableValue) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValueFromEquatable: { (element: LifetimeTracked) in
+    MinimalEquatableValue(element.value, identity: element.identity)
+  }
+)
+% end
+
+// Test sequence instances and iterators.
+CollectionTests.test("LazyMapCollection instances") {
+% for (traversal, kind) in variations:
+  do {
+    let expected = ["convent", "conform", "constrict", "condone"]
+    let base = ["vent", "form", "strict", "done"]
+% if kind == 'Sequence':
+    checkSequence(expected, MinimalSequence(elements: base).lazy.map { "con" + $0 })
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(expected, MinimalCollection(elements: base).lazy.map { "con" + $0 }, sameValue: { $0 == $1 })
+% else:
+    check${traversal}${kind}(expected, Minimal${traversal}${kind}(elements: base).lazy.map { "con" + $0 }, sameValue: { $0 == $1 })
+% end
+  }
+  do {
+    let expected = [1, 4, 9, 16, 25, 36, 49, 64]
+    let base = [1, 2, 3, 4, 5, 6, 7, 8]
+% if kind == 'Sequence':
+    checkSequence(expected, MinimalSequence(elements: base).lazy.map { $0 * $0 })
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(expected, MinimalCollection(elements: base).lazy.map { $0 * $0 }, sameValue: { $0 == $1 })
+% else:
+    check${traversal}${kind}(expected, Minimal${traversal}${kind}(elements: base).lazy.map { $0 * $0 }, sameValue: { $0 == $1 })
+% end
+  }
+% end
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

@gribozavr 

This PR adds validation tests for `LazyFilterCollection` and `LazyMapCollection`. As a side effect, it also makes `LifetimeTracked` formally `Comparable`.

NOTE: The tests run but some of them fail. Not sure if it's because I am using the stdlib test APIs wrong or because there is an underlying bug with the new collection code, but given they only occur with one of the collection subtypes I'm inclined to believe it's the latter. I've reproduced the failing tests below:

```
Collection: Some tests failed, aborting
UXPASS: []
FAIL: ["LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.Index/OutOfBounds/Left/NonEmpty", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.Index/OutOfBounds/Left/Empty", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.subscript(_: Range)/OutOfBounds/Left/NonEmpty/Get", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.subscript(_: Range)/OutOfBounds/Left/Empty/Get", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.index(where:)/semantics", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.Index/OutOfBounds/Left/NonEmpty", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.Index/OutOfBounds/Left/Empty", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.subscript(_: Range)/OutOfBounds/Left/NonEmpty/Get", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.subscript(_: Range)/OutOfBounds/Left/Empty/Get", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.Index/OutOfBounds/Left/NonEmpty", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.Index/OutOfBounds/Left/Empty", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.subscript(_: Range)/OutOfBounds/Left/NonEmpty/Get", "LazyMapRandomAccessCollection<Array<OpaqueValue<Int>>, OpaqueValue<Int>>.Type.subscript(_: Range)/OutOfBounds/Left/Empty/Get", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.index(where:)/semantics", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.Index/OutOfBounds/Left/NonEmpty", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.Index/OutOfBounds/Left/Empty", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.subscript(_: Range)/OutOfBounds/Left/NonEmpty/Get", "LazyMapRandomAccessCollection<Array<LifetimeTracked>, LifetimeTracked>.Type.subscript(_: Range)/OutOfBounds/Left/Empty/Get"]
SKIP: []
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
