### PR TITLE
[swiftc] Add test case for crash triggered in swift::constraints::ConstraintSystem::compareSolutions(…)

### DIFF
--- a/validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift
+++ b/validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class T,struct A{func b{}struct A{class B<T}func b:A.B{var _=b<T


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash with stack trace:

```
swift: /path/to/swift/lib/AST/ArchetypeBuilder.cpp:2026: static swift::Type swift::ArchetypeBuilder::mapTypeIntoContext(swift::DeclContext *, swift::Type, swift::LazyResolver *): Assertion `genericParams && "Missing generic parameters for dependent context"' failed.
10 swift           0x0000000000f509cc swift::constraints::ConstraintSystem::compareSolutions(swift::constraints::ConstraintSystem&, llvm::ArrayRef<swift::constraints::Solution>, swift::constraints::SolutionDiff const&, unsigned int, unsigned int) + 1580
11 swift           0x0000000000f52114 swift::constraints::ConstraintSystem::findBestSolution(llvm::SmallVectorImpl<swift::constraints::Solution>&, bool) + 372
12 swift           0x0000000000f69c29 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 121
13 swift           0x0000000000e5fcc2 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 674
14 swift           0x0000000000e66452 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
19 swift           0x0000000000f1fb79 swift::constraints::ConstraintSystem::diagnoseFailureForExpr(swift::Expr*) + 105
20 swift           0x0000000000f24b50 swift::constraints::ConstraintSystem::salvage(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::Expr*) + 4064
21 swift           0x0000000000e5fcf4 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 724
22 swift           0x0000000000e66452 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
23 swift           0x0000000000e675a7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
24 swift           0x0000000000e677bb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
27 swift           0x0000000000e78426 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
30 swift           0x0000000000ed8bca swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
31 swift           0x0000000000ed8a2e swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
32 swift           0x0000000000ed95c8 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 136
34 swift           0x0000000000e99f64 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 1268
35 swift           0x0000000000c37c1f swift::CompilerInstance::performSema() + 3295
37 swift           0x00000000007c5de6 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2838
38 swift           0x0000000000791e78 main + 2840
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28291-swift-constraints-constraintsystem-comparesolutions-71a91c.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift:10:45
2.  While type-checking declaration 0x5342958 at validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift:10:56
3.  While type-checking expression at [validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift:10:62 - line:10:64] RangeText="b<T"
4.  While type-checking expression at [validation-test/compiler_crashers/28291-swift-constraints-constraintsystem-comparesolutions.swift:10:62 - line:10:62] RangeText="b"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
