### PR TITLE
[swiftc] Add test case for crash triggered in swift::GenericParamList::getSubstitutionMap(…)

### DIFF
--- a/validation-test/compiler_crashers/28288-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28288-swift-genericparamlist-getsubstitutionmap.swift
@@ -1,0 +1,13 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol A{
+typealias B<a>:A
+enum S<T where B<Int>:d
+typealias d


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:139: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]: Assertion `!empty()' failed.
8  swift           0x00000000010cff58 swift::GenericParamList::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 1080
9  swift           0x0000000000ed957c swift::TypeChecker::applyUnboundGenericArguments(swift::UnboundGenericType*, swift::SourceLoc, swift::DeclContext*, llvm::MutableArrayRef<swift::TypeLoc>, bool, swift::GenericTypeResolver*) + 1164
10 swift           0x0000000000ed8f9f swift::TypeChecker::applyGenericArguments(swift::Type, swift::SourceLoc, swift::DeclContext*, swift::GenericIdentTypeRepr*, bool, swift::GenericTypeResolver*) + 431
14 swift           0x0000000000ed988e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
16 swift           0x0000000000eda8a4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
17 swift           0x0000000000ed978a swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 42
18 swift           0x0000000000ea7162 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 690
19 swift           0x0000000000ea8597 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
20 swift           0x0000000000ea8936 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
21 swift           0x0000000000e6cf7f swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 367
22 swift           0x000000000107b917 swift::ProtocolDecl::existentialTypeSupportedSlow(swift::LazyResolver*) + 151
26 swift           0x0000000001015ff4 swift::Decl::walk(swift::ASTWalker&) + 20
27 swift           0x0000000000eddeed swift::TypeChecker::checkUnsupportedProtocolType(swift::Decl*) + 157
29 swift           0x0000000000e6d251 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
34 swift           0x0000000000e72306 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
35 swift           0x0000000000e93d82 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 994
36 swift           0x0000000000c339ef swift::CompilerInstance::performSema() + 3295
38 swift           0x00000000007c4556 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2838
39 swift           0x0000000000791068 main + 2840
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28288-swift-genericparamlist-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28288-swift-genericparamlist-getsubstitutionmap-b0dd35.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28288-swift-genericparamlist-getsubstitutionmap.swift:10:1
2.  While type-checking 'B' at validation-test/compiler_crashers/28288-swift-genericparamlist-getsubstitutionmap.swift:11:1
3.  While resolving type B<Int> at [validation-test/compiler_crashers/28288-swift-genericparamlist-getsubstitutionmap.swift:12:16 - line:12:21] RangeText="B<Int>"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
