### PR TITLE
[test/IRGen] Disable incremental llvm compilation for the IRGen tests

### DIFF
--- a/test/IRGen/UseObjCMethod.swift
+++ b/test/IRGen/UseObjCMethod.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: objc_interop
 import Foundation

--- a/test/IRGen/abi_v7k.swift
+++ b/test/IRGen/abi_v7k.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -module-name test_v7k | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s -module-name test_v7k | FileCheck %s
 // RUN: %target-swift-frontend -S -primary-file %s -module-name test_v7k | FileCheck -check-prefix=V7K %s
 
 // REQUIRES: CPU=armv7k

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir | FileCheck -check-prefix=%target-cpu-%target-os %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=%target-cpu-%target-os %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
 // XFAIL: linux

--- a/test/IRGen/asan-attributes.swift
+++ b/test/IRGen/asan-attributes.swift
@@ -1,6 +1,6 @@
 // This test verifies that we add the function attributes used by ASan.
 
-// RUN: %target-swift-frontend -emit-ir -sanitize=address %s | FileCheck %s -check-prefix=ASAN
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -sanitize=address %s | FileCheck %s -check-prefix=ASAN
 
 // XFAIL: linux
 

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir > %t.ll
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen > %t.ll
 // RUN: FileCheck %s -check-prefix=GLOBAL < %t.ll
 // RUN: FileCheck %s < %t.ll
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 

--- a/test/IRGen/autolink_elf.swift
+++ b/test/IRGen/autolink_elf.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %swift -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name Empty -module-link-name swiftEmpty %S/../Inputs/empty.swift
-// RUN: %swift -target x86_64-unknown-linux-gnu %s -I %t -parse-stdlib -disable-objc-interop -module-name main -emit-ir -o - | FileCheck %s
+// RUN: %swift -target x86_64-unknown-linux-gnu %s -I %t -parse-stdlib -disable-objc-interop -module-name main -emit-ir -disable-incremental-llvm-codegen -o - | FileCheck %s
 
 // REQUIRES: X86
 

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
 
 // XFAIL: linux
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -primary-file %s -emit-ir -o - -disable-objc-attr-requires-foundation-module | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -parse-stdlib -primary-file %s -emit-ir -disable-incremental-llvm-codegen -o - -disable-objc-attr-requires-foundation-module | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 // REQUIRES: executable_test
 
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 import c_layout
 

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // RUN: mkdir -p %t/Empty.framework/Modules/Empty.swiftmodule
 // RUN: %target-swift-frontend -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty
-// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -F %t -DIMPORT_EMPTY -emit-ir > %t.ll
+// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -F %t -DIMPORT_EMPTY -emit-ir -disable-incremental-llvm-codegen > %t.ll
 // RUN: FileCheck %s < %t.ll
 // RUN: FileCheck -check-prefix=NEGATIVE %s < %t.ll
 

--- a/test/IRGen/clang_inline_reverse.swift
+++ b/test/IRGen/clang_inline_reverse.swift
@@ -1,6 +1,6 @@
 // Same test as clang_inline.swift, but with the order swapped.
 
-// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -emit-ir -module-name clang_inline | FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -primary-file %s -emit-ir -disable-incremental-llvm-codegen -module-name clang_inline | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 // XFAIL: linux

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // XFAIL: linux

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -disable-incremental-llvm-codegen -enable-resilience %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -disable-incremental-llvm-codegen -enable-resilience -O %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -o - -primary-file %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -disable-incremental-llvm-codegen -o - -primary-file %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/class_with_stub_initializers.swift
+++ b/test/IRGen/class_with_stub_initializers.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/concrete_inherits_generic_base.swift
+++ b/test/IRGen/concrete_inherits_generic_base.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name foo -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend -module-name foo -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 

--- a/test/IRGen/coverage.swift
+++ b/test/IRGen/coverage.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -emit-sil -o - | FileCheck %s --check-prefix=SIL
-// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -emit-ir -o - | FileCheck %s --check-prefix=IR
+// RUN: %target-swift-frontend %s -profile-generate -profile-coverage-mapping -emit-ir -disable-incremental-llvm-codegen -o - | FileCheck %s --check-prefix=IR
 
 // SIL-DAG: sil hidden @_TF8coverage2f1FT_T_
 // SIL-DAG: string_literal utf8 "{{.*}}coverage.swift:{{.*}}_TF8coverage2f1FT_T_"

--- a/test/IRGen/deallocate.swift
+++ b/test/IRGen/deallocate.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/decls.swift
+++ b/test/IRGen/decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // Check that we emit all local decls, not just the first one.
 func test1() {

--- a/test/IRGen/dependent_generic_base_class_constraint.swift
+++ b/test/IRGen/dependent_generic_base_class_constraint.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -verify %s
 class GenericClass<T> { }
 
 protocol MyProtocol { }

--- a/test/IRGen/dependent_reabstraction.swift
+++ b/test/IRGen/dependent_reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -parse-as-library | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen -parse-as-library | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/empty_objc_ivar.swift
+++ b/test/IRGen/empty_objc_ivar.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -verify %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -disable-incremental-llvm-codegen -verify %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %target-swift-frontend -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift
-// RUN: %target-swift-frontend -I %t -O -primary-file %s -emit-ir | FileCheck -check-prefix=CHECK -check-prefix=CHECK-NORMAL %s
-// RUN: %target-swift-frontend -I %t -O -primary-file %s -enable-testing -emit-ir | FileCheck -check-prefix=CHECK -check-prefix=CHECK-TESTABLE %s
+// RUN: %target-swift-frontend -I %t -O -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECK -check-prefix=CHECK-NORMAL %s
+// RUN: %target-swift-frontend -I %t -O -primary-file %s -enable-testing -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECK -check-prefix=CHECK-TESTABLE %s
 
 import def_enum
 

--- a/test/IRGen/enum_function_payload.swift
+++ b/test/IRGen/enum_function_payload.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s
 
 enum Singleton {
   case F(Singleton -> ())

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | FileCheck %s
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -disable-incremental-llvm-codegen -enable-resilience %s | FileCheck %s
+// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -disable-incremental-llvm-codegen -enable-resilience -O %s
 
 import resilient_enum
 import resilient_struct

--- a/test/IRGen/expressions.swift
+++ b/test/IRGen/expressions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -parse-stdlib -disable-access-control | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -disable-access-control | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/extension_conformance_anyobject_conformance.swift
+++ b/test/IRGen/extension_conformance_anyobject_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -verify %s
 
 public struct TestGeneratorCrashy <Key: AnyObject, Value: AnyObject> {
     public mutating func next() -> (Key, Value)? {

--- a/test/IRGen/foreign_class_extension.swift
+++ b/test/IRGen/foreign_class_extension.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/function-target-features.swift
+++ b/test/IRGen/function-target-features.swift
@@ -1,12 +1,12 @@
 // This test verifies that we produce target-cpu and target-features attributes
 // on functions.
 
-// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | FileCheck %s -check-prefix=AVX-FEATURE
-// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512f -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512er | FileCheck %s -check-prefix=TWO-AVX
-// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 | FileCheck %s -check-prefix=CORE-CPU
-// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | FileCheck %s -check-prefix=CORE-CPU-AND-FEATURES
-// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc x86-64 | FileCheck %s -check-prefix=X86-64-CPU
-// RUN: %target-swift-frontend -emit-ir -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7-avx -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc -avx | FileCheck %s -check-prefix=AVX-MINUS-FEATURE
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | FileCheck %s -check-prefix=AVX-FEATURE
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -o - %s -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512f -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx512er | FileCheck %s -check-prefix=TWO-AVX
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 | FileCheck %s -check-prefix=CORE-CPU
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7 -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc +avx | FileCheck %s -check-prefix=CORE-CPU-AND-FEATURES
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc x86-64 | FileCheck %s -check-prefix=X86-64-CPU
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -o - %s -Xcc -Xclang -Xcc -target-cpu -Xcc -Xclang -Xcc corei7-avx -Xcc -Xclang -Xcc -target-feature -Xcc -Xclang -Xcc -avx | FileCheck %s -check-prefix=AVX-MINUS-FEATURE
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/function_metadata.swift
+++ b/test/IRGen/function_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s | FileCheck %s
 
 func arch<F>(_ f: F) {}
 

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/generic_class_anyobject.swift
+++ b/test/IRGen/generic_class_anyobject.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/generic_enums.swift
+++ b/test/IRGen/generic_enums.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen
 
 struct Bar<A1, A2> {
   var a: A1

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -1,15 +1,15 @@
-// RUN: %swift -target x86_64-apple-macosx10.9 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
-// RUN: %swift -target i386-apple-ios7.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
-// RUN: %swift -target x86_64-apple-ios7.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
-// RUN: %swift -target i386-apple-tvos9.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
-// RUN: %swift -target x86_64-apple-tvos9.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
-// RUN: %swift -target i386-apple-watchos2.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
-// RUN: %swift -target armv7-apple-ios7.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
-// RUN: %swift -target arm64-apple-ios7.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
-// RUN: %swift -target armv7-apple-tvos9.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
-// RUN: %swift -target arm64-apple-tvos9.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
-// RUN: %swift -target armv7k-apple-watchos2.0 -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
-// RUN: %swift -target x86_64-unknown-linux-gnu -disable-objc-interop -emit-ir -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
+// RUN: %swift -target x86_64-apple-macosx10.9 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
+// RUN: %swift -target i386-apple-ios7.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
+// RUN: %swift -target x86_64-apple-ios7.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
+// RUN: %swift -target i386-apple-tvos9.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
+// RUN: %swift -target x86_64-apple-tvos9.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
+// RUN: %swift -target i386-apple-watchos2.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
+// RUN: %swift -target armv7-apple-ios7.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
+// RUN: %swift -target arm64-apple-ios7.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
+// RUN: %swift -target armv7-apple-tvos9.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
+// RUN: %swift -target arm64-apple-tvos9.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
+// RUN: %swift -target armv7k-apple-watchos2.0 -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-32 %s
+// RUN: %swift -target x86_64-unknown-linux-gnu -disable-objc-interop -emit-ir -disable-incremental-llvm-codegen -parse-stdlib -primary-file %s | FileCheck --check-prefix=CHECK --check-prefix=CHECK-64 %s
 
 // REQUIRES: X86
 

--- a/test/IRGen/generic_structs.swift
+++ b/test/IRGen/generic_structs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen
 
 struct A<T1, T2>
 {

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s | FileCheck %s
 
 // Make sure that optimization passes don't choke on storage types for generic tuples
-// RUN: %target-swift-frontend -emit-ir -O %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -O %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/indirect_return.swift
+++ b/test/IRGen/indirect_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 

--- a/test/IRGen/infinite_archetype.swift
+++ b/test/IRGen/infinite_archetype.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 

--- a/test/IRGen/invalid_alignment.swift
+++ b/test/IRGen/invalid_alignment.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -verify
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s -verify
 
 @_alignment(1) // expected-error{{cannot decrease alignment below natural alignment of 4}}
 struct Bar { var x, y, z, w: Float }

--- a/test/IRGen/lazy_globals.swift
+++ b/test/IRGen/lazy_globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -emit-ir -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -emit-ir -disable-incremental-llvm-codegen -primary-file %s | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/lazy_multi_file.swift
+++ b/test/IRGen/lazy_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/lazy_multi_file_helper.swift -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/lazy_multi_file_helper.swift -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=i386_or_x86_64
 

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -emit-module %S/Inputs/local_types_helper.swift -o %t
-// RUN: %target-swift-frontend -emit-ir -parse-as-library %s -I %t > %t.ll
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -parse-as-library %s -I %t > %t.ll
 // RUN: FileCheck %s < %t.ll
 // RUN: FileCheck -check-prefix=NEGATIVE %s < %t.ll
 

--- a/test/IRGen/mangle-anonclosure.swift
+++ b/test/IRGen/mangle-anonclosure.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -o - | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s -o - | FileCheck %s
 
 func someValidPointer<T>() -> UnsafeMutablePointer<T> { fatalError() }
 

--- a/test/IRGen/meta_meta_type.swift
+++ b/test/IRGen/meta_meta_type.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out | FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck -check-prefix=CHECKIR %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECKIR %s
 // REQUIRES: executable_test
 
 protocol Proto {

--- a/test/IRGen/metadata_dominance.swift
+++ b/test/IRGen/metadata_dominance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s | FileCheck %s
 
 func use_metadata<F>(_ f: F) {}
 

--- a/test/IRGen/method_linkage.swift
+++ b/test/IRGen/method_linkage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // Test if all methods which go into a vtable have at least the visibility of its class.
 // Reason: Derived classes from "outside" still have to put the less visible base members

--- a/test/IRGen/mixed_objc_native_protocol_constraints.swift
+++ b/test/IRGen/mixed_objc_native_protocol_constraints.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -verify %s
 
 // compiler_crashers/029-class-with-anyobject-type-constraint.swift
 // Test case submitted to project by https://github.com/jansabbe (Jan Sabbe)

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 
-// RUN: %target-swift-frontend %S/Inputs/multithread_module/main.swift -emit-ir -o %t/main.ll %s -o %t/mt_module.ll -num-threads 2 -O -g -module-name test
+// RUN: %target-swift-frontend %S/Inputs/multithread_module/main.swift -emit-ir -disable-incremental-llvm-codegen -o %t/main.ll %s -o %t/mt_module.ll -num-threads 2 -O -g -module-name test
 // RUN: FileCheck --check-prefix=CHECK-MAINLL %s <%t/main.ll
 // RUN: FileCheck --check-prefix=CHECK-MODULELL %s <%t/mt_module.ll
 

--- a/test/IRGen/noinline.swift
+++ b/test/IRGen/noinline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -O -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 public var x = 0
 

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -disable-incremental-llvm-codegen -primary-file %s | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_class_empty_fields.swift
+++ b/test/IRGen/objc_class_empty_fields.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_class_property.swift
+++ b/test/IRGen/objc_class_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t && mkdir %t
-// RUN: %target-swift-frontend -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -module-name main -primary-file %s %S/Inputs/objc_enum_multi_file_helper.swift -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module %S/Inputs/objc_enum_multi_file_helper.swift -o %t
-// RUN: %target-swift-frontend -module-name main -primary-file %s -I %t -DIMPORT -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -module-name main -primary-file %s -I %t -DIMPORT -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 #if IMPORT
 import objc_enum_multi_file_helper

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_globals.swift
+++ b/test/IRGen/objc_globals.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -whole-module-optimization -emit-ir %s | FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -whole-module-optimization -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 //
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_local.swift
+++ b/test/IRGen/objc_local.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-os %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-os %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_properties.swift
+++ b/test/IRGen/objc_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_properties_imported.swift
+++ b/test/IRGen/objc_properties_imported.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -o - -primary-file %s | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -disable-incremental-llvm-codegen -o - -primary-file %s | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir -disable-objc-attr-requires-foundation-module -use-jit | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module -use-jit | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_property_attrs.swift
+++ b/test/IRGen/objc_property_attrs.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_protocol_extended_method_types.swift
+++ b/test/IRGen/objc_protocol_extended_method_types.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_protocol_multi_file.swift
+++ b/test/IRGen/objc_protocol_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/objc_protocol_multi_file_helper.swift -g -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_protocols_jit.swift
+++ b/test/IRGen/objc_protocols_jit.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
-// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -use-jit -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -sdk %S/Inputs -I %t -primary-file %s -use-jit -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_remapped_inits.swift
+++ b/test/IRGen/objc_remapped_inits.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // FIXME: This test could use %clang-importer-sdk, but the compiler crashes.
 

--- a/test/IRGen/objc_structs.swift
+++ b/test/IRGen/objc_structs.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/objc_subscripts.swift
+++ b/test/IRGen/objc_subscripts.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_super.swift
+++ b/test/IRGen/objc_super.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s -check-prefix=CHECK-%target-os
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s -check-prefix=CHECK-%target-os
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/osx-targets.swift
+++ b/test/IRGen/osx-targets.swift
@@ -1,6 +1,6 @@
-// RUN: %swift %s -emit-ir | FileCheck %s
-// RUN: %swift -target x86_64-apple-macosx10.12 %s -emit-ir | FileCheck -check-prefix=CHECK-SPECIFIC %s
-// RUN: %swift -target x86_64-apple-darwin16 %s -emit-ir | FileCheck -check-prefix=CHECK-SPECIFIC %s
+// RUN: %swift %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
+// RUN: %swift -target x86_64-apple-macosx10.12 %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECK-SPECIFIC %s
+// RUN: %swift -target x86_64-apple-darwin16 %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECK-SPECIFIC %s
 
 // REQUIRES: OS=macosx
 

--- a/test/IRGen/partial_apply_generic.swift
+++ b/test/IRGen/partial_apply_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: %target-swift-frontend -use-jit -playground -parse-stdlib %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -use-jit -playground -parse-stdlib %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-resilience -enable-source-import -I %S/../Inputs | FileCheck %s
-// RUN: %target-swift-frontend %s -emit-ir -num-threads 8 -enable-resilience -enable-source-import -I %S/../Inputs | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen -enable-resilience -enable-source-import -I %S/../Inputs | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen -num-threads 8 -enable-resilience -enable-source-import -I %S/../Inputs | FileCheck %s
 
 import resilient_struct
 

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck %s
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -num-threads 8 | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen -num-threads 8 | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/protocol_extensions_constrain.swift
+++ b/test/IRGen/protocol_extensions_constrain.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
 
 // rdar://20532214 -- Wrong code for witness method lookup lets executable crash
 

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/rdar15304329.swift
+++ b/test/IRGen/rdar15304329.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -enable-reflection-metadata -enable-reflection-names -emit-ir %S/Inputs/reflection_metadata.swift | FileCheck %s
-// RUN: %target-swift-frontend -enable-reflection-metadata -emit-ir %S/Inputs/reflection_metadata.swift | FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
-// RUN: %target-swift-frontend -emit-ir %S/Inputs/reflection_metadata.swift | FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
+// RUN: %target-swift-frontend -enable-reflection-metadata -enable-reflection-names -emit-ir -disable-incremental-llvm-codegen %S/Inputs/reflection_metadata.swift | FileCheck %s
+// RUN: %target-swift-frontend -enable-reflection-metadata -emit-ir -disable-incremental-llvm-codegen %S/Inputs/reflection_metadata.swift | FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %S/Inputs/reflection_metadata.swift | FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
 
 // STRIP_REFLECTION_NAMES-NOT: {{.*}}swift3_reflstr
 // STRIP_REFLECTION_NAMES_DAG: {{.*}}swift3_reflect

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -parse-as-library -emit-ir %s | FileCheck %s
-// RUN: %target-swift-frontend -parse-as-library -O -emit-ir %s | FileCheck --check-prefix=OPT-CHECK %s
+// RUN: %target-swift-frontend -parse-as-library -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -O -emit-ir -disable-incremental-llvm-codegen %s | FileCheck --check-prefix=OPT-CHECK %s
 
 // Test that runtime functions are invoked using the new calling convention.
 // Test that wrappers are used to invoked them.

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -primary-file %s -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // <rdar://problem/21665983> IRGen crash with protocol extension involving same-type constraint to X<T>
 public struct DefaultFoo<T> {

--- a/test/IRGen/select_enum_optimized.swift
+++ b/test/IRGen/select_enum_optimized.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -O -disable-llvm-optzns -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -disable-llvm-optzns -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 enum NoPayload {
   case E0

--- a/test/IRGen/sil_generic_witness_methods.swift
+++ b/test/IRGen/sil_generic_witness_methods.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/sil_generic_witness_methods_objc.swift
+++ b/test/IRGen/sil_generic_witness_methods_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/sil_irgen_library.swift
+++ b/test/IRGen/sil_irgen_library.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -parse-as-library
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen -parse-as-library
 
 // Smoke test that SIL-IRGen can compile a library module offline.
 func f() {}

--- a/test/IRGen/sil_irgen_standalone.swift
+++ b/test/IRGen/sil_irgen_standalone.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen
 
 // Smoke test that SIL-IRGen can compile a standalone program offline.
 func f() {}

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %target-swift-frontend -emit-module -o %t %S/sil_witness_tables_external_conformance.swift
-// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/sil_witness_tables_external_witnesstable.swift
+++ b/test/IRGen/sil_witness_tables_external_witnesstable.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -sil-serialize-all -module-link-name swiftCore
-// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 import Swift
 

--- a/test/IRGen/sil_witness_tables_inherited_conformance.swift
+++ b/test/IRGen/sil_witness_tables_inherited_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // rdar://problem/20628295
 

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | FileCheck %s
-// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -disable-incremental-llvm-codegen -enable-resilience %s | FileCheck %s
+// RUN: %target-swift-frontend -I %S/../Inputs -enable-source-import -emit-ir -disable-incremental-llvm-codegen -enable-resilience -O %s
 
 import resilient_struct
 import resilient_enum

--- a/test/IRGen/subclass.swift
+++ b/test/IRGen/subclass.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/IRGen/tsan-attributes.swift
+++ b/test/IRGen/tsan-attributes.swift
@@ -1,6 +1,6 @@
 // This test verifies that we add the function attributes used by TSan.
 
-// RUN: %target-swift-frontend -emit-ir -sanitize=thread %s | FileCheck %s -check-prefix=TSAN
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen -sanitize=thread %s | FileCheck %s -check-prefix=TSAN
 
 // TSan is currently only supported on 64 bit mac and simulators.
 // (We do not test the simulators here.)

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 class C {}
 

--- a/test/IRGen/type_layout_objc.swift
+++ b/test/IRGen/type_layout_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+// RUN: %target-swift-frontend -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 
 class C {}
 protocol P: class {}

--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -disable-incremental-llvm-codegen %s | FileCheck %s
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/IRGen/vector_reduction.swift
+++ b/test/IRGen/vector_reduction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Ounchecked %s -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -Ounchecked %s -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/vtable_multi_file.swift
+++ b/test/IRGen/vtable_multi_file.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/vtable_multi_file_helper.swift -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/weak_import.swift
+++ b/test/IRGen/weak_import.swift
@@ -4,8 +4,8 @@
 // Specify explicit target triples for the deployment target to test weak
 // linking for a symbol introduced in OS X 10.51.
 //
-// RUN: %target-swift-frontend(mock-sdk: -target x86_64-apple-macosx10.50 -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck -check-prefix=CHECK-10_50 %s
-// RUN: %target-swift-frontend(mock-sdk: -target x86_64-apple-macosx10.51 -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | FileCheck -check-prefix=CHECK-10_51 %s
+// RUN: %target-swift-frontend(mock-sdk: -target x86_64-apple-macosx10.50 -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECK-10_50 %s
+// RUN: %target-swift-frontend(mock-sdk: -target x86_64-apple-macosx10.51 -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-incremental-llvm-codegen | FileCheck -check-prefix=CHECK-10_51 %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop

--- a/test/IRGen/witness_table_multifile.swift
+++ b/test/IRGen/witness_table_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/witness_table_multifile_2.swift -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/witness_table_multifile_2.swift -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 // CHECK: [[P_WITNESS_TABLE:%[A-Za-z0-9_]+]] = type { [{{24|12}} x i8], %swift.type*, i8** }
 

--- a/test/IRGen/witness_table_objc_associated_type.swift
+++ b/test/IRGen/witness_table_objc_associated_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -disable-incremental-llvm-codegen -disable-objc-attr-requires-foundation-module | FileCheck %s
 
 protocol A {}
 

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir -disable-incremental-llvm-codegen | FileCheck %s
 
 // rdar://24121475
 //   Ideally, these wouldn't be in the v-table at all; but as long as they


### PR DESCRIPTION
---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This makes the compiler's behavior at debug-time match its behavior at
the initial time of failure. It makes sense to update just the IRGen
tests in particular because these are the most likely to trigger backend
failures.
