### PR TITLE
[build-script] Don't run other products tests in "only_long" mode.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1010,14 +1010,7 @@ details of the setups of other systems or automated environments.""")
 
     if not args.test and not args.validation_test and not args.long_test:
         build_script_impl_inferred_args += [
-            "--skip-test-cmark",
-            "--skip-test-lldb",
             "--skip-test-swift",
-            "--skip-test-llbuild",
-            "--skip-test-swiftpm",
-            "--skip-test-xctest",
-            "--skip-test-foundation",
-            "--skip-test-libdispatch",
             "--skip-test-linux",
             "--skip-test-freebsd",
             "--skip-test-cygwin",
@@ -1028,6 +1021,17 @@ details of the setups of other systems or automated environments.""")
             "--skip-test-tvos-host",
             "--skip-test-watchos-simulator",
             "--skip-test-watchos-host",
+        ]
+
+    if not args.test:
+        build_script_impl_inferred_args += [
+            "--skip-test-cmark",
+            "--skip-test-lldb",
+            "--skip-test-llbuild",
+            "--skip-test-swiftpm",
+            "--skip-test-xctest",
+            "--skip-test-foundation",
+            "--skip-test-libdispatch",
         ]
 
     if args.validation_test:


### PR DESCRIPTION
#### What's in this pull request?

CC: @gribozavr @shahmishal 
Regarding: https://github.com/apple/swift/commit/457f2b901caad14e2085ea0fe2c9b116b5df3520#commitcomment-17319839

`build-script --long-test` (without `-t` or `-T`) should run _just_ the long test.
Since long tests is only in Swift, we should `--skip-test-***` on other products.

**WARNING**: This change may hide current CI bot failure while testing Foundation:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04-long-test/70/console

```
Test Suite 'TestNSAffineTransform' started at 03:57:06.975
/home/buildnode/jenkins/workspace/oss-swift-incremental-RA-linux-ubuntu-14_04-long-test/swift/utils/build-script-impl: line 2040: 40395 Segmentation fault      LD_LIBRARY_PATH="${INSTALL_DESTDIR}"/"${INSTALL_PREFIX}"/lib/swift/:"${build_dir}/Foundation":"${XCTEST_BUILD_DIR}":${LD_LIBRARY_PATH} "${build_dir}"/TestFoundation/TestFoundation
/home/buildnode/jenkins/workspace/oss-swift-incremental-RA-linux-ubuntu-14_04-long-test/swift/utils/build-script: command terminated with a non-zero exit status 139, aborting
```

I don't understand how that could be happen only in "Long Test" bots, because the compiled product itself must be identical to other test modes...
We might want to investigate it first.

FWIW, `utils/build-script --preset="buildbot_incremental_linux,long_test"` runs without any problem in my Ubuntu 15.10 with current master.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
