### PR TITLE
[SILGen] Recognize swift_newtype-ed CF foreign class types

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -871,6 +871,10 @@ public:
     return getAnyOptionalObjectType(ignored);
   }
 
+  // Return type underlying type of a swift_newtype annotated imported struct;
+  // otherwise, return the null type.
+  Type getSwiftNewtypeUnderlyingType();
+
   /// Return the type T after looking through all of the optional or
   /// implicitly-unwrapped optional types.
   Type lookThroughAllAnyOptionalTypes();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -404,8 +404,20 @@ enum class ConventionsKind : uint8_t {
           if (substTy->getClassOrBoundGenericClass()
               && substTy->getClassOrBoundGenericClass()->isForeign())
             return false;
+          // swift_newtype-ed CF type as foreign class
+          if (auto typedefTy = clangTy->getAs<clang::TypedefType>()) {
+            if (typedefTy->getDecl()->getAttr<clang::SwiftNewtypeAttr>()) {
+              // Make sure that we actually made the struct during import
+              if (auto underlyingType =
+                      substTy->getSwiftNewtypeUnderlyingType()) {
+                if (underlyingType->getClassOrBoundGenericClass() &&
+                    underlyingType->getClassOrBoundGenericClass()->isForeign())
+                  return false;
+              }
+            }
+          }
         }
-        
+
         return true;
       }
       return false;

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -57,10 +57,34 @@ typedef CFStringRef CFNewType __attribute((swift_newtype(struct)));
 // CF audited
 _Pragma("clang arc_cf_code_audited begin")
 extern const CFNewType MyCFNewTypeValue;
-CFNewType FooAudited(void);
+extern CFNewType FooAudited(void);
 _Pragma("clang arc_cf_code_audited end")
 extern const CFNewType MyCFNewTypeValueUnauditedButConst;
 
 // un-audited CFStringRef
 extern CFNewType MyCFNewTypeValueUnaudited;
-CFNewType FooUnaudited(void);
+extern CFNewType FooUnaudited(void);
+
+// Tests to show identical calling convention / binary representation for
+// new_type and non-new_type
+typedef CFStringRef MyABINewType __attribute((swift_newtype(struct)));
+typedef CFStringRef MyABIOldType;
+_Pragma("clang arc_cf_code_audited begin")
+extern const MyABINewType kMyABINewTypeGlobal;
+extern const MyABIOldType kMyABIOldTypeGlobal;
+extern MyABINewType getMyABINewType(void);
+extern MyABIOldType getMyABIOldType(void);
+extern void takeMyABINewType(MyABINewType);
+extern void takeMyABIOldType(MyABIOldType);
+
+extern void takeMyABINewTypeNonNull(__nonnull MyABINewType);
+extern void takeMyABIOldTypeNonNull(__nonnull MyABIOldType);
+_Pragma("clang arc_cf_code_audited end")
+
+typedef NSString *MyABINewTypeNS __attribute((swift_newtype(struct)));
+typedef NSString *MyABIOldTypeNS;
+extern MyABINewTypeNS getMyABINewTypeNS(void);
+extern MyABIOldTypeNS getMyABIOldTypeNS(void);
+extern void takeMyABINewTypeNonNullNS(__nonnull MyABINewTypeNS);
+extern void takeMyABIOldTypeNonNullNS(__nonnull MyABIOldTypeNS);
+

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -67,3 +67,36 @@ public func getUnmanagedCFNewType(useVar: Bool) -> Unmanaged<CFString> {
 // witness table.
 public func hasArrayOfClosedEnums(closed: [ClosedEnum]) {
 }
+
+// CHECK-LABEL: _TF7newtype11compareABIsFT_T_
+public func compareABIs() {
+  let new = getMyABINewType()
+  let old = getMyABIOldType()
+  takeMyABINewType(new)
+  takeMyABIOldType(old)
+
+  takeMyABINewTypeNonNull(new!)
+  takeMyABIOldTypeNonNull(old!)
+
+  let newNS = getMyABINewTypeNS()
+  let oldNS = getMyABIOldTypeNS()
+  takeMyABINewTypeNonNullNS(newNS!)
+  takeMyABIOldTypeNonNullNS(oldNS!)
+
+  // Make sure that the calling conventions align correctly, that is we don't
+  // have double-indirection or anything else like that
+  // CHECK: declare %struct.__CFString* @getMyABINewType() #0
+  // CHECK: declare %struct.__CFString* @getMyABIOldType() #0
+  //
+  // CHECK: declare void @takeMyABINewType(%struct.__CFString*) #0
+  // CHECK: declare void @takeMyABIOldType(%struct.__CFString*) #0
+  //
+  // CHECK: declare void @takeMyABINewTypeNonNull(%struct.__CFString*) #0
+  // CHECK: declare void @takeMyABIOldTypeNonNull(%struct.__CFString*) #0
+  //
+  // CHECK: declare %0* @getMyABINewTypeNS() #0
+  // CHECK: declare %0* @getMyABIOldTypeNS() #0
+  //
+  // CHECK: declare void @takeMyABINewTypeNonNullNS(%0*) #0
+  // CHECK: declare void @takeMyABIOldTypeNonNullNS(%0*) #0
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
Teach isClangTypeMoreIndirectThanSubstType about swift_newtype-ed
typedefs, which may be of CF foreign class type. In these cases, we
should reason about the underlying, wrapped type. Includes
refactoring of common logic and tests.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Teach isClangTypeMoreIndirectThanSubstType about swift_newtype-ed
typedefs, which may be of CF foreign class type. In these cases, we
should reason about the underlying, wrapped type. Includes
refactoring of common logic and tests.
