### PR TITLE
stdlib: use the reserved attribute spellings

### DIFF
--- a/stdlib/public/SDK/Dispatch/Dispatch.mm
+++ b/stdlib/public/SDK/Dispatch/Dispatch.mm
@@ -14,23 +14,23 @@
 
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift) __attribute__((visibility("hidden")))
-extern "C" dispatch_queue_attr_t 
+SWIFT_CC(swift)
+__attribute__((__visibility__("hidden"))) extern "C" dispatch_queue_attr_t
 _swift_dispatch_queue_concurrent(void) {
   return DISPATCH_QUEUE_CONCURRENT;
 }
 
-SWIFT_CC(swift) __attribute__((visibility("hidden")))
-extern "C" SWIFT_CC(swift) dispatch_data_t
-_swift_dispatch_data_empty(void) {
+SWIFT_CC(swift)
+__attribute__((__visibility__("hidden"))) extern "C" SWIFT_CC(swift)
+dispatch_data_t _swift_dispatch_data_empty(void) {
   return dispatch_data_empty;
 }
 
-#define SOURCE(t)                                         \
-  SWIFT_CC(swift) __attribute__((visibility("hidden")))   \
-  extern "C" dispatch_source_type_t                       \
-  _swift_dispatch_source_type_##t(void) {                 \
-    return DISPATCH_SOURCE_TYPE_##t;                      \
+#define SOURCE(t)                                                              \
+  SWIFT_CC(swift)                                                              \
+  __attribute__((__visibility__("hidden"))) extern "C" dispatch_source_type_t  \
+  _swift_dispatch_source_type_##t(void) {                                      \
+    return DISPATCH_SOURCE_TYPE_##t;                                           \
   }
 
 SOURCE(DATA_ADD)

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -48,11 +48,10 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
                                            __swift_size_t nitems);
 
 // String handling <string.h>
-__attribute__((pure))
-SWIFT_RUNTIME_STDLIB_INTERFACE
-__swift_size_t _swift_stdlib_strlen(const char *s);
+__attribute__((__pure__)) SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
+_swift_stdlib_strlen(const char *s);
 
-__attribute__((pure))
+__attribute__((__pure__))
 SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_memcmp(const void *s1, const void *s2, __swift_size_t n);
 
@@ -66,9 +65,8 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 int _swift_stdlib_close(int fd);
 
 // Non-standard extensions
-__attribute__((const))
-SWIFT_RUNTIME_STDLIB_INTERFACE
-__swift_size_t _swift_stdlib_malloc_size(const void *ptr);
+__attribute__((__const__)) SWIFT_RUNTIME_STDLIB_INTERFACE __swift_size_t
+_swift_stdlib_malloc_size(const void *ptr);
 
 // Random number <random>
 SWIFT_RUNTIME_STDLIB_INTERFACE

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -20,11 +20,11 @@
 #include "SwiftStdint.h"
 
 typedef struct {
-  __swift_uint32_t refCount __attribute__((unavailable));
+  __swift_uint32_t refCount __attribute__((__unavailable__));
 } StrongRefCount;
 
 typedef struct {
-  __swift_uint32_t weakRefCount __attribute__((unavailable));
+  __swift_uint32_t weakRefCount __attribute__((__unavailable__));
 } WeakRefCount;
 
 // not __cplusplus

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -58,32 +58,33 @@ extern const __swift_uint16_t *
 _swift_stdlib_ExtendedGraphemeClusterNoBoundaryRulesMatrix;
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((pure))
-__swift_int32_t _swift_stdlib_unicode_compare_utf16_utf16(
-  const __swift_uint16_t *Left, __swift_int32_t LeftLength,
-  const __swift_uint16_t *Right, __swift_int32_t RightLength);
+__attribute__((__pure__)) __swift_int32_t
+_swift_stdlib_unicode_compare_utf16_utf16(const __swift_uint16_t *Left,
+                                          __swift_int32_t LeftLength,
+                                          const __swift_uint16_t *Right,
+                                          __swift_int32_t RightLength);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((pure))
-__swift_int32_t _swift_stdlib_unicode_compare_utf8_utf16(
-  const char *Left, __swift_int32_t LeftLength,
-  const __swift_uint16_t *Right, __swift_int32_t RightLength);
+__attribute__((__pure__)) __swift_int32_t
+_swift_stdlib_unicode_compare_utf8_utf16(const char *Left,
+                                         __swift_int32_t LeftLength,
+                                         const __swift_uint16_t *Right,
+                                         __swift_int32_t RightLength);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((pure))
-__swift_int32_t _swift_stdlib_unicode_compare_utf8_utf8(
-  const char *Left, __swift_int32_t LeftLength,
-  const char *Right, __swift_int32_t RightLength);
+__attribute__((__pure__)) __swift_int32_t
+_swift_stdlib_unicode_compare_utf8_utf8(const char *Left,
+                                        __swift_int32_t LeftLength,
+                                        const char *Right,
+                                        __swift_int32_t RightLength);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((pure))
-__swift_intptr_t _swift_stdlib_unicode_hash(
-  const __swift_uint16_t *Str, __swift_int32_t Length);
+__attribute__((__pure__)) __swift_intptr_t
+_swift_stdlib_unicode_hash(const __swift_uint16_t *Str, __swift_int32_t Length);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
-__attribute__((pure))
-__swift_intptr_t _swift_stdlib_unicode_hash_ascii(
-  const char *Str, __swift_int32_t Length);
+__attribute__((__pure__)) __swift_intptr_t
+_swift_stdlib_unicode_hash_ascii(const char *Str, __swift_int32_t Length);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_int32_t _swift_stdlib_unicode_strToUpper(

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -38,13 +38,13 @@
 
 /// Attribute used to export symbols from the runtime.
 #if __MACH__
-# define SWIFT_RUNTIME_EXPORT __attribute__((visibility("default")))
+# define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("default")))
 #elif __ELF__
 // Use protected visibility for ELF, since we don't want Swift symbols to be
 // interposable. The relative relocations we form to metadata aren't
 // valid in ELF shared objects, and leaving them relocatable at load time
 // defeats the purpose of the relative references.
-# define SWIFT_RUNTIME_EXPORT __attribute__((visibility("protected")))
+# define SWIFT_RUNTIME_EXPORT __attribute__((__visibility__("protected")))
 #elif __CYGWIN__
 # define SWIFT_RUNTIME_EXPORT 
 #else

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -181,7 +181,7 @@ SWIFT_RUNTIME_EXPORT
 extern "C" void swift_willThrow(SwiftError *object);
 SWIFT_RUNTIME_EXPORT
 extern "C" void swift_unexpectedError(SwiftError *object)
-  __attribute__((noreturn));
+    __attribute__((__noreturn__));
 
 #if SWIFT_OBJC_INTEROP
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -160,8 +160,8 @@ reportBacktrace(int *count)
 extern "C" {
 CRASH_REPORTER_CLIENT_HIDDEN
 struct crashreporter_annotations_t gCRAnnotations
-    __attribute__((section("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
-        CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0};
+__attribute__((__section__("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
+    CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0};
 }
 
 // Report a message to any forthcoming crash log.

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -277,11 +277,9 @@ OpaqueValue *swift::swift_projectBox(HeapObject *o) {
 }
 
 // Forward-declare this, but define it after swift_release.
-extern "C" LLVM_LIBRARY_VISIBILITY
-void _swift_release_dealloc(HeapObject *object)
-  SWIFT_CC(RegisterPreservingCC_IMPL)
-  __attribute__((noinline,used));
-
+extern "C" LLVM_LIBRARY_VISIBILITY void
+_swift_release_dealloc(HeapObject *object) SWIFT_CC(RegisterPreservingCC_IMPL)
+    __attribute__((__noinline__, __used__));
 
 SWIFT_RT_ENTRY_VISIBILITY
 extern "C"

--- a/stdlib/public/runtime/Leaks.h
+++ b/stdlib/public/runtime/Leaks.h
@@ -29,16 +29,16 @@ struct HeapObject;
 
 SWIFT_RUNTIME_EXPORT
 extern "C" void swift_leaks_startTrackingObjects(const char *)
-    __attribute__((noinline, used));
+    __attribute__((__noinline__, __used__));
 SWIFT_RUNTIME_EXPORT
 extern "C" int swift_leaks_stopTrackingObjects(const char *)
-    __attribute__((noinline, used));
+    __attribute__((__noinline__, __used__));
 SWIFT_RUNTIME_EXPORT
 extern "C" void swift_leaks_startTrackingObject(swift::HeapObject *)
-    __attribute__((noinline, used));
+    __attribute__((__noinline__, __used__));
 SWIFT_RUNTIME_EXPORT
 extern "C" void swift_leaks_stopTrackingObject(swift::HeapObject *)
-    __attribute__((noinline, used));
+    __attribute__((__noinline__, __used__));
 
 #define SWIFT_LEAKS_START_TRACKING_OBJECT(obj)                                 \
   swift_leaks_startTrackingObject(obj)

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -47,7 +47,7 @@
 using namespace swift;
 
 #if SWIFT_HAS_ISA_MASKING
-OBJC_EXPORT __attribute__((weak_import))
+OBJC_EXPORT __attribute__((__weak_import__))
 const uintptr_t objc_debug_isa_class_mask;
 
 static uintptr_t computeISAMask() {
@@ -75,9 +75,9 @@ const ClassMetadata *swift::_swift_getClass(const void *object) {
 
 #if SWIFT_OBJC_INTEROP
 struct SwiftObject_s {
-  void *isa  __attribute__((unavailable));
-  uint32_t strongRefCount  __attribute__((unavailable));
-  uint32_t weakRefCount  __attribute__((unavailable));
+  void *isa __attribute__((__unavailable__));
+  uint32_t strongRefCount __attribute__((__unavailable__));
+  uint32_t weakRefCount __attribute__((__unavailable__));
 };
 
 static_assert(sizeof(SwiftObject_s) == sizeof(HeapObject),
@@ -88,10 +88,9 @@ static_assert(std::is_trivially_destructible<SwiftObject_s>::value,
               "SwiftObject must be trivially destructible");
 
 #if __has_attribute(objc_root_class)
-__attribute__((objc_root_class))
+__attribute__((__objc_root_class__))
 #endif
-SWIFT_RUNTIME_EXPORT
-@interface SwiftObject<NSObject> {
+SWIFT_RUNTIME_EXPORT @interface SwiftObject<NSObject> {
   SwiftObject_s header;
 }
 

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -285,7 +285,7 @@ extern "C" long double _swift_fmodl(long double lhs, long double rhs) {
     (defined(__linux__) && defined(__powerpc64__)) || \
     (defined(__ANDROID__) && defined(__arm64__))
 
-typedef int      ti_int __attribute__ ((mode (TI)));
+typedef int ti_int __attribute__((__mode__(TI)));
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 ti_int
@@ -335,7 +335,7 @@ __muloti4(ti_int a, ti_int b, int* overflow)
 // some other lower-level architecture issue that I'm
 // missing.  Perhaps relevant bug report:
 // FIXME: https://llvm.org/bugs/show_bug.cgi?id=14469
-typedef int      di_int __attribute__ ((mode (DI)));
+typedef int di_int __attribute__((__mode__(DI)));
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C"
 di_int


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This is a purely mechanical change replacing the attributes with the reserved
spelling.  Compilers are to not error when they encounter a reserved spelling
for an attribute which they do not support.
