### PR TITLE
Revert "[swift-3.0-preview-1][stdlib] Dictionary, Set: allow querying for a mismatched type when bridged"

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3275,9 +3275,7 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   @warn_unused_result
   internal func bridgingObjectForKey(_ aKey: AnyObject)
     -> AnyObject? {
-    guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
-    else { return nil }
-
+    let nativeKey = _forceBridgeFromObjectiveC(aKey, Key.self)
     let (i, found) = nativeStorage._find(
       nativeKey, startBucket: nativeStorage._bucket(nativeKey))
     if found {

--- a/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
+++ b/test/1_stdlib/Inputs/DictionaryKeyValueTypesObjC.swift
@@ -113,39 +113,6 @@ class TestObjCKeyTy : NSObject, NSCopying {
   var serial: Int
 }
 
-// A type that satisfies the requirements of an NSDictionary key (or an NSSet
-// member), but traps when any of its methods are called.
-class TestObjCInvalidKeyTy {
-  init() {
-    _objcKeyCount.fetchAndAdd(1)
-    serial = _objcKeySerial.addAndFetch(1)
-  }
-
-  deinit {
-    assert(serial > 0, "double destruction")
-    _objcKeyCount.fetchAndAdd(-1)
-    serial = -serial
-  }
-
-  @objc
-  var description: String {
-    assert(serial > 0, "dead TestObjCInvalidKeyTy")
-    fatalError()
-  }
-
-  @objc
-  func isEqual(_ object: AnyObject!) -> Bool {
-    fatalError()
-  }
-
-  @objc
-  var hash : Int {
-    fatalError()
-  }
-
-  var serial: Int
-}
-
 var _objcValueCount = _stdlib_AtomicInt(0)
 var _objcValueSerial = _stdlib_AtomicInt(0)
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -2558,11 +2558,6 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.ObjectForKey") {
 
   expectEmpty(d.object(forKey: TestObjCKeyTy(40)))
 
-  // NSDictionary can store mixed key types.  Swift's Dictionary is typed, but
-  // when bridged to NSDictionary, it should behave like one, and allow queries
-  // for mismatched key types.
-  expectEmpty(d.object(forKey: TestObjCInvalidKeyTy()))
-
   for i in 0..<3 {
     expectEqual(idValue10, unsafeBitCast(
       d.object(forKey: TestObjCKeyTy(10)), to: UInt.self))

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -2154,37 +2154,12 @@ SetTestSuite.test("BridgedToObjC.Verbatim.Count") {
 }
 
 SetTestSuite.test("BridgedToObjC.Verbatim.Contains") {
-  let s = getBridgedNSSetOfRefTypesBridgedVerbatim()
+  let nss = getBridgedNSSetOfRefTypesBridgedVerbatim()
 
-  var v: AnyObject? = s.member(TestObjCKeyTy(1010))
-  expectEqual(1010, (v as! TestObjCKeyTy).value)
-  let idValue10 = unsafeBitCast(v, to: UInt.self)
-
-  v = s.member(TestObjCKeyTy(2020))
-  expectEqual(2020, (v as! TestObjCKeyTy).value)
-  let idValue20 = unsafeBitCast(v, to: UInt.self)
-
-  v = s.member(TestObjCKeyTy(3030))
-  expectEqual(3030, (v as! TestObjCKeyTy).value)
-  let idValue30 = unsafeBitCast(v, to: UInt.self)
-
-  expectEmpty(s.member(TestObjCKeyTy(4040)))
-
-  // NSSet can store mixed key types.  Swift's Set is typed, but when bridged
-  // to NSSet, it should behave like one, and allow queries for mismatched key
-  // types.
-  expectEmpty(s.member(TestObjCInvalidKeyTy()))
-
-  for i in 0..<3 {
-    expectEqual(idValue10,
-      unsafeBitCast(s.member(TestObjCKeyTy(1010)), to: UInt.self))
-
-    expectEqual(idValue20,
-      unsafeBitCast(s.member(TestObjCKeyTy(2020)), to: UInt.self))
-
-    expectEqual(idValue30,
-      unsafeBitCast(s.member(TestObjCKeyTy(3030)), to: UInt.self))
-  }
+  expectNotEmpty(nss.member(TestObjCKeyTy(1010)))
+  expectNotEmpty(nss.member(TestObjCKeyTy(2020)))
+  expectNotEmpty(nss.member(TestObjCKeyTy(3030)))
+  expectEmpty(nss.member(TestObjCKeyTy(4040)))
 
   expectAutoreleasedKeysAndValues(unopt: (3, 0))
 }


### PR DESCRIPTION
Reverts apple/swift#2554
