### PR TITLE
AST: More robust rewrite of ProtocolConformance::getInheritedConformance.

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -468,69 +468,65 @@ ProtocolConformance *ProtocolConformance::subst(Module *module,
 
 ProtocolConformance *
 ProtocolConformance::getInheritedConformance(ProtocolDecl *protocol) const {
-  // Preserve specialization through this operation by peeling off the
-  // substitutions from a specialized conformance so we can apply them later.
-  const ProtocolConformance *unspecialized;
-  SubstitutionIterator subs;
+  auto &C = getProtocol()->getASTContext();
+  // Preserve specialization and class inheritance through this operation by
+  // reapplying them to the conformance we find.
   switch (getKind()) {
   case ProtocolConformanceKind::Specialized: {
     auto spec = cast<SpecializedProtocolConformance>(this);
-    unspecialized = spec->getGenericConformance();
-    subs = spec->getGenericSubstitutionIterator();
-    break;
-  }
+    auto inherited = spec->getGenericConformance()
+      ->getInheritedConformance(protocol);
+    assert(inherited->getType()->isEqual(spec->getGenericConformance()->getType())
+           && "inherited conformance doesn't match type?!");
     
-  case ProtocolConformanceKind::Normal:
-  case ProtocolConformanceKind::Inherited:
-    unspecialized = this;
-    break;
-  }
-  
-  
-  ProtocolConformance *foundInherited;
-  
-  // Search for the inherited conformance among our immediate parents.
-  auto &inherited = unspecialized->getInheritedConformances();
-  auto known = inherited.find(protocol);
-  if (known != inherited.end()) {
-    foundInherited = known->second;
-    goto found_inherited;
-  }
-
-  // If not there, the inherited conformance must be available through one of
-  // our parents.
-  for (auto &inheritedMapping : inherited)
-    if (inheritedMapping.first->inheritsFrom(protocol)) {
-      foundInherited = inheritedMapping.second->
-        getInheritedConformance(protocol);
-      goto found_inherited;
-    }
-
-  llvm_unreachable("Can't find the inherited conformance.");
-
-found_inherited:
-  
-  // Specialize the inherited conformance, if necessary.
-  if (!subs.empty()) {
     TypeSubstitutionMap subMap;
     ArchetypeConformanceMap conformanceMap;
-
+    
     // Fill in the substitution and conformance maps.
-    for (auto archAndSub : subs) {
+    for (auto archAndSub : spec->getGenericSubstitutionIterator()) {
       auto arch = archAndSub.first;
       auto sub = archAndSub.second;
       conformanceMap[arch] = sub.getConformances();
       if (arch->isPrimary())
         subMap[arch] = sub.getReplacement();
     }
-    return foundInherited->subst(getDeclContext()->getParentModule(),
-                                 getType(), subs.getSubstitutions(),
-                                 subMap, conformanceMap);
+    auto r = inherited->subst(getDeclContext()->getParentModule(),
+                            getType(), spec->getGenericSubstitutions(),
+                            subMap, conformanceMap);
+    assert(getType()->isEqual(r->getType())
+           && "substitution didn't produce conformance for same type?!");
+    return r;
   }
-  assert((getType()->isEqual(foundInherited->getType()) ||
-          foundInherited->getType()->isExactSuperclassOf(getType(), nullptr))
-         && "inherited conformance does not match type");
-  return foundInherited;
+    
+  case ProtocolConformanceKind::Inherited: {
+    auto classInherited = cast<InheritedProtocolConformance>(this);
+    auto protoInherited = classInherited->getInheritedConformance()
+      ->getInheritedConformance(protocol);
+    assert(protoInherited->getType()->isEqual(
+                           classInherited->getInheritedConformance()->getType())
+           && "inherited conformance doesn't match type?!");
+    return C.getInheritedConformance(classInherited->getType(),
+                                     protoInherited);
+  }
+
+  case ProtocolConformanceKind::Normal:
+    // For a normal conformance, do the inheritance lookup.
+    break;
+  }
+  
+  // Search for the inherited conformance among our immediate parents.
+  auto &inherited = getInheritedConformances();
+  auto known = inherited.find(protocol);
+  if (known != inherited.end())
+    return known->second;
+
+  // If not there, the inherited conformance must be available through one of
+  // our parents.
+  for (auto &inheritedMapping : inherited)
+    if (inheritedMapping.first->inheritsFrom(protocol))
+      return inheritedMapping.second->getInheritedConformance(protocol);
+
+  llvm_unreachable("Can't find the inherited conformance.");
 }
 
 #pragma mark Protocol conformance lookup

--- a/test/SILOptimizer/specialize_class_inherits_base_inherits_protocol.swift
+++ b/test/SILOptimizer/specialize_class_inherits_base_inherits_protocol.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | FileCheck %s
+
+protocol P { func p() -> Any.Type }
+protocol Q: P { }
+
+@inline(never) func sink<T>(_ x: T) {}
+
+func p<T: Q>(_ x: T) { sink(x.p()) }
+
+class Foo<T>: Q { func p() -> Any.Type { return T.self } }
+class Bar<T>: Foo<T> {}
+
+// CHECK-LABEL: sil @_TF48specialize_class_inherits_base_inherits_protocol3fooFT_T_
+public func foo() {
+  // CHECK: function_ref @_TTSf4d___TTSg5PMP____TF48specialize_class_inherits_base_inherits_protocol4sinkurFxT_
+  p(Bar<Int>())
+}
+

--- a/test/SILOptimizer/specialize_inherited.sil
+++ b/test/SILOptimizer/specialize_inherited.sil
@@ -39,7 +39,7 @@ bb0(%0 : $Int, %1 : $Int):
 
 // CHECK-LABEL: @_TTSg5C7inherit8MMStringCS_8MMObjects8HashableS__GSQCS_6MMFont___callee : $@convention(method) (@owned MMString, Int, @owned MMStorage<MMString, ImplicitlyUnwrappedOptional<MMFont>>) -> Bool {
 // CHECK: [[META:%[0-9]+]] = metatype $@thick MMString.Type
-// CHECK: [[ID3:%[0-9]+]] = witness_method $MMObject, #Equatable."=="!1 :
+// CHECK: [[ID3:%[0-9]+]] = witness_method $MMString, #Equatable."=="!1 :
 // CHECK: [[STACK2:%[0-9]+]] = alloc_stack $MMString
 // CHECK: [[STACK3:%[0-9]+]] = alloc_stack $MMString
 // CHECK: apply [[ID3]]<MMString>([[STACK2]], [[STACK3]], [[META]]) : $@convention(witness_method) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool


### PR DESCRIPTION
A recursive implementation is cleaner, and more cleanly preserves class inheritance and generic specialization through the operation to get the refined protocol conformance. Fixes SR-1323.
