### PR TITLE
fix SR-1109: don't use the clang resource override dir for glibc

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -391,11 +391,7 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     // and is not included in the resource directory with the other implicit
     // module maps. It's at {freebsd|linux}/{arch}/glibc.modulemap.
     SmallString<128> GlibcModuleMapPath;
-    if (!importerOpts.OverrideResourceDir.empty()) {
-      GlibcModuleMapPath = importerOpts.OverrideResourceDir;
-    } else if (!searchPathOpts.RuntimeResourcePath.empty()) {
-      GlibcModuleMapPath = searchPathOpts.RuntimeResourcePath;
-    }
+    GlibcModuleMapPath = searchPathOpts.RuntimeResourcePath;
 
     // Running without a resource directory is not a supported configuration.
     assert(!GlibcModuleMapPath.empty());


### PR DESCRIPTION
Fixes SR-1109.

Reviewed by: Jordan Rose

We were using the clang resource override dir in a place where it shouldn't be used. LLDB (and thus the REPL) is the only consumer of this feature.  It is meant for clang modules.
