### PR TITLE
Expose determinant property on Swift matrix types.

### DIFF
--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -811,7 +811,6 @@ public struct ${mattype} : CustomDebugStringConvertible {
   /// Inverse of the matrix if it exists, otherwise the contents of the
   /// resulting matrix are undefined.
   @_transparent
-  @warn_unused_result
   public var inverse: ${mattype} {
     %inverse_func = '__invert_' + ('f' if type == 'Float' else 'd') + str(cols)
     return ${mattype}(${inverse_func}(self.cmatrix))
@@ -819,7 +818,6 @@ public struct ${mattype} : CustomDebugStringConvertible {
 
   /// Determinant of the matrix.
   @_transparent
-  @warn_unused_result
   public var determinant: ${type} {
     return matrix_determinant(self.cmatrix)
   }

--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -810,11 +810,18 @@ public struct ${mattype} : CustomDebugStringConvertible {
 % if rows == cols:
   /// Inverse of the matrix if it exists, otherwise the contents of the
   /// resulting matrix are undefined.
+  @_transparent
+  @warn_unused_result
   public var inverse: ${mattype} {
-    get {
-      % inverse_func = '__invert_' + ('f' if type == 'Float' else 'd') + str(cols)
-      return ${mattype}(${inverse_func}(self.cmatrix))
-    }
+    %inverse_func = '__invert_' + ('f' if type == 'Float' else 'd') + str(cols)
+    return ${mattype}(${inverse_func}(self.cmatrix))
+  }
+
+  /// Determinant of the matrix.
+  @_transparent
+  @warn_unused_result
+  public var determinant: ${type} {
+    return matrix_determinant(self.cmatrix)
   }
 % end
 }

--- a/test/1_stdlib/simd.swift.gyb
+++ b/test/1_stdlib/simd.swift.gyb
@@ -340,5 +340,16 @@ simdTestSuite.test("matrix elements") {
 % end # for type
 }
 
+simdTestSuite.test("determinant") {
+% for type in float_types:
+%   for cols in [2,3,4]:
+%     mattype = ctype[type] + str(cols) + 'x' + str(cols)
+%     mat = 'm_' + mattype
+  var ${mat} = ${mattype}(2)
+  expectEqual(${mat}.determinant, ${1 << cols})
+%   end
+% end
+}
+
 runAllTests()
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### Expose the `.determinant` property for simd matrix types.

<!-- Description about pull request. -->

Currently to compute the determinant of, say, a float4x4, you need to use: `matrix_determinant(matrix.cmatrix)`.  This patch exposes it as `matrix.determinant`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
