### PR TITLE
[build-script] Fixed --extra-cmake-options

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -17,6 +17,8 @@ import os
 import platform
 import shutil
 import sys
+import pipes
+import shlex
 
 # FIXME: Instead of modifying the system path in order to enable imports from
 #        other directories, all Python modules related to the build script
@@ -59,6 +61,18 @@ def argparse_bool(string):
     if string in ['1', 'true', 'True']:
         return True
     raise argparse.ArgumentTypeError("%r is not a boolean value" % string)
+
+
+# Parse and split shell arguments string into a list of shell arguments.
+# Recognize `,` as a separator as well as white spaces.
+# string: -BAR="foo bar" -BAZ='foo,bar',-QUX 42
+# into
+# ['-BAR=foo bar', '-BAZ=foo,bar', "-QUX", "42"]
+def argparse_shell_split(string):
+    lex = shlex.shlex(string, posix=True)
+    lex.whitespace_split = True
+    lex.whitespace += ','
+    return list(lex)
 
 
 # Main entry point for the preset mode.
@@ -803,7 +817,9 @@ details of the setups of other systems or automated environments.""")
         help="Pass through extra options to CMake in the form of comma "
              "separated options '-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp'. Can be "
              "called multiple times to add multiple such options.",
-        action="append", dest="extra_cmake_options", default=[])
+        action="append",
+        type=argparse_shell_split,
+        default=[])
 
     args = migration.parse_args(parser, sys.argv[1:])
 
@@ -1247,12 +1263,16 @@ details of the setups of other systems or automated environments.""")
             "--extra-swift-args",
             ";".join(args.extra_swift_args)]
 
-    # If we have extra_cmake_args, combine all of them together and then add
+    # If we have extra_cmake_options, combine all of them together and then add
     # them as one command.
+    # Note that args.extra_cmake_options is a list of lists of options.
     if args.extra_cmake_options:
         build_script_impl_args += [
-            "--extra-cmake-options",
-            ",".join(args.extra_cmake_options)]
+            "--extra-cmake-options=%s" % ' '.join(
+                pipes.quote(opt)
+                for options in args.extra_cmake_options
+                for opt in options)
+        ]
 
     build_script_impl_args += args.build_script_impl_args
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -90,7 +90,6 @@ KNOWN_SETTINGS=(
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
     build-runtime-with-host-compiler   "1"       "use the host c++ compiler to build everything"
-    user-config-args            ""               "User-supplied arguments to cmake when used to do configuration"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"
     install-prefix              ""               "installation prefix"
@@ -221,6 +220,8 @@ KNOWN_SETTINGS=(
     android-icu-i18n-include           ""        "Path to a directory containing headers libicui18n"
     export-compile-commands            ""        "set to generate JSON compilation databases for each build product"
     check-args-only                    ""        "set to check all arguments are known. Exit with status 0 if success, non zero otherwise"
+    # TODO: Remove this some time later.
+    user-config-args            ""               "**Renamed to --extra-cmake-options**: User-supplied arguments to cmake when used to do configuration."
 )
 
 function toupper() {
@@ -694,6 +695,12 @@ while [[ "$1" ]] ; do
     shift
 done
 
+# TODO: Remove this some time later.
+if [[ "${USER_CONFIG_ARGS}" ]]; then
+    echo "Error: --user-config-args is renamed to --extra-cmake-options." 1>&2
+    exit 1
+fi
+
 if [[ "${CHECK_ARGS_ONLY}" ]]; then
     exit 0
 fi
@@ -1160,15 +1167,8 @@ if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
     )
 fi
 
-if [[ "${EXTRA_CMAKE_OPTIONS}" ]] ; then
-    for cmake_opt in $(echo "${EXTRA_CMAKE_OPTIONS}" | tr "," "\n")
-    do
-        COMMON_CMAKE_OPTIONS=(
-            "${COMMON_CMAKE_OPTIONS[@]}"
-            "${cmake_opt}"
-        )
-    done
-fi
+# Convert to an array.
+eval EXTRA_CMAKE_OPTIONS=(${EXTRA_CMAKE_OPTIONS})
 
 if [[ "${DISTCC}" ]] ; then
     # On some platforms, 'pump' may be unrelated to distcc, in which case it's
@@ -2055,7 +2055,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             set -x
             mkdir -p "${build_dir}"
             rm -f "${cmake_cache_path}"
-            (cd "${build_dir}" && "${CMAKE}" "${cmake_options[@]}" ${USER_CONFIG_ARGS} "${source_dir}")
+            (cd "${build_dir}" && "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}")
             { set +x; } 2>/dev/null
         fi
 


### PR DESCRIPTION
#### What's in this pull request?

CC: @akyrtzi, @gribozavr 

Follow up on #2146.
- Moved to the position where it can override any prior options, as discussed in #2146.
- Replaced `--user-config-args`: Error when `--user-config-args` is used.
  
  ```
  $ utils/build-script -- --user-config-args="-DMY_OPT=FOO"
  Error: --user-config-args is renamed to --extra-cmake-options.
  utils/build-script: command terminated with a non-zero exit status 1, aborting
  ```
- Get it to work as `build-script` arguments.<br>
  `build-script --extra-cmake-options="-DMY_OPTION=FOO"` didn't work at all.
- Fixed quoting problems.
  Make it work even if option values contain space or comma in them:
  
  Before:
  
  ```
  $ build-script -- --extra-cmake-options="-DMYOPTION=FOO BAR"
  ...
  + /usr/bin/cmake -G Ninja -DMYOPTION=FOO BAR -DCMAKE_C_COMPILER:PATH=...
                            ^ [ {-DMYOPTION=FOO}, {BAR} ]
  
  $ build-script -- --extra-cmake-options="-DMYOPTION='FOO BAR'"
  ...
  + /usr/bin/cmake -G Ninja '-DMYOPTION='\''FOO' 'BAR'\''' -DCMAKE_C_COMPILER:PATH=...
                            ^ [ {-DMYOPTION='FOO}, {BAR'} ]
  ```
  
  After:
  
  ```
  $ build-script --extra-cmake-options="-DMY_OPT='Hello, Swift' -DFOO=\"bar,baz\", -DBAR=12"
  ...
  + /usr/bin/cmake -G Ninja ... '-DMY_OPT=Hello, Swift' -DFOO=bar,baz -DBAR=12
  ```
  
  It recognizes `,`  and white spaces as separators. You can quote them if you want get them into values.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<!-- Thank you for your contribution to Swift! -->
