### PR TITLE
[RemoteAST][build-break] Fix missing cassert include

### DIFF
--- a/include/swift/Remote/Failure.h
+++ b/include/swift/Remote/Failure.h
@@ -23,6 +23,7 @@
 #include "llvm/Support/Compiler.h"
 #include <string>
 #include <cstring>
+#include <cassert>
 #include <type_traits>
 
 namespace swift {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

`assert` is undefined, causing the build to break (on at least Ubuntu 15.10) as of https://github.com/apple/swift/commit/093009b3ef9329e44d8d4b8b69e271ba5e3b80d2.

/cc @rjmccall 
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
