### PR TITLE
IRGen: Map Int and UInt to Clang types via NS[U]Integer.

### DIFF
--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -225,6 +225,30 @@ clang::CanQualType GenClangType::visitStructType(CanStructType type) {
   return Converter.reverseBuiltinTypeMapping(IGM, type);
 }
 
+static clang::CanQualType getClangBuiltinTypeFromTypedef(
+                      const clang::ASTContext &context, StringRef typedefName) {
+  auto identifier = &context.Idents.get(typedefName);
+  auto lookup = context.getTranslationUnitDecl()->lookup(identifier);
+  
+  clang::TypedefDecl *typedefDecl = nullptr;
+  for (auto found : lookup) {
+    auto foundTypedef = dyn_cast<clang::TypedefDecl>(found);
+    if (!foundTypedef)
+      continue;
+    typedefDecl = foundTypedef;
+    break;
+  }
+  if (!typedefDecl)
+    return {};
+  
+  auto underlyingTy =
+    context.getCanonicalType(typedefDecl->getUnderlyingType());
+  
+  if (underlyingTy->getAs<clang::BuiltinType>())
+    return underlyingTy;
+  return {};
+}
+
 clang::CanQualType
 ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
                                               CanStructType type) {
@@ -260,6 +284,22 @@ ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
                              clang::BuiltinType::Kind builtinKind) {
     CanType swiftType = getNamedSwiftType(stdlib, swiftName);
     if (!swiftType) return;
+    
+    // Handle Int and UInt specially. On Apple platforms, these correspond to
+    // the NSInteger and NSUInteger typedefs, so map them back to those typedefs
+    // if they're available, to ensure we get consistent ObjC @encode strings.
+    if (swiftType->getAnyNominal() == IGM.Context.getIntDecl()) {
+      if (auto NSIntegerTy = getClangBuiltinTypeFromTypedef(ctx, "NSInteger")) {
+        Cache.insert({swiftType, NSIntegerTy});
+        return;
+      }
+    } else if (swiftType->getAnyNominal() == IGM.Context.getUIntDecl()) {
+      if (auto NSUIntegerTy =
+            getClangBuiltinTypeFromTypedef(ctx, "NSUInteger")) {
+        Cache.insert({swiftType, NSUIntegerTy});
+        return;
+      }
+    }
 
     Cache.insert({swiftType, getClangBuiltinTypeFromKind(ctx, builtinKind)});
   };

--- a/test/IRGen/objc_int_encoding.sil
+++ b/test/IRGen/objc_int_encoding.sil
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_interop
+
+// CHECK: [[SELECTOR:@.*]] = private global {{.*}} c"fooWithX:\00"
+
+// CHECK-64: [[INT_UINT_METHOD_ENCODING:@.*]] = private unnamed_addr constant {{.*}} c"Q24@0:8q16\00"
+// CHECK-32: [[INT_UINT_METHOD_ENCODING:@.*]] = private unnamed_addr constant {{.*}} c"I12@0:4i8\00"
+
+// CHECK: @_INSTANCE_METHODS__TtC17objc_int_encoding3Foo = private constant {{.*}} [[SELECTOR]], {{.*}} [[INT_UINT_METHOD_ENCODING]], {{.*}} @_TToFC17objc_int_encoding3Foo3foofT1xSi_Su
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import Foundation
+
+class Foo: NSObject {
+  @objc override init() {}
+
+  @objc func foo(x: Int) -> UInt
+}
+
+sil hidden @_TToFC17objc_int_encoding3Foo3foofT1xSi_Su : $@convention(objc_method) (Int, @guaranteed Foo) -> UInt {
+entry(%0 : $Int, %1 : $Foo):
+  unreachable
+}
+sil @_TToFC17objc_int_encoding3FoocfT_S0_ : $@convention(objc_method) (@owned Foo) -> @owned Foo {
+entry(%1 : $Foo):
+  unreachable
+}
+
+sil_vtable Foo {}

--- a/test/Inputs/clang-importer-sdk/usr/include/objc/objc.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc/objc.h
@@ -4,8 +4,14 @@
 #define OBJC_ARC_UNAVAILABLE __attribute__((unavailable("not available in automatic reference counting mode")))
 #define NS_AUTOMATED_REFCOUNT_UNAVAILABLE OBJC_ARC_UNAVAILABLE
 
+#ifdef __LP64__
 typedef unsigned long NSUInteger;
 typedef long NSInteger;
+#else
+typedef unsigned int NSUInteger;
+typedef int NSInteger;
+#endif
+
 typedef __typeof__(__objc_yes) BOOL;
 
 typedef struct objc_selector    *SEL;


### PR DESCRIPTION
If NSInteger and NSUInteger typedefs are available in the current Clang context, use them when mapping Swift's Int and UInt to Clang types. This gives us consistent method and property type encodings for @objc methods with Clang, fixing rdar://problem/17506068.
