### PR TITLE
SR-1509: C preprocessor macros with casts should be visible to Swift

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -70,6 +70,21 @@ static bool isInSystemModule(DeclContext *D) {
   return false;
 }
 
+static ValueDecl *
+createMacroConstant(ClangImporter::Implementation &Impl,
+                    const clang::MacroInfo *macro,
+                    Identifier name,
+                    DeclContext *dc,
+                    Type type,
+                    const clang::APValue &value,
+                    ConstantConvertKind convertKind,
+                    bool isStatic,
+                    ClangNode ClangN) {
+  Impl.ImportedMacroConstants[macro] = {value, type};
+  return Impl.createConstant(name, dc, type, value, convertKind, isStatic,
+                             ClangN);
+}
+
 static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
                                        DeclContext *DC,
                                        const clang::MacroInfo *MI,
@@ -127,7 +142,8 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
         }
       }
 
-      return Impl.createConstant(name, DC, constantType, clang::APValue(value),
+      return createMacroConstant(Impl, MI, name, DC, constantType,
+                                 clang::APValue(value),
                                  ConstantConvertKind::Coerce,
                                  /*static*/ false, ClangN);
     }
@@ -144,7 +160,8 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
         value.changeSign();
       }
 
-      return Impl.createConstant(name, DC, constantType, clang::APValue(value),
+      return createMacroConstant(Impl, MI, name, DC, constantType,
+                                 clang::APValue(value),
                                  ConstantConvertKind::Coerce,
                                  /*static*/ false, ClangN);
     }
@@ -156,6 +173,11 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
 static bool isStringToken(const clang::Token &tok) {
   return tok.is(clang::tok::string_literal) ||
          tok.is(clang::tok::utf8_string_literal);
+}
+
+static bool isBitwiseOperator(const clang::Token &tok) {
+  return tok.is(clang::tok::amp) ||
+         tok.is(clang::tok::pipe);
 }
 
 // Describes the kind of string literal we're importing.
@@ -330,9 +352,53 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
       llvm::APSInt value{ base->getValue() << shift->getValue(),
                           clangTy->isUnsignedIntegerType() };
-      return impl.createConstant(name, DC, type, clang::APValue(value),
+      return createMacroConstant(impl, macro, name, DC, type,
+                                 clang::APValue(value),
                                  ConstantConvertKind::Coerce, /*static=*/false,
                                  ClangN);
+    // Check for a expression of the form (FLAG1 | FLAG2) or (FLAG1 & FLAG2)
+    } else if (tokenI[0].is(clang::tok::identifier) &&
+               isBitwiseOperator(tokenI[1]) &&
+               tokenI[2].is(clang::tok::identifier)) {
+      auto firstID = tokenI[0].getIdentifierInfo();
+      auto secondID = tokenI[2].getIdentifierInfo();
+
+      if (firstID->hasMacroDefinition() && secondID->hasMacroDefinition()) {
+        auto firstMacroInfo = impl.getClangPreprocessor().getMacroInfo(firstID);
+        auto secondMacroInfo = impl.getClangPreprocessor().getMacroInfo(
+                                                                      secondID);
+        auto firstIterator = impl.ImportedMacroConstants.find(firstMacroInfo);
+        if (firstIterator == impl.ImportedMacroConstants.end()) {
+          return nullptr;
+        }
+        auto secondIterator = impl.ImportedMacroConstants.find(secondMacroInfo);
+        if (secondIterator == impl.ImportedMacroConstants.end()) {
+          return nullptr;
+        }
+
+        auto firstConstant = firstIterator->second;
+        auto secondConstant = secondIterator->second;
+        auto firstValue = firstConstant.first;
+        auto secondValue = secondConstant.first;
+        if (!firstValue.isInt() || !secondValue.isInt()) {
+          return nullptr;
+        }
+
+        auto firstInteger = firstValue.getInt();
+        auto secondInteger = secondValue.getInt();
+        auto type = firstConstant.second;
+
+        clang::APValue value;
+        if (tokenI[1].is(clang::tok::pipe)) {
+          value = clang::APValue(firstInteger | secondInteger);
+        } else {
+          value = clang::APValue(firstInteger & secondInteger);
+        }
+        return createMacroConstant(impl, macro, name, DC, type,
+                                   value,
+                                   ConstantConvertKind::Coerce,
+                                   /*static=*/false, ClangN);
+      }
     }
     break;
   }

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -433,9 +433,17 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
         clang::APValue value;
         if (tokenI[1].is(clang::tok::pipe)) {
-          value = clang::APValue(firstInteger | secondInteger);
+          if (firstInteger.getBitWidth() == secondInteger.getBitWidth()) {
+            value = clang::APValue(firstInteger | secondInteger);
+          } else {
+            return nullptr;
+          }
         } else if (tokenI[1].is(clang::tok::amp)) {
-          value = clang::APValue(firstInteger & secondInteger);
+          if (firstInteger.getBitWidth() == secondInteger.getBitWidth()) {
+            value = clang::APValue(firstInteger & secondInteger);
+          } else {
+            return nullptr;
+          }
         } else if (tokenI[1].is(clang::tok::pipepipe)) {
           auto firstBool = firstInteger.getBoolValue();
           auto secondBool = firstInteger.getBoolValue();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -386,6 +386,10 @@ public:
                  SmallVector<std::pair<clang::MacroInfo *, ValueDecl *>, 2>>
     ImportedMacros;
 
+  // Mapping from macro to value for macros that expand to constant values.
+  llvm::DenseMap<const clang::MacroInfo *, std::pair<clang::APValue, Type>>
+    ImportedMacroConstants;
+
   /// Keeps track of active selector-based lookups, so that we don't infinitely
   /// recurse when checking whether a method with a given selector has already
   /// been imported.

--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -189,6 +189,8 @@ class <loc>FooClassDerived</loc> : <ref:Class>FooClassBase</ref>, <ref:Protocol>
 <decl:Var>var <loc>FOO_MACRO_5</loc>: <ref:Struct>UInt64</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_6</loc>: <ref:TypeAlias>typedef_int_t</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_7</loc>: <ref:TypeAlias>typedef_int_t</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_OR</loc>: <ref:Struct>Int32</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_AND</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_REDEF_1</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_REDEF_2</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Func>func <loc>theLastDeclInFoo()</loc></decl>

--- a/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.annotated.txt
@@ -181,11 +181,14 @@ class <loc>FooClassDerived</loc> : <ref:Class>FooClassBase</ref>, <ref:Protocol>
   func <loc>fooProtoFuncWithExtraIndentation2()</loc></decl>
   <decl:Func>class func <loc>fooProtoClassFunc()</loc></decl>
 }</decl>
+<decl:TypeAlias>typealias <loc>typedef_int_t</loc> = <ref:Struct>Int32</ref></decl>
 <decl:Var>var <loc>FOO_MACRO_1</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_2</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_3</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_4</loc>: <ref:Struct>UInt32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_5</loc>: <ref:Struct>UInt64</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_6</loc>: <ref:TypeAlias>typedef_int_t</ref> { get }</decl>
+<decl:Var>var <loc>FOO_MACRO_7</loc>: <ref:TypeAlias>typedef_int_t</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_REDEF_1</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Var>var <loc>FOO_MACRO_REDEF_2</loc>: <ref:Struct>Int32</ref> { get }</decl>
 <decl:Func>func <loc>theLastDeclInFoo()</loc></decl>
@@ -235,6 +238,8 @@ class <loc>FooClassDerived</loc> : <ref:Class>FooClassBase</ref>, <ref:Protocol>
   <decl:Constructor><loc>init!()</loc></decl>
   <decl:Constructor>convenience <loc>init!(<decl:Param>float f: <ref:Struct>Float</ref></decl>)</loc></decl>
 }</decl>
+<decl:Var>@available(*, unavailable, message: "use 'nil' instead of this imported macro")
+var <loc>FOO_NIL</loc>: ()</decl>
 <decl:Class>class <loc>FooUnavailableMembers</loc> : <ref:Class>FooClassBase</ref> {
   <decl:Constructor>convenience <loc>init!(<decl:Param>int i: <ref:Struct>Int32</ref></decl>)</loc></decl>
   <decl:Func>@available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")

--- a/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
+++ b/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
@@ -180,6 +180,7 @@ int fooFuncUsingVararg(int a, ...);// This comment should not show without decl.
 
 @class BarForwardDeclaredClass;
 enum BarforwardDeclaredEnum;
+typedef int typedef_int_t;
 
 /* FOO_MACRO_1 is the answer */
 #define FOO_MACRO_1 0
@@ -187,6 +188,8 @@ enum BarforwardDeclaredEnum;
 #define FOO_MACRO_3 (-1) // Don't use FOO_MACRO_3 on Saturdays.
 #define FOO_MACRO_4 0xffffffffu
 #define FOO_MACRO_5 0xffffffffffffffffull
+#define FOO_MACRO_6 ((typedef_int_t) 42)
+#define FOO_MACRO_7 ((typedef_int_t) -1)
 
 #define FOO_MACRO_UNDEF_1 0
 #undef FOO_MACRO_UNDEF_1

--- a/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
+++ b/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
@@ -191,7 +191,8 @@ typedef int typedef_int_t;
 #define FOO_MACRO_6 ((typedef_int_t) 42)
 #define FOO_MACRO_7 ((typedef_int_t) -1)
 #define FOO_MACRO_OR (FOO_MACRO_2 | FOO_MACRO_6)
-#define FOO_MACRO_AND (FOO_MACRO_2 | FOO_MACRO_6)
+#define FOO_MACRO_AND (FOO_MACRO_2 & FOO_MACRO_6)
+#define FOO_MACRO_BITWIDTH (FOO_MACRO_4 & FOO_MACRO_5)
 
 #define FOO_MACRO_UNDEF_1 0
 #undef FOO_MACRO_UNDEF_1

--- a/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
+++ b/test/IDE/Inputs/mock-sdk/Foo.framework/Headers/Foo.h
@@ -190,6 +190,8 @@ typedef int typedef_int_t;
 #define FOO_MACRO_5 0xffffffffffffffffull
 #define FOO_MACRO_6 ((typedef_int_t) 42)
 #define FOO_MACRO_7 ((typedef_int_t) -1)
+#define FOO_MACRO_OR (FOO_MACRO_2 | FOO_MACRO_6)
+#define FOO_MACRO_AND (FOO_MACRO_2 | FOO_MACRO_6)
 
 #define FOO_MACRO_UNDEF_1 0
 #undef FOO_MACRO_UNDEF_1

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -181,11 +181,14 @@ class FooClassDerived : FooClassBase, FooProtocolDerived {
   func fooProtoFuncWithExtraIndentation2()
   class func fooProtoClassFunc()
 }
+typealias typedef_int_t = Int32
 var FOO_MACRO_1: Int32 { get }
 var FOO_MACRO_2: Int32 { get }
 var FOO_MACRO_3: Int32 { get }
 var FOO_MACRO_4: UInt32 { get }
 var FOO_MACRO_5: UInt64 { get }
+var FOO_MACRO_6: typedef_int_t { get }
+var FOO_MACRO_7: typedef_int_t { get }
 var FOO_MACRO_REDEF_1: Int32 { get }
 var FOO_MACRO_REDEF_2: Int32 { get }
 func theLastDeclInFoo()
@@ -235,6 +238,8 @@ class FooClassWithClassProperties : FooClassBase {
   init!()
   convenience init!(float f: Float)
 }
+@available(*, unavailable, message: "use 'nil' instead of this imported macro")
+var FOO_NIL: ()
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)
   @available(*, unavailable, message: "use object construction 'FooUnavailableMembers(int:)'")

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.recursive.txt
@@ -189,6 +189,8 @@ var FOO_MACRO_4: UInt32 { get }
 var FOO_MACRO_5: UInt64 { get }
 var FOO_MACRO_6: typedef_int_t { get }
 var FOO_MACRO_7: typedef_int_t { get }
+var FOO_MACRO_OR: Int32 { get }
+var FOO_MACRO_AND: Int32 { get }
 var FOO_MACRO_REDEF_1: Int32 { get }
 var FOO_MACRO_REDEF_2: Int32 { get }
 func theLastDeclInFoo()

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -217,12 +217,16 @@ class FooClassDerived : FooClassBase, FooProtocolDerived {
   class func fooProtoClassFunc()
 }
 
+typealias typedef_int_t = Int32
+
 /* FOO_MACRO_1 is the answer */
 var FOO_MACRO_1: Int32 { get }
 var FOO_MACRO_2: Int32 { get }
 var FOO_MACRO_3: Int32 { get } // Don't use FOO_MACRO_3 on Saturdays.
 var FOO_MACRO_4: UInt32 { get }
 var FOO_MACRO_5: UInt64 { get }
+var FOO_MACRO_6: typedef_int_t { get }
+var FOO_MACRO_7: typedef_int_t { get }
 
 var FOO_MACRO_REDEF_1: Int32 { get }
 
@@ -285,6 +289,9 @@ class FooClassWithClassProperties : FooClassBase {
   init!()
   convenience init!(float f: Float)
 }
+
+@available(*, unavailable, message: "use 'nil' instead of this imported macro")
+var FOO_NIL: ()
 
 class FooUnavailableMembers : FooClassBase {
   convenience init!(int i: Int32)

--- a/test/IDE/Inputs/mock-sdk/Foo.printed.txt
+++ b/test/IDE/Inputs/mock-sdk/Foo.printed.txt
@@ -227,6 +227,8 @@ var FOO_MACRO_4: UInt32 { get }
 var FOO_MACRO_5: UInt64 { get }
 var FOO_MACRO_6: typedef_int_t { get }
 var FOO_MACRO_7: typedef_int_t { get }
+var FOO_MACRO_OR: Int32 { get }
+var FOO_MACRO_AND: Int32 { get }
 
 var FOO_MACRO_REDEF_1: Int32 { get }
 

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -146,7 +146,7 @@ func testCompleteModuleQualifiedFoo2() {
   Foo#^CLANG_QUAL_FOO_2^#
 // If the number of results below changes, then you need to add a result to the
 // list below.
-// CLANG_QUAL_FOO_2: Begin completions, 64 items
+// CLANG_QUAL_FOO_2: Begin completions, 69 items
 // CLANG_QUAL_FOO_2-DAG: Decl[Class]/OtherModule[Foo]:        .FooClassBase[#FooClassBase#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[Class]/OtherModule[Foo]:        .FooClassDerived[#FooClassDerived#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[Class]/OtherModule[Foo]:        .ClassWithInternalProt[#ClassWithInternalProt#]{{; name=.+$}}
@@ -176,6 +176,10 @@ func testCompleteModuleQualifiedFoo2() {
 // CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_3[#Int32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_4[#UInt32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_5[#UInt64#]{{; name=.+$}}
+// CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_6[#typedef_int_t#]{{; name=.+$}}
+// CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_7[#typedef_int_t#]{{; name=.+$}}
+// CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_OR[#Int32#]{{; name=.+$}}
+// CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_AND[#Int32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_REDEF_1[#Int32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FOO_MACRO_REDEF_2[#Int32#]{{; name=.+$}}
 // CLANG_QUAL_FOO_2-DAG: Decl[GlobalVar]/OtherModule[Foo]:    .FooEnum1X[#FooEnum1#]{{; name=.+$}}

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -293,6 +293,7 @@ class FooClassPropertyOwnership : FooClassBase {
 
     func _internalMeth1() -> AnyObject!
 }
+var FOO_NIL: ()
 class FooUnavailableMembers : FooClassBase {
 
     convenience init!(int i: Int32)
@@ -4222,519 +4223,529 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 6087,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6091,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6103,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6093,
+    key.offset: 6109,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6117,
+    key.offset: 6133,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6137,
+    key.offset: 6153,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6149,
+    key.offset: 6165,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6155,
+    key.offset: 6171,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6159,
+    key.offset: 6175,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6155,
+    key.offset: 6171,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6159,
+    key.offset: 6175,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6162,
+    key.offset: 6178,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6174,
+    key.offset: 6190,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6180,
+    key.offset: 6196,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6185,
+    key.offset: 6201,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6193,
+    key.offset: 6209,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6195,
+    key.offset: 6211,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6195,
+    key.offset: 6211,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6198,
+    key.offset: 6214,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 6208,
+    key.offset: 6224,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6219,
+    key.offset: 6235,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6224,
+    key.offset: 6240,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6243,
+    key.offset: 6259,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6248,
+    key.offset: 6264,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6272,
+    key.offset: 6288,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6277,
+    key.offset: 6293,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6295,
+    key.offset: 6311,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6300,
+    key.offset: 6316,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6330,
+    key.offset: 6346,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6335,
+    key.offset: 6351,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6365,
+    key.offset: 6381,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6370,
+    key.offset: 6386,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6399,
+    key.offset: 6415,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6404,
+    key.offset: 6420,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6435,
+    key.offset: 6451,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6440,
+    key.offset: 6456,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6473,
+    key.offset: 6489,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6478,
+    key.offset: 6494,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6511,
+    key.offset: 6527,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6516,
+    key.offset: 6532,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6548,
+    key.offset: 6564,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6553,
+    key.offset: 6569,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6587,
+    key.offset: 6603,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6592,
+    key.offset: 6608,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6612,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 6628,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6644,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6633,
+    key.offset: 6649,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6653,
+    key.offset: 6669,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6669,
+    key.offset: 6685,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6674,
+    key.offset: 6690,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6695,
+    key.offset: 6711,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6711,
+    key.offset: 6727,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6716,
+    key.offset: 6732,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "AnyObject",
     key.usr: "s:Ps9AnyObject",
-    key.offset: 6736,
+    key.offset: 6752,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6749,
+    key.offset: 6765,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6755,
+    key.offset: 6771,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6769,
+    key.offset: 6785,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6774,
+    key.offset: 6790,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6791,
+    key.offset: 6807,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6793,
+    key.offset: 6809,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 6796,
+    key.offset: 6812,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6808,
+    key.offset: 6824,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6813,
+    key.offset: 6829,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6825,
+    key.offset: 6841,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6827,
+    key.offset: 6843,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6827,
+    key.offset: 6843,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6830,
+    key.offset: 6846,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:Vs5Int32",
-    key.offset: 6840,
+    key.offset: 6856,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6846,
+    key.offset: 6862,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6853,
+    key.offset: 6869,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:Ps16RawRepresentable",
-    key.offset: 6867,
+    key.offset: 6883,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:Ps9Equatable",
-    key.offset: 6885,
+    key.offset: 6901,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6902,
+    key.offset: 6918,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6907,
+    key.offset: 6923,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6909,
+    key.offset: 6925,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6909,
+    key.offset: 6925,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 6919,
+    key.offset: 6935,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6932,
+    key.offset: 6948,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6937,
+    key.offset: 6953,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6946,
+    key.offset: 6962,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6937,
+    key.offset: 6953,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6946,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "UInt32",
-    key.usr: "s:Vs6UInt32",
-    key.offset: 6956,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6969,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6973,
+    key.offset: 6962,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:Vs6UInt32",
-    key.offset: 6983,
+    key.offset: 6972,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6992,
+    key.offset: 6985,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6996,
+    key.offset: 6989,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:Vs6UInt32",
+    key.offset: 6999,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7008,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7012,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7010,
+    key.offset: 7026,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7024,
+    key.offset: 7040,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7030,
+    key.offset: 7046,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7034,
+    key.offset: 7050,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7048,
+    key.offset: 7064,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7062,
+    key.offset: 7078,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7068,
+    key.offset: 7084,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7072,
+    key.offset: 7088,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7099,
+    key.offset: 7115,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7105,
+    key.offset: 7121,
     key.length: 3
   }
 ]
@@ -6900,10 +6911,26 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     ]
   },
   {
+    key.kind: source.lang.swift.decl.var.global,
+    key.name: "FOO_NIL",
+    key.usr: "c:Foo.h@4783@macro@FOO_NIL",
+    key.offset: 6087,
+    key.length: 15,
+    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_NIL</decl.name>: <decl.var.type><tuple>()</tuple></decl.var.type></decl.var.global>",
+    key.attributes: [
+      {
+        key.kind: source.lang.swift.attribute.availability,
+        key.is_unavailable: 1,
+        key.message: "use 'nil' instead of this imported macro"
+      }
+    ],
+    key.is_unavailable: 1
+  },
+  {
     key.kind: source.lang.swift.decl.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 6087,
+    key.offset: 6103,
     key.length: 661,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooUnavailableMembers</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -6918,7 +6945,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(int:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 6137,
+        key.offset: 6153,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>int</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6926,7 +6953,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "int",
             key.name: "i",
-            key.offset: 6162,
+            key.offset: 6178,
             key.length: 5
           }
         ]
@@ -6935,7 +6962,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "withInt(_:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 6174,
+        key.offset: 6190,
         key.length: 39,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>withInt</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooUnavailableMembers\">Self</ref.class>!</decl.function.returntype></decl.function.method.class>",
         key.entities: [
@@ -6943,7 +6970,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "i",
-            key.offset: 6198,
+            key.offset: 6214,
             key.length: 5
           }
         ],
@@ -6960,7 +6987,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "unavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)unavailable",
-        key.offset: 6219,
+        key.offset: 6235,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>unavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6976,7 +7003,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "swiftUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)swiftUnavailable",
-        key.offset: 6243,
+        key.offset: 6259,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>swiftUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6991,7 +7018,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "deprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)deprecated",
-        key.offset: 6272,
+        key.offset: 6288,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7007,7 +7034,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroduced()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroduced",
-        key.offset: 6295,
+        key.offset: 6311,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7022,7 +7049,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecated",
-        key.offset: 6330,
+        key.offset: 6346,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7041,7 +7068,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoleted()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoleted",
-        key.offset: 6365,
+        key.offset: 6381,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoleted</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7057,7 +7084,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailable",
-        key.offset: 6399,
+        key.offset: 6415,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7073,7 +7100,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroducedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroducedMsg",
-        key.offset: 6435,
+        key.offset: 6451,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7089,7 +7116,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecatedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecatedMsg",
-        key.offset: 6473,
+        key.offset: 6489,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecatedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7108,7 +7135,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoletedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoletedMsg",
-        key.offset: 6511,
+        key.offset: 6527,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoletedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7125,7 +7152,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailableMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailableMsg",
-        key.offset: 6548,
+        key.offset: 6564,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailableMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -7143,7 +7170,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6587,
+        key.offset: 6603,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7152,7 +7179,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6628,
+        key.offset: 6644,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7161,7 +7188,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6669,
+        key.offset: 6685,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -7170,7 +7197,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1::SYNTHESIZED::c:objc(cs)FooUnavailableMembers",
         key.original_usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 6711,
+        key.offset: 6727,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><ref.protocol usr=\"s:Ps9AnyObject\">AnyObject</ref.protocol>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -7180,7 +7207,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 6749,
+    key.offset: 6765,
     key.length: 19,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooCFType</decl.name></decl.class>"
   },
@@ -7188,14 +7215,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "FooCFTypeRelease(_:)",
     key.usr: "c:@F@FooCFTypeRelease",
-    key.offset: 6769,
+    key.offset: 6785,
     key.length: 38,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>FooCFTypeRelease</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"c:Foo.h@T@FooCFTypeRef\">FooCFType</ref.class>!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 6796,
+        key.offset: 6812,
         key.length: 10
       }
     ],
@@ -7212,7 +7239,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooSubFunc1(_:)",
     key.usr: "c:@F@fooSubFunc1",
-    key.offset: 6808,
+    key.offset: 6824,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Vs5Int32\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -7220,7 +7247,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 6830,
+        key.offset: 6846,
         key.length: 5
       }
     ]
@@ -7229,7 +7256,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 6846,
+    key.offset: 6862,
     key.length: 145,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:Ps16RawRepresentable\">RawRepresentable</ref.protocol>, <ref.protocol usr=\"s:Ps9Equatable\">Equatable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -7249,7 +7276,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:FVSC11FooSubEnum1cFVs6UInt32S_",
-        key.offset: 6902,
+        key.offset: 6918,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7257,7 +7284,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 6919,
+            key.offset: 6935,
             key.length: 6
           }
         ]
@@ -7266,7 +7293,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:FVSC11FooSubEnum1cFT8rawValueVs6UInt32_S_",
-        key.offset: 6932,
+        key.offset: 6948,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.conforms: [
@@ -7281,7 +7308,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 6956,
+            key.offset: 6972,
             key.length: 6
           }
         ]
@@ -7290,7 +7317,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:vVSC11FooSubEnum18rawValueVs6UInt32",
-        key.offset: 6969,
+        key.offset: 6985,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Vs6UInt32\">UInt32</ref.struct></decl.var.type></decl.var.instance>",
         key.conforms: [
@@ -7307,7 +7334,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 6992,
+    key.offset: 7008,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7315,7 +7342,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 7030,
+    key.offset: 7046,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -7323,7 +7350,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 7068,
+    key.offset: 7084,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   }


### PR DESCRIPTION
#### What's in this pull request?

This pull request adds the ability to import macros of the form `#define NAME ((type) constant)` to ClangImporter.

I've added two more cases to ImportMacro.cpp: one for macros with 4 tokens (e.g. `(cpu_type_t) 1`) and one for macros with 5 tokens (e.g. `(cpu_type_t) -1`). The macros need to match the following pattern: "l_paren identifier r_paren [signToken] numeric_constant" for the heuristic to apply. 
#### Resolved bug number: ([SR-1509](https://bugs.swift.org/browse/SR-1509))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
