### PR TITLE
Bitcast to the right type when allocating a buffer in init_existential_addr

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4316,6 +4316,10 @@ void IRGenSILFunction::visitInitExistentialAddrInst(swift::InitExistentialAddrIn
       return emitAllocateBuffer(*this, i->getLoweredConcreteType(), buffer);
     }
   }();
+
+  // Make sure we have a value of the right type.
+  address =
+    Builder.CreateBitCast(address, srcTI.getStorageType()->getPointerTo());
   
   setLoweredAddress(SILValue(i, 0), address);
 }

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -111,3 +111,33 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   return undef : $()
 }
+
+typealias Any = protocol<>
+
+struct Foo<T> {
+  private let x : T -> ()
+  private let y : T
+  private let z : Any
+}
+
+// rdar://25870973
+//   swift-2.2 specific test that field projections of concrete but
+//   non-fixed-size types don't crash south of an init_existential_addr.
+sil @bar : $@convention(thin) <T> (@out Foo<T>) -> ()
+sil @foo : $@convention(thin) <T> (@out Any, @in Foo<T>) -> () {
+bb0(%0 : $*Any, %1 : $*Foo<T>):
+  %2 = alloc_stack $Any
+
+  %3 = init_existential_addr %2 : $*Any, $Foo<T>
+  %fn = function_ref @bar : $@convention(thin) <T> (@out Foo<T>) -> ()
+  %result = apply %fn<T>(%3) : $@convention(thin) <T> (@out Foo<T>) -> ()
+
+  %4 = init_existential_addr %0 : $*Any, $Foo<T>
+  copy_addr %3 to [initialization] %4 : $*Foo<T>
+
+  destroy_addr %2 : $*Any
+
+  dealloc_stack %2 : $*Any
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Fixes a Swift 2.2 regression involving a certain SIL pattern, potentially formed by the optimizer, involving init_existential_addr's of non-fixed size.

<!-- Description about pull request. -->

Resolves rdar://25870973.

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
