### PR TITLE
[sil-devirtualizer] Fix some bugs in the devirtualizer.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1804,8 +1804,9 @@ static bool isBindableTo(Type a, Type b, LazyResolver *resolver) {
                  == substSubs[subi].getConformances().size());
           for (unsigned conformancei :
                  indices(origSubs[subi].getConformances())) {
-            if (origSubs[subi].getConformances()[conformancei]
-                  != substSubs[subi].getConformances()[conformancei])
+            if (origSubs[subi].getConformances()[conformancei].isConcrete() &&
+                origSubs[subi].getConformances()[conformancei] !=
+                    substSubs[subi].getConformances()[conformancei])
               return false;
           }
         }

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -509,10 +509,11 @@ static bool tryToSpeculateTarget(FullApplySite AI,
     return true;
   }
   auto NewInstPair = tryDevirtualizeClassMethod(AI, SubTypeValue);
-  assert(NewInstPair.first && "Expected to be able to devirtualize apply!");
-  replaceDeadApply(AI, NewInstPair.first);
-
-  return true;
+  if (NewInstPair.first) {
+    replaceDeadApply(AI, NewInstPair.first);
+    return true;
+  }
+  return Changed;
 }
 
 namespace {

--- a/test/SILOptimizer/devirt_unbound_generic.swift
+++ b/test/SILOptimizer/devirt_unbound_generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -O -emit-sil %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -O %s | FileCheck %s
 
 // We used to crash on this when trying to devirtualize t.boo(a, 1),
 // because it is an "apply" with unbound generic arguments and
@@ -73,3 +73,134 @@ func test3<T>(_ d: Derived<T>) {
 public func doTest3<T>(_ t:T) {
   test3(Derived<T>())
 }
+
+
+public protocol ProtocolWithAssocType {
+  associatedtype Element
+}
+
+private class CP<Base: ProtocolWithAssocType> {
+   var value: Base.Element
+   init(_ v: Base.Element) {
+     value = v
+   }
+
+   func getCount() -> Int32 {
+     return 1
+   }
+}
+
+private class Base1: ProtocolWithAssocType {
+   typealias Element = Int32
+}
+
+
+private class Base2<T>: ProtocolWithAssocType {
+   typealias Element = Int32
+}
+
+private class CP2: CP<Base2<Int>> {
+  init() {
+    super.init(1)
+  }
+
+  override func getCount() -> Int32 {
+    return 2
+  }
+}
+
+private class CP3: CP<Base2<Int>> {
+  init() {
+    super.init(1)
+  }
+
+  override func getCount() -> Int32 {
+    return 3
+  }
+}
+
+public class CC<CT> {
+   func next() -> CT? {
+     return nil
+   }
+}
+
+public protocol QQ {
+  associatedtype Base: PP
+}
+
+public protocol PP {
+  associatedtype Element
+}
+
+internal class D<DT: QQ> : CC<DT.Base.Element> {
+  override func next() -> DT.Base.Element? {
+    return nil
+  }
+}
+
+public struct S: PP {
+  public typealias Element = Int32
+}
+
+final public class E: QQ {
+  public typealias Base = S
+}
+
+// Check that c.next() inside test4 gets completely devirtualized.
+// CHECK-LABEL: sil @{{.*}}test4
+// CHECK-NOT: class_method
+// CHECK: return
+public func test4() -> Int32? {
+  let c: CC<Int32> = D<E>();
+  return c.next()
+}
+
+public func test5() -> Int32? {
+  return testDevirt(D<E>())
+}
+
+// Check that testDevirt is specialized and uses speculative devirtualization.
+// CHECK-LABEL: sil shared [noinline] @{{.*}}testDevirt
+// CHECK: checked_cast_br [exact] %{{.*}} : $CC<Int32> to $CC<Int32>
+// CHECK: class_method
+// CHECK: }
+@inline(never)
+public func testDevirt<T>(_ c: CC<T>) -> T? {
+  return c.next()
+}
+
+// The compiler used to crash on this code, because of
+// generic types involved in the devirtualization.
+//
+// rdar://25891588
+//
+// CHECK-LABEL: sil private [noinline] @{{.*}}test6
+// CHECK-NOT: class_method
+// CHECK-NOT: checked_cast_br
+// CHECK-NOT: class_method
+// CHECK: }
+@inline(never)
+private func test6<T: ProtocolWithAssocType>(_ c: CP<T>) -> T.Element {
+  return c.value
+}
+
+public func doTest6() {
+  test6(CP<Base1>(1))
+}
+
+// CHECK-LABEL: sil private [noinline] @{{.*}}test7
+// CHECK-NOT: class_method
+// CHECK: checked_cast_br
+// CHECK-NOT: class_method
+// CHECK: }
+@inline(never)
+private func test7<T: ProtocolWithAssocType>(_ c: CP<T>) -> Int32 {
+  return c.getCount()
+}
+
+public func doTest7() {
+  test7(CP2())
+}
+
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fix a couple of bugs in the devirtualizer.

rdar://25891588, rdar://25994886 and SR-1206
#### Resolved bug number: ([SR-1206](https://bugs.swift.org/browse/SR-1206))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- Don't crash if a class_method instruction could not be devirtualized.
- Improve devirtualization of methods with generic parameters and using dependent types.
- Fix a bug in isBindableToSuperclassOf, uncovered while fixing the original bug reported in SR-1206.
  This bug could lead in certain cases to invocations of a wrong method from the base class, instead
  of using a method from a derived class.

rdar://25891588   and SR-1206
