### PR TITLE
[build-script] Skip unsupported 'check-swift-only_long-optimize' test variant

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1227,7 +1227,7 @@ function calculate_targets_for_host() {
                 fi
             fi
             SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}${test_target_suffix}-${stdlib_deployment_target}")
-            if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" ]] ; then
+            if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" && "${test_subset_target_suffix}" != "-only_long" ]] ; then
                 SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}-optimize-${stdlib_deployment_target}")
             fi
         fi


### PR DESCRIPTION
#### What's in this pull request?

`build-script --long-test --test-optimized`

This tries to run `check-swift-only_long` and `check-swift-only_long-optimize`
But `check-swift-only_long-optimize` does not exist.

```
--- check-swift-only_long-optimize-linux-x86_64 ---
ninja: error: unknown target 'check-swift-only_long-optimize-linux-x86_64'
-- check-swift-only_long-optimize-linux-x86_64 finished --
```

CC: @gribozavr 
Why it's not supported?

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
