### PR TITLE
[Don't merge] stdlib: Dictionary, Set: stop overallocating the bitmap

### DIFF
--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -35,7 +35,7 @@ struct _UnsafeBitMap {
 
   public // @testable
   static func sizeInWords(forSizeInBits bitCount: Int) -> Int {
-    return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
+    return (bitCount + Int._sizeInBits - 1) / Int._sizeInBits
   }
 
   public // @testable

--- a/validation-test/stdlib/UnsafeBitMap.swift
+++ b/validation-test/stdlib/UnsafeBitMap.swift
@@ -41,8 +41,7 @@ UnsafeBitMapTests.test("wordIndex(_:), bitIndex(_:)") {
 #endif
 }
 
-UnsafeBitMapTests.test("sizeInWords(forSizeInBits:)")
-  .xfail(.always("the API is buggy")).code {
+UnsafeBitMapTests.test("sizeInWords(forSizeInBits:)") {
   expectEqual(0, _UnsafeBitMap.sizeInWords(forSizeInBits: 0))
 #if arch(i386) || arch(arm)
   for i in 1...32 {


### PR DESCRIPTION
The 'wordsFor(capacity:)' function was supposed to return the size in words, but returned the size in bits, overallocating the bitmap by a factor of 32 or 64, depending on the platform.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
