### PR TITLE
Remove code motion in ASO. 

### DIFF
--- a/lib/SILOptimizer/ARC/ARCBBState.cpp
+++ b/lib/SILOptimizer/ARC/ARCBBState.cpp
@@ -127,9 +127,6 @@ void ARCBBState::mergePredTopDown(ARCBBState &PredBBState) {
       PtrToTopDownState.blot(RefCountedValue);
       continue;
     }
-
-    DEBUG(llvm::dbgs() << "            Partial: "
-                       << (RefCountState.isPartial() ? "yes" : "no") << "\n");
   }
 }
 

--- a/lib/SILOptimizer/ARC/ARCMatchingSet.h
+++ b/lib/SILOptimizer/ARC/ARCMatchingSet.h
@@ -43,20 +43,8 @@ struct ARCMatchingSet {
   /// The set of reference count increments that were paired.
   llvm::SetVector<SILInstruction *> Increments;
 
-  /// An insertion point for an increment means the earliest point in the
-  /// program after the increment has occurred that the increment can be moved
-  /// to
-  /// without moving the increment over an instruction that may decrement a
-  /// reference count.
-  llvm::SetVector<SILInstruction *> IncrementInsertPts;
-
   /// The set of reference count decrements that were paired.
   llvm::SetVector<SILInstruction *> Decrements;
-
-  /// An insertion point for a decrement means the latest point in the program
-  /// before the decrement that the optimizer conservatively assumes that a
-  /// reference counted value could be used.
-  llvm::SetVector<SILInstruction *> DecrementInsertPts;
 
   // This is a data structure that cannot be moved or copied.
   ARCMatchingSet() = default;
@@ -68,15 +56,13 @@ struct ARCMatchingSet {
   void clear() {
     Ptr = SILValue();
     Increments.clear();
-    IncrementInsertPts.clear();
     Decrements.clear();
-    DecrementInsertPts.clear();
   }
 };
 
 struct MatchingSetFlags {
   bool KnownSafe;
-  bool Partial;
+  bool CodeMotionSafe;
 };
 static_assert(std::is_pod<MatchingSetFlags>::value,
               "MatchingSetFlags should be a pod.");

--- a/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalARCSequenceDataflow.cpp
@@ -107,7 +107,7 @@ bool ARCSequenceDataflowEvaluator::processBBTopDown(ARCBBState &BBState) {
       if (Op && OtherState->first == Op)
         continue;
 
-      OtherState->second.updateForSameLoopInst(&I, &I, SetFactory, AA);
+      OtherState->second.updateForSameLoopInst(&I, SetFactory, AA);
     }
   }
 
@@ -270,10 +270,6 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
     // that the instruction "visits".
     SILValue Op = Result.RCIdentity;
 
-    // If I is a use of the value that we are going to track, this is the
-    // position right after I where we would want to move the release.
-    auto *InsertPt = &*std::next(SILBasicBlock::iterator(&I));
-
     // For all other (reference counted value, ref count state) we are
     // tracking...
     for (auto &OtherState : BBState.getBottomupStates()) {
@@ -286,7 +282,7 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
       if (Op && OtherState->first == Op)
         continue;
 
-      OtherState->second.updateForSameLoopInst(&I, InsertPt, SetFactory, AA);
+      OtherState->second.updateForSameLoopInst(&I, SetFactory, AA);
     }
   }
 
@@ -306,13 +302,12 @@ bool ARCSequenceDataflowEvaluator::processBBBottomUp(
     PredTerminators.push_back(TermInst);
   }
 
-  auto *InsertPt = &*BB.begin();
   for (auto &OtherState : BBState.getBottomupStates()) {
     // If the other state's value is blotted, skip it.
     if (!OtherState.hasValue())
       continue;
 
-    OtherState->second.updateForPredTerminators(PredTerminators, InsertPt,
+    OtherState->second.updateForPredTerminators(PredTerminators,
                                                 SetFactory, AA);
   }
 

--- a/lib/SILOptimizer/ARC/RefCountState.cpp
+++ b/lib/SILOptimizer/ARC/RefCountState.cpp
@@ -187,7 +187,7 @@ bool BottomUpRefCountState::valueCanBeUsedGivenLatticeState() const {
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
 bool BottomUpRefCountState::handleUser(
-    ArrayRef<SILInstruction *> NewInsertPts, SILValue RCIdentity,
+    SILValue RCIdentity,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   assert(valueCanBeUsedGivenLatticeState() &&
          "Must be able to be used at this point of the lattice.");
@@ -196,13 +196,6 @@ bool BottomUpRefCountState::handleUser(
   switch (LatState) {
   case LatticeState::Decremented:
     LatState = LatticeState::MightBeUsed;
-    assert(InsertPts->empty() && "If we are decremented, we should have no "
-                                 "insertion points.");
-    InsertPts = SetFactory.get(NewInsertPts);
-    DEBUG(llvm::dbgs() << "    Insertion Points:\n";
-          for (auto I : *InsertPts) {
-            llvm::dbgs() << "                " << *I;
-          });
     return true;
   case LatticeState::MightBeUsed:
   case LatticeState::MightBeDecremented:
@@ -228,7 +221,7 @@ valueCanBeGuaranteedUsedGivenLatticeState() const {
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
 bool BottomUpRefCountState::handleGuaranteedUser(
-    ArrayRef<SILInstruction *> NewInsertPts, SILValue RCIdentity,
+    SILValue RCIdentity,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   assert(valueCanBeGuaranteedUsedGivenLatticeState() &&
          "Must be able to be used at this point of the lattice.");
@@ -237,13 +230,6 @@ bool BottomUpRefCountState::handleGuaranteedUser(
   switch (LatState) {
   // If were decremented, insert the insertion point.
   case LatticeState::Decremented: {
-    assert(InsertPts->empty() && "If we are decremented, we should have no "
-                                 "insertion points.");
-    InsertPts = SetFactory.get(NewInsertPts);
-    DEBUG(llvm::dbgs() << "    Insertion Points:\n";
-          for (auto I : *InsertPts) {
-            llvm::dbgs() << "                " << *I;
-          });
     LatState = LatticeState::MightBeDecremented;
     return true;
   }
@@ -289,7 +275,6 @@ handleRefCountInstMatch(SILInstruction *RefCountInst) {
   case LatticeState::MightBeUsed:
     // Unset InsertPt so we remove retain release pairs instead of
     // performing code motion.
-    InsertPts = ImmutablePointerSetFactory<SILInstruction>::getEmptySet();
     SWIFT_FALLTHROUGH;
   case LatticeState::MightBeDecremented:
     return true;
@@ -337,20 +322,6 @@ bool BottomUpRefCountState::merge(const BottomUpRefCountState &Other) {
     return false;
   }
 
-  // We need to determine if we performed any partial merging of insertion
-  // points.
-  Partial |= Other.Partial;
-  if (*InsertPts != *Other.InsertPts) {
-    Partial = true;
-    InsertPts = InsertPts->merge(Other.InsertPts);
-  }
-
-  DEBUG(llvm::dbgs() << "            Partial: " << (Partial ? "yes" : "no")
-                     << "\n");
-  DEBUG(llvm::dbgs() << "            Insertion Points:\n";
-        for (auto I : *InsertPts) {
-          llvm::dbgs() << "                " << *I;
-        });
   return true;
 }
 
@@ -358,7 +329,7 @@ bool BottomUpRefCountState::merge(const BottomUpRefCountState &Other) {
 // the value we are tracking. If so advance the state's sequence appropriately
 // and return true. Otherwise return false.
 bool BottomUpRefCountState::handlePotentialGuaranteedUser(
-    SILInstruction *PotentialGuaranteedUser, SILInstruction *InputInsertPt,
+    SILInstruction *PotentialGuaranteedUser,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
@@ -385,7 +356,7 @@ bool BottomUpRefCountState::handlePotentialGuaranteedUser(
       FoundNonARCUser = true;
 
   // Otherwise, update the ref count state given the guaranteed user.
-  return handleGuaranteedUser(InputInsertPt, getRCRoot(), SetFactory, AA);
+  return handleGuaranteedUser(getRCRoot(), SetFactory, AA);
 }
 
 /// Check if PotentialDecrement can decrement the reference count associated
@@ -419,7 +390,7 @@ bool BottomUpRefCountState::handlePotentialDecrement(
 // requires user to be alive. If so advance the state's sequence
 // appropriately and return true. Otherwise return false.
 bool BottomUpRefCountState::handlePotentialUser(
-    SILInstruction *PotentialUser, ArrayRef<SILInstruction *> InputInsertPts,
+    SILInstruction *PotentialUser,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
 
   // If we are not tracking a ref count, just return false.
@@ -444,11 +415,11 @@ bool BottomUpRefCountState::handlePotentialUser(
     if (mustUseValue(PotentialUser, getRCRoot(), AA))
       FoundNonARCUser = true;
 
-  return handleUser(InputInsertPts, getRCRoot(), SetFactory, AA);
+  return handleUser(getRCRoot(), SetFactory, AA);
 }
 
 void BottomUpRefCountState::updateForSameLoopInst(
-    SILInstruction *I, SILInstruction *InputInsertPt,
+    SILInstruction *I,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If this state is not tracking anything, there is nothing to update.
   if (!isTrackingRefCount())
@@ -458,7 +429,7 @@ void BottomUpRefCountState::updateForSameLoopInst(
   // instruction in a way that requires us to guarantee the lifetime of the
   // pointer up to this point. This has the effect of performing a use and a
   // decrement.
-  if (handlePotentialGuaranteedUser(I, InputInsertPt, SetFactory, AA)) {
+  if (handlePotentialGuaranteedUser(I, SetFactory, AA)) {
     DEBUG(llvm::dbgs() << "    Found Potential Guaranteed Use:\n        "
                        << getRCRoot());
     return;
@@ -475,13 +446,13 @@ void BottomUpRefCountState::updateForSameLoopInst(
 
   // Otherwise check if the reference counted value we are tracking
   // could be used by the given instruction.
-  if (!handlePotentialUser(I, InputInsertPt, SetFactory, AA))
+  if (!handlePotentialUser(I, SetFactory, AA))
     return;
   DEBUG(llvm::dbgs() << "    Found Potential Use:\n        " << getRCRoot());
 }
 
 void BottomUpRefCountState::updateForDifferentLoopInst(
-    SILInstruction *I, ArrayRef<SILInstruction *> InputInsertPts,
+    SILInstruction *I,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
@@ -492,7 +463,7 @@ void BottomUpRefCountState::updateForDifferentLoopInst(
         mayDecrementRefCount(I, getRCRoot(), AA)) {
       DEBUG(llvm::dbgs() << "    Found potential guaranteed use:\n        "
                          << getRCRoot());
-      handleGuaranteedUser(InputInsertPts, getRCRoot(), SetFactory, AA);
+      handleGuaranteedUser(getRCRoot(), SetFactory, AA);
       return;
     }
   }
@@ -500,13 +471,13 @@ void BottomUpRefCountState::updateForDifferentLoopInst(
   // We can just handle potential users normally, since if we handle the user we
   // already saw a decrement implying that we will treat this like a guaranteed
   // use.
-  if (!handlePotentialUser(I, InputInsertPts, SetFactory, AA))
+  if (!handlePotentialUser(I, SetFactory, AA))
     return;
   DEBUG(llvm::dbgs() << "    Found Potential Use:\n        " << getRCRoot());
 }
 
 void BottomUpRefCountState::updateForPredTerminators(
-    ArrayRef<SILInstruction *> Terms, SILInstruction *InputInsertPt,
+    ArrayRef<SILInstruction *> Terms,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If this state is not tracking anything, there is nothing to update.
   if (!isTrackingRefCount())
@@ -517,7 +488,7 @@ void BottomUpRefCountState::updateForPredTerminators(
                   [this, &AA](SILInstruction *I) -> bool {
                     return mayGuaranteedUseValue(I, getRCRoot(), AA);
                   })) {
-    handleGuaranteedUser(InputInsertPt, getRCRoot(), SetFactory, AA);
+    handleGuaranteedUser(getRCRoot(), SetFactory, AA);
     return;
   }
 
@@ -536,7 +507,7 @@ void BottomUpRefCountState::updateForPredTerminators(
        -> bool { return mayHaveSymmetricInterference(I, getRCRoot(), AA); }))
     return;
 
-  handleUser(InputInsertPt, getRCRoot(), SetFactory, AA);
+  handleUser(getRCRoot(), SetFactory, AA);
 }
 
 //===----------------------------------------------------------------------===//
@@ -575,7 +546,6 @@ void TopDownRefCountState::initWithArg(SILArgument *Arg) {
          "Expected a strong entrance here");
   RCRoot = Arg;
   KnownSafe = false;
-  InsertPts = ImmutablePointerSetFactory<SILInstruction>::getEmptySet();
 }
 
 /// Initialize this RefCountState with an instruction which introduces a new
@@ -588,7 +558,6 @@ void TopDownRefCountState::initWithEntranceInst(
          "Expected a strong entrance here");
   RCRoot = RCIdentity;
   KnownSafe = false;
-  InsertPts = ImmutablePointerSetFactory<SILInstruction>::getEmptySet();
 }
 
 /// Uninitialize the current state.
@@ -626,12 +595,11 @@ bool TopDownRefCountState::valueCanBeDecrementedGivenLatticeState() const {
 /// If advance the state's sequence appropriately for a decrement. If we do
 /// advance return true. Otherwise return false.
 bool TopDownRefCountState::handleDecrement(
-    SILInstruction *PotentialDecrement, SILInstruction *NewInsertPt,
+    SILInstruction *PotentialDecrement,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory) {
   switch (LatState) {
   case LatticeState::Incremented:
     LatState = LatticeState::MightBeDecremented;
-    InsertPts = SetFactory.merge(InsertPts, NewInsertPt);
     return true;
   case LatticeState::None:
   case LatticeState::MightBeDecremented:
@@ -691,7 +659,7 @@ valueCanBeGuaranteedUsedGivenLatticeState() const {
 /// Given the current lattice state, if we have seen a use, advance the
 /// lattice state. Return true if we do so and false otherwise.
 bool TopDownRefCountState::handleGuaranteedUser(
-    SILInstruction *PotentialGuaranteedUser, SILInstruction *NewInsertPt,
+    SILInstruction *PotentialGuaranteedUser,
     SILValue RCIdentity, ImmutablePointerSetFactory<SILInstruction> &SetFactory,
     AliasAnalysis *AA) {
   assert(valueCanBeGuaranteedUsedGivenLatticeState() &&
@@ -700,10 +668,7 @@ bool TopDownRefCountState::handleGuaranteedUser(
   switch (LatState) {
   // If were decremented, insert the insertion point.
   case LatticeState::Incremented: {
-    assert(InsertPts->empty() && "If we are decremented, we should have no "
-                                 "insertion points.");
     LatState = LatticeState::MightBeUsed;
-    InsertPts = SetFactory.get(NewInsertPt);
     return true;
   }
   case LatticeState::MightBeDecremented:
@@ -745,10 +710,6 @@ handleRefCountInstMatch(SILInstruction *RefCountInst) {
     return false;
   case LatticeState::Incremented:
   case LatticeState::MightBeDecremented:
-    // Unset InsertPt so we remove retain release pairs instead of performing
-    // code motion.
-    InsertPts = ImmutablePointerSetFactory<SILInstruction>::getEmptySet();
-    SWIFT_FALLTHROUGH;
   case LatticeState::MightBeUsed:
     return true;
   }
@@ -793,15 +754,6 @@ bool TopDownRefCountState::merge(const TopDownRefCountState &Other) {
     return false;
   }
 
-  Partial |= Other.Partial;
-  if (*InsertPts != *Other.InsertPts) {
-    Partial = true;
-    InsertPts = InsertPts->merge(Other.InsertPts);
-  }
-
-  DEBUG(llvm::dbgs() << "            Partial: " << (Partial ? "yes" : "no")
-                     << "\n");
-
   return true;
 }
 
@@ -809,7 +761,7 @@ bool TopDownRefCountState::merge(const TopDownRefCountState &Other) {
 // the value we are tracking. If so advance the state's sequence appropriately
 // and return true. Otherwise return false.
 bool TopDownRefCountState::handlePotentialGuaranteedUser(
-    SILInstruction *PotentialGuaranteedUser, SILInstruction *NewInsertPt,
+    SILInstruction *PotentialGuaranteedUser,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
@@ -829,7 +781,7 @@ bool TopDownRefCountState::handlePotentialGuaranteedUser(
     return false;
 
   // Otherwise, update our step given that we have a potential decrement.
-  return handleGuaranteedUser(PotentialGuaranteedUser, NewInsertPt, getRCRoot(),
+  return handleGuaranteedUser(PotentialGuaranteedUser, getRCRoot(),
                               SetFactory, AA);
 }
 
@@ -837,7 +789,7 @@ bool TopDownRefCountState::handlePotentialGuaranteedUser(
 // the value we are tracking. If so advance the state's sequence appropriately
 // and return true. Otherwise return false.
 bool TopDownRefCountState::handlePotentialDecrement(
-    SILInstruction *PotentialDecrement, SILInstruction *NewInsertPt,
+    SILInstruction *PotentialDecrement,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If we are not tracking a ref count, just return false.
   if (!isTrackingRefCount())
@@ -857,7 +809,7 @@ bool TopDownRefCountState::handlePotentialDecrement(
     return false;
 
   // Otherwise, update our state given the potential decrement.
-  return handleDecrement(PotentialDecrement, NewInsertPt, SetFactory);
+  return handleDecrement(PotentialDecrement, SetFactory);
 }
 
 // Check if PotentialUser could be a use of the reference counted value that
@@ -884,7 +836,7 @@ bool TopDownRefCountState::handlePotentialUser(SILInstruction *PotentialUser,
 }
 
 void TopDownRefCountState::updateForSameLoopInst(
-    SILInstruction *I, SILInstruction *NewInsertPt,
+    SILInstruction *I, 
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
@@ -894,7 +846,7 @@ void TopDownRefCountState::updateForSameLoopInst(
   // instruction in a way that requires us to guarantee the lifetime of the
   // pointer up to this point. This has the effect of performing a use and a
   // decrement.
-  if (handlePotentialGuaranteedUser(I, NewInsertPt, SetFactory, AA)) {
+  if (handlePotentialGuaranteedUser(I, SetFactory, AA)) {
     DEBUG(llvm::dbgs() << "    Found Potential Guaranteed Use:\n        "
                        << getRCRoot());
     return;
@@ -903,7 +855,7 @@ void TopDownRefCountState::updateForSameLoopInst(
   // Check if the instruction we are visiting could potentially decrement
   // the reference counted value we are tracking in a manner that could
   // cause us to change states. If we do change states continue...
-  if (handlePotentialDecrement(I, NewInsertPt, SetFactory, AA)) {
+  if (handlePotentialDecrement(I, SetFactory, AA)) {
     DEBUG(llvm::dbgs() << "    Found Potential Decrement:\n        "
                        << getRCRoot());
     return;
@@ -917,7 +869,7 @@ void TopDownRefCountState::updateForSameLoopInst(
 }
 
 void TopDownRefCountState::updateForDifferentLoopInst(
-    SILInstruction *I, SILInstruction *NewInsertPt,
+    SILInstruction *I,
     ImmutablePointerSetFactory<SILInstruction> &SetFactory, AliasAnalysis *AA) {
   // If we are not tracking anything, bail.
   if (!isTrackingRefCount())
@@ -927,7 +879,7 @@ void TopDownRefCountState::updateForDifferentLoopInst(
     if (mayGuaranteedUseValue(I, getRCRoot(), AA) ||
         mayDecrementRefCount(I, getRCRoot(), AA)) {
       DEBUG(llvm::dbgs() << "    Found potential guaranteed use!\n");
-      handleGuaranteedUser(I, NewInsertPt, getRCRoot(), SetFactory, AA);
+      handleGuaranteedUser(I, getRCRoot(), SetFactory, AA);
       return;
     }
   }

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts -disable-code-motion-arc=0 %s | FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts -disable-code-motion-arc=0 %s | FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -arc-loop-opts -disable-code-motion-arc=0 %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=0 -arc-sequence-opts %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts %s | FileCheck -check-prefix=CHECK -check-prefix=CHECK-LOOP %s
+// RUN: %target-sil-opt -enable-sil-verify-all -arc-loop-opts  %s | FileCheck -check-prefix=CHECK -check-prefix=CHECK-LOOP %s
 
 sil_stage canonical
 
@@ -218,9 +218,9 @@ bb0(%0 : $S):
 
 // CHECK-LABEL: sil @move_delete_retain_over_decrement_use_when_knownsafe : $@convention(thin) (@box Builtin.Int32) -> ()
 // CHECK: bb0
-// CHECK: integer_literal
+// CHECK: strong_retain
 // CHECK-NEXT: integer_literal
-// CHECK-NEXT: strong_retain
+// CHECK-NEXT: integer_literal
 // CHECK-NEXT: apply
 // CHECK-NEXT: apply
 // CHECK-NEXT: strong_release
@@ -243,9 +243,9 @@ bb0(%0 : $@box Builtin.Int32):
 
 // CHECK-LABEL: sil @delete_copyvalue_over_decrement_use_when_knownsafe : $@convention(thin) (S) -> ()
 // CHECK: bb0
-// CHECK: integer_literal
+// CHECK: retain_value
 // CHECK-NEXT: integer_literal
-// CHECK-NEXT: retain_value
+// CHECK-NEXT: integer_literal
 // CHECK-NEXT: apply
 // CHECK-NEXT: apply
 // CHECK-NEXT: release_value
@@ -544,8 +544,8 @@ bb0(%0 : $Cls):
 }
 
 // CHECK-LABEL: sil @dont_remove_as_arg0_may_be_indirectly_released_by_callee
-// CHECK: strong_retain
-// CHECK: strong_release
+// CHECK: retain_value
+// CHECK: release_value
 sil @dont_remove_as_arg0_may_be_indirectly_released_by_callee : $@convention(thin) (Cls, Cls) -> () {
 bb0(%0 : $Cls, %1 : $Cls):
   %2 = function_ref @release_arg1 : $@convention(thin) (Cls, Cls) -> ()
@@ -575,8 +575,8 @@ bb0(%0 : $Cls):
 }
 
 // CHECK-LABEL: sil @dont_remove_as_local_object_indirectly_escapes_to_callee
-// CHECK: strong_retain
-// CHECK: strong_release
+// CHECK: retain_value
+// CHECK: release_value
 sil @dont_remove_as_local_object_indirectly_escapes_to_callee : $@convention(thin) (Cls) -> () {
 bb0(%0 : $Cls):
   %1 = alloc_ref $Cls
@@ -1271,13 +1271,14 @@ bb0(%0 : $@box Builtin.Int32):
 // CHECK-LABEL: sil @increment_known_safe_merge_with_last_knownsafe : $@convention(thin) (@box Builtin.Int32) -> () {
 // CHECK: bb1:
 // CHECK-NEXT: strong_retain
+// CHECK-NEXT: strong_retain
 // CHECK-NEXT: br bb3
 // CHECK: bb2:
 // CHECK-NEXT: strong_retain
 // CHECK-NEXT: apply
+// CHECK-NEXT: strong_retain
 // CHECK-NEXT: br bb3
 // CHECK: bb3:
-// CHECK-NEXT: strong_retain
 // CHECK-NEXT: apply
 // CHECK-NEXT: apply
 // CHECK-NEXT: strong_release
@@ -1314,12 +1315,12 @@ bb3:
 // CHECK-NEXT: strong_retain
 // CHECK-NEXT: apply
 // CHECK-NEXT: apply
-// CHECK-NEXT: strong_release
 // CHECK-NEXT: cond_br
 // CHECK: bb1:
 // CHECK-NEXT: strong_release
+// CHECK-NEXT: strong_release
 // CHECK-NEXT: br bb3
-// CHECK-NOT: strong_release
+// CHECK: strong_release
 sil @decrement_known_safe_merge_with_last_knownsafe : $@convention(thin) (@box Builtin.Int32) -> () {
 bb0(%0 : $@box Builtin.Int32):
   %1 = function_ref @user : $@convention(thin) (@box Builtin.Int32) -> ()
@@ -1384,12 +1385,11 @@ bb3:
 /// we run into dominance problems if the bitcast is in a branch.
 // CHECK-LABEL: sil @switch_merge_with_bit_cast_in_branches : $@convention(thin) (@owned S) -> () {
 // CHECK: bb1:
-// CHECK-NOT: strong_retain
+// CHECK: strong_retain
 // CHECK: bb2:
-// CHECK-NOT: strong_retain
+// CHECK: strong_retain
 // CHECK: bb3:
-// CHECK: retain_value
-// CHECK: release_value
+// CHECK: strong_release 
 sil @switch_merge_with_bit_cast_in_branches : $@convention(thin) (@owned S) -> () {
 bb0(%0 : $S):
   cond_br undef, bb1, bb2
@@ -1591,10 +1591,12 @@ bb5:
   unreachable
 }
 
+// Only check for the removal of RR in bb0 when loop arc is enabled.
+//
 // CHECK-LABEL: sil @propagate_postdominating_owned_release_info : $@convention(thin) (@owned @box Builtin.Int32) -> () {
 // CHECK: bb0(
-// CHECK-NOT: retain
-// CHECK-NOT: release
+// CHECK-LOOP-NOT: retain
+// CHECK-LOOP-NOT: release
 // CHECK: bb1:
 // CHECK-NOT: retain
 // CHECK-NOT: release
@@ -1650,14 +1652,14 @@ bb0(%0 : $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil @guaranteed_check_if_we_already_have_insertion_pt_we_use_that_one : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
-// CHECK: function_ref @guaranteed_use
 // CHECK: strong_retain
+// CHECK: function_ref @guaranteed_use
 // CHECK: strong_release
 // CHECK: apply
 // CHECK: function_ref @guaranteed_use
 // CHECK: strong_retain
-// CHECK: strong_release
 // CHECK: function_ref @guaranteed_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+// CHECK: strong_release
 sil @guaranteed_check_if_we_already_have_insertion_pt_we_use_that_one : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject

--- a/test/SILOptimizer/arcsequenceopts_loops.sil
+++ b/test/SILOptimizer/arcsequenceopts_loops.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts -disable-code-motion-arc=0 %s | FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-loop-arc=1 -arc-sequence-opts  %s | FileCheck %s
 
 //////////////////
 // Declarations //
@@ -134,10 +134,10 @@ bb2:
 // CHECK: strong_retain
 // CHECK: apply
 // CHECK: apply
-// CHECK: strong_release
 // CHECK: bb1
 // CHECK-NOT: strong_retain
 // CHECK-NOT: strong_release
+// CHECK: bb2
 sil @self_loop_move_release_over_loops : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject
@@ -158,10 +158,9 @@ bb2:
 
 // Make sure we can move retains over loops.
 // CHECK-LABEL: sil @self_loop_move_retain_over_loops : $@convention(thin) (Builtin.NativeObject) -> () {
-// CHECK-NOT: strong_retain
-// CHECK-NOT: strong_release
-// CHECK: bb2
+// CHECK: bb0
 // CHECK: strong_retain
+// CHECK: bb2
 // CHECK: apply
 // CHECK: apply
 // CHECK: strong_release
@@ -328,13 +327,11 @@ bb6:
 // CHECK: bb4
 // CHECK: strong_release
 // CHECK: bb5
-// CHECK: strong_release
 // CHECK-NOT: strong_release
 // CHECK: bb6
-// CHECK: strong_release
 // CHECK-NOT: strong_release
 // CHECK: bb7
-// CHECK-NOT: strong_release
+// CHECK: strong_release
 sil @loop_multiple_exits_multiple_insertion_points : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   strong_retain %0 : $Builtin.NativeObject


### PR DESCRIPTION
Remove code motion in ASO. This code has been disabled for sometime.

As discussed, we separate the duty of moving retain release pairs with the task of removing them. Now the task of moving retains and releases are in Retain Release Code Motion committed in 51b1c0b.
