### PR TITLE
ValueLifetimeAnalysis: fix the case if the last use of the value is a…

### DIFF
--- a/test/SILOptimizer/closure_specialize.sil
+++ b/test/SILOptimizer/closure_specialize.sil
@@ -174,6 +174,15 @@ bb0(%0 : $@callee_owned (@owned A) -> ()):
   return %3 : $()
 }
 
+// CHECK-LABEL: sil shared {{.*}} @_TTS{{.*}}use_closure_throw : $@convention(thin) (@owned A) -> @error ErrorProtocol {
+sil hidden [noinline] @use_closure_throw : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> @error ErrorProtocol {
+bb0(%0 : $@callee_owned (@owned A) -> ()):
+  %1 = alloc_ref $A
+  %2 = apply %0(%1) : $@callee_owned (@owned A) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
 // CHECK-LABEL: sil {{.*}} @different_execution_counts
 // CHECK: bb0([[ARG:%.*]] : $A
 // CHECK:   strong_retain [[ARG]]
@@ -369,6 +378,45 @@ bb2:
 
 bb3:
   strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @insert_release_after_try_apply
+// CHECK: bb0(%0 : $A):
+// CHECK:   retain_value %0
+// CHECK: bb1:
+// CHECK:   retain_value %0
+// CHECK-NEXT:   try_apply
+// CHECK: bb2(%{{[0-9]+}} : $()):
+// CHECK-NEXT:   strong_release %0
+// CHECK-NEXT:   release_value %0
+// CHECK-NEXT:   br bb4
+// CHECK: bb3(%{{[0-9]+}} : $ErrorProtocol):
+// CHECK-NEXT:   strong_release %0
+// CHECK-NEXT:   release_value %0
+// CHECK-NEXT:   br bb4
+// CHECK: bb4:
+// CHECK-NOT: %0
+// CHECK:   return
+sil @insert_release_after_try_apply : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closure_throw : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> @error ErrorProtocol
+  br bb1
+
+bb1:
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  try_apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> @error ErrorProtocol, normal bb2, error bb3
+
+bb2(%n : $()):
+  br bb4
+
+bb3(%e : $ErrorProtocol):
+  br bb4
+
+bb4:
   %11 = tuple ()
   return %11 : $()
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… terminator instruction.

This bug let the ClosureSpecializer insert a release after a try_apply in the same basic block.
Fixes SR-1252
