### PR TITLE
[cmake] Properly use COMPONENT_DEPENDS when adding the dependency fro…

### DIFF
--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -6,6 +6,8 @@ add_swift_library(swiftLLVMPasses
   LLVMInlineTree.cpp
   LLVMStackPromotion.cpp
   LLVMMergeFunctions.cpp
+
+  COMPONENT_DEPENDS
+  analysis
   )
 
-add_dependencies(swiftLLVMPasses LLVMAnalysis)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This commit changes swiftLLVMPasses to properly use COMPONENT_DEPENDS to link against LLVMAnalysis instead of doing it directly. This allows for cmake to get the dependencies correct not by luck defacto, but rather by de jure logic.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…m swiftLLVMPasses on LLVMAnalysis.

We were previously just getting lucky. This ensures that we are doing this correctly.

rdar://26357000
