### PR TITLE
[Stdlib] Update the SeeAlso docs for flatten()

### DIFF
--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -123,7 +123,7 @@ extension Sequence where Iterator.Element : Sequence {
   /// - Returns: A flattened view of the elements of this
   ///   sequence of sequences.
   ///
-  /// - SeeAlso: `flatMap(_:)`, `joinWithSeparator(_:)`
+  /// - SeeAlso: `flatMap(_:)`, `joined(separator:)`
   @warn_unused_result
   public func flatten() -> FlattenSequence<Self> {
     return FlattenSequence(_base: self)
@@ -397,7 +397,7 @@ extension ${collectionForTraversal(traversal)}
   /// - Returns: A flattened view of the elements of this
   ///   collection of collections.
   ///
-  /// - SeeAlso: `flatMap(_:)`, `joinWithSeparator(_:)`
+  /// - SeeAlso: `flatMap(_:)`, `joined(separator:)`
   @warn_unused_result
   public func flatten() -> ${Collection}<Self> {
     return ${Collection}(self)


### PR DESCRIPTION
`flatten()` was still referencing `joinWithSeparator(_:)` even though
that's now been renamed to `joined(separator:)`.
