### PR TITLE
[stdlib] SE-0061: Add Generic Result and Error Handling to autoreleas…

### DIFF
--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -191,7 +191,9 @@ func __pushAutoreleasePool() -> OpaquePointer
 @_silgen_name("_swift_objc_autoreleasePoolPop")
 func __popAutoreleasePool(_ pool: OpaquePointer)
 
-public func autoreleasepool<Result>(_ body: @noescape () throws -> Result) rethrows -> Result {
+public func autoreleasepool<Result>(
+  _ body: @noescape () throws -> Result
+) rethrows -> Result {
   let pool = __pushAutoreleasePool()
   defer {
     __popAutoreleasePool(pool)

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -181,7 +181,7 @@ public struct NSZone {
 typealias Zone = NSZone
 
 //===----------------------------------------------------------------------===//
-// FIXME: @autoreleasepool substitute
+// @autoreleasepool substitute
 //===----------------------------------------------------------------------===//
 
 @warn_unused_result
@@ -191,10 +191,12 @@ func __pushAutoreleasePool() -> OpaquePointer
 @_silgen_name("_swift_objc_autoreleasePoolPop")
 func __popAutoreleasePool(_ pool: OpaquePointer)
 
-public func autoreleasepool(_ code: @noescape () -> Void) {
+public func autoreleasepool<Result>(_ body: @noescape () throws -> Result) rethrows -> Result {
   let pool = __pushAutoreleasePool()
-  code()
-  __popAutoreleasePool(pool)
+  defer {
+    __popAutoreleasePool(pool)
+  }
+  return try body()
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Interpreter/SDK/autorelease.swift
+++ b/test/Interpreter/SDK/autorelease.swift
@@ -38,17 +38,17 @@ print("autorelease test end")
 // Using an @objc class to check that errors are retained across the pool
 // boundaries. A classic crash is an error created inside a pool and then
 // zombied before handling it outside the pool.
-@objc class Error: NSObject, ErrorProtocol {
-  let message:String
-  init(message:String) {
+@objc class Error : NSObject, ErrorProtocol {
+  let message: String
+  init(message: String) {
     self.message = message
   }
 }
 
 // Check that rethrow works.
-func requireString(string:String?) throws -> String {
+func requireString(string: String?) throws -> String {
   guard let string = string else {
-    throw Error(message:"no string")
+    throw Error(message: "no string")
   }
   print("returning \"\(string)\"")
   return string

--- a/test/Interpreter/SDK/autorelease.swift
+++ b/test/Interpreter/SDK/autorelease.swift
@@ -34,3 +34,39 @@ print("autorelease test end")
 // CHECK-NEXT: object died
 // CHECK-NEXT: after call to useTemp
 // CHECK-NEXT: autorelease test end
+
+// Using an @objc class to check that errors are retained across the pool
+// boundaries. A classic crash is an error created inside a pool and then
+// zombied before handling it outside the pool.
+@objc class Error: NSObject, ErrorProtocol {
+  let message:String
+  init(message:String) {
+    self.message = message
+  }
+}
+
+// Check that rethrow works.
+func requireString(string:String?) throws -> String {
+  guard let string = string else {
+    throw Error(message:"no string")
+  }
+  print("returning \"\(string)\"")
+  return string
+}
+do {
+  try autoreleasepool {
+    try requireString(string: "ok")
+    try requireString(string: nil)
+  }
+} catch let err as Error {
+  print("caught \"\(err.message)\"")
+}
+// CHECK-NEXT:      returning "ok"
+// CHECK-NEXT:      caught "no string"
+
+// Check that a return value can be passed back.
+let result = try autoreleasepool {
+  return "a string"
+}
+print("result = \"\(result)\"")
+// CHECK-NEXT:      result = "a string"


### PR DESCRIPTION
Added `rethrows` and generic return type to `ObjectiveC.autoreleasepool`.
Added tests of these new capabilities.

Fixes #43454
