### PR TITLE
build-script: run all tests in check-swift-all-* targets, including long tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -244,6 +244,9 @@ if(PYTHONINTERP_FOUND)
 
             list(APPEND LIT_ARGS "--param" "run_only_tests=long_tests")
           endif()
+          if(test_subset STREQUAL "all")
+            list(APPEND LIT_ARGS "--param" "run_only_tests=all")
+          endif()
 
           set(directories)
           set(dependencies ${test_dependencies})

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -469,7 +469,7 @@ else:
     lit_config.fatal("Unknown test mode %r" % swift_test_mode)
 
 # Only run the subset of tests that require 'executable_test'?
-swift_run_only_tests = lit_config.params.get('run_only_tests', 'all')
+swift_run_only_tests = lit_config.params.get('run_only_tests', 'all_except_long')
 if swift_run_only_tests == 'all':
     config.available_features.add("executable_test")
 elif swift_run_only_tests == 'executable_tests':
@@ -480,6 +480,9 @@ elif swift_run_only_tests == 'non_executable_tests':
 elif swift_run_only_tests == 'long_tests':
     config.available_features.add("long_test")
     config.limit_to_features.add("long_test")
+elif swift_run_only_tests == 'all_except_long':
+    config.available_features.add("executable_test")
+    config.available_features.add("long_test")
 else:
     lit_config.fatal("Unknown test mode %r" % swift_run_only_tests)
 


### PR DESCRIPTION
I think this is a less surprising model than what we have now.
