### PR TITLE
[ASTVerifier] Check the type of a TupleExpr, at least at a basic level.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -836,6 +836,19 @@ struct ASTNodeBase {};
       verifyCheckedBase(S);
     }
 
+    void verifyChecked(TupleExpr *E) {
+      const TupleType *exprTy = E->getType()->castTo<TupleType>();
+      for_each(exprTy->getElements().begin(), exprTy->getElements().end(),
+               E->getElements().begin(),
+               [this](const TupleTypeElt &field, const Expr *elt) {
+        checkTrivialSubtype(field.getType()->getUnlabeledType(Ctx),
+                            elt->getType()->getUnlabeledType(Ctx),
+                            "tuple and element");
+      });
+      // FIXME: Check all the variadic elements.
+      verifyCheckedBase(E);
+    }
+
     void verifyChecked(InOutExpr *E) {
       Type srcObj = checkLValue(E->getSubExpr()->getType(),
                                 "result of InOutExpr");


### PR DESCRIPTION
Nothing too interesting; a swift-ci sanity check.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
