### PR TITLE
SwiftRemoteMirror: Dig into generic SIL boxes

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -957,7 +957,7 @@ protected:
       case MetadataKind::Function:
         return _readMetadata<TargetFunctionTypeMetadata>(address);
       case MetadataKind::HeapGenericLocalVariable:
-        return _readMetadata<TargetHeapLocalVariableMetadata>(address);
+        return _readMetadata<TargetGenericBoxHeapMetadata>(address);
       case MetadataKind::HeapLocalVariable:
         return _readMetadata<TargetHeapLocalVariableMetadata>(address);
       case MetadataKind::Metatype:


### PR DESCRIPTION
Generic SIL Boxes always have instatiated metadata with kind
HeapGenericLocalVariable, which includes a metadata pointer for the
boxed type.

TODO after this is to provide some kind of outgoing pointer map for
fixed heap boxes, whose metadata may be shared among different but
destructor-compatible types.

rdar://problem/26240419
