### PR TITLE
Collect builtins referenced by captures

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -660,6 +660,7 @@ public:
     for (auto CaptureType : CaptureTypes) {
       addTypeRef(Callee.getModule().getSwiftModule(), CaptureType,
                  /*global*/ true);
+      addBuiltinTypeRefs(CaptureType);
     }
 
     // Add the pairs that make up the generic param -> metadata source map


### PR DESCRIPTION
If there are any builtin types referenced by closure captures
[in the standard library], make sure to collect them so we emit
reflection metadata for them in the builtin section.
