### PR TITLE
Relax verification of dealloc_stack.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1434,7 +1434,8 @@ public:
             "unowned_release requires unowned type to be loadable");
   }
   void checkDeallocStackInst(DeallocStackInst *DI) {
-    require(isa<AllocStackInst>(DI->getOperand()),
+    require(isa<SILUndef>(DI->getOperand()) ||
+                isa<AllocStackInst>(DI->getOperand()),
             "Operand of dealloc_stack must be an alloc_stack");
   }
   void checkDeallocRefInst(DeallocRefInst *DI) {

--- a/test/SILOptimizer/unreachable_dealloc_stack.sil
+++ b/test/SILOptimizer/unreachable_dealloc_stack.sil
@@ -1,0 +1,34 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostics | FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+class TheClass {}
+
+// Ensure that when we remove the code after the apply of noreturn
+// function nada, we don't fail verification on a dealloc_stack with
+// an undef operand, but that we do later remove it in the diagnostics
+// passes.
+
+// CHECK-LABEL: sil @unreachable_dealloc_stack
+sil @unreachable_dealloc_stack: $@convention(method) (@guaranteed TheClass) -> () {
+bb0(%0 : $TheClass):
+  %1 = function_ref @nada : $@convention(c) @noreturn (Builtin.Int32) -> ()
+  %2 = integer_literal $Builtin.Int32, 0
+  // CHECK: apply{{.*}}
+  %3 = apply %1(%2) : $@convention(c) @noreturn (Builtin.Int32) -> ()
+  // CHECK-NEXT: unreachable
+  // CHECK-NOT: dealloc_stack
+  %4 = alloc_stack $TheClass
+  store %0 to %4 : $*TheClass
+  br bb1
+
+bb1:
+  dealloc_stack %4 : $*TheClass
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: sil @nada
+sil @nada : $@convention(c) @noreturn (Builtin.Int32) -> ()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Relax verification of dealloc_stack, allowing it to have an undef operand.
#### Resolved bug number: ([SR-967](https://bugs.swift.org/browse/SR-967))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Allow it to have undef as an operand.

This can happen when NoReturnFolding does RAUW for the instructions that
come after a @noreturn function, replacing the uses of those
instructions in blocks that are unreachable. These instructions end up
getting deleted during diagnose unreachable when we remove the
unreachable code.

Fixes SR-967 / rdar://problem/25882880.
