### PR TITLE
Fix stdlib deployment targets for powerpc64 and powerpc64le

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -74,9 +74,9 @@ def stdlib_deployment_targets():
         elif machine == 'aarch64':
             return ['linux-aarch64']
         elif machine == 'ppc64':
-            return ['linux-ppc64']
+            return ['linux-powerpc64']
         elif machine == 'ppc64le':
-            return ['linux-ppc64le']
+            return ['linux-powerpc64le']
     elif system == 'Darwin':
         if machine == 'x86_64':
             return [


### PR DESCRIPTION
We use powerpc64 and powerpc64le for the target names, not ppc64 and
ppc64le.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

We use powerpc64 and powerpc64le for the target names, not ppc64 and
ppc64le.
