### PR TITLE
SILGen: Contextualize parameter types in foreign-to-native thunks.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1091,7 +1091,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
         }
 
         auto foreignParam = foreignFnTy->getParameters()[foreignArgIndex++];
-        SILType foreignArgTy = foreignParam.getSILType();
+        SILType foreignArgTy = F.mapTypeIntoContext(foreignParam.getSILType());
         auto bridged = emitNativeToBridgedValue(fd, param,
                                 SILFunctionTypeRepresentation::CFunctionPointer,
                                 foreignArgTy.getSwiftRValueType());

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen %s | FileCheck %s
+// REQUIRES: objc_interop
+
+import objc_generics
+
+func callInitializer() {
+  _ = GenericClass(thing: NSObject())
+}
+
+// CHECK-LABEL: sil shared @_TFCSo12GenericClassCfT5thingGSQx__GSQGS_x__
+// CHECK:         thick_to_objc_metatype {{%.*}} : $@thick GenericClass<T>.Type to $@objc_metatype GenericClass<T>.Type


### PR DESCRIPTION
Now that foreign entry points may be imported as generic, we need to forward generic parameters when we thunk them. Fixes SR-1392.
