### PR TITLE
runtime: resolve a few global constructors

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -225,8 +225,6 @@ public:
 
 } // end anonymous namespace
 
-static Lazy<MetadataCache<BoxCacheEntry>> Boxes;
-
 SWIFT_RUNTIME_EXPORT
 BoxPair::Return
 swift::swift_allocBox(const Metadata *type) {
@@ -236,6 +234,8 @@ swift::swift_allocBox(const Metadata *type) {
 SWIFT_RT_ENTRY_IMPL_VISIBILITY
 extern "C"
 BoxPair::Return SWIFT_RT_ENTRY_IMPL(swift_allocBox)(const Metadata *type) {
+  static Lazy<MetadataCache<BoxCacheEntry>> Boxes;
+
   // Get the heap metadata for the box.
   auto &B = Boxes.get();
   const void *typeArg = type;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -291,9 +291,6 @@ namespace {
   };
 }
 
-/// The uniquing structure for ObjC class-wrapper metadata.
-static Lazy<MetadataCache<ObjCClassCacheEntry>> ObjCClassWrappers;
-
 const Metadata *
 swift::swift_getObjCClassMetadata(const ClassMetadata *theClass) {
   // If the class pointer is valid as metadata, no translation is required.
@@ -302,8 +299,10 @@ swift::swift_getObjCClassMetadata(const ClassMetadata *theClass) {
   }
 
 #if SWIFT_OBJC_INTEROP
-  // Search the cache.
+  /// The uniquing structure for ObjC class-wrapper metadata.
+  static Lazy<MetadataCache<ObjCClassCacheEntry>> ObjCClassWrappers;
 
+  // Search the cache.
   const size_t numGenericArgs = 1;
   const void *args[] = { theClass };
   auto &Wrappers = ObjCClassWrappers.get();
@@ -357,8 +356,6 @@ namespace {
   };
 }
 
-/// The uniquing structure for function type metadata.
-static Lazy<MetadataCache<FunctionCacheEntry>> FunctionTypes;
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata1(FunctionTypeFlags flags,
@@ -408,6 +405,9 @@ swift::swift_getFunctionTypeMetadata3(FunctionTypeFlags flags,
 
 const FunctionTypeMetadata *
 swift::swift_getFunctionTypeMetadata(const void *flagsArgsAndResult[]) {
+  /// The uniquing structure for function type metadata.
+  static Lazy<MetadataCache<FunctionCacheEntry>> FunctionTypes;
+
   auto flags = FunctionTypeFlags::fromIntValue(size_t(flagsArgsAndResult[0]));
 
   unsigned numArguments = flags.getNumArguments();
@@ -507,9 +507,6 @@ namespace {
     }
   };
 }
-
-/// The uniquing structure for tuple type metadata.
-static Lazy<MetadataCache<TupleCacheEntry>> TupleTypes;
 
 /// Given a metatype pointer, produce the value-witness table for it.
 /// This is equivalent to metatype->ValueWitnesses but more efficient.
@@ -971,6 +968,9 @@ swift::swift_getTupleTypeMetadata(size_t numElements,
                                   const Metadata * const *elements,
                                   const char *labels,
                                   const ValueWitnessTable *proposedWitnesses) {
+  /// The uniquing structure for tuple type metadata.
+  static Lazy<MetadataCache<TupleCacheEntry>> TupleTypes;
+
   // Bypass the cache for the empty tuple. We might reasonably get called
   // by generic code, like a demangler that produces type objects.
   if (numElements == 0) return &_TMT_;
@@ -1778,9 +1778,6 @@ namespace {
   };
 }
 
-/// The uniquing structure for metatype type metadata.
-static Lazy<MetadataCache<MetatypeCacheEntry>> MetatypeTypes;
-
 /// \brief Find the appropriate value witness table for the given type.
 static const ValueWitnessTable *
 getMetatypeValueWitnesses(const Metadata *instanceType) {
@@ -1793,6 +1790,9 @@ getMetatypeValueWitnesses(const Metadata *instanceType) {
 SWIFT_RUNTIME_EXPORT
 extern "C" const MetatypeMetadata *
 swift::swift_getMetatypeMetadata(const Metadata *instanceMetadata) {
+  /// The uniquing structure for metatype type metadata.
+  static Lazy<MetadataCache<MetatypeCacheEntry>> MetatypeTypes;
+
   // Search the cache.
   const size_t numGenericArgs = 1;
   const void *args[] = { instanceMetadata };
@@ -1844,9 +1844,6 @@ struct ExistentialMetatypeState {
   llvm::DenseMap<unsigned, const ExtraInhabitantsValueWitnessTable*>
     ValueWitnessTables;
 };
-
-/// The uniquing structure for existential metatype type metadata.
-static Lazy<ExistentialMetatypeState> ExistentialMetatypes;
 
 static const ExtraInhabitantsValueWitnessTable
 ExistentialMetatypeValueWitnesses_1 =
@@ -1905,6 +1902,9 @@ getExistentialMetatypeValueWitnesses(ExistentialMetatypeState &EM,
 SWIFT_RUNTIME_EXPORT
 extern "C" const ExistentialMetatypeMetadata *
 swift::swift_getExistentialMetatypeMetadata(const Metadata *instanceMetadata) {
+  /// The uniquing structure for existential metatype type metadata.
+  static Lazy<ExistentialMetatypeState> ExistentialMetatypes;
+
   // Search the cache.
   const size_t numGenericArgs = 1;
   const void *args[] = { instanceMetadata };
@@ -1969,9 +1969,6 @@ struct ExistentialTypeState {
   llvm::DenseMap<unsigned, const ExtraInhabitantsValueWitnessTable*>
     ClassValueWitnessTables;
 };
-
-/// The uniquing structure for existential type metadata.
-static Lazy<ExistentialTypeState> Existentials;
 
 static const ValueWitnessTable OpaqueExistentialValueWitnesses_0 =
   ValueWitnessTableForBox<OpaqueExistentialBox<0>>::table;
@@ -2279,8 +2276,10 @@ swift::swift_getExistentialTypeMetadata(size_t numProtocols,
       classConstraint = ProtocolClassConstraint::Class;
   }
 
-  // Search the cache.
+  /// The uniquing structure for existential type metadata.
+  static Lazy<ExistentialTypeState> Existentials;
 
+  // Search the cache.
   auto protocolArgs = reinterpret_cast<const void * const *>(protocols);
 
   auto &E = Existentials.get();
@@ -2385,10 +2384,10 @@ struct ForeignTypeState {
 };
 }
 
-static Lazy<ForeignTypeState> ForeignTypes;
-
 const ForeignTypeMetadata *
 swift::swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique) {
+  static Lazy<ForeignTypeState> ForeignTypes;
+
   // Fast path: check the invasive cache.
   if (auto unique = nonUnique->getCachedUniqueMetadata()) {
     return unique;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Remove the need for a few global constructors by sinking the global statics into
functions which use them.  They become lazily initialised, but due to the single
use should be fine.  NFC.
