### PR TITLE
[test] Add Android (and FreeBSD) to OS checks

### DIFF
--- a/test/1_stdlib/PrintFloat.swift
+++ b/test/1_stdlib/PrintFloat.swift
@@ -6,7 +6,7 @@
 // REQUIRES: executable_test
 
 import StdlibUnittest
-#if os(Linux) || os(FreeBSD)
+#if os(Linux) || os(FreeBSD) || os(Android)
   import Glibc
 #else
   import Darwin

--- a/test/Prototypes/FloatingPoint.swift
+++ b/test/Prototypes/FloatingPoint.swift
@@ -27,7 +27,7 @@ extension UInt32 : FloatingPointRepresentation {
 //  Ewwww? <rdar://problem/20060017>
 #if os(OSX) || os(iOS) || os(watchOS) || os(tvOS)
   import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || os(FreeBSD) || os(Android)
   import Glibc
 #endif
 

--- a/validation-test/StdlibUnittest/Stdin.swift
+++ b/validation-test/StdlibUnittest/Stdin.swift
@@ -6,7 +6,7 @@ import StdlibUnittest
 
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
 import Darwin
-#elseif os(Linux)
+#elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #endif
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -919,7 +919,7 @@ StringTests.test(
 #endif
 }
 
-#if os(Linux)
+#if os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #endif
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Add Android to the OS checks used to determine whether to import Glibc. These tests would pass on Android were it not for the fact that Android is not included in the Glibc check.

Also add FreeBSD where missing. I don't yet have a FreeBSD development environment handy, so I can't say for sure whether these pass. /cc @dcci 

Android tests are not currently run, but I'm working on that in https://github.com/apple/swift/pull/1714. These tests pass when run using the Android test config from that pull request.
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
