### PR TITLE
stdlib: set the right displayStyle in Optional's Mirror

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -103,6 +103,20 @@ extension Optional : CustomDebugStringConvertible {
   }
 }
 
+extension Optional : CustomReflectable {
+  public var customMirror: Mirror {
+    switch self {
+    case .some(let value):
+      return Mirror(
+        self,
+        children: [ "some": value ],
+        displayStyle: .optional)
+    case .none:
+      return Mirror(self, children: [:], displayStyle: .optional)
+    }
+  }
+}
+
 @_transparent
 @warn_unused_result
 public // COMPILER_INTRINSIC

--- a/test/1_stdlib/Optional.swift
+++ b/test/1_stdlib/Optional.swift
@@ -76,6 +76,50 @@ OptionalTests.test("Equatable") {
   expectEqual([false, true, false, false, true, false], testRelation(<))
 }
 
+OptionalTests.test("CustomReflectable") {
+  // Test with a non-refcountable type.
+  do {
+    let value: OpaqueValue<Int>? = nil
+    var output = ""
+    dump(value, to: &output)
+    expectEqual("- nil\n", output)
+    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+  }
+  do {
+    let value: OpaqueValue<Int>? = OpaqueValue(1010)
+    var output = ""
+    dump(value, to: &output)
+    let expected =
+      "▿ Optional(StdlibUnittest.OpaqueValue<Swift.Int>(value: 1010, identity: 0))\n" +
+      "  ▿ some: StdlibUnittest.OpaqueValue<Swift.Int>\n" +
+      "    - value: 1010\n" +
+      "    - identity: 0\n"
+    expectEqual(expected, output)
+    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+  }
+  // Test with a reference type.
+  do {
+    let value: LifetimeTracked? = nil
+    var output = ""
+    dump(value, to: &output)
+    expectEqual("- nil\n", output)
+    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+  }
+  do {
+    let value: LifetimeTracked? = LifetimeTracked(1010)
+    var output = ""
+    dump(value, to: &output)
+    let expected =
+      "▿ Optional(1010)\n" +
+      "  ▿ some: 1010 #0\n" +
+      "    - value: 1010\n" +
+      "    - identity: 0\n" +
+      "    - serialNumber: 1\n"
+    expectEqual(expected, output)
+    expectEqual(.optional, Mirror(reflecting: value).displayStyle)
+  }
+}
+
 struct X {}
 class C {}
 class D {}

--- a/test/1_stdlib/Reflection.swift
+++ b/test/1_stdlib/Reflection.swift
@@ -148,13 +148,6 @@ switch true.customPlaygroundQuickLook {
   default: print("wrong quicklook type")
 }
 
-// CHECK-NEXT: Optional("Hello world")
-// CHECK-NEXT:   some: "Hello world"
-dump(Optional<String>("Hello world"))
-// CHECK-NEXT: - nil
-let noneString: String? = nil
-dump(noneString)
-
 let intArray = [1,2,3,4,5]
 // CHECK-NEXT: 5 elements
 // CHECK-NEXT: 1

--- a/test/IDE/complete_generic_optional.swift
+++ b/test/IDE/complete_generic_optional.swift
@@ -11,6 +11,6 @@ struct Foo<T> {
 // SR-642 Code completion does not instantiate generic arguments of a type wrapped in an optional
 let x: Foo<Bar>? = Foo<Bar>()
 x.#^FOO_OPTIONAL_1^#
-// FOO_OPTIONAL_1: Begin completions, 5 items
+// FOO_OPTIONAL_1: Begin completions, 6 items
 // FOO_OPTIONAL_1-DAG: Decl[InstanceMethod]/CurrNominal/Erase[1]: ?.myFunction({#(foobar): Bar#})[#Void#]; name=myFunction(foobar: Bar)
 // FOO_OPTIONAL_1: End completions


### PR DESCRIPTION
Optional's Mirror (the default one) used to report the display style as
"enum", which is technically correct, but we have a more specific style
for Optional.

rdar://problem/24450196

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
