### PR TITLE
[IRGen] Don't emit ObjC class property metadata on old targets.

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1634,12 +1634,20 @@ namespace {
     llvm::Constant *buildPropertyList(ForMetaClass_t classOrMeta) {
       Size eltSize = 2 * IGM.getPointerSize();
       StringRef namePrefix;
+
       if (classOrMeta == ForClass) {
         return buildOptionalList(InstanceProperties, eltSize,
                                  chooseNamePrefix("_PROPERTIES_",
                                                   "_CATEGORY_PROPERTIES_",
                                                   "_PROTOCOL_PROPERTIES_"));
       }
+
+      // Older OSs' libobjcs can't handle class property data.
+      if ((IGM.Triple.isMacOSX() && IGM.Triple.isMacOSXVersionLT(10, 11)) ||
+          (IGM.Triple.isiOS() && IGM.Triple.isOSVersionLT(9))) {
+        return null();
+      }
+
       return buildOptionalList(ClassProperties, eltSize,
                                chooseNamePrefix("_CLASS_PROPERTIES_",
                                                 "_CATEGORY_CLASS_PROPERTIES_",

--- a/test/IRGen/objc_properties.swift
+++ b/test/IRGen/objc_properties.swift
@@ -1,6 +1,9 @@
-// RUN: %target-swift-frontend %s -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck %s
+// This file is also used by objc_properties_ios.swift.
 
-// REQUIRES: CPU=x86_64
+// RUN: %swift -target x86_64-apple-macosx10.11 %s -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck -check-prefix=CHECK -check-prefix=CHECK-NEW %s
+// RUN: %swift -target x86_64-apple-macosx10.10 %s -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck -check-prefix=CHECK -check-prefix=CHECK-OLD %s
+
+// REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 
 @objc class SomeObject {
@@ -94,14 +97,14 @@ class Class17127126 {
 // CHECK: [[SHARED_NAME:@.*]] = private unnamed_addr constant [11 x i8] c"sharedProp\00"
 // CHECK: [[SHARED_ATTRS:@.*]] = private unnamed_addr constant [17 x i8] c"Tq,N,VsharedProp\00"
 
-// CHECK: @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject = private constant { {{.*}}] } {
-// CHECK:   i32 16,
-// CHECK:   i32 1,
-// CHECK:   [1 x { i8*, i8* }] [{
-// CHECK:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SHARED_NAME]], i64 0, i64 0),
-// CHECK:     i8* getelementptr inbounds ([17 x i8], [17 x i8]* [[SHARED_ATTRS]], i64 0, i64 0)
-// CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK-NEW: @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject = private constant { {{.*}}] } {
+// CHECK-NEW:   i32 16,
+// CHECK-NEW:   i32 1,
+// CHECK-NEW:   [1 x { i8*, i8* }] [{
+// CHECK-NEW:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SHARED_NAME]], i64 0, i64 0),
+// CHECK-NEW:     i8* getelementptr inbounds ([17 x i8], [17 x i8]* [[SHARED_ATTRS]], i64 0, i64 0)
+// CHECK-NEW:   }]
+// CHECK-NEW: }, section "__DATA, __objc_const", align 8
 
 // CHECK: @_METACLASS_DATA__TtC15objc_properties10SomeObject = private constant { {{.*}} } {
 // CHECK-SAME:   i32 {{[0-9]+}}, i32 {{[0-9]+}}, i32 {{[0-9]+}}, i32 {{[0-9]+}},
@@ -109,7 +112,8 @@ class Class17127126 {
 // CHECK-SAME:   i8* getelementptr inbounds ([{{.+}} x i8], [{{.+}} x i8]* {{@.+}}, i64 0, i64 0),
 // CHECK-SAME:   { {{.+}} }* @_CLASS_METHODS__TtC15objc_properties10SomeObject,
 // CHECK-SAME:   i8* null, i8* null, i8* null,
-// CHECK-SAME:   { {{.+}} }* @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject
+// CHECK-NEW-SAME:   { {{.+}} }* @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject
+// CHECK-OLD-SAME:   i8* null
 // CHECK-SAME: }, section "__DATA, __objc_const", align 8
 
 // CHECK: @_INSTANCE_METHODS__TtC15objc_properties10SomeObject = private constant { {{.*}}] } {
@@ -207,14 +211,14 @@ class Class17127126 {
 // CHECK:   }]
 // CHECK: }, section "__DATA, __objc_const", align 8
 
-// CHECK: @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties" = private constant { {{.*}}] } {
-// CHECK:   i32 16,
-// CHECK:   i32 1,
-// CHECK:   [1 x { i8*, i8* }] [{
-// CHECK:     i8* getelementptr inbounds ([19 x i8], [19 x i8]* [[EXTENSIONCLASSPROPERTY_NAME]], i64 0, i64 0),
-// CHECK:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[EXTENSIONCLASSPROPERTY_ATTRS]], i64 0, i64 0)
-// CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK-NEW: @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties" = private constant { {{.*}}] } {
+// CHECK-NEW:   i32 16,
+// CHECK-NEW:   i32 1,
+// CHECK-NEW:   [1 x { i8*, i8* }] [{
+// CHECK-NEW:     i8* getelementptr inbounds ([19 x i8], [19 x i8]* [[EXTENSIONCLASSPROPERTY_NAME]], i64 0, i64 0),
+// CHECK-NEW:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[EXTENSIONCLASSPROPERTY_ATTRS]], i64 0, i64 0)
+// CHECK-NEW:   }]
+// CHECK-NEW: }, section "__DATA, __objc_const", align 8
 
 // CHECK: @"_CATEGORY__TtC15objc_properties10SomeObject_$_objc_properties" = private constant { {{.+}} } {
 // CHECK:   i8* getelementptr inbounds ([{{.+}} x i8], [{{.+}} x i8]* {{@.+}}, i64 0, i64 0),
@@ -223,7 +227,8 @@ class Class17127126 {
 // CHECK:   { {{.+}} }* @"_CATEGORY_CLASS_METHODS__TtC15objc_properties10SomeObject_$_objc_properties",
 // CHECK:   i8* null,
 // CHECK:   { {{.+}} }* @"_CATEGORY_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties", 
-// CHECK:   { {{.+}} }* @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties",
+// CHECK-NEW:   { {{.+}} }* @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties",
+// CHECK-OLD:   i8* null,
 // CHECK:   i32 60
 // CHECK: }, section "__DATA, __objc_const", align 8
 
@@ -248,7 +253,8 @@ class Class17127126 {
 // CHECK:   i32 96, i32 1,
 // CHECK:   { {{.+}} }* @_PROTOCOL_METHOD_TYPES__TtP15objc_properties5Proto_,
 // CHECK:   i8* null,
-// CHECK:   { {{.+}} }* @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_
+// CHECK-NEW:   { {{.+}} }* @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_
+// CHECK-OLD:   i8* null
 // CHECK: }, section "__DATA, __objc_const", align 8
 
 
@@ -267,11 +273,11 @@ class Class17127126 {
 // CHECK:   }]
 // CHECK: }, section "__DATA, __objc_const", align 8
 
-// CHECK: @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_ = private constant { {{.*}}] } {
-// CHECK:   i32 16,
-// CHECK:   i32 1,
-// CHECK:   [1 x { i8*, i8* }] [{
-// CHECK:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* [[PROTOCOLCLASSPROPERTY_NAME]], i64 0, i64 0),
-// CHECK:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[PROTOCOLCLASSPROPERTY_ATTRS]], i64 0, i64 0)
-// CHECK:   }]
-// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK-NEW: @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_ = private constant { {{.*}}] } {
+// CHECK-NEW:   i32 16,
+// CHECK-NEW:   i32 1,
+// CHECK-NEW:   [1 x { i8*, i8* }] [{
+// CHECK-NEW:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* [[PROTOCOLCLASSPROPERTY_NAME]], i64 0, i64 0),
+// CHECK-NEW:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[PROTOCOLCLASSPROPERTY_ATTRS]], i64 0, i64 0)
+// CHECK-NEW:   }]
+// CHECK-NEW: }, section "__DATA, __objc_const", align 8

--- a/test/IRGen/objc_properties_ios.swift
+++ b/test/IRGen/objc_properties_ios.swift
@@ -1,0 +1,6 @@
+// RUN: %swift -target x86_64-apple-ios9 %S/objc_properties.swift -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck -check-prefix=CHECK -check-prefix=CHECK-NEW %S/objc_properties.swift
+// RUN: %swift -target x86_64-apple-ios8 %S/objc_properties.swift -disable-target-os-checking -emit-ir -disable-objc-attr-requires-foundation-module | FileCheck -check-prefix=CHECK -check-prefix=CHECK-OLD %S/objc_properties.swift
+
+// REQUIRES: OS=ios
+// REQUIRES: CPU=x86_64
+// REQUIRES: objc_interop

--- a/test/Interpreter/objc_class_properties.swift
+++ b/test/Interpreter/objc_class_properties.swift
@@ -175,9 +175,7 @@ class NamingConflictSubclass : PropertyNamingConflict {
   override class var prop: AnyObject? { return NamingConflictSubclass() }
 }
 
-ClassProperties.test("namingConflict")
-  .skip(.osxMinorRange(10, 0...10, reason: "unexpected failures on 10.10"))
-  .code {
+ClassProperties.test("namingConflict") {
   let obj = PropertyNamingConflict()
   expectTrue(obj === obj.prop)
   expectEmpty(obj.dynamicType.prop)
@@ -200,25 +198,13 @@ extension NamingConflictSubclass : PropertyNamingConflictProto {
   }
 }
 
-ClassProperties.test("namingConflict/protocol")
-  .skip(.osxMinorRange(10, 0...10, reason: "unexpected failures on 10.10"))
-  .code {
+ClassProperties.test("namingConflict/protocol") {
   let obj: PropertyNamingConflictProto = NamingConflictSubclass()
   expectTrue(obj === obj.protoProp)
   expectEmpty(obj.dynamicType.protoProp)
 
   let type: PropertyNamingConflictProto.Type = NamingConflictSubclass.self
   expectEmpty(type.protoProp)
-}
-
-ClassProperties.test("runtime") {
-  let theClass: AnyObject = SwiftClass.self
-  let prop = class_getProperty(object_getClass(theClass), "value")
-  expectTrue(prop != nil)
-
-  let nameAsCString = property_getName(prop)
-  expectTrue(nameAsCString != nil)
-  expectEqual("value", String(cString: nameAsCString))
 }
 
 runAllTests()

--- a/test/Interpreter/objc_class_properties_runtime.swift
+++ b/test/Interpreter/objc_class_properties_runtime.swift
@@ -1,0 +1,85 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang -arch x86_64 -mmacosx-version-min=10.11 -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+
+// RUN: %swiftc_driver -target $(echo '%target-triple' | sed -E -e 's/macosx10.(9|10).*/macosx10.11/') -sdk %sdk -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
+// RUN: %t/a.out
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+import ObjCClasses
+
+class SwiftClass : ProtoWithClassProperty {
+  static var getCount = 0
+  static var setCount = 0
+
+  private static var _value: CInt = 0
+
+  @objc class func reset() {
+    getCount = 0
+    setCount = 0
+    _value = 0
+  }
+
+  @objc class var value: CInt {
+    get {
+      getCount += 1
+      return _value
+    }
+    set {
+      setCount += 1
+      _value = newValue
+    }
+  }
+
+  @objc class var optionalClassProp: Bool {
+    return true
+  }
+}
+
+class Subclass : ClassWithClassProperty {
+  static var getCount = 0
+  static var setCount = 0
+  
+  override class func reset() {
+    getCount = 0
+    setCount = 0
+    super.reset()
+  }
+
+  override class var value: CInt {
+    get {
+      getCount += 1
+      return super.value
+    }
+    set {
+      setCount += 1
+      super.value = newValue
+    }
+  }
+
+  override class var optionalClassProp: Bool {
+    return true
+  }
+}
+
+var ClassProperties = TestSuite("ClassProperties")
+
+ClassProperties.test("runtime")
+  .skip(.osxMinorRange(10, 0...10, reason: "not supported on 10.10 or below"))
+  .code {
+  let theClass: AnyObject = SwiftClass.self
+  let prop = class_getProperty(object_getClass(theClass), "value")
+  expectNotEmpty(prop)
+
+  let nameAsCString = property_getName(prop)
+  expectNotEmpty(nameAsCString)
+  expectEqual("value", String(cString: nameAsCString))
+}
+
+runAllTests()
+


### PR DESCRIPTION
The ObjC runtime on OS X 10.10 and older and iOS 9 and older can't handle them, so for these targets, emit nil for all class property lists.

It's a little unfortunate that this is target-dependent, but there's not much we can do about it.

This is the Swift version of apple/swift-clang@4611d28.

rdar://problem/25605427
