### PR TITLE
[Runtime] Android does not support constexpr

### DIFF
--- a/include/swift/Runtime/MutexPThread.h
+++ b/include/swift/Runtime/MutexPThread.h
@@ -26,10 +26,12 @@ typedef pthread_cond_t ConditionHandle;
 typedef pthread_mutex_t MutexHandle;
 typedef pthread_rwlock_t ReadWriteLockHandle;
 
-#if defined(__CYGWIN__)
+#if defined(__CYGWIN__) || defined(__ANDROID__)
 // At the moment CYGWIN pthreads implementation doesn't support the use of
 // constexpr for static allocation versions. The way they define things
-// results in a reinterpret_cast which violates constexpr.
+// results in a reinterpret_cast which violates constexpr. Similarly, Android's
+// pthread implementation makes use of volatile attributes that prevent it from
+// being marked as constexpr.
 #define CONDITION_SUPPORTS_CONSTEXPR 0
 #define MUTEX_SUPPORTS_CONSTEXPR 0
 #define READWRITELOCK_SUPPORTS_CONSTEXPR 0


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

As with Cygwin, Android must not use `constexpr` for pthread initializers.

This fixes the [Android build](https://github.com/apple/swift/blob/master/docs/Android.md).
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
