### PR TITLE
Don't stack promote allocations in no-return blocks.

### DIFF
--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -39,6 +39,7 @@ bb0(%0 : $YY):
   return %t : $()
 }
 
+sil @consume_int : $@convention(thin) (Int32) -> ()
 
 // CHECK-LABEL: sil @simple_promote
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] $XX
@@ -66,6 +67,29 @@ bb0:
   %f1 = function_ref @xx_init : $@convention(thin) (@guaranteed XX) -> XX
   %n1 = apply %f1(%o1) : $@convention(thin) (@guaranteed XX) -> XX
   return %n1 : $XX
+}
+
+// CHECK-LABEL: sil @dont_promote_in_unreachable
+// CHECK: bb1:
+// CHECK-NEXT: alloc_ref $XX
+sil @dont_promote_in_unreachable : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %o1 = alloc_ref $XX
+  %f1 = function_ref @xx_init : $@convention(thin) (@guaranteed XX) -> XX
+  %n1 = apply %f1(%o1) : $@convention(thin) (@guaranteed XX) -> XX
+  %l1 = ref_element_addr %n1 : $XX, #XX.x
+  %l2 = load %l1 : $*Int32
+  %f2 = function_ref @consume_int : $@convention(thin) (Int32) -> ()
+  %a = apply %f2(%l2) : $@convention(thin) (Int32) -> ()
+  // An unreachable block may missing the final release.
+  unreachable
+
+bb2:
+  %r = tuple ()
+  return %r : $()
 }
 
 // CHECK-LABEL: sil @promote_nested


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Such allocations may missing their final release, which confuses stack-promotion.

Fixes rdar://problem/25842757.
