### PR TITLE
IRGen: address a TODO in the type metadata emission

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1981,11 +1981,16 @@ llvm::Value *IRGenFunction::emitTypeLayoutRef(SILType type) {
 
 void IRGenModule::setTrueConstGlobal(llvm::GlobalVariable *var) {
   switch (TargetInfo.OutputObjectFormat) {
+  case llvm::Triple::UnknownObjectFormat:
+    llvm_unreachable("unknown object format");
   case llvm::Triple::MachO:
-    var->setSection("__TEXT, __const");
+    var->setSection("__TEXT,__const");
     break;
-  // TODO: ELF?
-  default:
+  case llvm::Triple::ELF:
+    var->setSection(".rodata");
+    break;
+  case llvm::Triple::COFF:
+    var->setSection(".rdata");
     break;
   }
 }

--- a/test/IRGen/nominal-type-section.swift
+++ b/test/IRGen/nominal-type-section.swift
@@ -1,0 +1,11 @@
+// RUN: %swift -target x86_64-apple-macosx10.10 -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | FileCheck %s -check-prefix CHECK-MACHO
+// RUN: %swift -target x86_64-unknown-linux-gnu -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | FileCheck %s -check-prefix CHECK-ELF
+// RUN: %swift -target x86_64-unknown-windows-itanium -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | FileCheck %s -check-prefix CHECK-COFF
+
+// CHECK-MACHO: @_TMnV4main1s = constant {{.*}}, section "__TEXT,__const"
+// CHECK-ELF: @_TMnV4main1s = {{.*}}constant {{.*}}, section ".rodata"
+// CHECK-COFF: @_TMnV4main1s = {{.*}}constant {{.*}}, section ".rdata"
+
+public struct s {
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Mark the explicit section for the nominal type metadata being emitted.  This is
constant data (post-relocation).  Map this to __TEXT,__const on MachO,
.data.rel.ro on ELF and .rdata on COFF.  Add the cases for COFF and ELF, and
change the switch to be covered.
