### PR TITLE
Runtime: Fix _SwiftNativeNSError's copyWithZone:.

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -89,6 +89,12 @@ using namespace swift;
   }
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  (void)zone;
+  // _SwiftNativeNSError is immutable, so we can return the same instance back.
+  return [self retain];
+}
+
 @end
 
 Class swift::getNSErrorClass() {

--- a/test/1_stdlib/ErrorProtocolBridging.swift
+++ b/test/1_stdlib/ErrorProtocolBridging.swift
@@ -60,6 +60,14 @@ ErrorProtocolBridgingTests.test("NSError") {
   expectEqual(NoisyErrorDeathCount, NoisyErrorLifeCount)
 }
 
+ErrorProtocolBridgingTests.test("NSCopying") {
+  autoreleasepool {
+    let orig = EnumError.ReallyBadError as NSError
+    let copy = orig.copy() as! NSError
+    expectEqual(orig, copy)
+  }
+}
+
 ErrorProtocolBridgingTests.test("NSError-to-enum bridging") {
   NoisyErrorLifeCount = 0
   NoisyErrorDeathCount = 0


### PR DESCRIPTION
The default implementation from NSObject doesn't know how to copy the Swift error payload, and the object's immutable anyway, so we just need to retain and return the object we already have.
