### PR TITLE
[Clang importer] Initial support for swift_newtype / swift_wrapper

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2034,6 +2034,17 @@ static bool moduleIsInferImportAsMember(const clang::NamedDecl *decl,
   return false;
 }
 
+// If this decl is associated with a swift_newtype typedef, return it, otherwise
+// null
+static clang::TypedefNameDecl *findSwiftNewtype(const clang::Decl *decl) {
+  if (auto varDecl = dyn_cast<clang::VarDecl>(decl))
+    if (auto typedefTy = varDecl->getType()->getAs<clang::TypedefType>())
+      if (typedefTy->getDecl()->hasAttr<clang::SwiftNewtypeAttr>())
+        return typedefTy->getDecl();
+
+  return nullptr;
+}
+
 auto ClangImporter::Implementation::importFullName(
        const clang::NamedDecl *D,
        ImportNameOptions options,
@@ -2068,8 +2079,11 @@ auto ClangImporter::Implementation::importFullName(
       result.EffectiveContext = enumDecl->getRedeclContext();
       break;
     }
+  // Import onto a swift_newtype if present
+  } else if (auto newtypeDecl = findSwiftNewtype(D)) {
+    result.EffectiveContext = newtypeDecl;
+  // Everything else goes into its redeclaration context.
   } else {
-    // Everything else goes into its redeclaration context.
     result.EffectiveContext = dc->getRedeclContext();
   }
 
@@ -2538,6 +2552,31 @@ auto ClangImporter::Implementation::importFullName(
 
   // Omit needless words.
   StringScratchSpace omitNeedlessWordsScratch;
+
+  // swift_newtype-ed declarations may have common words with the type name
+  // stripped.
+  if (auto newtypeDecl = findSwiftNewtype(D)) {
+    SmallString<32> newNameBuffer;
+    auto newtypeNameWords = camel_case::getWords(newtypeDecl->getName());
+    auto declNameWords = camel_case::getWords(baseName);
+
+    // Scan the decl name, and drop any words that appear in order in the type
+    // name
+    for (auto wI = declNameWords.begin(), skipWI = newtypeNameWords.begin();
+         wI != declNameWords.end(); ++wI) {
+      if (skipWI != newtypeNameWords.end() && *wI == *skipWI) {
+        ++skipWI;
+        continue;
+      }
+      newNameBuffer.append(*wI);
+    }
+
+    if (newNameBuffer.str() != baseName) {
+      baseName = omitNeedlessWordsScratch.copyString(newNameBuffer);
+      strippedPrefix = true;
+    }
+  }
+
   if (!result.isSubscriptAccessor()) {
     // Check whether the module in which the declaration resides has a
     // module prefix and will map into Swift as a type. If so, strip

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1280,6 +1280,10 @@ namespace {
         if (auto newtypeAttr =
                 Decl->template getAttr<clang::SwiftNewtypeAttr>()) {
           switch (newtypeAttr->getNewtypeKind()) {
+          case clang::SwiftNewtypeAttr::NK_Enum:
+            // TODO: import as closed enum instead
+
+            // For now, fall through and treat as a struct
           case clang::SwiftNewtypeAttr::NK_Struct: {
 
             auto underlyingType = Impl.importType(
@@ -1305,11 +1309,8 @@ namespace {
             Impl.registerExternalDecl(structDecl);
             return structDecl;
           }
+        }
 
-          case clang::SwiftNewtypeAttr::NK_Enum:
-            // TODO: support enum
-            break;
-          }
         }
       }
 

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -85,8 +85,8 @@ void EnumInfo::classifyEnum(const clang::EnumDecl *decl,
 ///
 /// This is used to derive the common prefix of enum constants so we can elide
 /// it from the Swift interface.
-static StringRef getCommonWordPrefix(StringRef a, StringRef b,
-                                     bool &followedByNonIdentifier) {
+StringRef importer::getCommonWordPrefix(StringRef a, StringRef b,
+                                        bool &followedByNonIdentifier) {
   auto aWords = camel_case::getWords(a), bWords = camel_case::getWords(b);
   auto aI = aWords.begin(), aE = aWords.end(), bI = bWords.begin(),
        bE = bWords.end();
@@ -124,7 +124,8 @@ static StringRef getCommonWordPrefix(StringRef a, StringRef b,
 /// in Cocoa and Cocoa Touch.
 ///
 /// \see getCommonWordPrefix
-static StringRef getCommonPluralPrefix(StringRef singular, StringRef plural) {
+StringRef importer::getCommonPluralPrefix(StringRef singular,
+                                          StringRef plural) {
   assert(!plural.empty());
 
   if (singular.empty())

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -97,6 +97,37 @@ private:
   void determineConstantNamePrefix(ASTContext &ctx, const clang::EnumDecl *);
   void classifyEnum(const clang::EnumDecl *, clang::Preprocessor &);
 };
+
+// Utility functions of primary interest to enum constant naming
+
+/// Returns the common prefix of two strings at camel-case word granularity.
+///
+/// For example, given "NSFooBar" and "NSFooBas", returns "NSFoo"
+/// (not "NSFooBa"). The returned StringRef is a slice of the "a" argument.
+///
+/// If either string has a non-identifier character immediately after the
+/// prefix, \p followedByNonIdentifier will be set to \c true. If both strings
+/// have identifier characters after the prefix, \p followedByNonIdentifier will
+/// be set to \c false. Otherwise, \p followedByNonIdentifier will not be
+/// changed from its initial value.
+///
+/// This is used to derive the common prefix of enum constants so we can elide
+/// it from the Swift interface.
+StringRef getCommonWordPrefix(StringRef a, StringRef b,
+                              bool &followedByNonIdentifier);
+
+/// Returns the common word-prefix of two strings, allowing the second string
+/// to be a common English plural form of the first.
+///
+/// For example, given "NSProperty" and "NSProperties", the full "NSProperty"
+/// is returned. Given "NSMagicArmor" and "NSMagicArmory", only
+/// "NSMagic" is returned.
+///
+/// The "-s", "-es", and "-ies" patterns cover every plural NS_OPTIONS name
+/// in Cocoa and Cocoa Touch.
+///
+/// \see getCommonWordPrefix
+StringRef getCommonPluralPrefix(StringRef singular, StringRef plural);
 }
 }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -87,6 +87,9 @@ namespace {
 
       /// The source type is any other pointer type.
       OtherPointer,
+
+      /// The source type created a new Swift type, using swift_newtype
+      SwiftNewtype,
     };
 
     ImportHintKind Kind;
@@ -118,6 +121,7 @@ namespace {
     case ImportHint::NSUInteger:
     case ImportHint::Reference:
     case ImportHint::Void:
+    case ImportHint::SwiftNewtype:
       return false;
 
     case ImportHint::Block:
@@ -544,8 +548,11 @@ namespace {
       Type mappedType = decl->getDeclaredType();
       ImportHint hint = ImportHint::None;
 
+      if (type->getDecl()->hasAttr<clang::SwiftNewtypeAttr>()) {
+        hint = ImportHint::SwiftNewtype;
+
       // For certain special typedefs, we don't want to use the imported type.
-      if (auto specialKind = Impl.getSpecialTypedefKind(type->getDecl())) {
+      } else if (auto specialKind = Impl.getSpecialTypedefKind(type->getDecl())) {
         switch (specialKind.getValue()) {
         case MappedTypeNameKind::DoNothing:
         case MappedTypeNameKind::DefineAndUse:

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -146,7 +146,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 12; // CG import-as-member
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 13; // swift_newtype(struct)
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -1,0 +1,19 @@
+@import Foundation;
+
+typedef NSString *SNTErrorDomain __attribute((swift_newtype(struct)))
+__attribute((swift_name("ErrorDomain")));
+
+extern void SNTErrorDomainProcess(SNTErrorDomain d)
+    __attribute((swift_name("ErrorDomain.process(self:)")));
+
+typedef struct {} Foo;
+
+extern const SNTErrorDomain SNTErrOne
+    __attribute((swift_name("ErrorDomain.one")));
+extern const SNTErrorDomain SNTErrTwo;
+extern const SNTErrorDomain SNTErrorDomainThree;
+extern const SNTErrorDomain SNTFourErrorDomain;
+extern const SNTErrorDomain SNTFive
+    __attribute((swift_name("stillAMember")));
+extern const SNTErrorDomain SNTElsewhere
+    __attribute((swift_name("Foo.err")));

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -17,3 +17,10 @@ extern const SNTErrorDomain SNTFive
     __attribute((swift_name("stillAMember")));
 extern const SNTErrorDomain SNTElsewhere
     __attribute((swift_name("Foo.err")));
+
+typedef NSString *SNTClosedEnum __attribute((swift_newtype(enum)))
+__attribute((swift_name("ClosedEnum")));
+
+extern const SNTClosedEnum SNTFirstClosedEntryEnum;
+extern const SNTClosedEnum SNTSecondEntry;
+extern const SNTClosedEnum SNTClosedEnumThirdEntry;

--- a/test/IDE/Inputs/custom-modules/module.map
+++ b/test/IDE/Inputs/custom-modules/module.map
@@ -11,6 +11,11 @@ module ImportedProtocols {
   }
 }
 
+module Newtype {
+  export *
+  header "Newtype.h"
+}
+
 module ImportAsMember {
   export *
 

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -31,3 +31,23 @@
 // PRINT-NEXT:    static let secondEntry: ClosedEnum
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }
+
+// RUN: %target-parse-verify-swift -I %S/Inputs/custom-modules
+import Newtype
+
+func tests() {
+	let errOne = ErrorDomain.one
+	errOne.process()
+
+	let fooErr = Foo.err
+	fooErr.process()
+	Foo().process() // expected-error{{value of type 'Foo' has no member 'process'}}
+
+	let thirdEnum = ClosedEnum.thirdEntry
+	thirdEnum.process()
+	  // expected-error@-1{{value of type 'ClosedEnum' has no member 'process'}}
+
+	let _ = ErrorDomain(rawValue: thirdEnum.rawValue)
+	let _ = ClosedEnum(rawValue: errOne.rawValue)
+
+}

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -11,7 +11,7 @@
 // PRINT-NEXT:    static let one: ErrorDomain
 // PRINT-NEXT:    static let errTwo: ErrorDomain
 // PRINT-NEXT:    static let three: ErrorDomain
-// PRINT-NEXT:    static let four: ErrorDomain
+// PRINT-NEXT:    static let fourErrorDomain: ErrorDomain
 // PRINT-NEXT:    static let stillAMember: ErrorDomain
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct Foo {
@@ -27,7 +27,7 @@
 // PRINT-NEXT:    let rawValue: NSString
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension ClosedEnum {
-// PRINT-NEXT:    static let firstEntry: ClosedEnum
+// PRINT-NEXT:    static let firstClosedEntryEnum: ClosedEnum
 // PRINT-NEXT:    static let secondEntry: ClosedEnum
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -2,23 +2,32 @@
 // RUN: FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
 // REQUIRES: objc_interop
 
-// PRINT:      struct ErrorDomain : RawRepresentable {
-// PRINT-NEXT:   init(rawValue: NSString)
-// PRINT-NEXT:   let rawValue: NSString
-// PRINT-NEXT: }
-// PRINT-NEXT: extension ErrorDomain {
-// PRINT-NEXT:   func process()
-// PRINT-NEXT:   static let one: ErrorDomain
-// PRINT-NEXT:   static let errTwo: ErrorDomain
-// PRINT-NEXT:   static let three: ErrorDomain
-// PRINT-NEXT:   static let four: ErrorDomain
-// PRINT-NEXT:   static let stillAMember: ErrorDomain
-// PRINT-NEXT: }
-// PRINT-NEXT: struct Foo {
-// PRINT-NEXT:   init()
-// PRINT-NEXT: }
-// PRINT-NEXT: extension Foo {
-// PRINT-NEXT:   static let err: ErrorDomain
-// PRINT-NEXT: }
-
-
+// PRINT-LABEL: struct ErrorDomain : RawRepresentable {
+// PRINT-NEXT:    init(rawValue: NSString)
+// PRINT-NEXT:    let rawValue: NSString
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension ErrorDomain {
+// PRINT-NEXT:    func process()
+// PRINT-NEXT:    static let one: ErrorDomain
+// PRINT-NEXT:    static let errTwo: ErrorDomain
+// PRINT-NEXT:    static let three: ErrorDomain
+// PRINT-NEXT:    static let four: ErrorDomain
+// PRINT-NEXT:    static let stillAMember: ErrorDomain
+// PRINT-NEXT:  }
+// PRINT-NEXT:  struct Foo {
+// PRINT-NEXT:    init()
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension Foo {
+// PRINT-NEXT:    static let err: ErrorDomain
+// PRINT-NEXT:  }
+//
+// TODO: update test when we can import it as actual new enum
+// PRINT-LABEL: struct ClosedEnum : RawRepresentable {
+// PRINT-NEXT:    init(rawValue: NSString)
+// PRINT-NEXT:    let rawValue: NSString
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension ClosedEnum {
+// PRINT-NEXT:    static let firstEntry: ClosedEnum
+// PRINT-NEXT:    static let secondEntry: ClosedEnum
+// PRINT-NEXT:    static let thirdEntry: ClosedEnum
+// PRINT-NEXT:  }

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=Newtype > %t.printed.A.txt
+// RUN: FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.A.txt
+// REQUIRES: objc_interop
+
+// PRINT:      struct ErrorDomain : RawRepresentable {
+// PRINT-NEXT:   init(rawValue: NSString)
+// PRINT-NEXT:   let rawValue: NSString
+// PRINT-NEXT: }
+// PRINT-NEXT: extension ErrorDomain {
+// PRINT-NEXT:   func process()
+// PRINT-NEXT:   static let one: ErrorDomain
+// PRINT-NEXT:   static let errTwo: ErrorDomain
+// PRINT-NEXT:   static let three: ErrorDomain
+// PRINT-NEXT:   static let four: ErrorDomain
+// PRINT-NEXT:   static let stillAMember: ErrorDomain
+// PRINT-NEXT: }
+// PRINT-NEXT: struct Foo {
+// PRINT-NEXT:   init()
+// PRINT-NEXT: }
+// PRINT-NEXT: extension Foo {
+// PRINT-NEXT:   static let err: ErrorDomain
+// PRINT-NEXT: }
+
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Adds initial support for swift_newtype(struct), and swift_newtype(enum) by treating as swift_newtype(struct). 
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
