### PR TITLE
[swiftc] Add test case for crash triggered in swift::Type::transform(…)

### DIFF
--- a/validation-test/compiler_crashers/28289-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28289-swift-type-transform.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{class B<t{typealias d<a>:S<a>class a:d
+class S<o


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2051: auto swift::ArchetypeBuilder::mapTypeIntoContext(Module *, swift::GenericParamList *, swift::Type, swift::LazyResolver *)::(anonymous class)::operator()(swift::Type) const: Assertion `genericParamsDepth >= depth' failed.
9  swift           0x00000000010d7dc4 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
10 swift           0x00000000010d8060 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 704
11 swift           0x00000000010d866c swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 2252
12 swift           0x0000000000fa689b swift::ArchetypeBuilder::mapTypeIntoContext(swift::DeclContext*, swift::Type, swift::LazyResolver*) + 171
13 swift           0x00000000010d4dd4 swift::TypeBase::getSuperclass(swift::LazyResolver*) + 244
14 swift           0x0000000000e7e25d swift::TypeChecker::defineDefaultConstructor(swift::NominalTypeDecl*) + 109
15 swift           0x0000000000e7d3a3 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1411
20 swift           0x0000000000e77716 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
23 swift           0x0000000000ed91fa swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 218
24 swift           0x0000000000f031ac swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
25 swift           0x0000000000e657e1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
27 swift           0x0000000000ed9346 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
28 swift           0x0000000000e991bd swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1117
29 swift           0x0000000000c36eef swift::CompilerInstance::performSema() + 3295
31 swift           0x00000000007c5006 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2838
32 swift           0x0000000000791b08 main + 2840
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28289-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28289-swift-type-transform-3028ba.o
1.  While type-checking expression at [validation-test/compiler_crashers/28289-swift-type-transform.swift:10:1 - line:11:9] RangeText="{class B<t{typealias d<a>:S<a>class a:d
2.  While type-checking 'B' at validation-test/compiler_crashers/28289-swift-type-transform.swift:10:2
3.  While defining default constructor for 'a' at validation-test/compiler_crashers/28289-swift-type-transform.swift:10:31
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
