### PR TITLE
[ClangImporter] Don't include Swift members in AnyObject lookup.

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1473,6 +1473,12 @@ public:
   static bool isNSString(const clang::Type *);
   static bool isNSString(clang::QualType);
 
+  /// Whether the given declaration was exported from Swift.
+  ///
+  /// Note that this only checks the immediate declaration being passed.
+  /// For things like methods and properties that are nested in larger types,
+  /// it's the top-level declaration that should be checked.
+  static bool hasNativeSwiftDecl(const clang::Decl *decl);
 };
 
 }

--- a/test/ClangModules/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
+++ b/test/ClangModules/MixedSource/Inputs/mixed-framework/Mixed.framework/Headers/Mixed.h
@@ -5,10 +5,19 @@ struct PureClangType {
 
 #ifndef SWIFT_CLASS_EXTRA
 #  define SWIFT_CLASS_EXTRA
+#  define SWIFT_PROTOCOL_EXTRA
 #endif
 
 #ifndef SWIFT_CLASS
 #  define SWIFT_CLASS(SWIFT_NAME) SWIFT_CLASS_EXTRA
+#endif
+
+#ifndef SWIFT_PROTOCOL
+#  define SWIFT_PROTOCOL(SWIFT_NAME) SWIFT_PROTOCOL_EXTRA
+#endif
+
+#ifndef SWIFT_EXTENSION(X)
+#  define SWIFT_EXTENSION(X) X##__LINE__
 #endif
 
 #ifndef SWIFT_CLASS_NAMED
@@ -24,6 +33,12 @@ struct PureClangType {
 SWIFT_CLASS("SwiftClass")
 __attribute__((objc_root_class))
 @interface SwiftClass
+- (void)method;
+@property (nonatomic) long integerProperty;
+@end
+
+@interface SwiftClass (SWIFT_EXTENSION(foo))
+- (void)extensionMethod;
 @end
 
 @interface SwiftClass (Category)
@@ -38,7 +53,14 @@ SWIFT_CLASS_NAMED("CustomNameClass")
 __attribute__((objc_root_class))
 @interface SwiftClassWithCustomName <SwiftProtoWithCustomName>
 @end
-  
+
+SWIFT_PROTOCOL("SwiftProto")
+@protocol SwiftProto
+- (void)protoMethod;
+@property (nonatomic) long protoProperty;
+@end
+
+
 id <SwiftProtoWithCustomName> __nonnull convertToProto(SwiftClassWithCustomName * __nonnull obj);
 
 

--- a/test/ClangModules/MixedSource/Inputs/mixed-framework/Mixed.swift
+++ b/test/ClangModules/MixedSource/Inputs/mixed-framework/Mixed.swift
@@ -5,6 +5,13 @@
   public func pureSwiftMethod(_ x: Int?) -> Bool {
     return x != nil ? true : false
   }
+
+  @objc public func method() {}
+  @objc public var integerProperty: Int = 0
+}
+
+extension SwiftClass {
+  @objc public func extensionMethod() {}
 }
 
 public class PureSwiftClass {
@@ -18,4 +25,9 @@ public protocol CustomName {}
 public class CustomNameClass : CustomName {
   public init() {}
   @nonobjc func pureSwiftMethod() {}
+}
+
+@objc public protocol SwiftProto {
+  @objc func protoMethod()
+  @objc var protoProperty: Int { get }
 }

--- a/test/ClangModules/MixedSource/import-mixed-framework.swift
+++ b/test/ClangModules/MixedSource/import-mixed-framework.swift
@@ -27,3 +27,11 @@ let _: CustomName = convertToProto(CustomNameClass())
 
 _ = SwiftClassWithCustomName() // expected-error {{'SwiftClassWithCustomName' has been renamed to 'CustomNameClass'}}
 
+func testAnyObject(_ obj: AnyObject) {
+  obj.method()
+  _ = obj.integerProperty
+  obj.extensionMethod()
+  obj.categoryMethod(clangStruct)
+  obj.protoMethod()
+  _ = obj.protoProperty
+}


### PR DESCRIPTION
More specifically, don't include declarations of methods and properties in the list of "all imported Objective-C members" if said method or property is in a generated header. (We actually key off of whether the enclosing class, protocol, or category is marked as coming from Swift, but since users aren't supposed to modify generated headers themselves it's much the same thing.)

This previously caused a crash because we tried to import a Clang member onto a Swift decl in order to provide the particular member on AnyObject.

rdar://problem/25955831 and probably also rdar://problem/25828987, which deals with the fix-it to migrate to `#selector`. (We do an AnyObject-like lookup to find out which class likely implements the specified selector.)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
