### PR TITLE
Typeref uniquing

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -56,9 +56,11 @@ public:
 
   template <typename T>
   void addPointer(const T *Pointer) {
-    auto Raw = reinterpret_cast<uintptr_t>(Pointer);
-    Bits.push_back((uint32_t)Raw);
-    Bits.push_back(Raw >> 32);
+    auto Raw = reinterpret_cast<uint32_t *>(&Pointer);
+    Bits.push_back(Raw[0]);
+    if (sizeof(const T *) > 4) {
+      Bits.push_back(Raw[1]);
+    }
   }
 
   void addInteger(uint32_t Integer) {

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -36,6 +36,82 @@ enum class TypeRefKind {
 #undef TYPEREF
 };
 
+/// An identifier containing the unique bit pattern made up of all of the
+/// instance data needed to uniquely identify a TypeRef.
+///
+/// This allows for uniquing (via Equal) and for keying into a dictionary for
+/// caching.
+///
+/// TypeRefs should be comparable by pointers, so if the TypeRefBuilder
+/// gets a request to build a TypeRef with the same constructor arguments,
+/// it should return the one already created with those arguments, not a fresh
+/// copy. This allows for fast identity comparisons and substitutions, for
+/// example. We use a similar strategy for Types in the full AST.
+class TypeRefID {
+
+  std::vector<uint32_t> Bits;
+
+public:
+  TypeRefID() = default;
+
+  template <typename T>
+  void addPointer(const T *Pointer) {
+    auto Raw = reinterpret_cast<uintptr_t>(Pointer);
+    Bits.push_back((uint32_t)Raw);
+    Bits.push_back(Raw >> 32);
+  }
+
+  void addInteger(uint32_t Integer) {
+    Bits.push_back(Integer);
+  }
+
+  void addInteger(uint64_t Integer) {
+    Bits.push_back((uint32_t)Integer);
+    Bits.push_back(Integer >> 32);
+  }
+
+  void addString(const std::string &String) {
+    if (String.empty()) {
+      Bits.push_back(0);
+    } else {
+      size_t i = 0;
+      size_t chunks = String.size() / 4;
+      for (size_t chunk = 0; chunk < chunks; ++chunk, i+=4) {
+        uint32_t entry = ((uint32_t) String[i]) +
+                         (((uint32_t) String[i+1]) << 8) +
+                         (((uint32_t) String[i+2]) << 16) +
+                         (((uint32_t) String[i+3]) << 24);
+        Bits.push_back(entry);
+      }
+      for(; i < String.size(); ++i) {
+        Bits.push_back(String[i]);
+      }
+    }
+  }
+
+  struct Hash {
+    std::size_t operator()(TypeRefID const &ID) const {
+      size_t Hash = 0;
+      std::hash<uint32_t> h;
+      for (auto x : ID.Bits) {
+        Hash ^= h(x) + 0x9e3779b9 + (Hash << 6) + (Hash >> 2);
+      }
+      return Hash;
+    }
+  };
+
+  struct Equal {
+    bool operator()(const TypeRefID &lhs, const TypeRefID &rhs) const {
+      return lhs.Bits == rhs.Bits;
+    }
+  };
+
+
+  bool operator==(const TypeRefID &Other) {
+    return Bits == Other.Bits;
+  }
+};
+
 class TypeRef;
 class TypeRefBuilder;
 using DepthAndIndex = std::pair<unsigned, unsigned>;
@@ -80,6 +156,12 @@ public:
     return MangledName;
   }
 
+  static TypeRefID Profile(const std::string &MangledName) {
+    TypeRefID ID;
+    ID.addString(MangledName);
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Builtin;
   }
@@ -107,6 +189,14 @@ public:
   }
 
   unsigned getDepth() const;
+
+  static TypeRefID Profile(const std::string &MangledName,
+                           const TypeRef *Parent) {
+    TypeRefID ID;
+    ID.addString(MangledName);
+    ID.addPointer(Parent);
+    return ID;
+  }
 };
 
 class NominalTypeRef final : public TypeRef, public NominalTypeTrait {
@@ -121,6 +211,8 @@ public:
                                       const TypeRef *Parent = nullptr) {
     return A.template makeTypeRef<NominalTypeRef>(MangledName, Parent);
   }
+
+  using NominalTypeTrait::Profile;
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Nominal;
@@ -152,6 +244,17 @@ public:
     return GenericParams;
   }
 
+  static TypeRefID Profile(const std::string &MangledName,
+                           const std::vector<const TypeRef *> &GenericParams,
+                           const TypeRef *Parent) {
+    TypeRefID ID;
+    ID.addString(MangledName);
+    for (auto Param : GenericParams)
+      ID.addPointer(Param);
+    ID.addPointer(Parent);
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::BoundGeneric;
   }
@@ -178,6 +281,16 @@ public:
 
   bool isVariadic() const {
     return Variadic;
+  }
+
+  static TypeRefID Profile(const std::vector<const TypeRef *> &Elements,
+                           bool Variadic) {
+    TypeRefID ID;
+    for (auto Element : Elements)
+      ID.addPointer(Element);
+
+    ID.addInteger(static_cast<uint32_t>(Variadic));
+    return ID;
   }
 
   static bool classof(const TypeRef *TR) {
@@ -216,6 +329,18 @@ public:
     return Flags;
   }
 
+  static TypeRefID Profile(const std::vector<const TypeRef *> &Arguments,
+                           const TypeRef *Result,
+                           FunctionTypeFlags Flags) {
+    TypeRefID ID;
+    for (auto Argument : Arguments) {
+      ID.addPointer(Argument);
+    }
+    ID.addPointer(Result);
+    ID.addInteger(static_cast<uint64_t>(Flags.getIntValue()));
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Function;
   }
@@ -236,6 +361,12 @@ public:
 
   const std::string &getMangledName() const {
     return MangledName;
+  }
+
+  static TypeRefID Profile(const std::string &MangledName) {
+    TypeRefID ID;
+    ID.addString(MangledName);
+    return ID;
   }
 
   static bool classof(const TypeRef *TR) {
@@ -267,6 +398,14 @@ public:
     return Protocols;
   }
 
+  static TypeRefID Profile(const std::vector<const TypeRef *> &Protocols) {
+    TypeRefID ID;
+    for (auto Protocol : Protocols) {
+      ID.addPointer(Protocol);
+    }
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::ProtocolComposition;
   }
@@ -296,6 +435,12 @@ public:
     return InstanceType;
   }
 
+  static TypeRefID Profile(const TypeRef *InstanceType) {
+    TypeRefID ID;
+    ID.addPointer(InstanceType);
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Metatype;
   }
@@ -316,6 +461,12 @@ public:
 
   const TypeRef *getInstanceType() const {
     return InstanceType;
+  }
+
+  static TypeRefID Profile(const TypeRef *InstanceType) {
+    TypeRefID ID;
+    ID.addPointer(InstanceType);
+    return ID;
   }
 
   static bool classof(const TypeRef *TR) {
@@ -343,6 +494,13 @@ public:
 
   uint32_t getIndex() const {
     return Index;
+  }
+
+  static TypeRefID Profile(uint32_t Depth, uint32_t Index) {
+    TypeRefID ID;
+    ID.addInteger(Depth);
+    ID.addInteger(Index);
+    return ID;
   }
 
   static bool classof(const TypeRef *TR) {
@@ -381,6 +539,15 @@ public:
     return cast<ProtocolTypeRef>(Protocol);
   }
 
+  static TypeRefID Profile(const std::string &Member, const TypeRef *Base,
+                           const TypeRef *Protocol) {
+    TypeRefID ID;
+    ID.addString(Member);
+    ID.addPointer(Base);
+    ID.addPointer(Protocol);
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::DependentMember;
   }
@@ -388,13 +555,9 @@ public:
 
 class ForeignClassTypeRef final : public TypeRef {
   std::string Name;
-  static const ForeignClassTypeRef *UnnamedSingleton;
 public:
   ForeignClassTypeRef(const std::string &Name)
     : TypeRef(TypeRefKind::ForeignClass), Name(Name) {}
-
-  static const ForeignClassTypeRef *getUnnamed();
-
 
   template <typename Allocator>
   static ForeignClassTypeRef *create(Allocator &A,
@@ -404,6 +567,12 @@ public:
 
   const std::string &getName() const {
     return Name;
+  }
+
+  static TypeRefID Profile(const std::string &Name) {
+    TypeRefID ID;
+    ID.addString(Name);
+    return ID;
   }
 
   static bool classof(const TypeRef *TR) {
@@ -429,6 +598,12 @@ public:
     return Name;
   }
 
+  static TypeRefID Profile(const std::string &Name) {
+    TypeRefID ID;
+    ID.addString(Name);
+    return ID;
+  }
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::ObjCClass;
   }
@@ -440,6 +615,10 @@ public:
   OpaqueTypeRef() : TypeRef(TypeRefKind::Opaque) {}
 
   static const OpaqueTypeRef *get();
+
+  static TypeRefID Profile() {
+    return TypeRefID();
+  }
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::Opaque;
@@ -457,6 +636,12 @@ public:
   const TypeRef *getType() const {
     return Type;
   }
+
+  static TypeRefID Profile(const TypeRef *Type) {
+    TypeRefID ID;
+    ID.addPointer(Type);
+    return ID;
+  }
 };
 
 class UnownedStorageTypeRef final : public ReferenceStorageTypeRef {
@@ -469,6 +654,8 @@ public:
                                        const TypeRef *Type) {
     return A.template makeTypeRef<UnownedStorageTypeRef>(Type);
   }
+
+  using ReferenceStorageTypeRef::Profile;
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::UnownedStorage;
@@ -486,6 +673,8 @@ public:
     return A.template makeTypeRef<WeakStorageTypeRef>(Type);
   }
 
+  using ReferenceStorageTypeRef::Profile;
+
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::WeakStorage;
   }
@@ -501,6 +690,8 @@ public:
                                                const TypeRef *Type) {
     return A.template makeTypeRef<UnmanagedStorageTypeRef>(Type);
   }
+
+  using ReferenceStorageTypeRef::Profile;
 
   static bool classof(const TypeRef *TR) {
     return TR->getKind() == TypeRefKind::UnmanagedStorage;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -96,6 +96,8 @@ public:
   TypeRefBuilder &operator=(const TypeRefBuilder &other) = delete;
 
 private:
+  /// Makes sure dynamically allocated TypeRefs stick around for the life of
+  /// this TypeRefBuilder and are automatically released.
   std::vector<std::unique_ptr<const TypeRef>> TypeRefPool;
   TypeConverter TC;
 
@@ -115,7 +117,8 @@ public:
     return BuiltinTypeRef::create(*this, mangledName);
   }
 
-  Optional<std::string> createNominalTypeDecl(const Demangle::NodePointer &node) {
+  Optional<std::string>
+  createNominalTypeDecl(const Demangle::NodePointer &node) {
     return Demangle::mangleNode(node);
   }
 

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -99,6 +99,21 @@ private:
   /// Makes sure dynamically allocated TypeRefs stick around for the life of
   /// this TypeRefBuilder and are automatically released.
   std::vector<std::unique_ptr<const TypeRef>> TypeRefPool;
+
+#define TYPEREF(Id, Parent) \
+  std::unordered_map<TypeRefID, const Id##TypeRef *, \
+                     TypeRefID::Hash, TypeRefID::Equal> Id##TypeRefs;
+#include "swift/Reflection/TypeRefs.def"
+
+#define FIND_OR_CREATE_TYPEREF(TypeRefTy, ...) \
+  auto ID = TypeRefTy::Profile(__VA_ARGS__); \
+  auto Entry = TypeRefTy##s.find(ID); \
+  if (Entry != TypeRefTy##s.end()) \
+    return Entry->second; \
+  auto TR = TypeRefTy::create(*this, __VA_ARGS__); \
+  TypeRefTy##s.insert({ID, TR}); \
+  return TR;
+
   TypeConverter TC;
 
 public:
@@ -114,7 +129,7 @@ public:
   ///
 
   const BuiltinTypeRef *createBuiltinType(const std::string &mangledName) {
-    return BuiltinTypeRef::create(*this, mangledName);
+    FIND_OR_CREATE_TYPEREF(BuiltinTypeRef, mangledName);
   }
 
   Optional<std::string>
@@ -129,20 +144,22 @@ public:
   const NominalTypeRef *createNominalType(
                                     const Optional<std::string> &mangledName,
                                     const TypeRef *parent) {
-    return NominalTypeRef::create(*this, *mangledName, parent);
+    FIND_OR_CREATE_TYPEREF(NominalTypeRef, *mangledName, parent);
   }
 
   const BoundGenericTypeRef *
   createBoundGenericType(const Optional<std::string> &mangledName,
                          const std::vector<const TypeRef *> &args,
                          const TypeRef *parent) {
-    return BoundGenericTypeRef::create(*this, *mangledName, args, parent);
+    FIND_OR_CREATE_TYPEREF(BoundGenericTypeRef, *mangledName, args, parent);
   }
 
   const TupleTypeRef *
   createTupleType(const std::vector<const TypeRef *> &elements,
                   std::string &&labels, bool isVariadic) {
-    return TupleTypeRef::create(*this, elements, isVariadic);
+    // FIXME: Add uniqueness checks in TupleTypeRef::Profile and
+    // unittests/Reflection/TypeRef.cpp if using labels for identity.
+    FIND_OR_CREATE_TYPEREF(TupleTypeRef, elements, isVariadic);
   }
 
   const FunctionTypeRef *
@@ -151,13 +168,14 @@ public:
                      const TypeRef *result,
                      FunctionTypeFlags flags) {
     // FIXME: don't ignore inOutArgs
-    return FunctionTypeRef::create(*this, args, result, flags);
+    // and add test to unittests/Reflection/TypeRef.cpp
+    FIND_OR_CREATE_TYPEREF(FunctionTypeRef, args, result, flags);
   }
 
   const ProtocolTypeRef *createProtocolType(const std::string &mangledName,
                                             const std::string &moduleName,
                                             const std::string &name) {
-    return ProtocolTypeRef::create(*this, mangledName);
+    FIND_OR_CREATE_TYPEREF(ProtocolTypeRef, mangledName);
   }
 
   const ProtocolCompositionTypeRef *
@@ -166,21 +184,21 @@ public:
       if (!isa<ProtocolTypeRef>(protocol))
         return nullptr;
     }
-    return ProtocolCompositionTypeRef::create(*this, protocols);
+    FIND_OR_CREATE_TYPEREF(ProtocolCompositionTypeRef, protocols);
   }
 
   const ExistentialMetatypeTypeRef *
   createExistentialMetatypeType(const TypeRef *instance) {
-    return ExistentialMetatypeTypeRef::create(*this, instance);
+    FIND_OR_CREATE_TYPEREF(ExistentialMetatypeTypeRef, instance);
   }
 
   const MetatypeTypeRef *createMetatypeType(const TypeRef *instance) {
-    return MetatypeTypeRef::create(*this, instance);
+    FIND_OR_CREATE_TYPEREF(MetatypeTypeRef, instance);
   }
 
   const GenericTypeParameterTypeRef *
   createGenericTypeParameterType(unsigned depth, unsigned index) {
-    return GenericTypeParameterTypeRef::create(*this, depth, index);
+    FIND_OR_CREATE_TYPEREF(GenericTypeParameterTypeRef, depth, index);
   }
 
   const DependentMemberTypeRef *
@@ -189,32 +207,39 @@ public:
                             const TypeRef *protocol) {
     if (!isa<ProtocolTypeRef>(protocol))
       return nullptr;
-    return DependentMemberTypeRef::create(*this, member, base, protocol);
+    FIND_OR_CREATE_TYPEREF(DependentMemberTypeRef, member, base, protocol);
   }
 
   const UnownedStorageTypeRef *createUnownedStorageType(const TypeRef *base) {
-    return UnownedStorageTypeRef::create(*this, base);
+    FIND_OR_CREATE_TYPEREF(UnownedStorageTypeRef, base);
   }
 
   const UnmanagedStorageTypeRef *
   createUnmanagedStorageType(const TypeRef *base) {
-    return UnmanagedStorageTypeRef::create(*this, base);
+    FIND_OR_CREATE_TYPEREF(UnmanagedStorageTypeRef, base);
   }
 
   const WeakStorageTypeRef *createWeakStorageType(const TypeRef *base) {
-    return WeakStorageTypeRef::create(*this, base);
+    FIND_OR_CREATE_TYPEREF(WeakStorageTypeRef, base);
+  }
+
+  const ObjCClassTypeRef *
+  createObjCClassType(const std::string &mangledName) {
+    FIND_OR_CREATE_TYPEREF(ObjCClassTypeRef, mangledName);
   }
 
   const ObjCClassTypeRef *getUnnamedObjCClassType() {
-    return ObjCClassTypeRef::getUnnamed();
+    return createObjCClassType("");
   }
 
-  const ForeignClassTypeRef *createForeignClassType(std::string &&mangledName) {
-    return ForeignClassTypeRef::getUnnamed(); // FIXME
+  const ForeignClassTypeRef *
+  createForeignClassType(const std::string &mangledName) {
+    FIND_OR_CREATE_TYPEREF(ForeignClassTypeRef, mangledName);
   }
 
-  const ForeignClassTypeRef *getUnnamedForeignClassType() {
-    return ForeignClassTypeRef::getUnnamed();
+  const ForeignClassTypeRef *
+  getUnnamedForeignClassType() {
+    return createForeignClassType("");
   }
 
   const OpaqueTypeRef *getOpaqueType() {

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -300,20 +300,6 @@ struct TypeRefIsConcrete
   }
 };
 
-const ForeignClassTypeRef *
-ForeignClassTypeRef::UnnamedSingleton = new ForeignClassTypeRef("");
-
-const ForeignClassTypeRef *ForeignClassTypeRef::getUnnamed() {
-  return UnnamedSingleton;
-}
-
-const ObjCClassTypeRef *
-ObjCClassTypeRef::UnnamedSingleton = new ObjCClassTypeRef("");
-
-const ObjCClassTypeRef *ObjCClassTypeRef::getUnnamed() {
-  return UnnamedSingleton;
-}
-
 const OpaqueTypeRef *
 OpaqueTypeRef::Singleton = new OpaqueTypeRef();
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -52,6 +52,7 @@ if(SWIFT_BUILD_TOOLS)
     #
     # FIXME: cross-compile runtime unittests.
     add_subdirectory(runtime)
+    add_subdirectory(Reflection)
   endif()
 
   if(SWIFT_BUILD_SOURCEKIT)

--- a/unittests/Reflection/CMakeLists.txt
+++ b/unittests/Reflection/CMakeLists.txt
@@ -1,0 +1,9 @@
+if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
+   ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
+  if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
+    add_swift_unittest(SwiftReflectionTests
+      TypeRef.cpp)
+    target_link_libraries(SwiftReflectionTests
+      swiftReflection${SWIFT_PRIMARY_VARIANT_SUFFIX})
+  endif()
+endif()

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -1,0 +1,313 @@
+//===--- TypeRef.cpp - TypeRef tests --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Reflection/TypeRefBuilder.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace reflection;
+
+static const std::string ABC = "ABC";
+static const std::string ABCD = "ABCD";
+static const std::string XYZ = "XYZ";
+static const std::string Empty = "";
+static const std::string MyClass = "MyClass";
+static const std::string NotMyClass = "NotMyClass";
+static const std::string Module = "Module";
+static const std::string Shmodule = "Shmodule";
+static const std::string Protocol = "Protocol";
+static const std::string Shmrotocol = "Shmrotocol";
+
+TEST(TypeRefTest, UniqueBuiltinTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto BI1 = Builder.createBuiltinType(ABC);
+  auto BI2 = Builder.createBuiltinType(ABC);
+  auto BI3 = Builder.createBuiltinType(ABCD);
+
+  EXPECT_EQ(BI1, BI2);
+  EXPECT_NE(BI2, BI3);
+}
+
+TEST(TypeRefTest, UniqueNominalTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto N2 = Builder.createNominalType(ABC, nullptr);
+  auto N3 = Builder.createNominalType(ABCD, nullptr);
+
+  EXPECT_EQ(N1, N2);
+  EXPECT_NE(N2, N3);
+
+  auto N4 = Builder.createNominalType(ABC, N1);
+  auto N5 = Builder.createNominalType(ABC, N1);
+
+  EXPECT_EQ(N4, N5);
+  EXPECT_NE(N4, N1);
+}
+
+TEST(TypeRefTest, UniqueBoundGenericTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
+  auto GTP01 = Builder.createGenericTypeParameterType(0, 1);
+
+  auto BG1 = Builder.createBoundGenericType(ABC, {}, nullptr);
+  auto BG2 = Builder.createBoundGenericType(ABC, {}, nullptr);
+  auto BG3 = Builder.createBoundGenericType(ABCD, {}, nullptr);
+
+  EXPECT_EQ(BG1, BG2);
+  EXPECT_NE(BG2, BG3);
+
+  std::vector<const TypeRef *> GenericParams { GTP00, GTP01 };
+
+  auto BG4 = Builder.createBoundGenericType(ABC, GenericParams, nullptr);
+  auto BG5 = Builder.createBoundGenericType(ABC, GenericParams, nullptr);
+  auto BG6 = Builder.createBoundGenericType(ABC, GenericParams, BG1);
+
+  EXPECT_EQ(BG4, BG5);
+  EXPECT_NE(BG5, BG6);
+  EXPECT_NE(BG5, BG1);
+}
+
+TEST(TypeRefTest, UniqueTupleTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto N2 = Builder.createNominalType(XYZ, nullptr);
+
+  std::vector<const TypeRef *> Void;
+  auto Void1 = Builder.createTupleType(Void, "", false);
+  auto Void2 = Builder.createTupleType(Void, "", false);
+
+  EXPECT_EQ(Void1, Void2);
+
+  std::vector<const TypeRef *> Elements1 { N1, N2 };
+  std::vector<const TypeRef *> Elements2 { N1, N2, N2 };
+
+  auto T1 = Builder.createTupleType(Elements1, "", false);
+  auto T2 = Builder.createTupleType(Elements1, "", false);
+  auto T3 = Builder.createTupleType(Elements2, "", false);
+
+  EXPECT_EQ(T1, T2);
+  EXPECT_NE(T2, T3);
+  EXPECT_NE(T1, Void1);
+
+  auto T4 = Builder.createTupleType(Elements1, "", true);
+  auto T5 = Builder.createTupleType(Elements1, "", true);
+  auto T6 = Builder.createTupleType(Elements1, "", false);
+
+  EXPECT_EQ(T4, T5);
+  EXPECT_NE(T5, T6);
+}
+
+TEST(TypeRefTest, UniqueFunctionTypeRef) {
+
+  TypeRefBuilder Builder;
+
+  std::vector<const TypeRef *> Void;
+  auto VoidResult = Builder.createTupleType(Void, "", false);
+  std::vector<bool> VoidInout;
+  auto Arg1 = Builder.createNominalType(ABC, nullptr);
+  auto Arg2 = Builder.createNominalType(XYZ, nullptr);
+
+  std::vector<const TypeRef *> Arguments1 { Arg1, Arg2 };
+  std::vector<bool> Inout1 { false, false };
+  auto Result = Builder.createTupleType({Arg1, Arg2}, "", false);
+
+  std::vector<const TypeRef *> Arguments2 { Arg1, Arg1 };
+  std::vector<bool> Inout2 { false, false };
+
+  auto F1 = Builder.createFunctionType(Arguments1, Inout1, Result,
+                                       FunctionTypeFlags());
+  auto F2 = Builder.createFunctionType(Arguments1, Inout1, Result,
+                                       FunctionTypeFlags());
+  auto F3 = Builder.createFunctionType(Arguments2, Inout1, Result,
+                                       FunctionTypeFlags());
+
+  EXPECT_EQ(F1, F2);
+  EXPECT_NE(F2, F3);
+
+  auto F4 = Builder.createFunctionType(Arguments1, Inout1, Result,
+                                       FunctionTypeFlags().withThrows(true));
+  auto F5 = Builder.createFunctionType(Arguments1, Inout1, Result,
+                                       FunctionTypeFlags().withThrows(true));
+
+  EXPECT_EQ(F4, F5);
+  EXPECT_NE(F4, F1);
+
+  auto VoidVoid1 = Builder.createFunctionType(Void, VoidInout, VoidResult,
+                                              FunctionTypeFlags());
+  auto VoidVoid2 = Builder.createFunctionType(Void, VoidInout, VoidResult,
+                                              FunctionTypeFlags());
+
+  EXPECT_EQ(VoidVoid1, VoidVoid2);
+  EXPECT_NE(VoidVoid1, F1);
+}
+
+TEST(TypeRefTest, UniqueProtocolTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto P1 = Builder.createProtocolType(ABC, Module, Protocol);
+  auto P2 = Builder.createProtocolType(ABC, Module, Protocol);
+  auto P3 = Builder.createProtocolType(ABCD, Module, Shmrotocol);
+  auto P4 = Builder.createProtocolType(XYZ, Shmodule, Protocol);
+
+  EXPECT_EQ(P1, P2);
+  EXPECT_NE(P2, P3);
+  EXPECT_NE(P2, P3);
+  EXPECT_NE(P3, P4);
+
+  auto PC1 = Builder.createProtocolCompositionType({P1, P2});
+  auto PC2 = Builder.createProtocolCompositionType({P1, P2});
+  auto PC3 = Builder.createProtocolCompositionType({P1, P2, P2});
+  auto Any = Builder.createProtocolCompositionType({});
+
+  EXPECT_EQ(PC1, PC2);
+  EXPECT_NE(PC2, PC3);
+  EXPECT_NE(PC1, Any);
+}
+
+TEST(TypeRefTest, UniqueMetatypeTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto M1 = Builder.createMetatypeType(N1);
+  auto M2 = Builder.createMetatypeType(N1);
+  auto MM3 = Builder.createMetatypeType(M1);
+
+  EXPECT_EQ(M1, M2);
+  EXPECT_NE(M2, MM3);
+}
+
+TEST(TypeRefTest, UniqueExistentialMetatypeTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto M1 = Builder.createExistentialMetatypeType(N1);
+  auto M2 = Builder.createExistentialMetatypeType(N1);
+  auto MM3 = Builder.createExistentialMetatypeType(M1);
+
+  EXPECT_EQ(M1, M2);
+  EXPECT_NE(M2, MM3);
+}
+
+TEST(TypeRefTest, UniqueGenericTypeParameterTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
+  auto GTP00_2 = Builder.createGenericTypeParameterType(0, 0);
+  auto GTP01 = Builder.createGenericTypeParameterType(0, 1);
+  auto GTP10 = Builder.createGenericTypeParameterType(1, 0);
+
+  EXPECT_EQ(GTP00, GTP00_2);
+  EXPECT_NE(GTP00, GTP01);
+  EXPECT_NE(GTP01, GTP10);
+}
+
+TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto N2 = Builder.createNominalType(XYZ, nullptr);
+  auto P1 = Builder.createProtocolType(ABC, Module, Protocol);
+  auto P2 = Builder.createProtocolType(ABCD, Shmodule, Protocol);
+
+  auto DM1 = Builder.createDependentMemberType("Index", N1, P1);
+  auto DM2 = Builder.createDependentMemberType("Index", N1, P1);
+  auto DM3 = Builder.createDependentMemberType("Element", N1, P1);
+  auto DM4 = Builder.createDependentMemberType("Index", N2, P1);
+  auto DM5 = Builder.createDependentMemberType("Index", N2, P2);
+
+  EXPECT_EQ(DM1, DM2);
+  EXPECT_NE(DM2, DM3);
+  EXPECT_NE(DM2, DM4);
+  EXPECT_NE(DM4, DM5);
+}
+
+TEST(TypeRefTest, UniqueForeignClassTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto UN1 = Builder.getUnnamedForeignClassType();
+  auto UN2 = Builder.getUnnamedForeignClassType();
+  auto FC1 = Builder.createForeignClassType(ABC);
+  auto FC2 = Builder.createForeignClassType(ABC);
+  auto FC3 = Builder.createForeignClassType(ABCD);
+
+  EXPECT_EQ(UN1, UN2);
+  EXPECT_EQ(FC1, FC2);
+  EXPECT_NE(FC2, FC3);
+}
+
+TEST(TypeRefTest, UniqueObjCClassTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto UN1 = Builder.getUnnamedObjCClassType();
+  auto UN2 = Builder.getUnnamedObjCClassType();
+  auto FC1 = Builder.createObjCClassType(ABC);
+  auto FC2 = Builder.createObjCClassType(ABC);
+  auto FC3 = Builder.createObjCClassType(ABCD);
+
+  EXPECT_EQ(UN1, UN2);
+  EXPECT_EQ(FC1, FC2);
+  EXPECT_NE(FC2, FC3);
+}
+
+TEST(TypeRefTest, UniqueOpaqueTypeRef) {
+  TypeRefBuilder Builder;
+
+  auto Op = OpaqueTypeRef::get();
+  auto Op1 = Builder.getOpaqueType();
+  auto Op2 = Builder.getOpaqueType();
+
+  EXPECT_EQ(Op, Op1);
+  EXPECT_EQ(Op1, Op2);
+}
+
+TEST(TypeRefTest, UniqueUnownedStorageType) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(MyClass, nullptr);
+  auto N2 = Builder.createNominalType(NotMyClass, nullptr);
+  auto RS1 = Builder.createUnownedStorageType(N1);
+  auto RS2 = Builder.createUnownedStorageType(N1);
+  auto RS3 = Builder.createUnownedStorageType(N2);
+
+  EXPECT_EQ(RS1, RS2);
+  EXPECT_NE(RS2, RS3);
+}
+
+TEST(TypeRefTest, UniqueWeakStorageType) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(MyClass, nullptr);
+  auto N2 = Builder.createNominalType(NotMyClass, nullptr);
+  auto RS1 = Builder.createWeakStorageType(N1);
+  auto RS2 = Builder.createWeakStorageType(N1);
+  auto RS3 = Builder.createWeakStorageType(N2);
+
+  EXPECT_EQ(RS1, RS2);
+  EXPECT_NE(RS2, RS3);
+}
+
+TEST(TypeRefTest, UniqueUnmanagedStorageType) {
+  TypeRefBuilder Builder;
+
+  auto N1 = Builder.createNominalType(MyClass, nullptr);
+  auto N2 = Builder.createNominalType(NotMyClass, nullptr);
+  auto RS1 = Builder.createUnmanagedStorageType(N1);
+  auto RS2 = Builder.createUnmanagedStorageType(N1);
+  auto RS3 = Builder.createUnmanagedStorageType(N2);
+
+  EXPECT_EQ(RS1, RS2);
+  EXPECT_NE(RS2, RS3);
+}


### PR DESCRIPTION
We'd like to be able to compare TypeRefs with pointer equality,
but we can't link LLVMSupport, so make a lightweight TypeRefID
like FoldingSetID, that only supports the input types necessary
to unique TypeRefs.

rdar://problem/25924875
