### PR TITLE
[stdlib/cygwin] Removed the workaround of print() (SR-612)

### DIFF
--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -28,11 +28,6 @@ public func print(
   separator: String = " ",
   terminator: String = "\n"
 ) {
-#if os(Windows)
-  // FIXME: This fix is for 'crash at hook(output.left)' in cygwin.
-  //        Proper fix is needed. see: https://bugs.swift.org/browse/SR-612
-  let _playgroundPrintHook: ((String) -> Void)? = nil
-#endif
   if let hook = _playgroundPrintHook {
     var output = _TeeStream(left: "", right: _Stdout())
     _print(


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-612](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Currently, in Cygwin, the print() function works well without any workaround.
I presume this bug is fixed by side effect of some other commit, but couldn't find out exactly what.
