### PR TITLE
Added '-Blinker' frontend driver option for cross-linker search path

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -268,6 +268,10 @@ def use_ld : Joined<["-"], "use-ld=">,
   Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Specifies the linker to be used">;
 
+def ld_path : Separate<["-"], "Blinker">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Specifies where to look for the linker">;
+
 def Xlinker : Separate<["-"], "Xlinker">,
   Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Specifies an option which should be passed to the linker">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1281,6 +1281,12 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   if (!Linker.empty()) {
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
   }
+  
+  // Add the linker search path
+  if (const Arg *A = context.Args.getLastArg(options::OPT_ld_path)) {
+    Arguments.push_back("-B");
+    Arguments.push_back(context.Args.MakeArgString(A->getValue()));
+  }
 
   std::string Target = getTargetForLinker();
   if (!Target.empty()) {


### PR DESCRIPTION
#### What's in this pull request?

Added a -Blinker fronted driver option. This works like clang/gcc's "-B" flag (which allows specifying an alternate toolchain location).

Currently, you can cross-compile with swift (assuming you've got a copy of the standard library compiled for the target), like so:
`swiftc -target armv7-unknown-linux-gnueabihf -sdk ${sysroot} -resource-dir ${sdk-location} main.swift`

However, this only works for modules (swiftmodules), not for executables. The host swift generates a link command to clang++ with `-fuse-ld=gold`, as it should, but there is currently no way to tell it where to find the gold cross-linker. Normally, you would put this information behind the '-B' switch, so we provide the same kind of functionality here.

Adding `-Blinker ${gcc-toolchain-path}` to the above command allows swift to cross-compile executables.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
