### PR TITLE
test: update DebugInfo tests for LLVM

### DIFF
--- a/test/DebugInfo/DynamicSelf.swift
+++ b/test/DebugInfo/DynamicSelf.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 class C {
@@ -11,8 +10,9 @@ class C {
 extension C {
   class func Factory() -> Self {
     // Currently we emit the static type C for r.
-    // CHECK: !DILocalVariable(name: "r", {{.*}}line: [[@LINE+2]], type: ![[SELFTY:[0-9]+]])
-    // CHECK: ![[SELFTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtDC11DynamicSelf1C", {{.*}}, baseType: !"_TtC11DynamicSelf1C")
+    // CHECK-DAG: !DILocalVariable(name: "r", {{.*}}line: [[@LINE+2]], type: ![[SELFTY:[0-9]+]])
+    // CHECK-DAG: ![[SELFTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtDC11DynamicSelf1C", {{.*}}, baseType: ![[SELFBT:[0-9]+]])
+    // CHECK-DAG: ![[SELFBT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "C", {{.*}}, identifier: "_TtC11DynamicSelf1C")
     let r = self.init(number: 0)
     return r
   }

--- a/test/DebugInfo/Errors.swift
+++ b/test/DebugInfo/Errors.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 class Obj {}
 
@@ -11,7 +10,8 @@ func simple(_ placeholder: Int64) throws -> () {
   // CHECK: define {{.*}}void @_TF6Errors6simpleFzVs5Int64T_(i64, %swift.refcounted*, %swift.error**)
   // CHECK: call void @llvm.dbg.declare
   // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[ERROR:[0-9]+]], metadata ![[DEREF:[0-9]+]])
-  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 3, {{.*}} type: !"_TtPs13ErrorProtocol_", flags: DIFlagArtificial)
+  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 3, {{.*}}, type: ![[TYPE:[0-9]+]], flags: DIFlagArtificial)
+  // CHECK: ![[TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "ErrorProtocol", {{.*}}, identifier: "_TtPs13ErrorProtocol_")
   // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)
   throw MyError.Simple
 }

--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-swift-frontend -emit-module-path %t/basic.swiftmodule %S/basic.swift
 
@@ -22,10 +21,10 @@ markUsed(basic.foo(1, 2))
 
 // DWARF: .debug_info
 // DWARF: DW_TAG_module
-// DWARF:   DW_AT_name {{.*}}"Swift"
+// DWARF:   DW_AT_name {{.*}}"Foo"
 // DWARF:   DW_AT_LLVM_include_path
 // DWARF: DW_TAG_module
-// DWARF:   DW_AT_name {{.*}}"Foo"
+// DWARF:   DW_AT_name {{.*}}"Swift"
 // DWARF:   DW_AT_LLVM_include_path
 // DWARF: DW_TAG_module
 // DWARF:   DW_AT_name {{.*}}"basic"

--- a/test/DebugInfo/archetype.swift
+++ b/test/DebugInfo/archetype.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
 
 protocol IntegerArithmetic {
@@ -10,8 +9,6 @@ protocol RandomAccessIndex : IntegerArithmetic {
   static func uncheckedSubtract(_ lhs: Self, rhs: Self) -> (Distance, Bool)
 }
 
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtTQQq_F9archetype16ExistentialTuple
-// CHECK-SAME:             identifier: [[TT:".+"]])
 // archetype.ExistentialTuple <A : RandomAccessIndex, B>(x : A, y : A) -> B
 // CHECK: !DISubprogram(name: "ExistentialTuple", linkageName: "_TF9archetype16ExistentialTuple
 // CHECK-SAME:          line: [[@LINE+2]]
@@ -20,8 +17,10 @@ func ExistentialTuple<T: RandomAccessIndex>(_ x: T, y: T) -> T.Distance {
   // (B, Swift.Bool)
   // CHECK: !DILocalVariable(name: "tmp"
   // CHECK-SAME:             line: [[@LINE+2]]
-  // CHECK-SAME:             type: ![[TT]]
+  // CHECK-SAME:             type: ![[TT:[0-9]+]]
   var tmp : (T.Distance, Bool) = T.uncheckedSubtract(x, rhs: y)
   return _overflowChecked((tmp.0, tmp.1))
 }
+
+// CHECK: ![[TT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtTQQq_F9archetype16ExistentialTuple
 

--- a/test/DebugInfo/archetypes2.swift
+++ b/test/DebugInfo/archetypes2.swift
@@ -1,14 +1,16 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -verify -g -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 
 class C<A> {
-// CHECK-DAG: !DILocalVariable(name: "x", arg: 1,{{.*}}line: [[@LINE+2]],{{.*}}type: !"_TtQq_C11archetypes21C"
-// CHECK-DAG: !DILocalVariable(name: "y", arg: 2,{{.*}}line: [[@LINE+1]],{{.*}}type: !"_TtQq_FC11archetypes21C3foo
+  // CHECK-DAG: !DILocalVariable(name: "x", arg: 1, {{.*}}, line: [[@LINE+4]], {{.*}}, type: ![[X_TYPE:[0-9]+]]
+  // CHECK-DAG: ![[X_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}}, identifier: "_TtQq_C11archetypes21C")
+  // CHECK-DAG: !DILocalVariable(name: "y", arg: 2, {{.*}}, line: [[@LINE+2]], {{.*}}, type: ![[Y_TYPE:[0-9]+]]
+  // CHECK-DAG: ![[Y_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, {{.*}} identifier: "_TtQq_FC11archetypes21C3foo
   func foo<B>(_ x: A, y :B) {
     markUsed("hello world")
   }
 }
 
 C<Int64>().foo(1, y: 3.14);
+

--- a/test/DebugInfo/attributes.swift
+++ b/test/DebugInfo/attributes.swift
@@ -1,9 +1,7 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module %s -emit-ir -g -o - | FileCheck %s
 
 // REQUIRES: objc_interop
 
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "ObjCClass",{{.*}} line: [[@LINE+1]],{{.*}} runtimeLang: DW_LANG_Swift,{{.*}} identifier: [[TY0:"[^"]*"]])
 @objc class ObjCClass {
       @IBAction func click(_: AnyObject?) -> () {}
 }
@@ -21,7 +19,8 @@ class SwiftClass {
 // an artificial variable.
 // DISABLED: [ DW_TAG_variable ] [OBJC_METACLASS_$__TtC10attributes9ObjCClass]
 
-// CHECK-DAG: !DIGlobalVariable(name: "strongRef0",{{.*}}line: [[@LINE+1]],{{.*}} type: ![[TY0]],{{.*}} isLocal: false, isDefinition: true
+// CHECK-DAG: !DIGlobalVariable(name: "strongRef0", {{.*}}, line: [[@LINE+3]], type: ![[TY0:[0-9]+]], isLocal: false, isDefinition: true
+// CHECK-DAG: ![[TY0]] = !DICompositeType(tag: DW_TAG_structure_type, name: "ObjCClass", {{.*}}, line: [[@LINE-18]], {{.*}}, runtimeLang: DW_LANG_Swift, identifier: "_TtC10attributes9ObjCClass")
 var strongRef0 : ObjCClass
 var strongRef1 : SwiftClass = SwiftClass()
 

--- a/test/DebugInfo/bound-namealiastype.swift
+++ b/test/DebugInfo/bound-namealiastype.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -emit-ir -g %s -o - | FileCheck %s
 
 public protocol OS_dispatch_queue {
@@ -9,8 +8,9 @@ func dispatch_queue_create() -> dispatch_queue_t! {
   return nil
 }
 
-// CHECK: !DICompositeType(tag: DW_TAG_union_type,
-// CHECK-SAME:             identifier: "_TtGSQa4main16dispatch_queue_t_"
 // CHECK: !DIGlobalVariable(name: "queue",
-// CHECK-SAME: line: [[@LINE+1]], type: !"_TtGSQa4main16dispatch_queue_t_"
+// CHECK-SAME:              line: [[@LINE+3]], type: ![[TYPE:[0-9]+]]
+// CHECK: ![[TYPE]] = !DICompositeType(tag: DW_TAG_union_type,
+// CHECK-SAME:                  identifier: "_TtGSQa4main16dispatch_queue_t_"
 public var queue = dispatch_queue_create()
+

--- a/test/DebugInfo/byref-capture.swift
+++ b/test/DebugInfo/byref-capture.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 func makeIncrementor(_ inc : Int64) -> () -> Int64
@@ -11,8 +10,10 @@ func makeIncrementor(_ inc : Int64) -> () -> Int64
     // CHECK-SAME:                        metadata ![[EMPTY:.*]])
     // CHECK: ![[EMPTY]] = !DIExpression()
     // CHECK: ![[SUM_CAPTURE]] = !DILocalVariable(name: "sum", arg: 1,
-    // CHECK-SAME:     line: [[@LINE-8]], type: !"_TtRVs5Int64"
-    //                                               ^ inout type.
+    // CHECK-SAME:                                line: [[@LINE-8]],
+    // CHECK-SAME:                                type: ![[TYPE:[0-9]+]]
+    //                                                  ^ inout type.
+    // CHECK: ![[TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtRVs5Int64", {{.*}}
     sum += inc
     return sum
   }

--- a/test/DebugInfo/enum.swift
+++ b/test/DebugInfo/enum.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
 
 // CHECK: ![[EMPTY:.*]] = !{}
@@ -13,6 +12,8 @@ enum Either {
 }
 let E : Either = .Neither;
 
+// CHECK: ![[MAYBE_INT_PAIR_BASE_TYPE:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", {{.*}}, identifier: "_TtSi")
+
 // CHECK: !DICompositeType(tag: DW_TAG_union_type, name: "Color",
 // CHECK-SAME:             line: [[@LINE+3]]
 // CHECK-SAME:             size: 8, align: 8,
@@ -20,8 +21,9 @@ let E : Either = .Neither;
 enum Color : UInt64 {
 // This is effectively a 2-bit bitfield:
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "Red"
-// CHECK-SAME:           baseType: !"_TtVs6UInt64"
+// CHECK-SAME:           baseType: ![[COLOR_BASE_TYPE:[0-9]+]]
 // CHECK-SAME:           size: 8, align: 8{{[,)]}}
+// CHECK: ![[COLOR_BASE_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "UInt64", {{.*}}, identifier: "_TtVs6UInt64")
   case Red, Green, Blue
 }
 
@@ -81,6 +83,8 @@ public enum List<T> {
        indirect case Tail(List, T)
        case End
 
-// CHECK: !DILocalVariable(name: "self", arg: 1, {{.*}} line: [[@LINE+1]], type: !"_TtGO4enum4ListQq_S0__", flags: DIFlagArtificial)
+// CHECK: ![[SELF_TYPE:[0-9]+]] = !DICompositeType(tag: DW_TAG_union_type, name: "List", {{.*}}, identifier: "_TtGO4enum4ListQq_S0__")
+// CHECK: !DILocalVariable(name: "self", arg: 1, {{.*}} line: [[@LINE+1]], type: ![[SELF_TYPE]], flags: DIFlagArtificial)
        func fooMyList() {}
 }
+

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 // CHECK-DAG: ![[SINODE:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64",{{.*}} identifier: [[SI:.*]])
@@ -11,35 +10,42 @@ func baz(_ i: Float) -> Int64 { return 0; }
 func barz(_ i: Float, _ j: Float) -> Int64 { return 0; }
 func main() -> Int64 {
 
-    // CHECK-DAG: !DILocalVariable(name: "bar_function_pointer",{{.*}} line: [[@LINE+1]],{{.*}} type: !"[[BARPT:[^,]+]]"
+    // CHECK-DAG: !DILocalVariable(name: "bar_function_pointer", {{.*}}, line: [[@LINE+2]], type: ![[BARPT:[0-9]+]])
+    // CHECK-DAG: ![[BARPT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtFT_T_", {{.*}}, elements: ![[BARMEMBERS:[0-9]+]], {{.*}}, identifier: "_TtFT_T_")
     var bar_function_pointer = bar
-    // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "[[BARPT]]",{{.*}} elements: ![[BARMEMBERS:[0-9]+]]
-    // CHECK-DAG: ![[BARMEMBERS]] = !{![[BARMEMBER:.*]], {{.*}}}
-    // CHECK-DAG: ![[BARMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BARPTR:[0-9]+]]
-    // CHECK-DAG: ![[BARPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type,{{.*}} baseType: ![[BART:[0-9]+]]
+    // CHECK-DAG: ![[BARMEMBERS]] = !{![[BARMEMBER:[0-9]+]], {{.*}}}
+    // CHECK-DAG: ![[BARMEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}, baseType: ![[BARPTR:[0-9]+]]
+    // CHECK-DAG: ![[BARPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BART:[0-9]+]]
     // CHECK-DAG: ![[BART]] = !DISubroutineType(types: ![[BARARGS:[0-9]+]])
-    // CHECK-DAG: ![[BARARGS]] = !{!"_TtT_"}
+    // CHECK-DAG: ![[BARARGS]] = !{![[BARARGSTYPE:[0-9]+]]}
+    // CHECK-DAG: ![[BARARGSTYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtT_", {{.*}}, identifier: "_TtT_")
     bar_function_pointer();// Set breakpoint here
 
-    // CHECK-DAG: !DILocalVariable(name: "baz_function_pointer",{{.*}} type: !"[[BAZPT:[^,]+]]"
-    // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "[[BAZPT]]",{{.*}} elements: ![[BAZMEMBERS:[0-9]+]]
-    // CHECK-DAG: ![[BAZMEMBERS]] = !{![[BAZMEMBER:.*]], {{.*}}}
-    // CHECK-DAG: ![[BAZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BAZPTR:[0-9]+]]
-    // CHECK-DAG: ![[BAZPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type,{{.*}} baseType: ![[BAZT:[0-9]+]]
-    // CHECK-DAG: ![[BAZT]] = !DISubroutineType(types: ![[BAZARGS:.*]])
-    // CHECK-DAG: ![[BAZARGS]] = !{!"_TtVs5Int64", !"_TtSf"}
+    // CHECK-DAG: !DILocalVariable(name: "baz_function_pointer", {{.*}}, type: ![[BAZPT:[0-9]+]])
+    // CHECK-DAG: ![[BAZPT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtFSfVs5Int64", {{.*}}, elements: ![[BAZMEMBERS:[0-9]+]], {{.*}}, identifier: "_TtFSfVs5Int64")
+    // CHECK-DAG: ![[BAZMEMBERS]] = !{![[BAZMEMBER:[0-9]+]], {{.*}}}
+    // CHECK-DAG: ![[BAZMEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}, baseType: ![[BAZPTR:[0-9]+]]
+    // CHECK-DAG: ![[BAZPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BAZT:[0-9]+]]
+    // CHECK-DAG: ![[BAZT]] = !DISubroutineType(types: ![[BAZARGS:[0-9]+]])
+    // CHECK-DAG: ![[BAZARGS]] = !{![[BAZARG0T:[0-9]+]], ![[BAZARG1T:[0-9]+]]}
+    // CHECK-DAG: ![[BAZARG0T]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64", {{.*}}, identifier: "_TtVs5Int64")
+    // CHECK-DAG: ![[BAZARG1T]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float", {{.*}}, identifier: "_TtSf")
     var baz_function_pointer = baz
     baz_function_pointer(2.89)
 
-    // CHECK-DAG: !DILocalVariable(name: "barz_function_pointer",{{.*}} type: !"[[BARZPT:[^,]+]]"
-    // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "[[BARZPT]]",{{.*}} elements: ![[BARZMEMBERS:[0-9]+]]
-    // CHECK-DAG: ![[BARZMEMBERS]] = !{![[BARZMEMBER:.*]], {{.*}}}
-    // CHECK-DAG: ![[BARZMEMBER]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[BARZPTR:[0-9]+]]
-    // CHECK-DAG: ![[BARZPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type,{{.*}} baseType: ![[BARZT:[0-9]+]]
-    // CHECK-DAG: ![[BARZT]] = !DISubroutineType(types: ![[BARZARGS:.*]])
-    // CHECK-DAG: ![[BARZARGS]] = !{!"_TtVs5Int64", !"_TtSf", !"_TtSf"}
+    // CHECK-DAG: !DILocalVariable(name: "barz_function_pointer", {{.*}}, type: ![[BARZPT:[0-9]+]])
+    // CHECK-DAG: ![[BARZPT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtFTSfSf_Vs5Int64", {{.*}}, elements: ![[BARZMEMBERS:[0-9]+]]
+    // CHECK-DAG: ![[BARZMEMBERS]] = !{![[BARZMEMBER:[0-9]+]], {{.*}}}
+    // CHECK-DAG: ![[BARZMEMBER]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}, baseType: ![[BARZPTR:[0-9]+]]
+    // CHECK-DAG: ![[BARZPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[BARZT:[0-9]+]]
+    // CHECK-DAG: ![[BARZT]] = !DISubroutineType(types: ![[BARZARGS:[0-9]+]])
+    // CHECK-DAG: ![[BARZARGS]] = !{![[BARZARG0T:[0-9]+]], ![[BARZARG1T:[0-9]+]], ![[BARZARG2T:[0-9]+]]}
+    // CHECK-DAG: ![[BARZARG0T]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64", {{.*}}, identifier: "_TtVs5Int64")
+    // CHECK-DAG: ![[BARZARG1T]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float", {{.*}}, identifier: "_TtSf")
+    // CHECK-DAG: ![[BARZARG2T]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float", {{.*}}, identifier: "_TtSf")
     var barz_function_pointer = barz
     return barz_function_pointer(2.89, -1.0)
 }
 
 main()
+

--- a/test/DebugInfo/generic_arg.swift
+++ b/test/DebugInfo/generic_arg.swift
@@ -1,5 +1,5 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+
 import StdlibUnittest
 func foo<T>(_ x: T) -> () {
   // CHECK: define {{.*}} @_TF11generic_arg3foourFxT_
@@ -15,8 +15,10 @@ func foo<T>(_ x: T) -> () {
   // CHECK-SAME:                       flags: DIFlagArtificial)
   // CHECK: ![[EMPTY]] = !DIExpression()
   // CHECK: ![[X1]] = !DILocalVariable(name: "x", arg: 1,
-  // CHECK-SAME:          line: 3, type: !"_TtQq_F11generic_arg3foourFxT_")
+  // CHECK-SAME:                       line: 3, type: ![[XTY:[0-9]+]])
+  // CHECK: ![[XTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_F11generic_arg3foourFxT_", {{.*}}, identifier: "_TtQq_F11generic_arg3foourFxT_")
   _blackHole(x)
 }
 
 foo(42)
+

--- a/test/DebugInfo/generic_arg3.swift
+++ b/test/DebugInfo/generic_arg3.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 func apply<Type>(_ T : Type, fn: (Type) -> Type) -> Type { return fn(T) }
@@ -11,7 +10,9 @@ public func f<Type>(_ value : Type)
   // CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
   // No deref here: The argument is an Archetype and this implicitly indirect.
   // CHECK: ![[EXPR]] = !DIExpression()
+  // CHECK: ![[ARGTY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_F12generic_arg31furFxT_", {{.*}}, identifier: "_TtQq_F12generic_arg31furFxT_")
   // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
-  // CHECK-SAME:     line: [[@LINE+1]], type: !"_TtQq_F12generic_arg31furFxT_")
+  // CHECK-SAME:                        line: [[@LINE+1]], type: ![[ARGTY]])
   apply(value) { arg in return arg }
 }
+

--- a/test/DebugInfo/generic_arg4.swift
+++ b/test/DebugInfo/generic_arg4.swift
@@ -1,6 +1,6 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 // REQUIRES: objc_interop
+
 public struct Q<T> {
   let x: T
 }
@@ -10,8 +10,8 @@ public struct Q<T> {
   // CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
   // No deref here: the array argument is passed by value.
   // CHECK: ![[EXPR]] = !DIExpression()
-  // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE+2]],
-  // CHECK-SAME:   type: !"_TtGSaGV12generic_arg41QQq_FS_3foourFGSaGS0_x__T___")
+  // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1, {{.*}}, line: [[@LINE+2]], type: ![[ARGTY:[0-9]+]])
+  // CHECK: ![[ARGTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Array", {{.*}}, identifier: "_TtGSaGV12generic_arg41QQq_FS_3foourFGSaGS0_x__T___")
 public func foo<T>(_ arg: [Q<T>]) {
 }
+

--- a/test/DebugInfo/generic_arg5.swift
+++ b/test/DebugInfo/generic_arg5.swift
@@ -1,5 +1,5 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+
 public struct S<Type>
 {
   let value : Type
@@ -10,14 +10,18 @@ public func foo<Type>(_ values : [S<Type>])
   // CHECK: define {{.*}}_TFF12generic_arg53foourFGSaGVS_1Sx__T_U_FGS0_Q__GSqGS0_Q___
   // CHECK: store %[[TY:.*]]* %1, %[[TY]]** %[[ALLOCA:.*]], align
   // CHECK: call void @llvm.dbg.declare(metadata %[[TY]]** %[[ALLOCA]],
-  // CHECK-SAME:       metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
+  // CHECK-SAME:                        metadata ![[ARG:.*]], metadata ![[EXPR:.*]])
   // The argument is a by-ref struct and thus needs to be dereferenced.
   // CHECK: ![[ARG]] = !DILocalVariable(name: "arg", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE+3]],
-  // CHECK-SAME:     type: !"_TtGV12generic_arg51SQq_FS_3foourFGSaGS0_x__T__")
+  // CHECK-SAME:                        line: [[@LINE+6]],
+  // CHECK-SAME:                        type: ![[ARGTY:[0-9]+]])
+  // CHECK: ![[ARGTY]] = !DICompositeType(tag: DW_TAG_structure_type,
+  // CHECK-SAME:                          name: "S", {{.*}},
+  // CHECK-SAME:                          identifier: "_TtGV12generic_arg51SQq_FS_3foourFGSaGS0_x__T__")
   // CHECK: ![[EXPR]] = !DIExpression(DW_OP_deref)
   let _ = values.flatMap { arg in
     return arg
   }
  
 }
+

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -verify -g -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
@@ -13,14 +12,14 @@ class AnotherClass : AProtocol {
   func f() -> String { return "B" }
 }
 
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_F12generic_args9aFunction{{.*}}",{{.*}} elements: ![[PROTOS:[0-9]+]]
-// CHECK-DAG: ![[PROTOS]] = !{![[INHERIT:.*]]}
-// CHECK-DAG: ![[INHERIT]] = !DIDerivedType(tag: DW_TAG_inheritance,{{.*}} baseType: ![[PROTOCOL:"[^"]+"]]
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtMP12generic_args9AProtocol_",{{.*}} identifier: [[PROTOCOL]]
-// CHECK-DAG: !DILocalVariable(name: "x", arg: 1,{{.*}} type: ![[T:.*]])
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_F12generic_args9aFunction{{.*}}, identifier: [[T]])
-// CHECK-DAG: !DILocalVariable(name: "y", arg: 2,{{.*}} type: ![[Q:.*]])
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq0_F12generic_args9aFunction{{.*}}, identifier: [[Q]])
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_F12generic_args9aFunction{{.*}}", {{.*}}, elements: ![[PROTOS:[0-9]+]]
+// CHECK-DAG: ![[PROTOS]] = !{![[INHERITANCE:[0-9]+]]}
+// CHECK-DAG: ![[INHERITANCE]] = !DIDerivedType(tag: DW_TAG_inheritance, {{.*}}, baseType: ![[PROTOCOL:[0-9]+]])
+// CHECK-DAG: ![[PROTOCOL]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtMP12generic_args9AProtocol_", {{.*}}, identifier: "_TtMP12generic_args9AProtocol_")
+// CHECK-DAG: !DILocalVariable(name: "x", arg: 1, {{.*}}, type: ![[T:[0-9]+]])
+// CHECK-DAG: ![[T]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_F12generic_args9aFunction{{.*}}"
+// CHECK-DAG: !DILocalVariable(name: "y", arg: 2, {{.*}}, type: ![[Q:[0-9]+]])
+// CHECK-DAG: ![[Q]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq0_F12generic_args9aFunction{{.*}}"
 func aFunction<T : AProtocol, Q : AProtocol>(_ x: T, _ y: Q, _ z: String) {
    markUsed("I am in \(z): \(x.f()) \(y.f())")
 }
@@ -38,14 +37,16 @@ struct Wrapper<T: AProtocol> {
 
   func passthrough(_ t: T) -> T {
     // The type of local should have the context Wrapper<T>.
-    // CHECK-DAG: !DILocalVariable(name: "local",{{.*}} line: [[@LINE+1]],{{.*}} type: !"_TtQq_V12generic_args7Wrapper"
+    // CHECK-DAG: !DILocalVariable(name: "local", {{.*}}, line: [[@LINE+2]], type: ![[LOCALTY:[0-9]+]])
+    // CHECK-DAG: ![[LOCALTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtQq_V12generic_args7Wrapper", {{.*}}, identifier: "_TtQq_V12generic_args7Wrapper")
     var local = t
     local = t
     return local
   }
 }
 
-// CHECK: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+1]], type: !"_TtFQq_F12generic_args5applyu0_rFTx1fFxq__q_Qq0_F12generic_args5applyu0_rFTx1fFxq__q_")
+// CHECK-DAG: !DILocalVariable(name: "f", {{.*}}, line: [[@LINE+2]], type: ![[FTY:[0-9]+]])
+// CHECK-DAG: ![[FTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtFQq_F12generic_args5applyu0_rFTx1fFxq__q_Qq0_F12generic_args5applyu0_rFTx1fFxq__q_", {{.*}}, identifier: "_TtFQq_F12generic_args5applyu0_rFTx1fFxq__q_Qq0_F12generic_args5applyu0_rFTx1fFxq__q_")
 func apply<T, U> (_ x: T, f: (T) -> (U)) -> U {
   return f(x)
 }

--- a/test/DebugInfo/generic_enum.swift
+++ b/test/DebugInfo/generic_enum.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
@@ -17,10 +16,12 @@ func unwrapTrivialGeneric<T, U>(_ tg: TrivialGeneric<T, U>) -> (T, U) {
 func wrapTrivialGeneric<T, U>(_ t: T, u: U) -> TrivialGeneric<T, U> {
   return .x(t, u)
 }
-// CHECK-DAG: !DIGlobalVariable(name: "tg",{{.*}} line: [[@LINE+2]],{{.*}} type: !"_TtGO12generic_enum14TrivialGenericVs5Int64SS_",{{.*}} isLocal: false, isDefinition: true
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_union_type, name: "TrivialGeneric", {{.*}}identifier: "_TtGO12generic_enum14TrivialGenericVs5Int64SS_"
+
+// CHECK-DAG: !DIGlobalVariable(name: "tg", {{.*}}, line: [[@LINE+2]], type: ![[TGTY:[0-9]+]], isLocal: false, isDefinition: true
+// CHECK-DAG: ![[TGTY]] = !DICompositeType(tag: DW_TAG_union_type, name: "TrivialGeneric", {{.*}}, identifier: "_TtGO12generic_enum14TrivialGenericVs5Int64SS_")
 var tg : TrivialGeneric<Int64, String> = .x(23, "skidoo")
 switch tg {
 case .x(var t, var u):
   markUsed("\(t) \(u)")
 }
+

--- a/test/DebugInfo/generic_enum_closure.swift
+++ b/test/DebugInfo/generic_enum_closure.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
 
 struct __CurrentErrno {}
@@ -10,7 +9,8 @@ struct CErrorOr<T>
     // CHECK-NOT: define
     // This is a SIL-level debug_value_addr instruction.
     // CHECK: call void @llvm.dbg.value({{.*}}, metadata ![[SELF:.*]], metadata !{{[0-9]+}})
-    // CHECK-DAG: ![[SELF]] = !DILocalVariable(name: "self", arg:{{.*}} type: !"_TtGV20generic_enum_closure8CErrorOrQq_S0__"
+    // CHECK-DAG: ![[SELF]] = !DILocalVariable(name: "self", arg: {{[0-9]+}}, {{.*}}, type: ![[SELFTY:[0-9]+]]
+    // CHECK-DAG: ![[SELFTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "CErrorOr", {{.*}}, identifier: "_TtGV20generic_enum_closure8CErrorOrQq_S0__")
     value = .none
   }
   func isError() -> Bool {

--- a/test/DebugInfo/inout.swift
+++ b/test/DebugInfo/inout.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -module-name inout -o %t.ll
 // RUN: cat %t.ll | FileCheck %s
 // RUN: cat %t.ll | FileCheck %s --check-prefix=PROMO-CHECK
@@ -11,22 +10,23 @@ typealias MyFloat = Float
 
 // CHECK: define hidden void @_TF5inout13modifyFooHeap
 // CHECK: %[[ALLOCA:.*]] = alloca %Vs5Int64*
-// CHECK: %[[ALLOCB:.*]] = alloca %Sf
+// CHECK: %[[ALLOCB:.*]] = alloca %float
 // CHECK: call void @llvm.dbg.declare(metadata
 // CHECK-SAME:                        %[[ALLOCA]], metadata ![[A:[0-9]+]]
 // CHECK: call void @llvm.dbg.declare(metadata
-// CHECK-SAME:       %[[ALLOCB]], metadata ![[B:[0-9]+]], metadata !{{[0-9]+}})
+// CHECK-SAME:                        %[[ALLOCB]], metadata ![[B:[0-9]+]], metadata !{{[0-9]+}})
 
 // Closure with promoted capture.
 // PROMO-CHECK: define {{.*}}@_TTSf2i___TFF5inout13modifyFooHeapFTRVs5Int64Sf_T_U_FT_S0_
 // PROMO-CHECK: call void @llvm.dbg.declare(metadata {{(i32|i64)}}* %
 // PROMO-CHECK-SAME:   metadata ![[A1:[0-9]+]], metadata ![[EMPTY_EXPR:[0-9]+]])
 
-// PROMO-CHECK: ![[EMPTY_EXPR]] = !DIExpression()
-// PROMO-CHECK: ![[A1]] = !DILocalVariable(name: "a", arg: 1
-// PROMO-CHECK-SAME:                       type: !"_TtVs5Int64"
+// PROMO-CHECK-DAG: ![[EMPTY_EXPR]] = !DIExpression()
+// PROMO-CHECK-DAG: ![[A1]] = !DILocalVariable(name: "a", arg: 1, {{.*}}, type: ![[A1TY:[0-9]+]])
+// PROMO-CHECK-DAG: ![[A1TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64", {{.*}}, identifier: "_TtVs5Int64")
 func modifyFooHeap(_ a: inout Int64,
-// CHECK-DAG: ![[A]] = !DILocalVariable(name: "a", arg: 1{{.*}} line: [[@LINE-1]],{{.*}} type: !"_TtRVs5Int64"
+// CHECK-DAG: ![[A]] = !DILocalVariable(name: "a", arg: 1, {{.*}}, line: [[@LINE-1]], type: ![[ATY:[0-9]+]]
+// CHECK-DAG: ![[ATY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtRVs5Int64", {{.*}}, identifier: "_TtRVs5Int64")
                    _ b: MyFloat)
 {
     var b = b
@@ -41,13 +41,15 @@ func modifyFooHeap(_ a: inout Int64,
 // Inout reference type.
 // FOO-CHECK: define {{.*}}@_TF5inout9modifyFooFTRVs5Int64Sf_T_
 // FOO-CHECK: call void @llvm.dbg.declare(metadata %Vs5Int64** %
-// FOO-CHECK-SAME:          metadata ![[U:[0-9]+]], metadata ![[EMPTY_EXPR:.*]])
+// FOO-CHECK-SAME:                        metadata ![[U:[0-9]+]], metadata ![[EMPTY_EXPR:.*]])
 // FOO-CHECK: ![[EMPTY_EXPR]] = !DIExpression()
 func modifyFoo(_ u: inout Int64,
-// FOO-CHECK-DAG: !DILocalVariable(name: "v", arg: 2{{.*}} line: [[@LINE+2]],{{.*}} type: ![[MYFLOAT:[0-9]+]]
-// FOO-CHECK-DAG: [[U]] = !DILocalVariable(name: "u", arg: 1{{.*}} line: [[@LINE-2]],{{.*}} type: !"_TtRVs5Int64"
+// FOO-CHECK-DAG: !DILocalVariable(name: "v", arg: 2, {{.*}}, line: [[@LINE+3]], type: ![[MYFLOAT:[0-9]+]]
+// FOO-CHECK-DAG: [[U]] = !DILocalVariable(name: "u", arg: 1, {{.*}}, line: [[@LINE-2]], type: ![[UTY:[0-9]+]]
+// FOO-CHECK-DAG: ![[UTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtRVs5Int64", {{.*}}, identifier: "_TtRVs5Int64")
                _ v: MyFloat)
-// FOO-CHECK-DAG: ![[MYFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_Tta5inout7MyFloat",{{.*}} baseType: !"_TtSf"
+// FOO-CHECK-DAG: ![[MYFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_Tta5inout7MyFloat", {{.*}}, baseType: ![[MYFLOAT_BASE_TYPE:[0-9]+]])
+// FOO-CHECK-DAG: ![[MYFLOAT_BASE_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float", {{.*}}, identifier: "_TtSf")
 {
     if (v > 2.71) {
       u = u - 41

--- a/test/DebugInfo/mangling.swift
+++ b/test/DebugInfo/mangling.swift
@@ -1,12 +1,4 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
-
-// Type:
-// Swift.Dictionary<Swift.Int64, Swift.String>
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Dictionary",{{.*}} identifier: [[DT:[^,)]+]])
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtT4NameSS2IdVs5Int64_",{{.*}} identifier: [[TT1:[^,)]+]])
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtTSS2IdVs5Int64_",{{.*}} identifier: [[TT2:[^,)]+]])
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtTSSVs5Int64_",{{.*}} identifier: [[TT3:[^,)]+]])
 
 func markUsed<T>(_ t: T) {}
 
@@ -14,28 +6,40 @@ func markUsed<T>(_ t: T) {}
 // mangling.myDict : Swift.Dictionary<Swift.Int64, Swift.String>
 // CHECK: !DIGlobalVariable(name: "myDict",
 // CHECK-SAME:       linkageName: "_Tv8mangling6myDictGVs10DictionaryVs5Int64SS_",
-// CHECK-SAME:              line: [[@LINE+2]]
-// CHECK-SAME:              type: ![[DT]]
+// CHECK-SAME:              line: [[@LINE+5]]
+// CHECK-SAME:              type: ![[DT:[0-9]+]]
+// CHECK: ![[DT]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                      name: "Dictionary",
+// CHECK-SAME:                identifier: "_TtGVs10DictionaryVs5Int64SS_")
 var myDict = Dictionary<Int64, String>()
 myDict[12] = "Hello!"
 
 // mangling.myTuple1 : (Name : Swift.String, Id : Swift.Int64)
 // CHECK: !DIGlobalVariable(name: "myTuple1",
 // CHECK-SAME:       linkageName: "_Tv8mangling8myTuple1T4NameSS2IdVs5Int64_",
-// CHECK-SAME:              line: [[@LINE+2]]
-// CHECK-SAME:              type: ![[TT1]]
+// CHECK-SAME:              line: [[@LINE+5]]
+// CHECK-SAME:              type: ![[TT1:[0-9]+]]
+// CHECK: ![[TT1]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                       name: "_TtT4NameSS2IdVs5Int64_",
+// CHECK-SAME:                 identifier: "_TtT4NameSS2IdVs5Int64_")
 var myTuple1 : (Name: String, Id: Int64) = ("A", 1)
 // mangling.myTuple2 : (Swift.String, Id : Swift.Int64)
 // CHECK: !DIGlobalVariable(name: "myTuple2",
 // CHECK-SAME:       linkageName: "_Tv8mangling8myTuple2TSS2IdVs5Int64_",
-// CHECK-SAME:              line: [[@LINE+2]]
-// CHECK-SAME:              type: ![[TT2]]
+// CHECK-SAME:              line: [[@LINE+5]]
+// CHECK-SAME:              type: ![[TT2:[0-9]+]]
+// CHECK: ![[TT2]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                       name: "_TtTSS2IdVs5Int64_",
+// CHECK-SAME:                 identifier: "_TtTSS2IdVs5Int64_")
 var myTuple2 : (      String, Id: Int64) = ("B", 2)
 // mangling.myTuple3 : (Swift.String, Swift.Int64)
 // CHECK: !DIGlobalVariable(name: "myTuple3",
 // CHECK-SAME:       linkageName: "_Tv8mangling8myTuple3TSSVs5Int64_",
-// CHECK-SAME:              line: [[@LINE+2]]
-// CHECK-SAME:              type: ![[TT3]]
+// CHECK-SAME:              line: [[@LINE+5]]
+// CHECK-SAME:              type: ![[TT3:[0-9]+]]
+// CHECK: ![[TT3]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:                       name: "_TtTSSVs5Int64_",
+// CHECK-SAME:                 identifier: "_TtTSSVs5Int64_")
 var myTuple3 : (      String,     Int64) = ("C", 3)
 
 markUsed(myTuple1.Id)

--- a/test/DebugInfo/protocol-sugar.swift
+++ b/test/DebugInfo/protocol-sugar.swift
@@ -1,8 +1,10 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
+
 protocol A {}
 protocol B {}
 typealias C = protocol<B, A>
 protocol D {}
 var p: protocol<C, D>?
-// CHECK: !DIGlobalVariable(name: "p", {{.*}}type: !"_TtGSqP4main1AS_1BS_1D__"
+// CHECK: !DIGlobalVariable(name: "p", {{.*}}, type: ![[PTY:[0-9]+]]
+// CHECK: ![[PTY]] = !DICompositeType(tag: DW_TAG_union_type, name: "Optional", {{.*}}, identifier: "_TtGSqP4main1AS_1BS_1D__")
+

--- a/test/DebugInfo/protocolarg.swift
+++ b/test/DebugInfo/protocolarg.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
@@ -8,22 +7,20 @@ public protocol IGiveOutInts {
 }
 
 // CHECK: define {{.*}}@_TF11protocolarg16printSomeNumbersFPS_12IGiveOutInts_T_
-// CHECK: @llvm.dbg.declare(metadata %P11protocolarg12IGiveOutInts_* %
-// CHECK-SAME:              metadata ![[VAR:.*]], metadata ![[EMPTY:.*]])
 // CHECK: @llvm.dbg.declare(metadata %P11protocolarg12IGiveOutInts_** %
-// CHECK-SAME:              metadata ![[ARG:.*]], metadata ![[DEREF:.*]])
-
-// FIXME: Should be DW_TAG_interface_type
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "IGiveOutInts"
-// CHECK-SAME:             identifier: [[PT:"[^"]+"]]
+// CHECK-SAME:              metadata ![[ARG:[0-9]+]], metadata ![[DEREF:[0-9]+]])
+// CHECK: @llvm.dbg.declare(metadata %P11protocolarg12IGiveOutInts_* %
+// CHECK-SAME:              metadata ![[VAR:[0-9]+]], metadata ![[EMPTY:[0-9]+]])
 
 public func printSomeNumbers(_ gen: IGiveOutInts) {
   var gen = gen
-  // CHECK: ![[EMPTY]] = !DIExpression()
-  // CHECK: ![[VAR]] = !DILocalVariable(name: "gen", {{.*}} line: [[@LINE-2]]
-  // CHECK: ![[ARG]] = !DILocalVariable(name: "gen", arg: 1,
-  // CHECK-SAME:                        line: [[@LINE-5]], type: ![[PT]]
-  // CHECK: ![[DEREF]] = !DIExpression(DW_OP_deref)
+  // CHECK-DAG: ![[EMPTY]] = !DIExpression()
+  // CHECK-DAG: ![[ARG]] = !DILocalVariable(name: "gen", arg: 1, {{.*}}, line: [[@LINE-3]], type: ![[PT:[0-9]+]]
+  // CHECK-DAG: ![[VAR]] = !DILocalVariable(name: "gen", {{.*}} line: [[@LINE-3]]
+  // CHECK-DAG: ![[DEREF]] = !DIExpression(DW_OP_deref)
   markUsed(gen.callMe())
 }
+
+// FIXME: Should be DW_TAG_interface_type
+// CHECK-DAG: ![[PT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "IGiveOutInts"
 

--- a/test/DebugInfo/self.swift
+++ b/test/DebugInfo/self.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
 
 public struct stuffStruct {
@@ -13,13 +12,12 @@ public func f() {
 // In the constructor, self has a type of "inout stuffStruct", but it
 // is constructed in an alloca. The debug info for the alloca should not
 // describe a reference type as we would normally do with inout arguments.
-//
+
 // CHECK: define {{.*}} @_TFV4self11stuffStructCfT_S0_(
 // CHECK-NEXT: entry:
 // CHECK-NEXT: %[[ALLOCA:.*]] = alloca %V4self11stuffStruct, align {{(4|8)}}
-// CHECK: call void @llvm.dbg.declare(metadata %V4self11stuffStruct* %[[ALLOCA]], metadata ![[SELF:.*]], metadata !{{[0-9]+}}), !dbg
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "stuffStruct",
-// CHECK-SAME:             identifier: [[STUFFSTRUCT:"[^"]+"]]
-// CHECK: ![[SELF]] = !DILocalVariable(name: "self", arg: 1,
-// CHECK-SAME:                         type: ![[STUFFSTRUCT]]
+// CHECK: call void @llvm.dbg.declare(metadata %V4self11stuffStruct* %[[ALLOCA]], metadata ![[SELF:[0-9]+]], metadata !{{[0-9]+}}), !dbg
+
+// CHECK-DAG: ![[SELF]] = !DILocalVariable(name: "self", arg: 1, {{.*}}, type: ![[STUFFSTRUCT:[0-9]+]]
+// CHECK-DAG: ![[STUFFSTRUCT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "stuffStruct", {{.*}}, identifier: "_TtV4self11stuffStruct"
 

--- a/test/DebugInfo/structs.swift
+++ b/test/DebugInfo/structs.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | FileCheck %s
 // Capture the pointer size from type Int
 // CHECK: %Si = type <{ i[[PTRSIZE:[0-9]+]] }>
@@ -11,24 +10,21 @@ func test(_ x : A) {
   var vx = x
 }
 // CHECK:    define hidden void @_TF7structs4test
-// CHECK: [[VX:%.*]] = alloca
 // CHECK: [[X_DBG:%.*]] = alloca
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}* [[X_DBG]], metadata [[X_MD:!.*]], metadata
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "A"
-// CHECK-SAME:             identifier: [[A_DI:"[^"]+"]]
-
+// CHECK: call void @llvm.dbg.declare(metadata {{.*}}* [[X_DBG]], metadata ![[X_MD:[0-9]+]], metadata
+// CHECK: ![[ATY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "A", {{.*}}, identifier: "[[A_DI:[^"]+]]"
 
 class C {
   var lots_of_extra_storage: (Int, Int, Int) = (1, 2, 3)
   var member: C = C()
 }
 
+// CHECK: ![[X_MD]] = !DILocalVariable(name: "x", arg: 1
+// CHECK-SAME:                         type: ![[ATY]]
+
 // A class is represented by a pointer, so B's total size should be PTRSIZE.
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "B",
-// CHECK-SAME:             {{.*}}size: [[PTRSIZE]]
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "B", {{.*}}, size: [[PTRSIZE]]
 struct B {
   var c : C
 }
 
-// CHECK: [[X_MD]] = !DILocalVariable(name: "x", arg: 1
-// CHECK-SAME:                         type: ![[A_DI]]

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend -emit-ir -g %s -o %t.ll
 // RUN: FileCheck %s --check-prefix CHECK-HIDDEN < %t.ll
 // RUN: FileCheck %s --check-prefix IMPORT-CHECK < %t.ll
@@ -21,12 +20,11 @@ class MyObject : NSObject {
   // LOC-CHECK: ret {{.*}}, !dbg ![[DBG:.*]]
   // LOC-CHECK: ret
   var MyArr = NSArray()
-// IMPORT-CHECK: filename: "test-foundation.swift"
-// IMPORT-CHECK: [[FOUNDATION:[0-9]+]] = !DIModule({{.*}} name: "Foundation",
-// IMPORT-CHECK-SAME:                              {{.*}} includePath:
-// IMPORT-CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "NSArray",
-// IMPORT-CHECK-SAME:             scope: ![[FOUNDATION]]
-// IMPORT-CHECK: !DIImportedEntity(tag: DW_TAG_imported_module, {{.*}}entity: ![[FOUNDATION]]
+
+  // IMPORT-CHECK-DAG: !DIFile(filename: "test-foundation.swift"
+  // IMPORT-CHECK-DAG: ![[FOUNDATION:[0-9]+]] = !DIModule({{.*}}, name: "Foundation", includePath:
+  // IMPORT-CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "NSArray", scope: ![[FOUNDATION]]
+  // IMPORT-CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, {{.*}}, entity: ![[FOUNDATION]]
 
   func foo(_ obj: MyObject) {
     return obj.foo(obj)

--- a/test/DebugInfo/test_ints.swift
+++ b/test/DebugInfo/test_ints.swift
@@ -1,8 +1,9 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 // These two should not have the same type.
-// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Int64"
+
+// CHECK: !DIGlobalVariable(name: "a", {{.*}}, line: [[@LINE+6]], type: ![[ATY:[0-9]+]]
+// CHECK: ![[ATY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64"
 // CHECK-SAME:             size: 64, align: 64
 // CHECK-NOT:              offset: 0
 // CHECK-NOT:              DIFlagFwdDecl
@@ -11,7 +12,7 @@
 // CHECK-SAME:              type: !"_TtVs5Int64"
 var a : Int64 = 2
 
-// CHECK: !DIGlobalVariable(name: "b",{{.*}} line: [[@LINE+2]]
-// CHECK-SAME:              type: !"_TtSi"
+// CHECK: !DIGlobalVariable(name: "b", {{.*}}, line: [[@LINE+2]], type: ![[BTY:[0-9]+]]
+// CHECK: ![[BTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", {{.*}}, identifier: "_TtSi")
 var b = 2
 

--- a/test/DebugInfo/typealias.swift
+++ b/test/DebugInfo/typealias.swift
@@ -1,12 +1,14 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 
 class DWARF {
-// CHECK-DAG: ![[DIEOFFSET:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtaC9typealias5DWARF9DIEOffset",{{.*}} line: [[@LINE+1]], baseType: !"_TtVs6UInt32")
+  // CHECK-DAG: ![[DIEOFFSET:[0-9]+]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtaC9typealias5DWARF9DIEOffset", {{.*}}, line: [[@LINE+2]], baseType: ![[DIE_OFFSET_BASETYPE:[0-9]+]])
+  // CHECK-DAG: ![[DIE_OFFSET_BASETYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "UInt32", {{.*}}, identifier: "_TtVs6UInt32")
   typealias DIEOffset = UInt32
-  // CHECK-DAG: ![[PRIVATETYPE:.*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtaC9typealias5DWARFP{{.+}}11PrivateType",{{.*}} line: [[@LINE+1]], baseType: !"_TtT_")
+
+  // CHECK-DAG: ![[PRIVATETYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_TtaC9typealias5DWARFP{{.+}}11PrivateType",{{.*}} line: [[@LINE+2]], baseType: ![[PRIVATETYPE_BASETYPE:[0-9]+]])
+  // CHECK-DAG: ![[PRIVATETYPE_BASETYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtT_", {{.*}}, identifier: "_TtT_")
   private typealias PrivateType = ()
   private static func usePrivateType() -> PrivateType { return () }
 }
@@ -24,3 +26,4 @@ func main () {
 }
 
 main();
+

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar26102242
 // RUN: %target-swift-frontend %s -g -emit-ir -o - | FileCheck %s
 
 // Ensure that the debug info we're emitting passes the back end verifier.
@@ -58,10 +57,11 @@ var g = foo(1.0);
 
 // Tuple types.
 var tuple: (Int, Bool) = (1, true)
-// CHECK-DAG: !DIGlobalVariable(name: "tuple", linkageName: "_Tv{{9variables|4main}}5tupleTSiSb_",{{.*}} type: ![[TUPTY:[^,)]+]]
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type,{{.*}} elements: ![[ELEMS:[0-9]+]],{{.*}} identifier: [[TUPTY]]
+// CHECK-DAG: !DIGlobalVariable(name: "tuple", linkageName: "_Tv{{9variables|4main}}5tupleTSiSb_", {{.*}}, type: ![[TUPTY:[0-9]+]]
+// CHECK-DAG: ![[TUPTY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtTSiSb_", {{.*}}, elements: ![[ELEMS:[0-9]+]], {{.*}}, identifier: "_TtTSiSb_")
 // CHECK-DAG: ![[ELEMS]] = !{![[MI64:[0-9]+]], ![[MB:[0-9]+]]}
-// CHECK-DAG: ![[MI64]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: !"_TtSi"
+// CHECK-DAG: ![[MI64]] = !DIDerivedType(tag: DW_TAG_member, {{.*}}, baseType: ![[MI64BT:[0-9]+]]
+// CHECK-DAG: ![[MI64BT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", {{.*}}, identifier: "_TtSi")
 // CHECK-DAG: ![[MB]] = !DIDerivedType(tag: DW_TAG_member,{{.*}} baseType: ![[B]]
 func myprint(_ p: (i: Int, b: Bool)) {
      print("\(p.i) -> \(p.b)")
@@ -72,8 +72,8 @@ func myprint(_ p: (i: Int, b: Bool)) {
 myprint(tuple)
 
 // Arrays are represented as an instantiation of Array.
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "Array",{{.*}} identifier: [[Array:"[^"]+"]]
-// CHECK-DAG: !DIGlobalVariable(name: "array_of_tuples",{{.*}} type: ![[Array]]
+// CHECK-DAG: !DIGlobalVariable(name: "array_of_tuples", {{.*}} type: ![[ARRAYTYPE:[0-9]+]]
+// CHECK-DAG: ![[ARRAYTYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Array", {{.*}}, identifier: "_TtGSaT1aSi1bSi__")
 var array_of_tuples : [(a : Int, b : Int)] = [(1,2)]
 var twod : [[Int]] = [[1]]
 
@@ -81,9 +81,9 @@ func bar(_ x: [(a : Int, b : Int)], y: [[Int]]) {
 }
 
 
-// CHECK-DAG: !DIGlobalVariable(name: "P",{{.*}} type: ![[PTY:[0-9]+]]
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "_TtT1xSd1ySd1zSd_",{{.*}} identifier: [[PTUP:[^,)]+]]
-// CHECK-DAG: ![[PTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_Tta{{9variables|4main}}5Point",{{.*}} baseType: ![[PTUP]]
+// CHECK-DAG: !DIGlobalVariable(name: "P", {{.*}}, type: ![[PTY:[0-9]+]]
+// CHECK-DAG: ![[PTY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "_Tta{{9variables|4main}}5Point", {{.*}}, baseType: ![[PBT:[0-9]+]]
+// CHECK-DAG: ![[PBT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_TtT1xSd1ySd1zSd_", {{.*}}, identifier: "_TtT1xSd1ySd1zSd_")
 typealias Point = (x: Double, y: Double, z: Double)
 var P:Point = (1, 2, 3)
 func myprint(_ p: (x: Double, y: Double, z: Double)) {
@@ -103,8 +103,9 @@ enum TriValue {
   case true_
   case top
 }
-// CHECK-DAG: !DIGlobalVariable(name: "unknown",{{.*}} type: !"_TtO{{9variables|4main}}8TriValue"
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_union_type, name: "TriValue", {{.*}}identifier: "_TtO{{9variables|4main}}8TriValue"
+
+// CHECK-DAG: !DIGlobalVariable(name: "unknown", {{.*}}, type: ![[UNKNOWNTY:[0-9]+]]
+// CHECK-DAG: ![[UNKNOWNTY]] = !DICompositeType(tag: DW_TAG_union_type, name: "TriValue", {{.*}}, identifier: "_TtO{{9variables|4main}}8TriValue")
 var unknown = TriValue.top
 func myprint(_ value: TriValue) {
      switch value {
@@ -116,3 +117,4 @@ func myprint(_ value: TriValue) {
 myprint(unknown)
 
 // CHECK-DAG: !DIFile(filename: "variables.swift"
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

The type hierarchy has been reworked in the LLVM DI representation.  This
percolates down to the DI tests.  This updates the tests to match the new
representation.  There are a few whitespace changes that were made to aid
myself when validating the changes.  NFC.
