### PR TITLE
[SR-710][Frontend] Add `-dump-xctest-methods`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2305,6 +2305,11 @@ public:
   /// True if this is a C function that was imported as a member of a type in
   /// Swift.
   bool isImportAsMember() const;
+
+  /// True if this matches what XCTest considers to be a viable test: a class
+  /// instance method that takes no parameters, returns void, and begins with
+  /// "test".
+  bool isTestCandidate() const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1149,6 +1149,12 @@ public:
     getInterfaceHash(str);
     out << str << '\n';
   }
+
+  /// Outputs Unified Symbol Resolutions (USRs) and a newline for each
+  /// function declaration in this source file that matches what XCTest
+  /// considers to be a viable test: a class instance method that takes no
+  /// parameters, returns void, and begins with "test".
+  void dumpXCTestMethods(llvm::raw_ostream &out);
 };
 
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -139,6 +139,12 @@ public:
     /// Parse, type-check, and dump type refinement context hierarchy
     DumpTypeRefinementContexts,
 
+    /// Parse, type-check, and dump a list of Unified Symbol Resolutions
+    /// (USRs)for each function declaration that matches what XCTest considers
+    /// to be a viable test: a class instance method that takes no parameters,
+    /// returns void, and begins with "test".
+    DumpXCTestMethods,
+
     EmitSILGen, ///< Emit raw SIL
     EmitSIL, ///< Emit canonical SIL
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -389,6 +389,10 @@ def print_ast : Flag<["-"], "print-ast">,
   HelpText<"Parse and type-check input file(s) and pretty print AST(s)">,
   ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def dump_xctest_methods : Flag<["-"], "dump-xctest-methods">,
+  HelpText<"Dump a list of methods that match what XCTest considers a test">,
+  ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
 // Other Modes
 def repl : Flag<["-"], "repl">,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -26,6 +26,8 @@
 #include "swift/AST/ReferencedNameTracker.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/PrintOptions.h"
+#include "swift/AST/SourceEntityWalker.h"
+#include "swift/AST/USRGeneration.h"
 #include "swift/Basic/SourceManager.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/DenseMap.h"
@@ -1602,6 +1604,27 @@ TypeRefinementContext *SourceFile::getTypeRefinementContext() {
 
 void SourceFile::setTypeRefinementContext(TypeRefinementContext *Root) {
   TRC = Root;
+}
+
+void SourceFile::dumpXCTestMethods(llvm::raw_ostream &out) {
+  class XCTestASTWalker : public SourceEntityWalker {
+  llvm::raw_ostream &OS;
+  public:
+    XCTestASTWalker(llvm::raw_ostream &OS) : OS(OS) {}
+  private:
+    bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
+      if (auto VD = dyn_cast<ValueDecl>(D)) {
+        if (VD->isTestCandidate()) {
+          ide::printDeclUSR(VD, OS);
+          OS << "\n";
+        }
+      }
+      return true;
+    }
+  };
+
+  XCTestASTWalker walker(out);
+  walker.walk(*this);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -946,6 +946,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
     case options::OPT_dump_ast:
     case options::OPT_print_ast:
     case options::OPT_dump_type_refinement_contexts:
+    case options::OPT_dump_xctest_methods:
     case options::OPT_dump_interface_hash:
       OI.CompilerOutputType = types::TY_Nothing;
       break;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -245,6 +245,8 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
       Action = FrontendOptions::DumpAST;
     } else if (Opt.matches(OPT_dump_type_refinement_contexts)) {
       Action = FrontendOptions::DumpTypeRefinementContexts;
+    } else if (Opt.matches(OPT_dump_xctest_methods)) {
+      Action = FrontendOptions::DumpXCTestMethods;
     } else if (Opt.matches(OPT_dump_interface_hash)) {
       Action = FrontendOptions::DumpInterfaceHash;
     } else if (Opt.matches(OPT_print_ast)) {
@@ -424,6 +426,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
     case FrontendOptions::DumpTypeRefinementContexts:
+    case FrontendOptions::DumpXCTestMethods:
       // Textual modes.
       Opts.setSingleOutputFilename("-");
       break;
@@ -613,6 +616,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
     case FrontendOptions::DumpTypeRefinementContexts:
+    case FrontendOptions::DumpXCTestMethods:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
       Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_dependencies);
@@ -639,6 +643,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
     case FrontendOptions::DumpTypeRefinementContexts:
+    case FrontendOptions::DumpXCTestMethods:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:
       Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_header);
@@ -667,6 +672,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     case FrontendOptions::DumpAST:
     case FrontendOptions::PrintAST:
     case FrontendOptions::DumpTypeRefinementContexts:
+    case FrontendOptions::DumpXCTestMethods:
     case FrontendOptions::EmitSILGen:
     case FrontendOptions::Immediate:
     case FrontendOptions::REPL:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -25,6 +25,7 @@ bool FrontendOptions::actionHasOutput() const {
   case DumpInterfaceHash:
   case PrintAST:
   case DumpTypeRefinementContexts:
+  case DumpXCTestMethods:
     return false;
   case EmitSILGen:
   case EmitSIL:
@@ -53,6 +54,7 @@ bool FrontendOptions::actionIsImmediate() const {
   case DumpInterfaceHash:
   case PrintAST:
   case DumpTypeRefinementContexts:
+  case DumpXCTestMethods:
   case EmitSILGen:
   case EmitSIL:
   case EmitSIBGen:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -699,6 +699,7 @@ static bool performCompile(CompilerInstance &Instance,
       Action == FrontendOptions::DumpAST ||
       Action == FrontendOptions::PrintAST ||
       Action == FrontendOptions::DumpTypeRefinementContexts ||
+      Action == FrontendOptions::DumpXCTestMethods ||
       Action == FrontendOptions::DumpInterfaceHash) {
     SourceFile *SF = PrimarySourceFile;
     if (!SF) {
@@ -709,6 +710,8 @@ static bool performCompile(CompilerInstance &Instance,
       SF->print(llvm::outs(), PrintOptions::printEverything());
     else if (Action == FrontendOptions::DumpTypeRefinementContexts)
       SF->getTypeRefinementContext()->dump(llvm::errs(), Context.SourceMgr);
+    else if (Action == FrontendOptions::DumpXCTestMethods)
+      SF->dumpXCTestMethods(llvm::errs());
     else if (Action == FrontendOptions::DumpInterfaceHash)
       SF->dumpInterfaceHash(llvm::errs());
     else

--- a/test/Driver/dump-xctest-methods.swift
+++ b/test/Driver/dump-xctest-methods.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -dump-xctest-methods %s 2>&1 | FileCheck %s
+
+// CHECK-NOT: test_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethod
+func test_takesNoParams_andReturnsVoid_butIsNotAnInstanceMethod() {}
+
+class MyClass {
+  // CHECK-NOT: doesNotStartWithTest
+  func doesNotStartWithTest() {}
+
+  // CHECK-NOT: test_takesAParam
+  func test_startsWithTest_butTakesAParam(param: Int) {}
+
+  // CHECK-NOT: test_startsWithTest_andTakesNoParams_butReturnsNonVoid
+  func test_startsWithTest_andTakesNoParams_butReturnsNonVoid() -> Int {}
+
+  // CHECK: s:FC4main7MyClass45test_startsWithTest_takesNoParams_returnsVoidFT_T_
+  func test_startsWithTest_takesNoParams_returnsVoid() {}
+
+  // CHECK: s:FC4main7MyClass55test_startsWithTest_takesNoParams_returnsVoid_andThrowsFzT_T_
+  func test_startsWithTest_takesNoParams_returnsVoid_andThrows() throws {}
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

[SR-710](https://bugs.swift.org/browse/SR-710) tracks a major goal for Swift 3: having SwiftPM/corelibs-xctest automatically generate a list of test methods to execute. Several approaches to this problem were discussed on the mailing list:
1. Port SourceKit to Linux, using a different form of IPC since XPC is not available.
2. Add a C header to libIDE (like libclang or sourcekitd). A tool to generate an XCTest "manifest" would link against libIDE and use the C header.
3. Add a `swiftc` option that would output a list of test methods. A tool to generate an XCTest "manifest" would use `swiftc`.

The [discussion appeared to have settled on option 3](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20160328/001595.html). This commit implements the `swiftc` option: `swiftc -frontend -dump-xctest-methods`.

To encode all the information a manifest generation tool would need, `-dump-xctest-methods` outputs USRs, such as the following:

```
s:FC4main7MyClass55test_startsWithTest_takesNoParams_returnsVoid_andThrowsFzT_T_
```

These can be transformed and demangled:
1. Remove the "s:" prefix.
2. Prepend a "_T".
3. Run `swift-demangle` on the string.

A test manifest generation tool can use this new option and the steps above to generate the following for each `XCTestCase` subclass that defines test candidate methods:

```
extension MyTestCase {
  static var allTests: [(String, MyTestCase -> () throws -> Void)] {
    return [
      ("testFoo", testFoo),
      ("testBar", testBar),
    ]
  }
}
```

/cc @gribozavr @ddunbar 
#### ~~Resolved~~ Related bug number: ([SR-710](https://bugs.swift.org/browse/SR-710))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
