### PR TITLE
Simplify function signature optimzation.

### DIFF
--- a/include/swift/SIL/Mangle.h
+++ b/include/swift/SIL/Mangle.h
@@ -104,6 +104,7 @@ template <typename SubType>
 class SpecializationMangler : public SpecializationManglerBase {
   SubType *asImpl() { return static_cast<SubType *>(this); }
 public:
+  Mangle::Mangler &getMangler() const { return M; }
 
   ~SpecializationMangler() = default;
 

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -808,7 +808,8 @@ class ProjectionTree {
 
   SILModule &Mod;
 
-  llvm::BumpPtrAllocator &Allocator;
+  /// The allocator we use to allocate ProjectionTreeNodes in the tree.
+  llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> Allocator;
 
   // A common pattern is a 3 field struct.
   llvm::SmallVector<ProjectionTreeNode *, 4> ProjectionTreeNodes;
@@ -818,12 +819,10 @@ class ProjectionTree {
 
 public:
   /// Construct a projection tree from BaseTy.
-  ProjectionTree(SILModule &Mod, llvm::BumpPtrAllocator &Allocator,
-                 SILType BaseTy);
+  ProjectionTree(SILModule &Mod, SILType BaseTy);
   /// Construct an uninitialized projection tree, which can then be
   /// initialized by initializeWithExistingTree.
-  ProjectionTree(SILModule &Mod, llvm::BumpPtrAllocator &Allocator) 
-    : Mod(Mod), Allocator(Allocator) {}
+  ProjectionTree(SILModule &Mod) : Mod(Mod)  {}
   ~ProjectionTree();
   ProjectionTree(const ProjectionTree &) = delete;
   ProjectionTree(ProjectionTree &&) = default;
@@ -936,7 +935,7 @@ private:
   void createRoot(SILType BaseTy) {
     assert(ProjectionTreeNodes.empty() &&
            "Should only create root when ProjectionTreeNodes is empty");
-    auto *Node = new (Allocator) ProjectionTreeNode(BaseTy);
+    auto *Node = new (Allocator.Allocate()) ProjectionTreeNode(BaseTy);
     ProjectionTreeNodes.push_back(Node);
   }
 
@@ -944,7 +943,8 @@ private:
                                      SILType BaseTy,
                                      const Projection &P) {
     unsigned Index = ProjectionTreeNodes.size();
-    auto *Node = new (Allocator) ProjectionTreeNode(Parent, Index, BaseTy, P);
+    auto *Node = new (Allocator.Allocate()) ProjectionTreeNode(Parent, Index,
+                                                               BaseTy, P);
     ProjectionTreeNodes.push_back(Node);
     return ProjectionTreeNodes[Index];
   }

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -730,11 +730,6 @@ class ProjectionTreeNode {
       Initialized(false), IsLive(false) {}
 
 public:
-  enum LivenessKind : unsigned {
-    NormalUseLiveness = 0,
-    IgnoreEpilogueReleases = 1,
-  };
-
   class NewAggregateBuilder;
 
   ~ProjectionTreeNode() = default;
@@ -799,8 +794,7 @@ private:
 
   void processUsersOfValue(ProjectionTree &Tree,
                            llvm::SmallVectorImpl<ValueNodePair> &Worklist,
-                           SILValue Value, ProjectionTreeNode::LivenessKind Kind,
-                           llvm::DenseSet<SILInstruction *> &Releases);
+                           SILValue Value);
 
   void createNextLevelChildren(ProjectionTree &Tree);
 
@@ -816,11 +810,6 @@ class ProjectionTree {
 
   llvm::BumpPtrAllocator &Allocator;
 
-  /// The way we compute what is live and what is dead.
-  ProjectionTreeNode::LivenessKind Kind;
-
-  llvm::DenseSet<SILInstruction *> EpilogueReleases;
-
   // A common pattern is a 3 field struct.
   llvm::SmallVector<ProjectionTreeNode *, 4> ProjectionTreeNodes;
   llvm::SmallVector<unsigned, 3> LiveLeafIndices;
@@ -831,9 +820,6 @@ public:
   /// Construct a projection tree from BaseTy.
   ProjectionTree(SILModule &Mod, llvm::BumpPtrAllocator &Allocator,
                  SILType BaseTy);
-  ProjectionTree(SILModule &Mod, llvm::BumpPtrAllocator &Allocator,
-                 SILType BaseTy, ProjectionTreeNode::LivenessKind Kind, 
-                 llvm::DenseSet<SILInstruction*> Insts);
   /// Construct an uninitialized projection tree, which can then be
   /// initialized by initializeWithExistingTree.
   ProjectionTree(SILModule &Mod, llvm::BumpPtrAllocator &Allocator) 

--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -189,6 +189,9 @@ private:
   ExitKind Kind;
   llvm::SmallMapVector<SILArgument *, ReleaseList, 8> ArgInstMap;
 
+  /// Set to true if we found some releases but not all for the argument.
+  llvm::DenseSet<SILArgument *> FoundSomeReleases;
+
   /// Eventually this will be used in place of HasBlock.
   SILBasicBlock *ProcessedBlock;
 
@@ -238,6 +241,12 @@ public:
         return true;
     }
     return false;
+  }
+
+  /// Return true if we've found some epilgoue releases for the argument
+  /// but not all.
+  bool hasSomeReleasesForArgument(SILArgument *Arg) {
+    return FoundSomeReleases.find(Arg) != FoundSomeReleases.end();
   }
 
   bool isSingleRelease(SILArgument *Arg) const {

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -76,13 +76,13 @@ struct ArgumentDescriptor {
   /// to the original argument. The reason why we do this is to make sure we
   /// have access to the original argument's state if we modify the argument
   /// when optimizing.
-  ArgumentDescriptor(llvm::BumpPtrAllocator &BPA, SILArgument *A)
+  ArgumentDescriptor(SILArgument *A)
       : Arg(A), PInfo(Arg->getKnownParameterInfo()), Index(A->getIndex()),
         Decl(A->getDecl()), IsEntirelyDead(false), Explode(false),
         OwnedToGuaranteed(false),
         IsIndirectResult(A->isIndirectResult()),
         CalleeRelease(), CalleeReleaseInThrowBlock(),
-        ProjTree(A->getModule(), BPA, A->getType())  {}
+        ProjTree(A->getModule(), A->getType())  {}
 
   ArgumentDescriptor(const ArgumentDescriptor &) = delete;
   ArgumentDescriptor(ArgumentDescriptor &&) = default;

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -28,14 +28,14 @@
 
 namespace swift {
 
-using ReleaseSet = llvm::DenseSet<SILInstruction *>;
-
 /// A structure that maintains all of the information about a specific
 /// SILArgument that we are tracking.
 struct ArgumentDescriptor {
-
   /// The argument that we are tracking original data for.
   SILArgument *Arg;
+
+  /// Parameter Info.
+  SILParameterInfo PInfo;
 
   /// The original index of this argument.
   unsigned Index;
@@ -48,6 +48,9 @@ struct ArgumentDescriptor {
 
   /// Should the argument be exploded ?
   bool Explode;
+  
+  /// This parameter is owned to guaranteed.
+  bool OwnedToGuaranteed;
 
   /// Is this parameter an indirect result?
   bool IsIndirectResult;
@@ -73,17 +76,13 @@ struct ArgumentDescriptor {
   /// to the original argument. The reason why we do this is to make sure we
   /// have access to the original argument's state if we modify the argument
   /// when optimizing.
-  ArgumentDescriptor(llvm::BumpPtrAllocator &BPA, SILArgument *A,
-                     ReleaseSet Releases)
-      : Arg(A), Index(A->getIndex()),
+  ArgumentDescriptor(llvm::BumpPtrAllocator &BPA, SILArgument *A)
+      : Arg(A), PInfo(Arg->getKnownParameterInfo()), Index(A->getIndex()),
         Decl(A->getDecl()), IsEntirelyDead(false), Explode(false),
+        OwnedToGuaranteed(false),
         IsIndirectResult(A->isIndirectResult()),
         CalleeRelease(), CalleeReleaseInThrowBlock(),
-        ProjTree(A->getModule(), BPA, A->getType(), 
-        ProjectionTreeNode::LivenessKind::IgnoreEpilogueReleases, 
-        Releases) {
-    ProjTree.computeUsesAndLiveness(A);
-  }
+        ProjTree(A->getModule(), BPA, A->getType())  {}
 
   ArgumentDescriptor(const ArgumentDescriptor &) = delete;
   ArgumentDescriptor(ArgumentDescriptor &&) = default;
@@ -95,35 +94,12 @@ struct ArgumentDescriptor {
     return Arg->hasConvention(P);
   }
 
-  /// Convert the potentially multiple interface params associated with this
-  /// argument.
-  void
-  computeOptimizedInterfaceParams(SmallVectorImpl<SILParameterInfo> &Out) const;
-
-  /// Add potentially multiple new arguments to NewArgs from the caller's apply
-  /// or try_apply inst.
-  void addCallerArgs(SILBuilder &Builder, FullApplySite FAS,
-                     SmallVectorImpl<SILValue> &NewArgs) const;
-
-  /// Add potentially multiple new arguments to NewArgs from the thunk's
-  /// function arguments.
-  void addThunkArgs(SILBuilder &Builder, SILBasicBlock *BB,
-                    SmallVectorImpl<SILValue> &NewArgs) const;
-
-  /// Optimize the argument at ArgOffset and return the index of the next
-  /// argument to be optimized.
-  ///
-  /// The return value makes it easy to SROA arguments since we can return the
-  /// amount of SROAed arguments we created.
-  unsigned updateOptimizedBBArgs(SILBuilder &Builder, SILBasicBlock *BB,
-                                 unsigned ArgOffset);
-
   bool canOptimizeLiveArg() const {
     return Arg->getType().isObject();
   }
 
   /// Return true if it's both legal and a good idea to explode this argument.
-  bool shouldExplode() const {
+  bool shouldExplode(ConsumedArgToEpilogueReleaseMatcher &ERM) const {
     // We cannot optimize the argument.
     if (!canOptimizeLiveArg())
       return false;
@@ -150,6 +126,9 @@ struct ResultDescriptor {
   /// @owned or we could not find such a release in the callee, this is null.
   RetainList CalleeRetain;
 
+  /// This is owned to guaranteed.
+  bool OwnedToGuaranteed;
+
   /// Initialize this argument descriptor with all information from A that we
   /// use in our optimization.
   ///
@@ -157,8 +136,9 @@ struct ResultDescriptor {
   /// to the original argument. The reason why we do this is to make sure we
   /// have access to the original argument's state if we modify the argument
   /// when optimizing.
-  ResultDescriptor() {};
-  ResultDescriptor(SILResultInfo RI) : ResultInfo(RI), CalleeRetain() {}
+  ResultDescriptor() {}
+  ResultDescriptor(SILResultInfo RI) 
+    : ResultInfo(RI), CalleeRetain(), OwnedToGuaranteed(false) {}
 
   ResultDescriptor(const ResultDescriptor &) = delete;
   ResultDescriptor(ResultDescriptor &&) = default;
@@ -171,100 +151,12 @@ struct ResultDescriptor {
   }
 };
 
-class FunctionSignatureInfo {
-  /// Should this function be optimized.
-  bool ShouldOptimize;
-
-  /// Optimizing this function may lead to good performance potential.
-  bool HighlyProfitable;
-
-  /// Function currently analyzing.
-  SILFunction *F;
-
-  /// The allocator we are using.
-  llvm::BumpPtrAllocator &Allocator;
-
-  /// The alias analysis currently using.
-  AliasAnalysis *AA;
-
-  /// The rc-identity analysis currently using.
-  RCIdentityFunctionInfo *RCFI;
-
-  /// Does any call inside the given function may bind dynamic 'Self' to a
-  /// generic argument of the callee.
-  bool MayBindDynamicSelf;
-
-  /// Did we decide to change the self argument? If so we need to
-  /// change the calling convention 'method' to 'freestanding'.
-  bool ShouldModifySelfArgument = false;
-
-  /// A list of structures which present a "view" of precompiled information on
-  /// an argument that we will use during our optimization.
-  llvm::SmallVector<ArgumentDescriptor, 8> ArgDescList;
-
-  /// Keep a "view" of precompiled information on the direct results
-  /// which we will use during our optimization.
-  llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
-
-
-public:
-  FunctionSignatureInfo(SILFunction *F, llvm::BumpPtrAllocator &BPA,
-                        AliasAnalysis *AA, RCIdentityFunctionInfo *RCFI) :
-  ShouldOptimize(false), HighlyProfitable(false), F(F), Allocator(BPA),
-  AA(AA), RCFI(RCFI), MayBindDynamicSelf(computeMayBindDynamicSelf(F)) {
-    analyze();
-  }
-
-  bool shouldOptimize() const { return ShouldOptimize; }
-  bool profitableOptimize() const { return HighlyProfitable; }
-
-  void analyze();
-  bool analyzeParameters();
-  bool analyzeResult();
-
-  /// Returns the mangled name of the function that should be generated from
-  /// this function analyzer.
-  std::string getOptimizedName() const;
-
-  bool shouldModifySelfArgument() const { return ShouldModifySelfArgument; }
-  ArrayRef<ArgumentDescriptor> getArgDescList() const { return ArgDescList; }
-  ArrayRef<ResultDescriptor> getResultDescList() {return ResultDescList;}
-  SILFunction *getAnalyzedFunction() const { return F; }
-
-private:
-  /// Is the given argument required by the ABI?
-  ///
-  /// Metadata arguments may be required if dynamic Self is bound to any generic
-  /// parameters within this function's call sites.
-  bool isArgumentABIRequired(SILArgument *Arg) {
-    // This implicitly asserts that a function binding dynamic self has a self
-    // metadata argument or object from which self metadata can be obtained.
-    return MayBindDynamicSelf && (F->getSelfMetadataArgument() == Arg);
-  }
-};
-
-
-
+/// Returns true if F is a function which the pass know show to specialize
+/// function signatures for.
 bool canSpecializeFunction(SILFunction *F);
 
-void 
-addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
-                                      SILLocation Loc,
-                                      OperandValueArrayRef Parameters,
-                                      ArrayRef<ArgumentDescriptor> &ArgDescs);
-
-void
-addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
-                                      SILLocation Loc,
-                                      ArrayRef<SILArgument*> Parameters,
-                                      ArrayRef<ArgumentDescriptor> &ArgDescs);
-void
-addRetainsForConvertedDirectResults(SILBuilder &Builder,
-                                    SILLocation Loc,
-                                    SILValue ReturnValue,
-                                    SILInstruction *AI,
-                                    ArrayRef<ResultDescriptor> DirectResults);
-
+/// Return true if this argument is used in a non-trivial way.
+bool hasNonTrivialNonDebugUse(SILArgument *Arg);
 
 } // end namespace swift
 

--- a/lib/SIL/Mangle.cpp
+++ b/lib/SIL/Mangle.cpp
@@ -81,7 +81,7 @@ FunctionSignatureSpecializationMangler(SpecializationPass P, Mangler &M,
 void
 FunctionSignatureSpecializationMangler::
 setArgumentDead(unsigned ArgNo) {
-  Args[ArgNo].first = ArgumentModifierIntBase(ArgumentModifier::Dead);
+  Args[ArgNo].first |= ArgumentModifierIntBase(ArgumentModifier::Dead);
 }
 
 void

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -1142,8 +1142,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 ProjectionTree::
-ProjectionTree(SILModule &Mod, llvm::BumpPtrAllocator &BPA, SILType BaseTy) 
-  : Mod(Mod), Allocator(BPA) {
+ProjectionTree(SILModule &Mod, SILType BaseTy) : Mod(Mod) {
   DEBUG(llvm::dbgs() << "Constructing Projection Tree For : " << BaseTy);
 
   // Create the root node of the tree with our base type.
@@ -1161,7 +1160,8 @@ void
 ProjectionTree::initializeWithExistingTree(const ProjectionTree &PT) {
   LiveLeafIndices = PT.LiveLeafIndices;
   for (const auto &N : PT.ProjectionTreeNodes) {
-    ProjectionTreeNodes.push_back(new (Allocator) ProjectionTreeNode(*N));
+    ProjectionTreeNodes.push_back(new (Allocator.Allocate())
+                                  ProjectionTreeNode(*N));
   }
 }
 

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -740,6 +740,10 @@ processMatchingReleases() {
     if (releaseArgument(Arg.second, Arg.first))
       continue;
 
+    // OK. we did find some epilogue releases, just not all.
+    if (!Arg.second.empty())
+      FoundSomeReleases.insert(Arg.first);
+
     ArgToRemove.insert(Arg.first);
   }
 

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -9,6 +9,25 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// This pass defines function signature related optimizations. Everytime a
+/// function signature optimization is performed, changes are made to the
+/// original function and after all function signature optimizations are
+/// finished, a new function is created and the old function is turned into
+/// a thunk.
+///
+/// Another possibility is to implement these optimizations as separate passes,
+/// but then we would send slightly different functions to the pass pipeline
+/// multiple times through notifyPassManagerOfFunction. 
+///
+/// TODO: Optimize function with generic parameters.
+///
+/// TODO: Improve epilogue release matcher, i.e. do a data flow instead of
+/// only finding releases in the return block. 
+///
+//===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-function-signature-opt"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
@@ -19,7 +38,9 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h"
 #include "swift/SILOptimizer/Utils/Local.h"
-#include "swift/SIL/Projection.h"
+#include "swift/SILOptimizer/Utils/SILInliner.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/Mangle.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILValue.h"
@@ -34,6 +55,38 @@ STATISTIC(NumOwnedConvertedToGuaranteed, "Total owned args -> guaranteed args");
 STATISTIC(NumOwnedConvertedToNotOwnedResult, "Total owned result -> not owned result");
 STATISTIC(NumSROAArguments, "Total SROA arguments optimized");
 
+using SILParameterInfoList = llvm::SmallVector<SILParameterInfo, 8>;
+using SILResultInfoList =  llvm::SmallVector<SILResultInfo, 8>;
+using ArgumentIndexMap = llvm::SmallDenseMap<int, int>;
+
+//===----------------------------------------------------------------------===//
+//                           Utilties 
+//===----------------------------------------------------------------------===//
+
+/// Return the single apply found in this function.
+static SILInstruction *findOnlyApply(SILFunction *F) {
+  SILInstruction *OnlyApply = nullptr;
+  for (auto &B : *F) {
+    for (auto &X : B) {
+      if (!isa<ApplyInst>(X) && !isa<TryApplyInst>(X))
+        continue;
+      assert(!OnlyApply && "There are more than 1 function calls");
+      OnlyApply = &X;
+    }
+  }
+  assert(OnlyApply && "There is no function calls");
+  return OnlyApply;
+}
+
+/// Return a unique name in the current module. We should not be blocked
+/// from being able to FSO a function just because we have a name conflict.
+///
+/// TODO: we should teach the demangler to understand this suffix.
+static std::string getUniqueName(std::string Name, SILModule &M) {
+  if (!M.lookUpFunction(Name))
+    return Name;
+  return getUniqueName(Name + "_unique_suffix", M);
+}
 
 /// Creates a decrement on \p Ptr at insertion point \p InsertPt that creates a
 /// strong_release if \p Ptr has reference semantics itself or a release_value
@@ -52,346 +105,394 @@ static SILInstruction *createDecrement(SILValue Ptr, SILInstruction *InsertPt) {
 }
 
 //===----------------------------------------------------------------------===//
-//                     Argument and Result Optimizer
+//                     Function Signature Transformation 
 //===----------------------------------------------------------------------===//
+class FunctionSignatureTransform {
+  /// The actual function to analyze and transform.
+  SILFunction *F;
 
-static void
-computeOptimizedInterfaceParams(const ArgumentDescriptor &AD,
-                                SmallVectorImpl<SILParameterInfo> &Out) {
-  DEBUG(llvm::dbgs() << "        Computing Interface Params\n");
+  /// The newly created function.
+  SILFunction *NewF;
+
+  /// The pass manager we are using.
+  SILPassManager *PM;
+
+  /// The alias analysis we are using.
+  AliasAnalysis *AA;
+
+  /// The RC identity analysis we are using.
+  RCIdentityAnalysis *RCIA;
+
+  // The function signature mangler we are using.
+  FunctionSignatureSpecializationMangler &FM;
+
+  // Keep tracks to argument mapping.
+  ArgumentIndexMap &AIM;
+
+  // Self arument is modified.
+  bool shouldModifySelfArgument;
+
+  /// Keep a "view" of precompiled information on argumentis that we use 
+  /// during our optimization.
+  llvm::SmallVector<ArgumentDescriptor, 4> &ArgumentDescList;
+
+  /// Keep a "view" of precompiled information on the direct results that we
+  /// will use during our optimization.
+  llvm::SmallVector<ResultDescriptor, 4> &ResultDescList;
+
+  /// May dynamically bind to self.
+  bool MayDynamicBindSelf;
+
+  /// Does this function have a caller inside current module
+  bool hasCaller;
+
+  /// Return a function name based on ArgumentDescList and ResultDescList.
+  std::string createOptimizedSILFunctionName();
+
+  /// Return a function type based on ArgumentDescList and ResultDescList.
+  CanSILFunctionType createOptimizedSILFunctionType();
+
+  // This implicitly asserts that a function binding dynamic self has a 
+  // self metadata argument or object from which self metadata can be obtained.
+  bool isArgumentABIRequired(SILArgument *Arg) {
+    return MayDynamicBindSelf && (F->getSelfMetadataArgument() == Arg);
+  }
+
+private:
+  /// ----------------------------------------------------------///
+  /// Dead argument transformation.                             ///
+  /// ----------------------------------------------------------///
+  /// Find any dead argument opportunities.
+  bool DeadArgumentAnalyzeParameters();
+  /// Do the actual dead argument transformations.
+  void DeadArgumentTransformParameters();
+  /// Remove the dead argument once the new function is created.
+  void DeadArgumentFinalizeOptimizedFunction();
+
+  /// ----------------------------------------------------------///
+  /// Owned to guaranteed transformation.                       ///
+  /// ----------------------------------------------------------///
+  bool OwnedToGuaranteedAnalyzeResults();
+  bool OwnedToGuaranteedAnalyzeParameters();
+  void OwnedToGuaranteedTransformResults();
+  void OwnedToGuaranteedTransformParameters();
+
+  /// Find any owned to guaranteed opportunities.
+  bool OwnedToGuaranteedAnalyze() {
+    bool Result = OwnedToGuaranteedAnalyzeResults();
+    bool Params = OwnedToGuaranteedAnalyzeParameters();
+    return Params || Result;
+  }
+
+  /// Do the actual owned to guaranteeed transformations.
+  void OwnedToGuaranteedTransform() {
+    OwnedToGuaranteedTransformResults();
+    OwnedToGuaranteedTransformParameters();
+  }
+
+  /// Set up epilogue work for the thunk result based in the given argument.
+  void OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD,
+                                         SILBuilder &Builder,
+                                         SILFunction *F);
+
+  /// Set up epilogue work for the thunk argument based in the given argument.
+  void OwnedToGuaranteedAddArgumentRelease(ArgumentDescriptor &AD,
+                                           SILBuilder &Builder,
+                                           SILFunction *F); 
+
+  /// Add the release for converted arguments and result.
+  void OwnedToGuaranteedFinalizeThunkFunction(SILBuilder &B, SILFunction *F);
+
+  /// ----------------------------------------------------------///
+  /// Argument explosion transformation.                        ///
+  /// ----------------------------------------------------------///
+  /// Find any argument explosion opportunities.
+  bool ArgumentExplosionAnalyzeParameters();
+  /// Explode the argument in the optimized function and replace the uses of
+  /// the original argument.
+  void ArgumentExplosionFinalizeOptimizedFunction();
+
+  /// Setup the thunk arguments based on the given argument descriptor info.
+  /// Every transformation must defines this interface. Default implementation
+  /// simply passes it through.
+  void addThunkArgument(ArgumentDescriptor &AD, SILBuilder &Builder,
+                        SILBasicBlock *BB, 
+                        llvm::SmallVectorImpl<SILValue> &NewArgs) {
+    // Dead argument.
+    if (AD.IsEntirelyDead) {
+      return;
+    }
+
+    // Explode the argument.
+    if (AD.Explode) {
+      llvm::SmallVector<SILValue, 4> LeafValues;
+      AD.ProjTree.createTreeFromValue(Builder, BB->getParent()->getLocation(),
+                                      BB->getBBArg(AD.Index), LeafValues);
+      NewArgs.append(LeafValues.begin(), LeafValues.end());
+      return;
+    }
+
+    // All other arguments get pushed as what they are.
+    NewArgs.push_back(BB->getBBArg(AD.Index));
+  } 
+
+  /// Take ArgumentDescList and ResultDescList and create an optimized function
+  /// based on the current function we are analyzing. This also has the side effect
+  /// of turning the current function into a thunk.
+  void createFunctionSignatureOptimizedFunction();
+
+  /// Compute the optimized function type based on the given argument descriptor.
+  void computeOptimizedArgInterface(ArgumentDescriptor &A, SILParameterInfoList &O);
+
+public:
+  /// Constructor.
+  FunctionSignatureTransform(SILFunction *F, bool hasCaller, SILPassManager *PM,
+                             AliasAnalysis *AA, RCIdentityAnalysis *RCIA,
+                             FunctionSignatureSpecializationMangler &FM,
+                             ArgumentIndexMap &AIM,
+                             llvm::SmallVector<ArgumentDescriptor, 4> &ADL,
+                             llvm::SmallVector<ResultDescriptor, 4> &RDL)
+    : F(F), NewF(nullptr), PM(PM), AA(AA), RCIA(RCIA), FM(FM),
+      AIM(AIM), shouldModifySelfArgument(false), ArgumentDescList(ADL),
+      ResultDescList(RDL), MayDynamicBindSelf(computeMayBindDynamicSelf(F)),
+      hasCaller(hasCaller) {}
+
+  /// Return the optimized function.
+  SILFunction *getOptimizedFunction() { return NewF; }
+
+  /// Run the optimization.
+  bool run() {
+    bool Changed = false;
+    // Run OwnedToGuaranteed optimization.
+    if (OwnedToGuaranteedAnalyze()) {
+      Changed = true;
+      OwnedToGuaranteedTransform();
+    }
+
+    // Run DeadArgument elimination transformation. We only specialize
+    // if this function has a caller inside the current module or we have
+    // already created a thunk.
+    if ((hasCaller || Changed) && DeadArgumentAnalyzeParameters()) {
+      Changed = true;
+      DeadArgumentTransformParameters();
+    }
+
+    // Run ArgumentExplosion transformation. We only specialize
+    // if this function has a caller inside the current module or we have
+    // already created a thunk.
+    //
+    // NOTE: we run argument explosion last because we've already initialized
+    // the ArgumentDescList to have unexploded number of arguments. Exploding
+    // it without changing the argument count is not going to help with
+    // owned-to-guaranteed transformation. 
+    // 
+    // In order to not miss any opportunity, we send the optimized function
+    // to the passmanager to optimize any opportunities exposed by argument
+    // explosion.
+    if ((hasCaller || Changed) && ArgumentExplosionAnalyzeParameters()) {
+      Changed = true;
+    }
+
+    // Create the specialized function and invalidate the old function.
+    if (Changed) {
+      createFunctionSignatureOptimizedFunction();
+      PM->invalidateAnalysis(F, SILAnalysis::InvalidationKind::Everything);
+    }
+    return Changed;
+  }
+};
+
+std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
+  // Handle arguments' changes.
+  for (unsigned i : indices(ArgumentDescList)) {
+    const ArgumentDescriptor &Arg = ArgumentDescList[i];
+    if (Arg.IsEntirelyDead) {
+      FM.setArgumentDead(i);
+      // No point setting other attribute if argument is dead.
+      continue;
+    }   
+
+    // If we have an @owned argument and found a callee release for it,
+    // convert the argument to guaranteed.
+    if (Arg.OwnedToGuaranteed) {
+      FM.setArgumentOwnedToGuaranteed(i);
+    }
+
+    // If this argument is not dead and we can explode it, add 's' to the
+    // mangling.
+    if (Arg.Explode) {
+      FM.setArgumentSROA(i);
+    }   
+  }
+
+  // Handle return value's change.
+  // FIXME: handle multiple direct results here
+  if (ResultDescList.size() == 1 && !ResultDescList[0].CalleeRetain.empty())
+    FM.setReturnValueOwnedToUnowned();
+
+  FM.mangle();
+  return FM.getMangler().finalize();
+}
+
+/// Compute what the function interface will look like based on the
+/// optimization we are doing on the given argument descriptor. Default
+/// implemenation simply passes it through.
+void
+FunctionSignatureTransform::
+computeOptimizedArgInterface(ArgumentDescriptor &AD, SILParameterInfoList &Out) {
+  // If this argument is live, but we cannot optimize it.
+  if (!AD.canOptimizeLiveArg()) {
+    Out.push_back(AD.PInfo);
+    return;
+  }
+
   // If we have a dead argument, bail.
   if (AD.IsEntirelyDead) {
-    DEBUG(llvm::dbgs() << "            Dead!\n");
     ++NumDeadArgsEliminated;
     return;
   }
 
-  // If we have an indirect result, bail.
-  if (AD.IsIndirectResult) {
-    DEBUG(llvm::dbgs() << "            Indirect result.\n");
-    return;
-  }
+  // Explode the argument or not ?
+  if (AD.Explode) {
+    ++NumSROAArguments;
+    llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
+    AD.ProjTree.getLeafNodes(LeafNodes);
+    for (auto Node : LeafNodes) {
+      SILType Ty = Node->getType();
+      DEBUG(llvm::dbgs() << "                " << Ty << "\n");
+      // If Ty is trivial, just pass it directly.
+      if (Ty.isTrivial(AD.Arg->getModule())) {
+        SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+                                 ParameterConvention::Direct_Unowned);
+        Out.push_back(NewInfo);
+        continue;
+      }
 
-  auto ParameterInfo = AD.Arg->getKnownParameterInfo();
-
-  // If this argument is live, but we cannot optimize it.
-  if (!AD.canOptimizeLiveArg()) {
-    DEBUG(llvm::dbgs() << "            Cannot optimize live arg!\n");
-    Out.push_back(ParameterInfo);
+      // Ty is not trivial, pass it through as the original calling convention.
+      SILParameterInfo NewInfo(Ty.getSwiftRValueType(), AD.OwnedToGuaranteed ? 
+                               ParameterConvention::Direct_Guaranteed : 
+                               AD.PInfo.getConvention());
+      Out.push_back(NewInfo);
+    }
     return;
   }
 
   // If we cannot explode this value, handle callee release and return.
-  if (!AD.Explode) {
-    DEBUG(llvm::dbgs() << "            ProjTree cannot explode arg.\n");
-    // If we found releases in the callee in the last BB on an @owned
-    // parameter, change the parameter to @guaranteed and continue...
-    if (!AD.CalleeRelease.empty()) {
-      DEBUG(llvm::dbgs() << "            Has callee release.\n");
-      assert(ParameterInfo.getConvention() ==
-                 ParameterConvention::Direct_Owned &&
-             "Can only transform @owned => @guaranteed in this code path");
-      SILParameterInfo NewInfo(ParameterInfo.getType(),
-                               ParameterConvention::Direct_Guaranteed);
-      Out.push_back(NewInfo);
-      ++NumOwnedConvertedToGuaranteed;
-      return;
-    }
-
-    DEBUG(llvm::dbgs() << "            Does not have callee release.\n");
-    // Otherwise just propagate through the parameter info.
-    Out.push_back(ParameterInfo);
-    return;
-  }
-
-  ++NumSROAArguments;
-  DEBUG(llvm::dbgs() << "            ProjTree can explode arg.\n");
-  // Ok, we need to use the projection tree. Iterate over the leafs of the
-  // tree...
-  llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
-  AD.ProjTree.getLeafNodes(LeafNodes);
-  DEBUG(llvm::dbgs() << "            Leafs:\n");
-  for (auto Node : LeafNodes) {
-    // Node type.
-    SILType Ty = Node->getType();
-    DEBUG(llvm::dbgs() << "                " << Ty << "\n");
-    // If Ty is trivial, just pass it directly.
-    if (Ty.isTrivial(AD.Arg->getModule())) {
-      SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
-                               ParameterConvention::Direct_Unowned);
-      Out.push_back(NewInfo);
-      continue;
-    }
-
-    // If Ty is guaranteed, just pass it through.
-    ParameterConvention Conv = ParameterInfo.getConvention();
-    if (Conv == ParameterConvention::Direct_Guaranteed) {
-      assert(AD.CalleeRelease.empty() && "Guaranteed parameter should not have a "
-                                      "callee release.");
-      SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
-                               ParameterConvention::Direct_Guaranteed);
-      Out.push_back(NewInfo);
-      continue;
-    }
-
-    // If Ty is not trivial and we found a callee release, pass it as
-    // guaranteed.
-    assert(ParameterInfo.getConvention() == ParameterConvention::Direct_Owned &&
-           "Can only transform @owned => @guaranteed in this code path");
-    if (!AD.CalleeRelease.empty()) {
-      SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
-                               ParameterConvention::Direct_Guaranteed);
-      Out.push_back(NewInfo);
-      ++NumOwnedConvertedToGuaranteed;
-      continue;
-    }
-
-    // Otherwise, just add Ty as an @owned parameter.
-    SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
-                             ParameterConvention::Direct_Owned);
+  // If we found releases in the callee in the last BB on an @owned
+  // parameter, change the parameter to @guaranteed and continue...
+  if (AD.OwnedToGuaranteed) {
+    ++NumOwnedConvertedToGuaranteed;
+    SILParameterInfo NewInfo(AD.PInfo.getType(),
+                             ParameterConvention::Direct_Guaranteed);
     Out.push_back(NewInfo);
-  }
-}
-
-static void
-addThunkArgs(const ArgumentDescriptor &AD, SILBuilder &Builder,
-             SILBasicBlock *BB, llvm::SmallVectorImpl<SILValue> &NewArgs) {
-  if (AD.IsEntirelyDead)
-    return;
-
-  if (!AD.Explode) {
-    NewArgs.push_back(BB->getBBArg(AD.Index));
     return;
   }
 
-  AD.ProjTree.createTreeFromValue(Builder, BB->getParent()->getLocation(),
-                                  BB->getBBArg(AD.Index), NewArgs);
+  // Otherwise just propagate through the parameter info.
+  Out.push_back(AD.PInfo);
 }
 
-static unsigned
-updateOptimizedBBArgs(const ArgumentDescriptor &AD, SILBuilder &Builder,
-                      SILBasicBlock *BB, unsigned ArgOffset) {
-  // If this argument is completely dead, delete this argument and return
-  // ArgOffset.
-  if (AD.IsEntirelyDead) {
-    // If we have a callee release and we are dead, set the callee release's
-    // operand to undef. We do not need it to have the argument anymore, but we
-    // do need the instruction to be non-null.
-    //
-    // TODO: This should not be necessary.
-    for (auto &X : AD.CalleeRelease) {
-      SILType CalleeReleaseTy = X->getOperand(0)->getType();
-      X->setOperand(
-          0, SILUndef::get(CalleeReleaseTy, Builder.getModule()));
-    }
-
-    // We should be able to recursively delete all of the remaining
-    // instructions.
-    SILArgument *Arg = BB->getBBArg(ArgOffset);
-    eraseUsesOfValue(Arg);
-    BB->eraseBBArg(ArgOffset);
-    return ArgOffset;
-  }
-
-  // If this argument is not dead and we did not perform SROA, increment the
-  // offset and return.
-  if (!AD.Explode) {
-    return ArgOffset + 1;
-  }
-
-  // Create values for the leaf types.
-  llvm::SmallVector<SILValue, 8> LeafValues;
-
-  // Create a reference to the old arg offset and increment arg offset so we can
-  // create the new arguments.
-  unsigned OldArgOffset = ArgOffset++;
-
-  // We do this in the same order as leaf types since ProjTree expects that the
-  // order of leaf values matches the order of leaf types.
-  {
-    llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
-    AD.ProjTree.getLeafNodes(LeafNodes);
-    for (auto Node : LeafNodes) {
-      LeafValues.push_back(BB->insertBBArg(
-          ArgOffset++, Node->getType(), BB->getBBArg(OldArgOffset)->getDecl()));
-    }
-  }
-
-  // We have built a projection tree and filled it with liveness information.
-  //
-  // Use this as a base to replace values in current function with their leaf
-  // values.
-  //
-  // NOTE: this also allows us to NOT modify the results of an analysis pass.
-  llvm::BumpPtrAllocator Allocator;
-  ProjectionTree PT(BB->getModule(), Allocator);
-  PT.initializeWithExistingTree(AD.ProjTree);
-
-  // Then go through the projection tree constructing aggregates and replacing
-  // uses.
-  //
-  // TODO: What is the right location to use here?
-  PT.replaceValueUsesWithLeafUses(Builder, BB->getParent()->getLocation(),
-                                  LeafValues);
-
-  // We ignored debugvalue uses when we constructed the new arguments, in order
-  // to preserve as much information as possible, we construct a new value for
-  // OrigArg from the leaf values and use that in place of the OrigArg.
-  SILValue NewOrigArgValue = PT.computeExplodedArgumentValue(Builder,
-                                           BB->getParent()->getLocation(),
-                                           LeafValues);
-
-  // Replace all uses of the original arg with the new value.
-  SILArgument *OrigArg = BB->getBBArg(OldArgOffset);
-  OrigArg->replaceAllUsesWith(NewOrigArgValue);
-
-  // Now erase the old argument since it does not have any uses. We also
-  // decrement ArgOffset since we have one less argument now.
-  BB->eraseBBArg(OldArgOffset);
-  --ArgOffset;
-
-  return ArgOffset;
-}
-
-namespace {
-
-/// A class that contains all analysis information we gather about our
-/// function. Also provides utility methods for creating the new empty function.
-class SignatureOptimizer {
-  FunctionSignatureInfo &FSI;
-
-public:
-  SignatureOptimizer() = delete;
-  SignatureOptimizer(const SignatureOptimizer &) = delete;
-  SignatureOptimizer(SignatureOptimizer &&) = delete;
-
-  SignatureOptimizer(FunctionSignatureInfo &FSI) : FSI(FSI) {}
-
-  ArrayRef<ArgumentDescriptor> getArgDescList() const {
-    return FSI.getArgDescList();
-  }
-
-  ArrayRef<ArgumentDescriptor> getArgDescList() {
-    return FSI.getArgDescList();
-  }
-
-  ArrayRef<ResultDescriptor> getResultDescList() {
-    return FSI.getResultDescList();
-  }
-
-  /// Create a new empty function with the optimized signature found by this
-  /// analysis.
-  ///
-  /// *NOTE* This occurs in the same module as F.
-  SILFunction *createEmptyFunctionWithOptimizedSig(const std::string &Name);
-
-private:
-  /// Compute the CanSILFunctionType for the optimized function.
-  CanSILFunctionType createOptimizedSILFunctionType();
-};
-
-} // end anonymous namespace
-
-CanSILFunctionType SignatureOptimizer::createOptimizedSILFunctionType() {
-  auto *F = FSI.getAnalyzedFunction();
-
-  const ASTContext &Ctx = F->getModule().getASTContext();
+CanSILFunctionType FunctionSignatureTransform::createOptimizedSILFunctionType() {
   CanSILFunctionType FTy = F->getLoweredFunctionType();
-
   // The only way that we modify the arity of function parameters is here for
   // dead arguments. Doing anything else is unsafe since by definition non-dead
   // arguments will have SSA uses in the function. We would need to be smarter
   // in our moving to handle such cases.
   llvm::SmallVector<SILParameterInfo, 8> InterfaceParams;
-  for (auto &ArgDesc : getArgDescList()) {
-    computeOptimizedInterfaceParams(ArgDesc, InterfaceParams);
+  for (auto &ArgDesc : ArgumentDescList) {
+    computeOptimizedArgInterface(ArgDesc, InterfaceParams);
   }
 
   // ResultDescs only covers the direct results; we currently can't ever
   // change an indirect result.  Piece the modified direct result information
   // back into the all-results list.
   llvm::SmallVector<SILResultInfo, 8> InterfaceResults;
-  auto ResultDescs = getResultDescList();
+  auto &ResultDescs = ResultDescList;
   for (SILResultInfo InterfaceResult : FTy->getAllResults()) {
     if (InterfaceResult.isDirect()) {
       auto &RV = ResultDescs[0];
-      ResultDescs = ResultDescs.slice(0);
       if (!RV.CalleeRetain.empty()) {
+        ++NumOwnedConvertedToNotOwnedResult;
         InterfaceResults.push_back(SILResultInfo(InterfaceResult.getType(),
                                                  ResultConvention::Unowned));
-        ++NumOwnedConvertedToNotOwnedResult;
         continue;
-      }
-    }
+      }   
+    }   
 
     InterfaceResults.push_back(InterfaceResult);
   }
 
-  auto InterfaceErrorResult = FTy->getOptionalErrorResult();
-  auto ExtInfo = FTy->getExtInfo();
-
   // Don't use a method representation if we modified self.
-  if (FSI.shouldModifySelfArgument())
+  auto ExtInfo = FTy->getExtInfo();
+  if (shouldModifySelfArgument) {
     ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
+  }
 
   return SILFunctionType::get(FTy->getGenericSignature(), ExtInfo,
                               FTy->getCalleeConvention(), InterfaceParams,
-                              InterfaceResults, InterfaceErrorResult, Ctx);
+                              InterfaceResults, FTy->getOptionalErrorResult(),
+                              F->getModule().getASTContext());
 }
 
-SILFunction *
-SignatureOptimizer::
-createEmptyFunctionWithOptimizedSig(const std::string &NewFName) {
-
-  auto *F = FSI.getAnalyzedFunction();
+void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
+  // Create the optimized function !
   SILModule &M = F->getModule();
-
-  // Create the new optimized function type.
-  CanSILFunctionType NewFTy = createOptimizedSILFunctionType();
-
-  // Create the new function.
-  auto *NewF = M.createFunction(
-      F->getLinkage(), NewFName, NewFTy, nullptr, F->getLocation(), F->isBare(),
+  std::string Name = getUniqueName(createOptimizedSILFunctionName(), M);
+  NewF = M.createFunction(
+      F->getLinkage(), Name,
+      createOptimizedSILFunctionType(), nullptr, F->getLocation(), F->isBare(),
       F->isTransparent(), F->isFragile(), F->isThunk(), F->getClassVisibility(),
       F->getInlineStrategy(), F->getEffectsKind(), 0, F->getDebugScope(),
       F->getDeclContext());
 
+  // Then we transfer the body of F to NewF.
+  NewF->spliceBody(F);
   NewF->setDeclCtx(F->getDeclContext());
 
   // Array semantic clients rely on the signature being as in the original
   // version.
-  for (auto &Attr : F->getSemanticsAttrs())
+  for (auto &Attr : F->getSemanticsAttrs()) {
     if (!StringRef(Attr).startswith("array."))
       NewF->addSemanticsAttr(Attr);
+  }
 
-  return NewF;
-}
+  // Do the last bit of work to the newly created optimized function.
+  ArgumentExplosionFinalizeOptimizedFunction();
+  DeadArgumentFinalizeOptimizedFunction();
 
-static void createThunkBody(SILBasicBlock *BB, SILFunction *NewF,
-                            SignatureOptimizer &Optimizer) {
-  // TODO: What is the proper location to use here?
-  SILLocation Loc = BB->getParent()->getLocation();
-  SILBuilder Builder(BB);
-  Builder.setCurrentDebugScope(BB->getParent()->getDebugScope());
+  // Create the thunk body !
+  F->setThunk(IsThunk);
+  // The thunk now carries the information on how the signature is
+  // optimized. If we inline the thunk, we will get the benefit of calling
+  // the signature optimized function without additional setup on the
+  // caller side.
+  F->setInlineStrategy(AlwaysInline);
+  SILBasicBlock *ThunkBody = F->createBasicBlock();
+  for (auto &ArgDesc : ArgumentDescList) {
+    ThunkBody->createBBArg(ArgDesc.Arg->getType(), ArgDesc.Decl);
+  }
+
+  SILLocation Loc = ThunkBody->getParent()->getLocation();
+  SILBuilder Builder(ThunkBody);
+  Builder.setCurrentDebugScope(ThunkBody->getParent()->getDebugScope());
 
   FunctionRefInst *FRI = Builder.createFunctionRef(Loc, NewF);
 
   // Create the args for the thunk's apply, ignoring any dead arguments.
   llvm::SmallVector<SILValue, 8> ThunkArgs;
-  ArrayRef<ArgumentDescriptor> ArgDescs = Optimizer.getArgDescList();
-  for (auto &ArgDesc : ArgDescs) {
-    addThunkArgs(ArgDesc, Builder, BB, ThunkArgs);
+  for (auto &ArgDesc : ArgumentDescList) {
+    addThunkArgument(ArgDesc, Builder, ThunkBody, ThunkArgs);
   }
 
   // We are ignoring generic functions and functions with out parameters for
   // now.
+  SILValue ReturnValue;
   SILType LoweredType = NewF->getLoweredType();
   SILType ResultType = LoweredType.getFunctionInterfaceResultType();
-  SILValue ReturnValue;
   auto FunctionTy = LoweredType.castTo<SILFunctionType>();
   if (FunctionTy->hasErrorResult()) {
     // We need a try_apply to call a function with an error result.
-    SILFunction *Thunk = BB->getParent();
+    SILFunction *Thunk = ThunkBody->getParent();
     SILBasicBlock *NormalBlock = Thunk->createBasicBlock();
     ReturnValue = NormalBlock->createBBArg(ResultType, 0);
     SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
@@ -401,131 +502,325 @@ static void createThunkBody(SILBasicBlock *BB, SILFunction *NewF,
     Builder.createTryApply(Loc, FRI, LoweredType, ArrayRef<Substitution>(),
                            ThunkArgs, NormalBlock, ErrorBlock);
 
-    // If we have any arguments that were consumed but are now guaranteed,
-    // insert a release_value in the error block.
     Builder.setInsertionPoint(ErrorBlock);
-    for (auto &ArgDesc : ArgDescs) {
-      if (ArgDesc.CalleeRelease.empty())
-        continue;
-      Builder.createReleaseValue(Loc, BB->getBBArg(ArgDesc.Index),
-                                 Atomicity::Atomic);
-    }
     Builder.createThrow(Loc, ErrorArg);
-
-    // Also insert release_value in the normal block (done below).
     Builder.setInsertionPoint(NormalBlock);
   } else {
-    ReturnValue =
-        Builder.createApply(Loc, FRI, LoweredType, ResultType,
-                            ArrayRef<Substitution>(), ThunkArgs, false);
+    ReturnValue = Builder.createApply(Loc, FRI, LoweredType, ResultType,
+                                      ArrayRef<Substitution>(), ThunkArgs,
+                                      false);
   }
 
-  // Add releases for the converted @owned to @guaranteed parameter.
-  addReleasesForConvertedOwnedParameter(Builder, Loc, BB->getBBArgs(),
-                                        ArgDescs);
-
-  // Handle @owned to @unowned return value conversion.
-  addRetainsForConvertedDirectResults(Builder, Loc, ReturnValue, nullptr,
-                                      Optimizer.getResultDescList());
-
-  // Function that are marked as @NoReturn must be followed by an 'unreachable'
-  // instruction.
+  // Set up the return results.
   if (NewF->getLoweredFunctionType()->isNoReturn()) {
     Builder.createUnreachable(Loc);
-    return;
+  } else {
+    Builder.createReturn(Loc, ReturnValue);
   }
 
-  Builder.createReturn(Loc, ReturnValue);
-}
-
-static SILFunction *
-createOptimizedFunctionBody(SILFunction *F, const std::string &NewFName,
-                            SignatureOptimizer &Optimizer) {
-  // First we create an empty function (i.e. no BB) whose function signature has
-  // had its arity modified.
-  //
-  // We only do this to remove dead arguments. All other function signature
-  // optimization is done later by modifying the function signature elements
-  // themselves.
-  SILFunction *NewF = Optimizer.createEmptyFunctionWithOptimizedSig(NewFName);
-
-  // Then we transfer the body of F to NewF. At this point, the arguments of the
-  // first BB will not match.
-  NewF->spliceBody(F);
-  // Do the same with the call graph.
-
-  // Then perform any updates to the arguments of NewF.
-  SILBasicBlock *NewFEntryBB = &*NewF->begin();
-  ArrayRef<ArgumentDescriptor> ArgDescs = Optimizer.getArgDescList();
-  unsigned ArgOffset = 0;
-  SILBuilder Builder(NewFEntryBB->begin());
-  Builder.setCurrentDebugScope(NewFEntryBB->getParent()->getDebugScope());
-  for (auto &ArgDesc : ArgDescs) {
-    // We always need to reset the insertion point in case we delete the first
-    // instruction.
-    Builder.setInsertionPoint(NewFEntryBB->begin());
-    DEBUG(llvm::dbgs() << "Updating arguments at ArgOffset: " << ArgOffset
-                       << " for: " << *ArgDesc.Arg);
-    ArgOffset = updateOptimizedBBArgs(ArgDesc, Builder, NewFEntryBB, ArgOffset);
-  }
-
-  // Otherwise generate the thunk body just in case.
-  SILBasicBlock *ThunkBody = F->createBasicBlock();
-  for (auto &ArgDesc : ArgDescs) {
-    ThunkBody->createBBArg(ArgDesc.Arg->getType(), ArgDesc.Decl);
-  }
-  createThunkBody(ThunkBody, NewF, Optimizer);
-
-  F->setThunk(IsThunk);
+  // Do the last bit work to finalize the thunk.
+  OwnedToGuaranteedFinalizeThunkFunction(Builder, F);
   assert(F->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
-
-  return NewF;
 }
 
-/// Create an optimized version of the current function.
-static SILFunction* 
-createOptimizedFunction(RCIdentityFunctionInfo *RCIA,
-                        FunctionSignatureInfo *FSI,
-                        AliasAnalysis *AA, SILFunction *F) {
-  // This is the new function name.
-  auto NewFName = FSI->getOptimizedName();
+/// ----------------------------------------------------------///
+/// Dead argument transformation.                             ///
+/// ----------------------------------------------------------///
+bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
+  // Did we decide we should optimize any parameter?
+  bool SignatureOptimize = false;
+  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
 
-  // If we already have a specialized version of this function, do not
-  // respecialize. For now just bail.
-  if (F->getModule().lookUpFunction(NewFName))
-    return nullptr;
+  // Analyze the argument information.
+  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+    ArgumentDescriptor &A = ArgumentDescList[i];
+    if (!A.canOptimizeLiveArg()) {
+      continue;
+    }
 
-  ++NumFunctionSignaturesOptimized;
-  SignatureOptimizer Optimizer(*FSI);
+    // Check whether argument is dead.
+    A.IsEntirelyDead = true;
+    A.IsEntirelyDead &= !isArgumentABIRequired(Args[i]);
+    A.IsEntirelyDead &= !hasNonTrivialNonDebugUse(Args[i]); 
+    SignatureOptimize |= A.IsEntirelyDead;
 
-  // Otherwise, move F over to NewF.
-  SILFunction *NewF = createOptimizedFunctionBody(F, NewFName, Optimizer);
+    if (A.IsEntirelyDead && Args[i]->isSelf()) {
+      shouldModifySelfArgument = true;
+    }
+  }
+  return SignatureOptimize;
+}
 
+void FunctionSignatureTransform::DeadArgumentTransformParameters() {
+  SILBasicBlock *BB = &*F->begin();
+  for (const ArgumentDescriptor &AD : ArgumentDescList) {
+    if (!AD.IsEntirelyDead)
+      continue;
+    eraseUsesOfValue(BB->getBBArg(AD.Index));
+  }
+}
+
+void FunctionSignatureTransform::DeadArgumentFinalizeOptimizedFunction() {
+  auto *BB = &*NewF->begin();
+  // Remove any dead argument starting from the last argument to the first.
+  for (const ArgumentDescriptor &AD : reverse(ArgumentDescList)) {
+    if (!AD.IsEntirelyDead)
+      continue;
+    BB->eraseBBArg(AD.Arg->getIndex());
+  }
+}
+
+/// ----------------------------------------------------------///
+/// Owned to Guaranteed transformation.                       ///
+/// ----------------------------------------------------------///
+bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeParameters() {
+  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+  // A map from consumed SILArguments to the release associated with an
+  // argument.
+  //
+  // TODO: The return block and throw block should really be abstracted away.
+  ConsumedArgToEpilogueReleaseMatcher ArgToReturnReleaseMap(RCIA->get(F), F);
+  ConsumedArgToEpilogueReleaseMatcher ArgToThrowReleaseMap(
+      RCIA->get(F), F, ConsumedArgToEpilogueReleaseMatcher::ExitKind::Throw);
+
+  // Did we decide we should optimize any parameter?
+  bool SignatureOptimize = false;
+
+  // Analyze the argument information.
+  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+    ArgumentDescriptor &A = ArgumentDescList[i];
+    if (!A.canOptimizeLiveArg()) {
+      continue;
+    }
+
+    // See if we can find a ref count equivalent strong_release or release_value
+    // at the end of this function if our argument is an @owned parameter.
+    if (A.hasConvention(SILArgumentConvention::Direct_Owned)) {
+      auto Releases = ArgToReturnReleaseMap.getReleasesForArgument(A.Arg);
+      if (!Releases.empty()) {
+        // If the function has a throw block we must also find a matching
+        // release in the throw block.
+        auto ReleasesInThrow = ArgToThrowReleaseMap.getReleasesForArgument(A.Arg);
+        if (!ArgToThrowReleaseMap.hasBlock() || !ReleasesInThrow.empty()) {
+          A.CalleeRelease = Releases;
+          A.CalleeReleaseInThrowBlock = ReleasesInThrow;
+          // We can convert this parameter to a @guaranteed.
+          A.OwnedToGuaranteed = true;
+          SignatureOptimize = true;
+        }
+      }
+    }
+
+    // Modified self argument.
+    if (A.OwnedToGuaranteed && Args[i]->isSelf()) {
+      shouldModifySelfArgument = true;
+    }
+  }
+  return SignatureOptimize;
+}
+
+bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeResults() {
+  auto FTy = F->getLoweredFunctionType();
+  // For now, only do anything if there's a single direct result.
+  if (FTy->getDirectResults().size() != 1)
+    return false; 
+
+  bool SignatureOptimize = false;
+  if (ResultDescList[0].hasConvention(ResultConvention::Owned)) {
+    auto &RI = ResultDescList[0];
+    // We have an @owned return value, find the epilogue retains now.
+    ConsumedResultToEpilogueRetainMatcher ReturnRetainMap(RCIA->get(F), AA, F);
+    auto Retains = ReturnRetainMap.getEpilogueRetains();
+    // We do not need to worry about the throw block, as the return value is only
+    // going to be used in the return block/normal block of the try_apply
+    // instruction.
+    if (!Retains.empty()) {
+      RI.CalleeRetain = Retains;
+      SignatureOptimize = true;
+      RI.OwnedToGuaranteed = true;
+    }
+  }
+  return SignatureOptimize;
+}
+
+void FunctionSignatureTransform::OwnedToGuaranteedTransformParameters() {
   // And remove all Callee releases that we found and made redundant via owned
   // to guaranteed conversion.
-  //
-  // TODO: If more stuff needs to be placed here, refactor into its own method.
-  for (auto &A : Optimizer.getArgDescList()) {
-    for (auto &X : A.CalleeRelease) 
+  for (const ArgumentDescriptor &AD : ArgumentDescList) {
+    if (!AD.OwnedToGuaranteed)
+      continue;
+    for (auto &X : AD.CalleeRelease) 
       X->eraseFromParent();
-    for (auto &X : A.CalleeReleaseInThrowBlock) 
+    for (auto &X : AD.CalleeReleaseInThrowBlock) 
       X->eraseFromParent();
   }
+}
 
+void FunctionSignatureTransform::OwnedToGuaranteedTransformResults() {
   // And remove all callee retains that we found and made redundant via owned
   // to unowned conversion.
-  for (const ResultDescriptor &RD : Optimizer.getResultDescList()) {
+  for (const ResultDescriptor &RD : ResultDescList) {
+    if (!RD.OwnedToGuaranteed)
+      continue;
     for (auto &X : RD.CalleeRetain) {
       if (isa<StrongRetainInst>(X) || isa<RetainValueInst>(X)) {
         X->eraseFromParent();
         continue;
       }
-      assert(isa<ApplyInst>(X) && "Unknown epilogue retain");
       // Create a release to balance it out.
+      assert(isa<ApplyInst>(X) && "Unknown epilogue retain");
       createDecrement(X, dyn_cast<ApplyInst>(X)->getParent()->getTerminator());
     }
   }
-  return NewF;
+}
+
+void FunctionSignatureTransform::
+OwnedToGuaranteedFinalizeThunkFunction(SILBuilder &Builder, SILFunction *F) {
+  // Finish the epilogue work for the argument as well as result.
+  for (auto &ArgDesc : ArgumentDescList) {
+    OwnedToGuaranteedAddArgumentRelease(ArgDesc, Builder, F);
+  }
+  for (auto &ResDesc : ResultDescList) {
+    OwnedToGuaranteedAddResultRelease(ResDesc, Builder, F);
+  }
+}
+
+/// Set up epilogue work for the thunk arguments based in the given argument.
+/// Default implementation simply passes it through.
+void
+FunctionSignatureTransform::
+OwnedToGuaranteedAddArgumentRelease(ArgumentDescriptor &AD, SILBuilder &Builder,
+                                    SILFunction *F) {
+  // If we have any arguments that were consumed but are now guaranteed,
+  // insert a release_value.
+  if (!AD.OwnedToGuaranteed) {
+    return;
+  }
+
+  SILInstruction *Call = findOnlyApply(F);
+  if (isa<ApplyInst>(Call)) {
+    Builder.setInsertionPoint(&*std::next(SILBasicBlock::iterator(Call)));
+    Builder.createReleaseValue(RegularLocation(SourceLoc()),
+                               F->getArguments()[AD.Index],
+                               Atomicity::Atomic);
+  } else {
+    SILBasicBlock *NormalBB = dyn_cast<TryApplyInst>(Call)->getNormalBB();
+    Builder.setInsertionPoint(&*NormalBB->begin());
+    Builder.createReleaseValue(RegularLocation(SourceLoc()),
+                               F->getArguments()[AD.Index],
+                               Atomicity::Atomic);
+
+    SILBasicBlock *ErrorBB = dyn_cast<TryApplyInst>(Call)->getErrorBB();
+    Builder.setInsertionPoint(&*ErrorBB->begin());
+    Builder.createReleaseValue(RegularLocation(SourceLoc()),
+                               F->getArguments()[AD.Index],
+                               Atomicity::Atomic);
+  }
+}
+
+void
+FunctionSignatureTransform::
+OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD, SILBuilder &Builder,
+                                  SILFunction *F) {
+ // If we have any result that were consumed but are now guaranteed,
+  // insert a release_value.
+  if (!RD.OwnedToGuaranteed) {
+    return;
+  }
+
+  SILInstruction *Call = findOnlyApply(F);
+  if (isa<ApplyInst>(Call)) {
+    Builder.setInsertionPoint(&*std::next(SILBasicBlock::iterator(Call)));
+    Builder.createRetainValue(RegularLocation(SourceLoc()), Call,
+                              Atomicity::Atomic);
+  } else {
+    SILBasicBlock *NormalBB = dyn_cast<TryApplyInst>(Call)->getNormalBB();
+    Builder.setInsertionPoint(&*NormalBB->begin());
+    Builder.createRetainValue(RegularLocation(SourceLoc()),
+                              NormalBB->getBBArg(0), Atomicity::Atomic);
+  }
+}
+
+/// ----------------------------------------------------------///
+/// Argument Explosion transformation.                        ///
+/// ----------------------------------------------------------///
+bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
+  // Did we decide we should optimize any parameter?
+  bool SignatureOptimize = false;
+  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+  ConsumedArgToEpilogueReleaseMatcher ArgToReturnReleaseMap(RCIA->get(F), F);
+
+  // Analyze the argument information.
+  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+    ArgumentDescriptor &A = ArgumentDescList[i];
+    // Do not optimize argument.
+    if (!A.canOptimizeLiveArg()) {
+      continue;
+    }
+
+    A.ProjTree.computeUsesAndLiveness(A.Arg);
+    A.Explode = A.shouldExplode(ArgToReturnReleaseMap);
+
+    // Modified self argument.
+    if (A.Explode && Args[i]->isSelf()) {
+      shouldModifySelfArgument = true;
+    }
+
+    SignatureOptimize |= A.Explode;
+  }
+  return SignatureOptimize;
+}
+
+void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
+  SILBasicBlock *BB = &*NewF->begin();
+  SILBuilder Builder(BB->begin());
+  Builder.setCurrentDebugScope(BB->getParent()->getDebugScope());
+  unsigned TotalArgIndex = 0;
+  for (ArgumentDescriptor &AD : ArgumentDescList) {
+    // Simply continue if do not explode.
+    if (!AD.Explode) {
+      AIM[TotalArgIndex] = AD.Index;
+      TotalArgIndex ++;
+      continue;
+    }
+
+    // OK, we need to explode this argument.
+    unsigned ArgOffset = ++TotalArgIndex;
+    unsigned OldArgIndex = ArgOffset - 1; 
+    llvm::SmallVector<SILValue, 8> LeafValues;
+
+    // We do this in the same order as leaf types since ProjTree expects that the
+    // order of leaf values matches the order of leaf types.
+    llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
+    AD.ProjTree.getLeafNodes(LeafNodes);
+    for (auto Node : LeafNodes) {
+      LeafValues.push_back(BB->insertBBArg(ArgOffset++, Node->getType(),
+                           BB->getBBArg(OldArgIndex)->getDecl()));
+      AIM[TotalArgIndex - 1] = AD.Index;
+      TotalArgIndex ++;
+    }
+
+    // Then go through the projection tree constructing aggregates and replacing
+    // uses.
+    AD.ProjTree.replaceValueUsesWithLeafUses(Builder, BB->getParent()->getLocation(),
+                                             LeafValues);
+
+    // We ignored debugvalue uses when we constructed the new arguments, in order
+    // to preserve as much information as possible, we construct a new value for
+    // OrigArg from the leaf values and use that in place of the OrigArg.
+    SILValue NewOrigArgValue = AD.ProjTree.computeExplodedArgumentValue(Builder,
+                                             BB->getParent()->getLocation(),
+                                             LeafValues);
+
+    // Replace all uses of the original arg with the new value.
+    SILArgument *OrigArg = BB->getBBArg(OldArgIndex);
+    OrigArg->replaceAllUsesWith(NewOrigArgValue);
+
+    // Now erase the old argument since it does not have any uses. We also
+    // decrement ArgOffset since we have one less argument now.
+    BB->eraseBBArg(OldArgIndex); 
+    TotalArgIndex --;
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -535,60 +830,72 @@ namespace {
 class FunctionSignatureOpts : public SILFunctionTransform {
 public:
   void run() override {
-    auto *RCIA = getAnalysis<RCIdentityAnalysis>();
-    auto *AA = PM->getAnalysis<AliasAnalysis>();
-    auto *CA = PM->getAnalysis<CallerAnalysis>();
-
-    SILFunction *F = getFunction();
-    llvm::BumpPtrAllocator Allocator;
-    FunctionSignatureInfo FSI(F, Allocator, AA, RCIA->get(F));
+    auto *F = getFunction();
+    // This is the function to optimize.
     DEBUG(llvm::dbgs() << "*** FSO on function: " << F->getName() << " ***\n");
 
     // Don't optimize callees that should not be optimized.
     if (!F->shouldOptimize())
       return;
 
-    // If there is no opportunity on the signature, simply return.
-    if (!FSI.shouldOptimize())
-     return;
+    // Does this function have a caller inside this module.
+    bool hasCaller = PM->getAnalysis<CallerAnalysis>()->hasCaller(F);
 
-    // If this function does not have a caller in the current module.
-    if (!CA->hasCaller(F)) {
-      // If this function maybe called indirectly, e.g. from virtual table
-      // do not function signature specialize it, as this will introduce a thunk.
-      if (canBeCalledIndirectly(F->getRepresentation()))
-        return;
-      // if its not highly profitable to optimize this function. We do not
-      // function signature specialize it.
-      if (!FSI.profitableOptimize())
-        return;
-    }
+    // If this function does not have a direct caller in the current module
+    // and maybe called indirectly, e.g. from virtual table do not function
+    // signature specialize it, as this will introduce a thunk.
+    if (!hasCaller && canBeCalledIndirectly(F->getRepresentation()))
+      return; 
 
     // Check the signature of F to make sure that it is a function that we
     // can specialize. These are conditions independent of the call graph.
     if (!canSpecializeFunction(F))
       return;
 
-    // Try to create an optimized function based on the signature analysis.
-    SILFunction *NewF = 
-                 createOptimizedFunction(RCIA->get(F), &FSI, AA, F);
-  
-    if (NewF) { 
-      // The thunk now carries the information on how the signature is
-      // optimized. If we inline the thunk, we will get the benefit of calling
-      // the signature optimized function without additional setup on the
-      // caller side.
-      F->setInlineStrategy(AlwaysInline);
+    llvm::BumpPtrAllocator BPA;
+    auto *AA = PM->getAnalysis<AliasAnalysis>();
+    auto *RCIA = getAnalysis<RCIdentityAnalysis>();
+
+    // As we optimize the function more and more, the name of the function is
+    // going to change, make sure the mangler is aware of all the changes done
+    // to the function.
+    Mangle::Mangler M;
+    auto P = SpecializationPass::FunctionSignatureOpts;
+    FunctionSignatureSpecializationMangler FM(P, M, F->isFragile(), F);
+
+    /// Keep a map between the exploded argument index and the original argument
+    /// index.
+    llvm::SmallDenseMap<int, int> AIM;
+    int asize = F->begin()->getBBArgs().size();
+    for (auto i = 0; i < asize; ++i) {
+      AIM[i] = i;
+    }
+
+    // Allocate the argument and result descriptors.
+    llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
+    llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
+    ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
+    for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+      ArgumentDescList.emplace_back(BPA, Args[i]);
+    }
+    for (SILResultInfo IR : F->getLoweredFunctionType()->getAllResults()) {
+      ResultDescList.emplace_back(IR);
+    }
+
+    // Owned to guaranteed optimization.
+    FunctionSignatureTransform FST(F, hasCaller, PM, AA, RCIA, FM, AIM,
+                                   ArgumentDescList, ResultDescList);
+    if (FST.run()) {
+      ++ NumFunctionSignaturesOptimized;
+      // The old function must be a thunk now.
+      assert(F->isThunk() && "Old function should have been turned into a thunk");
       // Make sure the PM knows about this function. This will also help us
       // with self-recursion.
-      notifyPassManagerOfFunction(NewF);
-      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+      notifyPassManagerOfFunction(FST.getOptimizedFunction());
     }
   }
 
-  StringRef getName() override {
-    return "Function Signature Optimization";
-  }
+  StringRef getName() override { return "Function Signature Optimization"; }
 };
 
 } // end anonymous namespace

--- a/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
@@ -22,6 +22,33 @@
 
 using namespace swift;
 
+bool swift::hasNonTrivialNonDebugUse(SILArgument *Arg) {
+  llvm::SmallVector<SILInstruction *, 8> Worklist;
+  llvm::SmallPtrSet<SILInstruction *, 8> SeenInsts;
+
+  for (Operand *I : getNonDebugUses(SILValue(Arg)))
+    Worklist.push_back(I->getUser());
+
+  while (!Worklist.empty()) {
+    SILInstruction *U = Worklist.pop_back_val();
+    if (!SeenInsts.insert(U).second)
+      continue;
+
+    // If U is a terminator inst, return false.
+    if (isa<TermInst>(U))
+      return true;
+
+    // If U has side effects...
+    if (U->mayHaveSideEffects()) 
+      return true;
+
+    // Otherwise add all non-debug uses of I to the worklist.
+    for (Operand *I : getNonDebugUses(SILValue(U)))
+      Worklist.push_back(I->getUser());
+  }
+  return false;
+}
+
 static bool isSpecializableRepresentation(SILFunctionTypeRepresentation Rep) {
   switch (Rep) {
   case SILFunctionTypeRepresentation::Method:
@@ -42,6 +69,10 @@ bool swift::canSpecializeFunction(SILFunction *F) {
   // Do not specialize the signature of SILFunctions that are external
   // declarations since there is no body to optimize.
   if (F->isExternalDeclaration())
+    return false;
+
+  // For now ignore functions with indirect results.
+  if (F->getLoweredFunctionType()->hasIndirectResults())
     return false;
 
   // Do not specialize functions that are available externally. If an external
@@ -68,337 +99,3 @@ bool swift::canSpecializeFunction(SILFunction *F) {
   return true;
 }
 
-void swift::
-addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
-                                      SILLocation Loc,
-                                      ArrayRef<SILArgument*> Parameters,
-                                      ArrayRef<ArgumentDescriptor> &ArgDescs) {
-  // If we have any arguments that were consumed but are now guaranteed,
-  // insert a release_value.
-  for (auto &ArgDesc : ArgDescs) {
-    if (ArgDesc.CalleeRelease.empty())
-      continue;
-    Builder.createReleaseValue(Loc, Parameters[ArgDesc.Index],
-                               Atomicity::Atomic);
-  }
-}
-
-void swift::
-addReleasesForConvertedOwnedParameter(SILBuilder &Builder,
-                                      SILLocation Loc,
-                                      OperandValueArrayRef Parameters,
-                                      ArrayRef<ArgumentDescriptor> &ArgDescs) {
-  // If we have any arguments that were consumed but are now guaranteed,
-  // insert a release_value.
-  for (auto &ArgDesc : ArgDescs) {
-    // The argument is dead. Make sure we have a release to balance out
-    // the retain for creating the @owned parameter.
-    if (ArgDesc.IsEntirelyDead && 
-        ArgDesc.Arg->getKnownParameterInfo().getConvention() ==
-        ParameterConvention::Direct_Owned) {
-      Builder.createReleaseValue(Loc, Parameters[ArgDesc.Index],
-                                 Atomicity::Atomic);
-      continue;
-    }
-    if (ArgDesc.CalleeRelease.empty())
-      continue;
-    Builder.createReleaseValue(Loc, Parameters[ArgDesc.Index],
-                               Atomicity::Atomic);
-  }
-}
-
-void swift::
-addRetainsForConvertedDirectResults(SILBuilder &Builder,
-                                    SILLocation Loc,
-                                    SILValue ReturnValue,
-                                    SILInstruction *AI,
-                                    ArrayRef<ResultDescriptor> DirectResults) {
-  for (auto I : indices(DirectResults)) {
-    auto &RV = DirectResults[I];
-    if (RV.CalleeRetain.empty()) continue;
-
-    bool IsSelfRecursionEpilogueRetain = false;
-    for (auto &X : RV.CalleeRetain) {
-      IsSelfRecursionEpilogueRetain |= (AI == X);
-    }
-
-    // We do not create a retain if this ApplyInst is a self-recursion.
-    if (IsSelfRecursionEpilogueRetain)
-      continue;
-
-    // Extract the return value if necessary.
-    SILValue SpecificResultValue = ReturnValue;
-    if (DirectResults.size() != 1)
-      SpecificResultValue = Builder.createTupleExtract(Loc, ReturnValue, I);
-
-    Builder.createRetainValue(Loc, SpecificResultValue, Atomicity::Atomic);
-  }
-}
-
-using namespace swift;
-
-//===----------------------------------------------------------------------===//
-//                                  Utility
-//===----------------------------------------------------------------------===//
-
-/// Returns true if I is a release instruction.
-static bool isRelease(SILInstruction *I) {
-  switch (I->getKind()) {
-  case ValueKind::StrongReleaseInst:
-  case ValueKind::ReleaseValueInst:
-    return true;
-  default:
-    return false;
-  }
-}
-
-/// Returns true if LHS and RHS contain identical set of releases.
-static bool hasIdenticalReleases(ReleaseList LHS, ReleaseList RHS) {
-  llvm::DenseSet<SILInstruction *> Releases;
-  if (LHS.size() != RHS.size())
-    return false;
-  for (auto &X : LHS) 
-    Releases.insert(X);
-  for (auto &X : RHS) 
-    if (Releases.find(X) == Releases.end())
-      return false;
-  return true;
-}
-
-static ReleaseSet
-collectEpilogueReleases(ConsumedArgToEpilogueReleaseMatcher &Return,
-                        ConsumedArgToEpilogueReleaseMatcher &Throw,
-                        SILArgument *Arg) {
-  ReleaseSet EpilogueReleases;
-  // Handle return block.
-  auto ReturnReleases = Return.getReleasesForArgument(Arg);
-  if (ReturnReleases.empty())
-    return EpilogueReleases;
-  for (auto &X : Return.getReleasesForArgument(Arg)) 
-    EpilogueReleases.insert(X);
-
-  // Handle throw block.
-  if (!Throw.hasBlock())
-    return EpilogueReleases;
-  auto ThrowReleases = Throw.getReleasesForArgument(Arg);
-  if (ThrowReleases.empty()) {
-    EpilogueReleases.clear();
-    return EpilogueReleases;
-  }
-  for (auto &X : ThrowReleases) 
-    EpilogueReleases.insert(X);
-
-  return EpilogueReleases;
-}
-
-/// Returns .Some(I) if I is a release that is the only non-debug instruction
-/// with side-effects in the use-def graph originating from Arg. Returns
-/// .Some(nullptr), if all uses from the arg were either debug insts or do not
-/// have side-effects. Returns .None if there were any non-release instructions
-/// with side-effects in the use-def graph from Arg or if there were multiple
-/// release instructions with side-effects in the use-def graph from Arg.
-static llvm::Optional<ReleaseList>
-getNonTrivialNonDebugReleaseUse(SILArgument *Arg) {
-  llvm::SmallVector<SILInstruction *, 8> Worklist;
-  llvm::SmallPtrSet<SILInstruction *, 8> SeenInsts;
-  ReleaseList Result;
-
-  for (Operand *I : getNonDebugUses(SILValue(Arg)))
-    Worklist.push_back(I->getUser());
-
-  while (!Worklist.empty()) {
-    SILInstruction *U = Worklist.pop_back_val();
-    if (!SeenInsts.insert(U).second)
-      continue;
-
-    // If U is a terminator inst, return false.
-    if (isa<TermInst>(U))
-      return None;
-
-    // If U has side effects...
-    if (U->mayHaveSideEffects()) {
-      // And is not a release_value, return None.
-      if (!isRelease(U))
-        return None;
-
-      // Otherwise, set result to that value.
-      Result.push_back(U);
-      continue;
-    }
-
-    // Otherwise add all non-debug uses of I to the worklist.
-    for (Operand *I : getNonDebugUses(U))
-      Worklist.push_back(I->getUser());
-  }
-
-  return Result;
-}
-
-bool FunctionSignatureInfo::analyzeParameters() {
-  // For now ignore functions with indirect results.
-  if (F->getLoweredFunctionType()->hasIndirectResults())
-    return false;
-
-  ArrayRef<SILArgument *> Args = F->begin()->getBBArgs();
-
-  // A map from consumed SILArguments to the release associated with an
-  // argument.
-  ConsumedArgToEpilogueReleaseMatcher ArgToReturnReleaseMap(RCFI, F);
-  ConsumedArgToEpilogueReleaseMatcher ArgToThrowReleaseMap(
-      RCFI, F, ConsumedArgToEpilogueReleaseMatcher::ExitKind::Throw);
-
-  // Did we decide we should optimize any parameter?
-  bool SignatureOptimize = false;
-
-  // Analyze the argument information.
-  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
-    // Find all the epilogue releases for this argument.
-    auto EpilogueReleases = collectEpilogueReleases(ArgToReturnReleaseMap,
-                                                    ArgToThrowReleaseMap,
-                                                    Args[i]);
-    ArgumentDescriptor A(Allocator, Args[i], EpilogueReleases);
-    bool HaveOptimizedArg = false;
-
-    // Whether we will explode the argument or not.
-    A.Explode = A.shouldExplode();
-
-    bool isABIRequired = isArgumentABIRequired(Args[i]);
-    auto OnlyRelease = getNonTrivialNonDebugReleaseUse(Args[i]);
-
-    // If this argument is not ABI required and has no uses except for debug
-    // instructions, remove it.
-    if (!isABIRequired && OnlyRelease && OnlyRelease.getValue().empty()) {
-      A.IsEntirelyDead = true;
-      HaveOptimizedArg = true;
-    }
-
-    // See if we can find a ref count equivalent strong_release or release_value
-    // at the end of this function if our argument is an @owned parameter.
-    if (A.hasConvention(SILArgumentConvention::Direct_Owned)) {
-      auto Releases = ArgToReturnReleaseMap.getReleasesForArgument(A.Arg);
-      if (!Releases.empty()) {
-
-        // If the function has a throw block we must also find a matching
-        // release in the throw block.
-        auto ReleasesInThrow = ArgToThrowReleaseMap.getReleasesForArgument(A.Arg);
-        if (!ArgToThrowReleaseMap.hasBlock() || !ReleasesInThrow.empty()) {
-
-          // TODO: accept a second release in the throw block to let the
-          // argument be dead.
-          if (OnlyRelease && hasIdenticalReleases(OnlyRelease.getValue(), Releases)) {
-            A.IsEntirelyDead = true;
-          }
-
-          A.CalleeRelease = Releases;
-          A.CalleeReleaseInThrowBlock = ReleasesInThrow;
-          HaveOptimizedArg = true;
-        }
-      }
-    }
-
-    if (A.Explode) {
-      HaveOptimizedArg = true;
-    }
-
-    if (HaveOptimizedArg) {
-      SignatureOptimize = true;
-      // Store that we have modified the self argument. We need to change the
-      // calling convention later.
-      if (Args[i]->isSelf())
-        ShouldModifySelfArgument = true;
-    }
-
-    // Add the argument to our list.
-    ArgDescList.push_back(std::move(A));
-  }
- 
-  return SignatureOptimize;
-}
-
-bool FunctionSignatureInfo::analyzeResult() {
-  // For now ignore functions with indirect results.
-  if (F->getLoweredFunctionType()->hasIndirectResults())
-    return false;
-
-  // Did we decide we should optimize any parameter?
-  bool SignatureOptimize = false;
-
-  // Analyze return result information.
-  auto DirectResults = F->getLoweredFunctionType()->getDirectResults();
-  for (SILResultInfo DirectResult : DirectResults) {
-    ResultDescList.emplace_back(DirectResult);
-  }
-  // For now, only do anything if there's a single direct result.
-  if (DirectResults.size() == 1 &&
-      ResultDescList[0].hasConvention(ResultConvention::Owned)) {
-    auto &RI = ResultDescList[0];
-    // We have an @owned return value, find the epilogue retains now.
-    ConsumedResultToEpilogueRetainMatcher RVToReturnRetainMap(RCFI, AA, F);
-    auto Retains = RVToReturnRetainMap.getEpilogueRetains();
-    // We do not need to worry about the throw block, as the return value is only
-    // going to be used in the return block/normal block of the try_apply instruction.
-    if (!Retains.empty()) {
-      RI.CalleeRetain = Retains;
-      SignatureOptimize = true;
-    }
-  }
-  return SignatureOptimize;
-}
-
-/// This function goes through the arguments of F and sees if we have anything
-/// to optimize in which case it returns true. If we have nothing to optimize,
-/// it returns false.
-void FunctionSignatureInfo::analyze() {
-  // Compute the signature optimization.
-  bool OptimizedParams = analyzeParameters();
-  bool OptimizedResult = analyzeResult();
-  ShouldOptimize = OptimizedParams || OptimizedResult;
-  // We set this function to highly profitable if we have a O2G on one of its
-  // parameters or results.
-  for (auto &X : ArgDescList) {
-    HighlyProfitable |= !X.CalleeRelease.empty();
-  }
-  for (auto &X : ResultDescList) {
-    HighlyProfitable |= !X.CalleeRetain.empty();
-  }
-}
-
-//===----------------------------------------------------------------------===//
-//                                  Mangling
-//===----------------------------------------------------------------------===//
-
-std::string FunctionSignatureInfo::getOptimizedName() const {
-  Mangle::Mangler M;
-  auto P = SpecializationPass::FunctionSignatureOpts;
-  FunctionSignatureSpecializationMangler FSSM(P, M, F->isFragile(), F);
-
-  // Handle arguments' changes.
-  for (unsigned i : indices(ArgDescList)) {
-    const ArgumentDescriptor &Arg = ArgDescList[i];
-    if (Arg.IsEntirelyDead) {
-      FSSM.setArgumentDead(i);
-    }
-
-    // If we have an @owned argument and found a callee release for it,
-    // convert the argument to guaranteed.
-    if (!Arg.CalleeRelease.empty()) {
-      FSSM.setArgumentOwnedToGuaranteed(i);
-    }
-
-    // If this argument is not dead and we can explode it, add 's' to the
-    // mangling.
-    if (Arg.Explode && !Arg.IsEntirelyDead) {
-      FSSM.setArgumentSROA(i);
-    }
-  }
-
-  // Handle return value's change.
-  // FIXME: handle multiple direct results here
-  if (ResultDescList.size() == 1 &&
-      !ResultDescList[0].CalleeRetain.empty())
-    FSSM.setReturnValueOwnedToUnowned();
-
-  FSSM.mangle();
-
-  return M.finalize();
-}

--- a/test/SILOptimizer/cast_folding_objc_no_foundation.swift
+++ b/test/SILOptimizer/cast_folding_objc_no_foundation.swift
@@ -25,7 +25,7 @@ func testAnyObjectToArrayString(_ a: AnyObject) -> Bool {
   return a is [String]
 }
 
-// CHECK-LABEL: sil hidden [noinline] @_TTSf4dg___TF31cast_folding_objc_no_foundation30testAnyObjectToArrayNotBridgedFPs9AnyObject_Sb
+// CHECK-LABEL: sil hidden [noinline] @_TTSf4d___TF31cast_folding_objc_no_foundation30testAnyObjectToArrayNotBridgedFPs9AnyObject_Sb
 // CHECK-NEXT: bb0:
 // CHECK: [[VALUE:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK: [[RESULT:%.*]] = struct $Bool ([[VALUE]] : $Builtin.Int1)

--- a/test/SILOptimizer/devirt_base_class.swift
+++ b/test/SILOptimizer/devirt_base_class.swift
@@ -39,8 +39,6 @@ private func foo(_ a: A) -> Int {
 // CHECK-NOT: function_ref
 // CHECK: return
 
-
-
 print("foo(C()) = \(foo(C()))")
 
 private class F1 {

--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -179,7 +179,7 @@ final class C2:C {
 // Check that the Optional return value from doSomething
 // gets properly unwrapped into a Payload object and then further
 // devirtualized.
-// CHECK-LABEL: sil hidden @_TTSf4dg___TF23devirt_covariant_return7driver1FCS_2C1Vs5Int32
+// CHECK-LABEL: sil hidden @_TTSf4d___TF23devirt_covariant_return7driver1FCS_2C1Vs5Int32
 // CHECK: integer_literal $Builtin.Int32, 2
 // CHECK: struct $Int32 (%{{.*}} : $Builtin.Int32)
 // CHECK-NOT: class_method

--- a/test/SILOptimizer/devirt_protocol_method_invocations.swift
+++ b/test/SILOptimizer/devirt_protocol_method_invocations.swift
@@ -99,7 +99,7 @@ public func test_devirt_protocol_method_invocation(_ c: C) -> Int {
 // In fact, the call is expected to be inlined and then constant-folded
 // into a single integer constant.
 
-// CHECK-LABEL: sil [noinline] @_TTSf4dg___TF34devirt_protocol_method_invocations48test_devirt_protocol_extension_method_invocationFCS_1CVs5Int32
+// CHECK-LABEL: sil [noinline] @_TTSf4d___TF34devirt_protocol_method_invocations48test_devirt_protocol_extension_method_invocationFCS_1CVs5Int32
 // CHECK-NOT: checked_cast
 // CHECK-NOT: open_existential
 // CHECK-NOT: witness_method

--- a/test/SILOptimizer/devirt_value_metatypes.swift
+++ b/test/SILOptimizer/devirt_value_metatypes.swift
@@ -36,7 +36,7 @@ public class D : C {
 // CHECK-NOT: value_metatype %
 // D.foo is an internal method, D has no subclasses and it is a wmo compilation,
 // therefore D.foo method invocation can be devirtualized.
-// CHECK: function_ref @_TTSf4d___TZFC22devirt_value_metatypes1D3foofT_Si 
+// CHECK: function_ref @_TTSf4d___TZFC22devirt_value_metatypes1D3foofT_Si
 // CHECK-NOT: value_metatype %
 // CHECK-NOT: checked_cast_br
 // CHECK-NOT: class_method

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -221,7 +221,7 @@ bb3:
 //
 // CHECK-LABEL: sil [thunk] [always_inline] @exploded_release_to_dead_argument
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
-// CHECK: [[IN1:%.*]] = function_ref @_TTSf4dg__exploded_release_to_dead_argument 
+// CHECK: [[IN1:%.*]] = function_ref @_TTSf4d__exploded_release_to_dead_argument
 // CHECK: apply [[IN1]]()
 // CHECK: release_value [[INPUT_ARG0]] 
 sil @exploded_release_to_dead_argument : $@convention(thin) (@owned boo) -> () {
@@ -1096,8 +1096,8 @@ bb3:
 
 // CHECK-LABEL: sil [fragile] [thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[INPUT_PTR1:%.*]] : $Builtin.NativeObject, [[INPUT_PTR2:%.*]] : $Builtin.NativeObject):
-// CHECK: release_value [[INPUT_PTR1]] : $Builtin.NativeObject
 // CHECK: release_value [[INPUT_PTR2]] : $Builtin.NativeObject
+// CHECK: release_value [[INPUT_PTR1]] : $Builtin.NativeObject
 sil [fragile] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   // make it a non-trivial function
@@ -1141,8 +1141,8 @@ bb2:
 
 // CHECK-LABEL: sil [fragile] [thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[INPUT_PTR1:%.*]] : $Builtin.NativeObject, [[INPUT_PTR2:%.*]] : $Builtin.NativeObject):
-// CHECK: release_value [[INPUT_PTR1]] : $Builtin.NativeObject
 // CHECK: release_value [[INPUT_PTR2]] : $Builtin.NativeObject
+// CHECK: release_value [[INPUT_PTR1]] : $Builtin.NativeObject
 sil [fragile] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   // make it a non-trivial function
@@ -1199,21 +1199,21 @@ bb2(%5 : $Builtin.NativeObject):
 // CHECK-NEXT: release_value [[INPUT_PTR_1]] : $Builtin.NativeObject
 // CHECK: [[MULTIBB_RELEASEINEXIT_TWOARGS1:%.*]] = function_ref @_TTSfq4g_g__owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
 // CHECK: apply [[MULTIBB_RELEASEINEXIT_TWOARGS1]]([[INPUT_PTR_1]], [[INPUT_PTR_2]])
-// CHECK: release_value [[INPUT_PTR_1]]
 // CHECK: release_value [[INPUT_PTR_2]]
+// CHECK: release_value [[INPUT_PTR_1]]
 // CHECK: [[MULTIBB_RELEASEINEXIT_TWOARGS1:%.*]] = function_ref @_TTSfq4g_g__owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
 // CHECK: apply [[MULTIBB_RELEASEINEXIT_TWOARGS1]]([[INPUT_PTR_2]], [[INPUT_PTR_1]])
-// CHECK: release_value [[INPUT_PTR_2]]
 // CHECK: release_value [[INPUT_PTR_1]]
+// CHECK: release_value [[INPUT_PTR_2]]
 
 // CHECK: [[MULTIBB_RELEASEINEXIT_TWOARGS2:%.*]] = function_ref @_TTSfq4g_g__owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
 // CHECK: apply [[MULTIBB_RELEASEINEXIT_TWOARGS2]]([[INPUT_PTR_2]], [[INPUT_PTR_1]])
-// CHECK: release_value [[INPUT_PTR_2]]
 // CHECK: release_value [[INPUT_PTR_1]]
+// CHECK: release_value [[INPUT_PTR_2]]
 // CHECK: [[MULTIBB_RELEASEINEXIT_TWOARGS2:%.*]] = function_ref @_TTSfq4g_g__owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@guaranteed Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
 // CHECK: apply [[MULTIBB_RELEASEINEXIT_TWOARGS2]]([[INPUT_PTR_1]], [[INPUT_PTR_2]])
-// CHECK: release_value [[INPUT_PTR_1]]
 // CHECK: release_value [[INPUT_PTR_2]]
+// CHECK: release_value [[INPUT_PTR_1]]
 
 sil [fragile] @owned_to_guaranteed_simple_singlebb_multiple_arg_caller : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
@@ -1369,8 +1369,6 @@ bb0(%0 : $Builtin.Int32):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @_TTSf4dg__exploded_release_to_dead_argument
-
 // CHECK-LABEL: sil @_TTSf4gs__exploded_release_to_guaranteed_param
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $Int):
 // CHECK-NOT: strong_release
@@ -1387,9 +1385,6 @@ bb0(%0 : $Builtin.Int32):
 // CHECK: bb0
 // CHECK-NOT: retain_value
 // CHECK: return
-
-// CHECK-LABEL: sil [thunk] [always_inline] @_TTSf4s__single_owned_return_value_with_interfering_release : $@convention(thin) (@owned foo, @owned foo, Int) -> boo {
-// CHECK: retain_value
 
 // CHECK-LABEL: @_TTSfq4n_g_owned_to_unowned_retval_with_error_result : $@convention(thin) (@owned boo) -> (boo, @error ErrorProtocol) {
 // CHECK: bb2

--- a/test/SILOptimizer/functionsigopts_sroa.sil
+++ b/test/SILOptimizer/functionsigopts_sroa.sil
@@ -441,7 +441,7 @@ bb0(%0 : $S2):
 // This test checks if we can handle @owned structs correctly
 // CHECK-LABEL: sil [fragile] [thunk] [always_inline] @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 // CHECK: bb0([[IN1:%.*]] : $S5, [[IN2:%.*]] : $S5):
-// CHECK: [[FN:%.*]] = function_ref @_TTSfq4dg_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
+// CHECK: [[FN:%.*]] = function_ref @_TTSfq4d_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S5, #S5.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN2]] : $S5, #S5.f1
 // CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
@@ -489,7 +489,7 @@ bb0(%0 : $S5, %1 : $S5):
 
 // CHECK-LABEL: sil [fragile] @owned_struct_1_caller : $@convention(thin) (S5) -> () {
 // CHECK: bb0([[IN:%.*]] : $S5):
-// CHECK: [[FN:%.*]] = function_ref @_TTSfq4dg_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
+// CHECK: [[FN:%.*]] = function_ref @_TTSfq4d_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S5, #S5.f2
 // CHECK: [[EXT2:%.*]] = struct_extract [[IN]] : $S5, #S5.f1
 // CHECK: [[EXT4:%.*]] = struct_extract [[EXT1]] : $S1, #S1.f2
@@ -960,7 +960,7 @@ bb0(%0 : $SingleFieldLvl1):
 
 
 
-// CHECK-LABEL: sil [fragile] @_TTSfq4dg_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
+// CHECK-LABEL: sil [fragile] @_TTSfq4d_gs__owned_struct_1_callee : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 // CHECK: bb0([[IN1:%.*]] : $S4, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int32):
 // CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, [[IN3]] : $Builtin.Int32)
 // CHECK: [[STRUCT3:%.*]] = struct $S5 ([[IN1]] : $S4, [[STRUCT1]] : $S1)
@@ -985,8 +985,8 @@ bb0(%0 : $SingleFieldLvl1):
 
 // CHECK-LABEL: sil [fragile] @_TTSfq4n_s_s__ignore_ptrs_callee : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16) {
 // CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $Builtin.Int16, [[IN3:%.*]] : $Builtin.Int16):
-// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: [[STRUCT2:%.*]] = struct $S1 ([[IN2]] : $Builtin.Int16, undef : $Builtin.Int32)
+// CHECK: [[STRUCT1:%.*]] = struct $S1 ([[IN3]] : $Builtin.Int16, undef : $Builtin.Int32)
 // CHECK: debug_value [[STRUCT2]]
 // CHECK: debug_value [[STRUCT1]]
 // CHECK: [[FN:%.*]] = function_ref @s1_ptr_user : $@convention(thin) (@in S1) -> ()

--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -301,7 +301,7 @@ public func testStructWithMultipleInitsAndInlinedInitializer() {
 // CHECK: struct_extract %0 : $StructWithOnlyPublicLetProperties, #StructWithOnlyPublicLetProperties.Prop0
 // CHECK: return
 
-// CHECK-WMO-LABEL: sil @_TF19let_properties_opts31testStructPropertyAccessibilityFVS_33StructWithOnlyPublicLetPropertiesVs5Int32 
+// CHECK-WMO-LABEL: sil @_TF19let_properties_opts31testStructPropertyAccessibilityFVS_33StructWithOnlyPublicLetPropertiesVs5Int32
 // CHECK-WMO: struct_extract %0 : $StructWithOnlyPublicLetProperties, #StructWithOnlyPublicLetProperties.Prop0
 // CHECK-WMO: return
 public func testStructPropertyAccessibility(_ b: StructWithOnlyPublicLetProperties) -> Int32 {


### PR DESCRIPTION
Several functionalities have been added to FSO over time and the logic has become
muddled.

We were always looking at a static image of the SIL and try to reason about what kind of
function signature related optimizations we can do.

This can easily lead to muddled logic. e.g. we need to consider 2 different function
signature optimizations together instead of independently.

Split 1 single function to do all sorts of different analyses in FSO into several
small transformations, each of which does a specific job. After every analysis, we produce
a new function and eventually we collapse all intermediate thunks to in a single thunk.

With this change, it will be easier to implement function signature optimization as now
we can do them independently now.

Minimal modifications to the test cases.
