### PR TITLE
build: link LLVMCoverage some more

### DIFF
--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -7,4 +7,5 @@ target_link_libraries(SwiftASTTests
    swiftAST
    # FIXME: Circular dependencies.
    swiftParse
+   LLVMCoverage
 )

--- a/unittests/IDE/CMakeLists.txt
+++ b/unittests/IDE/CMakeLists.txt
@@ -4,4 +4,5 @@ add_swift_unittest(SwiftIDETests
   )
 target_link_libraries(SwiftIDETests
   swiftIDE
+  LLVMCoverage
 )


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

These tests seem to link against libraries needing LLVMCoverage.  This fixes the
dependency.
