### PR TITLE
When producing backtraces, do not use backtrace_symbol, invoke dladdr…

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,2 +1,2 @@
 [flake8]
-filename = *.py,80+-check,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,gyb,line-directive,mock-distcc,ns-html2rst,recursive-lipo,rth,split-generated-tests,submit-benchmark-results,update-checkout,viewcfg
+filename = *.py,80+-check,Benchmark_Driver,Benchmark_DTrace.in,Benchmark_GuardMalloc.in,Benchmark_RuntimeLeaksRunner.in,build-script,gyb,line-directive,mock-distcc,ns-html2rst,recursive-lipo,rth,split-generated-tests,submit-benchmark-results,update-checkout,viewcfg,backtrace-check

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -24,11 +24,19 @@
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Mutex.h"
 #include "swift/Basic/Demangle.h"
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+
 #include <cxxabi.h>
+
 #if !defined(__CYGWIN__) && !defined(__ANDROID__)
+
 // execinfo.h is not available on Android. Checks in this file ensure that
 // fatalError behaves as expected, but without stack traces.
 #include <execinfo.h>
+// We are only using dlfcn.h in code that is invoked on non cygwin/android
+// platforms. So I am putting it here.
+#include <dlfcn.h>
 #endif
 
 #ifdef __APPLE__
@@ -41,112 +49,88 @@ enum: uint32_t {
 };
 } // end namespace FatalErrorFlags
 
+using namespace swift;
+
 #if !defined(__CYGWIN__) && !defined(__ANDROID__)
-LLVM_ATTRIBUTE_ALWAYS_INLINE
-static bool
-isIdentifier(char c)
-{
-  return isalnum(c) || c == '_' || c == '$';
-}
 
-static bool
-demangledLinePrefix(std::string line, std::string prefix,
-                    std::string &out,
-                    bool (*demangle)(std::string, std::string &))
-{
-  int symbolStart = -1;
-  int symbolEnd = -1;
-  
-  for (size_t i = 0; i < line.size(); i++) {
-    char c = line[i];
-    
-    bool hasBegun = symbolStart != -1;
-    bool isIdentifierChar = isIdentifier(c);
-    bool isEndOfSymbol = hasBegun && !isIdentifierChar;
-    bool isEndOfLine = i == line.size() - 1;
-    
-    if (isEndOfLine || isEndOfSymbol) {
-      symbolEnd = i;
-      break;
-    }
+static bool getSymbolNameAddr(llvm::StringRef libraryName, Dl_info dlinfo,
+                              std::string &symbolName, uintptr_t &addrOut) {
 
-    bool canFindPrefix = (line.size() - 2) - i > prefix.size();
-    if (!hasBegun && canFindPrefix && !isIdentifierChar &&
-        line.substr(i + 1, prefix.size()) == prefix) {
-      symbolStart = i + 1;
-      continue;
-    }
-  }
-  
-  if (symbolStart == -1 || symbolEnd == -1) {
-    out = line;
+  // If we failed to find a symbol and thus dlinfo->dli_sname is nullptr, we
+  // need to use the hex address.
+  bool hasUnavailableAddress = dlinfo.dli_sname == nullptr;
+
+  // If the address is unavailable, just use <unavailable> as the symbol
+  // name. We do not set addrOut, since addrOut will be set to our ptr address.
+  if (hasUnavailableAddress) {
+    symbolName += "<unavailable>";
     return false;
-  } else {
-    auto symbol = line.substr(symbolStart, symbolEnd - symbolStart);
-    
-    std::string demangled;
-    bool success = demangle(symbol, demangled);
-    
-    if (success) {
-      line.replace(symbolStart, symbolEnd - symbolStart, demangled);
-    }
-    
-    out = line;
-    
-    return success;
   }
-}
 
-static std::string
-demangledLine(std::string line) {
-  std::string res;
-  bool success = false;
-  auto cppPrefix = "_Z"; // not sure how to check for DARWIN's __Z here.
-  success = demangledLinePrefix(line, cppPrefix, res,
-                                [](std::string symbol, std::string &out) {
-    int status;
-    auto demangled = abi::__cxa_demangle(symbol.c_str(), 0, 0, &status);
-    if (demangled == NULL || status != 0) {
-      out = symbol;
-      return false;
-    } else {
-      out = demangled;
-      free(demangled);
-      return true;
-    }
-  });
-  if (success) return res;
-  success = demangledLinePrefix(line, "_T", res,
-                                [](std::string symbol, std::string &out) {
-    out = swift::Demangle::demangleSymbolAsString(symbol);
+  // Ok, now we know that we have some sort of "real" name. Set the outAddr.
+  addrOut = uintptr_t(dlinfo.dli_saddr);
+
+  // First lets try to demangle using cxxabi. If this fails, we will try to
+  // demangle with swift. We are taking advantage of __cxa_demangle actually
+  // providing failure status instead of just returning the original string like
+  // swift demangle.
+  int status;
+  char *demangled = abi::__cxa_demangle(dlinfo.dli_sname, 0, 0, &status);
+  if (status == 0) {
+    assert(demangled != nullptr && "If __cxa_demangle succeeds, demangled "
+                                   "should never be nullptr");
+    symbolName += demangled;
+    free(demangled);
     return true;
-  });
-  if (success) return res;
-  return line;
+  }
+  assert(demangled == nullptr && "If __cxa_demangle fails, demangled should "
+                                 "be a nullptr");
+
+  // Otherwise, try to demangle with swift. If swift fails to demangle, it will
+  // just pass through the original output.
+  symbolName = demangleSymbolAsString(
+      dlinfo.dli_sname, strlen(dlinfo.dli_sname),
+      Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+  return true;
 }
 
-const int STACK_DEPTH = 128;
+/// This function dumps one line of a stack trace. It is assumed that \p address
+/// is the address of the stack frame at index \p index.
+static void dumpStackTraceEntry(unsigned index, void *framePC) {
+  Dl_info dlinfo;
 
-static char **
-reportBacktrace(int *count)
-{
-  void **addrs = (void **)malloc(sizeof(void *) * STACK_DEPTH);
-  if (addrs == NULL) {
-    if (count) *count = 0;
-    return NULL;
-  }
-  int symbolCount = backtrace(addrs, STACK_DEPTH);
-  if (count) *count = symbolCount;
-
-  char **symbols = backtrace_symbols(addrs, symbolCount);
-  free(addrs);
-  if (symbols == NULL) {
-    if (count) *count = 0;
-    return NULL;
+  // 0 is failure for dladdr. We do not use nullptr since it is an int
+  // argument. This violates normal unix patterns. See man page for dladdr on OS
+  // X.
+  if (0 == dladdr(framePC, &dlinfo)) {
+    return;
   }
 
-  return symbols;
+  // According to the man page of dladdr, if dladdr returns non-zero, then we
+  // know that it must have fname, fbase set. Thus, we find the library name
+  // here.
+  StringRef libraryName = StringRef(dlinfo.dli_fname).rsplit('/').second;
+
+  // Next we get the symbol name that we are going to use in our backtrace.
+  std::string symbolName;
+  // We initialize symbolAddr to framePC so that if we succeed in finding the
+  // symbol, we get the offset in the function and if we fail to find the symbol
+  // we just get HexAddr + 0.
+  uintptr_t symbolAddr = uintptr_t(framePC);
+  bool foundSymbol =
+      getSymbolNameAddr(libraryName, dlinfo, symbolName, symbolAddr);
+
+  // We do not use %p here for our pointers since the format is implementation
+  // defined. This makes it logically impossible to check the output. Forcing
+  // hexadecimal solves this issue.
+  static const char *backtraceEntryFormat = "%-4u %-34s 0x%0.16lx %s + %td\n";
+
+  // Then dump the backtrace.
+  fprintf(stderr, backtraceEntryFormat, index, libraryName.data(),
+          foundSymbol ? symbolAddr : uintptr_t(framePC), symbolName.c_str(),
+          ptrdiff_t(uintptr_t(framePC) - symbolAddr));
 }
+
 #endif
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
@@ -200,7 +184,6 @@ reportOnCrash(uint32_t flags, const char *message)
 
 #endif
 
-
 // Report a message to system console and stderr.
 static void
 reportNow(uint32_t flags, const char *message)
@@ -212,12 +195,13 @@ reportNow(uint32_t flags, const char *message)
 #if !defined(__CYGWIN__) && !defined(__ANDROID__)
   if (flags & FatalErrorFlags::ReportBacktrace) {
     fputs("Current stack trace:\n", stderr);
-    int count = 0;
-    char **trace = reportBacktrace(&count);
-    for (int i = 0; i < count; i++) {
-      fprintf(stderr, "%s\n", demangledLine(trace[i]).c_str());
+    constexpr unsigned maxSupportedStackDepth = 128;
+    void *addrs[maxSupportedStackDepth];
+
+    int symbolCount = backtrace(addrs, maxSupportedStackDepth);
+    for (int i = 0; i < symbolCount; ++i) {
+      dumpStackTraceEntry(i, addrs[i]);
     }
-    free(trace);
   }
 #endif
 }

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: not --crash %t/a.out 2>&1 | %S/../../utils/backtrace-check
+
+// This is not supported on watchos, ios, or tvos
+// UNSUPPORTED: OS=watchos
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=tvos
+
+// REQUIRES: executable_test
+
+func main() {
+  let x = UnsafePointer<Int>(bitPattern: 0)!
+  print("\(x.pointee)")
+}
+
+main()

--- a/utils/backtrace-check
+++ b/utils/backtrace-check
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# This script uses a regex to validate the output of our backtraces.
+# The layout we assume is:
+#
+# <frame number> <library name> <address> <demangled name> + <offset>
+#
+# It currently just checks that the backtrace results in at least one correctly
+# formatted entry. It does not directly validate the input since the output
+# would not be robust against standard library changes.
+#
+# TODO: We could have the user pass in the frame number, library name, and
+# demangled name. These we can always validate as true in a robust way. On the
+# other hand, address and offset are more difficult to validate in a robust way
+# in the face of small codegen differences, so without any further thought I
+# imagine we can just check the format.
+#
+# 11 libswiftCore.dylib 0x000000000dce84d0l _fatalErrorMessage(StaticString,
+# StaticString, StaticString, UInt, flags : UInt32) -> () + 444
+
+import sys
+import os
+import re
+
+TARGET_RE = re.compile(
+    "(?P<index>\d+) +(?P<object>\S+) +(?P<address>0x[0-9a-fA-F]{16}) "
+    "(?P<routine>[^+]+) [+] (?P<offset>\d+)")
+
+lines = sys.stdin.readlines()
+
+found_stack_trace_start = False
+found_stack_trace_entry = False
+for l in lines:
+    l = l.rstrip("\n")
+
+    # First see if we found the start of our stack trace start. If so, set the
+    # found  stack trace flag and continue.
+    if l == "Current stack trace:":
+        assert(not found_stack_trace_start)
+        found_stack_trace_start = True
+        continue
+
+    # Otherwise, if we have not yet found the stack trace start, continue. We
+    # need to find the stack trace start line.
+    if not found_stack_trace_start:
+        continue
+
+    # Ok, we are in the middle of matching a stack trace entry.
+    m = TARGET_RE.match(l)
+    # If we fail to match, we have exited the stack trace entry region
+    if m is None:
+        break
+    # At this point, we know that we have some sort of match.
+    found_stack_trace_entry = True
+    print("Stack Trace Entry:")
+    print("\tIndex: '%(index)s'\n\tObject File: '%(object)s'\n\tAddress: "
+          "'%(address)s'\n\tRoutine: '%(routine)s'\n\tOffset: '%(offset)s'"
+          "\n" % m.groupdict())
+
+# Once we have processed all of the lines, make sure that we found at least one
+# stack trace entry.
+assert(found_stack_trace_entry)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When producing backtraces, do not use backtrace_symbol, invoke dladdr directly.

Previously, we were using backtrace_symbol and then parsing/modifying its
output. By just using dladdr directly, we have a cleaner and more robust
solution.

rdar://25064742

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
