### PR TITLE
Changed StaticUnsafeMutex to have the swift:: namespace

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -172,7 +172,7 @@ reportOnCrash(uint32_t flags, const char *message)
   // mutex calls fatalError when an error is detected and fatalError ends up
   // calling us. In other words we could get infinite recursion if the
   // mutex errors.
-  static StaticUnsafeMutex crashlogLock();
+  static swift::StaticUnsafeMutex crashlogLock();
 
   crashlogLock.lock();
 


### PR DESCRIPTION
#### What's in this pull request?

Changed StaticUnsafeMutex to have the swift:: namespace to deal with upstream clang changes.
This is one of the changes that is safe to drop into master.

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

to fix upstream clang build errors.
