### PR TITLE
CGFloat: add CGFloat.init(CGFloat), which makes CGFloat similar to Float and Double

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -46,6 +46,11 @@ public struct CGFloat {
     self.native = NativeType(value)
   }
 
+  @_transparent
+  public init(_ value: CGFloat) {
+    self = value
+  }
+
   /// The native value.
   public var native: NativeType
 }

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift
@@ -15,9 +15,6 @@
 // MARK: Exposing SCNFloat
 
 #if os(OSX)
-private extension CGFloat {
-   init(_ x: CGFloat) { self = x }
-}
 public typealias SCNFloat = CGFloat
 #elseif os(iOS) || os(tvOS)
 public typealias SCNFloat = Float

--- a/test/Interpreter/SDK/CoreGraphics_CGFloat.swift
+++ b/test/Interpreter/SDK/CoreGraphics_CGFloat.swift
@@ -21,6 +21,7 @@ CGFloatTestSuite.test("init") {
   expectEqual(0.0, CGFloat())
   expectEqual(4.125, CGFloat(Float(4.125)))
   expectEqual(4.125, CGFloat(Double(4.125)))
+  expectEqual(4.125, CGFloat(CGFloat(Double(4.125))))
 
   expectEqual(42, CGFloat(Int(42)))
   expectEqual(42, CGFloat(Int8(42)))


### PR DESCRIPTION
This is an API bugfix, this API was accidentally omitted when we added CGFloat to the overlay, so no evolution proposal is necessary.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
