### PR TITLE
SILGen: Mark function escapes for script globals captured by closures.

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -403,6 +403,11 @@ public:
   substSelfTypeIntoProtocolRequirementType(CanGenericFunctionType reqtTy,
                                            ProtocolConformance *conformance);
 
+  /// Emit a `mark_function_escape` instruction for top-level code when a
+  /// function or closure at top level refers to script globals.
+  void emitMarkFunctionEscapeForTopLevelCodeGlobals(SILLocation loc,
+                                                const CaptureInfo &captureInfo);
+
 private:
   /// Emit the deallocator for a class that uses the objc allocator.
   void emitObjCAllocatorDestructor(ClassDecl *cd, DestructorDecl *dd);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1182,6 +1182,13 @@ public:
     // Emit the closure body.
     SGF.SGM.emitClosure(e);
 
+    // If we're in top-level code, we don't need to physically capture script
+    // globals, but we still need to mark them as escaping so that DI can flag
+    // uninitialized uses.
+    if (&SGF == SGF.SGM.TopLevelSGF) {
+      SGF.SGM.emitMarkFunctionEscapeForTopLevelCodeGlobals(e,e->getCaptureInfo());
+    }
+    
     // A directly-called closure can be emitted as a direct call instead of
     // really producing a closure object.
     SILDeclRef constant(e);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -378,6 +378,14 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
     wasSpecialized = true;
   }
 
+  // If we're in top-level code, we don't need to physically capture script
+  // globals, but we still need to mark them as escaping so that DI can flag
+  // uninitialized uses.
+  if (this == SGM.TopLevelSGF) {
+    SGM.emitMarkFunctionEscapeForTopLevelCodeGlobals(loc,
+                                                   TheClosure.getCaptureInfo());
+  }
+
   if (!TheClosure.getCaptureInfo().hasLocalCaptures() && !wasSpecialized) {
     auto result = ManagedValue::forUnmanaged(functionRef);
     return emitOrigToSubstValue(loc, result,

--- a/test/1_stdlib/tgmath.swift
+++ b/test/1_stdlib/tgmath.swift
@@ -104,11 +104,11 @@ let gz = CGFloat(3.3)
 let ix = Int(11)
 
 // outputs
-var d1, d2: Double
-var f1, f2: Float
-var g1, g2: CGFloat
-var i1, i2, i3: Int
-var b1, b2, b3: Bool
+var d1: Double = 0, d2: Double = 0
+var f1: Float = 0, f2: Float = 0
+var g1: CGFloat = 0, g2: CGFloat = 0
+var i1 = 0, i2 = 0, i3 = 0
+var b1 = false, b2 = false, b3 = false
 
 MathTests.test("Unary functions") {
   (d1, f1, g1) = (acos(dx), acos(fx), acos(gx))

--- a/test/SILGen/closure_script_global_escape.swift
+++ b/test/SILGen/closure_script_global_escape.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -module-name foo -emit-silgen %s | FileCheck %s
+// RUN: %target-swift-frontend -module-name foo -emit-sil -verify %s
+
+// CHECK-LABEL: sil @main
+
+// CHECK: [[GLOBAL:%.*]] = global_addr @_Tv3foo4flagSb
+// CHECK: [[MARK:%.*]] = mark_uninitialized [var] [[GLOBAL]]
+var flag: Bool // expected-note* {{defined here}}
+
+// CHECK: mark_function_escape [[MARK]]
+func useFlag() { // expected-error{{'flag' used by function definition before being initialized}}
+  _ = flag
+}
+
+// CHECK: [[CLOSURE:%.*]] = function_ref @_TF3fooU_FT_T_
+// CHECK: mark_function_escape [[MARK]]
+// CHECK: thin_to_thick_function [[CLOSURE]]
+_ = { _ = flag } // expected-error{{'flag' captured by a closure before being initialized}}
+
+// CHECK: mark_function_escape [[MARK]]
+// CHECK: [[CLOSURE:%.*]] = function_ref @_TF3fooU0_FT_T_
+// CHECK: apply [[CLOSURE]]
+_ = { _ = flag }() // expected-error{{'flag' captured by a closure before being initialized}}
+
+flag = true
+
+// CHECK: mark_function_escape [[MARK]]
+func useFlag2() {
+  _ = flag
+}
+
+// CHECK: [[CLOSURE:%.*]] = function_ref @_TF3fooU1_FT_T_
+// CHECK: mark_function_escape [[MARK]]
+// CHECK: thin_to_thick_function [[CLOSURE]]
+_ = { _ = flag }
+
+// CHECK: mark_function_escape [[MARK]]
+// CHECK: [[CLOSURE:%.*]] = function_ref @_TF3fooU2_FT_T_
+// CHECK: apply [[CLOSURE]]
+_ = { _ = flag }()


### PR DESCRIPTION
We did this for func decls in scripts, so that DI can flag func decls that access script globals before they've been initialized, but we failed to do so for closures, causing us to miss DI violations when closures referenced script globals before their initialization. Fixes rdar://problem/24357063.
