### PR TITLE
[SR-1287][build-script] Revert "Clear CMakeCache.txt before (re)configuration"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1963,7 +1963,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_TOOLS_DEPLOYMENT_TARGETS[@]}"
                     ( ! -z "${generator_output_path}" && ! -f "${generator_output_path}" ) ]] ; then
             set -x
             mkdir -p "${build_dir}"
-            rm -f "${cmake_cache_path}"
             (cd "${build_dir}" && "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}")
             { set +x; } 2>/dev/null
         fi


### PR DESCRIPTION
#### What's in this pull request?

CC: @tfiala @gribozavr 

Revert #2226
That is the trigger of [SR-1287](https://bugs.swift.org/browse/SR-1287)

https://cmake.org/runningcmake/

> If you have not already hand-edited the cache file,
> you could just delete it before re-running CMake.

is not quite right.
see: https://cmake.org/Bug/view.php?id=14820

If we find a reliable way to clear the cache, we should apply it.
But not this way.
#### Resolved bug number: ([SR-1287](https://bugs.swift.org/browse/SR-1287))

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
