### PR TITLE
[swift-3.0-preview-1] stdlib: use _precondition(), not precondition()

### DIFF
--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -103,7 +103,7 @@ public struct CollectionOfOne<Element>
     }
     set {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
-      precondition(bounds.count == newValue.count,
+      _precondition(bounds.count == newValue.count,
         "CollectionOfOne can't be resized")
       if let newElement = newValue.first {
         _element = newElement

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -812,37 +812,37 @@ public struct AnyIndex : Comparable {
 ///   identical.
 @warn_unused_result
 public func == (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-  precondition(lhs._typeID == rhs._typeID, "base index types differ")
+  _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._equal(to: rhs._box)
 }
 
 @warn_unused_result
 public func != (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-  precondition(lhs._typeID == rhs._typeID, "base index types differ")
+  _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._notEqual(to: rhs._box)
 }
 
 @warn_unused_result
 public func < (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-  precondition(lhs._typeID == rhs._typeID, "base index types differ")
+  _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._less(than: rhs._box)
 }
 
 @warn_unused_result
 public func <= (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-  precondition(lhs._typeID == rhs._typeID, "base index types differ")
+  _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._lessOrEqual(to: rhs._box)
 }
 
 @warn_unused_result
 public func > (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-  precondition(lhs._typeID == rhs._typeID, "base index types differ")
+  _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._greater(than: rhs._box)
 }
 
 @warn_unused_result
 public func >= (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
-  precondition(lhs._typeID == rhs._typeID, "base index types differ")
+  _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._greaterOrEqual(to: rhs._box)
 }
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -459,8 +459,8 @@ extension ${Self}: BinaryFloatingPoint {
   /// Compares not equal to every value, including itself.  Most operations
   /// with a NaN operand will produce a NaN result.
   public init(nan payload: RawSignificand, signaling: Bool) {
-    precondition(payload < ${Self}._quietNaNMask,
-                 "NaN payload is not encodable.")
+    _precondition(payload < ${Self}._quietNaNMask,
+      "NaN payload is not encodable.")
     var significand = payload
     if !signaling { significand |= ${Self}._quietNaNMask }
     self.init(sign: .plus,

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -100,7 +100,7 @@ where Index : Strideable,
   }
 
   internal func _validityChecked(_ i: Index) -> Index {
-    precondition(i >= startIndex && i <= endIndex, "index out of range")
+    _precondition(i >= startIndex && i <= endIndex, "index out of range")
     return i
   }
   

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1039,7 +1039,7 @@ extension Sequence where
   ///   the beginning of the sequence.
   @warn_unused_result
   public func dropFirst(_ n: Int) -> AnySequence<Iterator.Element> {
-    precondition(n >= 0, "Can't drop a negative number of elements from a sequence")
+    _precondition(n >= 0, "Can't drop a negative number of elements from a sequence")
     if n == 0 { return AnySequence(self) }
     return AnySequence(_DropFirstSequence(_iterator: makeIterator(), limit: n))
   }
@@ -1062,7 +1062,7 @@ extension Sequence where
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   @warn_unused_result
   public func dropLast(_ n: Int) -> AnySequence<Iterator.Element> {
-    precondition(n >= 0, "Can't drop a negative number of elements from a sequence")
+    _precondition(n >= 0, "Can't drop a negative number of elements from a sequence")
     if n == 0 { return AnySequence(self) }
 
     // FIXME: <rdar://problem/21885650> Create reusable RingBuffer<T>
@@ -1107,7 +1107,7 @@ extension Sequence where
   /// - Complexity: O(1)
   @warn_unused_result
   public func prefix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
-    precondition(maxLength >= 0, "Can't take a prefix of negative length from a sequence")
+    _precondition(maxLength >= 0, "Can't take a prefix of negative length from a sequence")
     if maxLength == 0 {
       return AnySequence(EmptyCollection<Iterator.Element>())
     }


### PR DESCRIPTION
- Explanation: `precondition()`, when used in the standard library, does not respect the debug/release build setting of the module or application importing the standard library.  The standard library should use `_precondition()`.
- Scope of Issue: Traps in affected places don’t produce helpful messages even in debug mode.
- Risk: The risk is low, code generation for optimized mode is not affected at all.
- Reviewed By: @moiseev

rdar://problem/26260277
