### PR TITLE
[SR-1421][SourceKit] Remove misleading help text

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -402,7 +402,9 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
   switch (Opts.Request) {
   case SourceKitRequest::None:
     llvm::errs() << "request is not set\n";
-    llvm::cl::PrintHelpMessage();
+    // FIXME: This non-zero return value is not propogated as an exit code.
+    //        In other words, despite returning 1 here, the program still exits
+    //        with a zero (successful) exit code.
     return 1;
 
   case SourceKitRequest::ProtocolVersion:


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

`sourcekitd-test` does not use LLVM's command line parsing utilities at all, except to print a help message. However, the help message is misleading: by default `llvm::cl` explains the `-help`, `-help-hidden`, and `-version` options are available, but `sourcekitd-test` does not support any of those.

[SR-1421](https://bugs.swift.org/browse/SR-1421) tracks improving `sourcekitd-test` help output, which will most likely involve migrating it to LLVM's command line library. In the meantime, remove the misleading "help" message.

Also, it should be noted that the return value of `1` returned after printing the help message is not actually translated into a non-zero exit code for the program. Add a "FIXME" to track the issue for now.
#### ~~Resolved~~ Related bug number: ([SR-1421](https://bugs.swift.org/browse/SR-1421))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
