### PR TITLE
StdlibCollectionUnittest: MinimalIterator: allow multiple nil returns

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -22,14 +22,6 @@ from gyb_stdlib_support import (
 
 import StdlibUnittest
 
-/// State that is created every time a fresh generator is created with
-/// `MinimalSequence.makeIterator()`.
-internal class _MinimalIteratorPrivateState<T> {
-  internal init() {}
-
-  internal var returnedNilCounter: Int = 0
-}
-
 /// State shared by all generators of a MinimalSequence.
 internal class _MinimalIteratorSharedState<T> {
   internal init(_ data: [T]) {
@@ -64,26 +56,12 @@ public struct MinimalIterator<T> : IteratorProtocol {
 
   public func next() -> T? {
     if _sharedState.i == _sharedState.data.count {
-      if isConsumed {
-        expectUnreachable("next() was called on a consumed generator")
-      }
-      _privateState.returnedNilCounter += 1
       return nil
     }
     defer { _sharedState.i += 1 }
     return _sharedState.data[_sharedState.i]
   }
 
-  public var isConsumed: Bool {
-    return returnedNilCounter >= 1
-  }
-
-  public var returnedNilCounter: Int {
-    return _privateState.returnedNilCounter
-  }
-
-  internal let _privateState: _MinimalIteratorPrivateState<T> =
-    _MinimalIteratorPrivateState()
   internal let _sharedState: _MinimalIteratorSharedState<T>
 }
 


### PR DESCRIPTION
SE-0052 requires all iterators to return nil indefinitely after all elements have been consumed.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
