### PR TITLE
[stdlib] Expanded string slicing test

### DIFF
--- a/test/1_stdlib/subString.swift
+++ b/test/1_stdlib/subString.swift
@@ -16,9 +16,8 @@ func checkMatch<S: Collection, T: Collection
   expectEqual(x[i], y[i])
 }
 
-let s = "abcdefg"
-
 SubstringTests.test("String") {
+  let s = "abcdefg"
   let s1 = s[s.index(s.startIndex, offsetBy: 2) ..<
     s.index(s.startIndex, offsetBy: 4)]
   let s2 = s1[s1.startIndex..<s1.endIndex]
@@ -32,6 +31,7 @@ SubstringTests.test("String") {
 SubstringTests.test("CharacterView")
   .xfail(.always("CharacterView slices don't share indices"))
   .code {
+  let s = "abcdefg"
   var t = s.characters.dropFirst(2)
   var u = t.dropFirst(2)
   
@@ -57,6 +57,7 @@ SubstringTests.test("CharacterView")
 SubstringTests.test("UnicodeScalars")
   .xfail(.always("UnicodeScalarsView slices don't share indices"))
   .code {
+  let s = "abcdefg"
   var t = s.unicodeScalars.dropFirst(2)
   var u = t.dropFirst(2)
   
@@ -82,8 +83,9 @@ SubstringTests.test("UnicodeScalars")
 SubstringTests.test("UTF16View")
   .xfail(.always("UTF16View slices don't share indices"))
   .code {
-  var t = s.utf16.dropFirst(2)
-  var u = t.dropFirst(2)
+  let s = "abcdefg"
+  let t = s.utf16.dropFirst(2)
+  let u = t.dropFirst(2)
   
   checkMatch(s.utf16, t, t.startIndex)
   checkMatch(s.utf16, t, t.index(after: t.startIndex))
@@ -96,8 +98,9 @@ SubstringTests.test("UTF16View")
 }
 
 SubstringTests.test("UTF8View") {
-  var t = s.utf8.dropFirst(2)
-  var u = t.dropFirst(2)
+  let s = "abcdefg"
+  let t = s.utf8.dropFirst(2)
+  let u = t.dropFirst(2)
   
   checkMatch(s.utf8, t, t.startIndex)
   checkMatch(s.utf8, t, t.index(after: t.startIndex))

--- a/test/1_stdlib/subString.swift
+++ b/test/1_stdlib/subString.swift
@@ -1,15 +1,110 @@
-// RUN: %target-run-simple-swift | FileCheck %s
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 
-func test(_ s: String) {
-  print(s)
-  var s2 = s[s.index(s.startIndex, offsetBy: 2)..<s.index(s.startIndex, offsetBy: 4)]
-  print(s2)
-  var s3 = s2[s2.startIndex..<s2.startIndex]
-  var s4 = s3[s2.startIndex..<s2.startIndex]
+import StdlibUnittest
+
+var SubstringTests = TestSuite("SubstringTests")
+
+func checkMatch<S: Collection, T: Collection
+  where S.Index == T.Index, S.Iterator.Element == T.Iterator.Element,
+  S.Iterator.Element: Equatable>(
+  _ x: S, _ y: T, _ i: S.Index) {
+  
+  expectEqual(x[i], y[i])
 }
 
-test("some text")
+let s = "abcdefg"
 
-// CHECK: some text
-// CHECK: me
+SubstringTests.test("String") {
+  let s1 = s[s.index(s.startIndex, offsetBy: 2) ..<
+    s.index(s.startIndex, offsetBy: 4)]
+  let s2 = s1[s1.startIndex..<s1.endIndex]
+  let s3 = s2[s1.startIndex..<s1.endIndex]
+  
+  expectEqual(s1, "cd")
+  expectEqual(s2, "cd")
+  expectEqual(s3, "cd")
+}
+
+SubstringTests.test("CharacterView")
+  .xfail(.always("CharacterView slices don't share indices"))
+  .code {
+  var t = s.characters.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.characters, t, t.startIndex)
+  checkMatch(s.characters, t, t.index(after: t.startIndex))
+  checkMatch(s.characters, t, t.index(before: t.endIndex))
+  
+  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+  
+  checkMatch(s.characters, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.index(after: u.startIndex))
+  checkMatch(t, u, u.index(before: u.endIndex))
+  
+  u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
+  expectEqual(String(u), "Efg")
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+}
+
+SubstringTests.test("UnicodeScalars")
+  .xfail(.always("UnicodeScalarsView slices don't share indices"))
+  .code {
+  var t = s.unicodeScalars.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.unicodeScalars, t, t.startIndex)
+  checkMatch(s.unicodeScalars, t, t.index(after: t.startIndex))
+  checkMatch(s.unicodeScalars, t, t.index(before: t.endIndex))
+  
+  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+  
+  checkMatch(s.unicodeScalars, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.index(after: u.startIndex))
+  checkMatch(t, u, u.index(before: u.endIndex))
+  
+  u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
+  expectEqual(String(u), "Efg")
+  expectEqual(String(t), "Cdefg")
+  expectEqual(s, "abcdefg")
+}
+
+SubstringTests.test("UTF16View")
+  .xfail(.always("UTF16View slices don't share indices"))
+  .code {
+  var t = s.utf16.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.utf16, t, t.startIndex)
+  checkMatch(s.utf16, t, t.index(after: t.startIndex))
+  checkMatch(s.utf16, t, t.index(before: t.endIndex))
+  
+  checkMatch(s.utf16, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.index(after: u.startIndex))
+  checkMatch(t, u, u.index(before: u.endIndex))
+}
+
+SubstringTests.test("UTF8View") {
+  var t = s.utf8.dropFirst(2)
+  var u = t.dropFirst(2)
+  
+  checkMatch(s.utf8, t, t.startIndex)
+  checkMatch(s.utf8, t, t.index(after: t.startIndex))
+  
+  checkMatch(s.utf8, t, u.startIndex)
+  checkMatch(t, u, u.startIndex)
+  checkMatch(t, u, u.index(after: u.startIndex))
+}
+
+runAllTests()

--- a/test/1_stdlib/subString.swift
+++ b/test/1_stdlib/subString.swift
@@ -39,15 +39,12 @@ SubstringTests.test("CharacterView")
   checkMatch(s.characters, t, t.index(after: t.startIndex))
   checkMatch(s.characters, t, t.index(before: t.endIndex))
   
-  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
-  expectEqual(String(t), "Cdefg")
-  expectEqual(s, "abcdefg")
-  
   checkMatch(s.characters, t, u.startIndex)
   checkMatch(t, u, u.startIndex)
   checkMatch(t, u, u.index(after: u.startIndex))
   checkMatch(t, u, u.index(before: u.endIndex))
   
+  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
   u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
   expectEqual(String(u), "Efg")
   expectEqual(String(t), "Cdefg")
@@ -65,15 +62,12 @@ SubstringTests.test("UnicodeScalars")
   checkMatch(s.unicodeScalars, t, t.index(after: t.startIndex))
   checkMatch(s.unicodeScalars, t, t.index(before: t.endIndex))
   
-  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
-  expectEqual(String(t), "Cdefg")
-  expectEqual(s, "abcdefg")
-  
   checkMatch(s.unicodeScalars, t, u.startIndex)
   checkMatch(t, u, u.startIndex)
   checkMatch(t, u, u.index(after: u.startIndex))
   checkMatch(t, u, u.index(before: u.endIndex))
   
+  t.replaceSubrange(t.startIndex...t.startIndex, with: ["C"])
   u.replaceSubrange(u.startIndex...u.startIndex, with: ["E"])
   expectEqual(String(u), "Efg")
   expectEqual(String(t), "Cdefg")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This updates the tests for substrings to include sharing indices with string view slices. The tests are currently `xfail`'d for CharacterView, UnicodeScalarView, and UTF16View.

<details>
  <summary>

<b>Current test output:</b></summary>



```
[ RUN      ] SubstringTests.String
[       OK ] SubstringTests.String
[ RUN      ] SubstringTests.CharacterView (XFAIL: [Always(reason: CharacterView slices don't share indices)])
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "a" (of type Swift.Character)
stdout>>> actual: "c" (of type Swift.Character)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "b" (of type Swift.Character)
stdout>>> actual: "d" (of type Swift.Character)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "e" (of type Swift.Character)
stdout>>> actual: "g" (of type Swift.Character)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "a" (of type Swift.Character)
stdout>>> actual: "C" (of type Swift.Character)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "C" (of type Swift.Character)
stdout>>> actual: "e" (of type Swift.Character)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "d" (of type Swift.Character)
stdout>>> actual: "f" (of type Swift.Character)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "e" (of type Swift.Character)
stdout>>> actual: "g" (of type Swift.Character)
[    XFAIL ] SubstringTests.CharacterView
[ RUN      ] SubstringTests.UnicodeScalars (XFAIL: [Always(reason: UnicodeScalarsView slices don't share indices)])
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "a" (of type Swift.UnicodeScalar)
stdout>>> actual: "c" (of type Swift.UnicodeScalar)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "b" (of type Swift.UnicodeScalar)
stdout>>> actual: "d" (of type Swift.UnicodeScalar)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "e" (of type Swift.UnicodeScalar)
stdout>>> actual: "g" (of type Swift.UnicodeScalar)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "a" (of type Swift.UnicodeScalar)
stdout>>> actual: "C" (of type Swift.UnicodeScalar)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "C" (of type Swift.UnicodeScalar)
stdout>>> actual: "e" (of type Swift.UnicodeScalar)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "d" (of type Swift.UnicodeScalar)
stdout>>> actual: "f" (of type Swift.UnicodeScalar)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: "e" (of type Swift.UnicodeScalar)
stdout>>> actual: "g" (of type Swift.UnicodeScalar)
[    XFAIL ] SubstringTests.UnicodeScalars
[ RUN      ] SubstringTests.UTF16View (XFAIL: [Always(reason: UTF16View slices don't share indices)])
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 97 (of type Swift.UInt16)
stdout>>> actual: 99 (of type Swift.UInt16)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 98 (of type Swift.UInt16)
stdout>>> actual: 100 (of type Swift.UInt16)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 101 (of type Swift.UInt16)
stdout>>> actual: 103 (of type Swift.UInt16)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 97 (of type Swift.UInt16)
stdout>>> actual: 99 (of type Swift.UInt16)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 99 (of type Swift.UInt16)
stdout>>> actual: 101 (of type Swift.UInt16)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 100 (of type Swift.UInt16)
stdout>>> actual: 102 (of type Swift.UInt16)
stdout>>> check failed at ...swift/test/1_stdlib/subString.swift, line 16
stdout>>> expected: 101 (of type Swift.UInt16)
stdout>>> actual: 103 (of type Swift.UInt16)
[    XFAIL ] SubstringTests.UTF16View
[ RUN      ] SubstringTests.UTF8View
[       OK ] SubstringTests.UTF8View
SubstringTests: All tests passed
```

</details>
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
