### PR TITLE
[build-presents] Enable SwiftPM in incremental OS X builds.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -236,7 +236,7 @@ assertions
 
 # Build llbuild & swiftpm here
 llbuild
-#swiftpm
+swiftpm
 
 dash-dash
 


### PR DESCRIPTION
#### What's in this pull request?

This PR enables the SwiftPM tests on the OS X builders. I believe it is an oversight that it has been disabled.

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- This is enabled for the package builder bots and the Linux, I think it is an
  oversight that it has been disabled on the OS X bots for all this time.
