### PR TITLE
Further refinement of `isBindableTo` for BoundGenericType conformances.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1804,10 +1804,18 @@ static bool isBindableTo(Type a, Type b, LazyResolver *resolver) {
                  == substSubs[subi].getConformances().size());
           for (unsigned conformancei :
                  indices(origSubs[subi].getConformances())) {
-            if (origSubs[subi].getConformances()[conformancei].isConcrete() &&
-                origSubs[subi].getConformances()[conformancei] !=
-                    substSubs[subi].getConformances()[conformancei])
-              return false;
+            // An abstract conformance can be bound to a concrete one.
+            // A concrete conformance may be bindable to a different
+            // specialization of the same root conformance.
+            auto origConf = origSubs[subi].getConformances()[conformancei],
+                 substConf = substSubs[subi].getConformances()[conformancei];
+            if (origConf.isConcrete()) {
+              if (!substConf.isConcrete())
+                return false;
+              if (origConf.getConcrete()->getRootNormalConformance()
+                   != substConf.getConcrete()->getRootNormalConformance())
+                return false;
+            }
           }
         }
         


### PR DESCRIPTION
The conformances for e.g. `Foo<T>` might still be bindable to those for `Foo<Int>`; we can handle this by looking to see if the conformances' root NormalProtocolConformances match instead of their leaf specializations.
