### PR TITLE
[test] SR-1238: Add test for UnsafePointer and UnsafeMutablePointer conformance to Comparable

### DIFF
--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -389,5 +389,26 @@ UnsafeMutablePointerTestSuite.test("customPlaygroundQuickLook") {
   }
 }
 
-runAllTests()
+% for (SelfName, SelfType) in [
+%         ('UnsafePointer', 'UnsafePointer<Int>'),
+%         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Int>')]:
 
+${SelfName}TestSuite.test("Comparable") {
+  let instances = [
+    0x00000001,
+    0xFF00FF00,
+    0x00001111,
+    0x00000002,
+    0xFFFFFFFF,
+    0x00001111
+  ].map { ($0, ${SelfType}(bitPattern: $0)!) }
+
+  func comparisonOracle(i: Int, j: Int) -> ExpectedComparisonResult {
+    return instances[i].0 <=> instances[j].0
+  }
+  checkComparable(instances.map { $0.1 }, oracle: comparisonOracle)
+}
+
+% end
+
+runAllTests()

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -394,14 +394,23 @@ UnsafeMutablePointerTestSuite.test("customPlaygroundQuickLook") {
 %         ('UnsafeMutablePointer', 'UnsafeMutablePointer<Int>')]:
 
 ${SelfName}TestSuite.test("Comparable") {
-  let instances = [
+  var addresses: [UInt] = [
     0x00000001,
     0xFF00FF00,
     0x00001111,
     0x00000002,
     0xFFFFFFFF,
     0x00001111
-  ].map { ($0, ${SelfType}(bitPattern: $0)!) }
+  ]
+
+  #if arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
+  addresses += [
+    0xFFFFFFFF80000000,
+    0x8000000000000000
+  ]
+  #endif
+
+  let instances = addresses.map { ($0, ${SelfType}(bitPattern: $0)!) }
 
   func comparisonOracle(i: Int, j: Int) -> ExpectedComparisonResult {
     return instances[i].0 <=> instances[j].0


### PR DESCRIPTION
#### What's in this pull request?

Added tests for `Comparable` conformance of `UnsafePointer` and `UnsafeMutablePointer`
#### Resolved bug number: ([SR-1238](https://bugs.swift.org/browse/SR-1238))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
