### PR TITLE
Configure XCTest for Dispatch if included in Foundation on Linux

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2087,6 +2087,13 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
+                
+                # Staging: require opt-in for building with dispatch
+                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
+                    LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
+                fi
+                
                 if [[ "$(uname -s)" == "Darwin" ]] ; then
                     # xcodebuild requires swift-stdlib-tool to build a Swift
                     # framework. This is normally present when building XCTest
@@ -2101,7 +2108,8 @@ for host in "${ALL_HOSTS[@]}"; do
                 call "${XCTEST_SOURCE_DIR}"/build_script.py \
                     --swiftc="${SWIFTC_BIN}" \
                     --build-dir="${XCTEST_BUILD_DIR}" \
-                    --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation"
+                    --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                    $LIBDISPATCH_BUILD_ARGS
 
                 # XCTest builds itself and doesn't rely on cmake
                 continue


### PR DESCRIPTION
#### What's in this pull request?

When libdispatch is added into the builds on Linux (for use by Foundation), there are subsequent build errors in XCTest as it needs access to build artefacts from libdispatch due to the downward dependency from Foundation. These changes pass the source and build locations through to XCTest if libdispatch is included in the builds.

The XCTest PR that picks up and uses the arguments has been merged already:
https://github.com/apple/swift-corelibs-xctest/pull/107
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

N/A

!-- This selection should only be completed by Swift admin -->
Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
