### PR TITLE
[WIP] SE-0066: Standardize Function Type Syntax

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -615,6 +615,8 @@ ERROR(expected_type_before_arrow,none,
       "expected type before '->'", ())
 ERROR(expected_type_after_arrow,none,
       "expected type after '->'", ())
+ERROR(non_tuple_function_param_type,none,
+      "type before '->' must be wrapped in parentheses", ())
 
 // Enum Types
 ERROR(expected_expr_enum_case_raw_value,PointsToFirstBadToken,

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -187,6 +187,12 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
   // Handle type-function if we have an arrow.
   SourceLoc arrowLoc;
   if (consumeIf(tok::arrow, arrowLoc)) {
+    if (!isa<TupleTypeRepr>(ty.get())) {
+      diagnose(ty.get()->getStartLoc(), diag::non_tuple_function_param_type)
+        .highlight(ty.get()->getSourceRange())
+        .fixItInsert(ty.get()->getStartLoc(), "(")
+        .fixItInsertAfter(ty.get()->getEndLoc(), ")");
+    }
     ParserResult<TypeRepr> SecondHalf =
       parseType(diag::expected_type_function_result);
     if (SecondHalf.hasCodeCompletion())

--- a/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
+++ b/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
@@ -39,7 +39,7 @@ infix operator ∘ {
 ///
 /// - Returns: a function that applies ``g`` to the result of applying ``f``
 ///   to the argument of the new function.
-public func ∘<T, U, V>(g: U -> V, f: T -> U) -> (T -> V) {
+public func ∘<T, U, V>(g: (U) -> V, f: (T) -> U) -> ((T) -> V) {
   return { g(f($0)) }
 }
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2271,8 +2271,8 @@ public func expectEqualsUnordered<
 }
 
 public func expectEqualFunctionsForDomain<ArgumentType, Result : Equatable>(
-    _ arguments: [ArgumentType], _ function1: ArgumentType -> Result,
-    _ function2: ArgumentType -> Result
+    _ arguments: [ArgumentType], _ function1: (ArgumentType) -> Result,
+    _ function2: (ArgumentType) -> Result
 ) {
   for a in arguments {
     let expected = function1(a)
@@ -2285,8 +2285,8 @@ public func expectEqualMethodsForDomain<
   SelfType, ArgumentType, Result : Equatable
 >(
   _ selfs: [SelfType], _ arguments: [ArgumentType],
-  _ function1: SelfType -> ArgumentType -> Result,
-  _ function2: SelfType -> ArgumentType -> Result
+  _ function1: (SelfType) -> (ArgumentType) -> Result,
+  _ function2: (SelfType) -> (ArgumentType) -> Result
 ) {
   for s in selfs {
     for a in arguments {
@@ -2313,7 +2313,7 @@ public func expectEqualUnicodeScalars(
   }
 }
 
-func compose<A, B, C>(_ f: A -> B, _ g: B -> C) -> A -> C {
+func compose<A, B, C>(_ f: (A) -> B, _ g: (B) -> C) -> (A) -> C {
   return { a in
     return g(f(a))
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Implements SE-0066: Standardize Function Type Syntax

Still needs test and `stdlib` migration.
#### Resolved bug number: ([SR-1434](https://bugs.swift.org/browse/SR-1434))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
