### PR TITLE
DeadObjectElimination: use the debug location of the array store inst…

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -549,6 +549,7 @@ static void insertReleases(ArrayRef<StoreInst*> Stores,
   for (auto *Store : Stores)
     SSAUp.AddAvailableValue(Store->getParent(), Store->getSrc());
 
+  SILLocation Loc = Stores[0]->getLoc();
   for (auto *RelPoint : ReleasePoints) {
     SILBuilder B(RelPoint);
     // This does not use the SSAUpdater::RewriteUse API because it does not do
@@ -557,9 +558,9 @@ static void insertReleases(ArrayRef<StoreInst*> Stores,
     // can simply ask SSAUpdater for the reaching store.
     SILValue RelVal = SSAUp.GetValueAtEndOfBlock(RelPoint->getParent());
     if (StVal->getType().isReferenceCounted(RelPoint->getModule()))
-      B.createStrongRelease(RelPoint->getLoc(), RelVal, Atomicity::Atomic);
+      B.createStrongRelease(Loc, RelVal, Atomicity::Atomic);
     else
-      B.createReleaseValue(RelPoint->getLoc(), RelVal, Atomicity::Atomic);
+      B.createReleaseValue(Loc, RelVal, Atomicity::Atomic);
   }
 }
 

--- a/test/SILOptimizer/dead_array_elim.sil
+++ b/test/SILOptimizer/dead_array_elim.sil
@@ -25,13 +25,9 @@ sil [_semantics "array.uninitialized"] @allocArray : $@convention(thin) <τ_0_0>
 // CHECK-LABEL: sil @deadarray
 // CHECK-NOT: apply
 // CHECK-NOT: store
-// CHECK: strong_retain
-// CHECK-NEXT: strong_release
-// CHECK-NEXT: strong_release
-// CHECK-NEXT: tuple ()
-// CHECK-NEXT: return
 sil @deadarray : $@convention(thin) (@owned TrivialDestructor) -> () {
 bb0(%0 : $TrivialDestructor):
+// CHECK: strong_retain %0 : $TrivialDestructor
   %2 = integer_literal $Builtin.Word, 2
   // function_ref Swift._allocateUninitializedArray <A> (Builtin.Word) -> (Swift.Array<A>, Builtin.RawPointer)
   %3 = function_ref @allocArray : $@convention(thin) <τ_0_0> (Builtin.Word) -> @owned (Array<τ_0_0>, Builtin.RawPointer)
@@ -39,16 +35,20 @@ bb0(%0 : $TrivialDestructor):
   %5 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 0
   %6 = tuple_extract %4 : $(Array<TrivialDestructor>, Builtin.RawPointer), 1
   %7 = pointer_to_address %6 : $Builtin.RawPointer to $*TrivialDestructor
+// CHECK-NEXT: strong_release %0 : $TrivialDestructor, loc "{{.*}}":[[@LINE+1]]:3
   store %0 to %7 : $*TrivialDestructor
   %9 = integer_literal $Builtin.Word, 1
   %10 = index_addr %7 : $*TrivialDestructor, %9 : $Builtin.Word
+// CHECK-NEXT: strong_release %0 : $TrivialDestructor, loc "{{.*}}":[[@LINE+1]]:3
   store %0 to %10 : $*TrivialDestructor
   %13 = struct_extract %5 : $Array<TrivialDestructor>, #Array._buffer
   %14 = struct_extract %13 : $_ArrayBuffer<TrivialDestructor>, #_ArrayBuffer._storage
   %15 = struct_extract %14 : $_BridgeStorage<_ContiguousArrayStorageBase, _NSArrayCore>, #_BridgeStorage.rawValue
   strong_retain %0 : $TrivialDestructor
   strong_release %15 : $Builtin.BridgeObject
+// CHECK-NEXT: tuple ()
   %18 = tuple ()
+// CHECK-NEXT: return
   return %18 : $()
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ead of the (unknown) instruction of the lifetime frontier.

The location of the lifetimefrontier can be a return-location which is invalid for the generated release instruction.
