### PR TITLE
Revert "Temporarily comment out some runtime tests due to linker failure."

### DIFF
--- a/test/1_stdlib/RuntimeObjC.swift
+++ b/test/1_stdlib/RuntimeObjC.swift
@@ -682,10 +682,6 @@ RuntimeFoundationWrappers.test("_stdlib_NSStringUppercaseString/NoLeak") {
   expectEqual(0, nsStringCanaryCount)
 }
 
-// FIXME: Temporarily commented out due to linker failure in finding
-// __swift_stdlib_CFStringCreateCopy, __swift_stdlib_CFStringGetCharactersPtr,
-// and  __swift_stdlib_CFStringGetLength during optimized builds. 
-/*
 RuntimeFoundationWrappers.test("_stdlib_CFStringCreateCopy/NoLeak") {
   nsStringCanaryCount = 0
   autoreleasepool {
@@ -715,7 +711,6 @@ RuntimeFoundationWrappers.test("_stdlib_CFStringGetCharactersPtr/NoLeak") {
   }
   expectEqual(0, nsStringCanaryCount)
 }
-*/
 
 RuntimeFoundationWrappers.test("bridgedNSArray") {
   var c = [NSObject]()


### PR DESCRIPTION
This reverts commit ada23b18bde998aad4aa9c1ec1aa040014f5b864.

I can't reproduce the failure locally.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
