### PR TITLE
Add opaque context pointer to SwiftRemoteMirror C API Reader API

### DIFF
--- a/include/swift/Remote/CMemoryReader.h
+++ b/include/swift/Remote/CMemoryReader.h
@@ -34,24 +34,27 @@ public:
     assert(this->Impl.getPointerSize && "No getPointerSize implementation");
     assert(this->Impl.getStringLength && "No stringLength implementation");
     assert(this->Impl.readBytes && "No readBytes implementation");
-    assert(this->Impl.getPointerSize() != 0 && "Invalid target pointer size");
+    assert(this->Impl.getPointerSize(this->Impl.reader_context) != 0 &&
+           "Invalid target pointer size");
   }
 
   uint8_t getPointerSize() override {
-    return Impl.getPointerSize();
+    return Impl.getPointerSize(Impl.reader_context);
   }
 
   uint8_t getSizeSize() override {
-    return Impl.getSizeSize();
+    return Impl.getSizeSize(Impl.reader_context);
   }
 
   RemoteAddress getSymbolAddress(const std::string &name) override {
-    auto addressData = Impl.getSymbolAddress(name.c_str(), name.size());
+    auto addressData = Impl.getSymbolAddress(Impl.reader_context,
+                                             name.c_str(), name.size());
     return RemoteAddress(addressData);
   }
 
   uint64_t getStringLength(RemoteAddress address) {
-    return Impl.getStringLength(address.getAddressData());
+    return Impl.getStringLength(Impl.reader_context,
+                                address.getAddressData());
   }
 
   bool readString(RemoteAddress address, std::string &dest) override {
@@ -68,7 +71,8 @@ public:
   }
 
   bool readBytes(RemoteAddress address, uint8_t *dest, uint64_t size) override {
-    return Impl.readBytes(address.getAddressData(), dest, size);
+    return Impl.readBytes(Impl.reader_context,
+                          address.getAddressData(), dest, size);
   }
 };
 

--- a/include/swift/SwiftRemoteMirror/MemoryReaderInterface.h
+++ b/include/swift/SwiftRemoteMirror/MemoryReaderInterface.h
@@ -28,13 +28,21 @@ extern "C" {
 
 typedef uint64_t addr_t;
 
-typedef uint8_t (*PointerSizeFunction)();
-typedef uint8_t (*SizeSizeFunction)();
-typedef bool (*ReadBytesFunction)(addr_t address, uint8_t *dest, uint64_t size);
-typedef uint64_t (*GetStringLengthFunction)(addr_t address);
-typedef addr_t (*GetSymbolAddressFunction)(const char *name, uint64_t name_length);
+typedef uint8_t (*PointerSizeFunction)(void *reader_context);
+typedef uint8_t (*SizeSizeFunction)(void * reader_context);
+typedef bool (*ReadBytesFunction)(void * reader_context, addr_t address,
+                                  uint8_t *dest, uint64_t size);
+typedef uint64_t (*GetStringLengthFunction)(void * reader_context,
+                                            addr_t address);
+typedef addr_t (*GetSymbolAddressFunction)(void * reader_context,
+                                           const char *name,
+                                           uint64_t name_length);
 
 typedef struct MemoryReaderImpl {
+  /// An opaque context that the implementor can specify to
+  /// be passed to each of the APIs below.
+  void *reader_context;
+
   /// Get the size in bytes of the target's pointer type.
   PointerSizeFunction getPointerSize;
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -23,12 +23,14 @@ using NativeReflectionContext
   = ReflectionContext<External<RuntimeTarget<sizeof(uintptr_t)>>>;
 
 SwiftReflectionContextRef
-swift_reflection_createReflectionContext(PointerSizeFunction getPointerSize,
+swift_reflection_createReflectionContext(void *reader_context,
+                                         PointerSizeFunction getPointerSize,
                                          SizeSizeFunction getSizeSize,
                                          ReadBytesFunction readBytes,
                                          GetStringLengthFunction getStringLength,
                                          GetSymbolAddressFunction getSymbolAddress) {
   MemoryReaderImpl ReaderImpl {
+    reader_context,
     getPointerSize,
     getSizeSize,
     readBytes,


### PR DESCRIPTION
Memory readers on the C-side of the API may actually have an object-
oriented design, so they may want to pass an instance to revive
when callbacks make it to the other side of the API boundary.
