### PR TITLE
Markup: Move Doxygen converter into a proper MarkupASTNode visitor

### DIFF
--- a/include/swift/Markup/AST.h
+++ b/include/swift/Markup/AST.h
@@ -729,6 +729,27 @@ bool isAFieldTag(StringRef Tag);
 void dump(const MarkupASTNode *Node, llvm::raw_ostream &OS, unsigned indent = 0);
 void printInlinesUnder(const MarkupASTNode *Node, llvm::raw_ostream &OS,
                        bool PrintDecorators = false);
+
+
+template <typename ImplClass, typename RetTy = void, typename... Args>
+class MarkupASTVisitor {
+public:
+  RetTy visit(const MarkupASTNode *Node, Args... args) {
+    switch (Node->getKind()) {
+#define MARKUP_AST_NODE(Id, Parent) \
+    case ASTNodeKind::Id: \
+      return static_cast<ImplClass*>(this) \
+        ->visit##Id(cast<const Id>(Node), \
+                    ::std::forward<Args>(args)...);
+#define ABSTRACT_MARKUP_AST_NODE(Id, Parent)
+#define MARKUP_AST_NODE_RANGE(Id, FirstId, LastId)
+#include "swift/Markup/ASTNodes.def"
+    }
+  }
+
+  virtual ~MarkupASTVisitor() {}
+};
+
 } // namespace markup
 } // namespace swift
 

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -4,26 +4,31 @@ SWIFT_CLASS("_TtC8comments4A000")
 @end
 
 
-
-/// Aaa.  A010.  Bbb.
+/**
+  Aaa.  A010.  Bbb.
+*/
 SWIFT_CLASS("_TtC8comments21A010_AttachToEntities")
 @interface A010_AttachToEntities
-
-/// Aaa.  init().
+/**
+  Aaa.  init().
+*/
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 - (NSInteger)objectAtIndexedSubscript:(NSInteger)i;
 - (void)setObject:(NSInteger)newValue atIndexedSubscript:(NSInteger)i;
-
-/// Aaa.  v1.
+/**
+  Aaa.  v1.
+*/
 @property (nonatomic) NSInteger v1;
-
-/// Aaa.  v2.
+/**
+  Aaa.  v2.
+*/
 @property (nonatomic, class, readonly) NSInteger v2;
 @end
 
 
-
-/// Aaa.  A013.
+/**
+  Aaa.  A013.
+*/
 SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_")
 @protocol A013_AttachToEntities
 @end
@@ -31,9 +36,10 @@ SWIFT_PROTOCOL("_TtP8comments21A013_AttachToEntities_")
 
 SWIFT_CLASS("_TtC8comments10ATXHeaders")
 @interface ATXHeaders
-
-/// <h1>LEVEL ONE</h1>
-/// <h2>LEVEL TWO</h2>
+/**
+  <h1>LEVEL ONE</h1>
+  <h2>LEVEL TWO</h2>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -41,10 +47,10 @@ SWIFT_CLASS("_TtC8comments10ATXHeaders")
 
 SWIFT_CLASS("_TtC8comments13AutomaticLink")
 @interface AutomaticLink
-
-/// And now for a URL.
-///
-/// <a href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</a>
+/**
+  And now for a URL.
+  <a href="http://developer.apple.com/swift/">http://developer.apple.com/swift/</a>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -52,11 +58,17 @@ SWIFT_CLASS("_TtC8comments13AutomaticLink")
 
 SWIFT_CLASS("_TtC8comments10BlockQuote")
 @interface BlockQuote
+/**
+  Aaa.
+  <blockquote>
+  Bbb.
 
-/// Aaa.
-///
-/// <blockquote>Bbb.</blockquote>
-/// <blockquote>Ccc.</blockquote>
+  </blockquote>
+  <blockquote>
+  Ccc.
+
+  </blockquote>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -64,23 +76,27 @@ SWIFT_CLASS("_TtC8comments10BlockQuote")
 
 SWIFT_CLASS("_TtC8comments5Brief")
 @interface Brief
-
-/// Aaa.
+/**
+  Aaa.
+*/
 - (void)f0;
-
-/// Aaa.
-///
-/// Bbb.
+/**
+  Aaa.
+  Bbb.
+*/
 - (void)f1;
+/**
+  Aaa.
+  <blockquote>
+  Bbb.
 
-/// Aaa.
-///
-/// <blockquote>Bbb.</blockquote>
+  </blockquote>
+*/
 - (void)f2;
-
-/// Aaa.
-///
-/// Bbb.
+/**
+  Aaa.
+  Bbb.
+*/
 - (void)f3;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -88,77 +104,74 @@ SWIFT_CLASS("_TtC8comments5Brief")
 
 SWIFT_CLASS("_TtC8comments16ClosureContainer")
 @interface ClosureContainer
+/**
+  Partially applies a binary operator.
+  \param a The left-hand side to partially apply.
 
-/// Partially applies a binary operator.
-///
-/// \param a The left-hand side to partially apply.
-///
-/// \param combine A binary operator.
-///
-/// \a combine parameters:
-/// <ul>
-/// <li>
-/// lhs: The left-hand side of the operator
-///
-/// </li>
-/// <li>
-/// rhs: The right-hand side of the operator
-///
-/// </li>
-/// </ul>
-///
-///
-/// \a combine returns: A result.
-///
-/// \a combine error: Nothing.
+  \param combine A binary operator.
+
+  \a combine parameters:
+  <ul>
+  <li>
+  lhs: The left-hand side of the operator
+  </li>
+  <li>
+  rhs: The right-hand side of the operator
+  </li>
+  </ul>
+
+
+  \a combine returns: A result.
+
+  \a combine error: Nothing.
+
+*/
 - (void)closureParameterExplodedExplodedWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger lhs, NSInteger rhs))combine;
+/**
+  Partially applies a binary operator.
+  \param a The left-hand side to partially apply.
 
-/// Partially applies a binary operator.
-///
-/// \param a The left-hand side to partially apply.
-///
-/// \param combine A binary operator.
-///
-/// \a combine parameters:
-/// <ul>
-/// <li>
-/// lhs: The left-hand side of the operator
-///
-/// </li>
-/// <li>
-/// rhs: The right-hand side of the operator
-///
-/// </li>
-/// </ul>
-///
-///
-/// \a combine returns: A result.
-///
-/// \a combine error: Nothing.
+  \param combine A binary operator.
+
+  \a combine parameters:
+  <ul>
+  <li>
+  lhs: The left-hand side of the operator
+  </li>
+  <li>
+  rhs: The right-hand side of the operator
+  </li>
+  </ul>
+
+
+  \a combine returns: A result.
+
+  \a combine error: Nothing.
+
+*/
 - (void)closureParameterOutlineExplodedWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger lhs, NSInteger rhs))combine;
+/**
+  Partially applies a binary operator.
+  \param a The left-hand side to partially apply.
 
-/// Partially applies a binary operator.
-///
-/// \param a The left-hand side to partially apply.
-///
-/// \param combine A binary operator.
-///
-/// \a combine parameters:
-/// <ul>
-/// <li>
-/// lhs: The left-hand side of the operator
-///
-/// </li>
-/// <li>
-/// rhs: The right-hand side of the operator
-///
-/// </li>
-/// </ul>
-///
-///
-/// \a combine returns: A result.
-///
-/// \a combine error: Nothing.
+  \param combine A binary operator.
+
+  \a combine parameters:
+  <ul>
+  <li>
+  lhs: The left-hand side of the operator
+  </li>
+  <li>
+  rhs: The right-hand side of the operator
+  </li>
+  </ul>
+
+
+  \a combine returns: A result.
+
+  \a combine error: Nothing.
+
+*/
 - (void)closureParameterOutlineOutlineWithA:(NSInteger)a combine:(NSInteger (^ _Nonnull)(NSInteger lhs, NSInteger rhs))combine;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -166,14 +179,14 @@ SWIFT_CLASS("_TtC8comments16ClosureContainer")
 
 SWIFT_CLASS("_TtC8comments9CodeBlock")
 @interface CodeBlock
+/**
+  This is how you use this code.
+  \code
+  f0() // WOW!
+  f0() // WOW!
+  f0() // WOW!
 
-/// This is how you use this code.
-///
-/// <code>f0() // WOW!
-/// f0() // WOW!
-/// f0() // WOW!
-/// 
-/// </code>
+  \endcode*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -181,8 +194,10 @@ SWIFT_CLASS("_TtC8comments9CodeBlock")
 
 SWIFT_CLASS("_TtC8comments8Emphasis")
 @interface Emphasis
-
-/// Aaa bbb ccc. Aaa bbb ccc.
+/**
+  Aaa <em>bbb</em> ccc.
+  Aaa <em>bbb</em> ccc.
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -190,17 +205,22 @@ SWIFT_CLASS("_TtC8comments8Emphasis")
 
 SWIFT_CLASS("_TtC8comments13EmptyComments")
 @interface EmptyComments
-
+/**
+*/
 - (void)f0;
-
-/// Aaa.
+/**
+  Aaa.
+*/
 - (void)f1;
-
+/**
+*/
 - (void)f2;
-
+/**
+*/
 - (void)f3;
-
-/// Aaa.
+/**
+  Aaa.
+*/
 - (void)f4;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -208,13 +228,16 @@ SWIFT_CLASS("_TtC8comments13EmptyComments")
 
 SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 @interface HasThrowingFunction
+/**
+  Might throw something.
+  \param x A number
 
-/// Might throw something.
-///
-/// \param x A number
-///
-/// \param error An error if <code>x == 0
-/// </code>
+
+  throws:
+  An error if \code
+  x == 0
+  \endcode
+*/
 - (void)f1:(NSInteger)x;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -222,11 +245,11 @@ SWIFT_CLASS("_TtC8comments19HasThrowingFunction")
 
 SWIFT_CLASS("_TtC8comments15HorizontalRules")
 @interface HorizontalRules
-
-/// Briefly.
-///
-/// <hr/>
-/// The end.
+/**
+  Briefly.
+  <hr/>
+  The end.
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -234,8 +257,9 @@ SWIFT_CLASS("_TtC8comments15HorizontalRules")
 
 SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
 @interface ImplicitNameLink
-
-/// Apple
+/**
+  <a href="https://www.apple.com/">Apple</a>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -243,33 +267,29 @@ SWIFT_CLASS("_TtC8comments16ImplicitNameLink")
 
 SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 @interface IndentedBlockComment
+/**
+  Brief.
+  First paragraph line.
+  Second paragraph line.
+  Now for a code sample:
+  \code
+  var x = 1
+  // var y = 2
+  var z = 3
 
-/// Brief.
-///
-/// First paragraph line.
-/// Second paragraph line.
-///
-/// Now for a code sample:
-///
-/// <code>var x = 1
-/// // var y = 2
-/// var z = 3
-/// 
-/// </code>
+  \endcode*/
 - (void)f1;
+/**
+  Hugely indented brief.
+  First paragraph line.
+  Second paragraph line.
+  Now for a code sample:
+  \code
+  var x = 1
+  // var y = 2
+  var z = 3
 
-/// Hugely indented brief.
-///
-/// First paragraph line.
-/// Second paragraph line.
-///
-/// Now for a code sample:
-///
-/// <code>var x = 1
-/// // var y = 2
-/// var z = 3
-/// 
-/// </code>
+  \endcode*/
 - (void)f2;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -277,8 +297,11 @@ SWIFT_CLASS("_TtC8comments20IndentedBlockComment")
 
 SWIFT_CLASS("_TtC8comments10InlineCode")
 @interface InlineCode
-
-/// Aaa bbb ccc.
+/**
+  Aaa \code
+  bbb
+  \endcode ccc.
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -286,8 +309,9 @@ SWIFT_CLASS("_TtC8comments10InlineCode")
 
 SWIFT_CLASS("_TtC8comments10InlineLink")
 @interface InlineLink
-
-/// Aaa bbb ccc.
+/**
+  Aaa <a href="/path/to/something">bbb</a> ccc.
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -295,10 +319,11 @@ SWIFT_CLASS("_TtC8comments10InlineLink")
 
 SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 @interface MultiLineBrief
-
-/// Brief first line. Brief after softbreak.
-///
-/// Some paragraph text.
+/**
+  Brief first line.
+  Brief after softbreak.
+  Some paragraph text.
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -306,58 +331,75 @@ SWIFT_CLASS("_TtC8comments14MultiLineBrief")
 
 SWIFT_CLASS("_TtC8comments11OrderedList")
 @interface OrderedList
-
-/// <ol><li>Aaa.</li><li>Bbb.
-/// Ccc.</li></ol>
+/**
+  <ol>
+    <li>
+      Aaa.
+    </li>
+    <li>
+      Bbb.
+      Ccc.
+    </li>
+  </ol>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
 
 
+/**
+  \param x A number
 
-/// \param x A number
+*/
 SWIFT_CLASS("_TtC8comments15ParamAndReturns")
 @interface ParamAndReturns
+/**
+  Aaa.  f0.
+  \param first Bbb.
 
-/// Aaa.  f0.
-///
-/// \param first Bbb.
-///
-/// \param second Ccc.  Ddd.
-/// Eee.
+  \param second Ccc.  Ddd.
+  Eee.
+
+*/
 - (void)f0:(NSInteger)first second:(double)second;
+/**
+  Aaa.  f1.
+  \param first Bbb.
 
-/// Aaa.  f1.
-///
-/// \param first Bbb.
-///
-/// \returns  Ccc.
-/// Ddd.
+
+  returns:
+  Ccc.
+  Ddd.
+*/
 - (void)f1:(NSInteger)first;
+/**
+  Aaa.  f2.
+  \param first 
 
-/// Aaa.  f2.
-///
-/// \param first 
-///
-/// \param second Aaa.
-///
-/// \param third 
-/// Bbb.
+  \param second Aaa.
+
+  \param third 
+  Bbb.
+
+*/
 - (void)f2:(NSInteger)first second:(double)second third:(float)third;
+/**
+  Aaa.  f3.
+  \param first Bbb.
 
-/// Aaa.  f3.
-///
-/// \param first Bbb.
-///
-/// \param second Ccc.
-///
-/// \param third Ddd.
+  \param second Ccc.
+
+  \param third Ddd.
+
+*/
 - (void)f3:(NSInteger)first second:(double)second third:(float)third;
+/**
+  Aaa.  f4.
 
-/// Aaa.  f4.
-///
-/// \returns  Eee.
-/// Fff.
+  returns:
+  Eee.
+  Fff.
+*/
 - (void)f4;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -365,12 +407,14 @@ SWIFT_CLASS("_TtC8comments15ParamAndReturns")
 
 SWIFT_CLASS("_TtC8comments16ParameterOutline")
 @interface ParameterOutline
+/**
+  \param x A number
 
-/// \param x A number
-///
-/// \param y A number
-///
-/// \param z A number
+  \param y A number
+
+  \param z A number
+
+*/
 - (void)f0:(NSInteger)x y:(NSInteger)y z:(NSInteger)z;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -378,13 +422,22 @@ SWIFT_CLASS("_TtC8comments16ParameterOutline")
 
 SWIFT_CLASS("_TtC8comments22ParameterOutlineMiddle")
 @interface ParameterOutlineMiddle
+/**
+  <ul>
+    <li>
+      This line should remain.
+    </li>
+    <li>
+      This line should also remain.
+    </li>
+  </ul>
+  \param x A number
 
-/// <ul><li>This line should remain.</li><li>This line should also remain.</li></ul>
-/// \param x A number
-///
-/// \param y A number
-///
-/// \param z A number
+  \param y A number
+
+  \param z A number
+
+*/
 - (void)f0:(NSInteger)x y:(NSInteger)y z:(NSInteger)z;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -398,8 +451,11 @@ SWIFT_CLASS("_TtC8comments13ReferenceLink")
 
 SWIFT_CLASS("_TtC8comments7Returns")
 @interface Returns
+/**
 
-/// \returns  A number
+  returns:
+  A number
+*/
 - (NSInteger)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -407,8 +463,10 @@ SWIFT_CLASS("_TtC8comments7Returns")
 
 SWIFT_CLASS("_TtC8comments18SeparateParameters")
 @interface SeparateParameters
+/**
+  \param x A number
 
-/// \param x A number
+*/
 - (void)f0:(NSInteger)x y:(NSInteger)y;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -416,13 +474,14 @@ SWIFT_CLASS("_TtC8comments18SeparateParameters")
 
 SWIFT_CLASS("_TtC8comments13SetextHeaders")
 @interface SetextHeaders
-
-/// <h1>LEVEL ONE</h1>
-/// <h2>LEVEL TWO</h2>
-/// <h3>LEVEL THREE</h3>
-/// <h4>LEVEL FOUR</h4>
-/// <h5>LEVEL FIVE</h5>
-/// <h5>LEVEL SIX</h5>
+/**
+  <h1>LEVEL ONE</h1>
+  <h2>LEVEL TWO</h2>
+  <h3>LEVEL THREE</h3>
+  <h4>LEVEL FOUR</h4>
+  <h5>LEVEL FIVE</h5>
+  <h5>LEVEL SIX</h5>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -430,8 +489,10 @@ SWIFT_CLASS("_TtC8comments13SetextHeaders")
 
 SWIFT_CLASS("_TtC8comments14StrongEmphasis")
 @interface StrongEmphasis
-
-/// Aaa bbb ccc. Aaa bbb ccc.
+/**
+  Aaa <em>bbb</em> ccc.
+  Aaa <em>bbb</em> ccc.
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end
@@ -439,10 +500,30 @@ SWIFT_CLASS("_TtC8comments14StrongEmphasis")
 
 SWIFT_CLASS("_TtC8comments13UnorderedList")
 @interface UnorderedList
-
-/// <ul><li>Aaa.</li><li>Bbb.
-/// Ccc.</li></ul>
-/// <ul><li>Ddd.</li><li>Eee.<ul><li>Fff.</li></ul></li></ul>
+/**
+  <ul>
+    <li>
+      Aaa.
+    </li>
+    <li>
+      Bbb.
+      Ccc.
+    </li>
+  </ul>
+  <ul>
+    <li>
+      Ddd.
+    </li>
+    <li>
+      Eee.
+      <ul>
+        <li>
+          Fff.
+        </li>
+      </ul>
+    </li>
+  </ul>
+*/
 - (void)f0;
 - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 @end

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -8,7 +8,9 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-LABEL: /// What a nightmare!
+// CHECK: /**
+// CHECK-NEXT: What a nightmare!
+// CHECK: */
 // CHECK-LABEL: double (^ _Nonnull block_nightmare(float (^ _Nonnull x)(NSInteger)))(char);
 
 /// What a nightmare!

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -69,9 +69,14 @@ import Foundation
   func methodNotExportedToObjC() {}
 }
 
-// CHECK-LABEL: /// Foo: A feer, a female feer.
+// CHECK: /**
+// CHECK-NEXT: Foo: A feer, a female feer.
+// CHECK-NEXT: */
+
 // CHECK-NEXT: typedef SWIFT_ENUM(NSInteger, FooComments) {
-// CHECK:   /// Zim: A zeer, a female zeer.
+// CHECK: /**
+// CHECK-NEXT: Zim: A zeer, a female zeer.
+// CHECK: */
 // CHECK-NEXT:   FooCommentsZim = 0,
 // CHECK-NEXT:   FooCommentsZang = 1,
 // CHECK-NEXT:   FooCommentsZung = 2,


### PR DESCRIPTION
Enclose the entire doc comment in /*\* */ to ensure that newlines
don't cause comments to leak out and get parsed as C.

rdar://problem/24923076
