### PR TITLE
[Platform] Simplify GLIBC_INCLUDE_PATH detection

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -37,22 +37,19 @@ foreach(sdk ${SWIFT_SDKS})
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
       set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
+      string(REPLACE "/$" "" sysroot "${SWIFT_SDK_${sdk}_PATH}")
 
       # Determine the location of glibc based on the target.
-      if(${sdk} STREQUAL "ANDROID")
-        set(GLIBC_INCLUDE_PATH "${SWIFT_ANDROID_SDK_PATH}/usr/include")
-        set(GLIBC_ARCH_INCLUDE_PATH ${GLIBC_INCLUDE_PATH})
-      else()
-        set(GLIBC_INCLUDE_PATH "/usr/include")
-        set(GLIBC_ARCH_INCLUDE_PATH ${GLIBC_INCLUDE_PATH})
-        if((${sdk} STREQUAL "LINUX" OR ${sdk} STREQUAL "FREEBSD") AND CMAKE_LIBRARY_ARCHITECTURE)
-          # FIXME: Some distributions install headers in
-          #        "/usr/include/x86_64-linux-gnu/sys/...". Here we use the host
-          #        machine's path, regardless of the SDK target we're building for.
-          #        This will break if cross-compiling from a distro that uses the
-          #        architecture as part of the path to a distro that does not.
-          set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
-        endif()
+      # FIXME: We generate glibc.modulemap that includes hardcoded SDK path in it.
+      #        That is, the SDK is not relocatable.
+      set(GLIBC_INCLUDE_PATH "${sysroot}/usr/include")
+      set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_INCLUDE_PATH}")
+      if(("${sdk}" STREQUAL "${SWIFT_HOST_VARIANT_SDK}") AND CMAKE_LIBRARY_ARCHITECTURE)
+        # Some distributions install headers in "/usr/include/x86_64-linux-gnu/sys/...".
+        # FIXME: Here, we handle only the host target's modulemap.
+        #        This will break if cross-compiling target that uses the
+        #        architecture as part of the header path.
+        set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
       endif()
 
       set(glibc_modulemap_source "glibc.modulemap.gyb")


### PR DESCRIPTION
#### What's in this pull request?

Using `SWIFT_SDK_${sdk}_PATH`.

Also, added `FIXME` about that we are generating `glibc.modulemap` with hardcoded SDK path.
Because of this, we cannot distribute Android capable toolchain.
I think, ultimately, we need to generate `glibc.modulemap` in `ClangImporter` based on `-sdk` argument.

CC: @modocache

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
