### PR TITLE
[swift-3.0-preview-1] SimplifyCFG: fix crash in case an enum payload is an enum

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -789,6 +789,14 @@ static NullablePtr<EnumElementDecl> getEnumCase(SILValue Val,
 
     EnumElementDecl *CommonCase = nullptr;
     for (std::pair<SILBasicBlock *, SILValue> Incoming : IncomingVals) {
+      TermInst *TI = Incoming.first->getTerminator();
+
+      // If the terminator of the incoming value is e.g. a switch_enum, the
+      // incoming value is the switch_enum operand and not the enum payload
+      // (which would be the real incoming value of the argument).
+      if (!isa<BranchInst>(TI) && !isa<CondBranchInst>(TI))
+        return nullptr;
+
       NullablePtr<EnumElementDecl> IncomingCase =
         getEnumCase(Incoming.second, Incoming.first, RecursionDepth + 1);
       if (!IncomingCase)

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -2643,6 +2643,10 @@ bb1(%10 : $Optional<TwoCase>):
   switch_enum %10 : $Optional<TwoCase>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
 
 bb2(%1 : $TwoCase):
+  // Simplification of that switch_enum crashed the compiler because
+  // SILArgument::getIncomingValues returns %10 ($Optional<TwoCase>) as the
+  // incoming value for %1 ($TwoCase).
+  // rdar://problem/26251856
   switch_enum %1 : $TwoCase, case #TwoCase.First!enumelt: bb3, case #TwoCase.Second!enumelt: bb4
 
 bb3:

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -2629,3 +2629,35 @@ bb3(%4 : $Optional<Int>):
 }
 
 
+// CHECK-LABEL: sil @dont_crash_on_enum_payload_is_enum
+// CHECK: bb0(%0 : $TwoCase):
+// CHECK:   switch_enum %0
+// CHECK: bb1:
+// CHECK:   return
+sil @dont_crash_on_enum_payload_is_enum : $@convention(thin) (TwoCase) -> () {
+bb0(%0 : $TwoCase):
+  %x = enum $Optional<TwoCase>, #Optional.some!enumelt.1, %0 : $TwoCase
+  br bb1(%x : $Optional<TwoCase>)
+
+bb1(%10 : $Optional<TwoCase>):
+  switch_enum %10 : $Optional<TwoCase>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%1 : $TwoCase):
+  switch_enum %1 : $TwoCase, case #TwoCase.First!enumelt: bb3, case #TwoCase.Second!enumelt: bb4
+
+bb3:
+  %f1 = function_ref @unknown : $@convention(thin) () -> ()
+  %n1 = apply %f1() : $@convention(thin) () -> ()
+  br bb6
+
+bb4:
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  %6 = tuple ()
+  return %6 : $()
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

fixes rdar://problem/26251856
