### PR TITLE
 [Sema] Limit inout capture to @noescape contexts

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2133,6 +2133,18 @@ NOTE(transitive_capture_through_here,none,
      "%0, declared here, captures %1",
      (Identifier, Identifier))
 
+ERROR(closure_implicit_capture_without_noescape,none,
+      "closure cannot implicitly capture an inout parameter unless @noescape",
+      ())
+ERROR(closure_implicit_capture_mutating_self,none,
+      "closure cannot implicitly capture a mutating self parameter",
+      ())
+ERROR(nested_function_with_implicit_capture_argument,none,
+      "nested function with %select{a |}0implicitly captured inout "
+      "parameter%select{|s}0 can only be used as a @noescape argument", (bool))
+ERROR(nested_function_escaping_inout_capture,none,
+      "nested function cannot capture inout parameter and escape", ())
+
 WARNING(recursive_accessor_reference,none,
         "attempting to %select{access|modify}1 %0 within its own "
         "%select{getter|setter}1", (Identifier, bool))

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -441,7 +441,9 @@ public:
       tryDiagnoseUnnecessaryCastOverOptionSet(TC.Context, E, ResultTy,
                                               DC->getParentModule());
     }
-    
+    if (auto DRE = dyn_cast<DeclRefExpr>(E))
+      if (auto FD = dyn_cast<FuncDecl>(DRE->getDecl()))
+        TC.addEscapingFunctionAsReturnValue(FD, RS);
     return RS;
   }
   

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -513,6 +513,59 @@ public:
   llvm::DenseMap<AnyFunctionRef, std::vector<Expr*>> LocalCFunctionPointers;
 
 private:
+  /// Return statements with functions as return values.
+  llvm::DenseMap<AbstractFunctionDecl *, llvm::DenseSet<ReturnStmt *>>
+    FunctionAsReturnValue;
+
+  /// Function apply expressions with a certain function as an arugment.
+  llvm::DenseMap<AbstractFunctionDecl *, llvm::DenseSet<ApplyExpr *>>
+    FunctionAsEscapingArg;
+
+public:
+  /// Record an occurence of a function that captures inout values as an
+  /// argument.
+  ///
+  /// \param decl the function that occurs as an arugment.
+  ///
+  /// \param apply the expression in which the function appears.
+  void addEscapingFunctionAsArgument(AbstractFunctionDecl *decl,
+                                     ApplyExpr *apply) {
+    FunctionAsEscapingArg[decl].insert(apply);
+  }
+
+  /// Find occurences of a function that captures inout values as arguments.
+  ///
+  /// \param decl the function that occurs as an arugment.
+  ///
+  /// \returns Expressions in which the function appears as arguments.
+  llvm::DenseSet<ApplyExpr *> &
+  getEscapingFunctionAsArgument(AbstractFunctionDecl *decl) {
+    return FunctionAsEscapingArg[decl];
+  }
+
+  /// Record an occurence of  a function that captures inout values as a return
+  /// value
+  ///
+  /// \param decl the function that occurs as a return value.
+  ///
+  /// \param stmt the expression in which the function appears.
+  void addEscapingFunctionAsReturnValue(AbstractFunctionDecl *decl,
+                                        ReturnStmt *stmt) {
+    FunctionAsReturnValue[decl].insert(stmt);
+  }
+
+  /// Find occurences of a function that captures inout values as return
+  /// values.
+  ///
+  /// \param decl the function that occurs as a return value.
+  ///
+  /// \returns Expressions in which the function appears as arguments.
+  llvm::DenseSet<ReturnStmt *> &
+  getEscapingFunctionAsReturnValue(AbstractFunctionDecl *decl) {
+    return FunctionAsReturnValue[decl];
+  }
+
+private:
   Type IntLiteralType;
   Type FloatLiteralType;
   Type BooleanLiteralType;

--- a/test/DebugInfo/inout.swift
+++ b/test/DebugInfo/inout.swift
@@ -5,24 +5,21 @@
 
 // LValues are direct values, too. They are reference types, though.
 
-func Close(_ fn: () -> Int64) { fn() }
+func Close(_ fn: @noescape () -> Int64) { fn() }
 typealias MyFloat = Float
 
 // CHECK: define hidden void @_TF5inout13modifyFooHeap
 // CHECK: %[[ALLOCA:.*]] = alloca %Vs5Int64*
-// CHECK: %[[ALLOCB:.*]] = alloca %Sf
 // CHECK: call void @llvm.dbg.declare(metadata
 // CHECK-SAME:                        %[[ALLOCA]], metadata ![[A:[0-9]+]]
-// CHECK: call void @llvm.dbg.declare(metadata
-// CHECK-SAME:       %[[ALLOCB]], metadata ![[B:[0-9]+]], metadata !{{[0-9]+}})
 
 // Closure with promoted capture.
-// PROMO-CHECK: define {{.*}}@_TTSf2i___TFF5inout13modifyFooHeapFTRVs5Int64Sf_T_U_FT_S0_
-// PROMO-CHECK: call void @llvm.dbg.declare(metadata {{(i32|i64)}}* %
+// PROMO-CHECK: define {{.*}}@_TFF5inout13modifyFooHeapFTRVs5Int64Sf_T_U_FT_S0_
+// PROMO-CHECK: call void @llvm.dbg.declare(metadata %Vs5Int64** %
 // PROMO-CHECK-SAME:   metadata ![[A1:[0-9]+]], metadata ![[EMPTY_EXPR:[0-9]+]])
 
-// PROMO-CHECK: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "_TtVs5Int64"
 // PROMO-CHECK: ![[EMPTY_EXPR]] = !DIExpression()
+// PROMO-CHECK: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "_TtRVs5Int64"
 // PROMO-CHECK: ![[A1]] = !DILocalVariable(name: "a", arg: 1
 // PROMO-CHECK-SAME:                       type: ![[INT]]
 func modifyFooHeap(_ a: inout Int64,
@@ -30,7 +27,7 @@ func modifyFooHeap(_ a: inout Int64,
   // CHECK-DAG: ![[RINT]] = !DICompositeType({{.*}}identifier: "_TtRVs5Int64"
                    _ b: MyFloat)
 {
-    var b = b
+    let b = b
     if (b > 2.71) {
       a = a + 12// Set breakpoint here
     }

--- a/test/Interpreter/capture_inout.swift
+++ b/test/Interpreter/capture_inout.swift
@@ -1,19 +1,14 @@
 // RUN: %target-run-simple-swift | FileCheck %s
 // REQUIRES: executable_test
 
-func foo(_ x: inout Int) -> () -> Int {
+func foo(_ x: inout Int) {
   func bar() -> Int {
     x += 1
     return x
   }
   bar()
-  return bar
 }
 
 var x = 219
-var f = foo(&x)
-print(x) // CHECK: 220
-print(f()) // CHECK: 221
-print(f()) // CHECK: 222
-print(f()) // CHECK: 223
+foo(&x)
 print(x) // CHECK: 220

--- a/test/SILGen/capture_inout.swift
+++ b/test/SILGen/capture_inout.swift
@@ -6,12 +6,12 @@ typealias Int = Builtin.Int64
 // CHECK: bb0([[X_INOUT:%.*]] : $*Builtin.Int64):
 // CHECK:   [[X_LOCAL:%.*]] = alloc_box $Builtin.Int64
 // CHECK:   [[FUNC:%.*]] = function_ref [[CLOSURE:@.*]] : $@convention(thin) (@owned @box Builtin.Int64) -> Builtin.Int64
-// CHECK:   partial_apply [[FUNC]]([[X_LOCAL]])
+// CHECK:   apply [[FUNC]]([[X_LOCAL]])
 // CHECK: }
 // CHECK: sil shared [[CLOSURE]] : $@convention(thin) (@owned @box Builtin.Int64) -> Builtin.Int64
-func foo(x: inout Int) -> () -> Int {
+func foo(x: inout Int) {
   func bar() -> Int {
     return x
   }
-  return bar
+  bar()
 }

--- a/test/SILOptimizer/allocbox_to_stack_not_crash.swift
+++ b/test/SILOptimizer/allocbox_to_stack_not_crash.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend %s -emit-ir -verify
+
+// Verify we don't crash on this.
+// rdar://15595118
+infix operator ~> { precedence 255 }
+protocol Target {}
+
+func ~> <Target, Arg0, Result>(x: inout Target, f: (_: inout Target, _: Arg0) -> Result) -> (Arg0) -> Result {
+  return { f(&x, $0) } // expected-error {{closure cannot implicitly capture an inout parameter unless @noescape}}
+}
+
+func ~> (x: inout Int, f: (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
+  return { f(&x, $0) } // expected-error {{closure cannot implicitly capture an inout parameter unless @noescape}}
+}
+

--- a/test/SILOptimizer/allocbox_to_stack_with_false.swift
+++ b/test/SILOptimizer/allocbox_to_stack_with_false.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s | FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s -verify | FileCheck %s
 
 // Make sure that materializations of computed properties such as 'false' and
 // 'true' don't leave needless stack allocations. <rdar://problem/15272642>
@@ -10,17 +10,3 @@
 func g() {
   if false {}
 }
-
-// Verify we don't crash on this.
-// rdar://15595118
-infix operator ~> { precedence 255 }
-protocol Target {}
-
-func ~> <Target, Arg0, Result>(x: inout Target, f: (_: inout Target, _: Arg0) -> Result) -> (Arg0) -> Result {
-  return { f(&x, $0) }
-}
-
-func ~> (x: inout Int, f: (_: inout Int, _: Target) -> Target) -> (Target) -> Target {
-  return { f(&x, $0) }
-}
-

--- a/test/Sema/diag_invalid_inout_captures.swift
+++ b/test/Sema/diag_invalid_inout_captures.swift
@@ -1,0 +1,27 @@
+// RUN: %target-parse-verify-swift
+
+func no_escape(_ you_say_price_of_my_love_is: @noescape () -> ()) {}
+func do_escape(_ not_a_price_you_are_willing_to_pay: () -> ()) {}
+
+struct you_cry_in_your_tea {
+  mutating func which_you_hurl_in_the_sea_when_you_see_me_go_by() {
+    no_escape { _ = self } // OK
+    do_escape { _ = self } // expected-error {{closure cannot implicitly capture a mutating self parameter}}
+  }
+}
+
+func why_so_sad(line: inout String) {
+    no_escape { line = "Remember we made an arrangement when you went away" } // OK
+    do_escape { line = "now you're making me mad" } // expected-error {{closure cannot implicitly capture an inout parameter unless @noescape}}
+}
+
+func remember(line: inout String) -> () -> Void {
+    func despite_our_estrangement() {
+        line = "I'm your man"
+    }
+    no_escape(despite_our_estrangement)
+    do_escape(despite_our_estrangement) // expected-error {{nested function with a implicitly captured inout parameter can only be used as a @noescape argument}}
+
+    return despite_our_estrangement // expected-error {{nested function cannot capture inout parameter and escape}}
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This patch adds limits to inout captures as specified in [SE-0035](https://github.com/apple/swift-evolution/blob/master/proposals/0035-limit-inout-capture.md).

The following diagnostics have been added:
1. implicit capture of inout arguments by closure literals that may escape (not
   mark by @noescape) is now invalid. This also includes implicit capture of
   `self`.
2. nested functions with inout captures cannot be used as arguments not marked
   @noescape.
3. nested function with inout captures cannot be a return value.

This change eliminates the need for the shadowing mechanism created for inout.

_The shadow copy and InOutDeshadowing SIL pass has not been eliminated yet. It's WIP and should come in a later PR._
#### Resolved bug number: ([SR-807](https://bugs.swift.org/browse/SR-807))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
