### PR TITLE
SE-0072: Fully eliminate implicit bridging conversions from Swift

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1587,8 +1587,10 @@ namespace {
         // Construct right-hand side.
         // FIXME: get the parameter from the init, and plug it in here.
         auto rhs = new (cxt)
-            DeclRefExpr(init->getParameterList(1)->get(0), DeclNameLoc(),
-                        /*Implicit=*/true);
+            CoerceExpr(new (cxt) DeclRefExpr(
+                        init->getParameterList(1)->get(0), 
+                        DeclNameLoc(),
+                        /*Implicit=*/true), {}, {nullptr, storedUnderlyingType});
 
         // Add assignment.
         auto assign = new (cxt) AssignExpr(lhs, SourceLoc(), rhs,

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -73,7 +73,7 @@ public func createTemporaryFile(
   _ fileNamePrefix: String, _ fileNameSuffix: String, _ contents: String
 ) -> String {
 #if _runtime(_ObjC)
-  let tempDir: NSString = NSTemporaryDirectory()
+  let tempDir: NSString = NSTemporaryDirectory() as NSString
   var fileName = tempDir.appendingPathComponent(
     fileNamePrefix + "XXXXXX" + fileNameSuffix)
 #else

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift
@@ -29,9 +29,9 @@ extension SCNVector3 {
     self.z = SCNFloat(z)
   }
   public init(_ x: CGFloat, _ y: CGFloat, _ z: CGFloat) {
-    self.x = SCNFloat(x)
-    self.y = SCNFloat(y)
-    self.z = SCNFloat(z)
+    self.x = SCNFloat(x as NSNumber)
+    self.y = SCNFloat(y as NSNumber)
+    self.z = SCNFloat(z as NSNumber)
   }
   public init(_ x: Double, _ y: Double, _ z: Double) {
     self.init(SCNFloat(x), SCNFloat(y), SCNFloat(z))
@@ -69,10 +69,10 @@ extension SCNVector4 {
     self.w = SCNFloat(w)
   }
   public init(_ x: CGFloat, _ y: CGFloat, _ z: CGFloat, _ w: CGFloat) {
-    self.x = SCNFloat(x)
-    self.y = SCNFloat(y)
-    self.z = SCNFloat(z)
-    self.w = SCNFloat(w)
+    self.x = SCNFloat(x as NSNumber)
+    self.y = SCNFloat(y as NSNumber)
+    self.z = SCNFloat(z as NSNumber)
+    self.w = SCNFloat(w as NSNumber)
   }
   public init(_ x: Double, _ y: Double, _ z: Double, _ w: Double) {
     self.init(SCNFloat(x), SCNFloat(y), SCNFloat(z), SCNFloat(w))
@@ -182,7 +182,7 @@ extension SCNSceneSource {
   @warn_unused_result
   public func entryWithIdentifier<T>(_ uid: String, withClass entryClass: T.Type) -> T? {
     return SCN_Swift_SCNSceneSource_entryWithIdentifier(
-      self, uid, entryClass as! AnyObject) as! T?
+      self, uid as NSString, entryClass as! AnyObject) as! T?
   }
 }
 

--- a/test/1_stdlib/ArrayBridge.swift
+++ b/test/1_stdlib/ArrayBridge.swift
@@ -529,7 +529,7 @@ func testRoundTrip() {
 
       // Clear out the stats before returning array
       BridgedSwift.resetStats()
-      return result
+      return result as NSArray
     }
   }
   
@@ -540,7 +540,7 @@ func testRoundTrip() {
     BridgedSwift(40), BridgedSwift(50) ]
   
   BridgedSwift.resetStats()
-  test.call(array)
+  test.call(array as NSArray)
   
   // CHECK-NEXT: ---Returned Array---
   print("---Returned Array---")

--- a/test/1_stdlib/DictionaryLiteral.swift
+++ b/test/1_stdlib/DictionaryLiteral.swift
@@ -48,7 +48,7 @@ expectType(DictionaryLiteral<String, NSString>.self, &stringNSStringLiteral)
 
 let aString = "1"
 let anNSString = "Foo" as NSString
-var stringNSStringLet: DictionaryLiteral = ["a": aString, "b": anNSString]
+var stringNSStringLet: DictionaryLiteral = [ "a": aString as NSString, "b": anNSString]
 expectType(DictionaryLiteral<String, NSString>.self, &stringNSStringLet)
 
 var hetero1: DictionaryLiteral = ["a": 1, "b": "Foo" as NSString]

--- a/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -44,18 +44,18 @@ func isCocoaDictionary<KeyTy : Hashable, ValueTy>(
 }
 
  func isNativeNSDictionary(_ d: NSDictionary) -> Bool {
-  let className: NSString = NSStringFromClass(d.dynamicType)
+  let className: NSString = NSStringFromClass(d.dynamicType) as NSString
   return className.range(of: "_NativeDictionaryStorageOwner").length > 0
 }
 
  func isCocoaNSDictionary(_ d: NSDictionary) -> Bool {
-  let className: NSString = NSStringFromClass(d.dynamicType)
+  let className: NSString = NSStringFromClass(d.dynamicType) as NSString
   return className.range(of: "NSDictionary").length > 0 ||
     className.range(of: "NSCFDictionary").length > 0
 }
 
  func isNativeNSArray(_ d: NSArray) -> Bool {
-  let className: NSString = NSStringFromClass(d.dynamicType)
+  let className: NSString = NSStringFromClass(d.dynamicType) as NSString
   return className.range(of: "_SwiftDeferredNSArray").length > 0
 }
 

--- a/test/1_stdlib/NSStringAPI.swift
+++ b/test/1_stdlib/NSStringAPI.swift
@@ -1043,8 +1043,8 @@ NSStringAPIs.test("paragraphRangeFor(_:)") {
 }
 
 NSStringAPIs.test("pathComponents") {
-  expectEqual(["/", "foo", "bar"], "/foo/bar".pathComponents)
-  expectEqual(["/", "абв", "где"], "/абв/где".pathComponents)
+  expectEqual([ "/", "foo", "bar" ] as [NSString], ("/foo/bar" as NSString).pathComponents)
+  expectEqual([ "/", "абв", "где" ] as [NSString], ("/абв/где" as NSString).pathComponents)
 }
 
 NSStringAPIs.test("pathExtension") {
@@ -1646,10 +1646,10 @@ NSStringAPIs.test("trimmingCharacters(in:)") {
 }
 
 NSStringAPIs.test("NSString.stringsByAppendingPaths(_:)") {
-  expectEqual([], "".strings(byAppendingPaths: []))
+  expectEqual([] as [NSString], ("" as NSString).strings(byAppendingPaths: []))
   expectEqual(
-    ["/tmp/foo", "/tmp/bar"],
-    "/tmp".strings(byAppendingPaths: ["foo", "bar"]))
+    [ "/tmp/foo", "/tmp/bar" ] as [NSString],
+    ("/tmp" as NSString).strings(byAppendingPaths: [ "foo", "bar" ]))
 }
 
 NSStringAPIs.test("substring(from:)") {
@@ -1867,8 +1867,8 @@ NSStringAPIs.test("MixedTypeComparisons") {
   expectTrue(ys != "\u{1e69}")
   expectFalse("\u{1e69}" == ys)
   expectTrue("\u{1e69}" != ys)
-  expectFalse(xs == ys)
-  expectTrue(xs != ys)
+  expectFalse(xs as NSString == ys)
+  expectTrue(xs as NSString != ys)
   expectTrue(ys == ys)
   expectFalse(ys != ys)
 }

--- a/test/1_stdlib/SceneKit.swift
+++ b/test/1_stdlib/SceneKit.swift
@@ -31,7 +31,7 @@ if #available(iOS 8.0, OSX 10.10, *) {
     expectEqual(scn_float_from_d, 2.0)
 
     let cg = CGFloat(3.0)
-    let scn_float_from_cg = SCNFloat(cg)
+    let scn_float_from_cg = SCNFloat(cg as NSNumber)
     expectEqual(scn_float_from_cg, 3.0)
 
     let node = SCNNode()

--- a/test/1_stdlib/StringDiagnostics.swift
+++ b/test/1_stdlib/StringDiagnostics.swift
@@ -45,15 +45,15 @@ func testNonAmbiguousStringComparisons() {
 
 func testAmbiguousStringComparisons(s: String) {
   let nsString = s as NSString
-  let a1 = s == nsString
-  let a2 = s != nsString
+  let a1 = s as NSString == nsString
+  let a2 = s as NSString != nsString
   let a3 = s < nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
   let a4 = s <= nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
   let a5 = s >= nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{25-25= as String}}
   let a6 = s > nsString // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{24-24= as String}}
   // now the other way
-  let a7 = nsString == s
-  let a8 = nsString != s
+  let a7 = nsString == s as NSString
+  let a8 = nsString != s as NSString
   let a9 = nsString < s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{20-20= as String}}
   let a10 = nsString <= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}
   let a11 = nsString >= s // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{21-21= as String}}

--- a/test/ClangModules/AppKit_test.swift
+++ b/test/ClangModules/AppKit_test.swift
@@ -23,7 +23,7 @@ func test(_ URL: NSURL, controller: NSDocumentController) {
 
 extension NSBox {
   func foo() {
-    print("abc") // expected-warning {{use of 'print' treated as a reference to instance method in class 'NSView'}}
+    print("abc" as NSString) // expected-warning {{use of 'print' treated as a reference to instance method in class 'NSView'}}
     // expected-note@-1 {{use 'self.' to silence this warning}} {{5-5=self.}}
     // expected-note@-2 {{use 'Swift.' to reference the global function}} {{5-5=Swift.}}
   }
@@ -31,7 +31,7 @@ extension NSBox {
 
 class MyView : NSView {
   func foo() {
-    print("abc") // expected-warning {{use of 'print' treated as a reference to instance method in class 'NSView'}}
+    print("abc" as NSString) // expected-warning {{use of 'print' treated as a reference to instance method in class 'NSView'}}
     // expected-note@-1 {{use 'self.' to silence this warning}} {{5-5=self.}}
     // expected-note@-2 {{use 'Swift.' to reference the global function}} {{5-5=Swift.}}
   }

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -92,12 +92,12 @@ func ==(x: OtherClass, y: OtherClass) -> Bool { return true }
 
 // Basic bridging
 func bridgeToObjC(_ s: BridgedStruct) -> BridgedClass {
-  return s
+  return s // expected-error{{cannot convert return expression of type 'BridgedStruct' to return type 'BridgedClass'}}
   return s as BridgedClass
 }
 
 func bridgeToAnyObject(_ s: BridgedStruct) -> AnyObject {
-  return s
+  return s // expected-error{{return expression of type 'BridgedStruct' does not conform to 'AnyObject'}}
   return s as AnyObject
 }
 
@@ -115,10 +115,10 @@ func bridgeFromObjCDerived(_ s: BridgedClassSub) -> BridgedStruct {
 func arrayToNSArray() {
   var nsa: NSArray
 
-  nsa = [AnyObject]()
-  nsa = [BridgedClass]()
-  nsa = [OtherClass]()
-  nsa = [BridgedStruct]()
+  nsa = [AnyObject]() // expected-error {{cannot assign value of type '[AnyObject]' to type 'NSArray'}}
+  nsa = [BridgedClass]() // expected-error {{cannot assign value of type '[BridgedClass]' to type 'NSArray'}}
+  nsa = [OtherClass]() // expected-error {{cannot assign value of type '[OtherClass]' to type 'NSArray'}}
+  nsa = [BridgedStruct]() // expected-error {{cannot assign value of type '[BridgedStruct]' to type 'NSArray'}}
   nsa = [NotBridgedStruct]() // expected-error{{cannot assign value of type '[NotBridgedStruct]' to type 'NSArray'}}
 
   nsa = [AnyObject]() as NSArray
@@ -153,13 +153,13 @@ func dictionaryToNSDictionary() {
 
   var nsd: NSDictionary
 
-  nsd = [NSObject : AnyObject]()
+  nsd = [NSObject : AnyObject]() // expected-error {{cannot assign value of type '[NSObject : AnyObject]' to type 'NSDictionary'}}
   nsd = [NSObject : AnyObject]() as NSDictionary
-  nsd = [NSObject : BridgedClass]()
+  nsd = [NSObject : BridgedClass]() // expected-error {{cannot assign value of type '[NSObject : BridgedClass]' to type 'NSDictionary'}}
   nsd = [NSObject : BridgedClass]() as NSDictionary
-  nsd = [NSObject : OtherClass]()
+  nsd = [NSObject : OtherClass]() // expected-error {{cannot assign value of type '[NSObject : OtherClass]' to type 'NSDictionary'}}
   nsd = [NSObject : OtherClass]() as NSDictionary
-  nsd = [NSObject : BridgedStruct]()
+  nsd = [NSObject : BridgedStruct]() // expected-error {{cannot assign value of type '[NSObject : BridgedStruct]' to type 'NSDictionary'}}
   nsd = [NSObject : BridgedStruct]() as NSDictionary
   nsd = [NSObject : NotBridgedStruct]() // expected-error{{cannot assign value of type '[NSObject : NotBridgedStruct]' to type 'NSDictionary'}}
   nsd = [NSObject : NotBridgedStruct]() as NSDictionary // expected-error{{cannot convert value of type '[NSObject : NotBridgedStruct]' to type 'NSDictionary' in coercion}}
@@ -169,18 +169,18 @@ func dictionaryToNSDictionary() {
   nsd = [NSObject : BridgedStruct?]()  // expected-error{{cannot assign value of type '[NSObject : BridgedStruct?]' to type 'NSDictionary'}}
   nsd = [NSObject : BridgedStruct?]() as NSDictionary //expected-error{{cannot convert value of type '[NSObject : BridgedStruct?]' to type 'NSDictionary' in coercion}}
 
-  nsd = [BridgedClass : AnyObject]()
+  nsd = [BridgedClass : AnyObject]() // expected-error {{cannot assign value of type '[BridgedClass : AnyObject]' to type 'NSDictionary'}}
   nsd = [BridgedClass : AnyObject]() as NSDictionary
-  nsd = [OtherClass : AnyObject]()
+  nsd = [OtherClass : AnyObject]() // expected-error {{cannot assign value of type '[OtherClass : AnyObject]' to type 'NSDictionary'}}
   nsd = [OtherClass : AnyObject]() as NSDictionary
-  nsd = [BridgedStruct : AnyObject]()
+  nsd = [BridgedStruct : AnyObject]() // expected-error {{cannot assign value of type '[BridgedStruct : AnyObject]' to type 'NSDictionary'}}
   nsd = [BridgedStruct : AnyObject]() as NSDictionary
   nsd = [NotBridgedStruct : AnyObject]()  // expected-error{{cannot assign value of type '[NotBridgedStruct : AnyObject]' to type 'NSDictionary'}}
   nsd = [NotBridgedStruct : AnyObject]() as NSDictionary  // expected-error{{cannot convert value of type '[NotBridgedStruct : AnyObject]' to type 'NSDictionary' in coercion}}
 
   // <rdar://problem/17134986>
   var bcOpt: BridgedClass?
-  nsd = [BridgedStruct() : bcOpt] // expected-error{{value of optional type 'BridgedClass?' not unwrapped; did you mean to use '!' or '?'?}}
+  nsd = [BridgedStruct() : bcOpt] // expected-error{{value of type 'BridgedStruct' does not conform to expected dictionary key type 'NSCopying'}}
   bcOpt = nil
   _ = nsd
 }
@@ -236,7 +236,7 @@ func rdar19695671() {
 // This failed at one point while fixing rdar://problem/19600325.
 func getArrayOfAnyObject(_: AnyObject) -> [AnyObject] { return [] }
 func testCallback(_ f: (AnyObject) -> AnyObject?) {}
-testCallback { return getArrayOfAnyObject($0) }
+testCallback { return getArrayOfAnyObject($0) } // expected-error {{cannot convert value of type '[AnyObject]' to closure result type 'AnyObject?'}}
 
 // <rdar://problem/19724719> Type checker thinks "(optionalNSString ?? nonoptionalNSString) as String" is a forced cast
 func rdar19724719(_ f: (String) -> (), s1: NSString?, s2: NSString) {
@@ -295,10 +295,10 @@ func rdar19836341(_ ns: NSString?, vns: NSString?) {
 
 // <rdar://problem/20029786> Swift compiler sometimes suggests changing "as!" to "as?!"
 func rdar20029786(_ ns: NSString?) {
-  var s: String = ns ?? "str" as String as String // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{19-19=(}} {{50-50=) as String}}
-  var s2 = ns ?? "str" as String as String
+  var s: String = ns ?? "str" as String as String // expected-error{{cannot convert value of type 'NSString?' to expected argument type 'String?'}}
+  var s2 = ns ?? "str" as String as String // expected-error {{binary operator '??' cannot be applied to operands of type 'NSString?' and 'String'}} expected-note{{}}
 
-  let s3: NSString? = "str" as String?
+  let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}
 
   var s4: String = ns ?? "str" // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}{{20-20=(}}{{31-31=) as String}}
   var s5: String = (ns ?? "str") as String // fixed version

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -42,6 +42,6 @@ func test(_ a : CFString!, b : CFString) {
 
 
 // <rdar://problem/22507759> QoI: poor error message for invalid unsafeDowncast()
-let r22507759: NSObject! = "test"
+let r22507759: NSObject! = "test" as NSString
 let _: NSString! = unsafeDowncast(r22507759)  // expected-error {{generic parameter 'T' could not be inferred}}
 

--- a/test/Interpreter/SDK/objc_array_of_classes.swift
+++ b/test/Interpreter/SDK/objc_array_of_classes.swift
@@ -29,7 +29,7 @@ var ArrayOfClassObjectBridging = TestSuite("ArrayOfClassObjectBridging")
 ArrayOfClassObjectBridging.test("bridging class object array to NSArray") {
   let classes: [NSObject.Type] = [NSObject.self, NSString.self, NSArray.self]
 
-  let classesBridged: NSArray = classes
+  let classesBridged: NSArray = classes as NSArray
 
   expectTrue(classesBridged.count == 3)
   expectTrue(classesBridged[0] === NSObject.self)
@@ -39,7 +39,7 @@ ArrayOfClassObjectBridging.test("bridging class object array to NSArray") {
 
 ArrayOfClassObjectBridging.test("bridging NSArray of class objects to [AnyObject]") {
   let classes: [NSObject.Type] = [NSObject.self, NSString.self, NSArray.self]
-  let classesBridged: NSArray = classes
+  let classesBridged: NSArray = classes as NSArray
   let classesUnbridgedAsAnyObject = classesBridged as [AnyObject]
 
   expectTrue(classesUnbridgedAsAnyObject.count == 3)
@@ -50,7 +50,7 @@ ArrayOfClassObjectBridging.test("bridging NSArray of class objects to [AnyObject
 
 ArrayOfClassObjectBridging.test("bridging NSArray of class objects to [AnyClass]") {
   let classes: [NSObject.Type] = [NSObject.self, NSString.self, NSArray.self]
-  let classesBridged: NSArray = classes
+  let classesBridged: NSArray = classes as NSArray
 
   if let classesUnbridgedAsAnyClass = classesBridged as? [AnyClass] {
     expectTrue(classesUnbridgedAsAnyClass.count == 3)
@@ -64,7 +64,7 @@ ArrayOfClassObjectBridging.test("bridging NSArray of class objects to [AnyClass]
 
 ArrayOfClassObjectBridging.test("bridging NSArray of class objects to [NSObject.Type]") {
   let classes: [NSObject.Type] = [NSObject.self, NSString.self, NSArray.self]
-  let classesBridged: NSArray = classes
+  let classesBridged: NSArray = classes as NSArray
 
   if let classesUnbridgedAsNSObjectType = classesBridged as? [NSObject.Type] {
     expectTrue(classesUnbridgedAsNSObjectType.count == 3)

--- a/test/Interpreter/imported_objc_generics.swift
+++ b/test/Interpreter/imported_objc_generics.swift
@@ -105,11 +105,11 @@ ImportedObjCGenerics.test("ProtocolConstraints") {
 }
 
 ImportedObjCGenerics.test("ClassConstraints") {
-  func makeContainedAnimalMakeNoise<T>(_ x: AnimalContainer<T>) -> NSString {
-    return x.object.noise
+  func makeContainedAnimalMakeNoise<T>(x: AnimalContainer<T>) -> NSString {
+    return x.object.noise as NSString
   }
   let petCarrier = AnimalContainer(object: Dog())
-  expectEqual("woof", makeContainedAnimalMakeNoise(petCarrier))
+  expectEqual("woof", makeContainedAnimalMakeNoise(x: petCarrier))
 }
 
 class ClassWithMethodsUsingObjCGenerics: NSObject {
@@ -147,20 +147,20 @@ ImportedObjCGenerics.test("InheritanceFromNongeneric") {
 
 public class InheritInSwift: Container<NSString> {
   public override init(object: NSString) {
-    super.init(object: object.lowercased)
+    super.init(object: object.lowercased as NSString)
   }
   public override var object: NSString {
     get {
-      return super.object.uppercased
+      return super.object.uppercased as NSString
     }
     set {
-      super.object = newValue.lowercased
+      super.object = newValue.lowercased as NSString
     }
   }
 
   public var superObject: NSString {
     get {
-      return super.object
+      return super.object as NSString
     }
   }
 }

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1386,9 +1386,9 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.DictionaryIsCopied") {
   }
 
   // Delete the key from the NSMutableDictionary.
-  assert(nsd[TestBridgedKeyTy(10)] != nil)
-  nsd.removeObject(forKey: TestBridgedKeyTy(10))
-  assert(nsd[TestBridgedKeyTy(10)] == nil)
+  assert(nsd[TestBridgedKeyTy(10) as NSCopying] != nil)
+  nsd.removeObject(forKey: TestBridgedKeyTy(10) as NSCopying)
+  assert(nsd[TestBridgedKeyTy(10) as NSCopying] == nil)
 
   // Find an existing key, again.
   do {
@@ -1856,7 +1856,7 @@ DictionaryTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt") {
   let removedElement = d.remove(at: foundIndex1)
   assert(identity1 == unsafeBitCast(d, to: Int.self))
   assert(isNativeDictionary(d))
-  assert(removedElement.0 == TestObjCKeyTy(10))
+  assert(removedElement.0 == TestObjCKeyTy(10) as TestBridgedKeyTy)
   assert(removedElement.1.value == 1010)
   assert(d.count == 2)
   assert(d.index(forKey: TestBridgedKeyTy(10)) == nil)
@@ -2913,11 +2913,11 @@ DictionaryTestSuite.test("DictionaryToNSDictionaryConversion") {
   d[TestObjCKeyTy(10)] = TestObjCValueTy(1010)
   d[TestObjCKeyTy(20)] = TestObjCValueTy(1020)
   d[TestObjCKeyTy(30)] = TestObjCValueTy(1030)
-  let nsd: NSDictionary = d
+  let nsd: NSDictionary = d as NSDictionary
 
   checkDictionaryFastEnumerationFromSwift(
     [ (10, 1010), (20, 1020), (30, 1030) ],
-    d, { d },
+    d as NSDictionary, { d as NSDictionary },
     { ($0 as! TestObjCKeyTy).value },
     { ($0 as! TestObjCValueTy).value })
 
@@ -3824,13 +3824,13 @@ DictionaryTestSuite.test("dropsBridgedCache") {
   // This test will only fail in address sanitizer.
   var dict = [0:10]
   do {
-    var bridged: NSDictionary = dict
+    var bridged: NSDictionary = dict as NSDictionary
     expectEqual(10, bridged[0] as! Int)
   }
 
   dict[0] = 11
   do {
-    var bridged: NSDictionary = dict
+    var bridged: NSDictionary = dict as NSDictionary
     expectEqual(11, bridged[0] as! Int)
   }
 }


### PR DESCRIPTION
SE-0072: Fully eliminate implicit bridging conversions from Swift

Per [Swift Evolution proposal SE-0072](https://github.com/apple/swift-evolution/blob/master/proposals/0072-eliminate-implicit-bridging-conversions.md), these changes prevent the compiler from introducing implicit bridging conversions during type checking.
