### PR TITLE
[swiftc] Add test case for crash triggered in swift::ValueDecl::setType(…)

### DIFF
--- a/validation-test/compiler_crashers/28292-swift-valuedecl-settype.swift
+++ b/validation-test/compiler_crashers/28292-swift-valuedecl-settype.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class a{init(A)class A:a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/Decl.cpp:1655: void swift::ValueDecl::setType(swift::Type): Assertion `!hasType() && "changing type of declaration"' failed.
8  swift           0x000000000108473c swift::ValueDecl::setType(swift::Type) + 92
9  swift           0x0000000000e788cc swift::configureConstructorType(swift::ConstructorDecl*, swift::Type, swift::Type, bool) + 428
14 swift           0x0000000000e7bf36 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
15 swift           0x0000000000e9d962 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int) + 994
16 swift           0x0000000000c37c0f swift::CompilerInstance::performSema() + 3295
18 swift           0x00000000007c5e46 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2838
19 swift           0x0000000000791ed8 main + 2840
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28292-swift-valuedecl-settype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28292-swift-valuedecl-settype-ee60c6.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28292-swift-valuedecl-settype.swift:10:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
