### PR TITLE
[build-script][SR-237] Migrate calculation of COMMON_CMAKE_OPTIONS and BUILD_ARGS to Python

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -15,6 +15,7 @@ import argparse
 import multiprocessing
 import os
 import platform
+import re
 import shutil
 import sys
 import pipes
@@ -74,6 +75,16 @@ def argparse_shell_split(string):
     lex.whitespace_split = True
     lex.whitespace += ','
     return list(lex)
+
+
+# Parse version string and split into a tuple of strings (major, minor, patch)
+# Support only "MAJOR.MINOR.PATCH" format.
+def argparse_clang_compiler_version(string):
+    m = re.match(r'([0-9]*)\.([0-9]*)\.([0-9]*)', string)
+    if m is not None:
+        return m.group(1, 2, 3)
+    raise argparse.ArgumentTypeError(
+        "%r is invalid version value. must be 'MAJOR.MINOR.PATCH'" % string)
 
 
 # Main entry point for the preset mode.
@@ -838,6 +849,7 @@ details of the setups of other systems or automated environments.""")
     parser.add_argument(
         "--clang-compiler-version",
         help="string that indicates a compiler version for Clang",
+        type=argparse_clang_compiler_version,
         metavar="MAJOR.MINOR.PATCH")
 
     parser.add_argument(
@@ -1286,7 +1298,7 @@ details of the setups of other systems or automated environments.""")
         build_script_impl_args += ["--enable-ubsan"]
     if args.clang_compiler_version:
         build_script_impl_args += [
-            "--clang-compiler-version", args.clang_compiler_version
+            "--clang-compiler-version=%s.%s.%s" % args.clang_compiler_version
         ]
     if args.verbose_build:
         build_script_impl_args += ["--verbose-build"]

--- a/utils/build-script
+++ b/utils/build-script
@@ -849,6 +849,19 @@ details of the setups of other systems or automated environments.""")
         type=argparse_shell_split,
         default=[])
 
+    parser.add_argument(
+        "--build-args",
+        help="arguments to the build tool. This would be prepended to the "
+             "default argument that is '-j8' when CMake generator is "
+             "\"Ninja\".",
+        type=argparse_shell_split,
+        default=[])
+
+    parser.add_argument(
+        "--verbose-build",
+        help="print the commands executed during the build",
+        action="store_true")
+
     args = migration.parse_args(parser, sys.argv[1:])
 
     build_script_impl = os.path.join(
@@ -1258,6 +1271,8 @@ details of the setups of other systems or automated environments.""")
         "--workspace", SWIFT_SOURCE_ROOT,
         "--common-cmake-options=%s" % ' '.join(
             pipes.quote(opt) for opt in cmake.common_options()),
+        "--build-args=%s" % ' '.join(
+            pipes.quote(arg) for arg in cmake.build_args()),
     ]
 
     if args.distcc:
@@ -1273,6 +1288,8 @@ details of the setups of other systems or automated environments.""")
         build_script_impl_args += [
             "--clang-compiler-version", args.clang_compiler_version
         ]
+    if args.verbose_build:
+        build_script_impl_args += ["--verbose-build"]
     if args.install_symroot:
         build_script_impl_args += [
             "--install-symroot", os.path.abspath(args.install_symroot)

--- a/utils/build-script
+++ b/utils/build-script
@@ -48,6 +48,7 @@ from swift_build_support import migration  # noqa (E402)
 import swift_build_support.ninja      # noqa (E402)
 import swift_build_support.tar        # noqa (E402)
 import swift_build_support.targets    # noqa (E402)
+from swift_build_support.cmake import CMake  # noqa (E402)
 
 
 # A strict parser for bools (unlike Python's `bool()`, where
@@ -813,6 +814,33 @@ details of the setups of other systems or automated environments.""")
         metavar="PATH")
 
     parser.add_argument(
+        "--host-cc",
+        help="the absolute path to CC, the 'clang' compiler for the host "
+             "platform. Default is auto detected.",
+        metavar="PATH")
+    parser.add_argument(
+        "--host-cxx",
+        help="the absolute path to CXX, the 'clang++' compiler for the host "
+             "platform. Default is auto detected.",
+        metavar="PATH")
+    parser.add_argument(
+        "--distcc",
+        help="use distcc in pump mode",
+        action="store_true")
+    parser.add_argument(
+        "--enable-asan",
+        help="enable Address Sanitizer",
+        action="store_true")
+    parser.add_argument(
+        "--enable-ubsan",
+        help="enable Undefined Behavior Sanitizer",
+        action="store_true")
+    parser.add_argument(
+        "--clang-compiler-version",
+        help="string that indicates a compiler version for Clang",
+        metavar="MAJOR.MINOR.PATCH")
+
+    parser.add_argument(
         "--extra-cmake-options",
         help="Pass through extra options to CMake in the form of comma "
              "separated options '-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp'. Can be "
@@ -954,11 +982,6 @@ details of the setups of other systems or automated environments.""")
         args.skip_test_watchos_simulator = True
 
     build_script_impl_inferred_args = []
-
-    if args.export_compile_commands:
-        build_script_impl_inferred_args += [
-            "--export-compile-commands"
-        ]
 
     if not args.test and not args.validation_test and not args.long_test:
         build_script_impl_inferred_args += [
@@ -1166,9 +1189,16 @@ details of the setups of other systems or automated environments.""")
 
     host_clang = swift_build_support.toolchain.host_clang(
         xcrun_toolchain=args.darwin_xcrun_toolchain)
-    if not host_clang:
+    if args.host_cc is None and host_clang is not None:
+        args.host_cc = str(host_clang.cc)
+    if args.host_cxx is None and host_clang is not None:
+        args.host_cxx = str(host_clang.cxx)
+    is_host_clang_ok = (
+        args.host_cc is not None and os.access(args.host_cc, os.X_OK) and
+        args.host_cxx is not None and os.access(args.host_cxx, os.X_OK))
+    if not is_host_clang_ok:
         print_with_argv0(
-            "Can't find clang.  Please install clang-3.5 or a later version.")
+            "Can't find clang. Please install clang-3.5 or a later version.")
         return 1
 
     host_cmake = args.cmake
@@ -1178,14 +1208,38 @@ details of the setups of other systems or automated environments.""")
     if not host_cmake:
         print_with_argv0("Can't find CMake. Please install CMake.")
         return 1
+
+    # distcc usage.
+    host_distcc = None
+    host_distcc_pump = None
+    if args.distcc:
+        host_distcc = swift_build_support.which('distcc')
+        # On some platforms, 'pump' may be unrelated to distcc, in which case
+        # it's called 'distcc-pump'.
+        host_distcc_pump = swift_build_support.which('distcc-pump')
+        if host_distcc_pump is None:
+            host_distcc_pump = swift_build_support.which('pump')
+
+        if host_distcc is None or host_distcc_pump is None:
+            print_with_argv0(
+                "Can't find distcc. Please install distcc")
+
+        host_distcc = str(host_distcc)
+        host_distcc_pump = str(host_distcc_pump)
+
+    cmake = CMake(args=args,
+                  host_cc=args.host_cc,
+                  host_cxx=args.host_cxx,
+                  host_distcc=host_distcc)
+
     build_script_impl_args = [
         "--build-dir", build_dir,
         "--install-prefix", os.path.abspath(args.install_prefix),
         "--host-target", args.host_target,
         "--stdlib-deployment-targets",
         " ".join(args.stdlib_deployment_targets),
-        "--host-cc", host_clang.cc,
-        "--host-cxx", host_clang.cxx,
+        "--host-cc", args.host_cc,
+        "--host-cxx", args.host_cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
         "--cmake", host_cmake,
         "--cmark-build-type", args.cmark_build_variant,
@@ -1201,8 +1255,24 @@ details of the setups of other systems or automated environments.""")
             args.swift_analyze_code_coverage).lower(),
         "--cmake-generator", args.cmake_generator,
         "--build-jobs", str(args.build_jobs),
-        "--workspace", SWIFT_SOURCE_ROOT
+        "--workspace", SWIFT_SOURCE_ROOT,
+        "--common-cmake-options=%s" % ' '.join(
+            pipes.quote(opt) for opt in cmake.common_options()),
     ]
+
+    if args.distcc:
+        build_script_impl_args += [
+            "--distcc",
+            "--distcc-pump=%s" % host_distcc_pump
+        ]
+    if args.enable_asan:
+        build_script_impl_args += ["--enable-asan"]
+    if args.enable_ubsan:
+        build_script_impl_args += ["--enable-ubsan"]
+    if args.clang_compiler_version:
+        build_script_impl_args += [
+            "--clang-compiler-version", args.clang_compiler_version
+        ]
     if args.install_symroot:
         build_script_impl_args += [
             "--install-symroot", os.path.abspath(args.install_symroot)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -89,6 +89,7 @@ KNOWN_SETTINGS=(
     enable-ubsan                ""               "enable Undefined Behavior Sanitizer"
     cmake                       ""               "path to the cmake binary"
     distcc                      ""               "use distcc in pump mode"
+    distcc-pump                 ""               "the path to distcc pump executable. This argument is required if distcc is set."
     build-runtime-with-host-compiler   "1"       "use the host c++ compiler to build everything"
     cmake-generator             "Unix Makefiles" "kind of build system to generate; see output of 'cmake --help' for choices"
     verbose-build               ""               "print the commands executed during the build"
@@ -218,8 +219,8 @@ KNOWN_SETTINGS=(
     android-icu-uc-include             ""        "Path to a directory containing headers for libicuuc"
     android-icu-i18n                   ""        "Path to a directory containing libicui18n.so"
     android-icu-i18n-include           ""        "Path to a directory containing headers libicui18n"
-    export-compile-commands            ""        "set to generate JSON compilation databases for each build product"
     check-args-only                    ""        "set to check all arguments are known. Exit with status 0 if success, non zero otherwise"
+    common-cmake-options               ""        "CMake options used for all targets, including LLVM/Clang"
     # TODO: Remove this some time later.
     user-config-args            ""               "**Renamed to --extra-cmake-options**: User-supplied arguments to cmake when used to do configuration."
 )
@@ -245,13 +246,6 @@ function true_false() {
 
 function to_varname() {
     toupper "${1//-/_}"
-}
-
-function join_array_with_delimiter() {
-    # $1 is the delimiter
-    local IFS="$1"
-    shift
-    echo "$*"
 }
 
 function set_lldb_build_mode() {
@@ -1132,63 +1126,11 @@ if ! [[ "${SKIP_TEST_BENCHMARKS}" ]] &&
 fi
 echo
 
-# CMake options used for all targets, including LLVM/Clang
-COMMON_CMAKE_OPTIONS=(
-    -G "${CMAKE_GENERATOR}"
-)
-
 COMMON_C_FLAGS=""
-SANITIZERS=()
-if [[ "${ENABLE_ASAN}" ]] ; then
-    SANITIZERS=(
-        "${SANITIZERS[@]}"
-        "Address"
-    )
-fi
-
-if [[ "${ENABLE_UBSAN}" ]] ; then
-    SANITIZERS=(
-        "${SANITIZERS[@]}"
-        "Undefined"
-    )
-fi
-
-if [[ -n "${SANITIZERS[@]}" ]] ; then
-    COMMON_CMAKE_OPTIONS=(
-        "${COMMON_CMAKE_OPTIONS[@]}"
-        -DLLVM_USE_SANITIZER=$(join_array_with_delimiter ";" "${SANITIZERS[@]}")
-    )
-fi
-
-if [[ "${EXPORT_COMPILE_COMMANDS}" ]] ; then
-    COMMON_CMAKE_OPTIONS=(
-        "${COMMON_CMAKE_OPTIONS[@]}"
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-    )
-fi
 
 # Convert to an array.
+eval COMMON_CMAKE_OPTIONS=(${COMMON_CMAKE_OPTIONS})
 eval EXTRA_CMAKE_OPTIONS=(${EXTRA_CMAKE_OPTIONS})
-
-if [[ "${DISTCC}" ]] ; then
-    # On some platforms, 'pump' may be unrelated to distcc, in which case it's
-    # called 'distcc-pump'.
-    DISTCC_PUMP="$(which distcc-pump || which pump)"
-    COMMON_CMAKE_OPTIONS=(
-        "${COMMON_CMAKE_OPTIONS[@]}"
-        -DCMAKE_C_COMPILER:PATH="$(which distcc)"
-        -DCMAKE_C_COMPILER_ARG1="${HOST_CC}"
-        -DCMAKE_CXX_COMPILER:PATH="$(which distcc)"
-        -DCMAKE_CXX_COMPILER_ARG1="${HOST_CXX}"
-    )
-else
-    COMMON_CMAKE_OPTIONS=(
-        "${COMMON_CMAKE_OPTIONS[@]}"
-        -DCMAKE_C_COMPILER:PATH="${HOST_CC}"
-        -DCMAKE_CXX_COMPILER:PATH="${HOST_CXX}"
-    )
-fi
-
 
 CMAKE_JOBS="${BUILD_JOBS}"
 if [[ "${DISTCC}" ]] ; then
@@ -1215,28 +1157,12 @@ case "${CMAKE_GENERATOR}" in
         BUILD_ARGS="${BUILD_ARGS} -parallelizeTargets"
         BUILD_ARGS="${BUILD_ARGS} -jobs ${CMAKE_JOBS}"
         BUILD_TARGET_FLAG="-target"
-        COMMON_CMAKE_OPTIONS=(
-            "${COMMON_CMAKE_OPTIONS[@]}"
-            -DCMAKE_CONFIGURATION_TYPES="Debug;Release;MinSizeRel;RelWithDebInfo"
-        )
 
         # FIXME: We currently do not support building compiler-rt with the
         # Xcode generator.
         SKIP_COMPILER_RT=1
         ;;
 esac
-
-if [[ "${CLANG_COMPILER_VERSION}" ]] ; then
-    major_version=$(echo "${CLANG_COMPILER_VERSION}" | sed -e 's/\([0-9]*\).*/\1/')
-    minor_version=$(echo "${CLANG_COMPILER_VERSION}" | sed -e 's/[^.]*\.\([0-9]*\).*/\1/')
-    patch_version=$(echo "${CLANG_COMPILER_VERSION}" | sed -e 's/[^.]*\.[^.]*\.\([0-9]*\)/\1/')
-    COMMON_CMAKE_OPTIONS=(
-        "${COMMON_CMAKE_OPTIONS[@]}"
-        -DLLVM_VERSION_MAJOR:STRING="${major_version}"
-        -DLLVM_VERSION_MINOR:STRING="${minor_version}"
-        -DLLVM_VERSION_PATCH:STRING="${patch_version}"
-    )
-fi
 
 function build_directory() {
     deployment_target=$1

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -774,6 +774,12 @@ if [[ "${SKIP_BUILD_WATCHOS_SIMULATOR}" ]] ; then
     SKIP_TEST_WATCHOS_SIMULATOR=1
 fi
 
+# FIXME: We currently do not support building compiler-rt with the
+# Xcode generator.
+if [[ "${CMAKE_GENERATOR}" == "Xcode" ]]; then
+    SKIP_COMPILER_RT=1
+fi
+
 # FIXME: We currently do not support cross-compiling swift with compiler-rt.
 if [[ "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARGETS}" ]]; then
     SKIP_COMPILER_RT=1
@@ -1131,38 +1137,11 @@ COMMON_C_FLAGS=""
 # Convert to an array.
 eval COMMON_CMAKE_OPTIONS=(${COMMON_CMAKE_OPTIONS})
 eval EXTRA_CMAKE_OPTIONS=(${EXTRA_CMAKE_OPTIONS})
+eval BUILD_ARGS=(${BUILD_ARGS})
 
-CMAKE_JOBS="${BUILD_JOBS}"
-if [[ "${DISTCC}" ]] ; then
-    CMAKE_JOBS="$(distcc -j)"
+if [[ "${CMAKE_GENERATOR}" == "Xcode" ]]; then
+    BUILD_TARGET_FLAG="-target"
 fi
-
-case "${CMAKE_GENERATOR}" in
-    Ninja)
-        BUILD_ARGS="${BUILD_ARGS} -j${CMAKE_JOBS}"
-        if [[ "${VERBOSE_BUILD}" ]] ; then
-            BUILD_ARGS="${BUILD_ARGS} -v"
-        fi
-        ;;
-    'Unix Makefiles')
-        BUILD_ARGS="${BUILD_ARGS} -j${CMAKE_JOBS}"
-        if [[ "${VERBOSE_BUILD}" ]] ; then
-            BUILD_ARGS="${BUILD_ARGS} VERBOSE=1"
-        fi
-        ;;
-    Xcode)
-        # -parallelizeTargets is an unsupported flag from the Xcode 3 days,
-        # but since we're not using proper Xcode 4 schemes, this is the
-        # only way to get target-level parallelism.
-        BUILD_ARGS="${BUILD_ARGS} -parallelizeTargets"
-        BUILD_ARGS="${BUILD_ARGS} -jobs ${CMAKE_JOBS}"
-        BUILD_TARGET_FLAG="-target"
-
-        # FIXME: We currently do not support building compiler-rt with the
-        # Xcode generator.
-        SKIP_COMPILER_RT=1
-        ;;
-esac
 
 function build_directory() {
     deployment_target=$1
@@ -2001,7 +1980,7 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
             fi
 
             set -x
-            ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product}) -- ${BUILD_ARGS} ${build_targets[@]}
+            ${DISTCC_PUMP} "${CMAKE}" --build "${build_dir}" $(cmake_config_opt ${product}) -- "${BUILD_ARGS[@]}" ${build_targets[@]}
             { set +x; } 2>/dev/null
         fi
 

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -16,7 +16,6 @@
 
 from numbers import Number
 import platform
-import re
 import subprocess
 
 from . import xcrun
@@ -129,12 +128,10 @@ class CMake(object):
                    "Debug;Release;MinSizeRel;RelWithDebInfo")
 
         if args.clang_compiler_version:
-            m = re.match(r'([0-9]*)\.([0-9]*)\.([0-9]*)',
-                         args.clang_compiler_version)
-            if m is not None:
-                define("LLVM_VERSION_MAJOR:STRING", m.group(1))
-                define("LLVM_VERSION_MINOR:STRING", m.group(2))
-                define("LLVM_VERSION_PATCH:STRING", m.group(3))
+            major, minor, patch = args.clang_compiler_version
+            define("LLVM_VERSION_MAJOR:STRING", major)
+            define("LLVM_VERSION_MINOR:STRING", minor)
+            define("LLVM_VERSION_PATCH:STRING", patch)
 
         return options
 

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -14,7 +14,9 @@
 #
 # ----------------------------------------------------------------------------
 
+import re
 import platform
+from numbers import Number
 
 from . import xcrun
 from .which import which
@@ -34,3 +36,103 @@ def host_cmake(xcrun_toolchain):
             return cmake
         else:
             return '/usr/local/bin/cmake'
+
+
+class CMakeOptions(object):
+    """List like object used to define cmake options
+    """
+
+    def __init__(self):
+        self._options = []
+
+    def define(self, var, value):
+        """Utility to define cmake options in this object.
+
+        opts.define("FOO", "BAR")       # -> -DFOO=BAR
+        opts.define("FLAG:BOOL", True)  # -> -FLAG:BOOL=TRUE
+        """
+        if var.endswith(':BOOL'):
+            value = self.true_false(value)
+        if value is None:
+            value = ""
+        elif not isinstance(value, (str, Number)):
+            raise ValueError('define: invalid value: %s' % value)
+        self._options.append('-D%s=%s' % (var, value))
+
+    @staticmethod
+    def true_false(value):
+        if hasattr(value, 'lower'):
+            value = value.lower()
+        if value in [True, 1, 'true', 'yes', '1']:
+            return 'TRUE'
+        if value in [False, 0, 'false', 'no', '0']:
+            return 'FALSE'
+        raise ValueError("true_false: invalid value: %s" % value)
+
+    def __len__(self):
+        return self._options.__len__()
+
+    def __iter__(self):
+        return self._options.__iter__()
+
+    def __add__(self, other):
+        ret = CMakeOptions()
+        ret._options += self._options
+        ret._options += list(other)
+        return ret
+
+    def __iadd__(self, other):
+        self._options += list(other)
+        return self
+
+
+class CMake(object):
+
+    def __init__(self, args, host_cc, host_cxx, host_distcc):
+        self.args = args
+        self.host_cc = host_cc
+        self.host_cxx = host_cxx
+        self.host_distcc = host_distcc
+
+    def common_options(self):
+        """Return options used for all products, including LLVM/Clang
+        """
+        args = self.args
+        options = CMakeOptions()
+        define = options.define
+
+        options += ['-G', args.cmake_generator]
+
+        sanitizers = []
+        if args.enable_asan:
+            sanitizers.append('Address')
+        if args.enable_ubsan:
+            sanitizers.append('Undefined')
+        if sanitizers:
+            define("LLVM_USE_SANITIZER", ";".join(sanitizers))
+
+        if args.export_compile_commands:
+            define("CMAKE_EXPORT_COMPILE_COMMANDS", "ON")
+
+        if args.distcc:
+            define("CMAKE_C_COMPILER:PATH", self.host_distcc)
+            define("CMAKE_C_COMPILER_ARG1", self.host_cc)
+            define("CMAKE_CXX_COMPILER:PATH", self.host_distcc)
+            define("CMAKE_CXX_COMPILER_ARG1", self.host_cxx)
+        else:
+            define("CMAKE_C_COMPILER:PATH", self.host_cc)
+            define("CMAKE_CXX_COMPILER:PATH", self.host_cxx)
+
+        if args.cmake_generator == 'Xcode':
+            define("CMAKE_CONFIGURATION_TYPES",
+                   "Debug;Release;MinSizeRel;RelWithDebInfo")
+
+        if args.clang_compiler_version:
+            m = re.match(r'([0-9]*)\.([0-9]*)\.([0-9]*)',
+                         args.clang_compiler_version)
+            if m is not None:
+                define("LLVM_VERSION_MAJOR:STRING", m.group(1))
+                define("LLVM_VERSION_MINOR:STRING", m.group(2))
+                define("LLVM_VERSION_PATCH:STRING", m.group(3))
+
+        return options

--- a/utils/swift_build_support/tests/mock-distcc
+++ b/utils/swift_build_support/tests/mock-distcc
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# mock-distcc - discc mock used from tests ----------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+from __future__ import print_function
+
+import sys
+
+
+try:
+    if sys.argv[1] == '-j':
+        print('6')
+        sys.exit(0)
+except Exception:
+    pass
+
+print("Error: invalid option", file=sys.stderr)
+sys.exit(1)

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -141,7 +141,7 @@ class CMakeTestCase(unittest.TestCase):
 
     def test_common_options_clang_compiler_version(self):
         args = self.default_args()
-        args.clang_compiler_version = "3.8.0"
+        args.clang_compiler_version = ("3", "8", "0")
         cmake = self.cmake(args)
         self.assertEqual(
             list(cmake.common_options()),
@@ -159,7 +159,7 @@ class CMakeTestCase(unittest.TestCase):
         args.export_compile_commands = True
         args.distcc = True
         args.cmake_generator = 'Xcode'
-        args.clang_compiler_version = "3.8.0"
+        args.clang_compiler_version = ("3", "8", "0")
         cmake = self.cmake(args)
         self.assertEqual(
             list(cmake.common_options()),

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -10,8 +10,13 @@
 
 import os
 import unittest
+from argparse import Namespace
 
-from swift_build_support.cmake import host_cmake
+from swift_build_support.cmake import (
+    host_cmake,
+    CMakeOptions,
+    CMake,
+)
 
 
 class HostCMakeTestCase(unittest.TestCase):
@@ -21,6 +26,243 @@ class HostCMakeTestCase(unittest.TestCase):
         cmake = host_cmake(xcrun_toolchain='default')
         self.assertEqual(os.path.split(cmake)[-1], 'cmake')
 
+
+class CMakeTestCase(unittest.TestCase):
+
+    def default_args(self):
+        "Return new args object with default values"
+        return Namespace(host_cc="/path/to/clang",
+                         host_cxx="/path/to/clang++",
+                         enable_asan=False,
+                         enable_ubsan=False,
+                         export_compile_commands=False,
+                         distcc=False,
+                         cmake_generator="Ninja",
+                         clang_compiler_version=None)
+
+    def cmake(self, args):
+        "Return new CMake object initialized with given args"
+        return CMake(args=args,
+                     host_cc=args.host_cc,
+                     host_cxx=args.host_cxx,
+                     host_distcc="/path/to/distcc")
+
+    def test_common_options_defaults(self):
+        args = self.default_args()
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++"])
+
+    def test_common_options_asan(self):
+        args = self.default_args()
+        args.enable_asan = True
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DLLVM_USE_SANITIZER=Address",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++"])
+
+    def test_common_options_ubsan(self):
+        args = self.default_args()
+        args.enable_ubsan = True
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DLLVM_USE_SANITIZER=Undefined",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++"])
+
+    def test_common_options_asan_ubsan(self):
+        args = self.default_args()
+        args.enable_asan = True
+        args.enable_ubsan = True
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DLLVM_USE_SANITIZER=Address;Undefined",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++"])
+
+    def test_common_options_export_compie_commands(self):
+        args = self.default_args()
+        args.export_compile_commands = True
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++"])
+
+    def test_common_options_distcc(self):
+        args = self.default_args()
+        args.distcc = True
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/distcc",
+             "-DCMAKE_C_COMPILER_ARG1=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/distcc",
+             "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++"])
+
+    def test_common_options_xcode(self):
+        args = self.default_args()
+        args.cmake_generator = 'Xcode'
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Xcode",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_CONFIGURATION_TYPES=" +
+             "Debug;Release;MinSizeRel;RelWithDebInfo"])
+
+    def test_common_options_clang_compiler_version(self):
+        args = self.default_args()
+        args.clang_compiler_version = "3.8.0"
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Ninja",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DLLVM_VERSION_MAJOR:STRING=3",
+             "-DLLVM_VERSION_MINOR:STRING=8",
+             "-DLLVM_VERSION_PATCH:STRING=0"])
+
+    def test_common_options_full(self):
+        args = self.default_args()
+        args.enable_asan = True
+        args.enable_ubsan = True
+        args.export_compile_commands = True
+        args.distcc = True
+        args.cmake_generator = 'Xcode'
+        args.clang_compiler_version = "3.8.0"
+        cmake = self.cmake(args)
+        self.assertEqual(
+            list(cmake.common_options()),
+            ["-G", "Xcode",
+             "-DLLVM_USE_SANITIZER=Address;Undefined",
+             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+             "-DCMAKE_C_COMPILER:PATH=/path/to/distcc",
+             "-DCMAKE_C_COMPILER_ARG1=/path/to/clang",
+             "-DCMAKE_CXX_COMPILER:PATH=/path/to/distcc",
+             "-DCMAKE_CXX_COMPILER_ARG1=/path/to/clang++",
+             "-DCMAKE_CONFIGURATION_TYPES=" +
+             "Debug;Release;MinSizeRel;RelWithDebInfo",
+             "-DLLVM_VERSION_MAJOR:STRING=3",
+             "-DLLVM_VERSION_MINOR:STRING=8",
+             "-DLLVM_VERSION_PATCH:STRING=0"])
+
+
+class CMakeOptionsTestCase(unittest.TestCase):
+    def test_define(self):
+        options = CMakeOptions()
+
+        options.define('OPT1:STRING', 'foo')
+
+        options.define('OPT2:BOOL', True)
+        options.define('OPT3:BOOL', 1)
+        options.define('OPT4:BOOL', 'True')
+        options.define('OPT5:BOOL', 'true')
+        options.define('OPT6:BOOL', 'YES')
+        options.define('OPT7:BOOL', '1')
+
+        options.define('OPT8:BOOL', False)
+        options.define('OPT9:BOOL', 0)
+        options.define('OPT10:BOOL', 'false')
+        options.define('OPT11:BOOL', 'False')
+        options.define('OPT12:BOOL', 'No')
+        options.define('OPT13:BOOL', '0')
+
+        options.define('OPT14', 12)
+        options.define('OPT15', '')
+        options.define('OPT16', None)
+        options.define('OPT17:PATH', 'foo')
+
+        self.assertRaises(ValueError, options.define, 'ERR', ["FOO"])
+        self.assertRaises(ValueError, options.define, 'ERR', {"FOO": 1})
+
+        self.assertRaises(ValueError, options.define, 'ERR:BOOL', None)
+        self.assertRaises(ValueError, options.define, 'ERR:BOOL', 3)
+        self.assertRaises(ValueError, options.define, 'ERR:BOOL', 'foo')
+        self.assertRaises(ValueError, options.define, 'ERR:BOOL', [1])
+
+        self.assertEqual(list(options), [
+            '-DOPT1:STRING=foo',
+            '-DOPT2:BOOL=TRUE',
+            '-DOPT3:BOOL=TRUE',
+            '-DOPT4:BOOL=TRUE',
+            '-DOPT5:BOOL=TRUE',
+            '-DOPT6:BOOL=TRUE',
+            '-DOPT7:BOOL=TRUE',
+            '-DOPT8:BOOL=FALSE',
+            '-DOPT9:BOOL=FALSE',
+            '-DOPT10:BOOL=FALSE',
+            '-DOPT11:BOOL=FALSE',
+            '-DOPT12:BOOL=FALSE',
+            '-DOPT13:BOOL=FALSE',
+            '-DOPT14=12',
+            '-DOPT15=',
+            '-DOPT16=',
+            '-DOPT17:PATH=foo'])
+
+    def test_operations(self):
+
+        options1 = CMakeOptions()
+        options1.define("OPT1_1", 'VAL1')
+        options1.define("OPT1_2", 'VAL2')
+
+        options2 = CMakeOptions()
+        options2.define("OPT2_1", 'VAL3')
+
+        options = options1 + options2
+        self.assertIsInstance(options, CMakeOptions)
+        self.assertEqual(list(options), [
+            "-DOPT1_1=VAL1",
+            "-DOPT1_2=VAL2",
+            "-DOPT2_1=VAL3"])
+
+        options_added = options + ["-CUSTOM", "12"]
+        self.assertIsInstance(options_added, CMakeOptions)
+        self.assertEqual(list(options_added), [
+            "-DOPT1_1=VAL1",
+            "-DOPT1_2=VAL2",
+            "-DOPT2_1=VAL3",
+            "-CUSTOM", "12"])
+
+        options += options2
+        self.assertIsInstance(options, CMakeOptions)
+        self.assertEqual(list(options), [
+            "-DOPT1_1=VAL1",
+            "-DOPT1_2=VAL2",
+            "-DOPT2_1=VAL3",
+            "-DOPT2_1=VAL3"])
+
+        options += ["-G", "Ninja"]
+        self.assertIsInstance(options, CMakeOptions)
+        self.assertEqual(list(options), [
+            "-DOPT1_1=VAL1",
+            "-DOPT1_2=VAL2",
+            "-DOPT2_1=VAL3",
+            "-DOPT2_1=VAL3",
+            "-G", "Ninja"])
+
+        list_options = ["-G", "Ninja"]
+        list_options += options1
+        self.assertIsInstance(list_options, list)
+        self.assertEqual(list_options, [
+            "-G", "Ninja",
+            "-DOPT1_1=VAL1",
+            "-DOPT1_2=VAL2"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### What's in this pull request?

More work on [[SR-237] Merge `build-script-impl` into `build-script`](https://bugs.swift.org/browse/SR-237).

This PR migrates calculation of `COMMON_CMAKE_OPTIONS` and `BUILD_ARGS` in `build-script-impl` to Python.

Migrated options:
`host-cc`, `host-cxx`, `distcc`, `enable-asan`, `enable-ubsan`, `clang-compiler-version`, `build-args`, and `verbose-build`.

Removed `build-script-impl` options:
`export-compile-commands` - not used in `build-script-impl` anymore, and not likely in the future.

Introduced `build-script-impl` options:
`distcc-pump` - finding `pump` is `build-script` job now.
`common-cmake-options` - calculated `COMMON_CMAKE_OPTIONS`. 
#### Resolved bug number: Partially [SR-237](https://bugs.swift.org/browse/SR-237)

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
