### PR TITLE
Completing LazyFilterCollections, adding tests for LazyFilterCollection

### DIFF
--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -179,7 +179,7 @@ public func > <Base : Collection>(
 ///   general operations on `LazyFilterCollection` instances may not have the
 ///   documented complexity.
 public struct ${Self}<
-  Base : Collection
+  Base : ${collectionForTraversal(Traversal)}
 > : LazyCollectionProtocol, ${collectionForTraversal(Traversal)} {
 
   /// A type that represents a valid position in the collection.
@@ -236,42 +236,9 @@ public struct ${Self}<
 %   if Traversal == 'Bidirectional':
   @warn_unused_result
   public func index(before i: Index) -> Index {
-    fatalError("FIXME: swift-3-indexing-model: implement")
+    return LazyFilterIndex(base: _previousFiltered(i.base))
   }
 %   end
-
-  // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
-  public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    _precondition(n >= 0,
-      "Only BidirectionalCollections can be advanced by a negative amount")
-    // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
-
-    var index = i.base
-    for _ in stride(from: 0, to: n, by: 1) {
-      _nextFilteredInPlace(&index)
-    }
-    return LazyFilterIndex(base: index)
-  }
-
-  // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
-  public func index(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
-  ) -> Index? {
-    _precondition(n >= 0,
-      "Only BidirectionalCollections can be advanced by a negative amount")
-    // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
-
-    var index = i.base
-    for _ in stride(from: 0, to: n, by: 1) {
-      if index == limit.base {
-        return nil
-      }
-      _nextFilteredInPlace(&index)
-    }
-    return LazyFilterIndex(base: index)
-  }
 
   /// Returns the next `index` of an element that `self._predicate` matches
   /// otherwise `self._base.endIndex`
@@ -294,6 +261,30 @@ public struct ${Self}<
       _base.formIndex(after: &index)
     } while index != _base.endIndex && !_predicate(_base[index])
   }
+
+%   if Traversal == 'Bidirectional':
+  /// Returns the previous `index` of an element that `self._predicate` matches
+  /// otherwise `self._base.startIndex`
+  @inline(__always)
+  internal func _previousFiltered(_ index: Base.Index) -> Base.Index {
+    var index = index
+    _previousFilteredInPlace(&index)
+    return index
+  }
+
+  /// Returns the first index `i` preceding `index` where
+  /// `_predicate(base[i]) == true`.
+  ///
+  /// - Precondition: `index != startIndex`
+  /// - Postcondition: `i < index`
+  @inline(__always)
+  internal func _previousFilteredInPlace(_ index: inout Base.Index) {
+    _precondition(index != _base.startIndex, "can't retreat before startIndex")
+    repeat {
+      _base.formIndex(before: &index)
+    } while !_predicate(_base[index])
+  }
+%   end
 
   /// Access the element at `position`.
   ///

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -1,0 +1,154 @@
+// -*- swift -*-
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %S/../../../utils/gyb %s -o %t/main.swift
+// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyFilterCollection.swift.a.out
+// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/LazyFilterCollection.swift.a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdlibCollectionUnittest
+
+var CollectionTests = TestSuite("Collection")
+
+%{
+variations = [('', 'Sequence'), ('', 'Collection'), ('Bidirectional', 'Collection')]
+}%
+
+// Test collections using value types as elements.
+% for (traversal, kind) in variations:
+CollectionTests.add${traversal}${kind}Tests(
+  make${kind}: { (elements: [OpaqueValue<Int>]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<OpaqueValue<Int>>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValue: identity,
+  extractValue: identity,
+  make${kind}OfEquatable: { (elements: [MinimalEquatableValue]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<MinimalEquatableValue>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValueIntoEquatable: identityEq,
+  extractValueFromEquatable: identityEq
+)
+% end
+
+// Test collections using reference types as elements.
+% for (traversal, kind) in variations:
+CollectionTests.add${traversal}${kind}Tests(
+  make${kind}: { (elements: [LifetimeTracked]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValue: { (element: OpaqueValue<Int>) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValue: { (element: LifetimeTracked) in
+    OpaqueValue(element.value, identity: element.identity)
+  },
+  make${kind}OfEquatable: { (elements: [LifetimeTracked]) -> LazyFilter${traversal}${kind}<Minimal${traversal}${kind}<LifetimeTracked>> in
+    // FIXME: create a better sequence and filter
+    Minimal${traversal}${kind}(elements: elements).lazy.filter { _ in return true }
+  },
+  wrapValueIntoEquatable: { (element: MinimalEquatableValue) in
+    LifetimeTracked(element.value, identity: element.identity)
+  },
+  extractValueFromEquatable: { (element: LifetimeTracked) in
+    MinimalEquatableValue(element.value, identity: element.identity)
+  }
+)
+% end
+
+// Test collection instances and iterators.
+% for (traversal, kind) in variations:
+CollectionTests.test("LazyFilterCollection instances (${traversal}${kind})") {
+  do {
+    // MinimalIterator will error if next() is called after exhaustion
+    var resiliency = CollectionMisuseResiliencyChecks.all
+    resiliency.callNextOnExhaustedGenerator = false
+
+    let expected : [String] = []
+    let base = ["apple", "orange", "banana", "grapefruit", "lychee"]
+% if kind == 'Sequence':
+    checkSequence(
+      expected,
+      MinimalSequence(elements: base).lazy.filter { _ in return false },
+      resiliencyChecks: resiliency
+    )
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(
+      expected,
+      MinimalCollection(elements: base).lazy.filter { _ in return false },
+      resiliencyChecks: resiliency,
+      sameValue: { $0 == $1 }
+    )
+% else:
+    check${traversal}${kind}(
+      expected,
+      Minimal${traversal}${kind}(elements: base).lazy.filter { _ in return false },
+      resiliencyChecks: resiliency,
+      sameValue: { $0 == $1 }
+    )
+% end
+  }
+  do {
+    var resiliency = CollectionMisuseResiliencyChecks.all
+    resiliency.callNextOnExhaustedGenerator = false
+
+    let expected = ["apple", "orange", "banana", "grapefruit", "lychee"]
+    let base = ["apple", "orange", "banana", "grapefruit", "lychee"]
+% if kind == 'Sequence':
+    checkSequence(
+      expected,
+      MinimalSequence(elements: base).lazy.filter { _ in return true },
+      resiliencyChecks: resiliency
+    )
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(
+      expected,
+      MinimalCollection(elements: base).lazy.filter { _ in return true },
+      resiliencyChecks: resiliency,
+      sameValue: { $0 == $1 }
+    )
+% else:
+    check${traversal}${kind}(
+      expected,
+      Minimal${traversal}${kind}(elements: base).lazy.filter { _ in return true },
+      resiliencyChecks: resiliency,
+      sameValue: { $0 == $1 }
+    )
+% end
+  }
+  do {
+    var resiliency = CollectionMisuseResiliencyChecks.all
+    resiliency.callNextOnExhaustedGenerator = false
+
+    let expected = [2, 4, 6, 8, 10, 12, 14, 16]
+    let base = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+% if kind == 'Sequence':
+    checkSequence(
+      expected,
+      MinimalSequence(elements: base).lazy.filter { $0 % 2 == 0 },
+      resiliencyChecks: resiliency
+    )
+% elif traversal == '' and kind == 'Collection':
+    checkForwardCollection(
+      expected,
+      MinimalCollection(elements: base).lazy.filter { $0 % 2 == 0 },
+      resiliencyChecks: resiliency,
+      sameValue: { $0 == $1 }
+    )
+% else:
+    check${traversal}${kind}(
+      expected,
+      Minimal${traversal}${kind}(elements: base).lazy.filter { $0 % 2 == 0 },
+      resiliencyChecks: resiliency,
+      sameValue: { $0 == $1 }
+    )
+% end
+  }
+}
+% end
+
+runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Proper support for LazyBidirectionalFilterCollection, as well as another test suite. Tests pass locally. @gribozavr 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes:
- Added proper LazyFilterBidirectionalCollection support
- Added tests for LazyFilterCollection variants
