### PR TITLE
[RemoteAST] Don't build remoteast-test for Android

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1863,7 +1863,8 @@ function(_add_swift_executable_single name)
       PROPERTIES FOLDER "Swift executables")
 endfunction()
 
-# Add an executable for the target machine.
+# Add an executable for each target variant. Executables are given suffixes
+# with the variant SDK and ARCH.
 #
 # See add_swift_executable for detailed documentation.
 #
@@ -1977,6 +1978,10 @@ endfunction()
 #
 #   source1 ...
 #     Sources to add into this executable.
+#
+# Note:
+#   Host executables are not given a variant suffix. To build a executable for
+#   each SDK and ARCH variant, use add_swift_target_executable.
 function(add_swift_executable name)
   # Parse the arguments we were given.
   cmake_parse_arguments(SWIFTEXE
@@ -1997,7 +2002,6 @@ function(add_swift_executable name)
 
   set(SWIFTEXE_SOURCES ${SWIFTEXE_UNPARSED_ARGUMENTS})
 
-  # Note: host tools don't get a variant suffix.
   _add_swift_executable_single(
       ${name}
       ${SWIFTEXE_SOURCES}

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_swift_target_executable(swift-remoteast-test
+add_swift_executable(swift-remoteast-test
   swift-remoteast-test.cpp
   LINK_LIBRARIES
     swiftRemoteAST)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

swiftRemoteAST and its dependencies must be linked against uuid, rt, tinfo, and pthread--none of which are available on Android. Exclude the remoteast-test target from being built for Android for now. This fixes the Android build.

/cc @rjmccall, who added this target in https://github.com/apple/swift/commit/e758ba3569a0d696e6812d10e7bfd5772b9e5667.
#### Resolved bug number: ([SR-1264](https://bugs.swift.org/browse/SR-1264))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
