### PR TITLE
[build-script-impl] Call the XCTest build_script.py on all platforms

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1934,6 +1934,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             xctest)
                 SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
                 XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
+                FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                     # xcodebuild requires swift-stdlib-tool to build a Swift
                     # framework. This is normally present when building XCTest
@@ -1941,27 +1942,16 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     # swiftc that was just built--no toolchain exists yet. As a
                     # result, we must copy swift-stdlib-tool ourselves.
                     copy_swift_stdlib_tool_substitute "$(build_directory_bin ${deployment_target} swift)/swift-stdlib-tool"
-
-                    set -x
-                    xcodebuild \
-                        -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
-                        -scheme SwiftXCTest \
-                        SWIFT_EXEC="${SWIFTC_BIN}" \
-                        SWIFT_LINK_OBJC_RUNTIME=YES \
-                        SYMROOT="${XCTEST_BUILD_DIR}" \
-                        OBJROOT="${XCTEST_BUILD_DIR}"
-                    { set +x; } 2>/dev/null
-                else
-                    FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
-                    set -x
-                    # FIXME: Use XCTEST_BUILD_TYPE (which is never properly
-                    #        set) to build either --debug or --release.
-                    "${XCTEST_SOURCE_DIR}"/build_script.py \
-                        --swiftc="${SWIFTC_BIN}" \
-                        --build-dir="${XCTEST_BUILD_DIR}" \
-                        --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation"
-                    { set +x; } 2>/dev/null
                 fi
+
+                set -x
+                # FIXME: Use XCTEST_BUILD_TYPE (which is never properly
+                #        set) to build either --debug or --release.
+                "${XCTEST_SOURCE_DIR}"/build_script.py \
+                    --swiftc="${SWIFTC_BIN}" \
+                    --build-dir="${XCTEST_BUILD_DIR}" \
+                    --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation"
+                { set +x; } 2>/dev/null
 
                 # XCTest builds itself and doesn't rely on cmake
                 continue
@@ -2243,26 +2233,14 @@ for deployment_target in "${STDLIB_DEPLOYMENT_TARGETS[@]}"; do
                 fi
                 echo "--- Running tests for ${product} ---"
                 SWIFTC_BIN="$(build_directory_bin ${deployment_target} swift)/swiftc"
-                if [[ "$(uname -s)" == "Darwin" ]] ; then
-                    set -x
-                    xcodebuild \
-                        -workspace "${XCTEST_SOURCE_DIR}"/XCTest.xcworkspace \
-                        -scheme SwiftXCTestFunctionalTests \
-                        SWIFT_EXEC="${SWIFTC_BIN}" \
-                        SWIFT_LINK_OBJC_RUNTIME=YES \
-                        SYMROOT="${XCTEST_BUILD_DIR}" \
-                        OBJROOT="${XCTEST_BUILD_DIR}"
-                    { set +x; } 2>/dev/null
-                else
-                    FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
-                    XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
-                    set -x
-                    "${XCTEST_SOURCE_DIR}"/build_script.py test \
-                        --swiftc="${SWIFTC_BIN}" \
-                        --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
-                        "${XCTEST_BUILD_DIR}"
-                    { set +x; } 2>/dev/null
-                fi
+                FOUNDATION_BUILD_DIR=$(build_directory ${deployment_target} foundation)
+                XCTEST_BUILD_DIR=$(build_directory ${deployment_target} xctest)
+                set -x
+                "${XCTEST_SOURCE_DIR}"/build_script.py test \
+                    --swiftc="${SWIFTC_BIN}" \
+                    --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                    "${XCTEST_BUILD_DIR}"
+                { set +x; } 2>/dev/null
                 echo "--- Finished tests for ${product} ---"
                 continue
                 ;;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Following up on https://github.com/apple/swift/pull/2137 and https://github.com/apple/swift-corelibs-xctest/pull/97, XCTest's own build script has gotten the capability of performing build and test actions on Darwin as well, so `build-script-impl` can now delegate to it there, reducing the amount of platform-specific logic here.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
