### PR TITLE
[gardening] Fix a pep8 warning

### DIFF
--- a/utils/swift_build_support/swift_build_support/__init__.py
+++ b/utils/swift_build_support/swift_build_support/__init__.py
@@ -16,3 +16,15 @@
 # ----------------------------------------------------------------------------
 
 from .which import which
+
+__all__ = [
+    "cmake",
+    "debug",
+    "migration",
+    "ninja",
+    "tar",
+    "targets",
+    "toolchain",
+    "which",
+    "xcrun",
+]


### PR DESCRIPTION
#### What's in this pull request?

Fixes this `flake8` warning:

```
./utils/swift_build_support/swift_build_support/__init__.py:18:1: F401 'which' imported but unused
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
