### PR TITLE
	ConformanceLookupTable: Recursively inherit into subclasses when incrementally adding extension conformances.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3203,6 +3203,10 @@ public:
   /// Retrieve the superclass of this class, or null if there is no superclass.
   Type getSuperclass() const { return LazySemanticInfo.Superclass.getPointer(); }
 
+  /// Retrieve the ClassDecl for the superclass of this class, or null if there
+  /// is no superclass.
+  ClassDecl *getSuperclassDecl() const;
+
   /// Set the superclass of this class.
   void setSuperclass(Type superclass) {
     LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -33,6 +33,7 @@ namespace swift {
   class Decl;
   class DeclContext;
   class Expr;
+  class ExtensionDecl;
   class GenericTypeParamDecl;
   class NormalProtocolConformance;
   class OperatorDecl;
@@ -80,6 +81,7 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::GenericTypeParamDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::OperatorDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ProtocolDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ValueDecl, swift::DeclAlignInBits)
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::ExtensionDecl, swift::DeclAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeBase, swift::TypeAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ArchetypeType, swift::TypeAlignInBits)

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SetVector.h"
+#include <unordered_map>
 
 namespace swift {
 
@@ -67,11 +68,16 @@ class ConformanceLookupTable {
   /// at that stage.
   typedef llvm::PointerIntPair<ExtensionDecl *, 1, bool> LastProcessedEntry;
 
-  /// Array indicating how far we have gotten in processing the
+  /// Array indicating how far we have gotten in processing each
   /// nominal type and list of extensions for each stage of
   /// conformance checking.
-  LastProcessedEntry LastProcessed[NumConformanceStages];
-
+  ///
+  /// Uses std::unordered_map instead of DenseMap so that stable interior
+  /// references can be taken.
+  std::unordered_map<NominalTypeDecl *,
+                     std::array<LastProcessedEntry, NumConformanceStages>>
+  LastProcessed;
+  
   /// The list of parsed extension declarations that have been delayed because
   /// no resolver was available at the time.
   ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4677,3 +4677,9 @@ Type TypeBase::getSwiftNewtypeUnderlyingType() {
 
   return {};
 }
+
+ClassDecl *ClassDecl::getSuperclassDecl() const {
+  if (auto superclass = getSuperclass())
+    return superclass->getClassOrBoundGenericClass();
+    return nullptr;
+}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4838,7 +4838,7 @@ namespace {
 
       // Synthesize trivial conformances for each of the protocols.
       SmallVector<ProtocolConformance *, 4> conformances;
-;
+
       auto dc = decl->getInnermostDeclContext();
       auto &ctx = Impl.SwiftContext;
       for (unsigned i = 0, n = protocols.size(); i != n; ++i) {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1171,7 +1171,8 @@ void PatternMatchEmission::bindNamedPattern(NamedPattern *pattern,
                                             bool forIrrefutableRow,
                                             bool hasMultipleItems) {
   bindVariable(pattern, pattern->getDecl(), value,
-               pattern->getType()->getCanonicalType(), forIrrefutableRow, hasMultipleItems);
+               pattern->getType()->getCanonicalType(), forIrrefutableRow,
+               hasMultipleItems);
 }
 
 /// Should we take control of the mang

--- a/test/decl/ext/Inputs/extension-inheritance-conformance-objc-multi-file-2.swift
+++ b/test/decl/ext/Inputs/extension-inheritance-conformance-objc-multi-file-2.swift
@@ -1,0 +1,2 @@
+extension Responder {}
+extension View {}

--- a/test/decl/ext/Inputs/extension-inheritance-conformance-objc.h
+++ b/test/decl/ext/Inputs/extension-inheritance-conformance-objc.h
@@ -1,0 +1,11 @@
+__attribute__((objc_root_class))
+@interface Object
++alloc;
+-init;
+@end
+
+@interface Responder: Object
+@end
+
+@interface View: Responder
+@end

--- a/test/decl/ext/extension-inheritance-conformance-native.swift
+++ b/test/decl/ext/extension-inheritance-conformance-native.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -parse -verify %s
+
+class Object {}
+class Responder: Object {}
+class View: Responder {}
+
+extension View {}
+
+protocol Foo {}
+
+extension Foo {
+  func bar() -> Self { return self }
+}
+
+extension Object: Foo {}
+
+_ = Object().bar()
+_ = Responder().bar()
+_ = View().bar()
+

--- a/test/decl/ext/extension-inheritance-conformance-objc-multi-file.swift
+++ b/test/decl/ext/extension-inheritance-conformance-objc-multi-file.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/extension-inheritance-conformance-objc.h -parse -verify -primary-file %s %S/Inputs/extension-inheritance-conformance-objc-multi-file-2.swift
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/extension-inheritance-conformance-objc.h -parse -verify %s -primary-file %S/Inputs/extension-inheritance-conformance-objc-multi-file-2.swift
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/extension-inheritance-conformance-objc.h -parse -verify -primary-file %S/Inputs/extension-inheritance-conformance-objc-multi-file-2.swift %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/extension-inheritance-conformance-objc.h -parse -verify %S/Inputs/extension-inheritance-conformance-objc-multi-file-2.swift -primary-file %s
+
+// REQUIRES: objc_interop
+
+protocol Foo {}
+
+extension Foo {
+  func bar() -> Self { return self }
+}
+
+extension Object: Foo {}
+
+let x = Object().bar()
+let y = Responder().bar()
+let z = View().bar()
+

--- a/test/decl/ext/extension-inheritance-conformance-objc.swift
+++ b/test/decl/ext/extension-inheritance-conformance-objc.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/extension-inheritance-conformance-objc.h -parse -verify %s
+
+// REQUIRES: objc_interop
+
+extension View {}
+
+protocol Foo {}
+
+extension Foo {
+  func bar() -> Self { return self }
+}
+
+extension Object: Foo {}
+
+_ = Object().bar()
+_ = Responder().bar()
+_ = View().bar()
+


### PR DESCRIPTION
Previously, we would only reliably propagate conformances from new extensions to immediate subclasses, since when we visit grandchild classes, we'd see no change in the immediate base class's status. Fix this by walking up the entire superclass chain when we look for new inherited conformances, and track the last processed state of different nominal type decls' extensions separately. Fixes SR-1480.
