### PR TITLE
SE-0070: Make Optional Requirements Objective-C-only.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -910,8 +910,8 @@ ERROR(attribute_does_not_apply_to_type,none,
       "attribute does not apply to type", ())
 ERROR(optional_attribute_non_protocol,none,
       "'optional' can only be applied to protocol members", ())
-ERROR(optional_attribute_non_objc_protocol,none,
-      "'optional' can only be applied to members of an @objc protocol", 
+ERROR(optional_attribute_non_objc_attribute,none,
+      "'optional' requirements are an Objective-C compatibility feature; add '@objc'", 
       ())
 ERROR(optional_attribute_initializer,none,
       "'optional' cannot be applied to an initializer", ())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7808,9 +7808,9 @@ static void validateAttributes(TypeChecker &TC, Decl *D) {
       TC.diagnose(OA->getLocation(),
                   diag::optional_attribute_non_protocol);
       D->getAttrs().removeAttribute(OA);
-    } else if (!cast<ProtocolDecl>(D->getDeclContext())->isObjC()) {
+    } else if (!D->getAttrs().getAttribute<ObjCAttr>()) {
       TC.diagnose(OA->getLocation(),
-                  diag::optional_attribute_non_objc_protocol);
+                  diag::optional_attribute_non_objc_attribute);
       D->getAttrs().removeAttribute(OA);
     } else if (isa<ConstructorDecl>(D)) {
       TC.diagnose(OA->getLocation(),

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -618,7 +618,7 @@ func _stdlib_installTrapInterceptor()
 
 #if _runtime(_ObjC)
 @objc protocol _StdlibUnittestNSException {
-  optional var name: AnyObject { get }
+  @objc optional var name: AnyObject { get }
 }
 #endif
 

--- a/test/IDE/complete_members_optional.swift
+++ b/test/IDE/complete_members_optional.swift
@@ -6,11 +6,11 @@
 
 @objc
 protocol HasOptionalMembers1 {
-  optional func optionalInstanceFunc() -> Int
-  optional static func optionalClassFunc() -> Int
+  @objc optional func optionalInstanceFunc() -> Int
+  @objc optional static func optionalClassFunc() -> Int
 
-  optional var optionalInstanceProperty: Int { get }
-  optional static var optionalClassProperty: Int { get }
+  @objc optional var optionalInstanceProperty: Int { get }
+  @objc optional static var optionalClassProperty: Int { get }
 }
 
 func sanityCheck1(_ a: HasOptionalMembers1) {

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -111,7 +111,7 @@ protocol ProtocolA {
   init(fromProtocolA: Int)
 
   func protoAFunc()
-  optional func protoAFuncOptional()
+  @objc optional func protoAFuncOptional()
 
   @noreturn
   func protoAFuncWithAttr()

--- a/test/IDE/complete_override_access_control.swift
+++ b/test/IDE/complete_override_access_control.swift
@@ -31,7 +31,7 @@ private protocol ProtocolAPrivate {
   init(fromProtocolA: TagPA)
 
   func protoAFunc(x: TagPA)
-  optional func protoAFuncOptional(x: TagPA)
+  @objc optional func protoAFuncOptional(x: TagPA)
 
   @noreturn
   func protoAFuncWithAttr(x: TagPA)
@@ -47,7 +47,7 @@ protocol ProtocolBInternal {
   init(fromProtocolB: TagPB)
 
   func protoBFunc(x: TagPB)
-  optional func protoBFuncOptional(x: TagPB)
+  @objc optional func protoBFuncOptional(x: TagPB)
 
   @noreturn
   func protoBFuncWithBttr(x: TagPB)
@@ -63,7 +63,7 @@ public protocol ProtocolCPublic {
   init(fromProtocolC: TagPC)
 
   func protoCFunc(x: TagPC)
-  optional func protoCFuncOptional(x: TagPC)
+  @objc optional func protoCFuncOptional(x: TagPC)
 
   @noreturn
   func protoCFuncWithCttr(x: TagPC)

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -478,10 +478,10 @@ protocol d0130_TestProtocol {
 @objc protocol d0140_TestObjCProtocol {
 // PASS_COMMON-LABEL: {{^}}@objc protocol d0140_TestObjCProtocol {{{$}}
 
-  optional var property1: Int { get }
+  @objc optional var property1: Int { get }
 // PASS_COMMON-NEXT: {{^}}  @objc optional var property1: Int { get }{{$}}
 
-  optional func protocolFunc1()
+  @objc optional func protocolFunc1()
 // PASS_COMMON-NEXT: {{^}}  @objc optional func protocolFunc1(){{$}}
 }
 

--- a/test/IRGen/objc_protocol_extended_method_types.swift
+++ b/test/IRGen/objc_protocol_extended_method_types.swift
@@ -58,16 +58,16 @@ import Foundation
 
 @objc protocol P {
   func requiredInstanceMethod(_ o: NSNumber) -> NSNumber
-  optional func optionalInstanceMethod(_ o: NSObject) -> NSObject
+  @objc optional func optionalInstanceMethod(_ o: NSObject) -> NSObject
   static func requiredClassMethod(_ o: NSString) -> NSString
-  optional static func optionalClassMethod(_ o: NSMutableString)
+  @objc optional static func optionalClassMethod(_ o: NSMutableString)
   var requiredInstanceProperty: NSMutableArray { get set }
   var requiredROInstanceProperty: NSMutableArray { get }
 
   func requiredInstanceMethod2(_ o: NSNumber) -> NSNumber
-  optional func optionalInstanceMethod2(_ o: NSObject) -> NSObject
+  @objc optional func optionalInstanceMethod2(_ o: NSObject) -> NSObject
   static func requiredClassMethod2(_ o: NSString) -> NSString
-  optional static func optionalClassMethod2(_ o: NSMutableString)
+  @objc optional static func optionalClassMethod2(_ o: NSMutableString)
   var requiredInstanceProperty2: NSMutableArray { get set }
   var requiredROInstanceProperty2: NSMutableArray { get }
 

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -8,11 +8,11 @@ protocol B { func b() }
 protocol C : class { func c() }
 @objc protocol O { func o() }
 @objc protocol OPT { 
-  optional func opt()
-  optional static func static_opt()
+  @objc optional func opt()
+  @objc optional static func static_opt()
 
-  optional var prop: O { get }
-  optional subscript (x: O) -> O { get }
+  @objc optional var prop: O { get }
+  @objc optional subscript (x: O) -> O { get }
 }
 
 protocol AB : A, B { func ab() }

--- a/test/Interpreter/SDK/objc_protocol_lookup.swift
+++ b/test/Interpreter/SDK/objc_protocol_lookup.swift
@@ -54,7 +54,7 @@ class Juice : NSObject {
 }
 
 @objc protocol Fruit {
-  optional var juice: Juice { get }
+  @objc optional var juice: Juice { get }
 }
 
 class Durian : NSObject, Fruit {

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -110,12 +110,12 @@ extension NSString : A, ZZZ {}
   func a()
   func b()
 
-  optional func c()
-  optional func d()
+  @objc optional func c()
+  @objc optional func d()
 
   func e()
 
-  optional func f()
+  @objc optional func f()
 }
 
 // NEGATIVE-NOT: @protocol PrivateProto
@@ -140,7 +140,7 @@ extension NSString : A, ZZZ {}
 @objc protocol Properties {
   var a: Int { get }
   var b: Properties? { get set }
-  optional var c: String { get }
+  @objc optional var c: String { get }
 }
 
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -229,7 +229,7 @@ func downcast(_ obj: AnyObject) -> X {
 @objc class Juice { }
 
 @objc protocol Fruit {
-  optional var juice: Juice { get }
+  @objc optional var juice: Juice { get }
 }
 
 // CHECK-LABEL: sil hidden @_TF14dynamic_lookup7consumeFPS_5Fruit_T_

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -1,11 +1,11 @@
 // RUN: %target-swift-frontend -parse-as-library -emit-silgen -disable-objc-attr-requires-foundation-module %s | FileCheck %s
 
 @objc protocol P1 {
-  optional func method(_ x: Int)
+  @objc optional func method(_ x: Int)
 
-  optional var prop: Int { get }
+  @objc optional var prop: Int { get }
 
-  optional subscript (i: Int) -> Int { get }
+  @objc optional subscript (i: Int) -> Int { get }
 }
 
 // CHECK-LABEL: sil hidden @{{.*}}optionalMethodGeneric{{.*}} : $@convention(thin) <T where T : P1> (@owned T) -> ()

--- a/test/Serialization/Inputs/def_class.swift
+++ b/test/Serialization/Inputs/def_class.swift
@@ -89,9 +89,9 @@ public extension PairLike where FirstType : Cacheable {
 public protocol ClassProto : class {}
 
 @objc public protocol ObjCProtoWithOptional {
-  optional func optionalMethod()
-  optional var optionalVar: Int { get }
-  optional subscript (i: Int) -> Int { get }
+  @objc optional func optionalMethod()
+  @objc optional var optionalVar: Int { get }
+  @objc optional subscript (i: Int) -> Int { get }
 }
 
 

--- a/test/SourceKit/DocSupport/Inputs/cake.swift
+++ b/test/SourceKit/DocSupport/Inputs/cake.swift
@@ -50,5 +50,5 @@ public extension S1 {
 
 @objc
 public protocol P2 {
-  optional func foo1()
+  @objc optional func foo1()
 }

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -23,7 +23,7 @@ enum MyEnum : Int {
 
 @objc protocol P2 {
 
-    optional func foo1()
+    @objc optional func foo1()
 }
 
 protocol Prot {
@@ -279,358 +279,363 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 272,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 278,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 281,
+    key.offset: 287,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 286,
+    key.offset: 292,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 296,
+    key.offset: 302,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 305,
+    key.offset: 311,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 317,
+    key.offset: 323,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 332,
+    key.offset: 338,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 345,
+    key.offset: 351,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 349,
+    key.offset: 355,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 352,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 358,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 369,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 374,
+    key.offset: 364,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 385,
+    key.offset: 375,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 390,
+    key.offset: 380,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 391,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 396,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 400,
+    key.offset: 406,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
-    key.offset: 410,
+    key.offset: 416,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 422,
+    key.offset: 428,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 427,
+    key.offset: 433,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 437,
+    key.offset: 443,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
-    key.offset: 447,
+    key.offset: 453,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 452,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 458,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 464,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 463,
+    key.offset: 469,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 474,
+    key.offset: 480,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 485,
+    key.offset: 491,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 490,
+    key.offset: 496,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 502,
+    key.offset: 508,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 509,
+    key.offset: 515,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 519,
+    key.offset: 525,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 524,
+    key.offset: 530,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 538,
+    key.offset: 544,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 543,
+    key.offset: 549,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 554,
+    key.offset: 560,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 559,
+    key.offset: 565,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 570,
+    key.offset: 576,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 575,
+    key.offset: 581,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 588,
+    key.offset: 594,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 593,
+    key.offset: 599,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 605,
+    key.offset: 611,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 612,
+    key.offset: 618,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 626,
+    key.offset: 632,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 630,
+    key.offset: 636,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 633,
+    key.offset: 639,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 646,
+    key.offset: 652,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 651,
+    key.offset: 657,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 658,
+    key.offset: 664,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
-    key.offset: 663,
+    key.offset: 669,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 669,
+    key.offset: 675,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 674,
+    key.offset: 680,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:C4cake2C1",
-    key.offset: 679,
+    key.offset: 685,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 682,
+    key.offset: 688,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 688,
+    key.offset: 694,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 691,
+    key.offset: 697,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 702,
+    key.offset: 708,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 707,
+    key.offset: 713,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 710,
+    key.offset: 716,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 721,
+    key.offset: 727,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 724,
+    key.offset: 730,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 733,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 735,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 733,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 735,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 739,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 743,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 745,
+    key.offset: 741,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 743,
+    key.offset: 739,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 745,
+    key.offset: 741,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 745,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 749,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 751,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 749,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 751,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 755,
     key.length: 2
   }
 ]
@@ -794,7 +799,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
     key.name: "P2",
     key.usr: "s:P4cake2P2",
     key.offset: 247,
-    key.length: 47,
+    key.length: 53,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name></decl.protocol>",
     key.entities: [
       {
@@ -802,8 +807,8 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.name: "foo1()",
         key.usr: "s:FP4cake2P24foo1FT_T_",
         key.offset: 272,
-        key.length: 20,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>optional</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>",
+        key.length: 26,
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>optional</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>",
         key.is_optional: 1
       }
     ]
@@ -812,7 +817,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot",
     key.usr: "s:P4cake4Prot",
-    key.offset: 296,
+    key.offset: 302,
     key.length: 102,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot</decl.name></decl.protocol>",
     key.entities: [
@@ -820,7 +825,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:P4cake4Prot7Element",
-        key.offset: 317,
+        key.offset: 323,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
       },
@@ -828,7 +833,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
         key.usr: "s:vP4cake4Prot1pSi",
-        key.offset: 345,
+        key.offset: 351,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -836,7 +841,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:FP4cake4Prot3fooFT_T_",
-        key.offset: 369,
+        key.offset: 375,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       },
@@ -844,7 +849,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:FP4cake4Prot4foo1FT_T_",
-        key.offset: 385,
+        key.offset: 391,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       }
@@ -852,7 +857,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 400,
+    key.offset: 406,
     key.length: 35,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -865,7 +870,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.name: "foo1()",
         key.usr: "s:FE4cakePS_4Prot4foo1FT_T_",
         key.default_implementation_of: "s:FP4cake4Prot4foo1FT_T_",
-        key.offset: 422,
+        key.offset: 428,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       }
@@ -878,7 +883,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.description: "Self.Element == Int"
       }
     ],
-    key.offset: 437,
+    key.offset: 443,
     key.length: 63,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -890,7 +895,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "extfoo()",
         key.usr: "s:Fe4cakeRxS_4Protwx7ElementzSirS0_6extfooFT_T_",
-        key.offset: 485,
+        key.offset: 491,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extfoo</decl.name>()</decl.function.method.instance>"
       }
@@ -900,7 +905,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
     key.kind: source.lang.swift.decl.struct,
     key.name: "S1",
     key.usr: "s:V4cake2S1",
-    key.offset: 502,
+    key.offset: 508,
     key.length: 142,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>",
     key.entities: [
@@ -908,7 +913,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.enum,
         key.name: "SE",
         key.usr: "s:OV4cake2S12SE",
-        key.offset: 519,
+        key.offset: 525,
         key.length: 63,
         key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>SE</decl.name></decl.enum>",
         key.entities: [
@@ -916,7 +921,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "a",
             key.usr: "s:FOV4cake2S12SE1aFMS1_S1_",
-            key.offset: 538,
+            key.offset: 544,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>a</decl.name></decl.enumelement>"
           },
@@ -924,7 +929,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "b",
             key.usr: "s:FOV4cake2S12SE1bFMS1_S1_",
-            key.offset: 554,
+            key.offset: 560,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>b</decl.name></decl.enumelement>"
           },
@@ -932,7 +937,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "c",
             key.usr: "s:FOV4cake2S12SE1cFMS1_S1_",
-            key.offset: 570,
+            key.offset: 576,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>c</decl.name></decl.enumelement>"
           }
@@ -942,7 +947,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:FV4cake2S14foo1FT_T_",
-        key.offset: 588,
+        key.offset: 594,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -950,7 +955,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.struct,
         key.name: "S2",
         key.usr: "s:VV4cake2S12S2",
-        key.offset: 605,
+        key.offset: 611,
         key.length: 37,
         key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name></decl.struct>",
         key.entities: [
@@ -958,7 +963,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
             key.kind: source.lang.swift.decl.var.instance,
             key.name: "b",
             key.usr: "s:vVV4cake2S12S21bSi",
-            key.offset: 626,
+            key.offset: 632,
             key.length: 10,
             key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>b</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>"
           }
@@ -988,7 +993,7 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.description: "T2.Element == T1.Element"
       }
     ],
-    key.offset: 646,
+    key.offset: 652,
     key.length: 106,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:tF4cake6genfoou0_RxS_4Prot_CS_2C1wx7ElementzSirFT1xx1yq__T_L_2T1Mx\"><decl.generic_type_param.name>T1</decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:P4cake4Prot\">Prot</ref.protocol></decl.generic_type_param.constraint></decl.generic_type_param>, <decl.generic_type_param usr=\"s:tF4cake6genfoou0_RxS_4Prot_CS_2C1wx7ElementzSirFT1xx1yq__T_L_2T2Mq_\"><decl.generic_type_param.name>T2</decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.class usr=\"s:C4cake2C1\">C1</ref.class></decl.generic_type_param.constraint></decl.generic_type_param> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T1.Element == Int</decl.generic_type_requirement>, <decl.generic_type_requirement>T2.Element == T1.Element</decl.generic_type_requirement>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label> <decl.var.parameter.name>ix</decl.var.parameter.name>: <decl.var.parameter.type>T1</decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label> <decl.var.parameter.name>iy</decl.var.parameter.name>: <decl.var.parameter.type>T2</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -996,14 +1001,14 @@ func genfoo<T1 : Prot, T2 : cake.C1 where T1.Element == Int, T2.Element == T1.El
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "ix",
-        key.offset: 739,
+        key.offset: 745,
         key.length: 2
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "y",
         key.name: "iy",
-        key.offset: 749,
+        key.offset: 755,
         key.length: 2
       }
     ]

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2009,7 +2009,7 @@ class SubclassThrowsObjCName : ThrowsObjCName {
 }
 
 @objc protocol ProtocolThrowsObjCName {
-  optional func doThing(_ x: String) throws -> String // expected-note{{requirement 'doThing' declared here}}
+  @objc optional func doThing(_ x: String) throws -> String // expected-note{{requirement 'doThing' declared here}}
 }
 
 class ConformsToProtocolThrowsObjCName1 : ProtocolThrowsObjCName {

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -4,7 +4,7 @@
 // nearly matches an optional requirement, but does not exactly match.
 
 @objc protocol P1 {
-  optional func doSomething(a: Int, b: Double) // expected-note 2{{requirement 'doSomething(a:b:)' declared here}}
+  @objc optional func doSomething(a: Int, b: Double) // expected-note 2{{requirement 'doSomething(a:b:)' declared here}}
 }
 
 class C1a : P1 {
@@ -44,8 +44,8 @@ class C1e : P1 {
 // Don't try to match an optional requirement against a declaration
 // that already satisfies one witness.
 @objc protocol P2 {
-  optional func doSomething(a: Int, b: Double)
-  optional func doSomething(a: Int, d: Double)
+  @objc optional func doSomething(a: Int, b: Double)
+  @objc optional func doSomething(a: Int, d: Double)
 }
 
 class C2a : P2 {
@@ -54,7 +54,7 @@ class C2a : P2 {
 
 // Cope with base names that change.
 @objc protocol P3 {
-  optional func doSomethingWithPriority(_ a: Int, d: Double) // expected-note{{requirement 'doSomethingWithPriority(_:d:)' declared here}}
+  @objc optional func doSomethingWithPriority(_ a: Int, d: Double) // expected-note{{requirement 'doSomethingWithPriority(_:d:)' declared here}}
 }
 
 class C3a : P3 {
@@ -66,7 +66,7 @@ class C3a : P3 {
 }
 
 @objc protocol P4 {
-  optional func doSomething(priority: Int, d: Double) // expected-note{{requirement 'doSomething(priority:d:)' declared here}}
+  @objc optional func doSomething(priority: Int, d: Double) // expected-note{{requirement 'doSomething(priority:d:)' declared here}}
 }
 
 class C4a : P4 {
@@ -80,7 +80,7 @@ class C4a : P4 {
 @objc class SomeClass { }
 
 @objc protocol P5 {
-  optional func methodWithInt(_: Int, forSomeClass: SomeClass, dividingDouble: Double)
+  @objc optional func methodWithInt(_: Int, forSomeClass: SomeClass, dividingDouble: Double)
   // expected-note@-1{{requirement 'methodWithInt(_:forSomeClass:dividingDouble:)' declared here}}
 }
 
@@ -93,7 +93,7 @@ class C5a : P5 {
 }
 
 @objc protocol P6 {
-  optional func method(_: Int, for someClass: SomeClass, dividing double: Double)
+  @objc optional func method(_: Int, for someClass: SomeClass, dividing double: Double)
   // expected-note@-1{{requirement 'method(_:for:dividing:)' declared here}}
 }
 
@@ -107,7 +107,7 @@ class C6a : P6 {
 
 // Use the first note to always describe why it didn't match.
 @objc protocol P7 {
-  optional func method(foo: Float)
+  @objc optional func method(foo: Float)
   // expected-note@-1{{requirement 'method(foo:)' declared here}}
 }
 

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -58,8 +58,8 @@ class C2b : P2 {
 }
 
 @objc protocol P3 {
-  optional func doSomething(x: Int)
-  optional func doSomething(y: Int)
+  @objc optional func doSomething(x: Int)
+  @objc optional func doSomething(y: Int)
 }
 
 class C3a : P3 {
@@ -69,10 +69,10 @@ class C3a : P3 {
 // Complain about optional requirements that aren't satisfied
 // according to Swift, but would conflict in Objective-C.
 @objc protocol OptP1 {
-  optional func method() // expected-note 2{{requirement 'method()' declared here}}
+  @objc optional func method() // expected-note 2{{requirement 'method()' declared here}}
 
-  optional var property1: ObjCClass { get } // expected-note 2{{requirement 'property1' declared here}}
-  optional var property2: ObjCClass { get set } // expected-note{{requirement 'property2' declared here}}
+  @objc optional var property1: ObjCClass { get } // expected-note 2{{requirement 'property1' declared here}}
+  @objc optional var property2: ObjCClass { get set } // expected-note{{requirement 'property2' declared here}}
 }
 
 @objc class OptC1a : OptP1 { // expected-note 3{{class 'OptC1a' declares conformance to protocol 'OptP1' here}}

--- a/test/decl/protocol/req/optional.swift
+++ b/test/decl/protocol/req/optional.swift
@@ -6,11 +6,11 @@
 @objc class ObjCClass { }
 
 @objc protocol P1 {
-  optional func method(_ x: Int) // expected-note 2{{requirement 'method' declared here}}
+  @objc optional func method(_ x: Int) // expected-note 2{{requirement 'method' declared here}}
 
-  optional var prop: Int { get } // expected-note{{requirement 'prop' declared here}}
+  @objc optional var prop: Int { get } // expected-note{{requirement 'prop' declared here}}
 
-  optional subscript (i: Int) -> ObjCClass? { get } // expected-note{{requirement 'subscript' declared here}}
+  @objc optional subscript (i: Int) -> ObjCClass? { get } // expected-note{{requirement 'subscript' declared here}}
 }
 
 @objc protocol P2 {
@@ -219,10 +219,14 @@ optional class optErrorClass { // expected-error{{'optional' modifier cannot be 
 }
   
 protocol optErrorProtocol {
-  optional func foo(_ x: Int) // expected-error{{'optional' can only be applied to members of an @objc protocol}}
+  optional func foo(_ x: Int) // expected-error{{'optional' requirements are an Objective-C compatibility feature; add '@objc'}}
+}
+
+@objc protocol optObjcAttributeProtocol {
+  optional func foo(_ x: Int) // expected-error{{'optional' requirements are an Objective-C compatibility feature; add '@objc'}}
   optional associatedtype Assoc  // expected-error{{'optional' modifier cannot be applied to this declaration}} {{3-12=}}
 }
 
 @objc protocol optionalInitProto {
-  optional init() // expected-error{{'optional' cannot be applied to an initializer}}
+  @objc optional init() // expected-error{{'optional' cannot be applied to an initializer}}
 }

--- a/test/decl/protocol/req/optionality.swift
+++ b/test/decl/protocol/req/optionality.swift
@@ -7,7 +7,7 @@
 // Parameters of IUO type.
 // ------------------------------------------------------------------------
 @objc protocol ParameterIUO1 {
-  optional func f0(_ x: C1!)
+  @objc optional func f0(_ x: C1!)
 }
 
 @objc class ParameterIUO1a : ParameterIUO1 {
@@ -27,7 +27,7 @@
 // ------------------------------------------------------------------------
 
 @objc protocol ParameterOpt1 {
-  optional func f0(_ x: C1?) // expected-note 2{{declared here}}
+  @objc optional func f0(_ x: C1?) // expected-note 2{{declared here}}
 }
 
 @objc class ParameterOpt1a : ParameterOpt1 {
@@ -46,7 +46,7 @@
 // Parameters of non-optional type.
 // ------------------------------------------------------------------------
 @objc protocol ParameterNonOpt1 {
-  optional func f0(_ x: C1) // expected-note 2{{declared here}}
+  @objc optional func f0(_ x: C1) // expected-note 2{{declared here}}
 }
 
 @objc class ParameterNonOpt1a : ParameterNonOpt1 {
@@ -65,7 +65,7 @@
 // Result of IUO type.
 // ------------------------------------------------------------------------
 @objc protocol ResultIUO1 {
-  optional func f0() -> C1!
+  @objc optional func f0() -> C1!
 }
 
 @objc class ResultIUO1a : ResultIUO1 {
@@ -84,7 +84,7 @@
 // Result of optional type.
 // ------------------------------------------------------------------------
 @objc protocol ResultOpt1 {
-  optional func f0() -> C1? // expected-note 2{{declared here}}
+  @objc optional func f0() -> C1? // expected-note 2{{declared here}}
 }
 
 @objc class ResultOpt1a : ResultOpt1 {
@@ -103,7 +103,7 @@
 // Result of non-optional type.
 // ------------------------------------------------------------------------
 @objc protocol ResultNonOpt1 {
-  optional func f0() -> C1 // expected-note 2 {{declared here}}
+  @objc optional func f0() -> C1 // expected-note 2 {{declared here}}
 }
 
 @objc class ResultNonOpt1a : ResultNonOpt1 {
@@ -122,7 +122,7 @@
 // Multiple parameter mismatches
 // ------------------------------------------------------------------------
 @objc protocol MultiParamsOpt1 {
-  optional func f0(_ x: C1?, y: C1) // expected-note{{here}}
+  @objc optional func f0(_ x: C1?, y: C1) // expected-note{{here}}
 }
 
 @objc class MultiParamsOpt1a : MultiParamsOpt1 {
@@ -133,7 +133,7 @@
 // Parameter and result type mismatches
 // ------------------------------------------------------------------------
 @objc protocol ParamAndResult1 {
-  optional func f0(_ x: C1?) -> C1 // expected-note{{here}}
+  @objc optional func f0(_ x: C1?) -> C1 // expected-note{{here}}
 }
 
 @objc class ParamAndResult1a : ParamAndResult1 {

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -4,7 +4,7 @@
 // methods.  They are treated as if they
 // were marked optional
 @objc protocol Proto {
-  @available(*,unavailable) optional func bad()
+  @objc @available(*,unavailable) optional func bad()
   func good()
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Optional protocol requirements now require an explicit @objc attribute.
#### Resolved bug number: ([SR-1395](https://bugs.swift.org/browse/SR-1395))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
