### PR TITLE
ABCOpt: we should not hoist bounds/overflow checks if the loop has mu…

### DIFF
--- a/test/SILOptimizer/abcopts.sil
+++ b/test/SILOptimizer/abcopts.sil
@@ -1124,17 +1124,19 @@ sil @unknown : $@convention(thin) () -> Builtin.Int1
 
 // RANGECHECK-LABEL: sil @rangeCheck_early_exit
 // RANGECHECK: bb0
+// RANGECHECK:   cond_fail
 // RANGECHECK:   cond_br {{.*}}, bb2, bb1
-// RANGECHECK: bb1
-// RANGECHECK:  [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// RANGECHECK: bb1:
+// RANGECHECK-NOT:  cond_fail
 // RANGECHECK:   br bb3
-// RANGECHECK: bb2
+// RANGECHECK: bb2:
 // RANGECHECK:  return
-// RANGECHECK: bb3
+// RANGECHECK: bb3({{.*}}):
+// RANGECHECK:  apply
 // RANGECHECK:  cond_br {{.*}}, bb4, bb2
-// RANGECHECK: bb4
-// RANGECHECK:   builtin "xor_Int1"([[TRUE]]
-// RANGECHECK:   builtin "xor_Int1"([[TRUE]]
+// RANGECHECK: bb4:
+// RANGECHECK:   cond_fail
+// RANGECHECK:   cond_fail
 // RANGECHECK:   cond_br {{.*}}, bb2, bb3
 // RANGECHECK: }
 sil @rangeCheck_early_exit : $@convention(thin) (Builtin.Int64) -> () {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ltiple exit edges.

fixes rdar://problem/26126534
