### PR TITLE
Teach the Swift front-end to generate code with sanitizer coverage

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -58,6 +58,13 @@ ERROR(error_unsupported_opt_for_target, none,
 ERROR(error_argument_not_allowed_with, none,
   "argument '%0' is not allowed with '%1'", (StringRef, StringRef))
 
+ERROR(error_option_requires_sanitizer, none,
+  "option '%0' requires a sanitizer to be enabled. Use -sanitize= to enable a"
+  " sanitizer", (StringRef))
+
+ERROR(error_option_missing_required_argument, none,
+  "option '%0' is missing a required argument (%1)", (StringRef, StringRef))
+
 ERROR(cannot_open_file,none,
   "cannot open file '%0' (%1)", (StringRef, StringRef))
 ERROR(cannot_open_serialized_file,none,

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -20,6 +20,9 @@
 
 #include "swift/AST/LinkLibrary.h"
 #include "swift/Basic/Sanitizers.h"
+// FIXME: This include is just for llvm::SanitizerCoverageOptions. We should
+// split the header upstream so we don't include so much.
+#include "llvm/Transforms/Instrumentation.h"
 #include <string>
 #include <vector>
 
@@ -159,19 +162,21 @@ public:
   /// List of backend command-line options for -embed-bitcode.
   std::vector<uint8_t> CmdArgs;
 
-  IRGenOptions() : OutputKind(IRGenOutputKind::LLVMAssembly), Verify(true),
-                   Optimize(false), Sanitize(SanitizerKind::None),
-                   DebugInfoKind(IRGenDebugInfoKind::None),
-                   UseJIT(false), DisableLLVMOptzns(false),
-                   DisableLLVMARCOpts(false), DisableLLVMSLPVectorizer(false),
-                   DisableFPElim(true), Playground(false),
-                   EmitStackPromotionChecks(false), GenerateProfile(false),
-                   PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
-                   HasValueNamesSetting(false), ValueNames(false),
-                   EnableReflectionMetadata(true), EnableReflectionNames(true),
-                   UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
-                   CmdArgs()
-                   {}
+  /// Which sanitizer coverage is turned on.
+  llvm::SanitizerCoverageOptions SanitizeCoverage;
+
+  IRGenOptions()
+      : OutputKind(IRGenOutputKind::LLVMAssembly), Verify(true),
+        Optimize(false), Sanitize(SanitizerKind::None),
+        DebugInfoKind(IRGenDebugInfoKind::None), UseJIT(false),
+        DisableLLVMOptzns(false), DisableLLVMARCOpts(false),
+        DisableLLVMSLPVectorizer(false), DisableFPElim(true), Playground(false),
+        EmitStackPromotionChecks(false), GenerateProfile(false),
+        PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
+        HasValueNamesSetting(false), ValueNames(false),
+        EnableReflectionMetadata(true), EnableReflectionNames(true),
+        UseIncrementalLLVMCodeGen(true), UseSwiftCall(false), CmdArgs(),
+        SanitizeCoverage(llvm::SanitizerCoverageOptions()) {}
 
   /// Gets the name of the specified output filename.
   /// If multiple files are specified, the last one is returned.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -466,4 +466,10 @@ def sanitize_EQ : CommaJoined<["-"], "sanitize=">,
   Flags<[FrontendOption, NoInteractiveOption]>, MetaVarName<"<check>">,
   HelpText<"Turn on runtime checks for erroneous behavior.">;
 
+def sanitize_coverage_EQ : CommaJoined<["-"], "sanitize-coverage=">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  MetaVarName<"<type>">,
+  HelpText<"Specify the type of coverage instrumentation for Sanitizers and"
+  " additional options separated by commas">;
+
 include "FrontendOptions.td"

--- a/include/swift/Option/SanitizerOptions.h
+++ b/include/swift/Option/SanitizerOptions.h
@@ -16,6 +16,9 @@
 #include "swift/Basic/Sanitizers.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Option/Arg.h"
+// FIXME: This include is just for llvm::SanitizerCoverageOptions. We should
+// split the header upstream so we don't include so much.
+#include "llvm/Transforms/Instrumentation.h"
 
 namespace swift {
 class DiagnosticEngine;
@@ -27,5 +30,11 @@ class DiagnosticEngine;
 SanitizerKind parseSanitizerArgValues(const llvm::opt::Arg *A,
                                       const llvm::Triple &Triple,
                                       DiagnosticEngine &Diag);
+
+/// \brief Parses a -sanitize-coverage= argument's value.
+llvm::SanitizerCoverageOptions
+parseSanitizerCoverageArgValue(const llvm::opt::Arg *A,
+                               const llvm::Triple &Triple,
+                               DiagnosticEngine &Diag, SanitizerKind sanitizer);
 }
 #endif // SWIFT_OPTIONS_SANITIZER_OPTIONS_H

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1104,6 +1104,11 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
   OI.SelectedSanitizer = SanitizerKind::None;
   if (const Arg *A = Args.getLastArg(options::OPT_sanitize_EQ))
     OI.SelectedSanitizer = parseSanitizerArgValues(A, TC.getTriple(), Diags);
+
+  // Check that the sanitizer coverage flags are supported if supplied.
+  if (const Arg *A = Args.getLastArg(options::OPT_sanitize_coverage_EQ))
+    (void)parseSanitizerCoverageArgValue(A, TC.getTriple(), Diags,
+                                         OI.SelectedSanitizer);
 }
 
 void Driver::buildActions(const ToolChain &TC,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -131,6 +131,7 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);
   inputArgs.AddLastArg(arguments, options::OPT_warnings_as_errors);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);
+  inputArgs.AddLastArg(arguments, options::OPT_sanitize_coverage_EQ);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1266,6 +1266,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.Sanitize = parseSanitizerArgValues(A, Triple, Diags);
   }
 
+  if (const Arg *A = Args.getLastArg(options::OPT_sanitize_coverage_EQ)) {
+    Opts.SanitizeCoverage =
+        parseSanitizerCoverageArgValue(A, Triple, Diags, Opts.Sanitize);
+  }
+
   if (Args.hasArg(OPT_disable_reflection_metadata)) {
     Opts.EnableReflectionMetadata = false;
     Opts.EnableReflectionNames = false;

--- a/test/Driver/sanitize_coverage.swift
+++ b/test/Driver/sanitize_coverage.swift
@@ -1,0 +1,38 @@
+// XFAIL: linux
+// Different sanitizer coverage types
+// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=func -sanitize=address %s | FileCheck -check-prefix=SANCOV_FUNC %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=bb -sanitize=address %s | FileCheck -check-prefix=SANCOV_BB %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=edge -sanitize=address %s | FileCheck -check-prefix=SANCOV_EDGE %s
+
+// Try some options
+// RUN: %swiftc_driver -driver-print-jobs -sanitize-coverage=edge,indirect-calls,trace-bb,trace-cmp,8bit-counters  -sanitize=address %s | FileCheck -check-prefix=SANCOV_EDGE_WITH_OPTIONS %s
+
+// Invalid command line arguments
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize-coverage=func %s 2>&1 | FileCheck -check-prefix=SANCOV_WITHOUT_XSAN %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize-coverage=bb %s 2>&1 | FileCheck -check-prefix=SANCOV_WITHOUT_XSAN %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize-coverage=edge %s 2>&1 | FileCheck -check-prefix=SANCOV_WITHOUT_XSAN %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=unknown %s 2>&1 | FileCheck -check-prefix=SANCOV_BAD_ARG %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=indirect-calls %s 2>&1 | FileCheck -check-prefix=SANCOV_MISSING_ARG %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=trace-bb %s 2>&1 | FileCheck -check-prefix=SANCOV_MISSING_ARG %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=trace-cmp %s 2>&1 | FileCheck -check-prefix=SANCOV_MISSING_ARG %s
+// RUN: not %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-coverage=8bit-counters %s 2>&1 | FileCheck -check-prefix=SANCOV_MISSING_ARG %s
+
+// SANCOV_FUNC: swift
+// SANCOV_FUNC-DAG: -sanitize-coverage=func
+// SANCOV_FUNC-DAG: -sanitize=address
+
+// SANCOV_BB: swift
+// SANCOV_BB-DAG: -sanitize-coverage=bb
+// SANCOV_BB-DAG: -sanitize=address
+
+// SANCOV_EDGE: swift
+// SANCOV_EDGE-DAG: -sanitize-coverage=edge
+// SANCOV_EDGE-DAG: -sanitize=address
+
+// SANCOV_EDGE_WITH_OPTIONS: swift
+// SANCOV_EDGE_WITH_OPTIONS-DAG: -sanitize-coverage=edge,indirect-calls,trace-bb,trace-cmp,8bit-counters
+// SANCOV_EDGE_WITH_OPTIONS-DAG: -sanitize=address
+
+// SANCOV_WITHOUT_XSAN: option '-sanitize-coverage=' requires a sanitizer to be enabled. Use -sanitize= to enable a sanitizer
+// SANCOV_BAD_ARG: unsupported argument 'unknown' to option '-sanitize-coverage='
+// SANCOV_MISSING_ARG: error: option '-sanitize-coverage=' is missing a required argument ("func", "bb", "edge")

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -1,0 +1,33 @@
+// XFAIL: linux
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=func %s | FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=bb %s | FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge %s | FileCheck %s -check-prefix=SANCOV
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,trace-cmp %s | FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,trace-bb %s | FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_BB
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,indirect-calls %s | FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_INDIRECT_CALLS
+// RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
+
+import Darwin
+
+// FIXME: We should have a reliable way of triggering an indirect call in the
+// LLVM IR generated from this code.
+func test() {
+  // Use random numbers so the compiler can't constant fold
+  let x = arc4random()
+  let y = arc4random()
+  // Comparison is to trigger insertion of __sanitizer_cov_trace_cmp
+  let z = x == y
+  print("\(z)")
+}
+
+test()
+
+// FIXME: We need a way to distinguish the different types of coverage instrumentation
+// that isn't really fragile. For now just check there's at least one call to the function
+// used to increment coverage count at a particular PC.
+// SANCOV: call void @__sanitizer_cov
+
+// SANCOV_TRACE_CMP: call void @__sanitizer_cov_trace_cmp
+// SANCOV_TRACE_BB: call void @__sanitizer_cov_trace_basic_block
+// SANCOV_INDIRECT_CALLS: call void @__sanitizer_cov_indir_call16
+// SANCOV_8BIT_COUNTERS: @__sancov_gen_cov_counter

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -1,0 +1,18 @@
+// RUN: %target-build-swift -sanitize=address -sanitize-coverage=edge %s -o %t_binary
+// RUN: rm -rf %t_coverage_dir
+// RUN: mkdir %t_coverage_dir
+// RUN: ASAN_OPTIONS=abort_on_error=0,coverage=1,coverage_dir=%t_coverage_dir %t_binary
+// check the coverage file exists
+// RUN: ls %t_coverage_dir/sanitizer_coverage.swift.tmp_binary.*.sancov > /dev/null
+
+// REQUIRES: executable_test
+// REQUIRES: asan_runtime
+// For now restrict this test to platforms where we know this test will pass
+// REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
+
+func sayHello() {
+  print("Hello")
+}
+
+sayHello()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Teach the Swift front-end to generate code with "Sanitizer Coverage" with a new command line flag
`-sanitize-coverage=`. This flag is analogous to Clang's `-fsanitize-coverage=`.

This instrumentation currently requires ASan or TSan to be enabled
because the module pass created by `createSanitizerCoverageModulePass()`
inserts calls into functions found in compiler-rt's "sanitizer_common".
"sanitizer_common" is not shipped as an individual library but instead
exists in several of the sanitizer runtime libraries so we have to
link with one of them to avoid linking errors.

The rationale between adding this feature is to allow experimentation
with libFuzzer which currently relies on "Sanitizer Coverage"
instrumentation.

CC: @AnnaZaks @devincoughlin

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
