### PR TITLE
IRGen: mark the end point at unreachable

### DIFF
--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -68,14 +68,16 @@ static CanType getNamedSwiftType(Module *stdlib, StringRef name) {
   return CanType();
 }
 
-static clang::CanQualType getClangBuiltinTypeFromKind(
-  const clang::ASTContext &context,
-  clang::BuiltinType::Kind kind) {
+static clang::CanQualType
+getClangBuiltinTypeFromKind(const clang::ASTContext &context,
+                            clang::BuiltinType::Kind kind) {
   switch (kind) {
-#define BUILTIN_TYPE(Id, SingletonId) \
-  case clang::BuiltinType::Id: return context.SingletonId;
+#define BUILTIN_TYPE(Id, SingletonId)                                          \
+  case clang::BuiltinType::Id:                                                 \
+    return context.SingletonId;
 #include "clang/AST/BuiltinTypes.def"
   }
+  llvm_unreachable("Unexpected builtin type!");
 }
 
 static clang::CanQualType getClangSelectorType(


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

  warning: control may reach end of non-void function [-Wreturn-type]

Add a llvm_unreachable to indicate that the function will always return or fail
more obviously rather than returning a garbage value.
