### PR TITLE
[CMakeLists] Use unique <var> for check_cxx_source_runs test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,8 +394,8 @@ const std::regex broken_regex{
 int main() {}
 ")
 
-    check_cxx_source_runs("${std_regex_test_source}" result)
-    if (result)
+    check_cxx_source_runs("${std_regex_test_source}" "${result_var_name}_TEST")
+    if ("${${result_var_name}_TEST}")
       set("${result_var_name}" TRUE PARENT_SCOPE)
     else()
       set("${result_var_name}" FALSE PARENT_SCOPE)


### PR DESCRIPTION
#### What's in this pull request?

CC: @gribozavr 

As discussed in https://github.com/apple/swift/pull/2012#discussion_r60973375
CMake `check_{c,cxx}_xxxx` family macros cache the result _associated
with result var name_. That means every tests must have unique names.

Apparently, as for now, this is the only code that has this problem.
But in `AddSwift.cmake`, or `SwiftList.cmake`, we have code like:

```
function(_list_add_string_suffix input_list suffix result_var_name)                
  set(result)
  ...
  set("${result_var_name}" "${result}" PARENT_SCOPE)                               
endfunction()                                                                      
```

Since `set(<var>)` does _NOT_ hide the cached value,
If `check_working_std_regex` success, it would not work, I think.

Test CMakeLists.txt:

``` cmake
cmake_minimum_required(VERSION 2.8.12)                                            

set(result "CACHED_RESULT" CACHE INTERNAL "RESULT")                               

function(my_func result_var_name)                                                 
    set(result)                                                                   
    list(APPEND result "BAZ!!")                                                   
    set("${result_var_name}" "${result}" PARENT_SCOPE)                            
endfunction()                                                                     

my_func(MY_FUNC_RESULT)                                                           
message("MY_FUNC_RESULT: ${MY_FUNC_RESULT}")                                      
```

Output:

```
MY_FUNC_RESULT: CACHED_RESULT;BAZ!!
```

In theory, to begin with empty value, we should write: `set(var_name "")` instead of `set(var_name)`.
But it's too annoying...

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
