### PR TITLE
IRGen: Use clang::Sema::LookupName instead of TranslationUnit::lookup to find NSInteger.

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -18,6 +18,7 @@
 namespace clang {
 class ASTContext;
 class Preprocessor;
+class Sema;
 } // namespace clang
 
 namespace swift {
@@ -30,6 +31,7 @@ protected:
 public:
   virtual clang::ASTContext &getClangASTContext() const = 0;
   virtual clang::Preprocessor &getClangPreprocessor() const = 0;
+  virtual clang::Sema &getClangSema() const = 0;
   virtual void printStatistics() const = 0;
 
   /// Returns the module that contains imports and declarations from all loaded

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -222,7 +222,7 @@ public:
   clang::TargetInfo &getTargetInfo() const;
   clang::ASTContext &getClangASTContext() const override;
   clang::Preprocessor &getClangPreprocessor() const override;
-  clang::Sema &getClangSema() const;
+  clang::Sema &getClangSema() const override;
   clang::CodeGenOptions &getClangCodeGenOpts() const;
 
   std::string getClangModuleHash() const;

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -28,6 +28,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/Type.h"
+#include "clang/Sema/Sema.h"
 #include "clang/Basic/TargetInfo.h"
 #include "IRGenModule.h"
 
@@ -226,18 +227,14 @@ clang::CanQualType GenClangType::visitStructType(CanStructType type) {
 }
 
 static clang::CanQualType getClangBuiltinTypeFromTypedef(
-                      const clang::ASTContext &context, StringRef typedefName) {
-  auto identifier = &context.Idents.get(typedefName);
-  auto lookup = context.getTranslationUnitDecl()->lookup(identifier);
+                                       clang::Sema &sema, StringRef typedefName) {
+  auto &context = sema.getASTContext();
   
-  clang::TypedefDecl *typedefDecl = nullptr;
-  for (auto found : lookup) {
-    auto foundTypedef = dyn_cast<clang::TypedefDecl>(found);
-    if (!foundTypedef)
-      continue;
-    typedefDecl = foundTypedef;
-    break;
-  }
+  auto identifier = &context.Idents.get(typedefName);
+  auto found = sema.LookupSingleName(sema.TUScope, identifier,
+                                     clang::SourceLocation(),
+                                     clang::Sema::LookupOrdinaryName);
+  auto typedefDecl = dyn_cast_or_null<clang::TypedefDecl>(found);
   if (!typedefDecl)
     return {};
   
@@ -285,17 +282,18 @@ ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
     CanType swiftType = getNamedSwiftType(stdlib, swiftName);
     if (!swiftType) return;
     
+    auto &sema = IGM.Context.getClangModuleLoader()->getClangSema();
     // Handle Int and UInt specially. On Apple platforms, these correspond to
     // the NSInteger and NSUInteger typedefs, so map them back to those typedefs
     // if they're available, to ensure we get consistent ObjC @encode strings.
     if (swiftType->getAnyNominal() == IGM.Context.getIntDecl()) {
-      if (auto NSIntegerTy = getClangBuiltinTypeFromTypedef(ctx, "NSInteger")) {
+      if (auto NSIntegerTy = getClangBuiltinTypeFromTypedef(sema, "NSInteger")){
         Cache.insert({swiftType, NSIntegerTy});
         return;
       }
     } else if (swiftType->getAnyNominal() == IGM.Context.getUIntDecl()) {
       if (auto NSUIntegerTy =
-            getClangBuiltinTypeFromTypedef(ctx, "NSUInteger")) {
+            getClangBuiltinTypeFromTypedef(sema, "NSUInteger")) {
         Cache.insert({swiftType, NSUIntegerTy});
         return;
       }


### PR DESCRIPTION
Sema's lookup is much more efficient.
