### PR TITLE
[swift-3.0-preview-1] stdlib: add SWIFT_RUNTIME_STDLIB_INTERFACE attribute where necessary

### DIFF
--- a/stdlib/public/SwiftShims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/CoreFoundationShims.h
@@ -20,6 +20,7 @@
 #define SWIFT_STDLIB_SHIMS_COREFOUNDATIONSHIMS_H
 
 #include "SwiftStdint.h"
+#include "Visibility.h"
 
 #ifdef __cplusplus
 namespace swift { extern "C" {
@@ -54,37 +55,46 @@ typedef unsigned char _swift_shims_Boolean;
 typedef __swift_uint16_t _swift_shims_UniChar;
 
 // Buffer is nullable in case the string is zero-length.
+SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_stdlib_CFStringGetCharacters(_swift_shims_CFStringRef __nonnull theString,
                            _swift_shims_CFRange range,
                            _swift_shims_UniChar *__nullable buffer);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const _swift_shims_UniChar *__nullable _swift_stdlib_CFStringGetCharactersPtr(
     _swift_shims_CFStringRef __nonnull theString);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_CFIndex
     _swift_stdlib_CFStringGetLength(_swift_shims_CFStringRef __nonnull theString);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_CFStringRef __nonnull _swift_stdlib_CFStringCreateWithSubstring(
     _swift_shims_CFAllocatorRef __nullable alloc,
     _swift_shims_CFStringRef __nonnull str, _swift_shims_CFRange range);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_UniChar
 _swift_stdlib_CFStringGetCharacterAtIndex(_swift_shims_CFStringRef __nonnull theString,
                             _swift_shims_CFIndex idx);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_CFStringRef __nonnull _swift_stdlib_CFStringCreateCopy(
     _swift_shims_CFAllocatorRef __nullable alloc,
     _swift_shims_CFStringRef __nonnull theString);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 const char *__nullable _swift_stdlib_CFStringGetCStringPtr(
     _swift_shims_CFStringRef __nonnull theString,
     _swift_shims_CFStringEncoding encoding);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_CFComparisonResult
 _swift_stdlib_CFStringCompare(_swift_shims_CFStringRef __nonnull theString1,
                 _swift_shims_CFStringRef __nonnull theString2,
                 _swift_shims_CFStringCompareFlags compareOptions);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_Boolean
 _swift_stdlib_CFStringFindWithOptions(_swift_shims_CFStringRef __nonnull theString,
                         _swift_shims_CFStringRef __nonnull stringToFind,
@@ -92,6 +102,7 @@ _swift_stdlib_CFStringFindWithOptions(_swift_shims_CFStringRef __nonnull theStri
                         _swift_shims_CFStringCompareFlags searchOptions,
                         _swift_shims_CFRange *__nullable result);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _swift_shims_CFStringRef __nonnull _swift_stdlib_objcDebugDescription(id __nonnull nsObject);
 #endif // __OBJC2__
 

--- a/stdlib/public/SwiftShims/FoundationShims.h
+++ b/stdlib/public/SwiftShims/FoundationShims.h
@@ -29,6 +29,10 @@
 
 #include "SwiftStdint.h"
 
+#ifdef __cplusplus
+namespace swift { extern "C" {
+#endif
+
 typedef struct {
   __swift_intptr_t location;
   __swift_intptr_t length;
@@ -50,7 +54,12 @@ typedef struct {
   __swift_intptr_t patchVersion;
 } _SwiftNSOperatingSystemVersion;
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 _SwiftNSOperatingSystemVersion _swift_stdlib_operatingSystemVersion();
+
+#ifdef __cplusplus
+}} // extern "C", namespace swift
+#endif
 
 #endif // SWIFT_STDLIB_SHIMS_FOUNDATIONSHIMS_H
 

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -60,7 +60,7 @@ static_assert(swift::IsTriviallyConstructible<HeapObject>::value,
 static_assert(std::is_trivially_destructible<HeapObject>::value,
               "HeapObject must be trivially destructible");
 
-}
-#endif 
+} // end namespace swift
+#endif
 
 #endif

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -17,6 +17,7 @@
 #include "swift/Runtime/Debug.h"
 #import <Foundation/Foundation.h>
 #include <TargetConditionals.h>
+#include "../SwiftShims/FoundationShims.h"
 
 using namespace swift;
 
@@ -74,8 +75,7 @@ static NSOperatingSystemVersion operatingSystemVersionFromPlist() {
 
 /// Return the version of the operating system currently running for use in
 /// API availability queries.
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" NSOperatingSystemVersion _swift_stdlib_operatingSystemVersion() {
+_SwiftNSOperatingSystemVersion swift::_swift_stdlib_operatingSystemVersion() {
   static NSOperatingSystemVersion version = ([]{
     // Use -[NSProcessInfo.operatingSystemVersion] when present
     // (on iOS 8 and OS X 10.10 and above).
@@ -88,5 +88,5 @@ extern "C" NSOperatingSystemVersion _swift_stdlib_operatingSystemVersion() {
     }
   })();
 
-  return version;
+  return { version.majorVersion, version.minorVersion, version.patchVersion };
 }

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -15,17 +15,18 @@
 //  defined here.
 //
 //===----------------------------------------------------------------------===//
+
 #include "../SwiftShims/GlobalObjects.h"
 #include "swift/Runtime/Metadata.h"
 
 namespace swift {
-
+// FIXME(ABI): does this declaration need SWIFT_RUNTIME_STDLIB_INTERFACE?
 // _direct type metadata for Swift._EmptyArrayStorage
 SWIFT_RUNTIME_STDLIB_INTERFACE
 extern "C" ClassMetadata _TMCs18_EmptyArrayStorage;
+}
 
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C" _SwiftEmptyArrayStorage _swiftEmptyArrayStorage = {
+swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   // HeapObject header;
   {
     &_TMCs18_EmptyArrayStorage, // isa pointer
@@ -38,16 +39,10 @@ extern "C" _SwiftEmptyArrayStorage _swiftEmptyArrayStorage = {
   }
 };
 
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
-__swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride = 0;
+__swift_uint64_t swift::_swift_stdlib_HashingDetail_fixedSeedOverride = 0;
 
 /// Backing storage for Swift.Process.arguments.
-SWIFT_RUNTIME_STDLIB_INTERFACE
-extern "C"
-void *_swift_stdlib_ProcessArguments = nullptr;
-
-}
+void *swift::_swift_stdlib_ProcessArguments = nullptr;
 
 namespace llvm { namespace hashing { namespace detail {
   // An extern variable expected by LLVM's hashing templates. We don't link any

--- a/test/1_stdlib/RuntimeObjC.swift
+++ b/test/1_stdlib/RuntimeObjC.swift
@@ -682,11 +682,6 @@ RuntimeFoundationWrappers.test("_stdlib_NSStringUppercaseString/NoLeak") {
   expectEqual(0, nsStringCanaryCount)
 }
 
-// FIXME: Temporarily commented out due to linker failure in finding
-// __swift_stdlib_CFStringCreateCopy, __swift_stdlib_CFStringGetCharactersPtr,
-// and  __swift_stdlib_CFStringGetLength during optimized builds.
-// rdar://problem/26239602
-/*
 RuntimeFoundationWrappers.test("_stdlib_CFStringCreateCopy/NoLeak") {
   nsStringCanaryCount = 0
   autoreleasepool {
@@ -716,7 +711,6 @@ RuntimeFoundationWrappers.test("_stdlib_CFStringGetCharactersPtr/NoLeak") {
   }
   expectEqual(0, nsStringCanaryCount)
 }
-*/
 
 RuntimeFoundationWrappers.test("bridgedNSArray") {
   var c = [NSObject]()


### PR DESCRIPTION
... and remove some redundant ones.

This change fixes the RuntimeObjC.swift test.

rdar://problem/26239602
- Explanation:  The standard library stubs that are written in C++ were not annotated with public visibility.  This can cause issues in optimized mode when the app can try to link against these hidden symbols.
- Scope:  Potentially, affects every app or module that builds in optimized mode.  In practice, we only saw one test failing.  The failures are hard to predict, because they are dependent on inliner decisions.
- Risk: The risk is low, the annotations are straightforward and are used already in other parts of the library.
- Reviewed By: @swiftix
- Testing: Existing tests were ran in regular and optimized mode.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
