### PR TITLE
added findFirst function for a sequence

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -354,6 +354,23 @@ extension Sequence {
 
     return Array(result)
   }
+    
+    /// Returns first element of `self`,
+    /// that satisfy the predicate `includeElement`.
+    @warn_unused_result
+    public func findFirst(@noescape includeElement: (Iterator.Element) throws -> Bool
+        ) rethrows -> Iterator.Element? {
+        
+        var iterator = self.makeIterator()
+        
+        while let element = iterator.next() {
+            if try includeElement(element) {
+                return element
+            }
+        }
+        
+        return nil
+    }
 
   @warn_unused_result
   public func suffix(maxLength: Int) -> AnySequence<Iterator.Element> {

--- a/test/1_stdlib/FindFirst.swift
+++ b/test/1_stdlib/FindFirst.swift
@@ -1,0 +1,64 @@
+//===--- FindFirst.swift - tests for finding first element that matches the predicate --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+// Also import modules which are used by StdlibUnittest internally. This
+// workaround is needed to link all required libraries in case we compile
+// StdlibUnittest with -sil-serialize-all.
+import SwiftPrivate
+#if _runtime(_ObjC)
+import ObjectiveC
+#endif
+
+let FindFirstTests = TestSuite("FindFirst")
+
+FindFirstTests.test("find first in integers collections") {
+    expectEqual([30 ,10, 90].findFirst({ $0 % 3 == 0 }) , 30)
+}
+
+FindFirstTests.test("find first in integers collections - finds nothing") {
+    expectEqual([33 ,11, 97].findFirst({ $0 % 2 == 0 }) , nil)
+}
+
+FindFirstTests.test("find first in String collections") {
+    expectEqual(["apple", "iOS", "mac"].findFirst({ $0 == "iOS" }), "iOS")
+}
+
+FindFirstTests.test("find first in String collections") {
+    expectEqual(["apple", "iOS", "mac"].findFirst({ $0 == "iPhone" }), nil)
+}
+
+FindFirstTests.test("find rawvalue in enum which satisfies the predicate") {
+    enum MockMenu: String {
+        case MenuItem1 = "MenuItem1"
+        case MenuItem2 = "MenuItem2"
+        case MenuItem3 = "MenuItem3"
+        case MenuItem4 = "MenuItem4"
+        case MenuItem5 = "MenuItem5"
+        
+        static func allValues() -> [MockMenu] {
+            return [.MenuItem1, .MenuItem2, .MenuItem3, .MenuItem4, .MenuItem5]
+        }
+    }
+    
+    func getMenuItemDisplayName(menuItem: MockMenu) -> String {
+        return MockMenu.allValues().findFirst({ $0 == menuItem })?.rawValue ?? ""
+    }
+    
+    expectEqual(getMenuItemDisplayName(.MenuItem1), "MenuItem1")
+    expectEqual(getMenuItemDisplayName(.MenuItem2), "MenuItem2")
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Many a times we want to grab the first element from a sequence that satisfies a predicate, for instance, grabbing a specific constraint from many constraints with a specific id, finding a view controller from childViewControllers which of a specific type. Rather than using filter (which will go through the complete sequence) and then first, findFirst function will terminate as soon as it finds an element that satisfies the predicate
For example: 

myViewController.childViewControllers.filter({ $0 is ChildViewControllerOne })?.first

The above statement will go through all the controllers and then return the first one. This can be written using findFirst as following:

myViewController.childViewControllers.findFirst({ $0 is ChildViewControllerOne })

This will terminate the loop as soon as it finds an element that satisfies the predicate.

This function can be used on any sequence
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Many a times we want to grab the first element from a sequence that satisfies a predicate, for instance, grabbing a specific constraint from many constraints with a specific id, finding a view controller from childViewControllers which of a specific type. Rather than using filter (which will go through the complete sequence) and then first, findFirst function will terminate as soon as it finds an element that satisfies the predicate
