### PR TITLE
[Swift 2.2] SR-1096: swift2.2 generics property crash

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -89,13 +89,7 @@ static_assert(std::is_trivially_destructible<SwiftObject_s>::value,
 __attribute__((objc_root_class))
 #endif
 @interface SwiftObject<NSObject> {
-  // FIXME: rdar://problem/18950072 Clang emits ObjC++ classes as having
-  // non-trivial structors if they contain any struct fields at all, regardless of
-  // whether they in fact have nontrivial default constructors. Dupe the body
-  // of SwiftObject_s into here as a workaround because we don't want to pay
-  // the cost of .cxx_destruct method dispatch at deallocation time.
-  void *magic_isa  __attribute__((unavailable));
-  long magic_refCount  __attribute__((unavailable));
+  SwiftObject_s header;
 }
 
 - (BOOL)isEqual:(id)object;

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -77,9 +77,12 @@ const ClassMetadata *swift::_swift_getClass(const void *object) {
 #if SWIFT_OBJC_INTEROP
 struct SwiftObject_s {
   void *isa  __attribute__((unavailable));
-  long refCount  __attribute__((unavailable));
+  uint32_t strongRefCount  __attribute__((unavailable));
+  uint32_t weakRefCount  __attribute__((unavailable));
 };
 
+static_assert(sizeof(SwiftObject_s) == sizeof(HeapObject),
+              "SwiftObject and HeapObject must have the same header");
 static_assert(std::is_trivially_constructible<SwiftObject_s>::value,
               "SwiftObject must be trivially constructible");
 static_assert(std::is_trivially_destructible<SwiftObject_s>::value,


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Cherry-pick @gparker42's fix for [SR-1096](https://bugs.swift.org/browse/SR-1096) into the 2.2 branch, as a last-minute fix for an issue that resulted in a crash on 32-bit platforms whenever a class contained generic stored properties. Also tracked as rdar://problem/25476641.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
