### PR TITLE
[runtime] Correct usage of add_custom_command_target in CMakeLists.txt

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -89,17 +89,23 @@ foreach(sdk ${SWIFT_CONFIGURED_SDKS})
 
       set(section_magic_begin_name "section_magic_begin-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
       set(section_magic_end_name "section_magic_end-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
-      add_custom_command_target(${section_magic_begin_name}_begin
-        OUTPUT  "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
-        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${section_magic_begin_name}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}" "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
-        DEPENDS ${section_magic_begin_name})
+      add_custom_command_target(section_magic_o
+        COMMAND
+            "${CMAKE_COMMAND}" -E copy
+            "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${section_magic_begin_name}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}"
+            "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
+        COMMAND
+            "${CMAKE_COMMAND}" -E copy
+            "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${section_magic_end_name}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}"
+            "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
+        OUTPUT
+            "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o"
+            "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
+        DEPENDS
+            ${section_magic_begin_name}
+            ${section_magic_end_name})
 
-      add_custom_command_target(${section_magic_begin_name}_end
-        OUTPUT  "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
-        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${section_magic_end_name}.dir/swift_sections.S${CMAKE_C_OUTPUT_EXTENSION}" "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"
-        DEPENDS ${section_magic_end_name})
-
-      list(APPEND object_target_list "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o" "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o")
+      list(APPEND object_target_list "${section_magic_o}")
 
       swift_install_in_component(stdlib
           FILES "${SWIFTLIB_DIR}/${arch_subdir}/swift_begin.o" "${SWIFTLIB_DIR}/${arch_subdir}/swift_end.o"

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -74,11 +74,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   add_swift_library(section_magic_begin IS_STDLIB IS_STDLIB_CORE
     swift_sections.S
     C_COMPILE_FLAGS ${swift_runtime_compile_flags} "-DSWIFT_BEGIN"
-    INSTALL_IN_COMPONENT stdlib)
+    INSTALL_IN_COMPONENT never_install)
   add_swift_library(section_magic_end IS_STDLIB IS_STDLIB_CORE
     swift_sections.S
     C_COMPILE_FLAGS ${swift_runtime_compile_flags} "-DSWIFT_END"
-    INSTALL_IN_COMPONENT stdlib)
+    INSTALL_IN_COMPONENT never_install)
 endif()
 
 set(object_target_list)


### PR DESCRIPTION
#### What's in this pull request?
- `COMMAND` arguments must immediately follow `<dependency_out_var_name>`. [See here](https://github.com/apple/swift/blob/9114293af7871886a50de44fd3f52f04dd6348db/cmake/modules/SwiftAddCustomCommandTarget.cmake#L75).
- Use generated target name instead of output file names.
- Unify 2 file copy `COMMAND` into 1 `add_custom_command_target`.

In addition, changed the component of `libsection_magic_{begin,end}.a` to `never_install`
I believe `swift_{begin,end}.o` are required, but `libsection_magic_{begin,end}.a` are _not_ for install.
Please correct me if I was wrong.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
