### PR TITLE
[build-script] Factor out calculation of args.build_subdir

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -48,6 +48,8 @@ from swift_build_support import migration  # noqa (E402)
 import swift_build_support.tar        # noqa (E402)
 import swift_build_support.targets    # noqa (E402)
 from swift_build_support.cmake import CMake  # noqa (E402)
+from swift_build_support.workspace import Workspace  # noqa(E402)
+from swift_build_support.workspace import compute_build_subdir  # noqa(E402)
 
 
 # A strict parser for bools (unlike Python's `bool()`, where
@@ -1203,69 +1205,21 @@ details of the setups of other systems or automated environments.""")
         ]
 
     if args.build_subdir is None:
-        # Create a name for the build directory.
-        args.build_subdir = args.cmake_generator.replace(" ", "_")
-        cmark_build_dir_label = args.cmark_build_variant
-        if args.cmark_assertions:
-            cmark_build_dir_label += "Assert"
+        args.build_subdir = compute_build_subdir(args)
 
-        llvm_build_dir_label = args.llvm_build_variant
-        if args.llvm_assertions:
-            llvm_build_dir_label += "Assert"
+    workspace = Workspace(
+        source_root=SWIFT_SOURCE_ROOT,
+        build_root=os.path.join(SWIFT_BUILD_ROOT, args.build_subdir))
 
-        swift_build_dir_label = args.swift_build_variant
-        if args.swift_assertions:
-            swift_build_dir_label += "Assert"
-        if args.swift_analyze_code_coverage != "false":
-            swift_build_dir_label += "Coverage"
-
-        swift_stdlib_build_dir_label = args.swift_stdlib_build_variant
-        if args.swift_stdlib_assertions:
-            swift_stdlib_build_dir_label += "Assert"
-
-        # FIXME: mangle LLDB build configuration into the directory name.
-        if (llvm_build_dir_label == swift_build_dir_label and
-                llvm_build_dir_label == swift_stdlib_build_dir_label and
-                llvm_build_dir_label == cmark_build_dir_label):
-            # Use a simple directory name if all projects use the same build
-            # type.
-            args.build_subdir += "-" + llvm_build_dir_label
-        elif (llvm_build_dir_label != swift_build_dir_label and
-                llvm_build_dir_label == swift_stdlib_build_dir_label and
-                llvm_build_dir_label == cmark_build_dir_label):
-            # Swift build type differs.
-            args.build_subdir += "-" + llvm_build_dir_label
-            args.build_subdir += "+swift-" + swift_build_dir_label
-        elif (llvm_build_dir_label == swift_build_dir_label and
-                llvm_build_dir_label != swift_stdlib_build_dir_label and
-                llvm_build_dir_label == cmark_build_dir_label):
-            # Swift stdlib build type differs.
-            args.build_subdir += "-" + llvm_build_dir_label
-            args.build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
-        elif (llvm_build_dir_label == swift_build_dir_label and
-                llvm_build_dir_label == swift_stdlib_build_dir_label and
-                llvm_build_dir_label != cmark_build_dir_label):
-            # cmark build type differs.
-            args.build_subdir += "-" + llvm_build_dir_label
-            args.build_subdir += "+cmark-" + cmark_build_dir_label
-        else:
-            # We don't know how to create a short name, so just mangle in all
-            # the information.
-            args.build_subdir += "+cmark-" + cmark_build_dir_label
-            args.build_subdir += "+llvm-" + llvm_build_dir_label
-            args.build_subdir += "+swift-" + swift_build_dir_label
-            args.build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
-
-    build_dir = os.path.join(SWIFT_BUILD_ROOT, args.build_subdir)
-
-    if args.clean and os.path.isdir(build_dir):
-        shutil.rmtree(build_dir)
+    if args.clean and os.path.isdir(workspace.build_root):
+        shutil.rmtree(workspace.build_root)
 
     cmake = CMake(args=args,
                   toolchain=toolchain)
 
     build_script_impl_args = [
-        "--build-dir", build_dir,
+        "--workspace", workspace.source_root,
+        "--build-dir", workspace.build_root,
         "--install-prefix", os.path.abspath(args.install_prefix),
         "--host-target", args.host_target,
         "--stdlib-deployment-targets",
@@ -1287,7 +1241,6 @@ details of the setups of other systems or automated environments.""")
             args.swift_analyze_code_coverage).lower(),
         "--cmake-generator", args.cmake_generator,
         "--build-jobs", str(args.build_jobs),
-        "--workspace", SWIFT_SOURCE_ROOT,
         "--common-cmake-options=%s" % ' '.join(
             pipes.quote(opt) for opt in cmake.common_options()),
         "--build-args=%s" % ' '.join(

--- a/utils/swift_build_support/swift_build_support/workspace.py
+++ b/utils/swift_build_support/swift_build_support/workspace.py
@@ -1,0 +1,88 @@
+# swift_build_support/workspace.py ------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+"""
+Represent whole source tree and the build directory
+"""
+# ----------------------------------------------------------------------------
+
+import os.path
+
+
+class Workspace(object):
+    def __init__(self, source_root, build_root):
+        self.source_root = source_root
+        self.build_root = build_root
+
+    def source_dir(self, path):
+        return os.path.join(self.source_root, path)
+
+    def build_dir(self, deployment_target, product):
+        return os.path.join(self.build_root,
+                            '%s-%s' % (product, deployment_target))
+
+
+def compute_build_subdir(args):
+    # Create a name for the build directory.
+    build_subdir = args.cmake_generator.replace(" ", "_")
+
+    cmark_build_dir_label = args.cmark_build_variant
+    if args.cmark_assertions:
+        cmark_build_dir_label += "Assert"
+
+    llvm_build_dir_label = args.llvm_build_variant
+    if args.llvm_assertions:
+        llvm_build_dir_label += "Assert"
+
+    swift_build_dir_label = args.swift_build_variant
+    if args.swift_assertions:
+        swift_build_dir_label += "Assert"
+    if args.swift_analyze_code_coverage != "false":
+        swift_build_dir_label += "Coverage"
+
+    swift_stdlib_build_dir_label = args.swift_stdlib_build_variant
+    if args.swift_stdlib_assertions:
+        swift_stdlib_build_dir_label += "Assert"
+
+    # FIXME: mangle LLDB build configuration into the directory name.
+    if (llvm_build_dir_label == swift_build_dir_label and
+            llvm_build_dir_label == swift_stdlib_build_dir_label and
+            llvm_build_dir_label == cmark_build_dir_label):
+        # Use a simple directory name if all projects use the same build
+        # type.
+        build_subdir += "-" + llvm_build_dir_label
+    elif (llvm_build_dir_label != swift_build_dir_label and
+            llvm_build_dir_label == swift_stdlib_build_dir_label and
+            llvm_build_dir_label == cmark_build_dir_label):
+        # Swift build type differs.
+        build_subdir += "-" + llvm_build_dir_label
+        build_subdir += "+swift-" + swift_build_dir_label
+    elif (llvm_build_dir_label == swift_build_dir_label and
+            llvm_build_dir_label != swift_stdlib_build_dir_label and
+            llvm_build_dir_label == cmark_build_dir_label):
+        # Swift stdlib build type differs.
+        build_subdir += "-" + llvm_build_dir_label
+        build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
+    elif (llvm_build_dir_label == swift_build_dir_label and
+            llvm_build_dir_label == swift_stdlib_build_dir_label and
+            llvm_build_dir_label != cmark_build_dir_label):
+        # cmark build type differs.
+        build_subdir += "-" + llvm_build_dir_label
+        build_subdir += "+cmark-" + cmark_build_dir_label
+    else:
+        # We don't know how to create a short name, so just mangle in all
+        # the information.
+        build_subdir += "+cmark-" + cmark_build_dir_label
+        build_subdir += "+llvm-" + llvm_build_dir_label
+        build_subdir += "+swift-" + swift_build_dir_label
+        build_subdir += "+stdlib-" + swift_stdlib_build_dir_label
+
+    return build_subdir

--- a/utils/swift_build_support/tests/test_workspace.py
+++ b/utils/swift_build_support/tests/test_workspace.py
@@ -1,0 +1,145 @@
+# tests/test_workspace.py ---------------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import argparse
+import itertools
+import os
+import shutil
+import tempfile
+import unittest
+
+from swift_build_support.workspace import (
+    Workspace,
+    compute_build_subdir,
+)
+
+
+class WorkspaceTestCase(unittest.TestCase):
+
+    def test_workspace(self):
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, 'foo'))
+
+        workspace = Workspace(source_root=tmpdir1,
+                              build_root=tmpdir2)
+
+        self.assertEqual(workspace.source_root, tmpdir1)
+        self.assertEqual(workspace.build_root, tmpdir2)
+
+        # source_dir
+        self.assertEqual(workspace.source_dir('foo'),
+                         os.path.join(tmpdir1, 'foo'))
+
+        # build_dir
+        self.assertEqual(workspace.build_dir('target', 'product'),
+                         os.path.join(tmpdir2, 'product-target'))
+
+        shutil.rmtree(tmpdir1)
+        shutil.rmtree(tmpdir2)
+
+
+class ComputeBuildSubdirTestCase(unittest.TestCase):
+
+    def create_basic_args(self, generator, variant, assertions):
+        return argparse.Namespace(
+            cmake_generator=generator,
+            cmark_build_variant=variant,
+            llvm_build_variant=variant,
+            swift_build_variant=variant,
+            swift_stdlib_build_variant=variant,
+            swift_analyze_code_coverage="false",
+            cmark_assertions=assertions,
+            llvm_assertions=assertions,
+            swift_assertions=assertions,
+            swift_stdlib_assertions=assertions)
+
+    def test_Ninja_ReleaseAssert(self):
+        # build-script -R
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=True)
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja-ReleaseAssert")
+
+    def test_Ninja_Release(self):
+        # build-script -R --no-assertions
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=False)
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja-Release")
+
+    def test_Ninja_Release_stdlib_ReleaseAssert(self):
+        # build-script -R --no-assertions --swift-stdlib-assertions
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=False)
+        args.swift_stdlib_assertions = True
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja-Release+stdlib-ReleaseAssert")
+
+    def test_Ninja_mixed(self):
+        # build-script -R --no-assertions
+        #     --llvm-build-variant=RelWithDebInfo
+        #     --swift-analyze-code-coverage="merged"
+        #     --swift-stdlib-assertions
+        args = self.create_basic_args(
+            "Ninja", variant="Release", assertions=False)
+        args.llvm_build_variant = "RelWithDebInfo"
+        args.swift_analyze_code_coverage = "merged"
+        args.swift_stdlib_assertions = True
+        self.assertEqual(compute_build_subdir(args),
+                         "Ninja+cmark-Release+llvm-RelWithDebInfo"
+                         "+swift-ReleaseCoverage+stdlib-ReleaseAssert")
+
+    def test_Unix_Makefiles_ReleaseAssert(self):
+        # build-script -R -m
+        args = self.create_basic_args(
+            "Unix Makefiles", variant="Release", assertions=True)
+        self.assertEqual(compute_build_subdir(args),
+                         "Unix_Makefiles-ReleaseAssert")
+
+    def test_all_combinations_are_unique(self):
+        productions = itertools.product(
+            ["Release", "Debug"],        # cmark_build_variant
+            ["Release", "Debug"],        # llvm_build_variant
+            ["Release", "Debug"],        # swift_build_variant
+            ["Release", "Debug"],        # swift_stdlib_build_variant
+            ["false", "true"],           # swift_analyze_code_coverage
+            [True, False],               # cmark_assertions
+            [True, False],               # llvm_assertions
+            [True, False],               # swift_assertions
+            [True, False],               # swift_stdlib_assertions
+        )
+        keys = [
+            "cmark_build_variant",
+            "llvm_build_variant",
+            "swift_build_variant",
+            "swift_stdlib_build_variant",
+            "swift_analyze_code_coverage",
+            "cmark_assertions",
+            "llvm_assertions",
+            "swift_assertions",
+            "swift_stdlib_assertions",
+        ]
+
+        def generate():
+            for c in productions:
+                args = argparse.Namespace(cmake_generator="Ninja")
+                for key, val in zip(keys, c):
+                    setattr(args, key, val)
+                yield compute_build_subdir(args)
+
+        seen = set()
+        for line in generate():
+            self.assertIsInstance(line, str)
+            self.assertNotIn(line, seen)
+            seen.add(line)
+        self.assertEqual(len(seen), 1 << 9)  # Iterated all productions.


### PR DESCRIPTION
#### What's in this pull request?

As a ground work for [SR-237](https://bugs.swift.org/browse/SR-237),
Factored out the default `args.build_subdir` calculation into
`swift_build_support.workspace` module, and added some tests.

Also, added `Workspace` object that represents the whole source tree,
and the build directory.
This would be a replacement of [`build_directory`](https://github.com/rintaro/swift/blob/00617f92dd8130686f15ab969576e3e9eacaa234/utils/build-script-impl#L1149-L1153) function in `build-script-impl` in the future.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
