### PR TITLE
Add 1 more iteration of release hoisting

### DIFF
--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -250,6 +250,7 @@ void AddSSAPasses(SILPassManager &PM, OptimizationLevelKind OpLevel) {
   } else
     PM.addEarlyCodeMotion();
 
+  PM.addReleaseHoisting();
   PM.addRetainSinking();
   PM.addARCSequenceOpts();
   PM.addRemovePins();


### PR DESCRIPTION
This fixes part of the regression we have in StringWithCString. With the new indexing model, we have more retain and release pairs to get rid of and we run out of RRCM and ASO iterations.

Update compilation time : ()
