### PR TITLE
[stdlib] SR-1519: Implement SE-0032: Add Sequence.first(predicate:)

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -127,7 +127,11 @@ public struct FindTest {
   ) {
     self.expected = expected
     self.element = MinimalEquatableValue(element)
-    self.sequence = sequence.map(MinimalEquatableValue.init)
+    var elementIndex = 0
+    self.sequence = sequence.map {
+    	defer { elementIndex += 1 }
+    	return MinimalEquatableValue($0, identity: elementIndex) 
+    }
     self.expectedLeftoverSequence = expectedLeftoverSequence.map(
       MinimalEquatableValue.init)
     self.loc = SourceLoc(file, line, comment: "test data")

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -127,7 +127,7 @@ public struct FindTest {
   ) {
     self.expected = expected
     self.element = MinimalEquatableValue(element)
-    self.sequence = sequence.enumerate().map {
+    self.sequence = sequence.enumerated().map {
       return MinimalEquatableValue($1, identity: $0) 
     }
     self.expectedLeftoverSequence = expectedLeftoverSequence.map(
@@ -1777,21 +1777,21 @@ self.test("\(testNamePrefix).forEach/semantics") {
 // first()
 //===----------------------------------------------------------------------===//
 
-SequenceTypeTests.test("\(testNamePrefix).first/semantics") {
+self.test("\(testNamePrefix).first/semantics") {
   for test in findTests {
-    let s = MinimalSequence<MinimalEquatableValue>(elements: test.sequence)
+    let s = makeWrappedSequenceWithEquatableElement(test.sequence)
     let closureLifetimeTracker = LifetimeTracked(0)
     let found = s.first {
       _blackHole(closureLifetimeTracker)
-      return $0 == test.element
+      return $0 == wrapValueIntoEquatable(test.element)
     }
     expectEqual(
-      test.expected == nil ? nil : test.element,
+      test.expected == nil ? nil : wrapValueIntoEquatable(test.element),
       found,
       stackTrace: SourceLocStack().with(test.loc))
-    if let found = found {
+    if test.expected != nil {
       expectEqual(
-        test.expected, found.identity,
+        test.expected, (found as? MinimalEquatableValue)?.identity,
         "find() should find only the first element matching its predicate")
     }
   }

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -81,6 +81,7 @@ public class SequenceLog {
   public static var map = TypeIndexed(0)
   public static var filter = TypeIndexed(0)
   public static var forEach = TypeIndexed(0)
+  public static var find = TypeIndexed(0)
   public static var dropFirst = TypeIndexed(0)
   public static var dropLast = TypeIndexed(0)
   public static var prefixMaxLength = TypeIndexed(0)
@@ -242,6 +243,13 @@ public struct ${Self}<
   ) rethrows {
     Log.forEach[selfType] += 1
     try base.forEach(body)
+  }
+  
+  public func find(
+    where predicate: @noescape (Base.Iterator.Element) throws -> Void
+  ) rethrows -> Base.Iterator.Element? {
+    Log.find[selfType] += 1
+    return base.find(where: predicate)
   }
 
   public typealias SubSequence = Base.SubSequence

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -249,7 +249,7 @@ public struct ${Self}<
     where predicate: @noescape (Base.Iterator.Element) throws -> Void
   ) rethrows -> Base.Iterator.Element? {
     Log.find[selfType] += 1
-    return base.find(where: predicate)
+    return try base.find(where: predicate)
   }
 
   public typealias SubSequence = Base.SubSequence

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -81,7 +81,7 @@ public class SequenceLog {
   public static var map = TypeIndexed(0)
   public static var filter = TypeIndexed(0)
   public static var forEach = TypeIndexed(0)
-  public static var find = TypeIndexed(0)
+  public static var first = TypeIndexed(0)
   public static var dropFirst = TypeIndexed(0)
   public static var dropLast = TypeIndexed(0)
   public static var prefixMaxLength = TypeIndexed(0)
@@ -114,7 +114,6 @@ public class CollectionLog : SequenceLog {
   public static var isEmpty = TypeIndexed(0)
   public static var count = TypeIndexed(0)
   public static var _customIndexOfEquatableElement = TypeIndexed(0)
-  public static var first = TypeIndexed(0)
   public static var advance = TypeIndexed(0)
   public static var advanceLimit = TypeIndexed(0)
   public static var distance = TypeIndexed(0)
@@ -245,11 +244,11 @@ public struct ${Self}<
     try base.forEach(body)
   }
   
-  public func find(
-    where predicate: @noescape (Base.Iterator.Element) throws -> Void
+  public func first(
+    where predicate: @noescape (Base.Iterator.Element) throws -> Bool
   ) rethrows -> Base.Iterator.Element? {
-    Log.find[selfType] += 1
-    return try base.find(where: predicate)
+    Log.first[selfType] += 1
+    return try base.first(where: predicate)
   }
 
   public typealias SubSequence = Base.SubSequence

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -564,6 +564,18 @@ public protocol Sequence {
     isSeparator: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence]
 
+  /// Returns the first element of the sequence that satisfies the given
+  /// predicate or nil if no such element is found.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the
+  ///   sequence as its argument and returns a Boolean value indicating
+  ///   whether the element is a match.
+  /// - Returns: The first match or `nil` if there was no match.
+  @warn_unused_result
+  func first(
+    predicate: @noescape (Iterator.Element) throws -> Bool
+  ) rethrows -> Iterator.Element?
+
   @warn_unused_result
   func _customContainsEquatableElement(
     _ element: Iterator.Element
@@ -950,12 +962,31 @@ extension Sequence {
   ///
   /// - Parameter body: A closure that takes an element of the sequence as a
   ///   parameter.
+  @warn_unused_result
   public func forEach(
     _ body: @noescape (Iterator.Element) throws -> Void
   ) rethrows {
     for element in self {
       try body(element)
     }
+  }
+  
+  /// Returns the first element of the sequence that satisfies the given
+  /// predicate or nil if no such element is found.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the
+  ///   sequence as its argument and returns a Boolean value indicating
+  ///   whether the element is a match.
+  /// - Returns: The first match or `nil` if there was no match.
+  public func first(
+    predicate: @noescape (Iterator.Element) throws -> Bool
+  ) rethrows -> Iterator.Element? {
+    for element in self {
+      if try predicate(element) {
+        return element
+      }
+    }
+    return nil
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -968,7 +968,13 @@ extension Sequence {
       try body(element)
     }
   }
-  
+}
+
+private enum _StopIteration: ErrorProtocol {
+    case stop
+}
+
+extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate or nil if no such element is found.
   ///
@@ -979,12 +985,16 @@ extension Sequence {
   public func first(
     where predicate: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
-    for element in self {
-      if try predicate(element) {
-        return element
+    var foundElement: Iterator.Element? = nil
+    do {
+      try self.forEach {
+        if try predicate($0) {
+          foundElement = $0
+          throw _StopIteration.stop
+        }
       }
-    }
-    return nil
+    } catch is _StopIteration { }
+    return foundElement
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -970,8 +970,8 @@ extension Sequence {
   }
 }
 
-private enum _StopIteration: ErrorProtocol {
-    case stop
+internal enum _StopIteration : ErrorProtocol {
+  case stop
 }
 
 extension Sequence {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -567,13 +567,12 @@ public protocol Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate or nil if no such element is found.
   ///
-  /// - Parameter predicate: A closure that takes an element of the
+  /// - Parameter where: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element is a match.
   /// - Returns: The first match or `nil` if there was no match.
-  @warn_unused_result
   func first(
-    predicate: @noescape (Iterator.Element) throws -> Bool
+    where: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element?
 
   @warn_unused_result
@@ -962,7 +961,6 @@ extension Sequence {
   ///
   /// - Parameter body: A closure that takes an element of the sequence as a
   ///   parameter.
-  @warn_unused_result
   public func forEach(
     _ body: @noescape (Iterator.Element) throws -> Void
   ) rethrows {
@@ -974,12 +972,12 @@ extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate or nil if no such element is found.
   ///
-  /// - Parameter predicate: A closure that takes an element of the
+  /// - Parameter where: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element is a match.
   /// - Returns: The first match or `nil` if there was no match.
   public func first(
-    predicate: @noescape (Iterator.Element) throws -> Bool
+    where predicate: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
     for element in self {
       if try predicate(element) {

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -617,6 +617,26 @@ SequenceTypeTests.test("contains/Predicate") {
 }
 
 //===----------------------------------------------------------------------===//
+// first()
+//===----------------------------------------------------------------------===//
+
+SequenceTypeTests.test("first/Predicate") {
+  for test in findTests {
+    let s = MinimalSequence<MinimalEquatableValue>(elements: test.sequence)
+    let found = s.first { $0 == test.element }
+    expectEqual(
+      test.expected == nil ? nil : test.element,
+      found,
+      stackTrace: SourceLocStack().with(test.loc))
+    if let found = found {
+      expectEqual(
+        test.expected, found.identity,
+        "find() should find only the first element matching its predicate")
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // reduce()
 //===----------------------------------------------------------------------===//
 

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -617,26 +617,6 @@ SequenceTypeTests.test("contains/Predicate") {
 }
 
 //===----------------------------------------------------------------------===//
-// first()
-//===----------------------------------------------------------------------===//
-
-SequenceTypeTests.test("first/Predicate") {
-  for test in findTests {
-    let s = MinimalSequence<MinimalEquatableValue>(elements: test.sequence)
-    let found = s.first { $0 == test.element }
-    expectEqual(
-      test.expected == nil ? nil : test.element,
-      found,
-      stackTrace: SourceLocStack().with(test.loc))
-    if let found = found {
-      expectEqual(
-        test.expected, found.identity,
-        "find() should find only the first element matching its predicate")
-    }
-  }
-}
-
-//===----------------------------------------------------------------------===//
 // reduce()
 //===----------------------------------------------------------------------===//
 
@@ -962,6 +942,16 @@ SequenceTypeTests.test("forEach/dispatch") {
   let tester = SequenceLog.dispatchTester([OpaqueValue(1)])
   tester.forEach { print($0) }
   expectCustomizable(tester, tester.log.forEach)
+}
+
+//===----------------------------------------------------------------------===//
+// first()
+//===----------------------------------------------------------------------===//
+
+SequenceTypeTests.test("first/dispatch") {
+  let tester = SequenceLog.dispatchTester([OpaqueValue(1)])
+  tester.first { return $0.value == 1 }
+  expectCustomizable(tester, tester.log.first)
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -950,7 +950,7 @@ SequenceTypeTests.test("forEach/dispatch") {
 
 SequenceTypeTests.test("first/dispatch") {
   let tester = SequenceLog.dispatchTester([OpaqueValue(1)])
-  tester.first { return $0.value == 1 }
+  tester.first { $0.value == 1 }
   expectCustomizable(tester, tester.log.first)
 }
 


### PR DESCRIPTION
#### What's in this pull request?

Implementation of SE-0032, adds `first()` to `Sequence` protocol along with default implementation.

I modified `FindTest` to give each of the elements a separate `identity` so the `find` test can verify it found the first element and not just any matching element.
#### Resolved bug number: ([SR-1519](https://bugs.swift.org/browse/SR-1519))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
