### PR TITLE
Fixing index(where:) API test

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -833,9 +833,9 @@ extension TestSuite {
 
     self.test("\(testNamePrefix).index(where:)/semantics") {
       for test in findTests {
-        let c = makeWrappedCollectionWithEquatableElement(test.sequence)
         let closureLifetimeTracker = LifetimeTracked(0)
         expectEqual(1, LifetimeTracked.instances)
+        let c = makeWrappedCollectionWithEquatableElement(test.sequence)
         let result = c.index {
           (candidate) in
           _blackHole(closureLifetimeTracker)

--- a/validation-test/stdlib/Collection/LazyMapCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyMapCollection.swift.gyb
@@ -44,16 +44,15 @@ CollectionTests.add${traversal}${kind}Tests(
   extractValue: { (element: LifetimeTracked) in
     OpaqueValue(element.value, identity: element.identity)
   },
-  // FIXME: use LifetimeTracked once bug is validated/fixed
-  make${kind}OfEquatable: { (elements: [MinimalEquatableValue]) -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<MinimalEquatableValue>, MinimalEquatableValue> in // -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>, LifetimeTracked> in
+  make${kind}OfEquatable: { (elements: [LifetimeTracked]) -> LazyMap${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>, LifetimeTracked> in
     Minimal${traversal}${kind}(elements: elements).lazy.map { $0 }
   },
-  wrapValueIntoEquatable: identityEq, //{ (element: MinimalEquatableValue) in
-//    LifetimeTracked(element.value, identity: element.identity)
-//  },
-  extractValueFromEquatable: identityEq //{ (element: LifetimeTracked) in
-//    MinimalEquatableValue(element.value, identity: element.identity)
-//  }
+  wrapValueIntoEquatable: { (element: MinimalEquatableValue) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValueFromEquatable: { (element: LifetimeTracked) in
+    MinimalEquatableValue(element.value, identity: element.identity)
+  }
 )
 % end
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A minor fix to some testing infrastructure, plus re-enabling some tests. Many thanks to @gribozavr for root-causing the problem.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes:
- Fixed a bug in the collection unit test exercising the index(where:) API
- Reenabled relevant LazyMapCollection tests
