### PR TITLE
SILGen: Track assumed-+0-self state of protocol method invocations.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1001,6 +1001,8 @@ public:
         // Prepare the callee.  This can modify both selfValue and subs.
         Callee theCallee = prepareArchetypeCallee(SGF, e, constant, selfValue,
                                                   substFnType, subs);
+        AssumedPlusZeroSelf = selfValue.isRValue()
+          && selfValue.forceAndPeekRValue(SGF).peekIsPlusZeroRValueOrTrivial();
 
         setSelfParam(std::move(selfValue), thisCallSite);
         setCallee(std::move(theCallee));
@@ -3718,7 +3720,16 @@ namespace {
 
       // Grab the SILLocation and the new managed value.
       SILLocation ArgLoc = ArgValue.getKnownRValueLocation();
-      ManagedValue ArgManagedValue = gen.emitManagedRetain(ArgLoc, ArgSILValue);
+      ManagedValue ArgManagedValue;
+      if (ArgSILValue->getType().isAddress()) {
+        auto result = gen.emitTemporaryAllocation(ArgLoc,
+                                                  ArgSILValue->getType());
+        gen.B.createCopyAddr(ArgLoc, ArgSILValue, result,
+                             IsNotTake, IsInitialization);
+        ArgManagedValue = gen.emitManagedBufferWithCleanup(result);
+      } else {
+        ArgManagedValue = gen.emitManagedRetain(ArgLoc, ArgSILValue);
+      }
 
       // Ok now we make our transformation. First set ArgValue to a used albeit
       // invalid, empty ArgumentSource.

--- a/test/SILGen/partial_apply_protocol_class_refinement_method.swift
+++ b/test/SILGen/partial_apply_protocol_class_refinement_method.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-silgen %s | FileCheck %s
+
+protocol P { func foo() }
+protocol Q: class, P {}
+
+// CHECK-LABEL: sil hidden @_TF46partial_apply_protocol_class_refinement_method12partialApplyFPS_1Q_FT_T_
+func partialApply(_ q: Q) -> () -> () {
+  // CHECK: [[OPENED:%.*]] = open_existential_ref
+  // CHECK: store [[OPENED]] to [[TMP:%.*]] :
+  // CHECK: copy_addr [[TMP:%.*]] to [initialization] [[CONSUMABLE_TMP:%.*]] :
+  // CHECK: apply {{%.*}}<{{.*}}>([[CONSUMABLE_TMP]])
+  return q.foo
+}


### PR DESCRIPTION
Fixes SR-613, a miscompile that caused an overrelease of "self" when partially applying a protocol method to a generic or existential of a refined class-constrained protocol.
