### PR TITLE
[Sema] Add a fix-it for non-optional bindings initialized with nil.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3274,7 +3274,8 @@ namespace {
       argExpr = new (ctx) ParenExpr(E->getLoc(), argExpr, E->getLoc(),
                                     /*hasTrailingClosure*/false);
       Expr *callExpr = new (ctx) CallExpr(fnRef, argExpr, /*implicit*/true);
-      bool invalid = tc.typeCheckExpression(callExpr, cs.DC, valueType,
+      bool invalid = tc.typeCheckExpression(callExpr, cs.DC,
+                                            TypeLoc::withoutLoc(valueType),
                                             CTP_CannotFail);
       (void) invalid;
       assert(!invalid && "conversion cannot fail");
@@ -3798,7 +3799,9 @@ getCallerDefaultArg(TypeChecker &tc, DeclContext *dc,
   }
 
   // Convert the literal to the appropriate type.
-  bool invalid = tc.typeCheckExpression(init, dc, defArg.second,CTP_CannotFail);
+  bool invalid = tc.typeCheckExpression(init, dc, 
+                                        TypeLoc::withoutLoc(defArg.second),
+                                        CTP_CannotFail);
   assert(!invalid && "conversion cannot fail");
   (void)invalid;
   return {init, defArg.first};

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2899,7 +2899,8 @@ typeCheckChildIndependently(Expr *subExpr, Type convertType,
       TCEOptions |= TypeCheckExprFlags::PreferForceUnwrapToOptional;
   }
 
-  bool hadError = CS->TC.typeCheckExpression(subExpr, CS->DC, convertType,
+  bool hadError = CS->TC.typeCheckExpression(subExpr, CS->DC,
+                                             TypeLoc::withoutLoc(convertType),
                                              convertTypePurpose, TCEOptions,
                                              listener);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3173,10 +3173,10 @@ ConstraintSystem::simplifyMemberConstraint(const Constraint &constraint) {
       // Determine whether or not we want to provide an optional chaining fixit or
       // a force unwrap fixit.
       bool optionalChain;
-      if (!contextualType)
+      if (!getContextualType())
         optionalChain = !(Options & ConstraintSystemFlags::PreferForceUnwrapToOptional);
       else
-        optionalChain = !contextualType->getOptionalObjectType().isNull();
+        optionalChain = !getContextualType()->getOptionalObjectType().isNull();
       auto fixKind = optionalChain ? FixKind::OptionalChaining : FixKind::ForceOptional;
 
       // Note the fix.
@@ -3206,10 +3206,10 @@ ConstraintSystem::simplifyMemberConstraint(const Constraint &constraint) {
     // Determine whether or not we want to provide an optional chaining fixit or
     // a force unwrap fixit.
     bool optionalChain;
-    if (!contextualType)
+    if (!getContextualType())
       optionalChain = !(Options & ConstraintSystemFlags::PreferForceUnwrapToOptional);
     else
-      optionalChain = !contextualType->getOptionalObjectType().isNull();
+      optionalChain = !getContextualType()->getOptionalObjectType().isNull();
     auto fixKind = optionalChain ? FixKind::OptionalChaining : FixKind::ForceOptional;
 
     // Note the fix.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -938,7 +938,7 @@ private:
   /// There can only be a single contextual type on the root of the expression
   /// being checked.  If specified, this holds its type along with the base
   /// expression, and the purpose of it.
-  Type contextualType;
+  TypeLoc contextualType;
   Expr *contextualTypeNode = nullptr;
   ContextualTypePurpose contextualTypePurpose = CTP_Unused;
   
@@ -1223,16 +1223,20 @@ public:
     this->FavoredTypes[E] = T;
   }
  
-  void setContextualType(Expr *E, Type T, ContextualTypePurpose purpose) {
+  void setContextualType(Expr *E, TypeLoc T, ContextualTypePurpose purpose) {
     contextualTypeNode = E;
     contextualType = T;
     contextualTypePurpose = purpose;
   }
 
   Type getContextualType(Expr *E) const {
-    return E == contextualTypeNode ? contextualType : Type();
+    return E == contextualTypeNode ? contextualType.getType() : Type();
   }
   Type getContextualType() const {
+    return contextualType.getType();
+  }
+
+  TypeLoc getContextualTypeLoc() const {
     return contextualType;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1625,6 +1625,13 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
     // If we already had an error, don't repeat the problem.
     if (contextualType.getType()->is<ErrorType>())
       return true;
+
+    // Only provide a TypeLoc if it makes sense to allow diagnostics.
+    if (auto *typedPattern = dyn_cast<TypedPattern>(pattern)) {
+      const Pattern *inner = typedPattern->getSemanticsProvidingPattern();
+      if (isa<NamedPattern>(inner) || isa<AnyPattern>(inner))
+        contextualType = typedPattern->getTypeLoc();
+    }
   }
     
   // Type-check the initializer.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2497,7 +2497,8 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
     // Check the raw value expr, if we have one.
     if (auto *rawValue = elt->getRawValueExpr()) {
       Expr *typeCheckedExpr = rawValue;
-      if (!TC.typeCheckExpression(typeCheckedExpr, ED, rawTy,
+      if (!TC.typeCheckExpression(typeCheckedExpr, ED, 
+                                  TypeLoc::withoutLoc(rawTy),
                                   CTP_EnumCaseRawValue)) {
         elt->setTypeCheckedRawValueExpr(typeCheckedExpr);
       }
@@ -2512,7 +2513,8 @@ static void checkEnumRawValues(TypeChecker &TC, EnumDecl *ED) {
       }
       elt->setRawValueExpr(nextValue);
       Expr *typeChecked = nextValue;
-      if (!TC.typeCheckExpression(typeChecked, ED, rawTy,
+      if (!TC.typeCheckExpression(typeChecked, ED, 
+                                  TypeLoc::withoutLoc(rawTy),
                                   CTP_EnumCaseRawValue))
         elt->setTypeCheckedRawValueExpr(typeChecked);
     }
@@ -7480,7 +7482,8 @@ void TypeChecker::addImplicitEnumConformances(EnumDecl *ED) {
     if (elt->getTypeCheckedRawValueExpr()) continue;
     Expr *typeChecked = elt->getRawValueExpr();
     Type rawTy = ArchetypeBuilder::mapTypeIntoContext(ED, ED->getRawType());
-    bool error = typeCheckExpression(typeChecked, ED, rawTy,
+    bool error = typeCheckExpression(typeChecked, ED, 
+                                     TypeLoc::withoutLoc(rawTy),
                                      CTP_EnumCaseRawValue);
     assert(!error); (void)error;
     elt->setTypeCheckedRawValueExpr(typeChecked);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1097,7 +1097,9 @@ public:
   /// \param convertType The type that the expression is being converted to,
   /// or null if the expression is standalone.  If the 'ConvertTypeIsOnlyAHint'
   /// option is specified, then this is only a hint, it doesn't produce a full
-  /// conversion constraint.
+  /// conversion constraint. The location information is only used for
+  /// diagnostics should the conversion fail; it is safe to pass a TypeLoc
+  /// without location information.
   ///
   /// \param options Options that control how type checking is performed.
   ///
@@ -1107,14 +1109,14 @@ public:
   ///
   /// \returns true if an error occurred, false otherwise.
   bool typeCheckExpression(Expr *&expr, DeclContext *dc,
-                           Type convertType = Type(),
+                           TypeLoc convertType = TypeLoc(),
                            ContextualTypePurpose convertTypePurpose =CTP_Unused,
                            TypeCheckExprOptions options =TypeCheckExprOptions(),
                            ExprTypeCheckListener *listener = nullptr);
 
   bool typeCheckExpression(Expr *&expr, DeclContext *dc,
                            ExprTypeCheckListener *listener) {
-    return typeCheckExpression(expr, dc, Type(), CTP_Unused,
+    return typeCheckExpression(expr, dc, TypeLoc(), CTP_Unused,
                                TypeCheckExprOptions(), listener);
   }
 
@@ -1147,12 +1149,8 @@ public:
   /// \param expr The expression to type-check, which will be modified in
   /// place.
   ///
-  /// \param convertType The type that the expression is being converted to,
-  /// or null if the expression is standalone.
-  ///
   /// \returns true if an error occurred, false otherwise.
-  bool typeCheckExpressionShallow(Expr *&expr, DeclContext *dc,
-                                  Type convertType = Type());
+  bool typeCheckExpressionShallow(Expr *&expr, DeclContext *dc);
 
   /// \brief Type check whether the given type declaration includes members of
   /// unsupported recursive value types.

--- a/test/decl/init/nil.swift
+++ b/test/decl/init/nil.swift
@@ -1,0 +1,28 @@
+// RUN: %target-parse-verify-swift
+
+var a: Int = nil
+// expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
+// expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
+
+var b: () -> Void = nil
+// expected-error@-1 {{nil cannot initialize specified type '() -> Void'}} 
+// expected-note@-2 {{add '?' to form the optional type '(() -> Void)?'}} {{8-8=(}} {{18-18=)?}}
+
+var c, d: Int = nil
+// expected-error@-1 {{type annotation missing in pattern}}
+// expected-error@-2 {{nil cannot initialize specified type 'Int'}} 
+// expected-note@-3 {{add '?' to form the optional type 'Int?'}} {{14-14=?}}
+
+var (e, f): (Int, Int) = nil
+// expected-error@-1 {{nil cannot initialize specified type '(Int, Int)'}} 
+
+var g: Int = nil, h: Int = nil
+// expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
+// expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
+// expected-error@-3 {{nil cannot initialize specified type 'Int'}} 
+// expected-note@-4 {{add '?' to form the optional type 'Int?'}} {{25-25=?}}
+
+var _: Int = nil
+// expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
+// expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
+


### PR DESCRIPTION
```
<stdin>:1:16: error: nil cannot initialize specified type 'Int'
var foo: Int = nil
               ^
<stdin>:1:10: note: add '?' to form the optional type 'Int?'
var foo: Int = nil
         ^
            ?
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
