### PR TITLE
Generate native glibc.modulemap when cross-compiling

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -180,7 +180,8 @@ function(_add_variant_swift_compile_flags
 
   list(APPEND result
       "-sdk" "${SWIFT_SDK_${sdk}_PATH}"
-      "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}")
+      "-target" "${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}"
+      "-resource-dir" "${SWIFTLIB_DIR}")
 
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     list(APPEND result

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -37,29 +37,26 @@ foreach(sdk ${SWIFT_SDKS})
     foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
       set(arch_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}")
       set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
-
-      # Determine the location of glibc based on the target.
-      if(${sdk} STREQUAL "ANDROID")
-        set(GLIBC_INCLUDE_PATH "${SWIFT_ANDROID_SDK_PATH}/usr/include")
-        set(GLIBC_ARCH_INCLUDE_PATH ${GLIBC_INCLUDE_PATH})
-      else()
-        set(GLIBC_INCLUDE_PATH "/usr/include")
-        set(GLIBC_ARCH_INCLUDE_PATH ${GLIBC_INCLUDE_PATH})
-        if((${sdk} STREQUAL "LINUX" OR ${sdk} STREQUAL "FREEBSD") AND CMAKE_LIBRARY_ARCHITECTURE)
-          # FIXME: Some distributions install headers in
-          #        "/usr/include/x86_64-linux-gnu/sys/...". Here we use the host
-          #        machine's path, regardless of the SDK target we're building for.
-          #        This will break if cross-compiling from a distro that uses the
-          #        architecture as part of the path to a distro that does not.
-          set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
-        endif()
+      
+      # Determine the location of glibc headers based on the target.
+      set(GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH "/usr/include")
+      set(GLIBC_SYSROOT_REALTIVE_ARCH_INCLUDE_PATH ${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH})
+      
+      # Some SDKs place their headers in architecture-specific subfolders.
+      if((${sdk} STREQUAL "LINUX" OR ${sdk} STREQUAL "FREEBSD") AND CMAKE_LIBRARY_ARCHITECTURE)
+        set(GLIBC_SYSROOT_REALTIVE_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_REALTIVE_ARCH_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
       endif()
+
+      set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_PATH}/${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
+      set(GLIBC_ARCH_INCLUDE_PATH "${SWIFT_SDK_${sdk}_PATH}/${GLIBC_SYSROOT_REALTIVE_ARCH_INCLUDE_PATH}")
 
       set(glibc_modulemap_source "glibc.modulemap.gyb")
       set(glibc_modulemap_out "${module_dir}/glibc.modulemap")
 
       # Configure the module map based on the target. Each platform needs to
       # reference different headers, based on what's available in their glibc.
+      # This is the 'glibc.modulemap' in the 'resource-dir', so 
+      # it's the one we'll look at during the build process.
       handle_gyb_source_single(glibc_modulemap_target
           SOURCE "${glibc_modulemap_source}"
           OUTPUT "${glibc_modulemap_out}"
@@ -68,11 +65,34 @@ foreach(sdk ${SWIFT_SDKS})
               "-DGLIBC_INCLUDE_PATH=${GLIBC_INCLUDE_PATH}"
               "-DGLIBC_ARCH_INCLUDE_PATH=${GLIBC_ARCH_INCLUDE_PATH}")
 
+      list(APPEND glibc_modulemap_target_list ${glibc_modulemap_target})
+
+      # If this SDK is a target for a non-native host, create a native modulemap 
+      # without a sysroot prefix. This is the one we'll install instead.
+      if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_PATH}" STREQUAL "/")
+
+        set(glibc_sysroot_relative_modulemap_out "${module_dir}/sysroot-relative-modulemaps/glibc.modulemap")
+        handle_gyb_source_single(glibc_modulemap_native_target
+            SOURCE "${glibc_modulemap_source}"
+            OUTPUT "${glibc_sysroot_relative_modulemap_out}"
+            FLAGS
+                "-DCMAKE_SDK=${sdk}"
+                "-DGLIBC_INCLUDE_PATH=${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}"
+                "-DGLIBC_ARCH_INCLUDE_PATH=${GLIBC_SYSROOT_REALTIVE_ARCH_INCLUDE_PATH}")
+
+        list(APPEND glibc_modulemap_target_list ${glibc_modulemap_native_target})
+        set(glibc_modulemap_out ${glibc_sysroot_relative_modulemap_out})
+      endif()
+
+      # FIXME: When SDK is a cross-compile target (SDK != Host), the generated
+      #        modulemap will be relative to the Host, with hardcoded paths.
+      #        It is not relocatable to the target platform itself.
+      #        This only affects ANDROID right now, but could affect cross-compiled LINUX targets
+        
       swift_install_in_component(sdk-overlay
           FILES "${glibc_modulemap_out}"
           DESTINATION "lib/swift/${arch_subdir}")
 
-      list(APPEND glibc_modulemap_target_list ${glibc_modulemap_target})
     endforeach()
   endif()
 endforeach()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When cross-compiling, we have to use generate a glibc.modulemap for use at build-time whose headers are in some sysroot folder on our local drives. This generated file obviously won't work once installed.

With this PR, we generate the glibc.modulemap needed for building while at the same time generating a non-prefixed version in `/native-substitutes/glibc.modulemap`. The non-prefixed one is the one which is added to the install list.

I think this issue is also a pain on Android. If somebody could test it, we could add an `or SDK == ANDROID` condition to generate the native modulemap.

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
