### PR TITLE
Fix @objc checking for optional value types

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -522,7 +522,7 @@ public:
   ForeignRepresentationInfo
   getForeignRepresentationInfo(NominalTypeDecl *nominal,
                                ForeignLanguage language,
-                               DeclContext *dc);
+                               const DeclContext *dc);
 
   /// Add a declaration to a list of declarations that need to be emitted
   /// as part of the current module or source file, but are otherwise not

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -254,7 +254,7 @@ public:
 
   /// Determine whether this protocol conformance is visible from the
   /// given declaration context.
-  bool isVisibleFrom(DeclContext *dc) const;
+  bool isVisibleFrom(const DeclContext *dc) const;
 
   /// Determine whether the witness for the given requirement
   /// is either the default definition or was otherwise deduced.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -712,7 +712,7 @@ public:
   /// Determine whether the given type is representable in the given
   /// foreign language.
   std::pair<ForeignRepresentableKind, ProtocolConformance *>
-  getForeignRepresentableIn(ForeignLanguage language, DeclContext *dc);
+  getForeignRepresentableIn(ForeignLanguage language, const DeclContext *dc);
 
   /// Determines whether the given Swift type is representable within
   /// the given foreign language.
@@ -720,14 +720,14 @@ public:
   /// A given Swift type is representable in the given foreign
   /// language if the Swift type can be used from source code written
   /// in that language.
-  bool isRepresentableIn(ForeignLanguage language, DeclContext *dc);
+  bool isRepresentableIn(ForeignLanguage language, const DeclContext *dc);
 
   /// Determines whether the type is trivially representable within
   /// the foreign language, meaning that it is both representable in
   /// that language and that the runtime representations are
   /// equivalent.
   bool isTriviallyRepresentableIn(ForeignLanguage language,
-                                  DeclContext *dc);
+                                  const DeclContext *dc);
 
   /// \brief Given that this is a nominal type or bound generic nominal
   /// type, return its parent type; this will be a null type if the type

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3795,7 +3795,7 @@ static NominalTypeDecl *findUnderlyingTypeInModule(ASTContext &ctx,
 ForeignRepresentationInfo
 ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
                                          ForeignLanguage language,
-                                         DeclContext *dc) {
+                                         const DeclContext *dc) {
   if (Impl.ForeignRepresentableCache.empty()) {
     // Local function to add a type with the given name and module as
     // trivially-representable.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -404,7 +404,7 @@ ProtocolConformance::getRootNormalConformance() const {
   return cast<NormalProtocolConformance>(C);
 }
 
-bool ProtocolConformance::isVisibleFrom(DeclContext *dc) const {
+bool ProtocolConformance::isVisibleFrom(const DeclContext *dc) const {
   // FIXME: Implement me!
   return true;
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1930,8 +1930,8 @@ bool TypeBase::isPotentiallyBridgedValueType() {
 }
 
 /// Determine whether this is a representable Objective-C object type.
-static ForeignRepresentableKind getObjCObjectRepresentable(Type type,
-                                                           DeclContext *dc) {
+static ForeignRepresentableKind
+getObjCObjectRepresentable(Type type, const DeclContext *dc) {
   // @objc metatypes are representable when their instance type is.
   if (auto metatype = type->getAs<AnyMetatypeType>()) {
     // If the instance type is not representable, the metatype is not
@@ -1986,7 +1986,8 @@ static ForeignRepresentableKind getObjCObjectRepresentable(Type type,
 /// to be reflected in PrintAsObjC, so that the Swift type will be
 /// properly printed for (Objective-)C and in SIL's bridging logic.
 static std::pair<ForeignRepresentableKind, ProtocolConformance *>
-getForeignRepresentable(Type type, ForeignLanguage language, DeclContext *dc) {
+getForeignRepresentable(Type type, ForeignLanguage language,
+                        const DeclContext *dc) {
   // Look through one level of optional type, but remember that we did.
   bool wasOptional = false;
   if (auto valueType = type->getAnyOptionalObjectType()) {
@@ -2218,11 +2219,13 @@ getForeignRepresentable(Type type, ForeignLanguage language, DeclContext *dc) {
 }
 
 std::pair<ForeignRepresentableKind, ProtocolConformance *>
-TypeBase::getForeignRepresentableIn(ForeignLanguage language, DeclContext *dc) {
+TypeBase::getForeignRepresentableIn(ForeignLanguage language,
+                                    const DeclContext *dc) {
   return getForeignRepresentable(Type(this), language, dc);
 }
 
-bool TypeBase::isRepresentableIn(ForeignLanguage language, DeclContext *dc) {
+bool TypeBase::isRepresentableIn(ForeignLanguage language,
+                                 const DeclContext *dc) {
   switch (getForeignRepresentableIn(language, dc).first) {
   case ForeignRepresentableKind::None:
     return false;
@@ -2236,7 +2239,7 @@ bool TypeBase::isRepresentableIn(ForeignLanguage language, DeclContext *dc) {
 }
 
 bool TypeBase::isTriviallyRepresentableIn(ForeignLanguage language,
-                                          DeclContext *dc) {
+                                          const DeclContext *dc) {
   switch (getForeignRepresentableIn(language, dc).first) {
   case ForeignRepresentableKind::None:
   case ForeignRepresentableKind::Bridged:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2296,25 +2296,14 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
 static bool isNullableTypeInC(SILModule &M, Type ty) {
   ty = ty->getLValueOrInOutObjectType()->getReferenceStorageReferent();
 
+  // Functions, class instances, and @objc existentials are all nullable.
   if (ty->hasReferenceSemantics())
     return true;
-  
-  auto &C = ty->getASTContext();
-  auto nom = ty->getAnyNominal();
-  if (!nom)
-    return false;
 
-  if (nom == C.getUnsafePointerDecl()
-      || nom == C.getUnsafeMutablePointerDecl()
-      || nom == C.getAutoreleasingUnsafeMutablePointerDecl()
-      || nom == C.getOpaquePointerDecl())
-    return true;
-  
-  auto selectorTy = M.Types.getSelectorType();
-  if (selectorTy && ty->isEqual(selectorTy))
-    return true;
-  
-  return false;
+  // Other types like UnsafePointer can also be nullable.
+  ty = OptionalType::get(ty);
+  return ty->isTriviallyRepresentableIn(ForeignLanguage::C,
+                                        M.getAssociatedContext());
 }
 
 /// Determine whether the given declaration returns a non-optional object that

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1106,6 +1106,7 @@ class infer_instanceVar1 {
   var var_Optional12: OpaquePointer?
   var var_Optional13: UnsafeMutablePointer<Int>?
   var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
+  var var_Optional15: NSRange? // another bridged struct
 
 // CHECK-LABEL: @objc var var_Optional1: Class_ObjC1?
 // CHECK-LABEL: @objc var var_Optional2: Protocol_ObjC1?
@@ -1121,6 +1122,7 @@ class infer_instanceVar1 {
 // CHECK-LABEL: @objc var var_Optional12: OpaquePointer?
 // CHECK-LABEL: @objc var var_Optional13: UnsafeMutablePointer<Int>?
 // CHECK-LABEL: @objc var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
+// CHECK-LABEL: @objc var var_Optional15: NSRange?
 
 
   var var_ImplicitlyUnwrappedOptional1: Class_ObjC1!
@@ -1159,6 +1161,7 @@ class infer_instanceVar1 {
   var var_Optional_fail14: CBool?
   var var_Optional_fail20: AnyObject??
   var var_Optional_fail21: AnyObject.Type??
+  var var_Optional_fail22: NSComparisonResult? // a non-bridged imported value type
 // CHECK-NOT: @objc{{.*}}Optional_fail
 
   // CHECK-LABEL: @objc var var_CFunctionPointer_1: @convention(c) () -> ()


### PR DESCRIPTION
We previously treated `NSFoo?` as ObjC-compatible simply because `NSFoo` was an imported type or was marked `@objc`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
