### PR TITLE
SILGen: Partial applications of methods don't lie about their nonnull-ness.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2381,14 +2381,19 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M, Expr *expr) {
     // or having a C-derived convention.
     ValueDecl *method = nullptr;
     if (auto selfApply = dyn_cast<ApplyExpr>(apply->getFn())) {
-      if (auto methodRef = dyn_cast<DeclRefExpr>(selfApply->getFn()))
+      if (auto methodRef = dyn_cast<DeclRefExpr>(selfApply->getFn())) {
         method = methodRef->getDecl();
+      }
     } else if (auto force = dyn_cast<ForceValueExpr>(apply->getFn())) {
       method = getFuncDeclFromDynamicMemberLookup(force->getSubExpr());
     } else if (auto bind = dyn_cast<BindOptionalExpr>(apply->getFn())) {
       method = getFuncDeclFromDynamicMemberLookup(bind->getSubExpr());
     } else if (auto fnRef = dyn_cast<DeclRefExpr>(apply->getFn())) {
-      method = fnRef->getDecl();
+      // Only consider a full application of a method. Partial applications
+      // never lie.
+      if (auto func = dyn_cast<AbstractFunctionDecl>(fnRef->getDecl()))
+        if (func->getParameterLists().size() == 1)
+          method = fnRef->getDecl();
     }
     if (method && mayLieAboutNonOptionalReturn(M, method))
       return true;

--- a/test/SILGen/lying_about_optional_return_objc.swift
+++ b/test/SILGen/lying_about_optional_return_objc.swift
@@ -37,6 +37,23 @@ func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {
   // CHECK: unchecked_ref_cast
   _ = b?[b!]
 
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.voidReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.voidPointerReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.opaquePointerReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.pointerReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.constPointerReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.idReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.selectorReturning
+  // CHECK: enum $Optional<{{.*}} -> {{.*}}>
+  _ = b?.objectReturning
+
   let dynamic: AnyObject? = b!
 
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
@@ -60,6 +77,23 @@ func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {
   // CHECK: unchecked_trivial_bit_cast
   _ = dynamic?.selector
 
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.voidReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.voidPointerReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.opaquePointerReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.pointerReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.constPointerReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.idReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.selectorReturning
+  // CHECK: unchecked_bitwise_cast {{%.*}} : $ImplicitlyUnwrappedOptional<{{.*}} -> {{.*}}> to $Optional<{{.*}} -> {{.*}}>
+  _ = dynamic?.objectReturning
+
   // CHECK: enum $Optional<()>, #Optional.some!enumelt.1, {{%.*}} : $()
   _ = dynamic?.voidReturning?()
   // CHECK: unchecked_trivial_bit_cast
@@ -77,4 +111,6 @@ func optionalChainingForeignFunctionTypeProperties(b: BlockProperty?) {
   // CHECK: unchecked_ref_cast
   _ = dynamic?.idReturning?()
   _ = dynamic?.objectReturning?()
+
+
 }


### PR DESCRIPTION
Fixes rdar://problem/26210805.
