### PR TITLE
Swift reflection test deps

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1129,7 +1129,7 @@ function(_add_swift_library_single target name)
   set(SWIFTLIB_SINGLE_LINK_LIBRARIES_WITHOUT_ICU)
   foreach(item ${SWIFTLIB_SINGLE_LINK_LIBRARIES})
     if(NOT "${item}" STREQUAL "icucore")
-      list(APPEND SWIFTLIB_SINGLE_LINK_LIBRARIES_WITHOUT_ICU "{$item}")
+      list(APPEND SWIFTLIB_SINGLE_LINK_LIBRARIES_WITHOUT_ICU "${item}")
     endif()
   endforeach()
 

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -6,3 +6,12 @@ add_swift_library(swiftSwiftReflectionTest SHARED IS_STDLIB
   SWIFT_MODULE_DEPENDS Darwin
   SWIFT_COMPILE_FLAGS ${swift_reflection_test_compile_flags}
   INSTALL_IN_COMPONENT stdlib-experimental)
+
+foreach(SDK ${SWIFT_SDKS})
+  foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
+    set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
+    add_dependencies(
+      "swiftSwiftReflectionTest${VARIANT_SUFFIX}"
+      "swift-reflection-test${VARIANT_SUFFIX}")
+  endforeach()
+endforeach()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -281,7 +281,6 @@ config.sil_opt = inferSwiftBinary('sil-opt')
 config.sil_extract = inferSwiftBinary('sil-extract')
 config.lldb_moduleimport_test = inferSwiftBinary('lldb-moduleimport-test')
 config.swift_ide_test = inferSwiftBinary('swift-ide-test')
-config.swift_reflection_test = inferSwiftBinary('swift-reflection-test')
 config.swift_reflection_dump = inferSwiftBinary('swift-reflection-dump')
 config.swift_remoteast_test = inferSwiftBinary('swift-remoteast-test')
 config.clang = inferSwiftBinary('clang')
@@ -862,7 +861,7 @@ config.substitutions.append(
      (subst_target_swift_ide_test_mock_sdk,
       subst_target_swift_ide_test_mock_sdk_after)))
 config.substitutions.append(('%target-swift-ide-test', config.target_swift_ide_test))
-config.substitutions.append(('%target-swift-reflection-test', '{test_runner}{variant_suffix} {arch}'.format(test_runner=config.swift_reflection_test, variant_suffix=config.variant_suffix, arch=run_cpu)))
+config.substitutions.append(('%target-swift-reflection-test', 'swift-reflection-test{variant_suffix} {arch}'.format(variant_suffix=config.variant_suffix, arch=run_cpu)))
 config.substitutions.append(('%target-swift-reflection-dump', '{} {} {}'.format(config.swift_reflection_dump, '-arch', run_cpu)))
 config.substitutions.append(('%target-swiftc_driver', config.target_swiftc_driver))
 config.substitutions.append(('%target-swift-remoteast-test-with-sdk',

--- a/tools/swift-reflection-test/CMakeLists.txt
+++ b/tools/swift-reflection-test/CMakeLists.txt
@@ -2,5 +2,6 @@ add_swift_target_executable(swift-reflection-test BUILD_WITH_STDLIB
   swift-reflection-test.cpp
   overrides.cpp
   LINK_FAT_LIBRARIES
-    swiftReflection)
+    swiftReflection
+    swiftRemoteMirror)
 


### PR DESCRIPTION
Fixes swift-reflection-test dependencies for uncommon build presets and links the test tool against the C library to better reflect the usage scenario. As a follow-up, we'll remove any use of the C++ APIs in the test tool.

rdar://problem/25943881
