### PR TITLE
[build-preset] Skip building benchmarks on the XCTest development preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -282,6 +282,7 @@ dash-dash
 skip-test-cmark
 skip-test-swift
 skip-test-foundation
+skip-build-benchmarks
 
 [preset: buildbot_incremental_asan,tools=RDA,stdlib=RDA]
 mixin-preset=buildbot_incremental_base_all_platforms


### PR DESCRIPTION
#### What's in this pull request?

I've been noticing when using the `corelibs-xctest` build script preset during iterative development that `cmake` performs a handful of build commands related to the Swift benchmark suite on every invocation of the script, even if no changes have been made. Building benchmarks does not provide any useful feedback while working on Corelibs XCTest, so this makes the build a little bit leaner.

/cc @modocache 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
