### PR TITLE
Runtime: Archive _SwiftNativeNSErrors as NSErrors.

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -95,6 +95,12 @@ using namespace swift;
   return [self retain];
 }
 
+- (Class)classForCoder {
+  // This is a runtime-private subclass. When archiving or unarchiving, do so
+  // as an NSError.
+  return [NSError class];
+}
+
 @end
 
 Class swift::getNSErrorClass() {

--- a/test/1_stdlib/ErrorProtocolBridging.swift
+++ b/test/1_stdlib/ErrorProtocolBridging.swift
@@ -68,6 +68,24 @@ ErrorProtocolBridgingTests.test("NSCopying") {
   }
 }
 
+func archiveAndUnarchiveObject<T: NSCoding where T: NSObject>(
+  _ object: T
+) -> T? {
+  let unarchiver = NSKeyedUnarchiver(forReadingWith:
+    NSKeyedArchiver.archivedData(withRootObject: object)
+  )
+  unarchiver.requiresSecureCoding = true
+  return unarchiver.decodeObjectOfClass(T.self, forKey: "root")
+}
+ErrorProtocolBridgingTests.test("NSCoding") {
+  autoreleasepool {
+    let orig = EnumError.ReallyBadError as NSError
+    let unarchived = archiveAndUnarchiveObject(orig)!
+    expectEqual(orig, unarchived)
+    expectTrue(unarchived.dynamicType == NSError.self)
+  }
+}
+
 ErrorProtocolBridgingTests.test("NSError-to-enum bridging") {
   NoisyErrorLifeCount = 0
   NoisyErrorDeathCount = 0


### PR DESCRIPTION
_SwiftNativeNSError is a runtime-private subclass, and NSError's inherited NSCoding implementation doesn't handle the Swift payload of bridged errors. We can't really archive arbitrary Swift values anyway yet, so just archive bridged NSError subclasses as regular NSErrors. Fixes rdar://problem/23051728.
