### PR TITLE
Convert "armv7l" to "armv7" for the architecture component of paths

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -57,6 +57,18 @@ namespace swift {
 
   /// Returns the platform Kind for Darwin triples.
   DarwinPlatformKind getDarwinPlatformKind(const llvm::Triple &triple);
+
+  /// Returns the architecture component of the path for a given target triple.
+  ///
+  /// Typically this is used for mapping the architecture component of the
+  /// path.
+  ///
+  /// For example, on Linux "armv6l" and "armv7l" are mapped to "armv6" and
+  /// "armv7", respectively, within LLVM. Therefore the component path for the
+  /// architecture specific objects will be found in their "mapped" paths.
+  ///
+  /// This is a stop-gap until full Triple support (ala Clang) exists within swiftc.
+  StringRef getMajorArchitectureName(const llvm::Triple &triple);
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PLATFORM_H

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -102,3 +102,21 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
 
   return "";
 }
+
+StringRef swift::getMajorArchitectureName(const llvm::Triple &Triple) {
+  if (Triple.isOSLinux()) {
+    switch(Triple.getSubArch()) {
+    default:
+      return Triple.getArchName();
+      break;
+    case llvm::Triple::SubArchType::ARMSubArch_v7:
+      return "armv7";
+      break;
+    case llvm::Triple::SubArchType::ARMSubArch_v6:
+      return "armv6";
+      break;
+    }
+  } else {
+    return Triple.getArchName();
+  }
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -398,7 +398,8 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
 
     llvm::sys::path::append(
       GlibcModuleMapPath,
-      swift::getPlatformNameForTriple(triple), triple.getArchName(),
+      swift::getPlatformNameForTriple(triple),
+      swift::getMajorArchitectureName(triple),
       "glibc.modulemap");
 
     // Only specify the module map if that file actually exists.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1171,28 +1171,6 @@ toolchains::GenericUnix::constructInvocation(const AutolinkExtractJobAction &job
   return {"swift-autolink-extract", Arguments};
 }
 
-// This function maps triples to the architecture component of the path
-// where the swift_begin.o and swift_end.o objects can be found.  This
-// is a stop-gap until full Triple support (ala Clang) exists within swiftc.
-StringRef
-getSectionMagicArch(const llvm::Triple &Triple) {
-  if (Triple.isOSLinux()) {
-    switch(Triple.getSubArch()) {
-    default:
-      return Triple.getArchName();
-      break;
-    case llvm::Triple::SubArchType::ARMSubArch_v7:
-      return "armv7";
-      break;
-    case llvm::Triple::SubArchType::ARMSubArch_v6:
-      return "armv6";
-      break;
-    }
-  } else {
-    return Triple.getArchName();
-  }
-}
-
 std::string toolchains::GenericUnix::getDefaultLinker() const {
   switch(getTriple().getArch()) {
   case llvm::Triple::arm:
@@ -1223,7 +1201,8 @@ std::string toolchains::GenericUnix::getPreInputObjectPath(
   // On Linux and FreeBSD (really, ELF binaries) we need to add objects
   // to provide markers and size for the metadata sections.
   SmallString<128> PreInputObjectPath = RuntimeLibraryPath;
-  llvm::sys::path::append(PreInputObjectPath, getSectionMagicArch(getTriple()));
+  llvm::sys::path::append(PreInputObjectPath,
+      swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(PreInputObjectPath, "swift_begin.o");
   return PreInputObjectPath.str();
 }
@@ -1231,7 +1210,8 @@ std::string toolchains::GenericUnix::getPreInputObjectPath(
 std::string toolchains::GenericUnix::getPostInputObjectPath(
     StringRef RuntimeLibraryPath) const {
   SmallString<128> PostInputObjectPath = RuntimeLibraryPath;
-  llvm::sys::path::append(PostInputObjectPath, getSectionMagicArch(getTriple()));
+  llvm::sys::path::append(PostInputObjectPath,
+      swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(PostInputObjectPath, "swift_end.o");
   return PostInputObjectPath.str();
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -48,27 +48,7 @@ static void updateRuntimeLibraryPath(SearchPathOptions &SearchPathOpts,
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
   SearchPathOpts.RuntimeLibraryPath = LibPath.str();
 
-  // The linux provided triple for ARM contains a trailing 'l'
-  // denoting little-endian.  This is not used in the path for
-  // libraries.  LLVM matches these SubArchTypes to the generic
-  // ARMSubArch_v7 (for example) type.  If that is the case,
-  // use the base of the architecture type in the library path.
-  if (Triple.isOSLinux()) {
-    switch(Triple.getSubArch()) {
-    default:
-      llvm::sys::path::append(LibPath, Triple.getArchName());
-      break;
-    case llvm::Triple::SubArchType::ARMSubArch_v7:
-      llvm::sys::path::append(LibPath, "armv7");
-      break;
-    case llvm::Triple::SubArchType::ARMSubArch_v6:
-      llvm::sys::path::append(LibPath, "armv6");
-      break;
-    }
-  } else {
-    llvm::sys::path::append(LibPath, Triple.getArchName());
-  }
-
+  llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
   SearchPathOpts.RuntimeLibraryImportPath = LibPath.str();
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Convert "armv7l" to "armv7" for the architecture component of paths

On the Raspberry Pi 2 when trying to import Glibc, without this patch, it will attempt to find the module map at `"/usr/lib/swift/linux/armv7l/glibc.modulemap"` and fail to do so.

With this patch it will attempt to find the module map at `"/usr/lib/swift/linux/armv7/glibc.modulemap"` where it will succeed in finding the module map.

Similar behavior currently happens in the Driver and Frontend. To DRY up this behavior it has been extracted to the Swift platform.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

/cc: @hpux735 I think he originally wrote some of this stuff. He might be able to provide pointers on pitfalls.
