### PR TITLE
[swift-3.0-preview-1] stdlib: use a more descriptive generic parameter name in flatMap()

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -620,10 +620,10 @@ extension Sequence {
   ///   and *n* is the length of the result.
   /// - SeeAlso: `flatten()`, `map(_:)`
   @warn_unused_result
-  public func flatMap<S : Sequence>(
-    _ transform: @noescape (${GElement}) throws -> S
-  ) rethrows -> [S.${GElement}] {
-    var result: [S.${GElement}] = []
+  public func flatMap<SegmentOfResult : Sequence>(
+    _ transform: @noescape (${GElement}) throws -> SegmentOfResult
+  ) rethrows -> [SegmentOfResult.${GElement}] {
+    var result: [SegmentOfResult.${GElement}] = []
     for element in self {
       result.append(contentsOf: try transform(element))
     }

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -151,7 +151,7 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#isOrderedBefore: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         reduce({#(initial): T#}, {#combine: (T, Equatable) throws -> T##(T, Equatable) throws -> T#})[' rethrows'][#T#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[S.Iterator.Element]#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[SegmentOfResult.Iterator.Element]#]{{; name=.+}}
 
 func testArchetypeReplacement3 (_ a : [Int]) {
   a.#^PRIVATE_NOMINAL_MEMBERS_7^#


### PR DESCRIPTION
We were already using this name in the lazy flatMap() overload, but we missed renaming the generic parameter in the eager one.
- Explanation: Change flatMap() should use ‘SegmentOfResult’ as the generic parameter name, as we agreed in API discussions.  This generic parameter name is not API.
- Scope of Issue: Everyone using code completion for flatMap().
- Risk: The risk is very low, the affected name is not API.
- Reviewed By:  @moiseev
- Testing: Existing tests were ran.

rdar://problem/26260182
