### PR TITLE
[QoI] Improve diagnostics when putting a class bound in a generic sig…

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1262,6 +1262,10 @@ ERROR(expected_rangle_generics_param,PointsToFirstBadToken,
       "expected '>' to complete generic parameter list", ())
 ERROR(expected_generics_parameter_name,PointsToFirstBadToken,
       "expected an identifier to name generic parameter", ())
+ERROR(unexpected_class_constraint,none,
+       "'class' constraint can only appear on protocol declarations", ())
+NOTE(suggest_anyobject,none,
+     "did you mean to constrain %0 with the 'AnyObject' protocol?", (Identifier))
 ERROR(expected_generics_type_restriction,none,
       "expected a type name or protocol composition restricting %0",
       (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2454,7 +2454,7 @@ ERROR(invalid_ownership_type,none,
       (/*Ownership*/unsigned, Type))
 ERROR(invalid_ownership_protocol_type,none,
       "'%select{strong|weak|unowned|unowned}0' may not be applied to "
-      "non-class-bound protocol %1; consider adding a class bound",
+      "non-class-bound %1; consider adding a protocol conformance that has a class bound",
       (/*Ownership*/unsigned, Type))
 ERROR(invalid_weak_ownership_not_optional,none,
       "'weak' variable should have optional type %0", (Type))

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -74,6 +74,12 @@ Parser::parseGenericParameters(SourceLoc LAngleLoc) {
         Ty = parseTypeIdentifier();
       } else if (Tok.getKind() == tok::kw_protocol) {
         Ty = parseTypeComposition();
+      } else if (Tok.getKind() == tok::kw_class) {
+        diagnose(Tok, diag::unexpected_class_constraint);
+        diagnose(Tok, diag::suggest_anyobject, Name)
+          .fixItReplace(Tok.getLoc(), "AnyObject");
+        consumeToken();
+        Invalid = true;
       } else {
         diagnose(Tok, diag::expected_generics_type_restriction, Name);
         Invalid = true;

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -117,3 +117,8 @@ leavings<T>(x: T) {} // expected-error {{found an unexpected second identifier i
 
 prefix operator % {}
 prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.
+
+struct Weak<T: class> { // expected-error {{'class' constraint can only appear on protocol declarations}}
+  // expected-note@-1 {{did you mean to constrain 'T' with the 'AnyObject' protocol?}} {{16-21=AnyObject}}
+  weak var value: T // expected-error {{'weak' may not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound}}
+}

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -155,14 +155,14 @@ weak
 var weak8 : Class? = Ty0()
 unowned var weak9 : Class = Ty0()
 weak
-var weak10 : NonClass = Ty0() // expected-error {{'weak' may not be applied to non-class-bound protocol 'NonClass'; consider adding a class bound}}
+var weak10 : NonClass = Ty0() // expected-error {{'weak' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 unowned
-var weak11 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound protocol 'NonClass'; consider adding a class bound}}
+var weak11 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 
 unowned
-var weak12 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound protocol 'NonClass'; consider adding a class bound}}
+var weak12 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 unowned
-var weak13 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound protocol 'NonClass'; consider adding a class bound}}
+var weak13 : NonClass = Ty0() // expected-error {{'unowned' may not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
 
 weak
 var weak14 : Ty0 // expected-error {{'weak' variable should have optional type 'Ty0?'}}


### PR DESCRIPTION
When declaring a nominal type:

struct Weak<T> {
  weak var value: T
}

The diagnostic might mislead the developer to adding ': class' literally
to the 'T' in the generic parameters for `Weak`:

"'weak' may not be applied to non-class-bound protocol 'T'; consider
adding a class bound"

This is misleading in two ways: 1, 'T' isn't necessarily a protocol
(this patch generalizes that part of the message) and 2, you can't put
`: class` in the generic parameter list for `Weak`. In addition, the
stray class constraint causes diagnostic spew that also hides the issue.

Also provide a fix-it to constrain with 'AnyObject', which is probably
what the devloper means in this case.

rdar://problem/25481209
