### PR TITLE
Eagerly emit reflection metadata as decls are emitted

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -759,7 +759,7 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
                     classTI.getLayout(*this),
                     classTI.getClassLayout(*this));
   emitNestedTypeDecls(D->getMembers());
-  addNominalTypeDecl(D);
+  emitReflectionMetadata(D);
 }
 
 namespace {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -849,10 +849,6 @@ void IRGenModule::finishEmitAfterTopLevel() {
   finalizeClangCodeGen();
 }
 
-void IRGenModule::addNominalTypeDecl(const NominalTypeDecl *Decl) {
-  NominalTypeDecls.push_back(Decl);
-}
-
 static void emitLazyTypeMetadata(IRGenModule &IGM, CanType type) {
   auto decl = type.getAnyNominal();
   assert(decl);
@@ -879,13 +875,6 @@ void IRGenerator::emitTypeMetadataRecords() {
     m.second->emitTypeMetadataRecords();
   }
 }
-
-void IRGenerator::emitReflectionMetadataRecords() {
-  for (auto &m : *this) {
-    m.second->emitReflectionMetadataRecords();
-  }
-}
-
 
 /// Emit any lazy definitions (of globals or functions or whatever
 /// else) that we require.
@@ -2766,8 +2755,7 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 }
 
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
-  ExtensionDecls.push_back(ext);
-
+  emitAssociatedTypeMetadataRecord(ext);
   emitNestedTypeDecls(ext->getMembers());
 
   // Generate a category if the extension either introduces a

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5514,7 +5514,7 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
   emitEnumMetadata(*this, theEnum);
   emitNestedTypeDecls(theEnum->getMembers());
-  addNominalTypeDecl(theEnum);
+  emitReflectionMetadata(theEnum);
 }
 
 void irgen::emitSwitchAddressOnlyEnumDispatch(IRGenFunction &IGF,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5675,7 +5675,7 @@ void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
   var->setConstant(true);
   var->setInitializer(init);
 
-  addNominalTypeDecl(protocol);
+  emitReflectionMetadata(protocol);
 }
 
 /// \brief Load a reference to the protocol descriptor for the given protocol.

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -207,8 +207,9 @@ public:
 
 class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
   static const uint32_t AssociatedTypeRecordSize = 8;
-  ArrayRef<const NominalTypeDecl *> NominalTypeDecls;
-  ArrayRef<const ExtensionDecl *> ExtensionDecls;
+
+  llvm::PointerUnion<const NominalTypeDecl *, const ExtensionDecl *>
+  NominalOrExtensionDecl;
 
   void addConformance(Module *ModuleContext,
                       CanType ConformingType,
@@ -247,9 +248,18 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
     }
   }
 
+  const NominalTypeDecl *getNominalTypeDecl() const {
+    return NominalOrExtensionDecl.dyn_cast<const NominalTypeDecl *>();
+  }
+
+  const ExtensionDecl *getExtensionDecl() const {
+    return NominalOrExtensionDecl.dyn_cast<const ExtensionDecl *>();
+  }
+
   void layout() {
-    for (auto Decl : NominalTypeDecls) {
-      PrettyStackTraceDecl DebugStack("emitting associated type metadata", Decl);
+    if (auto Decl = getNominalTypeDecl()) {
+      PrettyStackTraceDecl DebugStack("emitting associated type metadata",
+                                      Decl);
       for (auto Conformance : Decl->getAllConformances()) {
         if (Conformance->isIncomplete())
           continue;
@@ -257,9 +267,7 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
                        Decl->getDeclaredType()->getCanonicalType(),
                        Conformance);
       }
-    }
-
-    for (auto Ext : ExtensionDecls) {
+    } else if (auto Ext = getExtensionDecl()) {
       PrettyStackTraceDecl DebugStack("emitting associated type metadata", Ext);
       for (auto Conformance : Ext->getLocalConformances()) {
         auto Decl = Ext->getExtendedType()->getNominalOrBoundGenericNominal();
@@ -271,13 +279,16 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
   }
 
 public:
-  AssociatedTypeMetadataBuilder(IRGenModule &IGM,
-    ArrayRef<const NominalTypeDecl *> NominalTypeDecls,
-    ArrayRef<const ExtensionDecl *> ExtensionDecls,
-    llvm::SetVector<CanType> &BuiltinTypes)
+  AssociatedTypeMetadataBuilder(IRGenModule &IGM, const NominalTypeDecl *Decl,
+                                llvm::SetVector<CanType> &BuiltinTypes)
     : ReflectionMetadataBuilder(IGM, BuiltinTypes),
-      NominalTypeDecls(NominalTypeDecls),
-      ExtensionDecls(ExtensionDecls) {}
+      NominalOrExtensionDecl(Decl) {}
+
+  AssociatedTypeMetadataBuilder(IRGenModule &IGM, const ExtensionDecl *Decl,
+                                llvm::SetVector<CanType> &BuiltinTypes)
+    : ReflectionMetadataBuilder(IGM, BuiltinTypes),
+      NominalOrExtensionDecl(Decl) {}
+
 
   llvm::GlobalVariable *emit() {
     auto tempBase = std::unique_ptr<llvm::GlobalVariable>(
@@ -307,7 +318,7 @@ public:
 
 class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
   const uint32_t fieldRecordSize = 12;
-  ArrayRef<const NominalTypeDecl *> NominalTypeDecls;
+  const NominalTypeDecl *NTD;
 
   void addFieldDecl(const ValueDecl *value, CanType type) {
     reflection::FieldRecordFlags Flags;
@@ -330,77 +341,71 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
     }
   }
 
-  void addDecl(const NominalTypeDecl *decl) {
+  void layout() {
     using swift::reflection::FieldDescriptorKind;
 
-    PrettyStackTraceDecl DebugStack("emitting field type metadata", decl);
-    auto type = decl->getDeclaredType()->getCanonicalType();
-    addTypeRef(decl->getModuleContext(), type);
+    PrettyStackTraceDecl DebugStack("emitting field type metadata", NTD);
+    auto type = NTD->getDeclaredType()->getCanonicalType();
+    addTypeRef(NTD->getModuleContext(), type);
 
-    switch (decl->getKind()) {
-    case DeclKind::Class:
-    case DeclKind::Struct: {
-      auto properties = decl->getStoredProperties();
-      addConstantInt16(uint16_t(isa<StructDecl>(decl)
-                                ? FieldDescriptorKind::Struct
-                                : FieldDescriptorKind::Class));
-      addConstantInt16(fieldRecordSize);
-      addConstantInt32(std::distance(properties.begin(), properties.end()));
-      for (auto property : properties)
-        addFieldDecl(property,
-                     property->getInterfaceType()
+    switch (NTD->getKind()) {
+      case DeclKind::Class:
+      case DeclKind::Struct: {
+        auto properties = NTD->getStoredProperties();
+        addConstantInt16(uint16_t(isa<StructDecl>(NTD)
+                                  ? FieldDescriptorKind::Struct
+                                  : FieldDescriptorKind::Class));
+        addConstantInt16(fieldRecordSize);
+        addConstantInt32(std::distance(properties.begin(), properties.end()));
+        for (auto property : properties)
+          addFieldDecl(property,
+                       property->getInterfaceType()
                        ->getCanonicalType());
-      break;
-    }
-    case DeclKind::Enum: {
-      auto enumDecl = cast<EnumDecl>(decl);
-      auto cases = enumDecl->getAllElements();
-      addConstantInt16(uint16_t(FieldDescriptorKind::Enum));
-      addConstantInt16(fieldRecordSize);
-      addConstantInt32(std::distance(cases.begin(), cases.end()));
-      for (auto enumCase : cases) {
-        if (enumCase->hasArgumentType()) {
-          addFieldDecl(enumCase,
-                       enumCase->getArgumentInterfaceType()
-                         ->getCanonicalType());
-        } else {
-          addFieldDecl(enumCase, CanType());
-        }
+        break;
       }
-      break;
-    }
-    case DeclKind::Protocol: {
-      auto protocolDecl = cast<ProtocolDecl>(decl);
-      FieldDescriptorKind Kind;
-      if (protocolDecl->isObjC())
-        Kind = FieldDescriptorKind::ObjCProtocol;
-      else if (protocolDecl->requiresClass())
-        Kind = FieldDescriptorKind::ClassProtocol;
-      else
-        Kind = FieldDescriptorKind::Protocol;
-      addConstantInt16(uint16_t(Kind));
-      addConstantInt16(fieldRecordSize);
-      addConstantInt32(0);
-      break;
-    }
-    default:
-      llvm_unreachable("Not a nominal type");
-      break;
-    }
-  }
-
-  void layout() {
-    for (auto decl : NominalTypeDecls) {
-      addDecl(decl);
+      case DeclKind::Enum: {
+        auto enumDecl = cast<EnumDecl>(NTD);
+        auto cases = enumDecl->getAllElements();
+        addConstantInt16(uint16_t(FieldDescriptorKind::Enum));
+        addConstantInt16(fieldRecordSize);
+        addConstantInt32(std::distance(cases.begin(), cases.end()));
+        for (auto enumCase : cases) {
+          if (enumCase->hasArgumentType()) {
+            addFieldDecl(enumCase,
+                         enumCase->getArgumentInterfaceType()
+                         ->getCanonicalType());
+          } else {
+            addFieldDecl(enumCase, CanType());
+          }
+        }
+        break;
+      }
+      case DeclKind::Protocol: {
+        auto protocolDecl = cast<ProtocolDecl>(NTD);
+        FieldDescriptorKind Kind;
+        if (protocolDecl->isObjC())
+          Kind = FieldDescriptorKind::ObjCProtocol;
+        else if (protocolDecl->requiresClass())
+          Kind = FieldDescriptorKind::ClassProtocol;
+        else
+          Kind = FieldDescriptorKind::Protocol;
+        addConstantInt16(uint16_t(Kind));
+        addConstantInt16(fieldRecordSize);
+        addConstantInt32(0);
+        break;
+      }
+      default:
+        llvm_unreachable("Not a nominal type");
+        break;
     }
   }
 
 public:
   FieldTypeMetadataBuilder(IRGenModule &IGM,
-                           ArrayRef<const NominalTypeDecl *> NominalTypeDecls,
+                           const NominalTypeDecl * NTD,
                            llvm::SetVector<CanType> &BuiltinTypes)
     : ReflectionMetadataBuilder(IGM, BuiltinTypes),
-      NominalTypeDecls(NominalTypeDecls) {}
+      NTD(NTD) {}
 
   llvm::GlobalVariable *emit() {
 
@@ -770,46 +775,58 @@ llvm::Constant *IRGenModule::getAddrOfCaptureDescriptor(SILFunction &SILFn,
   return llvm::ConstantExpr::getBitCast(var, CaptureDescriptorPtrTy);
 }
 
-void IRGenModule::emitReflectionMetadataRecords() {
-  auto DoNotHaveDecls = NominalTypeDecls.empty() && ExtensionDecls.empty();
-  if (!IRGen.Opts.EnableReflectionMetadata ||
-      (!IRGen.Opts.EnableReflectionBuiltins && DoNotHaveDecls))
+void IRGenModule::emitReflectionMetadata(const NominalTypeDecl *Decl) {
+  if (!IRGen.Opts.EnableReflectionMetadata)
     return;
 
-  // We collect all referenced builtin types and emit records for them.
-  // In practice only the standard library should directly reference
-  // builtin types.
-  //
-  // FIXME: This metadata should be in the runtime instead.
   llvm::SetVector<CanType> BuiltinTypes;
 
-  {
-    FieldTypeMetadataBuilder builder(*this, NominalTypeDecls, BuiltinTypes);
-    auto var = builder.emit();
-    if (var)
-      addUsedGlobal(var);
-  }
+  emitFieldMetadataRecord(Decl);
+  emitAssociatedTypeMetadataRecord(Decl);
+}
 
-  {
-    AssociatedTypeMetadataBuilder builder(*this,
-                                          NominalTypeDecls,
-                                          ExtensionDecls,
-                                          BuiltinTypes);
-    auto var = builder.emit();
-    if (var)
-      addUsedGlobal(var);
-  }
+void IRGenModule::emitAssociatedTypeMetadataRecord(const NominalTypeDecl *Decl){
+  if (!IRGen.Opts.EnableReflectionMetadata)
+    return;
 
-  if (IRGen.Opts.EnableReflectionBuiltins) {
-    BuiltinTypes.insert(Context.TheNativeObjectType);
-    BuiltinTypes.insert(Context.TheUnknownObjectType);
-    BuiltinTypes.insert(Context.TheBridgeObjectType);
-    BuiltinTypes.insert(Context.TheRawPointerType);
-    BuiltinTypes.insert(Context.TheUnsafeValueBufferType);
+  AssociatedTypeMetadataBuilder builder(*this, Decl, BuiltinTypes);
+  auto var = builder.emit();
+  if (var)
+    addUsedGlobal(var);
+}
 
-    BuiltinTypeMetadataBuilder builder(*this, BuiltinTypes);
-    auto var = builder.emit();
-    if (var)
-      addUsedGlobal(var);
-  }
+void IRGenModule::emitAssociatedTypeMetadataRecord(const ExtensionDecl *Ext) {
+  if (!IRGen.Opts.EnableReflectionMetadata)
+    return;
+
+  AssociatedTypeMetadataBuilder builder(*this, Ext, BuiltinTypes);
+  auto var = builder.emit();
+  if (var)
+    addUsedGlobal(var);
+}
+
+void IRGenModule::emitBuiltinReflectionMetadata() {
+  if (!IRGen.Opts.EnableReflectionBuiltins)
+    return;
+
+  BuiltinTypes.insert(Context.TheNativeObjectType);
+  BuiltinTypes.insert(Context.TheUnknownObjectType);
+  BuiltinTypes.insert(Context.TheBridgeObjectType);
+  BuiltinTypes.insert(Context.TheRawPointerType);
+  BuiltinTypes.insert(Context.TheUnsafeValueBufferType);
+
+  BuiltinTypeMetadataBuilder builder(*this, BuiltinTypes);
+  auto var = builder.emit();
+  if (var)
+    addUsedGlobal(var);
+}
+
+void IRGenModule::emitFieldMetadataRecord(const NominalTypeDecl *Decl) {
+  if (!IRGen.Opts.EnableReflectionMetadata)
+    return;
+
+  FieldTypeMetadataBuilder builder(*this, Decl, BuiltinTypes);
+  auto var = builder.emit();
+  if (var)
+    addUsedGlobal(var);
 }

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -811,7 +811,7 @@ irgen::getPhysicalStructMemberAccessStrategy(IRGenModule &IGM,
 void IRGenModule::emitStructDecl(StructDecl *st) {
   emitStructMetadata(*this, st);
   emitNestedTypeDecls(st->getMembers());
-  addNominalTypeDecl(st);
+  emitReflectionMetadata(st);
 }
 
 namespace {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -586,7 +586,7 @@ static std::unique_ptr<llvm::Module> performIRGeneration(IRGenOptions &Opts,
       // In JIT mode these are manually registered above.
       IGM.emitProtocolConformances();
       IGM.emitTypeMetadataRecords();
-      IGM.emitReflectionMetadataRecords();
+      IGM.emitBuiltinReflectionMetadata();
     }
 
     // Okay, emit any definitions that we suddenly need.
@@ -739,7 +739,6 @@ static void performParallelIRGeneration(IRGenOptions &Opts,
   IRGenModule *PrimaryGM = irgen.getPrimaryIGM();
 
   irgen.emitProtocolConformances();
-  irgen.emitReflectionMetadataRecords();
 
   // Okay, emit any definitions that we suddenly need.
   irgen.emitLazyDefinitions();


### PR DESCRIPTION
Rather than collection nominal type and extension decls and emit
reflection metadata records in one go, we can emit them as they
are encountered and instead collection builtin types referenced
by those at the end.
