### PR TITLE
[swift-3.0-preview-1][stdlib] remove deprecated floating point APIs

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -136,9 +136,9 @@ public struct CGFloat {
     return CGFloat(NativeType.signalingNaN)
   }
   
-  @available(*, deprecated, renamed: "nan")
+  @available(*, unavailable, renamed: "nan")
   public static var quietNaN: CGFloat {
-    return CGFloat(NativeType.nan)
+    fatalError("unavailable")
   }
 
   public static var greatestFiniteMagnitude: CGFloat {
@@ -269,9 +269,9 @@ public struct CGFloat {
     return native.isSignalingNaN
   }
 
-  @available(*, deprecated, renamed: "isSignalingNaN")
+  @available(*, unavailable, renamed: "isSignalingNaN")
   public var isSignaling: Bool {
-    return native.isSignalingNaN
+    fatalError("unavailable")
   }
 
   public var isCanonical: Bool {
@@ -302,33 +302,25 @@ public struct CGFloat {
 }
 
 extension CGFloat {
-  @available(*, deprecated, message: "use CGFloat.leastNormalMagnitude")
-  @_transparent public static var min: CGFloat {
-#if arch(i386) || arch(arm)
-   return CGFloat(FLT_MIN)
-#else
-   return CGFloat(DBL_MIN)
-#endif
+  @available(*, unavailable, renamed: "leastNormalMagnitude")
+  public static var min: CGFloat {
+    fatalError("unavailable")
   }
 
-  @available(*, deprecated, message: "use CGFloat.greatestFiniteMagnitude")
-  @_transparent public static var max: CGFloat {
-#if arch(i386) || arch(arm)
-   return CGFloat(FLT_MAX)
-#else
-   return CGFloat(DBL_MAX)
-#endif
+  @available(*, unavailable, renamed: "greatestFiniteMagnitude")
+  public static var max: CGFloat {
+    fatalError("unavailable")
   }
 }
 
-@available(*, unavailable, message: "use CGFloat.leastNormalMagnitude")
+@available(*, unavailable, renamed: "CGFloat.leastNormalMagnitude")
 public var CGFLOAT_MIN: CGFloat {
-  fatalError("can't retrieve unavailable property")
+  fatalError("unavailable")
 }
 
-@available(*, unavailable, message: "use CGFloat.greatestFiniteMagnitude")
+@available(*, unavailable, renamed: "CGFloat.greatestFiniteMagnitude")
 public var CGFLOAT_MAX: CGFloat {
-  fatalError("can't retrieve unavailable property")
+  fatalError("unavailable")
 }
 
 extension CGFloat : CustomReflectable {
@@ -761,9 +753,9 @@ public func fmin(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
 
 @_transparent
 @warn_unused_result
-@available(*, deprecated, message: "use the floatingPointClass property.")
+@available(*, unavailable, message: "use the floatingPointClass property.")
 public func fpclassify(_ x: CGFloat) -> Int {
-  return fpclassify(x.native)
+  fatalError("unavailable")
 }
 
 @available(*, unavailable, message: "use the isNormal property.")

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -813,7 +813,7 @@ extension BinaryFloatingPoint {
     return true
   }
   
-  @available(*, deprecated, renamed: "isSignalingNaN")
+  @available(*, unavailable, renamed: "isSignalingNaN")
   public var isSignaling: Bool {
     return isSignalingNaN
   }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -207,8 +207,8 @@ extension ${Self}: BinaryFloatingPoint {
     return FloatingPointSign(rawValue: Int(bitPattern >> ${RawSignificand}(shift)))!
   }
 
-  @available(*, deprecated, message: "Use the .sign property instead.")
-  public var isSignMinus: Bool { return sign == .minus }
+  @available(*, unavailable, renamed: "sign")
+  public var isSignMinus: Bool { Builtin.unreachable() }
 
   public var exponentBitPattern: UInt {
     return UInt(bitPattern >> UInt${bits}(${Self}.significandBitCount)) &
@@ -337,8 +337,8 @@ extension ${Self}: BinaryFloatingPoint {
     return ${Self}(nan: 0, signaling: true)
   }
 
-  @available(*, deprecated, renamed: "nan")
-  public static var quietNaN: ${Self} { return nan }
+  @available(*, unavailable, renamed: "nan")
+  public static var quietNaN: ${Self} { Builtin.unreachable()}
 
   public static var greatestFiniteMagnitude: ${Self} {
     return ${Self}(sign: .plus,

--- a/test/1_stdlib/Float.swift
+++ b/test/1_stdlib/Float.swift
@@ -167,28 +167,28 @@ func checkInf(_ inf: TestFloat) {
   _precondition(!inf.isSubnormal)
   _precondition(inf.isInfinite)
   _precondition(!inf.isNaN)
-  _precondition(!inf.isSignaling)
+  _precondition(!inf.isSignalingNaN)
 }
 
 func testInf() {
   var stdlibPlusInf = TestFloat.infinity
   checkInf(stdlibPlusInf)
-  _precondition(!stdlibPlusInf.isSignMinus)
+  _precondition(stdlibPlusInf.sign == .plus)
   _precondition(stdlibPlusInf.floatingPointClass == .positiveInfinity)
 
   var stdlibMinusInf = -TestFloat.infinity
   checkInf(stdlibMinusInf)
-  _precondition(stdlibMinusInf.isSignMinus)
+  _precondition(stdlibMinusInf.sign == .minus)
   _precondition(stdlibMinusInf.floatingPointClass == .negativeInfinity)
 
   var computedPlusInf = 1.0 / noinlinePlusZero()
   checkInf(computedPlusInf)
-  _precondition(!computedPlusInf.isSignMinus)
+  _precondition(computedPlusInf.sign == .plus)
   _precondition(computedPlusInf.floatingPointClass == .positiveInfinity)
 
   var computedMinusInf = -1.0 / noinlinePlusZero()
   checkInf(computedMinusInf)
-  _precondition(computedMinusInf.isSignMinus)
+  _precondition(computedMinusInf.sign == .minus)
   _precondition(computedMinusInf.floatingPointClass == .negativeInfinity)
 
   _precondition(stdlibPlusInf == computedPlusInf)
@@ -207,7 +207,7 @@ testInf()
 //===---
 
 func checkNaN(_ nan: TestFloat) {
-  _precondition(!nan.isSignMinus)
+  _precondition(nan.sign == .plus)
   _precondition(!nan.isNormal)
   _precondition(!nan.isFinite)
   _precondition(!nan.isZero)
@@ -218,7 +218,7 @@ func checkNaN(_ nan: TestFloat) {
 
 func checkQNaN(_ qnan: TestFloat) {
   checkNaN(qnan)
-  _precondition(!qnan.isSignaling)
+  _precondition(!qnan.isSignalingNaN)
   _precondition(qnan.floatingPointClass == .quietNaN)
 }
 
@@ -226,7 +226,7 @@ func checkSNaN(_ snan: TestFloat) {
   checkNaN(snan)
 // sNaN cannot be fully supported on i386.
 #if !arch(i386)
-  _precondition(snan.isSignaling)
+  _precondition(snan.isSignalingNaN)
   _precondition(snan.floatingPointClass == .signalingNaN)
 #endif
 }
@@ -235,7 +235,7 @@ func testNaN() {
   var stdlibDefaultNaN = TestFloat.nan
   checkQNaN(stdlibDefaultNaN)
 
-  var stdlibQNaN = TestFloat.quietNaN
+  var stdlibQNaN = TestFloat.nan
   checkQNaN(stdlibQNaN)
 
   var stdlibSNaN = TestFloat.signalingNaN

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -17,7 +17,6 @@
   1.1.#^LITERAL2^#
 }
 // LITERAL2:         Begin completions
-// LITERAL2-DAG:     Decl[InstanceVar]/CurrNominal:      isSignMinus[#Bool#]; name=isSignMinus{{$}}
 // LITERAL2-DAG:     Decl[InstanceVar]/CurrNominal:      isNormal[#Bool#]; name=isNormal{{$}}
 // LITERAL2-DAG:     Decl[InstanceVar]/CurrNominal:      isFinite[#Bool#]; name=isFinite{{$}}
 // LITERAL2-DAG:     Decl[InstanceVar]/CurrNominal:      isZero[#Bool#]; name=isZero{{$}}


### PR DESCRIPTION
- Explanation: Remove deprecated floating point APIs.
- Scope of Issue: Slightly more advanced uses of floating point.
- Risk: medium risk, since this change removes APIs that were previously deprecated.
- Reviewed By: Steve Canon.
- Testing: manual; existing tests don't break.

rdar://problem/26357739

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
