### PR TITLE
[SilOptimizer] SR-1469: Issue diagnostic for `init?` at early return statement

### DIFF
--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1214,3 +1214,71 @@ class r23013334Derived : rdar16119509_Base {
 
 }
 
+// sr-1469
+struct SR1469_Struct1 {
+  let a: Int
+  let b: Int // expected-note {{'self.b' not initialized}}
+  
+  init?(x: Int, y: Int) {
+    self.a = x
+    if y == 42 {
+      return // expected-error {{return from initializer without initializing all stored properties}}
+    }
+    // many lines later
+    self.b = y
+  }
+}
+
+struct SR1469_Struct2 {
+  let a: Int
+  let b: Int // expected-note {{'self.b' not initialized}}
+  
+  init?(x: Int, y: Int) {
+    self.a = x
+    return // expected-error {{return from initializer without initializing all stored properties}}
+  }
+}
+
+struct SR1469_Struct3 {
+  let a: Int
+  let b: Int // expected-note {{'self.b' not initialized}}
+  
+  init?(x: Int, y: Int) {
+    self.a = x
+    if y == 42 {
+      self.b = y
+      return
+    }
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}
+
+enum SR1469_Enum1 {
+  case A, B
+  
+  init?(x: Int) {
+    if x == 42 {
+      return // expected-error {{return from enum initializer method without storing to 'self'}}
+    }
+    // many lines later
+    self = .A
+  }
+}
+
+enum SR1469_Enum2 {
+  case A, B
+  
+  init?() {
+    return // expected-error {{return from enum initializer method without storing to 'self'}}
+  }
+}
+enum SR1469_Enum3 {
+  case A, B
+  
+  init?(x: Int) {
+    if x == 42 {
+      self = .A
+      return
+    }
+  } // expected-error {{return from enum initializer method without storing to 'self'}}
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

In failable initializers the "return from initializer without initializing all stored properties" (resp. "return from enum initializer method without storing to 'self'" for enums) diagnostic is now reported at the early return instead of at the end of the initializer.
#### Resolved bug number: ([SR-1469](https://bugs.swift.org/browse/SR-1469))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
