### PR TITLE
Port the fix for SR-1267 back to the 2.2 branch, to fix a recent regression.

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -606,7 +606,11 @@ public:
   /// Get the declaration context that contains the conforming extension or
   /// nominal type declaration.
   DeclContext *getDeclContext() const {
-    return getType()->getClassOrBoundGenericClass();
+    auto bgc = getType()->getClassOrBoundGenericClass();
+
+    // In some cases, we may not have a BGC handy, in which case we should
+    // delegate to the inherited conformance for the decl context.
+    return bgc ? bgc : InheritedConformance->getDeclContext();
   }
 
   /// Retrieve the state of this conformance.

--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: cp %s %t/main.swift
+// RUN: %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
+
+// SR-1267, SR-1270
+import Foundation
+
+class TypeType<T where T: NSString> {
+    func call(notification: NSNotification?) {
+        let set = NSOrderedSet()
+        if let objects = set.array as? [T] {
+            let _ = (notification?.userInfo?["great_key"] as? NSSet).flatMap { updatedObjects in
+                return updatedObjects.filter({ element in
+                    guard let element = element as? T
+                        where objects.index(of: element) != nil
+                    else {
+                        return false
+                    }
+                    return true
+                })
+            } ?? []
+        }
+    }
+}

--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -1,3 +1,4 @@
+// XFAIL: linux
 // RUN: rm -rf %t && mkdir %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps

--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -13,7 +13,7 @@ class TypeType<T where T: NSString> {
             let _ = (notification?.userInfo?["great_key"] as? NSSet).flatMap { updatedObjects in
                 return updatedObjects.filter({ element in
                     guard let element = element as? T
-                        where objects.index(of: element) != nil
+                        where objects.indexOf(element) != nil
                     else {
                         return false
                     }


### PR DESCRIPTION
When obtaining the decl context for an inherited protocol conformance,
use the inherited conformance's decl context if the conformance type
does not yet have a registered class decl.

(Addresses SR-1267 and SR-1270)
