### PR TITLE
Contextualize capture list decls to enclosing autoclosures.

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -157,6 +157,17 @@ public:
     }
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
+  
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "only for use within the debugger") {
+    if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      return afd->dump();
+    }
+    if (auto ce = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
+      return ce->dump();
+    }
+    llvm_unreachable("unexpected AnyFunctionRef representation");
+  }
 };
 
 } // namespace swift

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -1216,22 +1216,6 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
 
   if (AFR.hasType() && !AFR.isObjC()) {
     finder.checkType(AFR.getType(), AFR.getLoc());
-#if 0
-    for (auto paramList : AFR.getParameterLists()) {
-      for (auto param : *paramList) {
-        // Passing parameters of class type doesn't require their metadata.
-        if (param->hasType()
-            && !param->getType()->is<MetatypeType>()
-            && !param->getType()->hasRetainablePointerRepresentation())
-          finder.checkType(param->getType(), param->getLoc());
-      }
-    }
-    
-    if (AFR.getBodyResultType()
-        && !AFR.getBodyResultType()->is<MetatypeType>()
-        && !AFR.getBodyResultType()->hasRetainablePointerRepresentation())
-      finder.checkType(AFR.getBodyResultType(), AFR.getLoc());
-#endif
   }
 
   // If this is an init(), explicitly walk the initializer values for members of

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -87,6 +87,16 @@ namespace {
         return { false, E };
       } 
 
+      // Capture lists need to be reparented to enclosing autoclosures.
+      if (auto CapE = dyn_cast<CaptureListExpr>(E)) {
+        if (isa<AutoClosureExpr>(ParentDC)) {
+          for (auto &Cap : CapE->getCaptureList()) {
+            Cap.Init->setDeclContext(ParentDC);
+            Cap.Var->setDeclContext(ParentDC);
+          }
+        }
+      }
+
       // Explicit closures start their own sequence.
       if (auto CE = dyn_cast<ClosureExpr>(E)) {
         // In the repl, the parent top-level context may have been re-written.

--- a/test/SILGen/capture_list_in_autoclosure.swift
+++ b/test/SILGen/capture_list_in_autoclosure.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s
+
+func block(_ f: () -> Void) -> Int { return 42 }
+func oneOf(_ a: Int?, _ b: @autoclosure () -> Int) -> Int { return 0 }
+class Foo {
+    private var value: Int?
+    func refresh() {
+        oneOf(self.value, block({
+            [unowned self] in _ = self
+        }))
+    }
+}


### PR DESCRIPTION
Without this fix, we would accidentally consider the autoclosure to capture the capture list decl, even though it's natively within the autoclosure's context. Fixes SR-848.
