### PR TITLE
SwiftReflectionTest: Don't exit until the parent asks for an instance

### DIFF
--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -418,7 +418,7 @@ public func reflect(function: () -> ()) {
 /// Call this function to indicate to the parent that there are
 /// no more instances to look at.
 public func doneReflecting() {
-  sendValue(InstanceKind.None.rawValue)
+  reflect(instanceAddress: UInt(InstanceKind.None.rawValue), kind: .None)
 }
 
 /* Example usage

--- a/validation-test/Reflection/example.swift
+++ b/validation-test/Reflection/example.swift
@@ -3,9 +3,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/example | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
-// rdar://problem/26230879
-// REQUIRES: OS=macosx
-
 import SwiftReflectionTest
 
 class Container {

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -3,9 +3,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/existentials | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
-// rdar://problem/26230879
-// REQUIRES: OS=macosx
-
 /*
    This file pokes at the swift_reflection_projectExistential API
    of the SwiftRemoteMirror library.

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -3,9 +3,6 @@
 // RUN: %target-run %target-swift-reflection-test %t/functions 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
-// rdar://problem/26230879
-// REQUIRES: OS=macosx
-
 /*
    This file pokes at the swift_reflection_infoForInstance() API
    of the SwiftRemoteMirror library.


### PR DESCRIPTION
Child processes were exiting too early before the parent has a chance
to read a null pointer from the child, indicating that there are no
more instances to reflect. This wasn't a problem on OS X because the
I/O latency is so small compared to the iOS simulator, where the
problem would come up under heavy load. This makes the end-to-end
remote mirror tests deterministic again.

rdar://problem/26230879
