### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::diagnoseFailureForExpr(…)

### DIFF
--- a/validation-test/compiler_crashers/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
+++ b/validation-test/compiler_crashers/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+func a{{String($0}{u
+return{


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
6  swift           0x00000000030e89fd llvm::llvm_unreachable_internal(char const*, char const*, unsigned int) + 461
14 swift           0x0000000000f1fb79 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
15 swift           0x0000000000f24b50 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
16 swift           0x0000000000e5fcf4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 724
17 swift           0x0000000000e66452 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
20 swift           0x0000000000ed8bca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
21 swift           0x0000000000ed8a2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
22 swift           0x0000000000ed95c8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
24 swift           0x0000000000e99f64 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1268
25 swift           0x0000000000c37c1f swift::CompilerInstance::performSema() + 3295
27 swift           0x00000000007c5de6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2838
28 swift           0x0000000000791e78 main + 2840
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28290-swift-constraints-constraintsystem-diagnosefailureforexpr-e5f947.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:9:1
2.  While type-checking expression at [validation-test/compiler_crashers/28290-swift-constraints-constraintsystem-diagnosefailureforexpr.swift:9:8 - line:10:7] RangeText="{String($0}{u
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
