### PR TITLE
[stdlib] testing index(...) dispatch for RandomAccessCollections with strideable indices

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -375,15 +375,17 @@ internal struct _CollectionStateTransition {
   }
 }
 
+% for Index in ['MinimalIndex', 'MinimalStrideableIndex']:
+
 //===----------------------------------------------------------------------===//
-// MinimalIndex
+// ${Index}
 //===----------------------------------------------------------------------===//
 
 /// Asserts that the two indices are allowed to participate in a binary
 /// operation.
 internal func _expectCompatibleIndices(
-  _ first: MinimalIndex,
-  _ second: MinimalIndex,
+  _ first: ${Index},
+  _ second: ${Index},
   ${TRACE}
 ) {
   if first._collectionState._id == second._collectionState._id {
@@ -398,7 +400,7 @@ internal func _expectCompatibleIndices(
   }
 
   func lastMutatedStateId(
-    of i: MinimalIndex,
+    of i: ${Index},
     in state: _CollectionState
   ) -> Int {
     let offset = i.position
@@ -429,7 +431,7 @@ internal func _expectCompatibleIndices(
   }
 }
 
-public struct MinimalIndex : Comparable {
+public struct ${Index} : Comparable {
   public init(
     collectionState: _CollectionState,
     position: Int,
@@ -439,7 +441,7 @@ public struct MinimalIndex : Comparable {
     expectTrapping(
       position,
       in: startIndex...endIndex)
-    self = MinimalIndex(
+    self = ${Index}(
       _collectionState: collectionState,
       uncheckedPosition: position)
   }
@@ -456,16 +458,42 @@ public struct MinimalIndex : Comparable {
   public let position: Int
 
   public static var trapOnRangeCheckFailure = ResettableValue(true)
+
+%   if 'Strideable' in Index:
+  public var timesAdvancedCalled = ResettableValue(0)
+  public var timesDistanceCalled = ResettableValue(0)
+%   end
 }
 
-public func == (lhs: MinimalIndex, rhs: MinimalIndex) -> Bool {
+public func == (lhs: ${Index}, rhs: ${Index}) -> Bool {
   _expectCompatibleIndices(lhs, rhs)
   return lhs.position == rhs.position
 }
 
-public func < (lhs: MinimalIndex, rhs: MinimalIndex) -> Bool {
+public func < (lhs: ${Index}, rhs: ${Index}) -> Bool {
   _expectCompatibleIndices(lhs, rhs)
   return lhs.position < rhs.position
+}
+
+% end
+
+extension MinimalStrideableIndex : Strideable {
+  public typealias Stride = Int
+
+  @warn_unused_result
+  public func distance(to other: MinimalStrideableIndex) -> Int {
+    timesDistanceCalled.value += 1
+    _expectCompatibleIndices(self, other)
+    return other.position - position
+  }
+
+  @warn_unused_result
+  public func advanced(by n: Int) -> MinimalStrideableIndex {
+    timesAdvancedCalled.value += 1
+    return MinimalStrideableIndex(
+      _collectionState: _collectionState,
+      uncheckedPosition: position + n)
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -482,9 +510,16 @@ Int64 distances.
 % for Traversal in TRAVERSALS:
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
-%       SelfSlice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
-%       Self = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
-%       SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
+%       for StrideableIndex in [ False, True ]:
+%         SelfSlice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
+%         Self = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
+%         Self += 'WithStrideableIndex' if StrideableIndex else ''
+%         SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
+%         Index = 'MinimalStrideableIndex' if StrideableIndex else 'MinimalIndex'
+%         # Only generating MinimalRandomAccessCollectionWithStrideableIndex
+%         if not StrideableIndex or (
+%           StrideableIndex and Traversal == 'RandomAccess' and
+%           not Mutable and not RangeReplaceable):
 
 /// A minimal implementation of `Collection` with extra checks.
 public struct ${Self}<T> : ${SelfProtocols} {
@@ -514,11 +549,16 @@ public struct ${Self}<T> : ${SelfProtocols} {
     }
   }
 
+%     if StrideableIndex:
+  public typealias Indices = CountableRange<${Index}>
+%     end
+
 %     if RangeReplaceable:
   public init() {
     self.underestimatedCount = 0
     self._elements = []
-    self._collectionState = _CollectionState(name: "\(self.dynamicType)", elementCount: 0)
+    self._collectionState =
+      _CollectionState(name: "\(self.dynamicType)", elementCount: 0)
   }
 
   public init<
@@ -538,40 +578,40 @@ public struct ${Self}<T> : ${SelfProtocols} {
     return MinimalIterator(_elements)
   }
 
-  public typealias Index = MinimalIndex
+  public typealias Index = ${Index}
   public typealias IndexDistance = Int
 
-  internal func _index(forPosition i: Int) -> MinimalIndex {
-    return MinimalIndex(
+  internal func _index(forPosition i: Int) -> ${Index} {
+    return ${Index}(
       collectionState: _collectionState,
       position: i,
       startIndex: _elements.startIndex,
       endIndex: _elements.endIndex)
   }
 
-  internal func _uncheckedIndex(forPosition i: Int) -> MinimalIndex {
-    return MinimalIndex(
+  internal func _uncheckedIndex(forPosition i: Int) -> ${Index} {
+    return ${Index}(
       _collectionState: _collectionState,
       uncheckedPosition: i)
   }
 
   public let timesStartIndexCalled = ResettableValue(0)
 
-  public var startIndex: MinimalIndex {
+  public var startIndex: ${Index} {
     timesStartIndexCalled.value += 1
     return _uncheckedIndex(forPosition: _elements.startIndex)
   }
 
   public let timesEndIndexCalled = ResettableValue(0)
 
-  public var endIndex: MinimalIndex {
+  public var endIndex: ${Index} {
     timesEndIndexCalled.value += 1
     return _uncheckedIndex(forPosition: _elements.endIndex)
   }
 
   public func _failEarlyRangeCheck(
-    _ index: MinimalIndex,
-    bounds: Range<MinimalIndex>
+    _ index: ${Index},
+    bounds: Range<${Index}>
   ) {
     _expectCompatibleIndices(
       _uncheckedIndex(forPosition: index.position),
@@ -590,8 +630,8 @@ public struct ${Self}<T> : ${SelfProtocols} {
   }
 
   public func _failEarlyRangeCheck(
-    _ range: Range<MinimalIndex>,
-    bounds: Range<MinimalIndex>
+    _ range: Range<${Index}>,
+    bounds: Range<${Index}>
   ) {
     _expectCompatibleIndices(
       _uncheckedIndex(forPosition: range.lowerBound.position),
@@ -613,14 +653,14 @@ public struct ${Self}<T> : ${SelfProtocols} {
   }
 
   @warn_unused_result
-  public func index(after i: MinimalIndex) -> MinimalIndex {
+  public func index(after i: ${Index}) -> ${Index} {
     _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
     return _uncheckedIndex(forPosition: i.position + 1)
   }
 
 %     if Traversal in ['Bidirectional', 'RandomAccess']:
   @warn_unused_result
-  public func index(before i: MinimalIndex) -> MinimalIndex {
+  public func index(before i: ${Index}) -> ${Index} {
     // FIXME: swift-3-indexing-model: perform a range check and use
     // return _uncheckedIndex(forPosition: i.position - 1)
     return _index(forPosition: i.position - 1)
@@ -628,7 +668,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
 %     end
 
   @warn_unused_result
-  public func distance(from start: MinimalIndex, to end: MinimalIndex)
+  public func distance(from start: ${Index}, to end: ${Index})
     -> IndexDistance {
 %     if Traversal == 'Forward':
     _precondition(start <= end,
@@ -657,7 +697,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
     return _index(forPosition: i.position + n)
   }
 
-  public subscript(i: MinimalIndex) -> T {
+  public subscript(i: ${Index}) -> T {
     get {
       _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
       return _elements[i.position]
@@ -670,7 +710,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
 %     end
   }
 
-  public subscript(bounds: Range<MinimalIndex>) -> ${SelfSlice}<${Self}<T>> {
+  public subscript(bounds: Range<${Index}>) -> ${SelfSlice}<${Self}<T>> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
       return ${SelfSlice}(base: self, bounds: bounds)
@@ -707,7 +747,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
   public mutating func replaceSubrange<
     C : Collection where C.Iterator.Element == T
   >(
-    _ subRange: Range<MinimalIndex>, with newElements: C
+    _ subRange: Range<${Index}>, with newElements: C
   ) {
     let oldCount = count
     _elements.replaceSubrange(
@@ -721,14 +761,14 @@ public struct ${Self}<T> : ${SelfProtocols} {
         + newCount - oldCount))
   }
 
-  public mutating func insert(_ newElement: T, at i: MinimalIndex) {
+  public mutating func insert(_ newElement: T, at i: ${Index}) {
     _willMutate(.insert(atIndex: i.position))
     _elements.insert(newElement, at: i.position)
   }
 
   public mutating func insert<
     S : Collection where S.Iterator.Element == T
-  >(contentsOf newElements: S, at i: MinimalIndex) {
+  >(contentsOf newElements: S, at i: ${Index}) {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -741,7 +781,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
   }
 
   @discardableResult
-  public mutating func remove(at i: MinimalIndex) -> T {
+  public mutating func remove(at i: ${Index}) -> T {
     _willMutate(.removeAtIndex(index: i.position))
     return _elements.remove(at: i.position)
   }
@@ -752,7 +792,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
     return _elements.removeLast()
   }
 
-  public mutating func removeSubrange(_ subRange: Range<MinimalIndex>) {
+  public mutating func removeSubrange(_ subRange: Range<${Index}>) {
     if !subRange.isEmpty {
       _willMutate(.removeRange(
         subRange: subRange.lowerBound.position..<subRange.upperBound.position))
@@ -788,6 +828,8 @@ public struct ${Self}<T> : ${SelfProtocols} {
 %   end
 }
 
+%         end
+%       end
 %     end
 %   end
 % end
@@ -822,18 +864,30 @@ public struct DefaultedSequence<Element> : Sequence {
 % for Traversal in TRAVERSALS:
 %   for Mutable in [ False, True ]:
 %     for RangeReplaceable in [ False, True ]:
-%       SelfSlice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
-%       Self = 'Defaulted' + SelfSlice.replace('Slice', 'Collection')
-%       Base = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
-%       SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
+%       for StrideableIndex in [ False, True ]:
+%         SelfSlice = sliceTypeName(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable)
+%         Self = 'Defaulted' + SelfSlice.replace('Slice', 'Collection')
+%         Self += 'WithStrideableIndex' if StrideableIndex else ''
+%         Base = 'Minimal' + SelfSlice.replace('Slice', 'Collection')
+%         Base += 'WithStrideableIndex' if StrideableIndex else ''
+%         SelfProtocols = ', '.join(protocolsForCollectionFeatures(traversal=Traversal, mutable=Mutable, rangeReplaceable=RangeReplaceable))
+%         Index = 'MinimalStrideableIndex' if StrideableIndex else 'MinimalIndex'
+%         # Only generating DefaultedRandomAccessCollectionWithStrideableIndex
+%         if not StrideableIndex or (
+%           StrideableIndex and Traversal == 'RandomAccess' and
+%           not Mutable and not RangeReplaceable):
 
 /// A Collection that uses as many default implementations as
 /// `Collection` can provide.
 public struct ${Self}<Element> : ${SelfProtocols} {
   public typealias Base = ${Base}<Element>
   public typealias Iterator = MinimalIterator<Element>
-  public typealias Index = MinimalIndex
+  public typealias Index = ${Index}
   public typealias IndexDistance = Int
+
+%   if StrideableIndex:
+  public typealias Indices = CountableRange<${Index}>
+%   end
 
 %   if Mutable or RangeReplaceable:
   public var base: Base
@@ -873,27 +927,29 @@ public struct ${Self}<Element> : ${SelfProtocols} {
     return base.makeIterator()
   }
 
+%     if not StrideableIndex:
+
   public let timesSuccessorCalled = ResettableValue(0)
 
   @warn_unused_result
-  public func index(after i: MinimalIndex) -> MinimalIndex {
+  public func index(after i: ${Index}) -> ${Index} {
     timesSuccessorCalled.value += 1
     return base.index(after: i)
   }
 
-%     if Traversal in ['Bidirectional', 'RandomAccess']:
+%       if Traversal in ['Bidirectional', 'RandomAccess']:
   public let timesPredecessorCalled = ResettableValue(0)
 
   @warn_unused_result
-  public func index(before i: MinimalIndex) -> MinimalIndex {
+  public func index(before i: ${Index}) -> ${Index} {
     timesPredecessorCalled.value += 1
     return base.index(before: i)
   }
-%     end
+%       end
 
-%     if Traversal == 'RandomAccess':
+%       if Traversal == 'RandomAccess':
   @warn_unused_result
-  public func distance(from start: MinimalIndex, to end: MinimalIndex)
+  public func distance(from start: ${Index}, to end: ${Index})
     -> IndexDistance {
     return base.distance(from: start, to: end)
   }
@@ -902,23 +958,25 @@ public struct ${Self}<Element> : ${SelfProtocols} {
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     return base.index(i, offsetBy: n)
   }
-%     end
+%       end
+
+%     end # if not StrideableIndex
 
   public let timesStartIndexCalled = ResettableValue(0)
 
-  public var startIndex: MinimalIndex {
+  public var startIndex: ${Index} {
     timesStartIndexCalled.value += 1
     return base.startIndex
   }
 
   public let timesEndIndexCalled = ResettableValue(0)
 
-  public var endIndex: MinimalIndex {
+  public var endIndex: ${Index} {
     timesEndIndexCalled.value += 1
     return base.endIndex
   }
 
-  public subscript(i: MinimalIndex) -> Element {
+  public subscript(i: ${Index}) -> Element {
     get {
       return base[i]
     }
@@ -932,7 +990,7 @@ public struct ${Self}<Element> : ${SelfProtocols} {
     // FIXME: swift-3-indexing-model: use defaults.
 //     if Self not in ['DefaultedCollection', 'DefaultedBidirectionalCollection', 'DefaultedRandomAccessCollection', 'DefaultedMutableCollection', 'DefaultedRangeReplaceableCollection']:
 
-  public subscript(bounds: Range<MinimalIndex>) -> ${SelfSlice}<${Self}<Base._Element>> {
+  public subscript(bounds: Range<${Index}>) -> ${SelfSlice}<${Self}<Base._Element>> {
     get {
       // FIXME: swift-3-indexing-model: range check.
       return ${SelfSlice}(base: self, bounds: bounds)
@@ -968,7 +1026,7 @@ public struct Defaulted${Traversal}RangeReplaceableSlice<Element>
   public typealias Self_ = Defaulted${Traversal}RangeReplaceableSlice<Element>
   public typealias Base = ${Base}<Element>
   public typealias Iterator = MinimalIterator<Element>
-  public typealias Index = MinimalIndex
+  public typealias Index = ${Index}
 
   public var base: Base
   public var startIndex: Index
@@ -1047,6 +1105,8 @@ public struct Defaulted${Traversal}RangeReplaceableSlice<Element>
 }
 */
 
+%         end
+%       end
 %     end
 %   end
 % end

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -92,7 +92,7 @@ extension RandomAccessIndexable {
 
 extension RandomAccessCollection
 where Index : Strideable, 
-      Index.Stride == IndexDistance, 
+      Index.Stride == IndexDistance,
       Indices == CountableRange<Index> {
 
   public var indices: CountableRange<Index> {

--- a/validation-test/stdlib/Index.swift.gyb
+++ b/validation-test/stdlib/Index.swift.gyb
@@ -53,37 +53,59 @@ Index.test("${TraversalCollection}/index(_:offsetBy:limitedBy:)/dispatch") {
 // Check that a random access collection doesn't call into O(n) predecessor
 // calls when it has a more efficient implementation.
 
+% for IsStrideable in [False, True]:
+%   Collection = 'DefaultedRandomAccessCollection'
+%   Collection += 'WithStrideableIndex' if IsStrideable else ''
+
 Index.test(
-  "DefaultedRandomAccessCollection/index(_:offsetBy:)/"
+  "${Collection}/index(_:offsetBy:)/"
   + "avoidsSuccessorAndPredecessor/dispatch"
 ) {
   for test in indexStepsFromTests.filter(
     {$0.limit == nil && $0.distance >= 0}
   ) {
-    let c = DefaultedRandomAccessCollection(Array(0..<10))
+    let c = ${Collection}(Array(0..<10))
 
     let i = c.nthIndex(test.startOffset)
     let result  = c.index(i, offsetBy: test.distance)
+
+%   if IsStrideable:
+    expectTrue(i.timesAdvancedCalled.value <= 1)
+    if i.timesAdvancedCalled.value == 0 {
+      expectEqual(1, i.timesDistanceCalled.value)
+    }
+%   else:
     expectEqual(0, c.timesSuccessorCalled.value)
     expectEqual(0, c.timesPredecessorCalled.value)
+%   end
   }
 }
 
 Index.test(
-  "DefaultedRandomAccessCollection/index(_:offsetBy:limitedBy:)/"
+  "${Collection}/index(_:offsetBy:limitedBy:)/"
   + "avoidsSuccessorAndPredecessor/dispatch"
 ) {
   for test in indexStepsFromTests.filter(
-    {$0.limit != nil && $0.distance >= 0}
+    {$0.limit != nil}
   ) {
-    let c = DefaultedRandomAccessCollection(Array(0..<10))
+    let c = ${Collection}(Array(0..<10))
 
     let i = c.nthIndex(test.startOffset)
     let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
     _ = c.index(i, offsetBy: test.distance, limitedBy: limit)
+
+%   if IsStrideable:
+    expectTrue(i.timesAdvancedCalled.value <= 1)
+    if i.timesAdvancedCalled.value == 0 {
+      expectEqual(1, i.timesDistanceCalled.value)
+    }
+%   else:
     expectEqual(0, c.timesSuccessorCalled.value)
     expectEqual(0, c.timesPredecessorCalled.value)
+%   end
   }
 }
+
+% end
 
 runAllTests()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Introducing MinimalStrideableIndex as well as new test collection types:
`MinimalRandomAccessCollectionWithStrideableIndex` and
`DefaultedRandonAccessCollectionWithStrideableIndex`, to test default
implementation of `index(...)` family of functions provided by the
standard library for the random access collections with strideable
indices.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
