### PR TITLE
[stdlib] rewrite parts of Collection.swift to leverage defer

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -217,9 +217,8 @@ extension Collection where SubSequence == Self {
   @warn_unused_result
   public mutating func popFirst() -> Iterator.Element? {
     guard !isEmpty else { return nil }
-    let element = first!
-    self = self[startIndex.successor()..<endIndex]
-    return element
+    defer { self = self[startIndex.successor()..<endIndex] }
+    return first!
   }
 }
 
@@ -232,9 +231,8 @@ extension Collection where
   @warn_unused_result
   public mutating func popLast() -> Iterator.Element? {
     guard !isEmpty else { return nil }
-    let element = last!
-    self = self[startIndex..<endIndex.predecessor()]
-    return element
+    defer { self = self[startIndex..<endIndex.predecessor()] }
+    return last!
   }
 }
 
@@ -539,9 +537,8 @@ extension Collection where SubSequence == Self {
   @discardableResult
   public mutating func removeFirst() -> Iterator.Element {
     _precondition(!isEmpty, "can't remove items from an empty collection")
-    let element = first!
-    self = self[startIndex.successor()..<endIndex]
-    return element
+    defer { self = self[startIndex.successor()..<endIndex] }
+    return first!
   }
 
   /// Remove the first `n` elements.
@@ -570,9 +567,8 @@ extension Collection
   /// - Precondition: `!self.isEmpty`
   @discardableResult
   public mutating func removeLast() -> Iterator.Element {
-    let element = last!
-    self = self[startIndex..<endIndex.predecessor()]
-    return element
+    defer { self = self[startIndex..<endIndex.predecessor()] }
+    return last!
   }
 
   /// Remove the last `n` elements.


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

I rewrote Collection.swift's `popFirst()`, `popLast()`, `removeFirst()` and `removeLast()` using defer.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
