### PR TITLE
[SourceKit] Register optional sources in CMake

### DIFF
--- a/tools/SourceKit/lib/Support/CMakeLists.txt
+++ b/tools/SourceKit/lib/Support/CMakeLists.txt
@@ -7,10 +7,11 @@ set(SourceKitSupport_sources
   UIDRegistry.cpp
 )
 
+set(SourceKitSupport_Darwin_sources
+  Concurrency-Mac.cpp)
+set(LLVM_OPTIONAL_SOURCES ${SourceKitSupport_Darwin_sources})
 if(APPLE)
-  list(APPEND SourceKitSupport_sources
-    Concurrency-Mac.cpp
-  )
+  list(APPEND SourceKitSupport_sources ${SourceKitSupport_Darwin_sources})
 endif()
 
 add_sourcekit_library(SourceKitSupport

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -7,10 +7,11 @@ set(sourcekitdAPI_sources
   TokenAnnotationsArray.cpp
 )
 
+set(sourcekitdAPI_Darwin_sources
+  sourcekitdAPI-XPC.cpp)
+set(LLVM_OPTIONAL_SOURCES ${sourcekitdAPI_Darwin_sources})
 if(APPLE)
-  list(APPEND sourcekitdAPI_sources
-    sourcekitdAPI-XPC.cpp
-  )
+  list(APPEND sourcekitdAPI_sources ${sourcekitdAPI_Darwin_sources})
 endif()
 
 add_sourcekit_library(sourcekitdAPI


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

LLVM's CMake modules include a function `llvm_process_sources()`, which (among other things) verifies that all source files in a directory are either included in the list of source files to process, or are included in a list `LLVM_OPTIONAL_SOURCES`.

SourceKit's CMake functions make use of this LLVM function, but do not register any files as "optional". When attempting to configure CMake to include SourceKit on a Linux host machine, source files that are only included on Darwin host machines cause this function to raise an error.

Mark Darwin-only SourceKit files as "optional" to avoid the error.
#### ~~Resolved~~ Related bug number: ([SR-710](https://bugs.swift.org/browse/SR-710))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
