### PR TITLE
[swift-3.0-preview-1] stdlib: Fix the signaling NaN representation

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -459,10 +459,11 @@ extension ${Self}: BinaryFloatingPoint {
   /// Compares not equal to every value, including itself.  Most operations
   /// with a NaN operand will produce a NaN result.
   public init(nan payload: RawSignificand, signaling: Bool) {
-    precondition(payload < ${Self}._quietNaNMask,
-                 "NaN payload is not encodable.")
+    // We use significandBitCount - 2 bits for NaN payload.
+    _precondition(payload < (${Self}._quietNaNMask >> 1),
+      "NaN payload is not encodable.")
     var significand = payload
-    if !signaling { significand |= ${Self}._quietNaNMask }
+    significand |= ${Self}._quietNaNMask >> (signaling ? 1 : 0)
     self.init(sign: .plus,
               exponentBitPattern: ${Self}._infinityExponent,
               significandBitPattern: significand)

--- a/test/1_stdlib/Float.swift
+++ b/test/1_stdlib/Float.swift
@@ -222,6 +222,15 @@ func checkQNaN(_ qnan: TestFloat) {
   _precondition(qnan.floatingPointClass == .quietNaN)
 }
 
+func checkSNaN(_ snan: TestFloat) {
+  checkNaN(snan)
+// sNaN cannot be fully supported on i386.
+#if !arch(i386)
+  _precondition(snan.isSignaling)
+  _precondition(snan.floatingPointClass == .signalingNaN)
+#endif
+}
+
 func testNaN() {
   var stdlibDefaultNaN = TestFloat.nan
   checkQNaN(stdlibDefaultNaN)
@@ -229,6 +238,8 @@ func testNaN() {
   var stdlibQNaN = TestFloat.quietNaN
   checkQNaN(stdlibQNaN)
 
+  var stdlibSNaN = TestFloat.signalingNaN
+  checkSNaN(stdlibSNaN)
   print("testNaN done")
 }
 testNaN()


### PR DESCRIPTION
- Explanation: signaling NaNs had wrong values.
- Scope of Issue: Advanced uses of floating point.
- Risk: The risk is low, since it is an obvious improvement, and a rarely-used API.
- Reviewed By: @stephentyrone
- Testing: Existing tests were ran, new tests were added.

rdar://problem/26270243
