### PR TITLE
[build-script] Fixed a typo in llvm configuration

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1614,7 +1614,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS_TO_BUILD}"
                     -DLLVM_INCLUDE_TESTS:BOOL=$(true_false "${SOURCE_TREE_INCLUDES_TESTS}")
-                    -LLVM_INCLUDE_DOCS:BOOL=TRUE
+                    -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     "${llvm_cmake_options[@]}"
                     "${LLVM_SOURCE_DIR}"
                 )


### PR DESCRIPTION
#### What's in this pull request?

Fixed a typo in llvm configuration options.
I believe it's NFC, because `LLVM_INCLUDE_DOCS` is `ON` by default.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
