### PR TITLE
[Coverage] Do not emit increments in certain implicitly-generated reg…

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -465,7 +465,7 @@ public:
 
   /// Emit code to increment a counter for profiling.
   void emitProfilerIncrement(ASTNode N) {
-    if (SGM.Profiler)
+    if (SGM.Profiler && SGM.Profiler->hasRegionCounters())
       SGM.Profiler->emitCounterIncrement(B, N);
   }
   

--- a/lib/SILGen/SILGenProfiling.h
+++ b/lib/SILGen/SILGenProfiling.h
@@ -57,11 +57,14 @@ public:
 
   bool hasRegionCounters() const { return NumRegionCounters != 0; }
 
+  /// Emit SIL to increment the counter for \c Node.
+  void emitCounterIncrement(SILGenBuilder &Builder, ASTNode Node);
+
+private:
   /// Map counters to ASTNodes and set them up for profiling the given function.
   void assignRegionCounters(AbstractFunctionDecl *Root);
 
-  /// Emit SIL to increment the counter for \c Node.
-  void emitCounterIncrement(SILGenBuilder &Builder, ASTNode Node);
+  friend struct ProfilerRAII;
 };
 
 } // end namespace Lowering

--- a/lib/SILGen/SILGenProfiling.h
+++ b/lib/SILGen/SILGenProfiling.h
@@ -27,12 +27,7 @@ namespace Lowering {
 class SILGenModule;
 class SILGenBuilder;
 
-/// RAII object to set up profiling for a function.
-struct ProfilerRAII {
-  SILGenModule &SGM;
-  ProfilerRAII(SILGenModule &SGM, AbstractFunctionDecl *D);
-  ~ProfilerRAII();
-};
+struct ProfilerRAII;
 
 /// Profiling state.
 class SILGenProfiling {
@@ -65,6 +60,15 @@ private:
   void assignRegionCounters(AbstractFunctionDecl *Root);
 
   friend struct ProfilerRAII;
+};
+
+/// RAII object to set up profiling for a function.
+struct ProfilerRAII {
+  SILGenModule &SGM;
+  std::unique_ptr<SILGenProfiling> PreviousProfiler;
+
+  ProfilerRAII(SILGenModule &SGM, AbstractFunctionDecl *D);
+  ~ProfilerRAII();
 };
 
 } // end namespace Lowering

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -53,4 +53,15 @@ func main() {
   let _ = Class1()
 }
 
+// rdar://problem/22761498 - enum declaration suppresses coverage
+func foo() {
+  var x : Int32 = 0   // CHECK-COV: 1|{{.*}}[[@LINE]]
+  enum ETy { case A } // CHECK-COV: 1|{{.*}}[[@LINE]]
+  repeat {            // CHECK-COV: 1|{{.*}}[[@LINE]]
+    x += 1            // CHECK-COV: 1|{{.*}}[[@LINE]]
+  } while x == 0      // CHECK-COV: 1|{{.*}}[[@LINE]]
+  x += 1              // CHECK-COV: 1|{{.*}}[[@LINE]]
+}
+
 main()
+foo()


### PR DESCRIPTION
#### What's in this pull request?

A code-coverage change that skips mapping compiler-generated decls, and another that fixes a coverage suppression issue caused by nested decls.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ions

Outside of constructors and destructors, it's wasteful to generate
coverage mappings for implicitly-generated regions. Get rid of these
mappings and any counter increments associated with them.
