### PR TITLE
QoI: Better diags for repeated identifier in function declarations

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -661,6 +661,8 @@ ERROR(expected_pattern,PointsToFirstBadToken,
       "expected pattern", ())
 ERROR(keyword_cant_be_identifier,none,
       "keyword '%0' cannot be used as an identifier here", (StringRef))
+ERROR(repeated_identifier,none,
+      "found an unexpected second identifier in %0 declaration; is there an accidental break?", (StringRef))
 NOTE(backticks_to_escape,none,
      "if this name is unavoidable, use backticks to escape it", ())
 ERROR(expected_rparen_tuple_pattern_list,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -663,6 +663,10 @@ ERROR(keyword_cant_be_identifier,none,
       "keyword '%0' cannot be used as an identifier here", (StringRef))
 ERROR(repeated_identifier,none,
       "found an unexpected second identifier in %0 declaration; is there an accidental break?", (StringRef))
+NOTE(join_identifiers,none,
+     "join the identifiers together", ())
+NOTE(join_identifiers_camel_case,none,
+     "join the identifiers together with camel-case", ())
 NOTE(backticks_to_escape,none,
      "if this name is unavoidable, use backticks to escape it", ())
 ERROR(expected_rparen_tuple_pattern_list,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4458,6 +4458,16 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
                                 diag::invalid_diagnostic);
     if (NameStatus.isError())
       return nullptr;
+  } else {
+    // We parsed an identifier for the function declaration. If we see another
+    // identifier, it might've been a single identifier that got broken by a
+    // space or newline accidentally.
+    if (Tok.isIdentifierOrUnderscore() && SimpleName.str().back() != '<') {
+      diagnose(Tok.getLoc(), diag::repeated_identifier, "function")
+        .fixItReplace(SourceRange(NameLoc, Tok.getLoc()),
+                      NameTok.getText().str() + Tok.getText().str());
+      consumeToken();
+    }
   }
 
   DebuggerContextChange DCC(*this, SimpleName, DeclKind::Func);

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -98,12 +98,22 @@ let for = 2
 // expected-error @-1 {{keyword 'for' cannot be used as an identifier here}}
 // expected-note @-2 {{if this name is unavoidable, use backticks to escape it}} {{5-8=`for`}}
 
-func dog cow() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-13=dogcow}}
-func friend ship<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-17=friendship}}
+func dog cow() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
+// expected-note@-1 {{join the identifiers together}} {{6-13=dogcow}}
+// expected-note@-2 {{join the identifiers together with camel-case}} {{6-13=dogCow}}
+func cat Mouse() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
+// expected-note@-1 {{join the identifiers together}} {{6-15=catMouse}}
+func friend ship<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
+// expected-note@-1 {{join the identifiers together}} {{6-17=friendship}}
+// expected-note@-2 {{join the identifiers together with camel-case}} {{6-17=friendShip}}
 func were
-wolf() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-5=werewolf}}
+wolf() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
+// expected-note@-1 {{join the identifiers together}} {{6-5=werewolf}}
+// expected-note@-2 {{join the identifiers together with camel-case}} {{6-5=wereWolf}}
 func hammer
-leavings<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-9=hammerleavings}}
+leavings<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
+// expected-note@-1 {{join the identifiers together}} {{6-9=hammerleavings}}
+// expected-note@-2 {{join the identifiers together with camel-case}} {{6-9=hammerLeavings}}
 
 prefix operator % {}
 prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -97,3 +97,13 @@ func repeat() {}
 let for = 2
 // expected-error @-1 {{keyword 'for' cannot be used as an identifier here}}
 // expected-note @-2 {{if this name is unavoidable, use backticks to escape it}} {{5-8=`for`}}
+
+func dog cow() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-13=dogcow}}
+func friend ship<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-17=friendship}}
+func were
+wolf() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-5=werewolf}}
+func hammer
+leavings<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}} {{6-9=hammerleavings}}
+
+prefix operator % {}
+prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.


### PR DESCRIPTION
A function declaration like:

func dog cow() {}

... yields a bunch of noisy diagnostics about expecting certain tokens, like
"expected '(' in argument list of function declaration", or the dreaded
"consecutive statements on a line must be separated by ';'". Instead,
look for a repeated identifier in this position and affirm that the
repeated identifier wasn't expected, suggesting that maybe this was a
single identifier with a break in it.

rdar://problem/25761940
