### PR TITLE
Override checking: believe full-name matches over types.

### DIFF
--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -77,7 +77,7 @@ func func11(_: @autoclosure(escaping) @noescape () -> ()) { } // expected-error{
 
 class Super {
   func f1(_ x: @autoclosure(escaping) () -> ()) { }
-  func f2(_ x: @autoclosure(escaping) () -> ()) { }
+  func f2(_ x: @autoclosure(escaping) () -> ()) { } // expected-note {{potential overridden instance method 'f2' here}}
   func f3(x: @autoclosure () -> ()) { }
 }
 

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -39,7 +39,7 @@ class A {
   var v8: Int = 0  // expected-note {{attempt to override property here}}
   var v9: Int { return 5 } // expected-note{{attempt to override property here}}
 
-  subscript (i: Int) -> String {
+  subscript (i: Int) -> String { // expected-note{{potential overridden subscript 'subscript' here}}
     get {
       return "hello"
     }
@@ -48,7 +48,7 @@ class A {
     }
   }
 
-  subscript (d: Double) -> String { // expected-note{{overridden declaration is here}}
+  subscript (d: Double) -> String { // expected-note{{overridden declaration is here}} expected-note{{potential overridden subscript 'subscript' here}}
     get {
       return "hello"
     }
@@ -57,11 +57,11 @@ class A {
     }
   }
 
-  subscript (i: Int8) -> A {
+  subscript (i: Int8) -> A { // expected-note{{potential overridden subscript 'subscript' here}}
     get { return self }
   }
 
-  subscript (i: Int16) -> A { // expected-note{{attempt to override subscript here}}
+  subscript (i: Int16) -> A { // expected-note{{attempt to override subscript here}} expected-note{{potential overridden subscript 'subscript' here}}
     get { return self }
     set { }
   }

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -124,6 +124,19 @@ class G {
 
   func g1(_: Int, string: String) { } // expected-note{{potential overridden instance method 'g1(_:string:)' here}} {{28-28=string }}
   func g1(_: Int, path: String) { } // expected-note{{potential overridden instance method 'g1(_:path:)' here}} {{28-28=path }}
+
+  func g2(_: Int, string: String) { } // expected-note{{potential overridden instance method 'g2(_:string:)' here}} {{none}}
+  func g2(_: Int, path: String) { }
+
+  func g3(_: Int, _ another: Int) { }
+  func g3(_: Int, path: String) { } // expected-note{{potential overridden instance method 'g3(_:path:)' here}} {{none}}
+
+  func g4(_: Int, _ another: Int) { }
+  func g4(_: Int, path: String) { }
+
+  init(a: Int) {} // expected-note {{potential overridden initializer 'init(a:)' here}} {{none}}
+  init(a: String) {} // expected-note {{potential overridden initializer 'init(a:)' here}} {{17-17=a }} expected-note {{potential overridden initializer 'init(a:)' here}} {{none}}
+  init(b: String) {} // expected-note {{potential overridden initializer 'init(b:)' here}} {{17-17=b }} expected-note {{potential overridden initializer 'init(b:)' here}} {{none}}
 }
 
 class H : G {
@@ -136,7 +149,15 @@ class H : G {
 
   override func f7(_: Int, int value: Int) { } // okay
 
-  override func g1(_: Int, s: String) { } // expected-error{{declaration 'g1(_:s:)' has different argument names from any potential overrides}}
+  override func g1(_: Int, s: String) { } // expected-error{{declaration 'g1(_:s:)' has different argument names from any potential overrides}}{{none}}
+  override func g2(_: Int, string: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
+  override func g3(_: Int, path: Int) { } // expected-error{{method does not override any method from its superclass}} {{none}}
+  override func g4(_: Int, string: Int) { } // expected-error{{argument names for method 'g4(_:string:)' do not match those of overridden method 'g4'}} {{28-28=_ }}
+
+  override init(x: Int) {} // expected-error{{argument names for initializer 'init(x:)' do not match those of overridden initializer 'init(a:)'}} {{17-17=a }}
+  override init(x: String) {} // expected-error{{declaration 'init(x:)' has different argument names from any potential overrides}} {{none}}
+  override init(a: Double) {} // expected-error{{initializer does not override a designated initializer from its superclass}} {{none}}
+  override init(b: Double) {} // expected-error{{initializer does not override a designated initializer from its superclass}} {{none}}
 }
 
 @objc class IUOTestBaseClass {
@@ -221,7 +242,7 @@ class GenericBase<T> {}
 class ConcreteDerived: GenericBase<Int> {}
 
 class OverriddenWithConcreteDerived<T> {
-  func foo() -> GenericBase<T> {}
+  func foo() -> GenericBase<T> {} // expected-note{{potential overridden instance method 'foo()' here}}
 }
 class OverridesWithMismatchedConcreteDerived<T>:
     OverriddenWithConcreteDerived<T> {


### PR DESCRIPTION
This at least emits notes when someone overrides something but gets the types a little wrong (more than just mismatched optionals, as handled in d669d152).

Part of rdar://problem/26183575, which is about QoI for [SE-0069](https://github.com/apple/swift-evolution/blob/master/proposals/0069-swift-mutability-for-foundation.md) related to overrides.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
