### PR TITLE
[IRGen] Rewrite dead method test in StdlibUnittest

### DIFF
--- a/test/IRGen/Inputs/report_dead_method_call/main.swift
+++ b/test/IRGen/Inputs/report_dead_method_call/main.swift
@@ -1,4 +1,8 @@
+// The StdlibUnittest test suite is placed here because it contains
+// expressions that are only allowed at the top level in files named
+// "main.swift".
 
+import StdlibUnittest
 
 @inline(never)
 func testProto(_ c: Container) {
@@ -27,16 +31,22 @@ func testPublicClass(_ c: PublicBase) {
 	c.ghi()
 }
 
-switch Process.argc {
-case 1:
-	callClass()
+let ReportDeadMethodCallTestSuite = TestSuite("ReportDeadMethodCall")
 
-case 2:
-	callProto()
-
-case 3:
-	callPublicClass()
-
-default:
-	break
+ReportDeadMethodCallTestSuite.test("Call class") {
+  expectCrashLater()
+  callClass()
 }
+
+ReportDeadMethodCallTestSuite.test("Call proto") {
+  expectCrashLater()
+  callProto()
+}
+
+ReportDeadMethodCallTestSuite.test("Call public class") {
+  expectCrashLater()
+  callPublicClass()
+}
+
+runAllTests()
+

--- a/test/IRGen/report_dead_method_call.swift
+++ b/test/IRGen/report_dead_method_call.swift
@@ -1,15 +1,15 @@
-// RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/report_dead_method_call/main.swift %s -O -Xfrontend -disable-access-control -o %t/a.out
-// RUN: %target-run %t/a.out 2> %t/err1.log; FileCheck %s < %t/err1.log
-// RUN: %target-run %t/a.out p1 2> %t/err2.log; FileCheck %s < %t/err2.log
-// RUN: %target-run %t/a.out p1 p2 2> %t/err3.log; FileCheck %s < %t/err3.log
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// We compile with -O (optimizations) and -disable-access-control (which
+// allows use to "call" methods that are removed by dead code elimination).
+// RUN: %target-build-swift %S/Inputs/report_dead_method_call/main.swift %s -O -Xfrontend -disable-access-control -o %t/report_dead_method_call
+
+// The private, unused methods are optimized away. The test calls these
+// methods anyway (since it has overridden the access control), so we
+// expect them to produce "fatal error: call of deleted method" when run.
+// RUN: %target-run %t/report_dead_method_call
 // REQUIRES: executable_test
-
-
-// The -disable-access-control option let us "call" methods, which are removed
-// by dead method elimination.
-
-// CHECK: fatal error: call of deleted method
 
 private protocol PrivateProto {
 	func abc()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

StdlibUnitest is the preferred system for testing that a certain piece of code crashes. It's also the only way to get this test to pass when run on an Android host device, since otherwise the device test runner exits before confirming the output via `FileCheck`.
#### Related pull request: https://github.com/apple/swift/pull/1714

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
