### PR TITLE
Stdlib float snan payload

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -459,10 +459,11 @@ extension ${Self}: BinaryFloatingPoint {
   /// Compares not equal to every value, including itself.  Most operations
   /// with a NaN operand will produce a NaN result.
   public init(nan payload: RawSignificand, signaling: Bool) {
-    precondition(payload < ${Self}._quietNaNMask,
-                 "NaN payload is not encodable.")
+    // We use significandBitCount - 2 bits for NaN payload.
+    _precondition(payload < (${Self}._quietNaNMask >> 1),
+      "NaN payload is not encodable.")
     var significand = payload
-    if !signaling { significand |= ${Self}._quietNaNMask }
+    significand |= ${Self}._quietNaNMask >> (signaling ? 1 : 0)
     self.init(sign: .plus,
               exponentBitPattern: ${Self}._infinityExponent,
               significandBitPattern: significand)

--- a/test/1_stdlib/Float.swift
+++ b/test/1_stdlib/Float.swift
@@ -222,6 +222,15 @@ func checkQNaN(_ qnan: TestFloat) {
   _precondition(qnan.floatingPointClass == .quietNaN)
 }
 
+func checkSNaN(_ snan: TestFloat) {
+  checkNaN(snan)
+// sNaN cannot be fully supported on i386.
+#if !arch(i386)
+  _precondition(snan.isSignaling)
+  _precondition(snan.floatingPointClass == .signalingNaN)
+#endif
+}
+
 func testNaN() {
   var stdlibDefaultNaN = TestFloat.nan
   checkQNaN(stdlibDefaultNaN)
@@ -229,6 +238,8 @@ func testNaN() {
   var stdlibQNaN = TestFloat.quietNaN
   checkQNaN(stdlibQNaN)
 
+  var stdlibSNaN = TestFloat.signalingNaN
+  checkSNaN(stdlibSNaN)
   print("testNaN done")
 }
 testNaN()

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -528,7 +528,7 @@ function set_deployment_target_based_options() {
                 -DLLVM_HOST_TRIPLE:STRING="${llvm_host_triple}"
                 -DLLVM_ENABLE_LIBCXX:BOOL=TRUE
                 -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${SKIP_COMPILER_RT})"
-                -DCOMPILER_RT_ENABLE_IOS:BOOL="$(false_true ${SKIP_IOS})"
+                -DCOMPILER_RT_ENABLE_IOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE
             )

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -53,6 +53,20 @@ NEXT_BRANCHES = {
     'swift-integration-tests': 'master',
 }
 
+SWIFT_3_0_PREVIEW_1_BRANCHES = {
+    'llvm': 'swift-3.0-branch',
+    'clang': 'swift-3.0-branch',
+    'swift': 'swift-3.0-preview-1-branch',
+    'lldb': 'swift-3.0-preview-1-branch',
+    'cmark': 'swift-3.0-preview-1-branch',
+    'llbuild': 'swift-3.0-preview-1-branch',
+    'swiftpm': 'swift-3.0-preview-1-branch',
+    'swift-corelibs-xctest': 'swift-3.0-preview-1-branch',
+    'swift-corelibs-foundation': 'swift-3.0-preview-1-branch',
+    'swift-corelibs-libdispatch': 'swift-3.0-preview-1-branch',
+    'swift-integration-tests': 'swift-3.0-preview-1-branch',
+    'compiler-rt': 'swift-3.0-branch',
+}
 
 def update_working_copy(repo_path, branch):
     if not os.path.isdir(repo_path):
@@ -97,6 +111,9 @@ def obtain_additional_swift_sources(
                 if branch:
                     if branch == "stable-next" or branch == "master-next":
                         repo_branch = NEXT_BRANCHES[dir_name]
+                    elif branch == "swift-3.0-branch" or \
+                        branch == "swift-3.0-preview-1-branch":
+                        repo_branch = SWIFT_3_0_PREVIEW_1_BRANCHES[dir_name]
                     else:
                         repo_branch = branch
                     src_path = SWIFT_SOURCE_ROOT + "/" + dir_name + "/" + \
@@ -153,6 +170,9 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         if branch:
             if branch == "stable-next" or branch == "master-next":
                 repo_branch = NEXT_BRANCHES[dir_name]
+            elif branch == "swift-3.0-branch" or \
+                branch == "swift-3.0-preview-1-branch":
+                        repo_branch = SWIFT_3_0_PREVIEW_1_BRANCHES[dir_name]
 
         update_working_copy(os.path.join(SWIFT_SOURCE_ROOT, dir_name),
                             repo_branch)


### PR DESCRIPTION
- Explanation: signaling NaNs had wrong values.
- Scope of Issue: Advanced uses of floating point.
- Risk: The risk is low, since it is an obvious improvement, and a rarely-used API.
- Reviewed By: @stephentyrone
- Testing: Existing tests were ran, new tests were added.

rdar://problem/26270243
