### PR TITLE
[CMake] Stop re-linking

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -35,8 +35,7 @@ function(generate_revision_inc revision_inc_var name dir)
     # Create custom target to generate the VC revision include.
     set(revision_inc "${CMAKE_CURRENT_BINARY_DIR}/${name}Revision.inc")
     string(TOUPPER ${name} upper_name)
-    add_custom_command(OUTPUT "${revision_inc}"
-      DEPENDS "${dep_file}" "${get_svn_script}"
+    execute_process(
       COMMAND
       ${CMAKE_COMMAND} "-DFIRST_SOURCE_DIR=${dir}"
                        "-DFIRST_NAME=${upper_name}"


### PR DESCRIPTION
#### What's in this pull request?

CC: @dabrahams 
https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20160404/001621.html

`${BUILD_DIR}/lib/Basic/SwiftRevision.inc` used to be re-generated every time
git revision "hash" has changed. I feel, that is superfluous while developing.

With this change, `{LLVM,Clang,Swift}Revision.inc` generation is done
at configure time, instead of build time. That means:
- Fresh build: build everything normally
- Rebuild with `--reconfigure`:  re-link and refresh `--version` output
- Rebuild without `--reconfigure`: no re-link and remain old  `--version` output

AFAIK, every CI build has `--reconfigure` or perform scratch build.
So, this change should not affect CI bot behavior.

I confirmed:

```
$ utils/build-script -R --reconfigure  # fresh build
[.. build everything ..]
$ git commit --amend  # just change the hash
$ utils/build-script -R --reconfigure
[.. rebuild Version.cpp.o and re-linking ..]
$ vim stdlib/public/core/Algorithm.swift   # add one empty line
$ utils/build-script -R
[.. no re-linking .. build stdlib ..]
$ git commit -a  # change hash
$ utils/build-script -R
[.. rebuild nothing ..]
$ utils/build-script -R --reconfigure
[.. rebuild Version.cpp.o and re-linking ..]
$ utils/build-script -R --reconfigure
[.. rebuild nothing ..]
```

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
