### PR TITLE
[Platform] Simplify glibc.modulemap generation

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -1,6 +1,74 @@
 include(SwiftAddCustomCommandTarget)
 include(SwiftSetIfArchBitness)
 
+# Create a target to process single gyb source with the 'gyb' tool.
+#
+# handle_gyb_source_single(
+#     dependency_out_var_name
+#     SOURCE src_gyb
+#     OUTPUT output
+#     [FLAGS [flags ...]])
+#     [DEPENDS [depends ...]]
+#     [COMMENT comment])
+#
+# dependency_out_var_name
+#   The name of a variable, to be set in the parent scope to be the target
+#   target that invoke gyb.
+#
+# src_gyb
+#   .gyb suffixed source file
+#
+# output
+#   Output filename to be generated
+#
+# flags ...
+#    gyb flags in addition to ${SWIFT_GYB_FLAGS}.
+#
+# depends ...
+#    gyb flags in addition to 'src_gyb' and sources of gyb itself.
+#
+# comment
+#    Additional comment.
+function(handle_gyb_source_single dependency_out_var_name)
+  set(options)
+  set(single_value_args SOURCE OUTPUT COMMENT)
+  set(multi_value_args FLAGS DEPENDS)
+  cmake_parse_arguments(
+      GYB_SINGLE # prefix
+      "${options}" "${single_value_args}" "${multi_value_args}" ${ARGN})
+
+  set(gyb_flags
+      "--test" # Run gyb's self-tests whenever we use it.  They're cheap
+               # enough and it keeps us honest.
+      ${SWIFT_GYB_FLAGS}
+      ${GYB_SINGLE_FLAGS})
+
+  set(gyb_tool "${SWIFT_SOURCE_DIR}/utils/gyb")
+  set(gyb_tool_source "${gyb_tool}" "${gyb_tool}.py")
+
+  get_filename_component(dir "${GYB_SINGLE_OUTPUT}" DIRECTORY)
+  get_filename_component(basename "${GYB_SINGLE_OUTPUT}" NAME)
+  add_custom_command_target(
+      dependency_target
+      COMMAND
+          "${CMAKE_COMMAND}" -E make_directory "${dir}"
+      COMMAND
+          "${gyb_tool}" "${gyb_flags}"
+          -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
+      COMMAND
+          "${CMAKE_COMMAND}" -E copy_if_different
+          "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_OUTPUT}"
+      COMMAND
+          "${CMAKE_COMMAND}" -E remove "${GYB_SINGLE_OUTPUT}.tmp"
+      OUTPUT "${GYB_SINGLE_OUTPUT}"
+      DEPENDS "${gyb_tool_source}" "${GYB_SINGLE_DEPENDS}" "${GYB_SINGLE_SOURCE}"
+      COMMENT "Generating ${basename} from ${GYB_SINGLE_SOURCE} ${GYB_SINGLE_COMMENT}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      SOURCES "${GYB_SINGLE_SOURCE}"
+      IDEMPOTENT)
+  set("${dependency_out_var_name}" "${dependency_target}" PARENT_SCOPE)
+endfunction()
+
 # Create a target to process .gyb files with the 'gyb' tool.
 #
 # handle_gyb_sources(
@@ -32,16 +100,8 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name arch)
     set(extra_gyb_flags "-DCMAKE_SIZEOF_VOID_P=${ptr_size}")
   endif()
 
-  set(gyb_flags
-      "--test" # Run gyb's self-tests whenever we use it.  They're cheap
-               # enough and it keeps us honest.
-      ${SWIFT_GYB_FLAGS}
-      ${extra_gyb_flags})
-
   set(dependency_targets)
   set(de_gybbed_sources)
-  set(gyb_tool "${SWIFT_SOURCE_DIR}/utils/gyb")
-  set(gyb_tool_source "${gyb_tool}" "${gyb_tool}.py")
   set(gyb_extra_sources
       "${SWIFT_SOURCE_DIR}/utils/GYBUnicodeDataUtils.py"
       "${SWIFT_SOURCE_DIR}/utils/SwiftIntTypes.py"
@@ -59,27 +119,15 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name arch)
       endif()
       set(output_file_name "${dir}/${src_sans_gyb}")
       list(APPEND de_gybbed_sources "${output_file_name}")
-      string(MD5 output_file_name_hash "${output_file_name}")
-      add_custom_command_target(
-          dependency_target
-          COMMAND
-            "${CMAKE_COMMAND}" -E make_directory "${dir}"
-          COMMAND
-            "${gyb_tool}" "${gyb_flags}" -o "${output_file_name}.tmp" "${src}"
-          COMMAND
-            "${CMAKE_COMMAND}" -E copy_if_different "${output_file_name}.tmp" "${output_file_name}"
-          COMMAND
-            "${CMAKE_COMMAND}" -E remove "${output_file_name}.tmp"
+      handle_gyb_source_single(dependency_target
+          SOURCE "${src}"
           OUTPUT "${output_file_name}"
-          DEPENDS "${gyb_tool_source}" "${src}" "${gyb_extra_sources}"
-          COMMENT "Generating ${src_sans_gyb} from ${src} with ptr size = ${ptr_size}"
-          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-          SOURCES "${src}"
-          IDEMPOTENT)
+          FLAGS ${extra_gyb_flags}
+          DEPENDS "${gyb_extra_sources}"
+          COMMENT "with ptr size = ${ptr_size}")
       list(APPEND dependency_targets "${dependency_target}")
     endif()
   endforeach()
   set("${dependency_out_var_name}" "${dependency_targets}" PARENT_SCOPE)
   set("${sources_var_name}" "${de_gybbed_sources}" PARENT_SCOPE)
 endfunction()
-

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -55,42 +55,25 @@ foreach(sdk ${SWIFT_SDKS})
         endif()
       endif()
 
+      set(glibc_modulemap_source "glibc.modulemap.gyb")
+      set(glibc_modulemap_out "${module_dir}/glibc.modulemap")
+
       # Configure the module map based on the target. Each platform needs to
       # reference different headers, based on what's available in their glibc.
-      set(glibc_modulemap_gyb_source "glibc.modulemap.in.gyb")
-      set(glibc_modulemap_gyb_configured
-          "${CMAKE_CURRENT_BINARY_DIR}/${arch_subdir}/glibc.modulemap.gyb")
-      configure_file(
-          ${glibc_modulemap_gyb_source}
-          ${glibc_modulemap_gyb_configured}
-          @ONLY)
+      handle_gyb_source_single(glibc_modulemap_target
+          SOURCE "${glibc_modulemap_source}"
+          OUTPUT "${glibc_modulemap_out}"
+          FLAGS
+              "-DCMAKE_SDK=${sdk}"
+              "-DGLIBC_INCLUDE_PATH=${GLIBC_INCLUDE_PATH}"
+              "-DGLIBC_ARCH_INCLUDE_PATH=${GLIBC_ARCH_INCLUDE_PATH}")
 
-      set(gyb_tool "${SWIFT_SOURCE_DIR}/utils/gyb")
-      set(glibc_modulemap_configured
-          "${CMAKE_CURRENT_BINARY_DIR}/${arch_subdir}/glibc.modulemap")
-      add_custom_command_target(glibc_modulemap_target
-          # We can't use handle_gyb_sources() here because we need to ensure
-          # gyb is invoked before we copy glibc.modulemap into the module dir.
-          # FIXME: Instead of using a combination of configure_file() and gyb,
-          #        we should use just gyb--it'd be simpler.
-          COMMAND
-              ${gyb_tool} "-DCMAKE_SDK=${sdk}" -o ${glibc_modulemap_configured} ${glibc_modulemap_gyb_configured}
-          COMMAND
-              ${CMAKE_COMMAND} -E make_directory ${module_dir}
-          COMMAND
-              ${CMAKE_COMMAND} -E copy_if_different
-              ${glibc_modulemap_configured}
-              "${module_dir}/glibc.modulemap"
-          OUTPUT "${module_dir}/glibc.modulemap"
-          DEPENDS ${glibc_modulemap_configured}
-          COMMENT "Copying Glibc module to ${module_dir}")
-
-      swift_install_in_component(stdlib
-          FILES "${module_dir}/glibc.modulemap"
+      swift_install_in_component(sdk-overlay
+          FILES "${glibc_modulemap_out}"
           DESTINATION "lib/swift/${arch_subdir}")
 
       list(APPEND glibc_modulemap_target_list ${glibc_modulemap_target})
     endforeach()
   endif()
 endforeach()
-add_custom_target(glibc_modulemap ALL DEPENDS ${glibc_modulemap_target_list})
+add_custom_target(glibc_modulemap DEPENDS ${glibc_modulemap_target_list})

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -29,110 +29,110 @@ module SwiftGlibc [system] {
   module C {
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
     module complex {
-      header "@GLIBC_INCLUDE_PATH@/complex.h"
+      header "${GLIBC_INCLUDE_PATH}/complex.h"
       export *
     }
 % end
 
 % if CMAKE_SDK in ["LINUX", "ANDROID", "CYGWIN"]:
     module features {
-      header "@GLIBC_INCLUDE_PATH@/features.h"
+      header "${GLIBC_INCLUDE_PATH}/features.h"
       export *
     }
 % end
 
     module ctype {
-      header "@GLIBC_INCLUDE_PATH@/ctype.h"
+      header "${GLIBC_INCLUDE_PATH}/ctype.h"
       export *
     }
     module errno {
-      header "@GLIBC_INCLUDE_PATH@/errno.h"
+      header "${GLIBC_INCLUDE_PATH}/errno.h"
       export *
     }
 
     module fenv {
-      header "@GLIBC_INCLUDE_PATH@/fenv.h"
+      header "${GLIBC_INCLUDE_PATH}/fenv.h"
       export *
     }
 
     // note: supplied by compiler
     // module float {
-    //   header "@GLIBC_INCLUDE_PATH@/float.h"
+    //   header "${GLIBC_INCLUDE_PATH}/float.h"
     //   export *
     // }
 
     module inttypes {
-      header "@GLIBC_INCLUDE_PATH@/inttypes.h"
+      header "${GLIBC_INCLUDE_PATH}/inttypes.h"
       export *
     }
 
     // note: potentially supplied by compiler
     // module iso646 {
-    //   header "@GLIBC_INCLUDE_PATH@/iso646.h"
+    //   header "${GLIBC_INCLUDE_PATH}/iso646.h"
     //   export *
     // }
     // module limits {
-    //   header "@GLIBC_INCLUDE_PATH@/limits.h"
+    //   header "${GLIBC_INCLUDE_PATH}/limits.h"
     //   export *
     // }
 
     module locale {
-      header "@GLIBC_INCLUDE_PATH@/locale.h"
+      header "${GLIBC_INCLUDE_PATH}/locale.h"
       export *
     }
     module math {
-      header "@GLIBC_INCLUDE_PATH@/math.h"
+      header "${GLIBC_INCLUDE_PATH}/math.h"
       export *
     }
     module setjmp {
-      header "@GLIBC_INCLUDE_PATH@/setjmp.h"
+      header "${GLIBC_INCLUDE_PATH}/setjmp.h"
       export *
     }
     module signal {
-      header "@GLIBC_INCLUDE_PATH@/signal.h"
+      header "${GLIBC_INCLUDE_PATH}/signal.h"
       export *
     }
 
     // note: supplied by the compiler
     // module stdarg {
-    //   header "@GLIBC_INCLUDE_PATH@/stdarg.h"
+    //   header "${GLIBC_INCLUDE_PATH}/stdarg.h"
     //   export *
     // }
     // module stdbool {
-    //   header "@GLIBC_INCLUDE_PATH@/stdbool.h"
+    //   header "${GLIBC_INCLUDE_PATH}/stdbool.h"
     //   export *
     // }
     // module stddef {
-    //   header "@GLIBC_INCLUDE_PATH@/stddef.h"
+    //   header "${GLIBC_INCLUDE_PATH}/stddef.h"
     //   export *
     // }
     // module stdint {
-    //   header "@GLIBC_INCLUDE_PATH@/stdint.h"
+    //   header "${GLIBC_INCLUDE_PATH}/stdint.h"
     //   export *
     // }
 
     module stdio {
-      header "@GLIBC_INCLUDE_PATH@/stdio.h"
+      header "${GLIBC_INCLUDE_PATH}/stdio.h"
       export *
     }
     module stdlib {
-      header "@GLIBC_INCLUDE_PATH@/stdlib.h"
+      header "${GLIBC_INCLUDE_PATH}/stdlib.h"
       export *
       export stddef
     }
     module string {
-      header "@GLIBC_INCLUDE_PATH@/string.h"
+      header "${GLIBC_INCLUDE_PATH}/string.h"
       export *
     }
 
     // note: supplied by the compiler
     // explicit module tgmath {
-    //   header "@GLIBC_INCLUDE_PATH@/tgmath.h"
+    //   header "${GLIBC_INCLUDE_PATH}/tgmath.h"
     //   export *
     // }
 
     module time {
-      header "@GLIBC_INCLUDE_PATH@/time.h"
+      header "${GLIBC_INCLUDE_PATH}/time.h"
       export *
     }
   }
@@ -141,164 +141,164 @@ module SwiftGlibc [system] {
   module POSIX {
 % if CMAKE_SDK in ["LINUX", "CYGWIN"]:
     module wait {
-      header "@GLIBC_INCLUDE_PATH@/wait.h"
+      header "${GLIBC_INCLUDE_PATH}/wait.h"
       export *
     }
 % end
 
 % if CMAKE_SDK in ["LINUX", "FREEBSD"]:
     module aio {
-      header "@GLIBC_INCLUDE_PATH@/aio.h"
+      header "${GLIBC_INCLUDE_PATH}/aio.h"
       export *
     }
     module cpio {
-      header "@GLIBC_INCLUDE_PATH@/cpio.h"
+      header "${GLIBC_INCLUDE_PATH}/cpio.h"
       export *
     }
     module fmtmsg {
-      header "@GLIBC_INCLUDE_PATH@/fmtmsg.h"
+      header "${GLIBC_INCLUDE_PATH}/fmtmsg.h"
       export *
     }
     module nl_types {
-      header "@GLIBC_INCLUDE_PATH@/nl_types.h"
+      header "${GLIBC_INCLUDE_PATH}/nl_types.h"
       export *
     }
     module ulimit {
-      header "@GLIBC_INCLUDE_PATH@/ulimit.h"
+      header "${GLIBC_INCLUDE_PATH}/ulimit.h"
       export *
     }
 % end
 
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
     module ftw {
-      header "@GLIBC_INCLUDE_PATH@/ftw.h"
+      header "${GLIBC_INCLUDE_PATH}/ftw.h"
       export *
     }
     module glob {
-      header "@GLIBC_INCLUDE_PATH@/glob.h"
+      header "${GLIBC_INCLUDE_PATH}/glob.h"
       export *
     }
     module iconv {
-      header "@GLIBC_INCLUDE_PATH@/iconv.h"
+      header "${GLIBC_INCLUDE_PATH}/iconv.h"
       export *
     }
     module langinfo {
-      header "@GLIBC_INCLUDE_PATH@/langinfo.h"
+      header "${GLIBC_INCLUDE_PATH}/langinfo.h"
       export *
     }
     module monetary {
-      header "@GLIBC_INCLUDE_PATH@/monetary.h"
+      header "${GLIBC_INCLUDE_PATH}/monetary.h"
       export *
     }
     module netdb {
-      header "@GLIBC_INCLUDE_PATH@/netdb.h"
+      header "${GLIBC_INCLUDE_PATH}/netdb.h"
       export *
     }
     module search {
-      header "@GLIBC_INCLUDE_PATH@/search.h"
+      header "${GLIBC_INCLUDE_PATH}/search.h"
       export *
     }
     module spawn {
-      header "@GLIBC_INCLUDE_PATH@/spawn.h"
+      header "${GLIBC_INCLUDE_PATH}/spawn.h"
       export *
     }
     module syslog {
-      header "@GLIBC_INCLUDE_PATH@/syslog.h"
+      header "${GLIBC_INCLUDE_PATH}/syslog.h"
       export *
     }
     module tar {
-      header "@GLIBC_INCLUDE_PATH@/tar.h"
+      header "${GLIBC_INCLUDE_PATH}/tar.h"
       export *
     }
     module utmpx {
-      header "@GLIBC_INCLUDE_PATH@/utmpx.h"
+      header "${GLIBC_INCLUDE_PATH}/utmpx.h"
       export *
     }
     module wordexp {
-      header "@GLIBC_INCLUDE_PATH@/wordexp.h"
+      header "${GLIBC_INCLUDE_PATH}/wordexp.h"
       export *
     }
 % end
 
     module arpa {
       module inet {
-        header "@GLIBC_INCLUDE_PATH@/arpa/inet.h"
+        header "${GLIBC_INCLUDE_PATH}/arpa/inet.h"
         export *
       }
       export *
     }
     module dirent {
-      header "@GLIBC_INCLUDE_PATH@/dirent.h"
+      header "${GLIBC_INCLUDE_PATH}/dirent.h"
       export *
     }
     module dlfcn {
-      header "@GLIBC_INCLUDE_PATH@/dlfcn.h"
+      header "${GLIBC_INCLUDE_PATH}/dlfcn.h"
       export *
     }
     module fcntl {
-      header "@GLIBC_INCLUDE_PATH@/fcntl.h"
+      header "${GLIBC_INCLUDE_PATH}/fcntl.h"
       export *
     }
     module fnmatch {
-      header "@GLIBC_INCLUDE_PATH@/fnmatch.h"
+      header "${GLIBC_INCLUDE_PATH}/fnmatch.h"
       export *
     }
     module grp {
-      header "@GLIBC_INCLUDE_PATH@/grp.h"
+      header "${GLIBC_INCLUDE_PATH}/grp.h"
       export *
     }
     module ioctl {
-      header "@GLIBC_ARCH_INCLUDE_PATH@/sys/ioctl.h"
+      header "${GLIBC_ARCH_INCLUDE_PATH}/sys/ioctl.h"
       export *
     }
     module libgen {
-      header "@GLIBC_INCLUDE_PATH@/libgen.h"
+      header "${GLIBC_INCLUDE_PATH}/libgen.h"
       export *
     }
     module net {
       module if {
-        header "@GLIBC_INCLUDE_PATH@/net/if.h"
+        header "${GLIBC_INCLUDE_PATH}/net/if.h"
         export *
       }
     }
     module netinet {
       module in {
-        header "@GLIBC_INCLUDE_PATH@/netinet/in.h"
+        header "${GLIBC_INCLUDE_PATH}/netinet/in.h"
         export *
 
-        exclude header "@GLIBC_INCLUDE_PATH@/netinet6/in6.h"
+        exclude header "${GLIBC_INCLUDE_PATH}/netinet6/in6.h"
       }
       module tcp {
-        header "@GLIBC_INCLUDE_PATH@/netinet/tcp.h"
+        header "${GLIBC_INCLUDE_PATH}/netinet/tcp.h"
         export *
       }
     }
     module poll {
-      header "@GLIBC_INCLUDE_PATH@/poll.h"
+      header "${GLIBC_INCLUDE_PATH}/poll.h"
       export *
     }
     module pthread {
-      header "@GLIBC_INCLUDE_PATH@/pthread.h"
+      header "${GLIBC_INCLUDE_PATH}/pthread.h"
       export *
     }
     module pwd {
-      header "@GLIBC_INCLUDE_PATH@/pwd.h"
+      header "${GLIBC_INCLUDE_PATH}/pwd.h"
       export *
     }
     module regex {
-      header "@GLIBC_INCLUDE_PATH@/regex.h"
+      header "${GLIBC_INCLUDE_PATH}/regex.h"
       export *
     }
     module sched {
-      header "@GLIBC_INCLUDE_PATH@/sched.h"
+      header "${GLIBC_INCLUDE_PATH}/sched.h"
       export *
     }
     module semaphore {
-      header "@GLIBC_INCLUDE_PATH@/semaphore.h"
+      header "${GLIBC_INCLUDE_PATH}/semaphore.h"
       export *
     }
     module strings {
-      header "@GLIBC_INCLUDE_PATH@/strings.h"
+      header "${GLIBC_INCLUDE_PATH}/strings.h"
       export *
     }
 
@@ -307,86 +307,86 @@ module SwiftGlibc [system] {
 
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN"]:
       module sem {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/sem.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/sem.h"
         export *
       }
       module shm {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/shm.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/shm.h"
         export *
       }
       module statvfs {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/statvfs.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/statvfs.h"
         export *
       }
 % end
 
       module ipc {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/ipc.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/ipc.h"
         export *
       }
       module mman {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/mman.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/mman.h"
         export *
       }
       module msg {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/msg.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/msg.h"
         export *
       }
       module resource {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/resource.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/resource.h"
         export *
       }
       module select {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/select.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/select.h"
         export *
       }
       module socket {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/socket.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/socket.h"
         export *
       }
       module stat {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/stat.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/stat.h"
         export *
       }
       module time {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/time.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/time.h"
         export *
       }
       module times {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/times.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/times.h"
         export *
       }
       module types {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/types.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/types.h"
         export *
       }
       module uio {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/uio.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/uio.h"
         export *
       }
       module un {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/un.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/un.h"
         export *
       }
       module utsname {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/utsname.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
         export *
       }
       module wait {
-        header "@GLIBC_ARCH_INCLUDE_PATH@/sys/wait.h"
+        header "${GLIBC_ARCH_INCLUDE_PATH}/sys/wait.h"
         export *
       }
     }
     module termios {
-      header "@GLIBC_INCLUDE_PATH@/termios.h"
+      header "${GLIBC_INCLUDE_PATH}/termios.h"
       export *
     }
     module unistd {
-      header "@GLIBC_INCLUDE_PATH@/unistd.h"
+      header "${GLIBC_INCLUDE_PATH}/unistd.h"
       export *
     }
     module utime {
-      header "@GLIBC_INCLUDE_PATH@/utime.h"
+      header "${GLIBC_INCLUDE_PATH}/utime.h"
       export *
     }
   }


### PR DESCRIPTION
#### What's in this pull request?

Follow up on #2081.
CC: @modocache @gribozavr 

All `glibc.modulemap` configuration is done only with `gyb` tool now.

Prior to this task, I factored out single gyb processing function in `SwiftHandleGybSources.cmake`: `handle_gyb_source_single()`

Small changes in addition:
- Changed component for `glibc.modulemap` from `stdlib` to `sdk-overlay` because `Glibc` module itself is `sdk-overlay`
- Removed `ALL` from `add_custom_target` because it's not needed to be.
- Removed unused `output_file_name_hash` variable from `handle_gyb_sources`.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
