### PR TITLE
[swift-3.0-preview-1] stdlib: use a more descriptive generic parameter name in flatMap()

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -620,10 +620,10 @@ extension Sequence {
   ///   and *n* is the length of the result.
   /// - SeeAlso: `flatten()`, `map(_:)`
   @warn_unused_result
-  public func flatMap<S : Sequence>(
-    _ transform: @noescape (${GElement}) throws -> S
-  ) rethrows -> [S.${GElement}] {
-    var result: [S.${GElement}] = []
+  public func flatMap<SegmentOfResult : Sequence>(
+    _ transform: @noescape (${GElement}) throws -> SegmentOfResult
+  ) rethrows -> [SegmentOfResult.${GElement}] {
+    var result: [SegmentOfResult.${GElement}] = []
     for element in self {
       result.append(contentsOf: try transform(element))
     }

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -151,7 +151,7 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#isOrderedBefore: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         reduce({#(initial): T#}, {#combine: (T, Equatable) throws -> T##(T, Equatable) throws -> T#})[' rethrows'][#T#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[S.Iterator.Element]#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[SegmentOfResult.Iterator.Element]#]{{; name=.+}}
 
 func testArchetypeReplacement3 (_ a : [Int]) {
   a.#^PRIVATE_NOMINAL_MEMBERS_7^#

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -528,7 +528,7 @@ function set_deployment_target_based_options() {
                 -DLLVM_HOST_TRIPLE:STRING="${llvm_host_triple}"
                 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
                 -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${SKIP_COMPILER_RT})"
-                -DCOMPILER_RT_ENABLE_IOS:BOOL="$(false_true ${SKIP_IOS})"
+                -DCOMPILER_RT_ENABLE_IOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE
             )

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -53,6 +53,20 @@ NEXT_BRANCHES = {
     'swift-integration-tests': 'master',
 }
 
+SWIFT_3_0_PREVIEW_1_BRANCHES = {
+    'llvm': 'swift-3.0-branch',
+    'clang': 'swift-3.0-branch',
+    'swift': 'swift-3.0-preview-1-branch',
+    'lldb': 'swift-3.0-preview-1-branch',
+    'cmark': 'swift-3.0-preview-1-branch',
+    'llbuild': 'swift-3.0-preview-1-branch',
+    'swiftpm': 'swift-3.0-preview-1-branch',
+    'swift-corelibs-xctest': 'swift-3.0-preview-1-branch',
+    'swift-corelibs-foundation': 'swift-3.0-preview-1-branch',
+    'swift-corelibs-libdispatch': 'swift-3.0-preview-1-branch',
+    'swift-integration-tests': 'swift-3.0-preview-1-branch',
+    'compiler-rt': 'swift-3.0-branch',
+}
 
 def update_working_copy(repo_path, branch):
     if not os.path.isdir(repo_path):
@@ -97,6 +111,9 @@ def obtain_additional_swift_sources(
                 if branch:
                     if branch == "stable-next" or branch == "master-next":
                         repo_branch = NEXT_BRANCHES[dir_name]
+                    elif branch == "swift-3.0-branch" or \
+                        branch == "swift-3.0-preview-1-branch":
+                        repo_branch = SWIFT_3_0_PREVIEW_1_BRANCHES[dir_name]
                     else:
                         repo_branch = branch
                     src_path = SWIFT_SOURCE_ROOT + "/" + dir_name + "/" + \
@@ -153,6 +170,9 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         if branch:
             if branch == "stable-next" or branch == "master-next":
                 repo_branch = NEXT_BRANCHES[dir_name]
+            elif branch == "swift-3.0-branch" or \
+                branch == "swift-3.0-preview-1-branch":
+                        repo_branch = SWIFT_3_0_PREVIEW_1_BRANCHES[dir_name]
 
         update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, dir_name),
                             repo_branch)


### PR DESCRIPTION
We were already using this name in the lazy flatMap() overload, but we missed renaming the generic parameter in the eager one.
