### PR TITLE
[build-script] Safe and simple argument migration

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -42,7 +42,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 import swift_build_support.toolchain  # noqa (E402)
 import swift_build_support.cmake      # noqa (E402)
 import swift_build_support.debug      # noqa (E402)
-from swift_build_support.migration import migrate_impl_args  # noqa (E402)
+from swift_build_support import migration  # noqa (E402)
 import swift_build_support.ninja      # noqa (E402)
 import swift_build_support.tar        # noqa (E402)
 import swift_build_support.targets    # noqa (E402)
@@ -800,7 +800,7 @@ details of the setups of other systems or automated environments.""")
         help="",
         nargs="*")
 
-    args = parser.parse_args(migrate_impl_args(sys.argv[1:], [
+    args = parser.parse_args(migration.migrate_impl_args(sys.argv[1:], [
         '--darwin-xcrun-toolchain',
         '--cmake',
         '--host-target',
@@ -820,6 +820,23 @@ details of the setups of other systems or automated environments.""")
         '--skip-test-watchos-simulator',
         '--skip-test-watchos-host',
     ]))
+
+    build_script_impl = os.path.join(
+        SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl")
+
+    if args.build_script_impl_args:
+        # If we received any impl args, check if `build-script-impl` would
+        # accept them or not before any further processing.
+        try:
+            migration.check_impl_args(build_script_impl,
+                                      args.build_script_impl_args)
+        except ValueError as e:
+            parser.print_usage(sys.stderr)
+            print(e, file=sys.stderr)
+            sys.exit(2)  # 2 is the same as `argparse` error exit code.
+
+        if '--check-args-only' in args.build_script_impl_args:
+            return 0
 
     if args.host_target is None or args.stdlib_deployment_targets is None:
         print_with_argv0("Unknown operating system.")
@@ -1160,7 +1177,6 @@ details of the setups of other systems or automated environments.""")
         print_with_argv0("Can't find CMake. Please install CMake.")
         return 1
     build_script_impl_args = [
-        os.path.join(SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl"),
         "--build-dir", build_dir,
         "--install-prefix", os.path.abspath(args.install_prefix),
         "--host-target", args.host_target,
@@ -1267,7 +1283,8 @@ details of the setups of other systems or automated environments.""")
     if args.show_sdks:
         swift_build_support.debug.print_xcodebuild_versions()
 
-    check_call(build_script_impl_args, disable_sleep=True)
+    check_call([build_script_impl] + build_script_impl_args,
+               disable_sleep=True)
 
     if args.symbols_package:
         print('--- Creating symbols package ---')

--- a/utils/build-script
+++ b/utils/build-script
@@ -162,7 +162,7 @@ Using option presets:
   using the name=value syntax on the command line.
 
 
-Any arguments passed after "--" are forwarded directly to Swift's
+Any arguments not listed are forwarded directly to Swift's
 'build-script-impl'.  See that script's help for details.
 
 Environment variables
@@ -795,31 +795,7 @@ details of the setups of other systems or automated environments.""")
              "called multiple times to add multiple such options.",
         action="append", dest="extra_cmake_options", default=[])
 
-    parser.add_argument(
-        "build_script_impl_args",
-        help="",
-        nargs="*")
-
-    args = parser.parse_args(migration.migrate_impl_args(sys.argv[1:], [
-        '--darwin-xcrun-toolchain',
-        '--cmake',
-        '--host-target',
-        '--stdlib-deployment-targets',
-        '--skip-build',
-        '--show-sdks',
-        '--install-prefix',
-        '--install-symroot',
-        '--symbols-package',
-        '--skip-test-ios',
-        '--skip-test-ios-simulator',
-        '--skip-test-ios-host',
-        '--skip-test-tvos',
-        '--skip-test-tvos-simulator',
-        '--skip-test-tvos-host',
-        '--skip-test-watchos',
-        '--skip-test-watchos-simulator',
-        '--skip-test-watchos-host',
-    ]))
+    args = migration.parse_args(parser, sys.argv[1:])
 
     build_script_impl = os.path.join(
         SWIFT_SOURCE_ROOT, "swift", "utils", "build-script-impl")

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -218,6 +218,7 @@ KNOWN_SETTINGS=(
     android-icu-i18n                   ""        "Path to a directory containing libicui18n.so"
     android-icu-i18n-include           ""        "Path to a directory containing headers libicui18n"
     export-compile-commands            ""        "set to generate JSON compilation databases for each build product"
+    check-args-only                    ""        "set to check all arguments are known. Exit with status 0 if success, non zero otherwise"
 )
 
 function toupper() {
@@ -671,11 +672,16 @@ while [[ "$1" ]] ; do
             ;;
 
         *)
-            usage
+            echo "Error: Invalid argument: $1" 1>&2
+            usage 1>&2
             exit 1
     esac
     shift
 done
+
+if [[ "${CHECK_ARGS_ONLY}" ]]; then
+    exit 0
+fi
 
 if [[ "${SKIP_IOS}" ]] ; then
     SKIP_BUILD_IOS=1

--- a/utils/swift_build_support/swift_build_support/migration.py
+++ b/utils/swift_build_support/swift_build_support/migration.py
@@ -17,6 +17,8 @@
 #
 # ----------------------------------------------------------------------------
 
+import subprocess
+
 
 def migrate_impl_args(argv, migrate_args):
     """
@@ -54,3 +56,22 @@ def migrate_impl_args(argv, migrate_args):
         impl_args.remove(impl_arg_to_remove)
 
     return args + impl_args
+
+
+def check_impl_args(build_script_impl, argv):
+    """
+    Check whether given argv are all known argument for `build-script-impl`.
+
+    Raise ValueError with message if any invalid argument is found.
+    Return nothing if success.
+    """
+    pipe = subprocess.Popen(
+        [build_script_impl, '--check-args-only=1'] + argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+
+    (_, err) = pipe.communicate()
+
+    if pipe.returncode != 0:
+        msg = str(err.splitlines()[0].decode())
+        raise ValueError(msg)

--- a/utils/swift_build_support/swift_build_support/migration.py
+++ b/utils/swift_build_support/swift_build_support/migration.py
@@ -20,47 +20,25 @@
 import subprocess
 
 
-def migrate_impl_args(argv, migrate_args):
+def parse_args(parser, argv):
     """
-    Given a list of arguments of the form:
+    Parse given argument list with given argparse.ArgumentParser.
 
-        --foo --bar=baz -- --flim=flam
+    Return a processed arguments object. Any unknown arguments are stored in
+    `build_script_impl_args` attribute as a list.
+    Ignores '--' to be compatible with old style argument list.
 
-    And a list of arguments to migrate, return a list in which the arguments
-    to migrate come before the '--' separator. For example, were we to migrate
-    '--flim', we would return:
-
-        --foo --bar=baz --flim=flam --
-
-    Note that we do not attempt to remove the '--' separator if it is no longer
-    necessary, nor do we replace '--flim' if it already appears before the
-    separator. In these cases, argparse "does the right thing": it can handle
-    a trailing separator, and when options that are specified twice argparse
-    uses the second value.
+        build-script -RT -- --reconfigure
     """
-    try:
-        split_index = argv.index('--')
-    except ValueError:
-        # If there is no separator, then we have nothing to migrate.
-        return argv
-
-    args = argv[:split_index]
-    impl_args = argv[split_index:]
-    impl_args_to_remove = []
-    for impl_arg in impl_args:
-        if impl_arg.split('=')[0] in migrate_args:
-            args.append(impl_arg)
-            impl_args_to_remove.append(impl_arg)
-
-    for impl_arg_to_remove in impl_args_to_remove:
-        impl_args.remove(impl_arg_to_remove)
-
-    return args + impl_args
+    args, unknown_args = parser.parse_known_args(
+        arg for arg in argv if arg != '--')
+    args.build_script_impl_args = unknown_args
+    return args
 
 
 def check_impl_args(build_script_impl, argv):
     """
-    Check whether given argv are all known argument for `build-script-impl`.
+    Check whether given argv are all known arguments for `build-script-impl`.
 
     Raise ValueError with message if any invalid argument is found.
     Return nothing if success.

--- a/utils/swift_build_support/tests/test_migration.py
+++ b/utils/swift_build_support/tests/test_migration.py
@@ -9,15 +9,16 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import unittest
+import os
 
-from swift_build_support.migration import migrate_impl_args
+from swift_build_support import migration
 
 
 class MigrateImplArgsTestCase(unittest.TestCase):
     def test_args_moved_before_separator(self):
         # Tests that '-RT --foo=bar -- --foo=baz --flim' is parsed as
         # '-RT --foo=bar --foo=baz -- --flim'
-        args = migrate_impl_args(
+        args = migration.migrate_impl_args(
             ['-RT', '--darwin-xcrun-toolchain=foo', '--',
              '--darwin-xcrun-toolchain=bar', '--other'],
             ['--darwin-xcrun-toolchain'])
@@ -26,6 +27,27 @@ class MigrateImplArgsTestCase(unittest.TestCase):
             args,
             ['-RT', '--darwin-xcrun-toolchain=foo',
              '--darwin-xcrun-toolchain=bar', '--', '--other'])
+
+    def test_check_impl_args(self):
+        # Assuming file locations:
+        #   utils/swift_build_support/tests/test_migration.py
+        #   utils/build-script-impl
+        build_script_impl = os.path.join(
+            os.path.dirname(__file__), '..', '..', 'build-script-impl')
+
+        self.assertIsNone(migration.check_impl_args(build_script_impl,
+                                                    ['--reconfigure']))
+
+        # FIXME: self.assertRaises context manager is not py2.6 compatible.
+        with self.assertRaises(ValueError) as cm:
+            migration.check_impl_args(build_script_impl, ['foo'])
+        self.assertIn('foo', str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            migration.check_impl_args(build_script_impl, ['--reconfigure',
+                                                          '--foo=true'])
+        self.assertIn('foo', str(cm.exception))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Warning:** This PR conflicts with #2283. I will rebase this PR if it's merged.
#### What's in this pull request?

This PR consists of 2 independent commits.

First, we should confirm all `build-script-impl` arguments are valid - at least known - before processing in `build-script`. For example: `build-script --clean -RT -- --verbose-buid`,
Current `build-script` deletes build directory despite `--verbose-buid` is not a valid argument. And the usage of `build-script-impl` is displayed.

To make it safe: 1) Introduce `--check-args-only` mode in `build-script-impl` that exits with 0 or non-zero immediately after parsing arguments. 2) Check impl args with `--check-args-only` before processing in `build-script`. 3) If impl exits with non zero status, display the usage of `build-script` and the error.
## 

Second, simplify arguments migration process.

Before, when we migrate arguments to Python (e.g. 120ec99be5fd251085dd13a7cbfe8f57e38232f5), we have to explicitly write migrated arguments:

``` python
migrate_impl_args(sys.argv[1:], [
    '--darwin-xcrun-toolchain',
    '--cmake',
    '--host-target',
    ...])
```

With this change, all unknown args are automatically forwarded to `build-script-impl`.
This makes arguments parsing a little more permissive: We accept any arguments at any position regardless it's migrated or not.
All of the followings are accepted:

```
build-script -RT -- --reconfigure
build-script --reconfigure -RT
build-script --reconfigure -- -RT
```

Although this change can be applied independently, without the former patch, error reporting for invalid  argument like `build-script  -R --xctets` would be delayed until invocation of `build-script-impl`.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
