### PR TITLE
Revert "stdlib: simplify the '+=' singature for arrays"

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1010,12 +1010,12 @@ extension ${Self} {
   }
 }
 
-// FIXME(ABI): remove this entrypoint.  The functionality should be provided by
-// a `+=` operator on `RangeReplaceableCollection`.
 /// Append the contents of `rhs` to `lhs`.
 public func += <
-  S : Sequence
->(lhs: inout ${Self}<S.Iterator.Element>, rhs: S) {
+  Element, S : Sequence
+  where
+  S.Iterator.Element == Element
+>(lhs: inout ${Self}<Element>, rhs: S) {
   let oldCount = lhs.count
   let capacity = lhs.capacity
   let newCount = oldCount + rhs.underestimatedCount
@@ -1027,12 +1027,12 @@ public func += <
   _arrayAppendSequence(&lhs._buffer, rhs)
 }
 
-// FIXME(ABI): remove this entrypoint.  The functionality should be provided by
-// a `+=` operator on `RangeReplaceableCollection`.
 /// Append the contents of `rhs` to `lhs`.
 public func += <
-  C : Collection
->(lhs: inout ${Self}<C.Iterator.Element>, rhs: C) {
+  Element, C : Collection
+  where
+  C.Iterator.Element == Element
+>(lhs: inout ${Self}<Element>, rhs: C) {
   let rhsCount = numericCast(rhs.count) as Int
 
   let oldCount = lhs.count

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -99,11 +99,14 @@ func test17875634() {
   var col = 2
   var coord = (row, col)
 
-  match += (1, 2) // expected-error{{argument type '(Int, Int)' does not conform to expected type 'Sequence'}}
+  match += (1, 2) // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)'}}
+  // expected-note @-1 {{overloads for '+=' exist with these partially matching parameter lists:}}
+  
+  match += (row, col) // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)'}}
+  // expected-note @-1 {{overloads for '+=' exist with these partially matching parameter lists:}}
 
-  match += (row, col) // expected-error{{argument type '(@lvalue Int, @lvalue Int)' does not conform to expected type 'Sequence'}}
-
-  match += coord // expected-error{{argument type '@lvalue (Int, Int)' does not conform to expected type 'Sequence'}}
+  match += coord // expected-error{{binary operator '+=' cannot be applied to operands of type '[(Int, Int)]' and '(Int, Int)'}}
+  // expected-note @-1 {{overloads for '+=' exist with these partially matching parameter lists:}}
 
   match.append(row, col) // expected-error{{extra argument in call}}
 


### PR DESCRIPTION
Reverts apple/swift#2286

It looks like it broke code completion tests: https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-15_10/4455/console
