### PR TITLE
[build-script-migrator] fix TypeError

### DIFF
--- a/utils/swift_build_support/swift_build_support/migration.py
+++ b/utils/swift_build_support/swift_build_support/migration.py
@@ -31,7 +31,7 @@ def parse_args(parser, argv):
         build-script -RT -- --reconfigure
     """
     args, unknown_args = parser.parse_known_args(
-        arg for arg in argv if arg != '--')
+        list(arg for arg in argv if arg != '--'))
     args.build_script_impl_args = unknown_args
     return args
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This fixes a TypeError when running the build script on OSX system Python.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

When running build-script, I get the output below:

```
utils/build-script --preset=drew --preset-file=../presets.ini  --preset-file=utils/build-presets.ini installable_package="`pwd`/../osx-caffeinated-$tag.tar.gz" install_destdir="`pwd`/../install" install_symroot="`pwd`/../install_symroot" symbols_package="`pwd`/../osx-caffeinated-symbols-$tag.tar.gz" darwin_toolchain_bundle_identifier="net.caffei.swift.$tag"  darwin_toolchain_display_name="caffeinated-$tag" install_toolchain_dir="/Library/Developer/Toolchains/caffeinated-$tag.xctoolchain"  darwin_toolchain_xctoolchain_name="caffeinated-$tag.xctoolchain" darwin_toolchain_version="caffeinated-$tag" darwin_toolchain_alias="caffeinated-$tag" darwin_toolchain_display_name_short="caffeinated-$tag"
utils/build-script: using preset 'drew', which expands to utils/build-script --ios --tvos --watchos --lldb --llbuild --swiftpm --release-debuginfo --build-subdir=buildbot_osx --ios --tvos --watchos --test --validation-test --long-test --assertions --no-swift-stdlib-assertions -- --lldb-no-debugserver --lldb-use-system-debugserver --lldb-build-type=Release --verbose-build --build-ninja --build-swift-static-stdlib --build-swift-stdlib-unittest-extra --compiler-vendor=apple '--swift-sdks=OSX;IOS;IOS_SIMULATOR;TVOS;TVOS_SIMULATOR;WATCHOS;WATCHOS_SIMULATOR' --install-swift --install-lldb --install-llbuild --install-swiftpm --install-destdir=/Users/drew/Code/swift-osx/swift/../install --darwin-install-extract-symbols --install-symroot=/Users/drew/Code/swift-osx/swift/../install_symroot --install-prefix=/Library/Developer/Toolchains/caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a.xctoolchain/usr --test-installable-package --reconfigure --installable-package=/Users/drew/Code/swift-osx/swift/../osx-caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a.tar.gz --swift-enable-ast-verifier=0 '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service' '--llvm-install-components=libclang;libclang-headers' --installable-package=/Users/drew/Code/swift-osx/swift/../osx-caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a.tar.gz --symbols-package=/Users/drew/Code/swift-osx/swift/../osx-caffeinated-symbols-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a.tar.gz --darwin-toolchain-bundle-identifier=net.caffei.swift.swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a --darwin-toolchain-display-name=caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a --darwin-toolchain-display-name-short=caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a --darwin-toolchain-name=caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a.xctoolchain --darwin-toolchain-version=caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a --darwin-toolchain-alias=caffeinated-swift-DEVELOPMENT-SNAPSHOT-2016-04-25-a --skip-test-ios --skip-test-tvos --skip-test-watchos
Traceback (most recent call last):
  File "utils/build-script", line 1339, in <module>
    sys.exit(main())
  File "utils/build-script", line 1335, in main
    return main_normal()
  File "utils/build-script", line 824, in main_normal
    args = migration.parse_args(parser, sys.argv[1:])
  File "utils/swift_build_support/swift_build_support/migration.py", line 34, in parse_args
    arg for arg in argv if arg != '--')
  File "/Library/Python/2.7/site-packages/argparse.py", line 1735, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/Library/Python/2.7/site-packages/argparse.py", line 1941, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/Library/Python/2.7/site-packages/argparse.py", line 1873, in consume_optional
    args = arg_strings[start:stop]
TypeError: 'generator' object has no attribute '__getitem__'
utils/build-script: command terminated with a non-zero exit status 1, aborting
```

This seems to be because the migrator script passes a generator where one was not expected.

Construct a list instead.
