### PR TITLE
Only configure swift-reflection-dump if the host SDK is requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,8 +746,13 @@ if(SWIFT_BUILD_TOOLS)
   add_subdirectory(include)
   add_subdirectory(lib)
   add_subdirectory(tools)
+endif()
+
+is_sdk_requested("${SWIFT_HOST_VARIANT_SDK}" SWIFT_HOST_SDK_REQUESTED)
+if(SWIFT_BUILD_TOOLS AND SWIFT_BUILD_STDLIB AND SWIFT_HOST_SDK_REQUESTED)
   add_subdirectory(tools/swift-reflection-dump)
 endif()
+
 add_subdirectory(utils)
 add_subdirectory(stdlib)
 


### PR DESCRIPTION
Since swift-reflection-dump is a host-only tool, for iOS-only builds or
other builds where the host SDK isn't configured, the
swift-reflection-dump tool will fail to find libswiftReflection.

rdar://problem/25858390
