### PR TITLE
[build-script] Fix --verbose-build argument to use bool type

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -872,7 +872,11 @@ details of the setups of other systems or automated environments.""")
     parser.add_argument(
         "--verbose-build",
         help="print the commands executed during the build",
-        action="store_true")
+        metavar="BOOL",
+        nargs='?',
+        type=argparse_bool,
+        default=False,
+        const=True)
 
     args = migration.parse_args(parser, sys.argv[1:])
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fix --verbose-build argument to use bool type

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
