### PR TITLE
[tests] Include 'long_test' in 'check-swift-all-*' test targets

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -471,6 +471,7 @@ else:
 swift_run_only_tests = lit_config.params.get('run_only_tests', 'all_except_long')
 if swift_run_only_tests == 'all':
     config.available_features.add("executable_test")
+    config.available_features.add("long_test")
 elif swift_run_only_tests == 'executable_tests':
     config.available_features.add("executable_test")
     config.limit_to_features.add("executable_test")


### PR DESCRIPTION
#### What's in this pull request?

`build-script -T --long-test`

`check-swift-all` should include `long_test` test cases.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
