### PR TITLE
Suppress warnings for unused results in benchmark tests

### DIFF
--- a/benchmark/single-source/AngryPhonebook.swift
+++ b/benchmark/single-source/AngryPhonebook.swift
@@ -36,7 +36,7 @@ public func run_AngryPhonebook(_ N: Int) {
   for _ in 1...N {
     for firstname in words {
       for lastname in words {
-        (firstname.uppercased(), lastname.lowercased())
+        _ = (firstname.uppercased(), lastname.lowercased())
       }
     }
   }

--- a/benchmark/single-source/NSError.swift
+++ b/benchmark/single-source/NSError.swift
@@ -30,7 +30,7 @@ class G : K {
 }
 
 func caller(_ x: P) throws {
-  try x.buzz()
+  _ = try x.buzz()
 }
 
 @inline(never)

--- a/benchmark/single-source/NSStringConversion.swift
+++ b/benchmark/single-source/NSStringConversion.swift
@@ -17,6 +17,6 @@ import Foundation
 public func run_NSStringConversion(_ N: Int) {
 let test:NSString = NSString(cString: "test", encoding: NSASCIIStringEncoding)!
   for _ in 1...N * 10000 {
-    test as String
+    _ = test as String
   }
 }

--- a/benchmark/single-source/ProtocolDispatch.swift
+++ b/benchmark/single-source/ProtocolDispatch.swift
@@ -18,7 +18,7 @@ public func run_ProtocolDispatch(_ N: Int) {
   let x = someProtocolFactory()
 
   for _ in 0...1000000 * N {
-    x.getValue()
+    _ = x.getValue()
   }
 }
 

--- a/benchmark/single-source/TypeFlood.swift
+++ b/benchmark/single-source/TypeFlood.swift
@@ -36,22 +36,22 @@ struct Some0<T> {
 
 @inline(never)
 func flood<T>(_ x: T) {
-  Some1<Some1<Some1<Some1<T>>>>() is Pingable
-  Some1<Some1<Some1<Some0<T>>>>() is Pingable
-  Some1<Some1<Some0<Some1<T>>>>() is Pingable
-  Some1<Some1<Some0<Some0<T>>>>() is Pingable
-  Some1<Some0<Some1<Some1<T>>>>() is Pingable
-  Some1<Some0<Some1<Some0<T>>>>() is Pingable
-  Some1<Some0<Some0<Some1<T>>>>() is Pingable
-  Some1<Some0<Some0<Some0<T>>>>() is Pingable
-  Some0<Some1<Some1<Some1<T>>>>() is Pingable
-  Some0<Some1<Some1<Some0<T>>>>() is Pingable
-  Some0<Some1<Some0<Some1<T>>>>() is Pingable
-  Some0<Some1<Some0<Some0<T>>>>() is Pingable
-  Some0<Some0<Some1<Some1<T>>>>() is Pingable
-  Some0<Some0<Some1<Some0<T>>>>() is Pingable
-  Some0<Some0<Some0<Some1<T>>>>() is Pingable
-  Some0<Some0<Some0<Some0<T>>>>() is Pingable
+  _ = Some1<Some1<Some1<Some1<T>>>>() is Pingable
+  _ = Some1<Some1<Some1<Some0<T>>>>() is Pingable
+  _ = Some1<Some1<Some0<Some1<T>>>>() is Pingable
+  _ = Some1<Some1<Some0<Some0<T>>>>() is Pingable
+  _ = Some1<Some0<Some1<Some1<T>>>>() is Pingable
+  _ = Some1<Some0<Some1<Some0<T>>>>() is Pingable
+  _ = Some1<Some0<Some0<Some1<T>>>>() is Pingable
+  _ = Some1<Some0<Some0<Some0<T>>>>() is Pingable
+  _ = Some0<Some1<Some1<Some1<T>>>>() is Pingable
+  _ = Some0<Some1<Some1<Some0<T>>>>() is Pingable
+  _ = Some0<Some1<Some0<Some1<T>>>>() is Pingable
+  _ = Some0<Some1<Some0<Some0<T>>>>() is Pingable
+  _ = Some0<Some0<Some1<Some1<T>>>>() is Pingable
+  _ = Some0<Some0<Some1<Some0<T>>>>() is Pingable
+  _ = Some0<Some0<Some0<Some1<T>>>>() is Pingable
+  _ = Some0<Some0<Some0<Some0<T>>>>() is Pingable
 }
 
 @inline(never)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This uses `_ =` to quiet some unused result and unused expression warnings.
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
