### PR TITLE
Run lldb tests during swift packaging

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -552,7 +552,6 @@ install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;sdk-overlay;license
 build-swift-static-stdlib
 build-swift-stdlib-unittest-extra
-skip-test-lldb
 
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out


### PR DESCRIPTION
This reverts commit 36da6bab1557d887a03afad482568bb3c66a4a02.

Now run lldb tests during package preset.
