### PR TITLE
[stdlib] moving the strideable test to where it belongs

### DIFF
--- a/test/1_stdlib/Strideable.swift
+++ b/test/1_stdlib/Strideable.swift
@@ -155,5 +155,13 @@ StrideTestSuite.test("OperatorOverloads") {
   }
 }
 
+StrideTestSuite.test("FloatingPointStride") {
+  var result = [Double]()
+  for i in stride(from: 1.4, through: 3.4, by: 1) {
+    result.append(i)
+  }
+  expectEqual([ 1.4, 2.4, 3.4 ], result)
+}
+
 runAllTests()
 

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -509,14 +509,5 @@ MiscTestSuite.test("reversed()") {
     result)
 }
 
-// FIXME: swift-3-indexing-model: this test does not belong in this file.
-MiscTestSuite.test("stride") {
-  var result = [Double]()
-  for i in stride(from: 1.4, through: 3.4, by: 1) {
-    result.append(i)
-  }
-  expectEqual([ 1.4, 2.4, 3.4 ], result)
-}
-
 runAllTests()
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Range test suite for some reason included a test for a `stride(from:through:by:)` function on `Double` values. Moving it to the appropriate test suite in Strideable.swift.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
