### PR TITLE
stdlib: refactor unsafe parts of Dictionary

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -114,6 +114,7 @@ set(SWIFTLIB_ESSENTIAL
   UnicodeScalar.swift
   UnicodeTrie.swift.gyb
   Unmanaged.swift
+  UnsafeBitMap.swift
   UnsafeBufferPointer.swift.gyb
   UnsafePointer.swift.gyb
   WriteBackMutableSlice.swift

--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -701,6 +701,14 @@ internal func _unsafeMinus(_ lhs: Int, _ rhs: Int) -> Int {
 #endif
 }
 
+internal func _unsafeMultiply(_ lhs: Int, _ rhs: Int) -> Int {
+#if INTERNAL_CHECKS_ENABLED
+  return lhs * rhs
+#else
+  return lhs &* rhs
+#endif
+}
+
 @available(*, unavailable, renamed: "Integer")
 public typealias IntegerType = Integer
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -140,5 +140,6 @@
     "Process.swift",
     "Tuple.swift",
     "NewtypeWrapper.swift",
+    "UnsafeBitMap.swift"
   ]
 }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2605,38 +2605,23 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   internal
   var _initializedHashtableEntriesBitMapStorage: UnsafeMutablePointer<UInt> {
-    get {
-      let start = UInt(Builtin.ptrtoint_Word(buffer._elementPointer._rawValue))
-      let alignment = UInt(alignof(UInt))
-      let alignMask = alignment &- UInt(1)
-      return UnsafeMutablePointer<UInt>(
-          bitPattern:(start &+ alignMask) & ~alignMask)!
-    }
+    return _roundUp(buffer._elementPointer, toAlignmentOf: UInt.self)
   }
 
   internal var _keys: UnsafeMutablePointer<Key> {
-    get {
-      let start =
-          UInt(Builtin.ptrtoint_Word(
-              _initializedHashtableEntriesBitMapStorage._rawValue)) &+
-          UInt(_BitMap.wordsFor(_capacity)) &* UInt(strideof(UInt))
-      let alignment = UInt(alignof(Key))
-      let alignMask = alignment &- UInt(1)
-      return UnsafeMutablePointer<Key>(
-          bitPattern:(start &+ alignMask) & ~alignMask)!
-    }
+    let bitMapSizeInBytes =
+      _unsafeMultiply(_BitMap.wordsFor(_capacity), strideof(UInt))
+    let start =
+      UnsafeMutablePointer<UInt8>(_initializedHashtableEntriesBitMapStorage)
+      + bitMapSizeInBytes
+    return _roundUp(start, toAlignmentOf: Key.self)
   }
 
 %if Self == 'Dictionary':
   internal var _values: UnsafeMutablePointer<Value> {
-    get {
-      let start = UInt(Builtin.ptrtoint_Word(_keys._rawValue)) &+
-        UInt(_capacity) &* UInt(strideof(Key.self))
-      let alignment = UInt(alignof(Value))
-      let alignMask = alignment &- UInt(1)
-      return UnsafeMutablePointer<Value>(
-          bitPattern:(start &+ alignMask) & ~alignMask)!
-    }
+    let keysSizeInBytes = _unsafeMultiply(_capacity, strideof(Key.self))
+    let start = UnsafeMutablePointer<UInt8>(_keys) + keysSizeInBytes
+    return _roundUp(start, toAlignmentOf: Value.self)
   }
 %end
 

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2460,13 +2460,16 @@ internal struct _BitMap {
   internal let values: UnsafeMutablePointer<UInt>
   internal let bitCount: Int
 
-  // Note: We use UInt here to get unsigned math (shifts).
-  internal static func wordIndex(_ i: UInt) -> UInt {
-    return i / UInt._sizeInBits
+  internal static func wordIndex(_ i: Int) -> Int {
+    // Note: We perform the operation on UInts to get faster unsigned math
+    // (shifts).
+    return Int(bitPattern: UInt(bitPattern: i) / UInt(UInt._sizeInBits))
   }
 
-  internal static func bitIndex(_ i: UInt) -> UInt {
-    return i % UInt._sizeInBits
+  internal static func bitIndex(_ i: Int) -> UInt {
+    // Note: We perform the operation on UInts to get faster unsigned math
+    // (shifts).
+    return UInt(bitPattern: i) % UInt(UInt._sizeInBits)
   }
 
   internal static func wordsFor(_ bitCount: Int) -> Int {
@@ -2493,21 +2496,18 @@ internal struct _BitMap {
   internal subscript(i: Int) -> Bool {
     get {
       _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
-      let idx = UInt(i)
-      let word = values[Int(_BitMap.wordIndex(idx))]
-      let bit = word & (1 << _BitMap.bitIndex(idx))
+      let word = values[_BitMap.wordIndex(i)]
+      let bit = word & (1 << _BitMap.bitIndex(i))
       return bit != 0
     }
     nonmutating set {
       _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
-      let idx = UInt(i)
-      let wordIdx = _BitMap.wordIndex(idx)
+      let wordIdx = _BitMap.wordIndex(i)
+      let bitMask = 1 << _BitMap.bitIndex(i)
       if newValue {
-        values[Int(wordIdx)] =
-            values[Int(wordIdx)] | (1 << _BitMap.bitIndex(idx))
+        values[wordIdx] = values[wordIdx] | bitMask
       } else {
-        values[Int(wordIdx)] =
-            values[Int(wordIdx)] & ~(1 << _BitMap.bitIndex(idx))
+        values[wordIdx] = values[wordIdx] & ~bitMask
       }
     }
   }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2490,7 +2490,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   /// Returns the bytes necessary to store a bit map of 'capacity' bytes and
   /// padding to align the start to word alignment.
   internal static func bytesForBitMap(capacity: Int) -> Int {
-    let numWords = _BitMap.sizeInWords(forCapacity: capacity)
+    let numWords = _UnsafeBitMap.sizeInWords(forCapacity: capacity)
     return numWords * strideof(UInt) + alignof(UInt)
   }
 
@@ -2554,7 +2554,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   internal var _keys: UnsafeMutablePointer<Key> {
     let bitMapSizeInBytes =
-      _unsafeMultiply(_BitMap.sizeInWords(forCapacity: _capacity), strideof(UInt))
+      _unsafeMultiply(_UnsafeBitMap.sizeInWords(forCapacity: _capacity), strideof(UInt))
     let start =
       UnsafeMutablePointer<UInt8>(_initializedHashtableEntriesBitMapStorage)
       + bitMapSizeInBytes
@@ -2582,7 +2582,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
       return _HashedContainerStorageHeader(capacity: capacity)
     }
     let storage = r as! StorageImpl
-    let initializedEntries = _BitMap(
+    let initializedEntries = _UnsafeBitMap(
         storage: storage._initializedHashtableEntriesBitMapStorage,
         bitCount: capacity)
     initializedEntries.initializeToZero()
@@ -2591,7 +2591,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   deinit {
     let capacity = _capacity
-    let initializedEntries = _BitMap(
+    let initializedEntries = _UnsafeBitMap(
         storage: _initializedHashtableEntriesBitMapStorage, bitCount: capacity)
     let keys = _keys
 %if Self == 'Dictionary':
@@ -2641,7 +2641,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   internal let buffer: StorageImpl
 
-  internal let initializedEntries: _BitMap
+  internal let initializedEntries: _UnsafeBitMap
   internal let keys: UnsafeMutablePointer<Key>
 %if Self == 'Dictionary':
   internal let values: UnsafeMutablePointer<Value>
@@ -2649,7 +2649,7 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   internal init(capacity: Int) {
     buffer = StorageImpl.create(capacity: capacity)
-    initializedEntries = _BitMap(
+    initializedEntries = _UnsafeBitMap(
       storage: buffer._initializedHashtableEntriesBitMapStorage,
       bitCount: capacity)
     keys = buffer._keys
@@ -3055,7 +3055,7 @@ internal struct _BridgedNative${Self}Storage {
   internal typealias SequenceElement = ${AnySequenceType}
 
   internal let buffer: StorageImpl
-  internal let initializedEntries: _BitMap
+  internal let initializedEntries: _UnsafeBitMap
   internal let keys: UnsafeMutablePointer<AnyObject>
 %if Self == 'Dictionary':
   internal let values: UnsafeMutablePointer<AnyObject>
@@ -3063,7 +3063,7 @@ internal struct _BridgedNative${Self}Storage {
 
   internal init(buffer: StorageImpl) {
     self.buffer = buffer
-    initializedEntries = _BitMap(
+    initializedEntries = _UnsafeBitMap(
       storage: buffer._initializedHashtableEntriesBitMapStorage,
       bitCount: buffer._capacity)
     keys = buffer._keys

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2482,9 +2482,7 @@ internal struct _BitMap {
   }
 
   internal var numberOfWords: Int {
-    get {
-      return _BitMap.wordsFor(bitCount)
-    }
+    return _BitMap.wordsFor(bitCount)
   }
 
   internal func initializeToZero() {
@@ -2573,9 +2571,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 %end
 
   internal var buffer: BufferPointer {
-    get {
-      return BufferPointer(self)
-    }
+    return BufferPointer(self)
   }
 
   // All underscored functions are unsafe and need a _fixLifetime in the caller.
@@ -2590,9 +2586,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   @_versioned
   internal var _capacity: Int {
-    get {
-      return _body.capacity
-    }
+    return _body.capacity
   }
 
   @_versioned
@@ -2606,9 +2600,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   }
 
   internal var _maxLoadFactorInverse : Double {
-    get {
-      return _body.maxLoadFactorInverse
-    }
+    return _body.maxLoadFactorInverse
   }
 
   internal
@@ -2654,7 +2646,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
     let requiredCapacity =
       bytesForBitMap(capacity: capacity) + bytesForKeys(capacity: capacity)
 %if Self == 'Dictionary':
-        + bytesForValues(capacity: capacity)
+      + bytesForValues(capacity: capacity)
 %end
 
     let r = super.create(minimumCapacity: requiredCapacity) { _ in
@@ -2729,8 +2721,8 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   internal init(capacity: Int) {
     buffer = StorageImpl.create(capacity: capacity)
     initializedEntries = _BitMap(
-        storage: buffer._initializedHashtableEntriesBitMapStorage,
-        bitCount: capacity)
+      storage: buffer._initializedHashtableEntriesBitMapStorage,
+      bitCount: capacity)
     keys = buffer._keys
 %if Self == 'Dictionary':
     values = buffer._values
@@ -2753,11 +2745,9 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   @_transparent
   public // @testable
   var capacity: Int {
-    get {
-      let result = buffer._capacity
-      _fixLifetime(buffer)
-      return result
-    }
+    let result = buffer._capacity
+    _fixLifetime(buffer)
+    return result
   }
 
   @_versioned
@@ -2776,11 +2766,9 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   @_transparent
   internal var maxLoadFactorInverse: Double {
-    get {
-      let result = buffer._maxLoadFactorInverse
-      _fixLifetime(buffer)
-      return result
-    }
+    let result = buffer._maxLoadFactorInverse
+    _fixLifetime(buffer)
+    return result
   }
 
   @_versioned
@@ -3144,7 +3132,6 @@ internal struct _BridgedNative${Self}Storage {
   internal let values: UnsafeMutablePointer<AnyObject>
 %end
 
-
   internal init(buffer: StorageImpl) {
     self.buffer = buffer
     initializedEntries = _BitMap(
@@ -3159,11 +3146,9 @@ internal struct _BridgedNative${Self}Storage {
 
   @_transparent
   internal var capacity: Int {
-    get {
-      let result = buffer._capacity
-      _fixLifetime(buffer)
-      return result
-    }
+    let result = buffer._capacity
+    _fixLifetime(buffer)
+    return result
   }
 
   @_versioned

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2472,7 +2472,7 @@ internal struct _BitMap {
     return UInt(bitPattern: i) % UInt(UInt._sizeInBits)
   }
 
-  internal static func wordsFor(_ bitCount: Int) -> Int {
+  internal static func sizeInWords(forCapacity bitCount: Int) -> Int {
     return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
   }
 
@@ -2482,7 +2482,7 @@ internal struct _BitMap {
   }
 
   internal var numberOfWords: Int {
-    return _BitMap.wordsFor(bitCount)
+    return _BitMap.sizeInWords(forCapacity: bitCount)
   }
 
   internal func initializeToZero() {
@@ -2544,7 +2544,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   /// Returns the bytes necessary to store a bit map of 'capacity' bytes and
   /// padding to align the start to word alignment.
   internal static func bytesForBitMap(capacity: Int) -> Int {
-    let numWords = _BitMap.wordsFor(capacity)
+    let numWords = _BitMap.sizeInWords(forCapacity: capacity)
     return numWords * strideof(UInt) + alignof(UInt)
   }
 
@@ -2608,7 +2608,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   internal var _keys: UnsafeMutablePointer<Key> {
     let bitMapSizeInBytes =
-      _unsafeMultiply(_BitMap.wordsFor(_capacity), strideof(UInt))
+      _unsafeMultiply(_BitMap.sizeInWords(forCapacity: _capacity), strideof(UInt))
     let start =
       UnsafeMutablePointer<UInt8>(_initializedHashtableEntriesBitMapStorage)
       + bitMapSizeInBytes

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2486,9 +2486,7 @@ internal struct _BitMap {
   }
 
   internal func initializeToZero() {
-    for i in 0 ..< numberOfWords {
-      (values + i).initialize(with: 0)
-    }
+    values.initialize(with: 0, count: numberOfWords)
   }
 
   internal subscript(i: Int) -> Bool {

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2490,7 +2490,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   /// Returns the bytes necessary to store a bit map of 'capacity' bytes and
   /// padding to align the start to word alignment.
   internal static func bytesForBitMap(capacity: Int) -> Int {
-    let numWords = _UnsafeBitMap.sizeInWords(forCapacity: capacity)
+    let numWords = _UnsafeBitMap.sizeInWords(forSizeInBits: capacity)
     return numWords * strideof(UInt) + alignof(UInt)
   }
 
@@ -2554,7 +2554,9 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   internal var _keys: UnsafeMutablePointer<Key> {
     let bitMapSizeInBytes =
-      _unsafeMultiply(_UnsafeBitMap.sizeInWords(forCapacity: _capacity), strideof(UInt))
+      _unsafeMultiply(
+        _UnsafeBitMap.sizeInWords(forSizeInBits: _capacity),
+        strideof(UInt))
     let start =
       UnsafeMutablePointer<UInt8>(_initializedHashtableEntriesBitMapStorage)
       + bitMapSizeInBytes

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2549,7 +2549,7 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   /// padding to align the start to word alignment.
   internal static func bytesForBitMap(capacity: Int) -> Int {
     let numWords = _BitMap.wordsFor(capacity)
-    return numWords * sizeof(UInt) + alignof(UInt)
+    return numWords * strideof(UInt) + alignof(UInt)
   }
 
   /// Returns the bytes necessary to store 'capacity' keys and padding to align

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2560,12 +2560,11 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
     return strideof(Key.self) * capacity + padding
   }
 
+%if Self == 'Dictionary':
   /// Returns the bytes necessary to store 'capacity' values and padding to
   /// align the start to the alignment of the 'Value' type assuming a base
   /// address aligned to the maximum of the alignment of the 'Key' type and the
   /// alignment of a word.
-
-%if Self == 'Dictionary':
   internal static func bytesForValues(capacity: Int) -> Int {
     let maxPrevAlignment = max(alignof(Key.self), alignof(UInt))
     let padding = max(0, alignof(Value.self) - maxPrevAlignment)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2455,60 +2455,6 @@ collections = [
 ]
 }%
 
-/// A wrapper around a bitmap storage with room for at least `bitCount` bits.
-internal struct _BitMap {
-  internal let values: UnsafeMutablePointer<UInt>
-  internal let bitCount: Int
-
-  internal static func wordIndex(_ i: Int) -> Int {
-    // Note: We perform the operation on UInts to get faster unsigned math
-    // (shifts).
-    return Int(bitPattern: UInt(bitPattern: i) / UInt(UInt._sizeInBits))
-  }
-
-  internal static func bitIndex(_ i: Int) -> UInt {
-    // Note: We perform the operation on UInts to get faster unsigned math
-    // (shifts).
-    return UInt(bitPattern: i) % UInt(UInt._sizeInBits)
-  }
-
-  internal static func sizeInWords(forCapacity bitCount: Int) -> Int {
-    return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
-  }
-
-  internal init(storage: UnsafeMutablePointer<UInt>, bitCount: Int) {
-    self.bitCount = bitCount
-    self.values = storage
-  }
-
-  internal var numberOfWords: Int {
-    return _BitMap.sizeInWords(forCapacity: bitCount)
-  }
-
-  internal func initializeToZero() {
-    values.initialize(with: 0, count: numberOfWords)
-  }
-
-  internal subscript(i: Int) -> Bool {
-    get {
-      _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
-      let word = values[_BitMap.wordIndex(i)]
-      let bit = word & (1 << _BitMap.bitIndex(i))
-      return bit != 0
-    }
-    nonmutating set {
-      _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
-      let wordIdx = _BitMap.wordIndex(i)
-      let bitMask = 1 << _BitMap.bitIndex(i)
-      if newValue {
-        values[wordIdx] = values[wordIdx] | bitMask
-      } else {
-        values[wordIdx] = values[wordIdx] & ~bitMask
-      }
-    }
-  }
-}
-
 /// Header part of the native storage.
 internal struct _HashedContainerStorageHeader {
   internal init(capacity: Int) {

--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A wrapper around a bitmap storage with room for at least `bitCount` bits.
-internal struct _BitMap {
+internal struct _UnsafeBitMap {
   internal let values: UnsafeMutablePointer<UInt>
   internal let bitCount: Int
 
@@ -37,7 +37,7 @@ internal struct _BitMap {
   }
 
   internal var numberOfWords: Int {
-    return _BitMap.sizeInWords(forCapacity: bitCount)
+    return _UnsafeBitMap.sizeInWords(forCapacity: bitCount)
   }
 
   internal func initializeToZero() {
@@ -47,14 +47,14 @@ internal struct _BitMap {
   internal subscript(i: Int) -> Bool {
     get {
       _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
-      let word = values[_BitMap.wordIndex(i)]
-      let bit = word & (1 << _BitMap.bitIndex(i))
+      let word = values[_UnsafeBitMap.wordIndex(i)]
+      let bit = word & (1 << _UnsafeBitMap.bitIndex(i))
       return bit != 0
     }
     nonmutating set {
       _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
-      let wordIdx = _BitMap.wordIndex(i)
-      let bitMask = 1 << _BitMap.bitIndex(i)
+      let wordIdx = _UnsafeBitMap.wordIndex(i)
+      let bitMask = 1 << _UnsafeBitMap.bitIndex(i)
       if newValue {
         values[wordIdx] = values[wordIdx] | bitMask
       } else {

--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -27,7 +27,7 @@ internal struct _UnsafeBitMap {
     return UInt(bitPattern: i) % UInt(UInt._sizeInBits)
   }
 
-  internal static func sizeInWords(forCapacity bitCount: Int) -> Int {
+  internal static func sizeInWords(forSizeInBits bitCount: Int) -> Int {
     return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
   }
 
@@ -37,7 +37,7 @@ internal struct _UnsafeBitMap {
   }
 
   internal var numberOfWords: Int {
-    return _UnsafeBitMap.sizeInWords(forCapacity: bitCount)
+    return _UnsafeBitMap.sizeInWords(forSizeInBits: bitCount)
   }
 
   internal func initializeToZero() {

--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -11,40 +11,51 @@
 //===----------------------------------------------------------------------===//
 
 /// A wrapper around a bitmap storage with room for at least `bitCount` bits.
-internal struct _UnsafeBitMap {
-  internal let values: UnsafeMutablePointer<UInt>
-  internal let bitCount: Int
+public // @testable
+struct _UnsafeBitMap {
+  public // @testable
+  let values: UnsafeMutablePointer<UInt>
 
-  internal static func wordIndex(_ i: Int) -> Int {
+  public // @testable
+  let bitCount: Int
+
+  public // @testable
+  static func wordIndex(_ i: Int) -> Int {
     // Note: We perform the operation on UInts to get faster unsigned math
     // (shifts).
     return Int(bitPattern: UInt(bitPattern: i) / UInt(UInt._sizeInBits))
   }
 
-  internal static func bitIndex(_ i: Int) -> UInt {
+  public // @testable
+  static func bitIndex(_ i: Int) -> UInt {
     // Note: We perform the operation on UInts to get faster unsigned math
     // (shifts).
     return UInt(bitPattern: i) % UInt(UInt._sizeInBits)
   }
 
-  internal static func sizeInWords(forSizeInBits bitCount: Int) -> Int {
+  public // @testable
+  static func sizeInWords(forSizeInBits bitCount: Int) -> Int {
     return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
   }
 
-  internal init(storage: UnsafeMutablePointer<UInt>, bitCount: Int) {
+  public // @testable
+  init(storage: UnsafeMutablePointer<UInt>, bitCount: Int) {
     self.bitCount = bitCount
     self.values = storage
   }
 
-  internal var numberOfWords: Int {
+  public // @testable
+  var numberOfWords: Int {
     return _UnsafeBitMap.sizeInWords(forSizeInBits: bitCount)
   }
 
-  internal func initializeToZero() {
+  public // @testable
+  func initializeToZero() {
     values.initialize(with: 0, count: numberOfWords)
   }
 
-  internal subscript(i: Int) -> Bool {
+  public // @testable
+  subscript(i: Int) -> Bool {
     get {
       _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
       let word = values[_UnsafeBitMap.wordIndex(i)]

--- a/stdlib/public/core/UnsafeBitMap.swift
+++ b/stdlib/public/core/UnsafeBitMap.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A wrapper around a bitmap storage with room for at least `bitCount` bits.
+internal struct _BitMap {
+  internal let values: UnsafeMutablePointer<UInt>
+  internal let bitCount: Int
+
+  internal static func wordIndex(_ i: Int) -> Int {
+    // Note: We perform the operation on UInts to get faster unsigned math
+    // (shifts).
+    return Int(bitPattern: UInt(bitPattern: i) / UInt(UInt._sizeInBits))
+  }
+
+  internal static func bitIndex(_ i: Int) -> UInt {
+    // Note: We perform the operation on UInts to get faster unsigned math
+    // (shifts).
+    return UInt(bitPattern: i) % UInt(UInt._sizeInBits)
+  }
+
+  internal static func sizeInWords(forCapacity bitCount: Int) -> Int {
+    return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
+  }
+
+  internal init(storage: UnsafeMutablePointer<UInt>, bitCount: Int) {
+    self.bitCount = bitCount
+    self.values = storage
+  }
+
+  internal var numberOfWords: Int {
+    return _BitMap.sizeInWords(forCapacity: bitCount)
+  }
+
+  internal func initializeToZero() {
+    values.initialize(with: 0, count: numberOfWords)
+  }
+
+  internal subscript(i: Int) -> Bool {
+    get {
+      _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
+      let word = values[_BitMap.wordIndex(i)]
+      let bit = word & (1 << _BitMap.bitIndex(i))
+      return bit != 0
+    }
+    nonmutating set {
+      _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
+      let wordIdx = _BitMap.wordIndex(i)
+      let bitMask = 1 << _BitMap.bitIndex(i)
+      if newValue {
+        values[wordIdx] = values[wordIdx] | bitMask
+      } else {
+        values[wordIdx] = values[wordIdx] & ~bitMask
+      }
+    }
+  }
+}
+

--- a/test/SILOptimizer/swap_refcnt.swift
+++ b/test/SILOptimizer/swap_refcnt.swift
@@ -2,10 +2,10 @@
 
 // Make sure we can swap two values in an array without retaining anything.
 
-//CHECK-LABEL: _TF11swap_refcnt11swapByIndex
-//CHECK-NOT: strong_retain
-//CHECK-NOT: strong_release
-//CHECK: return
+// CHECK-LABEL: sil @_TF11swap_refcnt11swapByIndex
+// CHECK-NOT: strong_retain
+// CHECK-NOT: strong_release
+// CHECK: return
 public func swapByIndex(A: inout [Int8], x : Int, y : Int) {
   swap(&A[x],&A[y])
 }

--- a/validation-test/stdlib/UnsafeBitMap.swift
+++ b/validation-test/stdlib/UnsafeBitMap.swift
@@ -1,0 +1,126 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var UnsafeBitMapTests = TestSuite("UnsafeBitMap")
+
+UnsafeBitMapTests.test("wordIndex(_:), bitIndex(_:)") {
+#if arch(i386) || arch(arm)
+  for i in 0...31 {
+    expectEqual(0, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+  for i in 32...63 {
+    expectEqual(1, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i - 32, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+  for i in 64...95 {
+    expectEqual(2, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i - 64, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+  for i in 96...127 {
+    expectEqual(3, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i - 96, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
+  for i in 0...63 {
+    expectEqual(0, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+  for i in 64...127 {
+    expectEqual(1, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i - 64, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+  for i in 192...255 {
+    expectEqual(3, _UnsafeBitMap.wordIndex(i), "i=\(i)")
+    expectEqual(i - 192, Int(_UnsafeBitMap.bitIndex(i)), "i=\(i)")
+  }
+#else
+  _UnimplementedError()
+#endif
+}
+
+UnsafeBitMapTests.test("sizeInWords(forSizeInBits:)")
+  .xfail(.always("the API is buggy")).code {
+  expectEqual(0, _UnsafeBitMap.sizeInWords(forSizeInBits: 0))
+#if arch(i386) || arch(arm)
+  for i in 1...32 {
+    expectEqual(1, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+  for i in 33...64 {
+    expectEqual(2, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+  for i in 65...96 {
+    expectEqual(3, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+  for i in 97...128 {
+    expectEqual(4, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le)
+  for i in 1...64 {
+    expectEqual(1, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+  for i in 65...128 {
+    expectEqual(2, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+  for i in 193...256 {
+    expectEqual(4, _UnsafeBitMap.sizeInWords(forSizeInBits: i), "i=\(i)")
+  }
+#else
+  _UnimplementedError()
+#endif
+}
+
+let sizes = [
+  0, 1, 2, 3, 7, 8, 9, 31, 32, 33, 48, 63, 64, 65, 127, 128, 129, 1024, 10000
+]
+
+func make(sizeInBits: Int) -> _UnsafeBitMap {
+  let sizeInWords = _UnsafeBitMap.sizeInWords(forSizeInBits: sizeInBits)
+  let storage = UnsafeMutablePointer<UInt>(allocatingCapacity: sizeInWords)
+  let bitMap = _UnsafeBitMap(storage: storage, bitCount: sizeInBits)
+  expectEqual(sizeInWords, bitMap.numberOfWords)
+  return bitMap
+}
+
+UnsafeBitMapTests.test("initializeToZero()")
+  .forEach(in: sizes) {
+  sizeInBits in
+  let bitMap = make(sizeInBits: sizeInBits)
+  defer { bitMap.values.deallocateCapacity(bitMap.numberOfWords) }
+
+  bitMap.initializeToZero()
+  for i in 0..<sizeInBits {
+    expectEqual(false, bitMap[i])
+  }
+}
+
+UnsafeBitMapTests.test("subscript")
+  .forEach(in: sizes) {
+  sizeInBits in
+  let bitMap = make(sizeInBits: sizeInBits)
+  defer { bitMap.values.deallocateCapacity(bitMap.numberOfWords) }
+
+  if sizeInBits != 0 {
+    bitMap.initializeToZero()
+    let index = 7882627 % sizeInBits
+    bitMap[index] = true
+    for i in 0..<sizeInBits {
+      expectEqual(i == index, bitMap[i])
+    }
+  }
+
+  if sizeInBits < 500 {
+    for i in 0..<sizeInBits {
+      bitMap.initializeToZero()
+      bitMap[i] = true
+      for j in 0..<sizeInBits {
+        expectEqual(i == j, bitMap[j])
+      }
+    }
+  }
+}
+
+runAllTests()
+


### PR DESCRIPTION
This is an NFC change that refactors unsafe parts of Dictionary to be more maintainable.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
