### PR TITLE
Bug-fixes related to the code motion of instructions using opened existentials.

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -231,6 +231,13 @@ static bool canHoistInstruction(SILInstruction *Inst, SILLoop *Loop,
   if (isa<AllocationInst>(Inst) || isa<DeallocStackInst>(Inst))
     return false;
 
+  // Can't hoist metatype instruction referring to an opened existential,
+  // because it may break the dominance relationship.
+  if (isa<MetatypeInst>(Inst) &&
+      Inst->getType().getSwiftRValueType()->hasOpenedExistential()) {
+    return false;
+  }
+
   // Can't hoist instructions which may have side effects.
   if (!hasNoSideEffect(Inst, SafeReads))
     return false;

--- a/lib/SILOptimizer/Transforms/Sink.cpp
+++ b/lib/SILOptimizer/Transforms/Sink.cpp
@@ -67,6 +67,19 @@ public:
     if (II->isAllocatingStack() || II->isDeallocatingStack())
       return false;
 
+    // We don't sink open_existential_* instructions, because
+    // there may be some instructions depending on them, e.g.
+    // metatype_inst, etc. But this kind of dependency
+    // cannot be expressed in SIL yet.
+    switch (II->getKind()) {
+    default: break;
+    case ValueKind::OpenExistentialBoxInst:
+    case ValueKind::OpenExistentialRefInst:
+    case ValueKind::OpenExistentialAddrInst:
+    case ValueKind::OpenExistentialMetatypeInst:
+      return false;
+    }
+
     SILBasicBlock *CurrentBlock = II->getParent();
     SILBasicBlock *Dest = nullptr;
     unsigned InitialLoopDepth = LoopInfo->getLoopDepth(CurrentBlock);

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -204,3 +204,43 @@ bb2:
   %52 = tuple ()
   return %52 : $()
 }
+
+public protocol P : class {
+  func foo() -> Int32
+  func boo() -> Int32
+}
+
+// Check that LICM does not hoist a metatype instruction before
+// the open_existential instruction which creates the archtype,
+// because this would break the dominance relation between them.
+// CHECK-LABEL: sil @dont_hoist_metatype
+// CHECK-NOT: metatype
+// CHECK-NOT: witness_method
+// CHECK: bb1({{%.*}} : $P)
+// CHECK-NOT: metatype
+// CHECK-NOT: witness_method
+// CHECK: open_existential_ref
+// CHECK: metatype
+// CHECK: witness_method
+// CHECK: cond_br
+sil @dont_hoist_metatype : $@convention(thin) (@inout Builtin.Int1, @owned P) -> () {
+bb0(%0 : $*Builtin.Int1, %1 : $P):
+  br bb1(%1 : $P)
+
+// Loop
+bb1(%existential : $P):
+  %2 = open_existential_ref %existential : $P to $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P
+  %3 = metatype $@thick (@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P).Type
+  %4 = witness_method $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P, #P.foo!1, %2 : $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> Int32
+  %5 = apply %4<@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P>(%2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> Int32
+  %6 = load %0 : $*Builtin.Int1
+  cond_br %6, bb3, bb1(%existential : $P)
+
+bb3:
+  br bb4
+
+bb4:
+  strong_release %1 : $P
+  %10 = tuple ()
+  return %10 : $()
+}

--- a/test/SILOptimizer/sink.sil
+++ b/test/SILOptimizer/sink.sil
@@ -212,6 +212,32 @@ bb1:
   return %4 : $()
 }
 
+public protocol P : class {
+  func foo() -> Int32
+  func boo() -> Int32
+}
+
+// Check that open_existential is not moved after its uses and still
+// dominates them after a run of a code sinking pass.
+// CHECK-LABEL: sil @dont_sink_open_existenial
+// CHECK-NOT: metatype
+// CHECK-NOT: witness_method
+// CHECK: open_existential_ref
+// CHECK: metatype
+sil @dont_sink_open_existenial : $@convention(thin) (@owned P) -> () {
+bb0(%0 : $P):
+  %1 = open_existential_ref %0 : $P to $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P
+  %2 = metatype $@thick (@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P).Type
+  %3 = witness_method $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P, #P.foo!1, %1 : $@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> Int32
+  br bb1
+
+bb1:
+  %4 = apply %3<@opened("C4960DBA-02C5-11E6-BE1B-B8E856428C60") P>(%1) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P> (@guaranteed τ_0_0) -> Int32
+  strong_release %0 : $P
+  %5 = tuple ()
+  return %5 : $()
+}
+
 sil_vtable X {
   #X.ping!1: _TFC14devirt_access21X4pingfS0_FT_Si	// devirt_access2.X.ping (devirt_access2.X)() -> Swift.Int
   #X.init!initializer.1: _TFC14devirt_access21XcfMS0_FT_S0_	// devirt_access2.X.init (devirt_access2.X.Type)() -> devirt_access2.X


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Fix bugs in the LICM and code sinking passes.
While moving the code around, these passes should always preserve the invariant that open_existential should dominate any instructions explicitly and implicitly using the opened archetype.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
