### PR TITLE
Update test to remove dependency on Foundation.

### DIFF
--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -4,17 +4,7 @@
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 
 // SR-1267, SR-1270
-class TypeType<T> { }
-protocol ProtocolType {}
-
-struct StructType<T> { }
-extension StructType where T : ProtocolType {
-    func testCase<T>() -> TypeType<T> {
-        return TypeType<T>()
-    }
-}
-
-class TestView : ProtocolType {}
-extension StructType where T : TestView {
-    var typeType : TypeType<T> { return testCase() }
-}
+protocol Protocol {}
+class ConformingClass: Protocol {}
+class BaseClass<T: Protocol> {}
+class ConcreteClass<T: ConformingClass> : BaseClass<T> {}

--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -4,22 +4,17 @@
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
 
 // SR-1267, SR-1270
-import Foundation
+class TypeType<T> { }
+protocol ProtocolType {}
 
-class TypeType<T where T: NSString> {
-    func call(notification: NSNotification?) {
-        let set = NSOrderedSet()
-        if let objects = set.array as? [T] {
-            let _ = (notification?.userInfo?["great_key"] as? NSSet).flatMap { updatedObjects in
-                return updatedObjects.filter({ element in
-                    guard let element = element as? T
-                        where objects.index(of: element) != nil
-                    else {
-                        return false
-                    }
-                    return true
-                })
-            } ?? []
-        }
+struct StructType<T> { }
+extension StructType where T : ProtocolType {
+    func testCase<T>() -> TypeType<T> {
+        return TypeType<T>()
     }
+}
+
+class TestView : ProtocolType {}
+extension StructType where T : TestView {
+    var typeType : TypeType<T> { return testCase() }
 }

--- a/test/NameBinding/InheritedConformance.swift
+++ b/test/NameBinding/InheritedConformance.swift
@@ -1,4 +1,3 @@
-// XFAIL: linux
 // RUN: rm -rf %t && mkdir %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -parse -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps


### PR DESCRIPTION
#### What's in this pull request?

Per @gribozavr's comment [here](https://github.com/apple/swift/commit/78db42ea71621324cef31493e23ea1883486d83a), this provides a slimmed test case in pure swift that uses no standard libraries.
#### Related to bug number: ([SR-1267](https://bugs.swift.org/browse/SR-1267))

The fix is already in place, but this provides a better test case.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Using APIs from Foundation and the standard library can be a source of
pain and can create fragile tests due to API changes. This reduces the
test case to pure swift and eliminates the use of the standard library APIs.

See also issue #2256

This is my first contribution to swift, so feedback welcome!
