### PR TITLE
[stdlib] Fix print method syntax and add the optional binding

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -229,10 +229,11 @@ if True:
 /// array's first and last elements. If the array is empty, these properties
 /// are `nil`.
 ///
-///     print(oddNumbers.first, oddNumbers.last, separator=", ")
+///     if let firstElement = oddNumbers.first, lastElement = oddNumbers.last {
+///         print(firstElement, lastElement, separator: ", ", terminator: "\n")
 ///     // Prints "1, 15"
 ///
-///     print(emptyDoubles.first, emptyDoubles.last, separator=", ")
+///     print(emptyDoubles.first, emptyDoubles.last, separator: ", ", terminator: "\n")
 ///     // Prints "nil, nil"
 ///
 /// You can access individual array elements through a subscript. The first
@@ -241,7 +242,7 @@ if True:
 /// the count of the array. Using a negative number or an index equal to or
 /// greater than `count` triggers a runtime error. For example:
 ///
-///     print(oddNumbers[0], oddNumbers[3], separator=", ")
+///     print(oddNumbers[0], oddNumbers[3], separator: ", ", terminator: "\n")
 ///     // Prints "1, 7"
 ///
 ///     print(emptyDoubles[0])
@@ -619,10 +620,10 @@ ${SubscriptDocComment}
   public subscript(index: Int) -> Element {
     get {
       // This call may be hoisted or eliminated by the optimizer.  If
-      // there is an inout violation, this value may be stale so needs to be 
+      // there is an inout violation, this value may be stale so needs to be
       // checked again below.
       let wasNativeTypeChecked = _hoistableIsNativeTypeChecked()
-      
+
       // Make sure the index is in range and wasNativeTypeChecked is
       // still valid.
       let token = _checkSubscript(
@@ -634,7 +635,7 @@ ${SubscriptDocComment}
     }
     mutableAddressWithPinnedNativeOwner {
       _makeMutableAndUniqueOrPinned() // makes the array native, too
-      _checkSubscript_native(index)   
+      _checkSubscript_native(index)
       return (_getElementAddress(index), Builtin.tryPin(_getOwner_native()))
     }
   }
@@ -750,7 +751,7 @@ ${SubscriptDocComment}
       // We are hiding the access to '_buffer.owner' behind
       // _getOwner() to help the compiler hoist uniqueness checks in
       // the case of class or Objective-C existential typed array
-      // elements. 
+      // elements.
       return _getOwnerWithSemanticLabel_native()
     }
 #endif
@@ -990,12 +991,12 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ///     func cacheImagesWithNames(names: [String]) {
   ///         // custom image loading and caching
   ///      }
-  /// 
+  ///
   ///     let namedHues: [String: Int] = ["Vermillion": 18, "Magenta": 302,
   ///             "Gold": 50, "Cerise": 320]
   ///     let colorNames = Array(namedHues.keys)
   ///     cacheImagesWithNames(colorNames)
-  /// 
+  ///
   ///     print(colorNames)
   ///     // Prints "["Gold", "Cerise", "Magenta", "Vermillion"]"
   ///
@@ -1082,15 +1083,15 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   internal static func _adoptStorage(
     _ storage: AnyObject, count: Int
   ) -> (Array, UnsafeMutablePointer<Element>) {
-    
+
     _sanityCheck(
       storage is _ContiguousArrayStorage<Element>, "Invalid array storage type")
-    
+
     let innerBuffer = _ContiguousArrayBuffer<Element>(
       count: count,
       storage: unsafeDowncast(
         storage, to: _ContiguousArrayStorage<Element>.self))
-    
+
     return (
       Array(_Buffer(innerBuffer, shiftedToStartIndex: 0)),
         innerBuffer.firstElementAddress)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -231,6 +231,7 @@ if True:
 ///
 ///     if let firstElement = oddNumbers.first, lastElement = oddNumbers.last {
 ///         print(firstElement, lastElement, separator: ", ", terminator: "\n")
+///     }
 ///     // Prints "1, 15"
 ///
 ///     print(emptyDoubles.first, emptyDoubles.last, separator: ", ", terminator: "\n")

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -230,11 +230,11 @@ if True:
 /// are `nil`.
 ///
 ///     if let firstElement = oddNumbers.first, lastElement = oddNumbers.last {
-///         print(firstElement, lastElement, separator: ", ", terminator: "\n")
+///         print(firstElement, lastElement, separator: ", ")
 ///     }
 ///     // Prints "1, 15"
 ///
-///     print(emptyDoubles.first, emptyDoubles.last, separator: ", ", terminator: "\n")
+///     print(emptyDoubles.first, emptyDoubles.last, separator: ", ")
 ///     // Prints "nil, nil"
 ///
 /// You can access individual array elements through a subscript. The first
@@ -243,7 +243,7 @@ if True:
 /// the count of the array. Using a negative number or an index equal to or
 /// greater than `count` triggers a runtime error. For example:
 ///
-///     print(oddNumbers[0], oddNumbers[3], separator: ", ", terminator: "\n")
+///     print(oddNumbers[0], oddNumbers[3], separator: ", ")
 ///     // Prints "1, 7"
 ///
 ///     print(emptyDoubles[0])
@@ -621,10 +621,10 @@ ${SubscriptDocComment}
   public subscript(index: Int) -> Element {
     get {
       // This call may be hoisted or eliminated by the optimizer.  If
-      // there is an inout violation, this value may be stale so needs to be
+      // there is an inout violation, this value may be stale so needs to be 
       // checked again below.
       let wasNativeTypeChecked = _hoistableIsNativeTypeChecked()
-
+      
       // Make sure the index is in range and wasNativeTypeChecked is
       // still valid.
       let token = _checkSubscript(
@@ -636,7 +636,7 @@ ${SubscriptDocComment}
     }
     mutableAddressWithPinnedNativeOwner {
       _makeMutableAndUniqueOrPinned() // makes the array native, too
-      _checkSubscript_native(index)
+      _checkSubscript_native(index)   
       return (_getElementAddress(index), Builtin.tryPin(_getOwner_native()))
     }
   }
@@ -752,7 +752,7 @@ ${SubscriptDocComment}
       // We are hiding the access to '_buffer.owner' behind
       // _getOwner() to help the compiler hoist uniqueness checks in
       // the case of class or Objective-C existential typed array
-      // elements.
+      // elements. 
       return _getOwnerWithSemanticLabel_native()
     }
 #endif
@@ -992,12 +992,12 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ///     func cacheImagesWithNames(names: [String]) {
   ///         // custom image loading and caching
   ///      }
-  ///
+  /// 
   ///     let namedHues: [String: Int] = ["Vermillion": 18, "Magenta": 302,
   ///             "Gold": 50, "Cerise": 320]
   ///     let colorNames = Array(namedHues.keys)
   ///     cacheImagesWithNames(colorNames)
-  ///
+  /// 
   ///     print(colorNames)
   ///     // Prints "["Gold", "Cerise", "Magenta", "Vermillion"]"
   ///
@@ -1084,15 +1084,15 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   internal static func _adoptStorage(
     _ storage: AnyObject, count: Int
   ) -> (Array, UnsafeMutablePointer<Element>) {
-
+    
     _sanityCheck(
       storage is _ContiguousArrayStorage<Element>, "Invalid array storage type")
-
+    
     let innerBuffer = _ContiguousArrayBuffer<Element>(
       count: count,
       storage: unsafeDowncast(
         storage, to: _ContiguousArrayStorage<Element>.self))
-
+    
     return (
       Array(_Buffer(innerBuffer, shiftedToStartIndex: 0)),
         innerBuffer.firstElementAddress)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?
- Fix print(_:separator =) with print(_:separator:terminator) syntax.
- First, last property of an array returns an optional type. So it needs to unwrap process. 
  Add the optional binding for accessing optional first, last property

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- Add optional binding for using optional first, last property
