### PR TITLE
[swift-3.0-preview-1] Change the names of the object-literal initializers to be semantically unambiguous.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4868,8 +4868,9 @@ bool FailureDiagnosis::visitObjectLiteralExpr(ObjectLiteralExpr *E) {
   if (constrs.size() != 1 || !isa<ConstructorDecl>(constrs.front()))
     return false;
   auto *constr = cast<ConstructorDecl>(constrs.front());
+  auto paramType = TC.getObjectLiteralParameterType(E, constr);
   if (!typeCheckChildIndependently(
-        E->getArg(), constr->getArgumentType(), CTP_CallArgument))
+        E->getArg(), paramType, CTP_CallArgument))
     return true;
 
   // Conditions for showing this diagnostic:

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1386,7 +1386,12 @@ namespace {
                        protocol->getDeclaredType(),
                        CS.getConstraintLocator(expr));
 
-      // Add constraint on args.
+      // The arguments are required to be argument-convertible to the
+      // idealized parameter type of the initializer, which generally
+      // simplifies the first label (e.g. "colorLiteralRed:") by stripping
+      // all the redundant stuff about literals (leaving e.g. "red:").
+      // Constraint application will quietly rewrite the type of 'args' to
+      // use the right labels before forming the call to the initializer.
       DeclName constrName = tc.getObjectLiteralConstructorName(expr);
       assert(constrName);
       ArrayRef<ValueDecl *> constrs = protocol->lookupDirect(constrName);
@@ -1395,8 +1400,9 @@ namespace {
         return nullptr;
       }
       auto *constr = cast<ConstructorDecl>(constrs.front());
+      auto constrParamType = tc.getObjectLiteralParameterType(expr, constr);
       CS.addConstraint(ConstraintKind::ArgumentTupleConversion,
-        expr->getArg()->getType(), constr->getArgumentType(),
+        expr->getArg()->getType(), constrParamType,
         CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument));
 
       Type result = tv;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1661,6 +1661,9 @@ public:
 
   DeclName getObjectLiteralConstructorName(ObjectLiteralExpr *expr);
 
+  Type getObjectLiteralParameterType(ObjectLiteralExpr *expr,
+                                     ConstructorDecl *ctor);
+
   /// Get the module appropriate for looking up standard library types.
   ///
   /// This is "Swift", if that module is imported, or the current module if

--- a/stdlib/public/SDK/AppKit/AppKit.swift
+++ b/stdlib/public/SDK/AppKit/AppKit.swift
@@ -68,7 +68,7 @@ public func NSApplicationMain(
 ) -> Int32
 
 extension NSColor : _ColorLiteralConvertible {
-  public required convenience init(red: Float, green: Float,
+  public required convenience init(colorLiteralRed red: Float, green: Float,
                                    blue: Float, alpha: Float) {
     self.init(srgbRed: CGFloat(red), green: CGFloat(green),
               blue: CGFloat(blue), alpha: CGFloat(alpha))
@@ -82,7 +82,7 @@ extension NSImage : _ImageLiteralConvertible {
     self.init(named: name)
   }
 
-  public required convenience init(resourceName name: String) {
+  public required convenience init(imageLiteralResourceName name: String) {
     self.init(failableImageLiteral: name)
   }
 }

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1338,7 +1338,8 @@ extension NSURL : _FileReferenceLiteralConvertible {
     self.init(fileURLWithPath: fullPath)
   }
 
-  public required convenience init(resourceName path: String) {
+  public required convenience
+  init(fileReferenceLiteralResourceName path: String) {
     self.init(failableFileReferenceLiteral: path)
   }
 }

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -219,7 +219,8 @@ extension UIView : _DefaultCustomPlaygroundQuickLookable {
 #endif
 
 extension UIColor : _ColorLiteralConvertible {
-  @nonobjc public required convenience init(red: Float, green: Float,
+  @nonobjc public required convenience init(colorLiteralRed red: Float,
+                                            green: Float,
                                             blue: Float, alpha: Float) {
     self.init(red: CGFloat(red), green: CGFloat(green),
               blue: CGFloat(blue), alpha: CGFloat(alpha))
@@ -233,7 +234,7 @@ extension UIImage : _ImageLiteralConvertible {
     self.init(named: name)
   }
 
-  public required convenience init(resourceName name: String) {
+  public required convenience init(imageLiteralResourceName name: String) {
     self.init(failableImageLiteral: name)
   }
 }

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -497,19 +497,19 @@ public protocol StringInterpolationConvertible {
 /// Conforming types can be initialized with color literals (e.g.
 /// `#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)`).
 public protocol _ColorLiteralConvertible {
-  init(red: Float, green: Float, blue: Float, alpha: Float)
+  init(colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float)
 }
 
 /// Conforming types can be initialized with image literals (e.g.
 /// `#imageLiteral(resourceName: "hi.png")`).
 public protocol _ImageLiteralConvertible {
-  init(resourceName: String)
+  init(imageLiteralResourceName path: String)
 }
 
 /// Conforming types can be initialized with strings (e.g.
 /// `#fileLiteral(resourceName: "resource.txt")`).
 public protocol _FileReferenceLiteralConvertible {
-  init(resourceName: String)
+  init(fileReferenceLiteralResourceName path: String)
 }
 
 /// A container is destructor safe if whether it may store to memory on

--- a/test/IDE/complete_value_literals.swift
+++ b/test/IDE/complete_value_literals.swift
@@ -201,7 +201,7 @@ func testTuple2() {
 // TUPLE_2: Literal[Tuple]/None/TypeRelation[Identical]: ({#(values)#})[#(MyInt1, MyString1, MyDouble1)#];
 
 struct MyColor1: _ColorLiteralConvertible {
-  init(red: Float, green: Float, blue: Float, alpha: Float) {}
+  init(colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
 }
 func testColor0() {
   let x: Int = #^COLOR_0^#
@@ -219,7 +219,7 @@ func testColor2() {
 // COLOR_2: Literal[_Color]/None/TypeRelation[Convertible]: #colorLiteral({#red: Float#}, {#green: Float#}, {#blue: Float#}, {#alpha: Float#})[#MyColor1#];
 
 struct MyImage1: _ImageLiteralConvertible {
-  init(resourceName: String) {}
+  init(imageLiteralResourceName: String) {}
 }
 func testImage0() {
   let x: Int = #^IMAGE_0^#

--- a/test/IDE/structure_object_literals.swift
+++ b/test/IDE/structure_object_literals.swift
@@ -1,14 +1,14 @@
 // RUN: %swift-ide-test -structure -source-filename %s | FileCheck %s
 
 struct S: _ColorLiteralConvertible {
-  init(red: Float, green: Float, blue: Float, alpha: Float) {}
+  init(colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
 }
 
 // CHECK: <gvar>let <name>y</name>: S = <object-literal-expression>#<name>colorLiteral</name>(<param><name>red</name>: 1</param>, <param><name>green</name>: 0</param>, <param><name>blue</name>: 0</param>, <param><name>alpha</name>: 1</param>)</object-literal-expression></gvar>
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
 
 struct I: _ImageLiteralConvertible {
-  init?(resourceName: String) {}
+  init?(imageLiteralResourceName: String) {}
 }
 
 // CHECK: <gvar>let <name>z</name>: I? = <object-literal-expression>#<name>imageLiteral</name>(<param><name>resourceName</name>: "hello.png"</param>)</object-literal-expression></gvar>

--- a/test/Sema/object_literals_ios.swift
+++ b/test/Sema/object_literals_ios.swift
@@ -2,7 +2,7 @@
 // REQUIRES: OS=ios
 
 struct S: _ColorLiteralConvertible {
-  init(red: Float, green: Float, blue: Float, alpha: Float) {}
+  init(colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
 }
 
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
@@ -10,14 +10,14 @@ let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{c
 let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{cannot convert value of type '(red: Int, bleen: Int, grue: Int, alpha: Int)' to expected argument type '(red: Float, green: Float, blue: Float, alpha: Float)'}}
 
 struct I: _ImageLiteralConvertible {
-  init(resourceName: String) {}
+  init(imageLiteralResourceName: String) {}
 }
 
 let z: I = #imageLiteral(resourceName: "hello.png")
 let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not infer type of image literal}} expected-note{{import UIKit to use 'UIImage' as the default image literal type}}
 
 struct Path: _FileReferenceLiteralConvertible {
-  init(resourceName: String) {}
+  init(fileReferenceLiteralResourceName: String) {}
 }
 
 let p1: Path = #fileLiteral(resourceName: "what.txt")

--- a/test/Sema/object_literals_osx.swift
+++ b/test/Sema/object_literals_osx.swift
@@ -2,7 +2,7 @@
 // REQUIRES: OS=macosx
 
 struct S: _ColorLiteralConvertible {
-  init(red: Float, green: Float, blue: Float, alpha: Float) {}
+  init(colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
 }
 
 let y: S = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)
@@ -10,14 +10,14 @@ let y2 = #colorLiteral(red: 1, green: 0, blue: 0, alpha: 1) // expected-error{{c
 let y3 = #colorLiteral(red: 1, bleen: 0, grue: 0, alpha: 1) // expected-error{{cannot convert value of type '(red: Int, bleen: Int, grue: Int, alpha: Int)' to expected argument type '(red: Float, green: Float, blue: Float, alpha: Float)'}}
 
 struct I: _ImageLiteralConvertible {
-  init(resourceName: String) {}
+  init(imageLiteralResourceName: String) {}
 }
 
 let z: I = #imageLiteral(resourceName: "hello.png")
 let z2 = #imageLiteral(resourceName: "hello.png") // expected-error{{could not infer type of image literal}} expected-note{{import AppKit to use 'NSImage' as the default image literal type}}
 
 struct Path: _FileReferenceLiteralConvertible {
-  init(resourceName: String) {}
+  init(fileReferenceLiteralResourceName: String) {}
 }
 
 let p1: Path = #fileLiteral(resourceName: "what.txt")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

We didn't actually intend to change how programmers normally
constructed these types, but the change to the object literal
syntax accidentally caused these initializers to have very
natural-seeming signatures.  These initializers also created
possible ambiguities with the actual initializers.  Renaming
them to refer to their function as literal initializers is the
right thing to do.

Unfortunately, this provided to be somewhat annoying, as the
code was written to assume that the argument tuple following
e.g. #colorLiteral could be directly passed to the initializer.
We solve this by hacking on both ends of the constraint system:
during generation we form a conversion constraint to the
original, idealized parameter type, and during application we
rewrite the argument tuple type to use the actual labels.
This nicely limits the additional complexity to just the
parts dealing with object literals.

Note that we can't just implicitly rewrite the tuple expression
because that would break invariants tying the labels to physical
source ranges.  We also don't want to just change the literal
syntax again and break compatibility with existing uses.

rdar://26148507
