### PR TITLE
powerpc64{le} test fixes

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -377,10 +377,12 @@ use this pattern::
   // RUN: %target-swift-frontend ... | FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 
   // CHECK: common line
-  // CHECK-i386:   only for i386
-  // CHECK-x86_64: only for x86_64
-  // CHECK-armv7:  only for armv7
-  // CHECK-arm64:  only for arm64
+  // CHECK-i386:        only for i386
+  // CHECK-x86_64:      only for x86_64
+  // CHECK-armv7:       only for armv7
+  // CHECK-arm64:       only for arm64
+  // CHECK-powerpc64:   only for powerpc64
+  // CHECK-powerpc64le: only for powerpc64le
 
 Features for ``REQUIRES`` and ``XFAIL``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/1_stdlib/tgmath.swift
+++ b/test/1_stdlib/tgmath.swift
@@ -7,7 +7,7 @@
   // where they doesn't have CoreGraphics module.
   #if arch(i386) || arch(arm)
     typealias CGFloat = Float
-  #elseif arch(x86_64) || arch(arm64)
+  #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
     typealias CGFloat = Double
   #endif
 #else

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -205,6 +205,38 @@ bb0:
 // CHECK-arm64-LABEL: declare i32 @ints(i32)
 // CHECK-arm64-LABEL: declare i32 @unsigneds(i32)
 
+// CHECK-powerpc64-LABEL: define{{( protected)?}} void @testIntegerExtension
+// CHECK-powerpc64:         call zeroext i8 @chareth(i8 zeroext %0)
+// CHECK-powerpc64:         call zeroext i8 @signedChareth(i8 zeroext %1)
+// CHECK-powerpc64:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
+// CHECK-powerpc64:         call signext i16 @eatMyShorts(i16 signext %3)
+// CHECK-powerpc64:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext %4)
+// CHECK-powerpc64:         call signext i32 @ints(i32 signext %5)
+// CHECK-powerpc64:         call zeroext i32 @unsigneds(i32 zeroext %6)
+// CHECK-powerpc64-LABEL: declare zeroext i8 @chareth(i8 zeroext)
+// CHECK-powerpc64-LABEL: declare zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-powerpc64-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-powerpc64-LABEL: declare signext i16 @eatMyShorts(i16 signext)
+// CHECK-powerpc64-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-powerpc64-LABEL: declare signext i32 @ints(i32 signext)
+// CHECK-powerpc64-LABEL: declare zeroext i32 @unsigneds(i32 zeroext)
+
+// CHECK-powerpc64le-LABEL: define{{( protected)?}} void @testIntegerExtension
+// CHECK-powerpc64le:         call zeroext i8 @chareth(i8 zeroext %0)
+// CHECK-powerpc64le:         call zeroext i8 @signedChareth(i8 zeroext %1)
+// CHECK-powerpc64le:         call zeroext i8 @unsignedChareth(i8 zeroext %2)
+// CHECK-powerpc64le:         call signext i16 @eatMyShorts(i16 signext %3)
+// CHECK-powerpc64le:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext %4)
+// CHECK-powerpc64le:         call signext i32 @ints(i32 signext %5)
+// CHECK-powerpc64le:         call zeroext i32 @unsigneds(i32 zeroext %6)
+// CHECK-powerpc64le-LABEL: declare zeroext i8 @chareth(i8 zeroext)
+// CHECK-powerpc64le-LABEL: declare zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-powerpc64le-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-powerpc64le-LABEL: declare signext i16 @eatMyShorts(i16 signext)
+// CHECK-powerpc64le-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-powerpc64le-LABEL: declare signext i32 @ints(i32 signext)
+// CHECK-powerpc64le-LABEL: declare zeroext i32 @unsigneds(i32 zeroext)
+
 sil @testIntegerExtension : $@convention(thin) (CChar, CSignedChar, CUnsignedChar, CShort, CUnsignedShort, CInt, CUnsignedInt) -> () {
 entry(%a : $CChar, %b : $CSignedChar, %c : $CUnsignedChar, %d : $CShort, %e : $CUnsignedShort, %f : $CInt, %g : $CUnsignedInt):
   %h = function_ref @chareth : $@convention(c) (CChar) -> CChar

--- a/test/IRGen/condfail.sil
+++ b/test/IRGen/condfail.sil
@@ -5,18 +5,22 @@ import Swift
 
 // Make sure we emit two traps.
 
-// CHECK-LABEL:  _test_cond_fail:
-// CHECK:        .cfi_startproc
-// CHECK-x86_64: ud2
-// CHECK-i386:   ud2
-// CHECK-arm64:  brk
-// CHECK-armv7:  trap
-// CHECK-NOT:    .cfi_endproc
-// CHECK-x86_64: ud2
-// CHECK-i386:   ud2
-// CHECK-arm64:  brk
-// CHECK-armv7:  trap
-// CHECK:        .cfi_endproc
+// CHECK-LABEL:       _test_cond_fail:
+// CHECK:             .cfi_startproc
+// CHECK-x86_64:      ud2
+// CHECK-i386:        ud2
+// CHECK-arm64:       brk
+// CHECK-armv7:       trap
+// CHECK-powerpc64:   trap
+// CHECK-powerpc64le: trap
+// CHECK-NOT:         .cfi_endproc
+// CHECK-x86_64:      ud2
+// CHECK-i386:        ud2
+// CHECK-arm64:       brk
+// CHECK-armv7:       trap
+// CHECK-powerpc64:   trap
+// CHECK-powerpc64le: trap
+// CHECK:             .cfi_endproc
 sil hidden @test_cond_fail : $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %2 = integer_literal $Builtin.Int32, 1


### PR DESCRIPTION
#### What's in this pull request?

Fixes all currently failing tests (with `utils/build-script -T -R`) on powerpc64le.  There is a patch to LLVM, which can be found [here](https://llvm.org/bugs/show_bug.cgi?id=26190), required to get good results on powerpc64{le}.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

N/A

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
