### PR TITLE
[SwiftRemoteMirror] Renamed addr_t to swift_addr_t

### DIFF
--- a/include/swift/SwiftRemoteMirror/MemoryReaderInterface.h
+++ b/include/swift/SwiftRemoteMirror/MemoryReaderInterface.h
@@ -26,17 +26,21 @@
 extern "C" {
 #endif
 
-typedef uint64_t addr_t;
+// They would think the type 'addr_t' is defined in the standard library
+// because it has the same name format with the types in <cstdint>. In
+// addition, the definition conflicts in Cygwin which defines it differently
+// in the system library, so we use 'swift_addr_t'.
+typedef uint64_t swift_addr_t;
 
 typedef uint8_t (*PointerSizeFunction)(void *reader_context);
 typedef uint8_t (*SizeSizeFunction)(void *reader_context);
-typedef int (*ReadBytesFunction)(void *reader_context, addr_t address,
-                                  void *dest, uint64_t size);
+typedef int (*ReadBytesFunction)(void *reader_context, swift_addr_t address,
+                                 void *dest, uint64_t size);
 typedef uint64_t (*GetStringLengthFunction)(void *reader_context,
-                                            addr_t address);
-typedef addr_t (*GetSymbolAddressFunction)(void *reader_context,
-                                           const char *name,
-                                           uint64_t name_length);
+                                            swift_addr_t address);
+typedef swift_addr_t (*GetSymbolAddressFunction)(void *reader_context,
+                                                 const char *name,
+                                                 uint64_t name_length);
 
 typedef struct MemoryReaderImpl {
   /// An opaque context that the implementor can specify to

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -147,10 +147,10 @@ swift_reflection_genericArgumentOfTypeRef(swift_typeref_t OpaqueTypeRef,
 /// Returns true if InstanceTypeRef and StartOfInstanceData contain valid
 /// valid values.
 int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
-                                        addr_t ExistentialAddress,
+                                        swift_addr_t ExistentialAddress,
                                         swift_typeref_t ExistentialTypeRef,
                                         swift_typeref_t *OutInstanceTypeRef,
-                                        addr_t *OutStartOfInstanceData);
+                                        swift_addr_t *OutStartOfInstanceData);
 
 /// Dump a brief description of the typeref as a tree to stderr.
 void swift_reflection_dumpTypeRef(swift_typeref_t OpaqueTypeRef);

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -248,10 +248,10 @@ swift_reflection_childOfInstance(SwiftReflectionContextRef ContextRef,
 }
 
 int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
-                                        addr_t ExistentialAddress,
+                                        swift_addr_t ExistentialAddress,
                                         swift_typeref_t ExistentialTypeRef,
                                         swift_typeref_t *InstanceTypeRef,
-                                        addr_t *StartOfInstanceData) {
+                                        swift_addr_t *StartOfInstanceData) {
   auto Context = reinterpret_cast<NativeReflectionContext *>(ContextRef);
   auto ExistentialTR = reinterpret_cast<const TypeRef *>(ExistentialTypeRef);
   auto RemoteExistentialAddress = RemoteAddress(ExistentialAddress);

--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -175,8 +175,8 @@ void PipeMemoryReader_collectBytesFromPipe(const PipeMemoryReader *Reader,
 }
 
 static
-int PipeMemoryReader_readBytes(void *Context,
-                               addr_t Address, void *Dest, uint64_t Size) {
+int PipeMemoryReader_readBytes(void *Context, swift_addr_t Address, void *Dest,
+                               uint64_t Size) {
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;
   uintptr_t TargetAddress = Address;
   size_t TargetSize = (size_t)Size;
@@ -189,8 +189,9 @@ int PipeMemoryReader_readBytes(void *Context,
 }
 
 static
-addr_t PipeMemoryReader_getSymbolAddress(void *Context, const char *SymbolName,
-                                         uint64_t Length) {
+swift_addr_t PipeMemoryReader_getSymbolAddress(void *Context,
+                                               const char *SymbolName,
+                                               uint64_t Length) {
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;
   uintptr_t Address = 0;
   int WriteFD = PipeMemoryReader_getParentWriteFD(Reader);
@@ -306,7 +307,7 @@ PipeMemoryReader_receiveReflectionInfo(SwiftReflectionContextRef RC,
   free(RemoteInfos);
 }
 
-uint64_t PipeMemoryReader_getStringLength(void *Context, addr_t Address) {
+uint64_t PipeMemoryReader_getStringLength(void *Context, swift_addr_t Address) {
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;
   int WriteFD = PipeMemoryReader_getParentWriteFD(Reader);
   uintptr_t TargetAddress = (uintptr_t)Address;
@@ -355,7 +356,7 @@ int reflectExistential(SwiftReflectionContextRef RC,
          instance);
 
   swift_typeref_t InstanceTypeRef;
-  addr_t StartOfInstanceData = 0;
+  swift_addr_t StartOfInstanceData = 0;
 
   // For testing purposes, we can assume that any existential is Any, since
   // we won't be looking at any witness tables that follow the container.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

They would think the type 'addr_t' is defined in the standard library
because it has the same name format with the types in `<cstdint>`. In
addition, the definition conflicts in Cygwin which defines it differently
in the system library.
