### PR TITLE
stdlib: remove most uses of @warn_unused_result, which does nothing now

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -221,7 +221,6 @@ public struct ${Self}<
     return base.underestimatedCount
   }
 
-  @warn_unused_result
   public func map<T>(
     _ transform: @noescape (Base.Iterator.Element) throws -> T
   ) rethrows -> [T] {
@@ -229,7 +228,6 @@ public struct ${Self}<
     return try base.map(transform)
   }
 
-  @warn_unused_result
   public func filter(
     _ includeElement: @noescape (Base.Iterator.Element) throws -> Bool
   ) rethrows -> [Base.Iterator.Element] {
@@ -367,7 +365,6 @@ public struct ${Self}<
     base._failEarlyRangeCheck(range, bounds: bounds)
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     Log.successor[selfType] += 1
     return base.index(after: i)
@@ -424,13 +421,11 @@ public struct ${Self}<
     return base.first
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     Log.advance[selfType] += 1
     return base.index(i, offsetBy: n)
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -438,7 +433,6 @@ public struct ${Self}<
     return base.index(i, offsetBy: n, limitedBy: limit)
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     Log.distance[selfType] += 1
     return base.distance(from: start, to: end)
@@ -555,7 +549,6 @@ public struct ${Self}<
   }
 %     end
 %     if Traversal in ['Bidirectional', 'RandomAccess']:
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     BidirectionalCollectionLog.predecessor[selfType] += 1
     return base.index(before: i)

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -117,7 +117,6 @@ public struct MinimalSequence<T> : Sequence, CustomDebugStringConvertible {
 
   public let timesMakeIteratorCalled = ResettableValue(0)
 
-  @warn_unused_result
   public func makeIterator() -> MinimalIterator<T> {
     timesMakeIteratorCalled.value += 1
     return MinimalIterator(_sharedState)
@@ -480,14 +479,12 @@ public func < (lhs: ${Index}, rhs: ${Index}) -> Bool {
 extension MinimalStrideableIndex : Strideable {
   public typealias Stride = Int
 
-  @warn_unused_result
   public func distance(to other: MinimalStrideableIndex) -> Int {
     timesDistanceCalled.value += 1
     _expectCompatibleIndices(self, other)
     return other.position - position
   }
 
-  @warn_unused_result
   public func advanced(by n: Int) -> MinimalStrideableIndex {
     timesAdvancedCalled.value += 1
     return MinimalStrideableIndex(
@@ -652,14 +649,12 @@ public struct ${Self}<T> : ${SelfProtocols} {
       in: bounds.lowerBound.position..<bounds.upperBound.position)
   }
 
-  @warn_unused_result
   public func index(after i: ${Index}) -> ${Index} {
     _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
     return _uncheckedIndex(forPosition: i.position + 1)
   }
 
 %     if Traversal in ['Bidirectional', 'RandomAccess']:
-  @warn_unused_result
   public func index(before i: ${Index}) -> ${Index} {
     // FIXME: swift-3-indexing-model: perform a range check and use
     // return _uncheckedIndex(forPosition: i.position - 1)
@@ -667,7 +662,6 @@ public struct ${Self}<T> : ${SelfProtocols} {
   }
 %     end
 
-  @warn_unused_result
   public func distance(from start: ${Index}, to end: ${Index})
     -> IndexDistance {
 %     if Traversal == 'Forward':
@@ -684,7 +678,6 @@ public struct ${Self}<T> : ${SelfProtocols} {
     return end.position - start.position
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
 %     if Traversal == 'Forward':
     _precondition(n >= 0,
@@ -851,7 +844,6 @@ public struct DefaultedSequence<Element> : Sequence {
       elements: elements, underestimatedCount: underestimatedCount))
   }
 
-  @warn_unused_result
   public func makeIterator() -> MinimalIterator<Element> {
     return base.makeIterator()
   }
@@ -921,7 +913,6 @@ public struct ${Self}<Element> : ${SelfProtocols} {
 
   public let timesMakeIteratorCalled = ResettableValue(0)
 
-  @warn_unused_result
   public func makeIterator() -> MinimalIterator<Element> {
     timesMakeIteratorCalled.value += 1
     return base.makeIterator()
@@ -931,7 +922,6 @@ public struct ${Self}<Element> : ${SelfProtocols} {
 
   public let timesSuccessorCalled = ResettableValue(0)
 
-  @warn_unused_result
   public func index(after i: ${Index}) -> ${Index} {
     timesSuccessorCalled.value += 1
     return base.index(after: i)
@@ -940,7 +930,6 @@ public struct ${Self}<Element> : ${SelfProtocols} {
 %       if Traversal in ['Bidirectional', 'RandomAccess']:
   public let timesPredecessorCalled = ResettableValue(0)
 
-  @warn_unused_result
   public func index(before i: ${Index}) -> ${Index} {
     timesPredecessorCalled.value += 1
     return base.index(before: i)
@@ -948,13 +937,11 @@ public struct ${Self}<Element> : ${SelfProtocols} {
 %       end
 
 %       if Traversal == 'RandomAccess':
-  @warn_unused_result
   public func distance(from start: ${Index}, to end: ${Index})
     -> IndexDistance {
     return base.distance(from: start, to: end)
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     return base.index(i, offsetBy: n)
   }
@@ -1062,7 +1049,6 @@ public struct Defaulted${Traversal}RangeReplaceableSlice<Element>
       base: Base(elements: elements))
   }
 
-  @warn_unused_result
   public func makeIterator() -> MinimalIterator<Element> {
     return MinimalIterator(Array(self))
   }

--- a/stdlib/private/StdlibUnittest/LifetimeTracked.swift
+++ b/stdlib/private/StdlibUnittest/LifetimeTracked.swift
@@ -42,12 +42,10 @@ public final class LifetimeTracked {
 }
 
 extension LifetimeTracked : Strideable {
-  @warn_unused_result
   public func distance(to other: LifetimeTracked) -> Int {
     return self.value.distance(to: other.value)
   }
 
-  @warn_unused_result
   public func advanced(by n: Int) -> LifetimeTracked {
     return LifetimeTracked(self.value.advanced(by: n))
   }

--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift.gyb
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift.gyb
@@ -173,13 +173,11 @@ public struct MinimalStrideableValue : Equatable, Comparable, Strideable {
 
   public typealias Stride = Int
 
-  @warn_unused_result
   public func distance(to other: MinimalStrideableValue) -> Stride {
     MinimalStrideableValue.timesDistanceWasCalled.value += 1
     return other.value - self.value
   }
 
-  @warn_unused_result
   public func advanced(by n: Stride) -> MinimalStrideableValue {
     MinimalStrideableValue.timesAdvancedWasCalled.value += 1
     return MinimalStrideableValue(self.value + n, identity: self.identity)

--- a/stdlib/private/StdlibUnittest/StringConvertible.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift.gyb
@@ -70,12 +70,10 @@ public struct CustomPrintableValue
 
   public typealias Stride = Int
 
-  @warn_unused_result
   public func distance(to other: CustomPrintableValue) -> Stride {
     return other.value - self.value
   }
 
-  @warn_unused_result
   public func advanced(by n: Stride) -> CustomPrintableValue {
     return CustomPrintableValue(self.value + n, identity: self.identity)
   }

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -56,17 +56,14 @@ extension DarwinBoolean : CustomStringConvertible {
 }
 
 extension DarwinBoolean : Equatable {}
-@warn_unused_result
 public func ==(lhs: DarwinBoolean, rhs: DarwinBoolean) -> Bool {
   return lhs.boolValue == rhs.boolValue
 }
 
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertBoolToDarwinBoolean(_ x: Bool) -> DarwinBoolean {
   return DarwinBoolean(x)
 }
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertDarwinBooleanToBool(_ x: DarwinBoolean) -> Bool {
   return Bool(x)
@@ -76,7 +73,6 @@ func _convertDarwinBooleanToBool(_ x: DarwinBoolean) -> Bool {
 // rdar://problem/19418937, so here are some @_transparent overloads
 // for DarwinBoolean.
 @_transparent
-@warn_unused_result
 public func && <T : Boolean>(
   lhs: T,
   rhs: @autoclosure () -> DarwinBoolean
@@ -85,7 +81,6 @@ public func && <T : Boolean>(
 }
 
 @_transparent
-@warn_unused_result
 public func || <T : Boolean>(
   lhs: T,
   rhs: @autoclosure () -> DarwinBoolean
@@ -160,7 +155,6 @@ public var stderr : UnsafeMutablePointer<FILE> {
 // fcntl.h
 //===----------------------------------------------------------------------===//
 
-@warn_unused_result
 @_silgen_name("_swift_Platform_open")
 func _swift_Platform_open(
   _ path: UnsafePointer<CChar>,
@@ -168,7 +162,6 @@ func _swift_Platform_open(
   _ mode: mode_t
 ) -> CInt
 
-@warn_unused_result
 @_silgen_name("_swift_Platform_openat")
 func _swift_Platform_openat(
   _ fd: CInt,
@@ -177,7 +170,6 @@ func _swift_Platform_openat(
   _ mode: mode_t
 ) -> CInt
 
-@warn_unused_result
 public func open(
   _ path: UnsafePointer<CChar>,
   _ oflag: CInt
@@ -185,7 +177,6 @@ public func open(
   return _swift_Platform_open(path, oflag, 0)
 }
 
-@warn_unused_result
 public func open(
   _ path: UnsafePointer<CChar>,
   _ oflag: CInt,
@@ -194,7 +185,6 @@ public func open(
   return _swift_Platform_open(path, oflag, mode)
 }
 
-@warn_unused_result
 public func openat(
   _ fd: CInt,
   _ path: UnsafePointer<CChar>,
@@ -203,7 +193,6 @@ public func openat(
   return _swift_Platform_openat(fd, path, oflag, 0)
 }
 
-@warn_unused_result
 public func openat(
   _ fd: CInt,
   _ path: UnsafePointer<CChar>,
@@ -213,7 +202,6 @@ public func openat(
   return _swift_Platform_openat(fd, path, oflag, mode)
 }
 
-@warn_unused_result
 @_silgen_name("_swift_Platform_fcntl")
 internal func _swift_Platform_fcntl(
   _ fd: CInt,
@@ -221,7 +209,6 @@ internal func _swift_Platform_fcntl(
   _ value: CInt
 ) -> CInt
 
-@warn_unused_result
 @_silgen_name("_swift_Platform_fcntlPtr")
 internal func _swift_Platform_fcntlPtr(
   _ fd: CInt,
@@ -229,7 +216,6 @@ internal func _swift_Platform_fcntlPtr(
   _ ptr: UnsafeMutablePointer<Void>
 ) -> CInt
 
-@warn_unused_result
 public func fcntl(
   _ fd: CInt,
   _ cmd: CInt
@@ -237,7 +223,6 @@ public func fcntl(
   return _swift_Platform_fcntl(fd, cmd, 0)
 }
 
-@warn_unused_result
 public func fcntl(
   _ fd: CInt,
   _ cmd: CInt,
@@ -246,7 +231,6 @@ public func fcntl(
   return _swift_Platform_fcntl(fd, cmd, value)
 }
 
-@warn_unused_result
 public func fcntl(
   _ fd: CInt,
   _ cmd: CInt,
@@ -358,14 +342,12 @@ public var SEM_FAILED: UnsafeMutablePointer<sem_t>? {
 #endif
 }
 
-@warn_unused_result
 @_silgen_name("_swift_Platform_sem_open2")
 internal func _swift_Platform_sem_open2(
   _ name: UnsafePointer<CChar>,
   _ oflag: CInt
 ) -> UnsafeMutablePointer<sem_t>?
 
-@warn_unused_result
 @_silgen_name("_swift_Platform_sem_open4")
 internal func _swift_Platform_sem_open4(
   _ name: UnsafePointer<CChar>,
@@ -374,7 +356,6 @@ internal func _swift_Platform_sem_open4(
   _ value: CUnsignedInt
 ) -> UnsafeMutablePointer<sem_t>?
 
-@warn_unused_result
 public func sem_open(
   _ name: UnsafePointer<CChar>,
   _ oflag: CInt
@@ -382,7 +363,6 @@ public func sem_open(
   return _swift_Platform_sem_open2(name, oflag)
 }
 
-@warn_unused_result
 public func sem_open(
   _ name: UnsafePointer<CChar>,
   _ oflag: CInt,
@@ -398,7 +378,6 @@ public func sem_open(
 
 // FreeBSD defines extern char **environ differently than Linux.
 #if os(FreeBSD)
-@warn_unused_result
 @_silgen_name("_swift_FreeBSD_getEnv")
 func _swift_FreeBSD_getEnv(
 ) -> UnsafeMutablePointer<UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>>

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -122,7 +122,6 @@ def TypedBinaryFunctions():
 // Note these do not have a corresponding LLVM intrinsic
 % for T, CT, f, ufunc in TypedUnaryFunctions():
 @_transparent
-@warn_unused_result
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return ${T}(${ufunc}${f}(${CT}(x)))
 }
@@ -134,7 +133,6 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():
 @_transparent
-@warn_unused_result
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return _${ufunc}(x)
 }
@@ -148,7 +146,6 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 % for ufunc in UnaryIntrinsicFunctions:
 %     for T, CT, f in OverlayFloatTypes():
 @_transparent
-@warn_unused_result
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return ${T}(${ufunc}${f}(${CT}(x)))
 }
@@ -161,7 +158,6 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 
 % for T, CT, f, bfunc in TypedBinaryFunctions():
 @_transparent
-@warn_unused_result
 public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
   return ${T}(${bfunc}${f}(${CT}(lhs), ${CT}(rhs)))
 }
@@ -203,7 +199,6 @@ public func signbit(_ value: ${T}) -> Int { return value.sign.rawValue }
 % # These are AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 @_transparent
-@warn_unused_result
 public func modf(_ value: ${T}) -> (${T}, ${T}) {
   var ipart = ${CT}(0)
   let fpart = modf${f}(${CT}(value), &ipart)
@@ -215,7 +210,6 @@ public func modf(_ value: ${T}) -> (${T}, ${T}) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the Int parameter.
 % for T, CT, f in AllFloatTypes():
 @_transparent
-@warn_unused_result
 public func ldexp(_ x: ${T}, _ n: Int) -> ${T} {
   return ${T}(ldexp${f}(${CT}(x), CInt(n)))
 }
@@ -225,7 +219,6 @@ public func ldexp(_ x: ${T}, _ n: Int) -> ${T} {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 @_transparent
-@warn_unused_result
 public func frexp(_ value: ${T}) -> (${T}, Int) {
   var exp = CInt(0)
   let frac = frexp${f}(${CT}(value), &exp)
@@ -237,7 +230,6 @@ public func frexp(_ value: ${T}) -> (${T}, Int) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the Int return.
 % for T, CT, f in AllFloatTypes():
 @_transparent
-@warn_unused_result
 public func ilogb(_ x: ${T}) -> Int {
   return Int(ilogb${f}(${CT}(x)) as CInt)
 }
@@ -247,7 +239,6 @@ public func ilogb(_ x: ${T}) -> Int {
 % # This is AllFloatTypes not OverlayFloatTypes because of the Int parameter.
 % for T, CT, f in AllFloatTypes():
 @_transparent
-@warn_unused_result
 public func scalbn(_ x: ${T}, _ n: Int) -> ${T} {
   return ${T}(scalbn${f}(${CT}(x), CInt(n)))
 }
@@ -258,7 +249,6 @@ public func scalbn(_ x: ${T}, _ n: Int) -> ${T} {
 % for T, CT, f in AllFloatTypes():
 #if os(Linux) || os(FreeBSD) || os(Android) || os(Windows)
 @_transparent
-@warn_unused_result
 public func lgamma(_ x: ${T}) -> (${T}, Int) {
   var sign = CInt(0)
   let value = lgamma${f}_r(${CT}(x), &sign)
@@ -268,13 +258,11 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 % # On Darwin platform,
 % # The real lgamma_r is not imported because it hides behind macro _REENTRANT.
 @_versioned
-@warn_unused_result
 @_silgen_name("_swift_Darwin_lgamma${f}_r")
 func _swift_Darwin_lgamma${f}_r(_: ${CT},
                                 _: UnsafeMutablePointer<CInt>) -> ${CT}
 
 @_transparent
-@warn_unused_result
 public func lgamma(_ x: ${T}) -> (${T}, Int) {
   var sign = CInt(0)
   let value = withUnsafeMutablePointer(&sign) { 
@@ -290,7 +278,6 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 @_transparent
-@warn_unused_result
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
   var quo = CInt(0)
   let rem = remquo${f}(${CT}(x), ${CT}(y), &quo)
@@ -301,7 +288,6 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 
 % for T, CT, f in OverlayFloatTypes():
 @_transparent
-@warn_unused_result
 public func nan(_ tag: String) -> ${T} {
   return ${T}(nan${f}(tag))
 }
@@ -310,7 +296,6 @@ public func nan(_ tag: String) -> ${T} {
 
 % for T, CT, f in OverlayFloatTypes():
 @_transparent
-@warn_unused_result
 public func fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} {
   return ${T}(fma${f}(${CT}(x), ${CT}(y), ${CT}(z)))
 }
@@ -319,13 +304,11 @@ public func fma(_ x: ${T}, _ y: ${T}, _ z: ${T}) -> ${T} {
 
 % # These C functions only support double. The overlay fixes the Int parameter.
 @_transparent
-@warn_unused_result
 public func jn(_ n: Int, _ x: Double) -> Double {
   return jn(CInt(n), x)
 }
 
 @_transparent
-@warn_unused_result
 public func yn(_ n: Int, _ x: Double) -> Double {
   return yn(CInt(n), x)
 }

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -174,7 +174,6 @@ public struct CGFloat {
     return CGFloat(native.nextDown)
   }
 
-  @warn_unused_result
   public static func abs(_ x: CGFloat) -> CGFloat {
     return CGFloat(NativeType.abs(x.native))
   }
@@ -218,17 +217,14 @@ public struct CGFloat {
   }
   */
 
-  @warn_unused_result
   public func isEqual(to other: CGFloat) -> Bool {
     return self.native.isEqual(to: other.native)
   }
 
-  @warn_unused_result
   public func isLess(than other: CGFloat) -> Bool {
     return self.native.isLess(than: other.native)
   }
 
-  @warn_unused_result
   public func isLessThanOrEqualTo(_ other: CGFloat) -> Bool {
     return self.native.isLessThanOrEqualTo(other.native)
   }
@@ -376,25 +372,21 @@ extension CGFloat : CustomReflectable {
 //  definitions in the standard lib, or both.
 
 @_transparent
-@warn_unused_result
 public func +(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
   return lhs.adding(rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func -(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
   return lhs.subtracting(rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func *(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
   return lhs.multiplied(by: rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func /(lhs: CGFloat, rhs: CGFloat) -> CGFloat {
   return lhs.divided(by: rhs)
 }
@@ -492,259 +484,216 @@ public func %=(lhs: inout CGFloat, rhs: CGFloat) {
 //===----------------------------------------------------------------------===//
 
 @_transparent
-@warn_unused_result
 public func acos(_ x: CGFloat) -> CGFloat {
   return CGFloat(acos(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func cos(_ x: CGFloat) -> CGFloat {
   return CGFloat(cos(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func sin(_ x: CGFloat) -> CGFloat {
   return CGFloat(sin(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func asin(_ x: CGFloat) -> CGFloat {
   return CGFloat(asin(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func atan(_ x: CGFloat) -> CGFloat {
   return CGFloat(atan(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func tan(_ x: CGFloat) -> CGFloat {
   return CGFloat(tan(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func acosh(_ x: CGFloat) -> CGFloat {
   return CGFloat(acosh(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func asinh(_ x: CGFloat) -> CGFloat {
   return CGFloat(asinh(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func atanh(_ x: CGFloat) -> CGFloat {
   return CGFloat(atanh(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func cosh(_ x: CGFloat) -> CGFloat {
   return CGFloat(cosh(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func sinh(_ x: CGFloat) -> CGFloat {
   return CGFloat(sinh(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func tanh(_ x: CGFloat) -> CGFloat {
   return CGFloat(tanh(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func exp(_ x: CGFloat) -> CGFloat {
   return CGFloat(exp(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func exp2(_ x: CGFloat) -> CGFloat {
   return CGFloat(exp2(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func expm1(_ x: CGFloat) -> CGFloat {
   return CGFloat(expm1(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func log(_ x: CGFloat) -> CGFloat {
   return CGFloat(log(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func log10(_ x: CGFloat) -> CGFloat {
   return CGFloat(log10(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func log2(_ x: CGFloat) -> CGFloat {
   return CGFloat(log2(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func log1p(_ x: CGFloat) -> CGFloat {
   return CGFloat(log1p(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func logb(_ x: CGFloat) -> CGFloat {
   return CGFloat(logb(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func cbrt(_ x: CGFloat) -> CGFloat {
   return CGFloat(cbrt(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func erf(_ x: CGFloat) -> CGFloat {
   return CGFloat(erf(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func erfc(_ x: CGFloat) -> CGFloat {
   return CGFloat(erfc(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func tgamma(_ x: CGFloat) -> CGFloat {
   return CGFloat(tgamma(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func fabs(_ x: CGFloat) -> CGFloat {
   return CGFloat(fabs(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func sqrt(_ x: CGFloat) -> CGFloat {
   return CGFloat(sqrt(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func ceil(_ x: CGFloat) -> CGFloat {
   return CGFloat(ceil(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func floor(_ x: CGFloat) -> CGFloat {
   return CGFloat(floor(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func nearbyint(_ x: CGFloat) -> CGFloat {
   return CGFloat(nearbyint(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func rint(_ x: CGFloat) -> CGFloat {
   return CGFloat(rint(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func round(_ x: CGFloat) -> CGFloat {
   return CGFloat(round(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func trunc(_ x: CGFloat) -> CGFloat {
   return CGFloat(trunc(x.native))
 }
 
 @_transparent
-@warn_unused_result
 public func atan2(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(atan2(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func hypot(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(hypot(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func pow(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(pow(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func fmod(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(fmod(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func remainder(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(remainder(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func copysign(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(copysign(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func nextafter(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(nextafter(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func fdim(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(fdim(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func fmax(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(fmax(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 public func fmin(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
   return CGFloat(fmin(lhs.native, rhs.native))
 }
 
 @_transparent
-@warn_unused_result
 @available(*, unavailable, message: "use the floatingPointClass property.")
 public func fpclassify(_ x: CGFloat) -> Int {
   fatalError("unavailable")
@@ -766,95 +715,80 @@ public func isnan(_ value: CGFloat) -> Bool { return value.isNaN }
 public func signbit(_ value: CGFloat) -> Int { return value.sign.rawValue }
 
 @_transparent
-@warn_unused_result
 public func modf(_ x: CGFloat) -> (CGFloat, CGFloat) {
   let (ipart, fpart) = modf(x.native)
   return (CGFloat(ipart), CGFloat(fpart))
 }
 
 @_transparent
-@warn_unused_result
 public func ldexp(_ x: CGFloat, _ n: Int) -> CGFloat {
   return CGFloat(ldexp(x.native, n))
 }
 
 @_transparent
-@warn_unused_result
 public func frexp(_ x: CGFloat) -> (CGFloat, Int) {
   let (frac, exp) = frexp(x.native)
   return (CGFloat(frac), exp)
 }
 
 @_transparent
-@warn_unused_result
 public func ilogb(_ x: CGFloat) -> Int {
   return ilogb(x.native)
 }
 
 @_transparent
-@warn_unused_result
 public func scalbn(_ x: CGFloat, _ n: Int) -> CGFloat {
   return CGFloat(scalbn(x.native, n))
 }
 
 @_transparent
-@warn_unused_result
 public func lgamma(_ x: CGFloat) -> (CGFloat, Int) {
   let (value, sign) = lgamma(x.native)
   return (CGFloat(value), sign)
 }
 
 @_transparent
-@warn_unused_result
 public func remquo(_ x: CGFloat, _ y: CGFloat) -> (CGFloat, Int) {
   let (rem, quo) = remquo(x.native, y.native)
   return (CGFloat(rem), quo)
 }
 
 @_transparent
-@warn_unused_result
 public func nan(_ tag: String) -> CGFloat {
   return CGFloat(nan(tag) as CGFloat.NativeType)
 }
 
 @_transparent
-@warn_unused_result
 public func fma(_ x: CGFloat, _ y: CGFloat, _ z: CGFloat) -> CGFloat {
   return CGFloat(fma(x.native, y.native, z.native))
 }
 
 @_transparent
-@warn_unused_result
 public func j0(_ x: CGFloat) -> CGFloat {
   return CGFloat(j0(Double(x.native)))
 }
 
 @_transparent
-@warn_unused_result
 public func j1(_ x: CGFloat) -> CGFloat {
   return CGFloat(j1(Double(x.native)))
 }
 
 @_transparent
-@warn_unused_result
 public func jn(_ n: Int, _ x: CGFloat) -> CGFloat {
   return CGFloat(jn(n, Double(x.native)))
 }
 
 @_transparent
-@warn_unused_result
 public func y0(_ x: CGFloat) -> CGFloat {
   return CGFloat(y0(Double(x.native)))
 }
 
 @_transparent
-@warn_unused_result
 public func y1(_ x: CGFloat) -> CGFloat {
   return CGFloat(y1(Double(x.native)))
 }
 
 @_transparent
-@warn_unused_result
 public func yn(_ n: Int, _ x: CGFloat) -> CGFloat {
   return CGFloat(yn(n, Double(x.native)))
 }

--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -52,7 +52,6 @@ extension CGPoint : CustomDebugStringConvertible {
 
 extension CGPoint : Equatable {}
 @_transparent // @fragile
-@warn_unused_result
 public func == (lhs: CGPoint, rhs: CGPoint) -> Bool {
   return lhs.x == rhs.x  &&  lhs.y == rhs.y
 }
@@ -95,7 +94,6 @@ extension CGSize : CustomDebugStringConvertible {
 
 extension CGSize : Equatable {}
 @_transparent // @fragile
-@warn_unused_result
 public func == (lhs: CGSize, rhs: CGSize) -> Bool {
   return lhs.width == rhs.width  &&  lhs.height == rhs.height
 }
@@ -119,7 +117,6 @@ public extension CGVector {
 
 extension CGVector : Equatable {}
 @_transparent // @fragile
-@warn_unused_result
 public func == (lhs: CGVector, rhs: CGVector) -> Bool {
   return lhs.dx == rhs.dx  &&  lhs.dy == rhs.dy
 }
@@ -180,7 +177,6 @@ public extension CGRect {
   }
 
   @_transparent // @fragile
-  @warn_unused_result
   func divide(_ atDistance: CGFloat, fromEdge: CGRectEdge)
     -> (slice: CGRect, remainder: CGRect)
   {
@@ -215,7 +211,6 @@ extension CGRect : CustomDebugStringConvertible {
 
 extension CGRect : Equatable {}
 @_transparent // @fragile
-@warn_unused_result
 public func == (lhs: CGRect, rhs: CGRect) -> Bool {
   return lhs.equalTo(rhs)
 }

--- a/stdlib/public/SDK/CoreMedia/CMTime.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTime.swift
@@ -71,49 +71,40 @@ extension CMTime {
   }
 }
 
-@warn_unused_result
 public func CMTIME_IS_VALID(_ time: CMTime) -> Bool {
   return time.isValid
 }
 
-@warn_unused_result
 public func CMTIME_IS_INVALID(_ time: CMTime) -> Bool {
   return !time.isValid
 }
 
-@warn_unused_result
 public func CMTIME_IS_POSITIVEINFINITY(_ time: CMTime) -> Bool {
   return time.isPositiveInfinity
 }
 
-@warn_unused_result
 public func CMTIME_IS_NEGATIVEINFINITY(_ time: CMTime) -> Bool {
   return time.isNegativeInfinity
 }
 
-@warn_unused_result
 public func CMTIME_IS_INDEFINITE(_ time: CMTime) -> Bool {
   return time.isIndefinite
 }
 
-@warn_unused_result
 public func CMTIME_IS_NUMERIC(_ time: CMTime) -> Bool {
   return time.isNumeric
 }
 
-@warn_unused_result
 public func CMTIME_HAS_BEEN_ROUNDED(_ time: CMTime) -> Bool {
   return time.hasBeenRounded
 }
 
 // CMTimeAdd
-@warn_unused_result
 public func + (addend1: CMTime, addend2: CMTime) -> CMTime {
   return CMTimeAdd(addend1, addend2)
 }
 
 // CMTimeSubtract
-@warn_unused_result
 public func - (minuend: CMTime, subtrahend: CMTime) -> CMTime {
   return CMTimeSubtract(minuend, subtrahend)
 }
@@ -121,27 +112,21 @@ public func - (minuend: CMTime, subtrahend: CMTime) -> CMTime {
 extension CMTime : Equatable, Comparable {}
 
 // CMTimeCompare
-@warn_unused_result
 public func < (time1: CMTime, time2: CMTime) -> Bool {
   return CMTimeCompare(time1, time2) < 0
 }
-@warn_unused_result
 public func <= (time1: CMTime, time2: CMTime) -> Bool {
   return CMTimeCompare(time1, time2) <= 0
 }
-@warn_unused_result
 public func > (time1: CMTime, time2: CMTime) -> Bool {
   return CMTimeCompare(time1, time2) > 0
 }
-@warn_unused_result
 public func >= (time1: CMTime, time2: CMTime) -> Bool {
   return CMTimeCompare(time1, time2) >= 0
 }
-@warn_unused_result
 public func == (time1: CMTime, time2: CMTime) -> Bool {
   return CMTimeCompare(time1, time2) == 0
 }
-@warn_unused_result
 public func != (time1: CMTime, time2: CMTime) -> Bool {
   return CMTimeCompare(time1, time2) != 0
 }

--- a/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
@@ -45,37 +45,29 @@ extension CMTimeRange {
     return CMTimeRangeGetEnd(self)
   }
 
-  @warn_unused_result
   public func union(_ otherRange: CMTimeRange) -> CMTimeRange {
     return CMTimeRangeGetUnion(self, otherRange)
   }
-  @warn_unused_result
   public func intersection(_ otherRange: CMTimeRange) -> CMTimeRange {
     return CMTimeRangeGetIntersection(self, otherRange)
   }
-  @warn_unused_result
   public func containsTime(_ time: CMTime) -> Bool {
     return CMTimeRangeContainsTime(self, time).boolValue
   }
-  @warn_unused_result
   public func containsTimeRange(_ range: CMTimeRange) -> Bool {
     return CMTimeRangeContainsTimeRange(self, range).boolValue
   }
 }
 
-@warn_unused_result
 public func CMTIMERANGE_IS_VALID (_ range: CMTimeRange) -> Bool {
   return range.isValid
 }
-@warn_unused_result
 public func CMTIMERANGE_IS_INVALID (_ range: CMTimeRange) -> Bool {
   return !range.isValid
 }
-@warn_unused_result
 public func CMTIMERANGE_IS_INDEFINITE (_ range: CMTimeRange) -> Bool {
   return range.isIndefinite
 }
-@warn_unused_result
 public func CMTIMERANGE_IS_EMPTY (_ range: CMTimeRange) -> Bool {
   return range.isEmpty
 }
@@ -83,12 +75,10 @@ public func CMTIMERANGE_IS_EMPTY (_ range: CMTimeRange) -> Bool {
 extension CMTimeRange : Equatable {}
 
 // CMTimeRangeEqual
-@warn_unused_result
 public func == (range1: CMTimeRange, range2: CMTimeRange) -> Bool {
   return CMTimeRangeEqual(range1, range2).boolValue
 }
 
-@warn_unused_result
 public func != (range1: CMTimeRange, range2: CMTimeRange) -> Bool {
   return !CMTimeRangeEqual(range1, range2).boolValue
 }

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -64,7 +64,6 @@ public var DISPATCH_QUEUE_PRIORITY_BACKGROUND: dispatch_queue_priority_t {
   return -32768
 }
 
-@warn_unused_result
 public func dispatch_get_global_queue(_ identifier: qos_class_t,
                                       _ flags: UInt) -> dispatch_queue_t {
   return dispatch_get_global_queue(Int(identifier.rawValue), flags)
@@ -74,7 +73,6 @@ public var DISPATCH_QUEUE_CONCURRENT: dispatch_queue_attr_t {
   return _swift_dispatch_queue_concurrent()
 }
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_queue_concurrent")
 internal func _swift_dispatch_queue_concurrent() -> dispatch_queue_attr_t
 
@@ -83,7 +81,6 @@ public var dispatch_data_empty: dispatch_data_t {
   return _swift_dispatch_data_empty()
 }
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_data_empty")
 internal func _swift_dispatch_data_empty() -> dispatch_data_t
 
@@ -150,48 +147,37 @@ public var DISPATCH_SOURCE_TYPE_WRITE: dispatch_source_type_t {
   return _swift_dispatch_source_type_write()
 }
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_DATA_ADD")
 internal func _swift_dispatch_source_type_data_add() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_DATA_OR")
 internal func _swift_dispatch_source_type_data_or() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_MACH_SEND")
 internal func _swift_dispatch_source_type_mach_send() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_MACH_RECV")
 internal func _swift_dispatch_source_type_mach_recv() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_MEMORYPRESSURE")
 internal func _swift_dispatch_source_type_memorypressure()
   -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_PROC")
 internal func _swift_dispatch_source_type_proc() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_READ")
 internal func _swift_dispatch_source_type_read() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_SIGNAL")
 internal func _swift_dispatch_source_type_signal() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_TIMER")
 internal func _swift_dispatch_source_type_timer() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_VNODE")
 internal func _swift_dispatch_source_type_vnode() -> dispatch_source_type_t
 
-@warn_unused_result
 @_silgen_name("_swift_dispatch_source_type_WRITE")
 internal func _swift_dispatch_source_type_write() -> dispatch_source_type_t
 

--- a/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
+++ b/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
@@ -20,12 +20,10 @@ extension String.UTF16View.Index : Strideable {
     self.init(_offset: offset)
   }
 
-  @warn_unused_result
   public func distance(to other: String.UTF16View.Index) -> Int {
     return other._offset.distance(to: _offset)
   }
 
-  @warn_unused_result
   public func advanced(by n: Int) -> String.UTF16View.Index {
     return String.UTF16View.Index(_offset.advanced(by: n))
   }

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -68,7 +68,6 @@ public class NSSimpleCString {}
 @available(*, unavailable, message: "Please use String or NSString")
 public class NSConstantString {}
 
-@warn_unused_result
 @_silgen_name("swift_convertStringToNSString")
 public // COMPILER_INTRINSIC
 func _convertStringToNSString(_ string: String) -> NSString {
@@ -924,7 +923,6 @@ extension NSRange {
     length = x.count
   }
 
-  @warn_unused_result
   public func toRange() -> Range<Int>? {
     if location == NSNotFound { return nil }
     return location..<(location+length)
@@ -936,7 +934,6 @@ extension NSRange {
 //===----------------------------------------------------------------------===//
 
 /// Returns a localized string, using the main bundle if one is not specified.
-@warn_unused_result
 public
 func NSLocalizedString(_ key: String,
                        tableName: String? = nil,
@@ -1008,7 +1005,6 @@ public typealias ErrorPointer = NSErrorPointer
 public // COMPILER_INTRINSIC
 let _nilObjCError: ErrorProtocol = _GenericObjCError.nilError
 
-@warn_unused_result
 @_silgen_name("swift_convertNSErrorToErrorProtocol")
 public // COMPILER_INTRINSIC
 func _convertNSErrorToErrorProtocol(_ error: NSError?) -> ErrorProtocol {
@@ -1018,7 +1014,6 @@ func _convertNSErrorToErrorProtocol(_ error: NSError?) -> ErrorProtocol {
   return _nilObjCError
 }
 
-@warn_unused_result
 @_silgen_name("swift_convertErrorProtocolToNSError")
 public // COMPILER_INTRINSIC
 func _convertErrorProtocolToNSError(_ error: ErrorProtocol) -> NSError {
@@ -1064,7 +1059,6 @@ extension NSString {
     self.init(format: format as String, locale: locale, arguments: va_args)
   }
 
-  @warn_unused_result
   public class func localizedStringWithFormat(
     _ format: NSString, _ args: CVarArg...
   ) -> Self {
@@ -1073,7 +1067,6 @@ extension NSString {
     }
   }
 
-  @warn_unused_result
   public func appendingFormat(_ format: NSString, _ args: CVarArg...)
   -> NSString {
     return withVaList(args) {
@@ -1212,20 +1205,17 @@ extension NSUndoManager {
 // NSCoder
 //===----------------------------------------------------------------------===//
 
-@warn_unused_result
 @_silgen_name("NS_Swift_NSCoder_decodeObject")
 internal func NS_Swift_NSCoder_decodeObject(
   _ self_: AnyObject,
   _ error: NSErrorPointer) -> AnyObject?
 
-@warn_unused_result
 @_silgen_name("NS_Swift_NSCoder_decodeObjectForKey")
 internal func NS_Swift_NSCoder_decodeObjectForKey(
   _ self_: AnyObject,
   _ key: AnyObject,
   _ error: NSErrorPointer) -> AnyObject?
 
-@warn_unused_result
 @_silgen_name("NS_Swift_NSCoder_decodeObjectOfClassForKey")
 internal func NS_Swift_NSCoder_decodeObjectOfClassForKey(
   _ self_: AnyObject,
@@ -1233,7 +1223,6 @@ internal func NS_Swift_NSCoder_decodeObjectOfClassForKey(
   _ key: AnyObject,
   _ error: NSErrorPointer) -> AnyObject?
 
-@warn_unused_result
 @_silgen_name("NS_Swift_NSCoder_decodeObjectOfClassesForKey")
 internal func NS_Swift_NSCoder_decodeObjectOfClassesForKey(
   _ self_: AnyObject,
@@ -1250,13 +1239,11 @@ internal func resolveError(_ error: NSError?) throws {
 }
 
 extension NSCoder {
-  @warn_unused_result
   public func decodeObjectOfClass<DecodedObjectType: NSCoding where DecodedObjectType: NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
     let result = NS_Swift_NSCoder_decodeObjectOfClassForKey(self as AnyObject, cls as AnyObject, key as AnyObject, nil)
     return result as! DecodedObjectType?
   }
 
-  @warn_unused_result
   @nonobjc
   public func decodeObjectOfClasses(_ classes: NSSet?, forKey key: String) -> AnyObject? {
     var classesAsNSObjects: Set<NSObject>? = nil
@@ -1269,7 +1256,6 @@ extension NSCoder {
     return self.__decodeObject(ofClasses: classesAsNSObjects, forKey: key)
   }
 
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObject() throws -> AnyObject? {
     var error: NSError?
@@ -1278,7 +1264,6 @@ extension NSCoder {
     return result
   }
 
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObjectForKey(_ key: String) throws -> AnyObject? {
     var error: NSError?
@@ -1287,7 +1272,6 @@ extension NSCoder {
     return result
   }
 
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObjectOfClass<DecodedObjectType: NSCoding where DecodedObjectType: NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
     var error: NSError?
@@ -1296,7 +1280,6 @@ extension NSCoder {
     return result as! DecodedObjectType?
   }
 
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func decodeTopLevelObjectOfClasses(_ classes: NSSet?, forKey key: String) throws -> AnyObject? {
     var error: NSError?
@@ -1310,7 +1293,6 @@ extension NSCoder {
 // NSKeyedUnarchiver
 //===----------------------------------------------------------------------===//
 
-@warn_unused_result
 @_silgen_name("NS_Swift_NSKeyedUnarchiver_unarchiveObjectWithData")
 internal func NS_Swift_NSKeyedUnarchiver_unarchiveObjectWithData(
   _ self_: AnyObject,
@@ -1318,7 +1300,6 @@ internal func NS_Swift_NSKeyedUnarchiver_unarchiveObjectWithData(
   _ error: NSErrorPointer) -> AnyObject?
 
 extension NSKeyedUnarchiver {
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public class func unarchiveTopLevelObjectWithData(_ data: NSData) throws -> AnyObject? {
     var error: NSError?

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -40,7 +40,6 @@ public protocol _ObjectiveCBridgeableErrorProtocol : ErrorProtocol {
 /// If the bridge succeeds, the bridged value is written to the uninitialized
 /// memory pointed to by 'out', and true is returned. Otherwise, 'out' is
 /// left uninitialized, and false is returned.
-@warn_unused_result
 @_silgen_name("swift_stdlib_bridgeNSErrorToErrorProtocol")
 public func _stdlib_bridgeNSErrorToErrorProtocol<
   T : _ObjectiveCBridgeableErrorProtocol
@@ -60,7 +59,6 @@ public protocol __BridgedNSError : RawRepresentable, ErrorProtocol {
 }
 
 // Allow two bridged NSError types to be compared.
-@warn_unused_result
 public func ==<T: __BridgedNSError where T.RawValue: SignedInteger>(
   lhs: T,
   rhs: T
@@ -88,7 +86,6 @@ public extension __BridgedNSError where RawValue: SignedInteger {
 }
 
 // Allow two bridged NSError types to be compared.
-@warn_unused_result
 public func ==<T: __BridgedNSError where T.RawValue: UnsignedInteger>(
   lhs: T,
   rhs: T
@@ -142,7 +139,6 @@ public struct NSCocoaError : RawRepresentable, _BridgedNSError {
   public static var _nsErrorDomain: String { return NSCocoaErrorDomain }
 }
 
-@warn_unused_result
 public func ~=(match: NSCocoaError, error: ErrorProtocol) -> Bool {
   guard let cocoaError = error as? NSCocoaError else { return false }
   return match.rawValue == cocoaError.rawValue

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -20,7 +20,6 @@
 // Property Lists need to be properly bridged
 //
 
-@warn_unused_result
 func _toNSArray<T, U : AnyObject>(_ a: [T], f: @noescape (T) -> U) -> NSArray {
   let result = NSMutableArray(capacity: a.count)
   for s in a {
@@ -29,14 +28,12 @@ func _toNSArray<T, U : AnyObject>(_ a: [T], f: @noescape (T) -> U) -> NSArray {
   return result
 }
 
-@warn_unused_result
 func _toNSRange(_ r: Range<String.Index>) -> NSRange {
   return NSRange(
     location: r.lowerBound._utf16Index,
     length: r.upperBound._utf16Index - r.lowerBound._utf16Index)
 }
 
-@warn_unused_result
 func _countFormatSpecifiers(_ a: String) -> Int {
   // The implementation takes advantage of the fact that internal
   // representation of String is UTF-16.  Because we only care about the ASCII
@@ -98,21 +95,18 @@ extension String {
 
   /// Return an `Index` corresponding to the given offset in our UTF-16
   /// representation.
-  @warn_unused_result
   func _index(_ utf16Index: Int) -> Index {
     return Index(_base: String.UnicodeScalarView.Index(utf16Index, _core))
   }
 
   /// Return a `Range<Index>` corresponding to the given `NSRange` of
   /// our UTF-16 representation.
-  @warn_unused_result
   func _range(_ r: NSRange) -> Range<Index> {
     return _index(r.location)..<_index(r.location + r.length)
   }
 
   /// Return a `Range<Index>?` corresponding to the given `NSRange` of
   /// our UTF-16 representation.
-  @warn_unused_result
   func _optionalRange(_ r: NSRange) -> Range<Index>? {
     if r.location == NSNotFound {
       return nil
@@ -153,7 +147,6 @@ extension String {
 
   /// Returns an Array of the encodings string objects support
   /// in the application's environment.
-  @warn_unused_result
   public static func availableStringEncodings() -> [NSStringEncoding] {
     var result = [NSStringEncoding]()
     var p = NSString.availableStringEncodings()
@@ -168,7 +161,6 @@ extension String {
 
   /// Returns the C-string encoding assumed for any method accepting
   /// a C string as an argument.
-  @warn_unused_result
   public static func defaultCStringEncoding() -> NSStringEncoding {
     return NSString.defaultCStringEncoding()
   }
@@ -176,7 +168,6 @@ extension String {
   // + (NSString *)localizedNameOfStringEncoding:(NSStringEncoding)encoding
 
   /// Returns a human-readable string giving the name of a given encoding.
-  @warn_unused_result
   public static func localizedName(
     of encoding: NSStringEncoding
   ) -> String {
@@ -188,7 +179,6 @@ extension String {
   /// Returns a string created by using a given format string as a
   /// template into which the remaining argument values are substituted
   /// according to the user's default locale.
-  @warn_unused_result
   public static func localizedStringWithFormat(
     _ format: String, _ arguments: CVarArg...
   ) -> String {
@@ -268,7 +258,6 @@ extension String {
   /// Returns a Boolean value that indicates whether the
   /// `String` can be converted to a given encoding without loss of
   /// information.
-  @warn_unused_result
   public func canBeConverted(to encoding: NSStringEncoding) -> Bool {
     return _ns.canBeConverted(to: encoding)
   }
@@ -294,7 +283,6 @@ extension String {
 
   /// Returns a capitalized representation of the `String`
   /// using the specified locale.
-  @warn_unused_result
   public func capitalized(with locale: NSLocale?) -> String {
     return _ns.capitalized(with: locale) as String
   }
@@ -303,7 +291,6 @@ extension String {
 
   /// Returns the result of invoking `compare:options:` with
   /// `NSCaseInsensitiveSearch` as the only option.
-  @warn_unused_result
   public func caseInsensitiveCompare(_ aString: String) -> NSComparisonResult {
     return _ns.caseInsensitiveCompare(aString)
   }
@@ -321,7 +308,6 @@ extension String {
   /// Returns a string containing characters the `String` and a
   /// given string have in common, starting from the beginning of each
   /// up to the first characters that aren't equivalent.
-  @warn_unused_result
   public func commonPrefix(
     with aString: String, options: NSStringCompareOptions = []) -> String {
     return _ns.commonPrefix(with: aString, options: options)
@@ -343,7 +329,6 @@ extension String {
 
   /// Compares the string using the specified options and
   /// returns the lexical ordering for the range.
-  @warn_unused_result
   public func compare(
     _ aString: String,
     options mask: NSStringCompareOptions = [],
@@ -384,7 +369,6 @@ extension String {
   /// value that indicates whether a match was possible, and by
   /// reference the longest path that matches the `String`.
   /// Returns the actual number of matching paths.
-  @warn_unused_result
   public func completePath(
     into outputName: UnsafeMutablePointer<String>? = nil,
     caseSensitive: Bool,
@@ -431,7 +415,6 @@ extension String {
 
   /// Returns an array containing substrings from the `String`
   /// that have been divided by characters in a given set.
-  @warn_unused_result
   public func components(separatedBy separator: NSCharacterSet) -> [String] {
     // FIXME: two steps due to <rdar://16971181>
     let nsa = _ns.components(separatedBy: separator) as NSArray
@@ -456,7 +439,6 @@ extension String {
 
   /// Returns a representation of the `String` as a C string
   /// using a given encoding.
-  @warn_unused_result
   public func cString(using encoding: NSStringEncoding) -> [CChar]? {
     return withExtendedLifetime(_ns) {
       (s: NSString) -> [CChar]? in
@@ -472,7 +454,6 @@ extension String {
 
   /// Returns an `NSData` object containing a representation of
   /// the `String` encoded using a given encoding.
-  @warn_unused_result
   public func data(
     using encoding: NSStringEncoding,
     allowLossyConversion: Bool = false
@@ -1025,7 +1006,6 @@ extension String {
 
   /// Returns the number of bytes required to store the
   /// `String` in a given encoding.
-  @warn_unused_result
   public func lengthOfBytes(using encoding: NSStringEncoding) -> Int {
     return _ns.lengthOfBytes(using: encoding)
   }
@@ -1034,7 +1014,6 @@ extension String {
 
   /// Returns the range of characters representing the line or lines
   /// containing a given range.
-  @warn_unused_result
   public func lineRange(for aRange: Range<Index>) -> Range<Index> {
     return _range(_ns.lineRange(for: _toNSRange(aRange)))
   }
@@ -1048,7 +1027,6 @@ extension String {
 
   /// Returns an array of linguistic tags for the specified
   /// range and requested tags within the receiving string.
-  @warn_unused_result
   public func linguisticTags(
     in range: Range<Index>,
     scheme tagScheme: String,
@@ -1076,7 +1054,6 @@ extension String {
 
   /// Compares the string and a given string using a
   /// case-insensitive, localized, comparison.
-  @warn_unused_result
   public
   func localizedCaseInsensitiveCompare(_ aString: String) -> NSComparisonResult {
     return _ns.localizedCaseInsensitiveCompare(aString)
@@ -1086,13 +1063,11 @@ extension String {
 
   /// Compares the string and a given string using a localized
   /// comparison.
-  @warn_unused_result
   public func localizedCompare(_ aString: String) -> NSComparisonResult {
     return _ns.localizedCompare(aString)
   }
 
   /// Compares strings as sorted by the Finder.
-  @warn_unused_result
   public func localizedStandardCompare(_ string: String) -> NSComparisonResult {
     return _ns.localizedStandardCompare(string)
   }
@@ -1114,7 +1089,6 @@ extension String {
   /// Returns a version of the string with all letters
   /// converted to lowercase, taking into account the specified
   /// locale.
-  @warn_unused_result
   public func lowercased(with locale: NSLocale?) -> String {
     return _ns.lowercased(with: locale)
   }
@@ -1123,7 +1097,6 @@ extension String {
 
   /// Returns the maximum number of bytes needed to store the
   /// `String` in a given encoding.
-  @warn_unused_result
   public
   func maximumLengthOfBytes(using encoding: NSStringEncoding) -> Int {
     return _ns.maximumLengthOfBytes(using: encoding)
@@ -1133,7 +1106,6 @@ extension String {
 
   /// Returns the range of characters representing the
   /// paragraph or paragraphs containing a given range.
-  @warn_unused_result
   public func paragraphRange(for aRange: Range<Index>) -> Range<Index> {
     return _range(_ns.paragraphRange(for: _toNSRange(aRange)))
   }
@@ -1177,7 +1149,6 @@ extension String {
   /// Parses the `String` as a text representation of a
   /// property list, returning an NSString, NSData, NSArray, or
   /// NSDictionary object, according to the topmost element.
-  @warn_unused_result
   public func propertyList() -> AnyObject {
     return _ns.propertyList()
   }
@@ -1186,7 +1157,6 @@ extension String {
 
   /// Returns a dictionary object initialized with the keys and
   /// values found in the `String`.
-  @warn_unused_result
   public
   func propertyListFromStringsFileFormat() -> [String : String] {
     return _ns.propertyListFromStringsFileFormat() as! [String : String]
@@ -1206,7 +1176,6 @@ extension String {
   /// Finds and returns the range in the `String` of the first
   /// character from a given character set found in a given range with
   /// given options.
-  @warn_unused_result
   public func rangeOfCharacter(
     from aSet: NSCharacterSet,
     options mask:NSStringCompareOptions = [],
@@ -1227,7 +1196,6 @@ extension String {
 
   /// Returns the range in the `String` of the composed
   /// character sequence located at a given index.
-  @warn_unused_result
   public
   func rangeOfComposedCharacterSequence(at anIndex: Index) -> Range<Index> {
     return _range(
@@ -1238,7 +1206,6 @@ extension String {
 
   /// Returns the range in the string of the composed character
   /// sequences for a given range.
-  @warn_unused_result
   public func rangeOfComposedCharacterSequences(
     for range: Range<Index>
   ) -> Range<Index> {
@@ -1268,7 +1235,6 @@ extension String {
   /// Finds and returns the range of the first occurrence of a
   /// given string within a given range of the `String`, subject to
   /// given options, using the specified locale, if any.
-  @warn_unused_result
   public func range(
     of aString: String,
     options mask: NSStringCompareOptions = [],
@@ -1301,7 +1267,6 @@ extension String {
   /// similar to how searches are done generally in the system.  The search is
   /// locale-aware, case and diacritic insensitive.  The exact list of search
   /// options applied may change over time.
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func localizedStandardContains(_ string: String) -> Bool {
     return _ns.localizedStandardContains(string)
@@ -1317,7 +1282,6 @@ extension String {
   /// similar to how searches are done generally in the system.  The search is
   /// locale-aware, case and diacritic insensitive.  The exact list of search
   /// options applied may change over time.
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func localizedStandardRange(of string: String) -> Range<Index>? {
     return _optionalRange(_ns.localizedStandardRange(of: string))
@@ -1348,7 +1312,6 @@ extension String {
   /// Returns a new string made from the `String` by replacing
   /// all characters not in the specified set with percent encoded
   /// characters.
-  @warn_unused_result
   public func addingPercentEncoding(
     withAllowedCharacters allowedCharacters: NSCharacterSet
   ) -> String? {
@@ -1384,7 +1347,6 @@ extension String {
   /// Returns a string made by appending to the `String` a
   /// string constructed from a given format string and the following
   /// arguments.
-  @warn_unused_result
   public func appendingFormat(
     _ format: String, _ arguments: CVarArg...
   ) -> String {
@@ -1419,7 +1381,6 @@ extension String {
 
   /// Returns a new string made by appending a given string to
   /// the `String`.
-  @warn_unused_result
   public func appending(_ aString: String) -> String {
     return _ns.appending(aString)
   }
@@ -1458,7 +1419,6 @@ extension String {
 
   /// Returns a string with the given character folding options
   /// applied.
-  @warn_unused_result
   public func folding(
     _ options: NSStringCompareOptions = [], locale: NSLocale?
   ) -> String {
@@ -1472,7 +1432,6 @@ extension String {
   /// Returns a new string formed from the `String` by either
   /// removing characters from the end, or by appending as many
   /// occurrences as necessary of a given pad string.
-  @warn_unused_result
   public func padding(
     toLength newLength: Int,
     withPad padString: String,
@@ -1497,7 +1456,6 @@ extension String {
 
   /// Returns a new string in which the characters in a
   /// specified range of the `String` are replaced by a given string.
-  @warn_unused_result
   public func replacingCharacters(
     in range: Range<Index>, with replacement: String
   ) -> String {
@@ -1517,7 +1475,6 @@ extension String {
   /// Returns a new string in which all occurrences of a target
   /// string in a specified range of the `String` are replaced by
   /// another given string.
-  @warn_unused_result
   public func replacingOccurrences(
     of target: String,
     with replacement: String,
@@ -1571,7 +1528,6 @@ extension String {
 
   /// Returns a new string made by removing from both ends of
   /// the `String` characters contained in a given character set.
-  @warn_unused_result
   public func trimmingCharacters(in set: NSCharacterSet) -> String {
     return _ns.trimmingCharacters(in: set)
   }
@@ -1589,7 +1545,6 @@ extension String {
 
   /// Returns a new string containing the characters of the
   /// `String` from the one at a given index to the end.
-  @warn_unused_result
   public func substring(from index: Index) -> String {
     return _ns.substring(from: index._utf16Index)
   }
@@ -1598,7 +1553,6 @@ extension String {
 
   /// Returns a new string containing the characters of the
   /// `String` up to, but not including, the one at a given index.
-  @warn_unused_result
   public func substring(to index: Index) -> String {
     return _ns.substring(to: index._utf16Index)
   }
@@ -1607,7 +1561,6 @@ extension String {
 
   /// Returns a string object containing the characters of the
   /// `String` that lie within a given range.
-  @warn_unused_result
   public func substring(with aRange: Range<Index>) -> String {
     return _ns.substring(with: _toNSRange(aRange))
   }
@@ -1626,7 +1579,6 @@ extension String {
   /// Returns a version of the string with all letters
   /// converted to uppercase, taking into account the specified
   /// locale.
-  @warn_unused_result
   public func uppercased(with locale: NSLocale?) -> String {
     return _ns.uppercased(with: locale)
   }
@@ -1669,7 +1621,6 @@ extension String {
   // - (nullable NSString *)stringByApplyingTransform:(NSString *)transform reverse:(BOOL)reverse NS_AVAILABLE(10_11, 9_0);
 
   /// Perform string transliteration.
-  @warn_unused_result
   @available(OSX 10.11, iOS 9.0, *)
   public func applyingTransform(
     _ transform: String, reverse: Bool
@@ -1685,7 +1636,6 @@ extension String {
   /// `self` by case-sensitive, non-literal search.
   ///
   /// Equivalent to `self.rangeOfString(other) != nil`
-  @warn_unused_result
   public func contains(_ other: String) -> Bool {
     let r = self.range(of: other) != nil
     if #available(OSX 10.10, iOS 8.0, *) {
@@ -1707,7 +1657,6 @@ extension String {
   ///     self.rangeOf(
   ///       other, options: .CaseInsensitiveSearch,
   ///       locale: NSLocale.current()) != nil
-  @warn_unused_result
   public func localizedCaseInsensitiveContains(_ other: String) -> Bool {
     let r = self.range(
       of: other, options: .caseInsensitiveSearch, locale: NSLocale.current()

--- a/stdlib/public/SDK/GameplayKit/GameplayKit.swift
+++ b/stdlib/public/SDK/GameplayKit/GameplayKit.swift
@@ -12,7 +12,6 @@
 
 @_exported import GameplayKit
 
-@warn_unused_result
 @_silgen_name("GK_Swift_GKEntity_componentForClass")
 internal func GK_Swift_GKEntity_componentForClass(
   _ self_: AnyObject,
@@ -24,7 +23,6 @@ internal func GK_Swift_GKEntity_componentForClass(
 extension GKEntity {
   /// Returns the component instance of the indicated class contained by the
   /// entity. Returns nil if entity does not have this component.
-  @warn_unused_result
   public func componentForClass<ComponentType : GKComponent>(
     _ componentClass: ComponentType.Type) -> ComponentType? {
     return GK_Swift_GKEntity_componentForClass(
@@ -32,7 +30,6 @@ extension GKEntity {
   }
 }
 
-@warn_unused_result
 @_silgen_name("GK_Swift_GKStateMachine_stateForClass")
 internal func GK_Swift_GKStateMachine_stateForClass(
   _ self_: AnyObject,
@@ -44,7 +41,6 @@ internal func GK_Swift_GKStateMachine_stateForClass(
 extension GKStateMachine {
   /// Returns the state instance of the indicated class contained by the state
   /// machine. Returns nil if state machine does not have this state.
-  @warn_unused_result
   public func stateForClass<StateType : GKState>(
     _ stateClass: StateType.Type) -> StateType? {
     return GK_Swift_GKStateMachine_stateForClass(

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -78,13 +78,11 @@ extension ObjCBool : CustomStringConvertible {
 
 // Functions used to implicitly bridge ObjCBool types to Swift's Bool type.
 
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertBoolToObjCBool(_ x: Bool) -> ObjCBool {
   return ObjCBool(x)
 }
 
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
   return Bool(x)
@@ -124,7 +122,6 @@ public struct Selector : StringLiteralConvertible {
   }
 }
 
-@warn_unused_result
 public func ==(lhs: Selector, rhs: Selector) -> Bool {
   return sel_isEqual(lhs, rhs)
 }
@@ -184,7 +181,6 @@ typealias Zone = NSZone
 // @autoreleasepool substitute
 //===----------------------------------------------------------------------===//
 
-@warn_unused_result
 @_silgen_name("_swift_objc_autoreleasePoolPush")
 func __pushAutoreleasePool() -> OpaquePointer
 
@@ -218,7 +214,6 @@ public var NO: ObjCBool {
 // rdar://problem/19418937, so here are some @_transparent overloads
 // for ObjCBool
 @_transparent
-@warn_unused_result
 public func && <T : Boolean>(
   lhs: T, rhs: @autoclosure () -> ObjCBool
 ) -> Bool {
@@ -226,7 +221,6 @@ public func && <T : Boolean>(
 }
 
 @_transparent
-@warn_unused_result
 public func || <T : Boolean>(
   lhs: T, rhs: @autoclosure () -> ObjCBool
 ) -> Bool {
@@ -254,7 +248,6 @@ extension NSObject : Equatable, Hashable {
   }
 }
 
-@warn_unused_result
 public func == (lhs: NSObject, rhs: NSObject) -> Bool {
   return lhs.isEqual(rhs)
 }

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift
@@ -169,7 +169,6 @@ extension SCNGeometryElement {
   }
 }
 
-@warn_unused_result
 @_silgen_name("SCN_Swift_SCNSceneSource_entryWithIdentifier")
 internal func SCN_Swift_SCNSceneSource_entryWithIdentifier(
   _ self_: AnyObject,
@@ -179,7 +178,6 @@ internal func SCN_Swift_SCNSceneSource_entryWithIdentifier(
 @available(iOS, introduced: 8.0)
 @available(OSX, introduced: 10.8)
 extension SCNSceneSource {
-  @warn_unused_result
   public func entryWithIdentifier<T>(_ uid: String, withClass entryClass: T.Type) -> T? {
     return SCN_Swift_SCNSceneSource_entryWithIdentifier(
       self, uid as NSString, entryClass as! AnyObject) as! T?

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -36,7 +36,6 @@ public extension UIOffset {
 //===----------------------------------------------------------------------===//
 
 @_transparent // @fragile
-@warn_unused_result
 public func == (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {
   return lhs.top == rhs.top &&
          lhs.left == rhs.left &&
@@ -47,7 +46,6 @@ public func == (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {
 extension UIEdgeInsets : Equatable {}
 
 @_transparent // @fragile
-@warn_unused_result
 public func == (lhs: UIOffset, rhs: UIOffset) -> Bool {
   return lhs.horizontal == rhs.horizontal &&
          lhs.vertical == rhs.vertical
@@ -85,21 +83,18 @@ public extension UIDeviceOrientation {
   }
 }
 
-@warn_unused_result
 public func UIDeviceOrientationIsLandscape(
   _ orientation: UIDeviceOrientation
 ) -> Bool {
   return orientation.isLandscape
 }
 
-@warn_unused_result
 public func UIDeviceOrientationIsPortrait(
   _ orientation: UIDeviceOrientation
 ) -> Bool {
   return orientation.isPortrait
 }
 
-@warn_unused_result
 public func UIDeviceOrientationIsValidInterfaceOrientation(
   _ orientation: UIDeviceOrientation) -> Bool
 {
@@ -122,13 +117,11 @@ public extension UIInterfaceOrientation {
   }
 }
 
-@warn_unused_result
 public func UIInterfaceOrientationIsPortrait(
   _ orientation: UIInterfaceOrientation) -> Bool {
   return orientation.isPortrait
 }
 
-@warn_unused_result
 public func UIInterfaceOrientationIsLandscape(
   _ orientation: UIInterfaceOrientation
 ) -> Bool {

--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -153,7 +153,6 @@ public struct ${vectype} :
 
 /// Vector sum of `lhs` and `rhs`.
 @inline(__always)
-@warn_unused_result
 public func ${wrap}+(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
   return ${vectype}(_bits:
 %if is_floating:
@@ -166,7 +165,6 @@ public func ${wrap}+(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
 
 /// Vector difference of `lhs` and `rhs`.
 @inline(__always)
-@warn_unused_result
 public func ${wrap}-(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
   return ${vectype}(_bits:
 %if is_floating:
@@ -179,7 +177,6 @@ public func ${wrap}-(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
 
 /// Negation of `rhs`.
 @inline(__always)
-@warn_unused_result
 public prefix func -(rhs: ${vectype}) -> ${vectype} {
   return ${vectype}(0) ${wrap}- rhs
 }
@@ -187,7 +184,6 @@ public prefix func -(rhs: ${vectype}) -> ${vectype} {
 /// Elementwise product of `lhs` and `rhs`.  A.k.a. the Hadamard or Schur
 /// product of the two vectors.
 @inline(__always)
-@warn_unused_result
 public func ${wrap}*(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
   return ${vectype}(_bits:
 %if is_floating:
@@ -201,7 +197,6 @@ public func ${wrap}*(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
 /// Elementwise quotient of `lhs` and `rhs`.  This is the inverse operation
 /// of the elementwise product.
 @inline(__always)
-@warn_unused_result
 public func /(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
   return ${vectype}(_bits:
 %if is_floating:
@@ -242,14 +237,12 @@ public func /=(lhs: inout ${vectype}, rhs: ${vectype}) -> Void {
 
 /// Scalar-Vector product.
 @inline(__always)
-@warn_unused_result
 public func ${wrap}*(lhs: ${type}, rhs: ${vectype}) -> ${vectype} {
   return ${vectype}(lhs) ${wrap}* rhs
 }
 
 /// Scalar-Vector product.
 @inline(__always)
-@warn_unused_result
 public func ${wrap}*(lhs: ${vectype}, rhs: ${type}) -> ${vectype} {
   return lhs ${wrap}* ${vectype}(rhs)
 }
@@ -266,7 +259,6 @@ public func *=(lhs: inout ${vectype}, rhs: ${type}) -> Void {
 /// Elementwise absolute value of a vector.  The result is a vector of the same
 /// length with all elements positive.
 @inline(__always)
-@warn_unused_result
 public func abs(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c: \
                     'abs(x.' + c + ')', \
@@ -277,7 +269,6 @@ public func abs(_ x: ${vectype}) -> ${vectype} {
 /// Elementwise minimum of two vectors.  Each component of the result is the
 /// smaller of the corresponding component of the inputs.
 @inline(__always)
-@warn_unused_result
 public func min(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:             \
                     'min(x.' + c + ', y.' + c + ')', \
@@ -287,7 +278,6 @@ public func min(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
 /// Elementwise maximum of two vectors.  Each component of the result is the
 /// larger of the corresponding component of the inputs.
 @inline(__always)
-@warn_unused_result
 public func max(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:             \
                     'max(x.' + c + ', y.' + c + ')', \
@@ -297,7 +287,6 @@ public func max(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
 /// Vector-scalar minimum.  Each component of the result is the minimum of the
 /// corresponding element of the input vector and the scalar.
 @inline(__always)
-@warn_unused_result
 public func min(_ vector: ${vectype}, _ scalar: ${type}) -> ${vectype} {
   return min(vector, ${vectype}(scalar))
 }
@@ -305,7 +294,6 @@ public func min(_ vector: ${vectype}, _ scalar: ${type}) -> ${vectype} {
 /// Vector-scalar maximum.  Each component of the result is the maximum of the
 /// corresponding element of the input vector and the scalar.
 @inline(__always)
-@warn_unused_result
 public func max(_ vector: ${vectype}, _ scalar: ${type}) -> ${vectype} {
   return max(vector, ${vectype}(scalar))
 }
@@ -314,7 +302,6 @@ public func max(_ vector: ${vectype}, _ scalar: ${type}) -> ${vectype} {
 /// the range formed by the corresponding elements of `min` and `max`.  Any
 /// lanes of `x` that contain NaN will end up with the `min` value.
 @inline(__always)
-@warn_unused_result
 public func clamp(_ x: ${vectype},
                   min: ${vectype},
                   max: ${vectype})
@@ -325,7 +312,6 @@ public func clamp(_ x: ${vectype},
 /// Clamp each element of `x` to the range [`min`, max].  If any lane of `x` is
 /// NaN, the corresponding lane of the result is `min`.
 @inline(__always)
-@warn_unused_result
 public func clamp(_ x: ${vectype},
                   min: ${type},
                   max: ${type})
@@ -335,21 +321,18 @@ public func clamp(_ x: ${vectype},
 
 /// Sum of the elements of the vector.
 @inline(__always)
-@warn_unused_result
 public func reduce_add(_ x: ${vectype}) -> ${type} {
   return ${(' '+wrap+'+ ').join(map(lambda x:'x.'+x, component[:size]))}
 }
 
 /// Minimum element of the vector.
 @inline(__always)
-@warn_unused_result
 public func reduce_min(_ x: ${vectype}) -> ${type} {
   return min(${', '.join(map(lambda x:'x.'+x, component[:size]))})
 }
 
 /// Maximum element of the vector.
 @inline(__always)
-@warn_unused_result
 public func reduce_max(_ x: ${vectype}) -> ${type} {
   return max(${', '.join(map(lambda x:'x.'+x, component[:size]))})
 }
@@ -360,7 +343,6 @@ public func reduce_max(_ x: ${vectype}) -> ${type} {
 /// is less than zero, +1 if the corresponding lane of `x` is greater than
 /// zero, and 0 otherwise.
 @inline(__always)
-@warn_unused_result
 public func sign(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:  \
                     'sign(x.' + c + ')', \
@@ -370,7 +352,6 @@ public func sign(_ x: ${vectype}) -> ${vectype} {
 /// Linear interpolation between `x` (at `t=0`) and `y` (at `t=1`).  May be
 /// used with `t` outside of [0, 1] as well.
 @inline(__always)
-@warn_unused_result
 public func mix(_ x: ${vectype}, _ y: ${vectype}, t: ${vectype}) -> ${vectype} {
   return x + t*(y-x)
 }
@@ -378,14 +359,12 @@ public func mix(_ x: ${vectype}, _ y: ${vectype}, t: ${vectype}) -> ${vectype} {
 /// Linear interpolation between `x` (at `t=0`) and `y` (at `t=1`).  May be
 /// used with `t` outside of [0, 1] as well.
 @inline(__always)
-@warn_unused_result
 public func mix(_ x: ${vectype}, _ y: ${vectype}, t: ${type}) -> ${vectype} {
   return x + t*(y-x)
 }
 
 /// Elementwise reciprocal.
 @inline(__always)
-@warn_unused_result
 public func recip(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:  \
                     'recip(x.' + c + ')', \
@@ -394,7 +373,6 @@ public func recip(_ x: ${vectype}) -> ${vectype} {
 
 /// Elementwise reciprocal square root.
 @inline(__always)
-@warn_unused_result
 public func rsqrt(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:  \
                     'rsqrt(x.' + c + ')', \
@@ -403,14 +381,12 @@ public func rsqrt(_ x: ${vectype}) -> ${vectype} {
 
 /// Alternate name for minimum of two floating-point vectors.
 @inline(__always)
-@warn_unused_result
 public func fmin(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return min(x, y)
 }
 
 /// Alternate name for maximum of two floating-point vectors.
 @inline(__always)
-@warn_unused_result
 public func fmax(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return max(x, y)
 }
@@ -418,7 +394,6 @@ public func fmax(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
 /// Each element of the result is the smallest integral value greater than or
 /// equal to the corresponding element of the input.
 @inline(__always)
-@warn_unused_result
 public func ceil(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:  \
                     'ceil(x.' + c + ')', \
@@ -428,7 +403,6 @@ public func ceil(_ x: ${vectype}) -> ${vectype} {
 /// Each element of the result is the largest integral value less than or equal
 /// to the corresponding element of the input.
 @inline(__always)
-@warn_unused_result
 public func floor(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:  \
                     'floor(x.' + c + ')', \
@@ -438,7 +412,6 @@ public func floor(_ x: ${vectype}) -> ${vectype} {
 /// Each element of the result is the closest integral value with magnitude
 /// less than or equal to that of the corresponding element of the input.
 @inline(__always)
-@warn_unused_result
 public func trunc(_ x: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:  \
                     'trunc(x.' + c + ')', \
@@ -449,14 +422,12 @@ public func trunc(_ x: ${vectype}) -> ${vectype} {
 /// the result would be 1.0 when `x` is a very small negative number, which may
 /// result in out-of-bounds table accesses in common usage.
 @inline(__always)
-@warn_unused_result
 public func fract(_ x: ${vectype}) -> ${vectype} {
   return fmin(x - floor(x), ${vectype}(${one_minus_ulp[type]}))
 }
 
 /// 0.0 if `x < edge`, and 1.0 otherwise.
 @inline(__always)
-@warn_unused_result
 public func step(_ x: ${vectype}, edge: ${vectype}) -> ${vectype} {
   return ${vectype}(${', '.join(map(lambda c:                 \
                     'step(x.' + c + ', edge: edge.' + c + ')', \
@@ -466,7 +437,6 @@ public func step(_ x: ${vectype}, edge: ${vectype}) -> ${vectype} {
 /// 0.0 if `x < edge0`, 1.0 if `x > edge1`, and cubic interpolation between
 /// 0 and 1 in the interval [edge0, edge1].
 @inline(__always)
-@warn_unused_result
 public func smoothstep(_ x: ${vectype},
                               edge0: ${vectype},
                               edge1: ${vectype})
@@ -477,14 +447,12 @@ public func smoothstep(_ x: ${vectype},
 
 /// Dot product of `x` and `y`.
 @inline(__always)
-@warn_unused_result
 public func dot(_ x: ${vectype}, _ y: ${vectype}) -> ${type} {
   return reduce_add(x * y)
 }
 
 /// Projection of `x` onto `y`.
 @inline(__always)
-@warn_unused_result
 public func project(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
   return dot(x, y) / dot(y, y) * y
 }
@@ -502,49 +470,42 @@ public func project(_ x: ${vectype}, _ y: ${vectype}) -> ${vectype} {
 /// Doing it this way avoids one or two square roots, which is a fairly costly
 /// operation.
 @inline(__always)
-@warn_unused_result
 public func length_squared(_ x: ${vectype}) -> ${type} {
   return dot(x, x)
 }
 
 /// Length (two-norm or "Euclidean norm") of `x`.
 @inline(__always)
-@warn_unused_result
 public func length(_ x: ${vectype}) -> ${type} {
   return sqrt(length_squared(x))
 }
 
 /// The one-norm (or "taxicab norm") of `x`.
 @inline(__always)
-@warn_unused_result
 public func norm_one(_ x: ${vectype}) -> ${type} {
   return reduce_add(abs(x))
 }
 
 /// The infinity-norm (or "sup norm") of `x`.
 @inline(__always)
-@warn_unused_result
 public func norm_inf(_ x: ${vectype}) -> ${type} {
   return reduce_max(abs(x))
 }
 
 /// Distance between `x` and `y`, squared.
 @inline(__always)
-@warn_unused_result
 public func distance_squared(_ x: ${vectype}, _ y: ${vectype}) -> ${type} {
   return length_squared(x - y)
 }
 
 /// Distance between `x` and `y`.
 @inline(__always)
-@warn_unused_result
 public func distance(_ x: ${vectype}, _ y: ${vectype}) -> ${type} {
   return length(x - y)
 }
 
 /// Unit vector pointing in the same direction as `x`.
 @inline(__always)
-@warn_unused_result
 public func normalize(_ x: ${vectype}) -> ${vectype} {
   return x * rsqrt(length_squared(x))
 }
@@ -553,7 +514,6 @@ public func normalize(_ x: ${vectype}) -> ${vectype} {
 /// through the origin.  E.g. if `x` is [1,2,3] and `n` is [0,0,1], the result
 /// is [1,2,-3].
 @inline(__always)
-@warn_unused_result
 public func reflect(_ x: ${vectype}, n: ${vectype}) -> ${vectype} {
   return x - 2 * dot(x, n) * n
 }
@@ -563,7 +523,6 @@ public func reflect(_ x: ${vectype}, n: ${vectype}) -> ${vectype} {
 /// incident vector and the surface is so small that total internal reflection
 /// occurs, zero is returned.
 @inline(__always)
-@warn_unused_result
 public func refract(_ x: ${vectype},
                            n: ${vectype},
                            eta: ${type})
@@ -580,24 +539,20 @@ public func refract(_ x: ${vectype},
 
 /// Returns -1 if `x < 0`, +1 if `x > 0`, and 0 otherwise (`sign(NaN)` is 0).
 @inline(__always)
-@warn_unused_result
 public func sign(_ x: ${type}) -> ${type} {
   return x < 0 ? -1 : (x > 0 ? 1 : 0)
 }
 
 /// Reciprocal.
 @inline(__always)
-@warn_unused_result
 public func recip(_ x: ${type}) -> ${type} { return 1/x }
 
 /// Reciprocal square root.
 @inline(__always)
-@warn_unused_result
 public func rsqrt(_ x: ${type}) -> ${type} { return 1/sqrt(x) }
 
 /// Returns 0.0 if `x < edge`, and 1.0 otherwise.
 @inline(__always)
-@warn_unused_result
 public func step(_ x: ${type}, edge: ${type}) -> ${type} {
   return x < edge ? 0.0 : 1.0
 }
@@ -605,7 +560,6 @@ public func step(_ x: ${type}, edge: ${type}) -> ${type} {
 /// Interprets two two-dimensional vectors as three-dimensional vectors in the
 /// xy-plane and computes their cross product, which lies along the z-axis.
 @inline(__always)
-@warn_unused_result
 public func cross(_ x: ${ctype[type]}2,
                        _ y: ${ctype[type]}2)
                          -> ${ctype[type]}3 {
@@ -616,7 +570,6 @@ public func cross(_ x: ${ctype[type]}2,
 /// perpendicular to the plane determined by `x` and `y`, with length equal to
 /// the oriented area of the parallelogram they determine.
 @inline(__always)
-@warn_unused_result
 public func cross(_ x: ${ctype[type]}3,
                        _ y: ${ctype[type]}3)
                          -> ${ctype[type]}3 {
@@ -820,7 +773,6 @@ public struct ${mattype} : CustomDebugStringConvertible {
 }
 
 /// Sum of two matrices.
-@warn_unused_result
 public func +(lhs: ${mattype}, rhs: ${mattype}) -> ${mattype} {
   return ${mattype}(${', '.join(map(lambda i: \
                     'lhs._columns.'+str(i)+' + rhs._columns.'+str(i), \
@@ -828,7 +780,6 @@ public func +(lhs: ${mattype}, rhs: ${mattype}) -> ${mattype} {
 }
 
 /// Negation of a matrix.
-@warn_unused_result
 public prefix func -(rhs: ${mattype}) -> ${mattype} {
   return ${mattype}(${', '.join(map(lambda i: \
                     '-rhs._columns.'+str(i),  \
@@ -836,7 +787,6 @@ public prefix func -(rhs: ${mattype}) -> ${mattype} {
 }
 
 /// Difference of two matrices.
-@warn_unused_result
 public func -(lhs: ${mattype}, rhs: ${mattype}) -> ${mattype} {
   return ${mattype}(${', '.join(map(lambda i: \
                     'lhs._columns.'+str(i)+' - rhs._columns.'+str(i), \
@@ -852,7 +802,6 @@ public func -=(lhs: inout ${mattype}, rhs: ${mattype}) -> Void {
 }
 
 /// Scalar-Matrix multiplication.
-@warn_unused_result
 public func *(lhs: ${type}, rhs: ${mattype}) -> ${mattype} {
   return ${mattype}(${', '.join(map(lambda i: \
                     'lhs*rhs._columns.'+str(i), \
@@ -860,7 +809,6 @@ public func *(lhs: ${type}, rhs: ${mattype}) -> ${mattype} {
 }
 
 /// Matrix-Scalar multiplication.
-@warn_unused_result
 public func *(lhs: ${mattype}, rhs: ${type}) -> ${mattype} {
   return rhs*lhs
 }
@@ -873,7 +821,6 @@ public func *=(lhs: inout ${mattype}, rhs: ${type}) -> Void {
 /// `${type}NxM` where `N` is the number of *columns* and `M` is the number of
 /// *rows*, so we multiply a `${type}3x2 * ${type}3` to get a `${type}2`, for
 /// example.
-@warn_unused_result
 public func *(lhs: ${mattype}, rhs: ${rowtype}) -> ${coltype} {
   return ${' + '.join(map(lambda i: \
          'lhs._columns.'+str(i)+'*rhs.'+component[i], \
@@ -881,7 +828,6 @@ public func *(lhs: ${mattype}, rhs: ${rowtype}) -> ${coltype} {
 }
 
 /// Vector-Matrix multiplication.
-@warn_unused_result
 public func *(lhs: ${coltype}, rhs: ${mattype}) -> ${rowtype} {
   return ${rowtype}(${', '.join(map(lambda i: \
                     'dot(lhs, rhs._columns.'+str(i)+')', \
@@ -893,7 +839,6 @@ public func *(lhs: ${coltype}, rhs: ${mattype}) -> ${rowtype} {
 /// product).
 %   lhstype = ctype[type] + str(k) + 'x' + str(rows)
 %   rhstype = ctype[type] + str(cols) + 'x' + str(k)
-@warn_unused_result
 public func *(lhs: ${lhstype}, rhs: ${rhstype}) -> ${mattype} {
   return ${mattype}(${', '.join(map(lambda i: \
                     'lhs*rhs._columns.'+str(i), \

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -13,7 +13,6 @@
 /// Returns the lesser of `x` and `y`.
 ///
 /// If `x == y`, returns `x`.
-@warn_unused_result
 public func min<T : Comparable>(_ x: T, _ y: T) -> T {
   // In case `x == y` we pick `x`.
   // This preserves any pre-existing order in case `T` has identity,
@@ -25,7 +24,6 @@ public func min<T : Comparable>(_ x: T, _ y: T) -> T {
 /// Returns the least argument passed.
 ///
 /// If there are multiple equal least arguments, returns the first one.
-@warn_unused_result
 public func min<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var minValue = min(min(x, y), z)
   // In case `value == minValue`, we pick `minValue`. See min(_:_:).
@@ -38,7 +36,6 @@ public func min<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 /// Returns the greater of `x` and `y`.
 ///
 /// If `x == y`, returns `y`.
-@warn_unused_result
 public func max<T : Comparable>(_ x: T, _ y: T) -> T {
   // In case `x == y`, we pick `y`. See min(_:_:).
   return y >= x ? y : x
@@ -47,7 +44,6 @@ public func max<T : Comparable>(_ x: T, _ y: T) -> T {
 /// Returns the greatest argument passed.
 ///
 /// If there are multiple equal greatest arguments, returns the last one.
-@warn_unused_result
 public func max<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var maxValue = max(max(x, y), z)
   // In case `value == maxValue`, we pick `value`. See min(_:_:).

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -38,7 +38,6 @@ public struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
   ///
   /// - Precondition: The elements actually have dynamic type `U`, and `U`
   ///   is a class or `@objc` existential.
-  @warn_unused_result
   internal func cast<U>(toBufferOf _: U.Type) -> _ArrayBuffer<U> {
     _sanityCheck(_isClassOrObjCExistential(Element.self))
     _sanityCheck(_isClassOrObjCExistential(U.self))
@@ -54,7 +53,6 @@ public struct _ArrayBuffer<Element> : _ArrayBufferProtocol {
   ///
   /// - Precondition: `U` is a class or `@objc` existential derived from
   /// `Element`.
-  @warn_unused_result
   internal func downcast<U>(
     toBufferWithDeferredTypeCheckOf _: U.Type
   ) -> _ArrayBuffer<U> {
@@ -96,7 +94,6 @@ extension _ArrayBuffer {
   }
 
   /// Returns `true` iff this buffer's storage is uniquely-referenced.
-  @warn_unused_result
   mutating func isUniquelyReferenced() -> Bool {
     if !_isClassOrObjCExistential(Element.self) {
       return _storage.isUniquelyReferenced_native_noSpareBits()
@@ -106,7 +103,6 @@ extension _ArrayBuffer {
 
   /// Returns `true` iff this buffer's storage is either
   /// uniquely-referenced or pinned.
-  @warn_unused_result
   mutating func isUniquelyReferencedOrPinned() -> Bool {
     if !_isClassOrObjCExistential(Element.self) {
       return _storage.isUniquelyReferencedOrPinned_native_noSpareBits()
@@ -118,7 +114,6 @@ extension _ArrayBuffer {
   ///
   /// - Precondition: `_isBridgedToObjectiveC(Element.self)`.
   ///   O(1) if the element type is bridged verbatim, O(N) otherwise.
-  @warn_unused_result
   public func _asCocoaArray() -> _NSArrayCore {
     _sanityCheck(
       _isBridgedToObjectiveC(Element.self),
@@ -131,7 +126,6 @@ extension _ArrayBuffer {
   /// `_ContiguousArrayBuffer` that can be grown in-place to allow the self
   /// buffer store minimumCapacity elements, returns that buffer.
   /// Otherwise, returns `nil`.
-  @warn_unused_result
   public mutating func requestUniqueMutableBackingBuffer(minimumCapacity: Int)
   -> NativeBuffer? {
     if _fastPath(isUniquelyReferenced()) {
@@ -143,12 +137,10 @@ extension _ArrayBuffer {
     return nil
   }
 
-  @warn_unused_result
   public mutating func isMutableAndUniquelyReferenced() -> Bool {
     return isUniquelyReferenced()
   }
 
-  @warn_unused_result
   public mutating func isMutableAndUniquelyReferencedOrPinned() -> Bool {
     return isUniquelyReferencedOrPinned()
   }
@@ -156,7 +148,6 @@ extension _ArrayBuffer {
   /// If this buffer is backed by a `_ContiguousArrayBuffer`
   /// containing the same number of elements as `self`, return it.
   /// Otherwise, return `nil`.
-  @warn_unused_result
   public func requestNativeBuffer() -> NativeBuffer? {
     if !_isClassOrObjCExistential(Element.self) {
       return _native
@@ -346,7 +337,6 @@ extension _ArrayBuffer {
 
   @_versioned
   @inline(__always)
-  @warn_unused_result
   func getElement(_ i: Int, wasNativeTypeChecked: Bool) -> Element {
     if _fastPath(wasNativeTypeChecked) {
       return _nativeTypeChecked[i]
@@ -356,7 +346,6 @@ extension _ArrayBuffer {
 
   @_versioned
   @inline(never)
-  @warn_unused_result
   func _getElementSlowPath(_ i: Int) -> AnyObject {
     _sanityCheck(
       _isClassOrObjCExistential(Element.self),

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -49,7 +49,6 @@ public protocol _ArrayBufferProtocol
   /// - Note: This function must remain mutating; otherwise the buffer
   ///   may acquire spurious extra references, which will cause
   ///   unnecessary reallocation.
-  @warn_unused_result
   mutating func requestUniqueMutableBackingBuffer(
     minimumCapacity: Int
   ) -> _ContiguousArrayBuffer<Element>?
@@ -60,13 +59,11 @@ public protocol _ArrayBufferProtocol
   /// - Note: This function must remain mutating; otherwise the buffer
   ///   may acquire spurious extra references, which will cause
   ///   unnecessary reallocation.
-  @warn_unused_result
   mutating func isMutableAndUniquelyReferenced() -> Bool
 
   /// If this buffer is backed by a `_ContiguousArrayBuffer`
   /// containing the same number of elements as `self`, return it.
   /// Otherwise, return `nil`.
-  @warn_unused_result
   func requestNativeBuffer() -> _ContiguousArrayBuffer<Element>?
 
   /// Replace the given `subRange` with the first `newCount` elements of

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -505,7 +505,6 @@ public struct ${Self}<Element>
 %end
   }
 
-  @warn_unused_result
   public func index(after i: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for Array performance.  The optimizer is not
@@ -524,7 +523,6 @@ public struct ${Self}<Element>
     i += 1
   }
 
-  @warn_unused_result
   public func index(before i: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for Array performance.  The optimizer is not
@@ -569,7 +567,6 @@ public struct ${Self}<Element>
   ///   - If `n > 0`, `n <= self.distance(from: i, to: self.endIndex)`
   ///   - If `n < 0`, `n >= self.distance(from: i, to: self.startIndex)`
   /// - Complexity: O(1)
-  @warn_unused_result
   public func index(_ i: Int, offsetBy n: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for Array performance.  The optimizer is not
@@ -620,7 +617,6 @@ public struct ${Self}<Element>
   ///
   /// - SeeAlso: `index(_:offsetBy:)`, `formIndex(_:offsetBy:limitedBy:)`
   /// - Complexity: O(1)
-  @warn_unused_result
   public func index(
     _ i: Int, offsetBy n: Int, limitedBy limit: Int
   ) -> Int? {
@@ -643,7 +639,6 @@ public struct ${Self}<Element>
   ///   - end: Another valid index of the collection. If `end` is equal to
   ///     `start`, the result is zero.
   /// - Returns: The distance between `start` and `end`.
-  @warn_unused_result
   public func distance(from start: Int, to end: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for Array performance.  The optimizer is not
@@ -792,33 +787,28 @@ ${SubscriptDocComment}
   /// type check.  May be hoisted by the optimizer, which means its
   /// results may be stale by the time they are used if there is an
   /// inout violation in user code.
-  @warn_unused_result
   @_semantics("array.props.isNativeTypeChecked")
   public // @testable
   func _hoistableIsNativeTypeChecked() -> Bool {
    return _buffer.arrayPropertyIsNativeTypeChecked
   }
 
-  @warn_unused_result
   @_semantics("array.get_count")
   internal func _getCount() -> Int {
     return _buffer.count
   }
-  @warn_unused_result
   @_semantics("array.get_capacity")
   internal func _getCapacity() -> Int {
     return _buffer.capacity
   }
 
   /// - Precondition: The array has a native buffer.
-  @warn_unused_result
   @_semantics("array.owner")
   internal func _getOwnerWithSemanticLabel_native() -> Builtin.NativeObject {
     return Builtin.castToNativeObject(_buffer.nativeOwner)
   }
 
   /// - Precondition: The array has a native buffer.
-  @warn_unused_result
   @inline(__always)
   internal func _getOwner_native() -> Builtin.NativeObject {
 #if _runtime(_ObjC)
@@ -898,7 +888,6 @@ ${SubscriptDocComment}
     _precondition(index >= startIndex, "Negative ${Self} index is out of range")
   }
 
-  @warn_unused_result
   @_semantics("array.get_element")
   @inline(__always)
   public // @testable
@@ -914,7 +903,6 @@ ${SubscriptDocComment}
 #endif
   }
 
-  @warn_unused_result
   @_semantics("array.get_element_address")
   internal func _getElementAddress(_ index: Int) -> UnsafeMutablePointer<Element> {
     return _buffer.subscriptBaseAddress + index
@@ -990,7 +978,6 @@ extension ${Self} : ArrayLiteralConvertible {
 /// This function is referenced by the compiler to allocate array literals.
 ///
 /// - Precondition: `storage` is `_ContiguousArrayStorage`.
-@warn_unused_result
 @inline(__always)
 public // COMPILER_INTRINSIC
 func _allocateUninitializedArray<Element>(_  builtinCount: Builtin.Word)
@@ -1014,7 +1001,6 @@ func _allocateUninitializedArray<Element>(_  builtinCount: Builtin.Word)
 
 // Referenced by the compiler to deallocate array literals on the
 // error path.
-@warn_unused_result
 @_semantics("array.dealloc_uninitialized")
 public func _deallocateUninitialized${Self}<Element>(
   _ array: ${Self}<Element>
@@ -1136,7 +1122,6 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// Entry point for `Array` literal construction; builds and returns
   /// a ${Self} of `count` uninitialized elements.
   @_versioned
-  @warn_unused_result
   @_semantics("array.uninitialized")
   internal static func _allocateUninitialized(
     _ count: Int
@@ -1153,7 +1138,6 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ///
   /// - Precondition: `storage is _ContiguousArrayStorage`.
   @_versioned
-  @warn_unused_result
   @_semantics("array.uninitialized")
   internal static func _adoptStorage(
     _ storage: AnyObject, count: Int
@@ -1475,7 +1459,6 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
     }
   }
 
-  @warn_unused_result
   public func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Element> {
     return _extractOrCopyToNativeArrayBuffer(self._buffer)
   }
@@ -1492,7 +1475,6 @@ extension ${Self} : CustomReflectable {
 }
 
 extension ${Self} : CustomStringConvertible, CustomDebugStringConvertible {
-  @warn_unused_result
   internal func _makeDescription(isDebug: Bool) -> String {
 %   if Self != 'Array':
     var result = isDebug ? "${Self}([" : "["
@@ -1533,7 +1515,6 @@ extension ${Self} : CustomStringConvertible, CustomDebugStringConvertible {
 extension ${Self} {
   @_versioned
   @_transparent
-  @warn_unused_result
   internal func _cPointerArgs() -> (AnyObject?, UnsafePointer<Void>?) {
     let p = _baseAddressIfContiguous
     if _fastPath(p != nil || isEmpty) {
@@ -1711,7 +1692,6 @@ internal func _expectEnd<C : Collection>(_ i: C.Index, _ s: C) {
     "invalid Collection: count differed in successive traversals")
 }
 
-@warn_unused_result
 internal func _growArrayCapacity(_ capacity: Int) -> Int {
   return capacity * 2
 }
@@ -2081,7 +2061,6 @@ internal func _arrayAppendSequence<
 // ArraySlice<Int> and Array<Int>.
 
 /// Returns `true` if these arrays contain the same elements.
-@warn_unused_result
 public func == <Element : Equatable>(
   lhs: ${Self}<Element>, rhs: ${Self}<Element>
 ) -> Bool {
@@ -2126,7 +2105,6 @@ public func == <Element : Equatable>(
 }
 
 /// Returns `true` if the arrays do not contain the same elements.
-@warn_unused_result
 public func != <Element : Equatable>(
   lhs: ${Self}<Element>, rhs: ${Self}<Element>
 ) -> Bool {
@@ -2140,7 +2118,6 @@ public func != <Element : Equatable>(
 ///
 /// - Precondition: `Base` is a base class or base `@objc` protocol (such
 ///   as `AnyObject`) of `Derived`.
-@warn_unused_result
 public func _arrayUpCast<Derived, Base>(_ a: Array<Derived>) -> Array<Base> {
   // FIXME: Dynamic casting is currently not possible without the objc runtime:
   // rdar://problem/18801510
@@ -2155,7 +2132,6 @@ extension Array {
   /// Returns `nil` otherwise.
   // Note: this function exists here so that Foundation doesn't have
   // to know Array's implementation details.
-  @warn_unused_result
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ source: AnyObject
   ) -> Array? {
@@ -2190,7 +2166,6 @@ extension Array {
   /// - Complexity: O(*n*) if the array is bridged, where *n* is the length
   ///   of the array; otherwise, O(1).
   /// - SeeAlso: `removeLast()`
-  @warn_unused_result
   public mutating func popLast() -> Element? {
     guard !isEmpty else { return nil }
     return removeLast()
@@ -2205,7 +2180,6 @@ extension ContiguousArray {
   ///
   /// - Complexity: O(1)
   /// - SeeAlso: `removeLast()`
-  @warn_unused_result
   public mutating func popLast() -> Element? {
     guard !isEmpty else { return nil }
     return removeLast()

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -18,7 +18,6 @@
 // UnsafeMutablePointer
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _isDebugAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:
@@ -30,7 +29,6 @@ func _isDebugAssertConfiguration() -> Bool {
 
 @_versioned
 @_transparent
-@warn_unused_result
 internal func _isReleaseAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:
   // 0: Debug
@@ -40,7 +38,6 @@ internal func _isReleaseAssertConfiguration() -> Bool {
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _isFastAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:
@@ -51,7 +48,6 @@ func _isFastAssertConfiguration() -> Bool {
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _isStdlibInternalChecksEnabled() -> Bool {
 #if INTERNAL_CHECKS_ENABLED
@@ -63,7 +59,6 @@ func _isStdlibInternalChecksEnabled() -> Bool {
 
 @_versioned
 @_transparent
-@warn_unused_result
 internal
 func _fatalErrorFlags() -> UInt32 {
   // The current flags are:

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -17,7 +17,6 @@ import SwiftShims
 ///
 /// This is a magic entry point known to the compiler. It is called in
 /// generated code for API availability checking.
-@warn_unused_result
 @_semantics("availability.osversion")
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
@@ -45,7 +44,6 @@ public func _stdlib_isOSVersionAtLeast(
 
 extension _SwiftNSOperatingSystemVersion : Comparable { }
 
-@warn_unused_result
 public func == (
   lhs: _SwiftNSOperatingSystemVersion,
   rhs: _SwiftNSOperatingSystemVersion
@@ -56,7 +54,6 @@ public func == (
 }
 
 /// Lexicographic comparison of version components.
-@warn_unused_result
 public func < (
   lhs: _SwiftNSOperatingSystemVersion,
   rhs: _SwiftNSOperatingSystemVersion
@@ -72,7 +69,6 @@ public func < (
   return lhs.patchVersion < rhs.patchVersion
 }
 
-@warn_unused_result
 public func >= (
   lhs: _SwiftNSOperatingSystemVersion,
   rhs: _SwiftNSOperatingSystemVersion

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -28,7 +28,6 @@ public protocol BidirectionalIndexable : Indexable {
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
-  @warn_unused_result
   func index(before i: Index) -> Index
 
   /// Replaces the given index with its predecessor.
@@ -72,7 +71,6 @@ public protocol BidirectionalCollection
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
-  @warn_unused_result
   func index(before i: Index) -> Index
 
   /// Replaces the given index with its predecessor.
@@ -118,7 +116,6 @@ extension BidirectionalIndexable {
     i = index(before: i)
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     if n >= 0 {
       return _advanceForward(i, by: n)
@@ -130,7 +127,6 @@ extension BidirectionalIndexable {
     return i
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -147,7 +143,6 @@ extension BidirectionalIndexable {
     return i
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     var start = start
     var count: IndexDistance = 0
@@ -187,7 +182,6 @@ extension BidirectionalCollection where SubSequence == Self {
   ///
   /// - Complexity: O(1).
   /// - SeeAlso: `removeLast()`
-  @warn_unused_result
   public mutating func popLast() -> Iterator.Element? {
     guard !isEmpty else { return nil }
     let element = last!
@@ -246,7 +240,6 @@ extension BidirectionalCollection {
   /// - Returns: A subsequence that leaves off `n` elements from the end.
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements to drop.
-  @warn_unused_result
   public func dropLast(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
@@ -275,7 +268,6 @@ extension BidirectionalCollection {
   ///   most `maxLength` elements.
   ///
   /// - Complexity: O(*n*), where *n* is equal to `maxLength`.
-  @warn_unused_result
   public func suffix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -103,7 +103,6 @@ extension Bool : _BuiltinBooleanLiteralConvertible, BooleanLiteralConvertible {
 
 extension Bool : Boolean {
   @_transparent
-  @warn_unused_result
   public func _getBuiltinLogicValue() -> Builtin.Int1 {
     return _value
   }
@@ -167,13 +166,11 @@ extension Bool : Equatable, Hashable {
 ///
 /// - Parameter a: The Boolean value to negate.
 @_transparent
-@warn_unused_result
 public prefix func !(a: Bool) -> Bool {
   return Bool(Builtin.xor_Int1(a._value, true._value))
 }
 
 @_transparent
-@warn_unused_result
 public func ==(lhs: Bool, rhs: Bool) -> Bool {
   return Bool(Builtin.cmp_eq_Int1(lhs._value, rhs._value))
 }

--- a/stdlib/public/core/Boolean.swift
+++ b/stdlib/public/core/Boolean.swift
@@ -27,7 +27,6 @@
 ///     // Prints "You look nice today!"
 ///
 /// - Parameter a: The Boolean value to negate.
-@warn_unused_result
 public prefix func !<T : Boolean>(a: T) -> Bool {
   return !a.boolValue
 }
@@ -65,7 +64,6 @@ public prefix func !<T : Boolean>(a: T) -> Bool {
 ///   - lhs: The left-hand side of the operation.
 ///   - rhs: The right-hand side of the operation.
 @inline(__always)
-@warn_unused_result
 public func && <T : Boolean, U : Boolean>(
   lhs: T, rhs: @autoclosure () throws -> U
 ) rethrows -> Bool {
@@ -106,7 +104,6 @@ public func && <T : Boolean, U : Boolean>(
 ///   - lhs: The left-hand side of the operation.
 ///   - rhs: The right-hand side of the operation.
 @inline(__always)
-@warn_unused_result
 public func || <T : Boolean, U : Boolean>(
   lhs: T, rhs: @autoclosure () throws -> U
 ) rethrows -> Bool {
@@ -149,7 +146,6 @@ public func || <T : Boolean, U : Boolean>(
 // rdar://problem/19418937, so here are some @_transparent overloads
 // for Bool.  We've done the same for ObjCBool.
 @_transparent
-@warn_unused_result
 public func && <T : Boolean>(
   lhs: T, rhs: @autoclosure () throws -> Bool
 ) rethrows -> Bool {
@@ -190,7 +186,6 @@ public func && <T : Boolean>(
 ///   - lhs: The left-hand side of the operation.
 ///   - rhs: The right-hand side of the operation.
 @_transparent
-@warn_unused_result
 public func || <T : Boolean>(
   lhs: T, rhs: @autoclosure () throws -> Bool
 ) rethrows -> Bool {

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -25,11 +25,9 @@ public protocol _ObjectiveCBridgeable {
   /// successfully to `Self`; for example, an `NSArray` will only
   /// convert successfully to `[String]` if it contains only
   /// `NSString`s.
-  @warn_unused_result
   static func _isBridgedToObjectiveC() -> Bool
 
   /// Convert `self` to Objective-C.
-  @warn_unused_result
   func _bridgeToObjectiveC() -> _ObjectiveCType
 
   /// Bridge from an Objective-C object of the bridged class type to a
@@ -162,7 +160,6 @@ public struct _BridgeableMetatype: _ObjectiveCBridgeable {
 ///   + otherwise, returns the result of `x._bridgeToObjectiveC()`;
 ///
 /// - otherwise, the result is empty.
-@warn_unused_result
 public func _bridgeToObjectiveC<T>(_ x: T) -> AnyObject? {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return unsafeBitCast(x, to: AnyObject.self)
@@ -170,7 +167,6 @@ public func _bridgeToObjectiveC<T>(_ x: T) -> AnyObject? {
   return _bridgeNonVerbatimToObjectiveC(x)
 }
 
-@warn_unused_result
 public func _bridgeToObjectiveCUnconditional<T>(_ x: T) -> AnyObject {
   let optResult: AnyObject? = _bridgeToObjectiveC(x)
   _precondition(optResult != nil,
@@ -180,7 +176,6 @@ public func _bridgeToObjectiveCUnconditional<T>(_ x: T) -> AnyObject {
 
 /// Same as `_bridgeToObjectiveCUnconditional`, but autoreleases the
 /// return value if `T` is bridged non-verbatim.
-@warn_unused_result
 func _bridgeToObjectiveCUnconditionalAutorelease<T>(_ x: T) -> AnyObject
 {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
@@ -195,7 +190,6 @@ func _bridgeToObjectiveCUnconditionalAutorelease<T>(_ x: T) -> AnyObject
   return bridged
 }
 
-@warn_unused_result
 @_silgen_name("_swift_bridgeNonVerbatimToObjectiveC")
 func _bridgeNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject?
 
@@ -210,7 +204,6 @@ func _bridgeNonVerbatimToObjectiveC<T>(_ x: T) -> AnyObject?
 ///     or a subclass of it, trap;
 ///   + otherwise, returns the result of `T._forceBridgeFromObjectiveC(x)`;
 /// - otherwise, trap.
-@warn_unused_result
 public func _forceBridgeFromObjectiveC<T>(_ x: AnyObject, _: T.Type) -> T {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return x as! T
@@ -223,7 +216,6 @@ public func _forceBridgeFromObjectiveC<T>(_ x: AnyObject, _: T.Type) -> T {
 
 /// Convert `x` from its Objective-C representation to its Swift
 /// representation.
-@warn_unused_result
 @_silgen_name("_forceBridgeFromObjectiveC_bridgeable")
 public func _forceBridgeFromObjectiveC_bridgeable<T:_ObjectiveCBridgeable>
   (_ x: T._ObjectiveCType, _: T.Type) -> T {
@@ -246,7 +238,6 @@ public func _forceBridgeFromObjectiveC_bridgeable<T:_ObjectiveCBridgeable>
 ///   + otherwise, returns the result of
 ///     `T._conditionallyBridgeFromObjectiveC(x)`;
 /// - otherwise, the result is empty.
-@warn_unused_result
 public func _conditionallyBridgeFromObjectiveC<T>(
   _ x: AnyObject,
   _: T.Type
@@ -262,7 +253,6 @@ public func _conditionallyBridgeFromObjectiveC<T>(
 
 /// Attempt to convert `x` from its Objective-C representation to its Swift
 /// representation.
-@warn_unused_result
 @_silgen_name("_conditionallyBridgeFromObjectiveC_bridgeable")
 public func _conditionallyBridgeFromObjectiveC_bridgeable<T:_ObjectiveCBridgeable>(
   _ x: T._ObjectiveCType,
@@ -300,7 +290,6 @@ func _bridgeNonVerbatimFromObjectiveCConditional<T>(
 /// - If `T` is a class type, returns `true`;
 /// - otherwise, if `T` conforms to `_ObjectiveCBridgeable`, returns
 ///   `T._isBridgedToObjectiveC()`.
-@warn_unused_result
 public func _isBridgedToObjectiveC<T>(_: T.Type) -> Bool {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return true
@@ -308,7 +297,6 @@ public func _isBridgedToObjectiveC<T>(_: T.Type) -> Bool {
   return _isBridgedNonVerbatimToObjectiveC(T.self)
 }
 
-@warn_unused_result
 @_silgen_name("_swift_isBridgedNonVerbatimToObjectiveC")
 func _isBridgedNonVerbatimToObjectiveC<T>(_: T.Type) -> Bool
 
@@ -316,13 +304,11 @@ func _isBridgedNonVerbatimToObjectiveC<T>(_: T.Type) -> Bool
 /// `_ObjectiveCBridgeable`, and can have its bits reinterpreted as an
 /// `AnyObject`.  When this function returns true, the storage of an
 /// `Array<T>` can be `unsafeBitCast` as an array of `AnyObject`.
-@warn_unused_result
 public func _isBridgedVerbatimToObjectiveC<T>(_: T.Type) -> Bool {
   return _isClassOrObjCExistential(T.self)
 }
 
 /// Retrieve the Objective-C type to which the given type is bridged.
-@warn_unused_result
 public func _getBridgedObjectiveCType<T>(_: T.Type) -> Any.Type? {
   if _fastPath(_isClassOrObjCExistential(T.self)) {
     return T.self
@@ -330,7 +316,6 @@ public func _getBridgedObjectiveCType<T>(_: T.Type) -> Any.Type? {
   return _getBridgedNonVerbatimObjectiveCType(T.self)
 }
 
-@warn_unused_result
 @_silgen_name("_swift_getBridgedNonVerbatimObjectiveCType")
 func _getBridgedNonVerbatimObjectiveCType<T>(_: T.Type) -> Any.Type?
 
@@ -469,7 +454,6 @@ extension AutoreleasingUnsafeMutablePointer : CustomDebugStringConvertible {
 }
 
 @_transparent
-@warn_unused_result
 public func == <Pointee> (
   lhs: AutoreleasingUnsafeMutablePointer<Pointee>,
   rhs: AutoreleasingUnsafeMutablePointer<Pointee>

--- a/stdlib/public/core/BridgeStorage.swift
+++ b/stdlib/public/core/BridgeStorage.swift
@@ -68,14 +68,12 @@ struct _BridgeStorage<
   }
   
   @inline(__always)
-  @warn_unused_result
   public // @testable
   mutating func isUniquelyReferencedNative() -> Bool {
     return _isUnique(&rawValue)
   }
 
   @inline(__always)
-  @warn_unused_result
   public // @testable
   mutating func isUniquelyReferencedOrPinnedNative() -> Bool {
     return _isUniqueOrPinned(&rawValue)
@@ -90,7 +88,6 @@ struct _BridgeStorage<
   }
   
   @inline(__always)
-  @warn_unused_result
   public // @testable
   func isNativeWithClearedSpareBits(_ bits: Int) -> Bool {
     return (_bitPattern(rawValue) &
@@ -123,7 +120,6 @@ struct _BridgeStorage<
   }
   
   @inline(__always)
-  @warn_unused_result
   public // @testable
   mutating func isUniquelyReferenced_native_noSpareBits() -> Bool {
     _sanityCheck(isNative)
@@ -131,7 +127,6 @@ struct _BridgeStorage<
   }
 
   @inline(__always)
-  @warn_unused_result
   public // @testable
   mutating func isUniquelyReferencedOrPinned_native_noSpareBits() -> Bool {
     _sanityCheck(isNative)

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -21,7 +21,6 @@ import SwiftShims
 /// In particular, `sizeof(X.self)`, when `X` is a class type, is the
 /// same regardless of how many stored properties `X` has.
 @_transparent
-@warn_unused_result
 public func sizeof<T>(_:T.Type) -> Int {
   return Int(Builtin.sizeof(T.self))
 }
@@ -32,21 +31,18 @@ public func sizeof<T>(_:T.Type) -> Int {
 /// In particular, `sizeof(a)`, when `a` is a class instance, is the
 /// same regardless of how many stored properties `a` has.
 @_transparent
-@warn_unused_result
 public func sizeofValue<T>(_:T) -> Int {
   return sizeof(T.self)
 }
 
 /// Returns the minimum memory alignment of `T`.
 @_transparent
-@warn_unused_result
 public func alignof<T>(_:T.Type) -> Int {
   return Int(Builtin.alignof(T.self))
 }
 
 /// Returns the minimum memory alignment of `T`.
 @_transparent
-@warn_unused_result
 public func alignofValue<T>(_:T) -> Int {
   return alignof(T.self)
 }
@@ -54,7 +50,6 @@ public func alignofValue<T>(_:T) -> Int {
 /// Returns the least possible interval between distinct instances of
 /// `T` in memory.  The result is always positive.
 @_transparent
-@warn_unused_result
 public func strideof<T>(_:T.Type) -> Int {
   return Int(Builtin.strideof_nonzero(T.self))
 }
@@ -62,13 +57,11 @@ public func strideof<T>(_:T.Type) -> Int {
 /// Returns the least possible interval between distinct instances of
 /// `T` in memory.  The result is always positive.
 @_transparent
-@warn_unused_result
 public func strideofValue<T>(_:T) -> Int {
   return strideof(T.self)
 }
 
 @_versioned
-@warn_unused_result
 internal func _roundUp(_ offset: Int, toAlignment alignment: Int) -> Int {
   _sanityCheck(offset >= 0)
   _sanityCheck(alignment > 0)
@@ -83,7 +76,6 @@ internal func _roundUp(_ offset: Int, toAlignment alignment: Int) -> Int {
 
 /// Returns a tri-state of 0 = no, 1 = yes, 2 = maybe.
 @_transparent
-@warn_unused_result
 public // @testable
 func _canBeClass<T>(_: T.Type) -> Int8 {
   return Int8(Builtin.canBeClass(T.self))
@@ -96,7 +88,6 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 ///   anything.
 ///
 @_transparent
-@warn_unused_result
 public func unsafeBitCast<T, U>(_ x: T, to: U.Type) -> U {
   _precondition(sizeof(T.self) == sizeof(U.self),
     "can't unsafeBitCast between types of different sizes")
@@ -105,45 +96,38 @@ public func unsafeBitCast<T, U>(_ x: T, to: U.Type) -> U {
 
 /// `unsafeBitCast` something to `AnyObject`.
 @_transparent
-@warn_unused_result
 public func _reinterpretCastToAnyObject<T>(_ x: T) -> AnyObject {
   return unsafeBitCast(x, to: AnyObject.self)
 }
 
 @_transparent
-@warn_unused_result
 func ==(lhs: Builtin.NativeObject, rhs: Builtin.NativeObject) -> Bool {
   return unsafeBitCast(lhs, to: Int.self) == unsafeBitCast(rhs, to: Int.self)
 }
 
 @_transparent
-@warn_unused_result
 func !=(lhs: Builtin.NativeObject, rhs: Builtin.NativeObject) -> Bool {
   return !(lhs == rhs)
 }
 
 @_transparent
-@warn_unused_result
 func ==(lhs: Builtin.RawPointer, rhs: Builtin.RawPointer) -> Bool {
   return unsafeBitCast(lhs, to: Int.self) == unsafeBitCast(rhs, to: Int.self)
 }
 
 @_transparent
-@warn_unused_result
 func !=(lhs: Builtin.RawPointer, rhs: Builtin.RawPointer) -> Bool {
   return !(lhs == rhs)
 }
 
 /// Returns `true` iff `t0` is identical to `t1`; i.e. if they are both
 /// `nil` or they both represent the same type.
-@warn_unused_result
 public func == (t0: Any.Type?, t1: Any.Type?) -> Bool {
   return unsafeBitCast(t0, to: Int.self) == unsafeBitCast(t1, to: Int.self)
 }
 
 /// Returns `false` iff `t0` is identical to `t1`; i.e. if they are both
 /// `nil` or they both represent the same type.
-@warn_unused_result
 public func != (t0: Any.Type?, t1: Any.Type?) -> Bool {
   return !(t0 == t1)
 }
@@ -169,7 +153,6 @@ func _conditionallyUnreachable() {
 }
 
 @_versioned
-@warn_unused_result
 @_silgen_name("_swift_isClassOrObjCExistentialType")
 func _swift_isClassOrObjCExistentialType<T>(_ x: T.Type) -> Bool
 
@@ -177,7 +160,6 @@ func _swift_isClassOrObjCExistentialType<T>(_ x: T.Type) -> Bool
 /// `AnyObject`.
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _isClassOrObjCExistential<T>(_ x: T.Type) -> Bool {
   let tmp = _canBeClass(x)
 
@@ -197,7 +179,6 @@ internal func _isClassOrObjCExistential<T>(_ x: T.Type) -> Bool {
 /// not much you can do with this other than use it to identify the
 /// object.
 @_transparent
-@warn_unused_result
 public func unsafeAddress(of object: AnyObject) -> UnsafePointer<Void> {
   return UnsafePointer(Builtin.bridgeToRawPointer(object))
 }
@@ -214,7 +195,6 @@ public func unsafeAddressOf(_ object: AnyObject) -> UnsafePointer<Void> {
 /// be either a class or a class protocol. Either T, U, or both may be
 /// optional references.
 @_transparent
-@warn_unused_result
 public func _unsafeReferenceCast<T, U>(_ x: T, to: U.Type) -> U {
   return Builtin.castReference(x)
 }
@@ -230,14 +210,12 @@ public func _unsafeReferenceCast<T, U>(_ x: T, to: U.Type) -> U {
 ///   `unsafeBitCast` because it's more restrictive, and because
 ///   checking is still performed in debug builds.
 @_transparent
-@warn_unused_result
 public func unsafeDowncast<T : AnyObject>(_ x: AnyObject, to: T.Type) -> T {
   _debugPrecondition(x is T, "invalid unsafeDowncast")
   return Builtin.castReference(x)
 }
 
 @inline(__always)
-@warn_unused_result
 public func _getUnsafePointerToStoredProperties(_ x: AnyObject)
   -> UnsafeMutablePointer<UInt8> {
   let storedPropertyOffset = _roundUp(
@@ -258,7 +236,6 @@ public func _getUnsafePointerToStoredProperties(_ x: AnyObject)
 @_versioned
 @_transparent
 @_semantics("branchhint")
-@warn_unused_result
 internal func _branchHint<C : Boolean>(_ actual: C, expected: Bool)
   -> Bool {
   return Bool(Builtin.int_expect_Int1(actual.boolValue._value, expected._value))
@@ -267,7 +244,6 @@ internal func _branchHint<C : Boolean>(_ actual: C, expected: Bool)
 /// Optimizer hint that `x` is expected to be `true`.
 @_transparent
 @_semantics("fastpath")
-@warn_unused_result
 public func _fastPath<C: Boolean>(_ x: C) -> Bool {
   return _branchHint(x.boolValue, expected: true)
 }
@@ -275,7 +251,6 @@ public func _fastPath<C: Boolean>(_ x: C) -> Bool {
 /// Optimizer hint that `x` is expected to be `false`.
 @_transparent
 @_semantics("slowpath")
-@warn_unused_result
 public func _slowPath<C : Boolean>(_ x: C) -> Bool {
   return _branchHint(x.boolValue, expected: false)
 }
@@ -293,7 +268,6 @@ public func _onFastPath() {
 /// Swift reference-counting.
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _usesNativeSwiftReferenceCounting(_ theClass: AnyClass) -> Bool {
 #if _runtime(_ObjC)
   return swift_objc_class_usesNativeSwiftReferenceCounting(
@@ -304,19 +278,16 @@ internal func _usesNativeSwiftReferenceCounting(_ theClass: AnyClass) -> Bool {
 #endif
 }
 
-@warn_unused_result
 @_silgen_name("swift_class_getInstanceExtents")
 func swift_class_getInstanceExtents(_ theClass: AnyClass)
   -> (negative: UInt, positive: UInt)
 
-@warn_unused_result
 @_silgen_name("swift_objc_class_unknownGetInstanceExtents")
 func swift_objc_class_unknownGetInstanceExtents(_ theClass: AnyClass)
   -> (negative: UInt, positive: UInt)
 
 /// - Returns: 
 @inline(__always)
-@warn_unused_result
 internal func _class_getInstancePositiveExtentSize(_ theClass: AnyClass) -> Int {
 #if _runtime(_ObjC)
   return Int(swift_objc_class_unknownGetInstanceExtents(theClass).positive)
@@ -400,7 +371,6 @@ internal var _objCTaggedPointerBits: UInt {
 /// Extract the raw bits of `x`.
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _bitPattern(_ x: Builtin.BridgeObject) -> UInt {
   return UInt(Builtin.castBitPatternFromBridgeObject(x))
 }
@@ -408,14 +378,12 @@ internal func _bitPattern(_ x: Builtin.BridgeObject) -> UInt {
 /// Extract the raw spare bits of `x`.
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _nonPointerBits(_ x: Builtin.BridgeObject) -> UInt {
   return _bitPattern(x) & _objectPointerSpareBits
 }
 
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _isObjCTaggedPointer(_ x: AnyObject) -> Bool {
   return (Builtin.reinterpretCast(x) & _objCTaggedPointerBits) != 0
 }
@@ -430,7 +398,6 @@ internal func _isObjCTaggedPointer(_ x: AnyObject) -> Bool {
 ///   `bits & _objectPointerSpareBits == bits`.
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _makeNativeBridgeObject(
   _ nativeObject: AnyObject, _ bits: UInt
 ) -> Builtin.BridgeObject {
@@ -443,7 +410,6 @@ internal func _makeNativeBridgeObject(
 
 /// Create a `BridgeObject` around the given `objCObject`.
 @inline(__always)
-@warn_unused_result
 public // @testable
 func _makeObjCBridgeObject(
   _ objCObject: AnyObject
@@ -464,7 +430,6 @@ func _makeObjCBridgeObject(
 ///      _objectPointerIsObjCBit`.
 @_versioned
 @inline(__always)
-@warn_unused_result
 internal func _makeBridgeObject(
   _ object: AnyObject, _ bits: UInt
 ) -> Builtin.BridgeObject {
@@ -490,7 +455,6 @@ internal func _makeBridgeObject(
 /// Returns the superclass of `t`, if any.  The result is `nil` if `t` is
 /// a root class or class protocol.
 @inline(__always)
-@warn_unused_result
 public // @testable
 func _getSuperclass(_ t: AnyClass) -> AnyClass? {
   return unsafeBitCast(
@@ -501,7 +465,6 @@ func _getSuperclass(_ t: AnyClass) -> AnyClass? {
 /// Returns the superclass of `t`, if any.  The result is `nil` if `t` is
 /// not a class, is a root class, or is a class protocol.
 @inline(__always)
-@warn_unused_result
 public // @testable
 func _getSuperclass(_ t: Any.Type) -> AnyClass? {
   return (t as? AnyClass).flatMap { _getSuperclass($0) }
@@ -529,7 +492,6 @@ func _getSuperclass(_ t: Any.Type) -> AnyClass? {
 /// Returns `true` if `object` is uniquely referenced.
 @_versioned
 @_transparent
-@warn_unused_result
 internal func _isUnique<T>(_ object: inout T) -> Bool {
   return Bool(Builtin.isUnique(&object))
 }
@@ -537,7 +499,6 @@ internal func _isUnique<T>(_ object: inout T) -> Bool {
 /// Returns `true` if `object` is uniquely referenced or pinned.
 @_versioned
 @_transparent
-@warn_unused_result
 internal func _isUniqueOrPinned<T>(_ object: inout T) -> Bool {
   return Bool(Builtin.isUniqueOrPinned(&object))
 }
@@ -545,7 +506,6 @@ internal func _isUniqueOrPinned<T>(_ object: inout T) -> Bool {
 /// Returns `true` if `object` is uniquely referenced.
 /// This provides sanity checks on top of the Builtin.
 @_transparent
-@warn_unused_result
 public // @testable
 func _isUnique_native<T>(_ object: inout T) -> Bool {
   // This could be a bridge object, single payload enum, or plain old
@@ -562,7 +522,6 @@ func _isUnique_native<T>(_ object: inout T) -> Bool {
 /// Returns `true` if `object` is uniquely referenced or pinned.
 /// This provides sanity checks on top of the Builtin.
 @_transparent
-@warn_unused_result
 public // @testable
 func _isUniqueOrPinned_native<T>(_ object: inout T) -> Bool {
   // This could be a bridge object, single payload enum, or plain old
@@ -578,7 +537,6 @@ func _isUniqueOrPinned_native<T>(_ object: inout T) -> Bool {
 /// Returns `true` if type is a POD type. A POD type is a type that does not
 /// require any special handling on copying or destruction.
 @_transparent
-@warn_unused_result
 public // @testable
 func _isPOD<T>(_ type: T.Type) -> Bool {
   return Bool(Builtin.ispod(type))
@@ -586,7 +544,6 @@ func _isPOD<T>(_ type: T.Type) -> Bool {
 
 /// Returns `true` if type is nominally an Optional type.
 @_transparent
-@warn_unused_result
 public // @testable
 func _isOptional<T>(_ type: T.Type) -> Bool {
   return Bool(Builtin.isOptional(type))

--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -64,7 +64,6 @@ def TypedUnaryIntrinsicFunctions():
 // Note these have a corresponding LLVM intrinsic
 % for T, CT, bits, ufunc in TypedUnaryIntrinsicFunctions():
 @_transparent
-@warn_unused_result
 public func _${ufunc}(_ x: ${T}) -> ${T} {
   return ${T}(_bits: Builtin.int_${ufunc}_FPIEEE${bits}(x._value))
 }

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -51,7 +51,6 @@ extension String {
   /// Returns `nil` if the `cString` is `nil` or if it contains ill-formed code
   /// units and no repairing has been requested. Otherwise replaces
   /// ill-formed code units with replacement characters (U+FFFD).
-  @warn_unused_result
   public static func decodeCString<Encoding : UnicodeCodec>(
     _ cString: UnsafePointer<Encoding.CodeUnit>?,
     as encoding: Encoding.Type,
@@ -77,7 +76,6 @@ extension String {
 /// From a non-`nil` `UnsafePointer` to a null-terminated string
 /// with possibly-transient lifetime, create a null-terminated array of 'C' char.
 /// Returns `nil` if passed a null pointer.
-@warn_unused_result
 public func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
   guard let s = p else {
     return nil
@@ -92,13 +90,11 @@ public func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
 
 extension String {
   @available(*, unavailable, message: "Please use String.init?(validatingUTF8:) instead. Note that it no longer accepts NULL as a valid input. Also consider using String(cString:), that will attempt to repair ill-formed code units.")
-  @warn_unused_result
   public static func fromCString(_ cs: UnsafePointer<CChar>) -> String? {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, message: "Please use String.init(cString:) instead. Note that it no longer accepts NULL as a valid input. See also String.decodeCString if you need more control.")
-  @warn_unused_result
   public static func fromCStringRepairingIllFormedUTF8(
     _ cs: UnsafePointer<CChar>
   ) -> (String?, hadError: Bool) {

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -163,20 +163,17 @@ extension OpaquePointer : CustomDebugStringConvertible {
 }
 
 extension Int {
-  @warn_unused_result
   public init(bitPattern pointer: OpaquePointer?) {
     self.init(bitPattern: UnsafePointer<Void>(pointer))
   }
 }
 
 extension UInt {
-  @warn_unused_result
   public init(bitPattern pointer: OpaquePointer?) {
     self.init(bitPattern: UnsafePointer<Void>(pointer))
   }
 }
 
-@warn_unused_result
 public func ==(lhs: OpaquePointer, rhs: OpaquePointer) -> Bool {
   return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
 }

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -119,7 +119,6 @@ public struct Character :
 
   /// Returns the index of the lowest byte that is 0xFF, or 8 if
   /// there is none.
-  @warn_unused_result
   static func _smallSize(_ value: UInt64) -> Int {
     var mask: UInt64 = 0xFF
     for i in 0..<8 {
@@ -131,7 +130,6 @@ public struct Character :
     return 8
   }
 
-  @warn_unused_result
   static func _smallValue(_ value: Builtin.Int63) -> UInt64 {
     return UInt64(Builtin.zext_Int63_Int64(value)) | (1<<63)
   }
@@ -318,7 +316,6 @@ internal var _minASCIICharReprBuiltin: Builtin.Int63 {
   }
 }
 
-@warn_unused_result
 public func ==(lhs: Character, rhs: Character) -> Bool {
   switch (lhs._representation, rhs._representation) {
   case let (.small(lbits), .small(rbits)) where
@@ -332,7 +329,6 @@ public func ==(lhs: Character, rhs: Character) -> Bool {
   }
 }
 
-@warn_unused_result
 public func <(lhs: Character, rhs: Character) -> Bool {
   switch (lhs._representation, rhs._representation) {
   case let (.small(lbits), .small(rbits)) where

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -218,13 +218,11 @@ public struct CountableClosedRange<
     return ClosedRangeIndex()
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range checks and tests.
     return i._successor(upperBound: upperBound)
   }
 
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range checks and tests.
     return i._predecessor(upperBound: upperBound)
@@ -274,7 +272,6 @@ public struct CountableClosedRange<
     self.upperBound = bounds.upper
   }
 
-  @warn_unused_result
   public func _customContainsEquatableElement(_ element: Bound) -> Bool? {
     return element >= self.lowerBound && element <= self.upperBound
   }
@@ -346,7 +343,6 @@ public struct ClosedRange<
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func contains(_ element: Bound) -> Bool {
     return element >= self.lowerBound && element <= self.upperBound
   }
@@ -372,7 +368,6 @@ public struct ClosedRange<
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-@warn_unused_result
 public func ... <Bound : Comparable> (minimum: Bound, maximum: Bound)
   -> ClosedRange<Bound> {
   _precondition(
@@ -392,7 +387,6 @@ public func ... <Bound : Comparable> (minimum: Bound, maximum: Bound)
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-@warn_unused_result
 public func ... <
   // WORKAROUND rdar://25214598 - should be just Bound : Strideable
   Bound : protocol<_Strideable, Comparable>

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -142,7 +142,6 @@ public protocol IndexableBase {
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
-  @warn_unused_result
   func index(after i: Index) -> Index
 
   /// Replaces the given index with its successor.
@@ -192,7 +191,6 @@ public protocol Indexable : IndexableBase {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  @warn_unused_result
   func index(_ i: Index, offsetBy n: IndexDistance) -> Index
 
   /// Returns an index that is the specified distance from the given index,
@@ -239,7 +237,6 @@ public protocol Indexable : IndexableBase {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  @warn_unused_result
   func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index?
@@ -303,7 +300,6 @@ public protocol Indexable : IndexableBase {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
-  @warn_unused_result
   func distance(from start: Index, to end: Index) -> IndexDistance
 }
 
@@ -676,7 +672,6 @@ public protocol Collection : Indexable, Sequence {
   ///
   /// - Complexity: O(1)
   /// - SeeAlso: `prefix(through:)`
-  @warn_unused_result
   func prefix(upTo end: Index) -> SubSequence
 
   /// Returns a subsequence from the specified position to the end of the
@@ -702,7 +697,6 @@ public protocol Collection : Indexable, Sequence {
   ///
   /// - Precondition: `start >= self.startIndex && start <= self.endIndex`
   /// - Complexity: O(1)
-  @warn_unused_result
   func suffix(from start: Index) -> SubSequence
 
   /// Returns a subsequence from the start of the collection through the
@@ -723,7 +717,6 @@ public protocol Collection : Indexable, Sequence {
   ///
   /// - Complexity: O(1)
   /// - SeeAlso: `prefix(upTo:)`
-  @warn_unused_result
   func prefix(through position: Index) -> SubSequence
 
   /// A Boolean value indicating whether the collection is empty.
@@ -759,7 +752,6 @@ public protocol Collection : Indexable, Sequence {
   /// otherwise, `nil`.
   ///
   /// - Complexity: O(N).
-  @warn_unused_result
   func _customIndexOfEquatableElement(_ element: Iterator.Element) -> Index??
 
   /// The first element of the collection.
@@ -803,7 +795,6 @@ public protocol Collection : Indexable, Sequence {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  @warn_unused_result
   func index(_ i: Index, offsetBy n: IndexDistance) -> Index
 
   /// Returns an index that is the specified distance from the given index,
@@ -850,7 +841,6 @@ public protocol Collection : Indexable, Sequence {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  @warn_unused_result
   func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index?
@@ -871,7 +861,6 @@ public protocol Collection : Indexable, Sequence {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
-  @warn_unused_result
   func distance(from start: Index, to end: Index) -> IndexDistance
 }
 
@@ -943,7 +932,6 @@ extension Indexable {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     // FIXME: swift-3-indexing-model: tests.
     return self._advanceForward(i, by: n)
@@ -993,7 +981,6 @@ extension Indexable {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -1052,7 +1039,7 @@ extension Indexable {
     i = limit
     return false
   }
-  
+
   /// Returns the distance between two indices.
   ///
   /// Unless the collection conforms to the `BidirectionalCollection` protocol,
@@ -1069,7 +1056,6 @@ extension Indexable {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     // FIXME: swift-3-indexing-model: tests.
     _precondition(start <= end,
@@ -1086,7 +1072,6 @@ extension Indexable {
 
   /// Do not use this method directly; call advanced(by: n) instead.
   @inline(__always)
-  @warn_unused_result
   internal func _advanceForward(_ i: Index, by n: IndexDistance) -> Index {
     _precondition(n >= 0,
       "Only BidirectionalCollections can be advanced by a negative amount")
@@ -1100,7 +1085,6 @@ extension Indexable {
 
   /// Do not use this method directly; call advanced(by: n, limit) instead.
   @inline(__always)
-  @warn_unused_result
   internal
   func _advanceForward(
     _ i: Index, by n: IndexDistance, limitedBy limit: Index
@@ -1167,7 +1151,6 @@ extension Collection where SubSequence == Self {
   ///   not empty; otherwise, `nil`.
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public mutating func popFirst() -> Iterator.Element? {
     guard !isEmpty else { return nil }
     let element = first!
@@ -1254,7 +1237,6 @@ extension Collection {
   ///   `Optional(Optional(index))` if an element was found.
   ///
   /// - Complexity: O(`count`).
-  @warn_unused_result
   public // dispatching
   func _customIndexOfEquatableElement(_: Iterator.Element) -> Index?? {
     return nil
@@ -1284,7 +1266,6 @@ extension Collection {
   ///   value of the same or of a different type.
   /// - Returns: An array containing the transformed elements of this
   ///   sequence.
-  @warn_unused_result
   public func map<T>(
     _ transform: @noescape (Iterator.Element) throws -> T
   ) rethrows -> [T] {
@@ -1326,7 +1307,6 @@ extension Collection {
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements to drop from
   ///   the beginning of the collection.
-  @warn_unused_result
   public func dropFirst(_ n: Int) -> SubSequence {
     _precondition(n >= 0, "Can't drop a negative number of elements from a collection")
     let start = index(startIndex,
@@ -1352,7 +1332,6 @@ extension Collection {
   ///   at the end.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  @warn_unused_result
   public func dropLast(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
@@ -1378,7 +1357,6 @@ extension Collection {
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A subsequence starting at the beginning of this collection
   ///   with at most `maxLength` elements.
-  @warn_unused_result
   public func prefix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,
@@ -1406,7 +1384,6 @@ extension Collection {
   ///   most `maxLength` elements.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
-  @warn_unused_result
   public func suffix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,
@@ -1442,7 +1419,6 @@ extension Collection {
   /// - Precondition: `end >= self.startIndex && end <= self.endIndex`
   /// - Complexity: O(1)
   /// - SeeAlso: `prefix(through:)`
-  @warn_unused_result
   public func prefix(upTo end: Index) -> SubSequence {
     return self[startIndex..<end]
   }
@@ -1470,7 +1446,6 @@ extension Collection {
   ///
   /// - Precondition: `start >= self.startIndex && start <= self.endIndex`
   /// - Complexity: O(1)
-  @warn_unused_result
   public func suffix(from start: Index) -> SubSequence {
     return self[start..<endIndex]
   }
@@ -1494,7 +1469,6 @@ extension Collection {
   ///
   /// - Complexity: O(1)
   /// - SeeAlso: `prefix(upTo:)`
-  @warn_unused_result
   public func prefix(through position: Index) -> SubSequence {
     return prefix(upTo: index(after: position))
   }
@@ -1543,7 +1517,6 @@ extension Collection {
   ///     returns a Boolean value indicating whether the sequence should be
   ///     split at that element.
   /// - Returns: An array of subsequences, split from this sequence's elements.
-  @warn_unused_result
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
@@ -1635,7 +1608,6 @@ extension Collection where Iterator.Element : Equatable {
   ///     returns a Boolean value indicating whether the sequence should be
   ///     split at that element.
   /// - Returns: An array of subsequences, split from this sequence's elements.
-  @warn_unused_result
   public func split(
     separator: Iterator.Element,
     maxSplits: Int = Int.max,

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -62,7 +62,6 @@ extension Collection where ${IElement} : Equatable {
   ///   found in the collection, returns `nil`.
   ///
   /// - SeeAlso: `index(where:)`
-  @warn_unused_result
   public func index(of element: ${IElement}) -> Index? {
     if let result = _customIndexOfEquatableElement(element) {
       return result
@@ -102,7 +101,6 @@ extension Collection {
   ///   returns `nil`.
   ///
   /// - SeeAlso: `index(of:)`
-  @warn_unused_result
   public func index(
     where predicate: @noescape (${IElement}) throws -> Bool
   ) rethrows -> Index? {
@@ -209,7 +207,6 @@ ${orderingExplanation}
   ///   collection is empty.
   ///
   /// - SeeAlso: `partition()`
-  @warn_unused_result
   public mutating func partition(
     isOrderedBefore: @noescape (${IElement}, ${IElement}) -> Bool
   ) -> Index
@@ -252,7 +249,6 @@ ${orderingExplanation}
   ///   equal to the collection's end index only if the collection is empty.
   ///
   /// - SeeAlso: `partition(isOrderedBefore:)`
-  @warn_unused_result
   public mutating func partition() -> Index
 
 %   end
@@ -677,7 +673,6 @@ extension MutableCollection where Self : RandomAccessCollection {
 
 extension Collection where ${IElement} : Equatable {
   @available(*, unavailable, renamed: "index(of:)")
-  @warn_unused_result
   public func indexOf(_ element: ${IElement}) -> Index? {
     Builtin.unreachable()
   }
@@ -685,7 +680,6 @@ extension Collection where ${IElement} : Equatable {
 
 extension Collection {
   @available(*, unavailable, renamed: "index(where:)")
-  @warn_unused_result
   public func indexOf(
     _ predicate: @noescape (${IElement}) throws -> Bool
   ) rethrows -> Index? {

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -59,14 +59,12 @@ public struct CollectionOfOne<Element>
   }
   
   /// Always returns `endIndex`.
-  @warn_unused_result
   public func index(after i: Int) -> Int {
     _precondition(i == startIndex)
     return endIndex
   }
 
   /// Always returns `startIndex`.
-  @warn_unused_result
   public func index(before i: Int) -> Int {
     _precondition(i == endIndex)
     return startIndex

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -195,7 +195,6 @@ public protocol RawRepresentable {
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
-@warn_unused_result
 public func == <
   T : RawRepresentable where T.RawValue : Equatable
 >(lhs: T, rhs: T) -> Bool {
@@ -207,7 +206,6 @@ public func == <
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
-@warn_unused_result
 public func != <
   T : RawRepresentable where T.RawValue : Equatable
 >(lhs: T, rhs: T) -> Bool {
@@ -221,7 +219,6 @@ public func != <
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
-@warn_unused_result
 public func != <
   T : Equatable where T : RawRepresentable, T.RawValue : Equatable
 >(lhs: T, rhs: T) -> Bool {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -36,12 +36,10 @@ internal final class _EmptyArrayStorage
 
   // FIXME(ABI): remove 'Void' arguments here and elsewhere in this file, they
   // are a workaround for an old compiler limitation.
-  @warn_unused_result
   override func _getNonVerbatimBridgedCount(_ dummy: Void) -> Int {
     return 0
   }
 
-  @warn_unused_result
   override func _getNonVerbatimBridgedHeapBuffer(
     _ dummy: Void
   ) -> _HeapBuffer<Int, AnyObject> {
@@ -50,7 +48,6 @@ internal final class _EmptyArrayStorage
   }
 #endif
 
-  @warn_unused_result
   override func canStoreElements(ofDynamicType _: Any.Type) -> Bool {
     return false
   }
@@ -127,7 +124,6 @@ final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorage1 {
   /// Returns the number of elements in the array.
   ///
   /// - Precondition: `Element` is bridged non-verbatim.
-  @warn_unused_result
   override internal func _getNonVerbatimBridgedCount(_ dummy: Void) -> Int {
     _sanityCheck(
       !_isBridgedVerbatimToObjectiveC(Element.self),
@@ -138,7 +134,6 @@ final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorage1 {
   /// Bridge array elements and return a new buffer that owns them.
   ///
   /// - Precondition: `Element` is bridged non-verbatim.
-  @warn_unused_result
   override internal func _getNonVerbatimBridgedHeapBuffer(_ dummy: Void) ->
     _HeapBuffer<Int, AnyObject> {
     _sanityCheck(
@@ -161,7 +156,6 @@ final class _ContiguousArrayStorage<Element> : _ContiguousArrayStorage1 {
   /// `Element`.  We can't store anything else without violating type
   /// safety; for example, the destructor has static knowledge that
   /// all of the elements can be destroyed as `Element`.
-  @warn_unused_result
   override func canStoreElements(
     ofDynamicType proposedElementType: Any.Type
   ) -> Bool {
@@ -297,7 +291,6 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     self = buffer
   }
 
-  @warn_unused_result
   public mutating func requestUniqueMutableBackingBuffer(
     minimumCapacity: Int
   ) -> _ContiguousArrayBuffer<Element>? {
@@ -307,12 +300,10 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
     return nil
   }
 
-  @warn_unused_result
   public mutating func isMutableAndUniquelyReferenced() -> Bool {
     return isUniquelyReferenced()
   }
 
-  @warn_unused_result
   public mutating func isMutableAndUniquelyReferencedOrPinned() -> Bool {
     return isUniquelyReferencedOrPinned()
   }
@@ -320,13 +311,11 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// If this buffer is backed by a `_ContiguousArrayBuffer`
   /// containing the same number of elements as `self`, return it.
   /// Otherwise, return `nil`.
-  @warn_unused_result
   public func requestNativeBuffer() -> _ContiguousArrayBuffer<Element>? {
     return self
   }
 
   @_versioned
-  @warn_unused_result
   func getElement(_ i: Int) -> Element {
     _sanityCheck(i >= 0 && i < count, "Array index out of range")
     return firstElementAddress[i]
@@ -421,7 +410,6 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// - Note: This does not mean the buffer is mutable.  Other factors
   ///   may need to be considered, such as whether the buffer could be
   ///   some immutable Cocoa container.
-  @warn_unused_result
   public mutating func isUniquelyReferenced() -> Bool {
     return __bufferPointer.holdsUniqueReference()
   }
@@ -429,7 +417,6 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// Returns `true` iff this buffer's storage is either
   /// uniquely-referenced or pinned.  NOTE: this does not mean
   /// the buffer is mutable; see the comment on isUniquelyReferenced.
-  @warn_unused_result
   public mutating func isUniquelyReferencedOrPinned() -> Bool {
     return __bufferPointer.holdsUniqueOrPinnedReference()
   }
@@ -440,7 +427,6 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// - Precondition: `Element` is bridged to Objective-C.
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   public func _asCocoaArray() -> _NSArrayCore {
     _sanityCheck(
         _isBridgedToObjectiveC(Element.self),
@@ -482,7 +468,6 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
   /// - Precondition: `U` is a class or `@objc` existential.
   ///
   /// - Complexity: O(N).
-  @warn_unused_result
   func storesOnlyElementsOfType<U>(
     _: U.Type
   ) -> Bool {
@@ -559,7 +544,6 @@ extension Sequence {
   }
 }
 
-@warn_unused_result
 internal func _copySequenceToNativeArrayBuffer<
   S : Sequence
 >(_ source: S) -> _ContiguousArrayBuffer<S.Iterator.Element> {
@@ -606,7 +590,6 @@ extension _ContiguousArrayBuffer {
 /// ARC loops, the extra retain, release overhead cannot be eliminated which
 /// makes assigning ranges very slow. Once this has been implemented, this code
 /// should be changed to use _UnsafePartiallyInitializedContiguousArrayBuffer.
-@warn_unused_result
 internal func _copyCollectionToNativeArrayBuffer<
   C : Collection
 >(_ source: C) -> _ContiguousArrayBuffer<C.Iterator.Element>
@@ -694,7 +677,6 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
   /// Returns the fully-initialized buffer. `self` is reset to contain an
   /// empty buffer and cannot be used afterward.
   @inline(__always) // For performance reasons.
-  @warn_unused_result
   mutating func finish() -> _ContiguousArrayBuffer<Element> {
     // Adjust the initialized count of the buffer.
     result.count = result.capacity - remainingCapacity
@@ -709,7 +691,6 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
   /// Returns the fully-initialized buffer. `self` is reset to contain an
   /// empty buffer and cannot be used afterward.
   @inline(__always) // For performance reasons.
-  @warn_unused_result
   mutating func finishWithOriginalCount() -> _ContiguousArrayBuffer<Element> {
     _sanityCheck(remainingCapacity == result.capacity - result.count,
       "_UnsafePartiallyInitializedContiguousArrayBuffer has incorrect count")

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -59,7 +59,6 @@ public struct EmptyCollection<Element> :
   ///
   /// EmptyCollection does not have any element indices, so it is not
   /// possible to advance indices.
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     _preconditionFailure("EmptyCollection can't advance indices")
   }
@@ -68,7 +67,6 @@ public struct EmptyCollection<Element> :
   ///
   /// EmptyCollection does not have any element indices, so it is not
   /// possible to advance indices.
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     _preconditionFailure("EmptyCollection can't advance indices")
   }
@@ -109,13 +107,11 @@ public struct EmptyCollection<Element> :
     return 0
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     _precondition(i == startIndex && n == 0, "Index out of range")
     return i
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -125,7 +121,6 @@ public struct EmptyCollection<Element> :
   }
 
   /// The distance between two indexes (always zero).
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     _precondition(start == 0, "From must be startIndex (or endIndex)")
     _precondition(end == 0, "To must be endIndex (or startIndex)")

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -122,14 +122,12 @@ extension ErrorProtocol {
 #if _runtime(_ObjC)
 // Helper functions for the C++ runtime to have easy access to domain and
 // code as Objective-C values.
-@warn_unused_result
 @_silgen_name("swift_stdlib_getErrorDomainNSString")
 public func _stdlib_getErrorDomainNSString<T : ErrorProtocol>(_ x: UnsafePointer<T>)
 -> AnyObject {
   return x.pointee._domain._bridgeToObjectiveCImpl()
 }
 
-@warn_unused_result
 @_silgen_name("swift_stdlib_getErrorCode")
 public func _stdlib_getErrorCode<T : ErrorProtocol>(_ x: UnsafePointer<T>) -> Int {
   return x.pointee._code
@@ -137,7 +135,6 @@ public func _stdlib_getErrorCode<T : ErrorProtocol>(_ x: UnsafePointer<T>) -> In
 
 // Known function for the compiler to use to coerce `ErrorProtocol` instances
 // to `NSError`.
-@warn_unused_result
 @_silgen_name("swift_bridgeErrorProtocolToNSError")
 public func _bridgeErrorProtocolToNSError(_ error: ErrorProtocol) -> AnyObject
 #endif

--- a/stdlib/public/core/Existential.swift
+++ b/stdlib/public/core/Existential.swift
@@ -45,7 +45,6 @@ internal struct _CollectionOf<
   internal let startIndex: IndexType
   internal let endIndex: IndexType
 
-  @warn_unused_result
   internal func index(after i: IndexType) -> IndexType {
     return i.advanced(by: 1)
   }

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -111,7 +111,6 @@ internal final class _IteratorBox<
   internal var _base: Base
 }
 
-@warn_unused_result
 internal func _typeID(_ instance: AnyObject) -> ObjectIdentifier {
   return ObjectIdentifier(instance.dynamicType)
 }
@@ -137,19 +136,16 @@ internal class _AnyRandomAccessCollectionBox<Element>
 {
 
 %   if Kind == 'Sequence':
-  @warn_unused_result
   internal func _makeIterator() -> AnyIterator<Element> { _abstract() }
 
   internal var _underestimatedCount: Int { _abstract() }
 
-  @warn_unused_result
   internal func _map<T>(
     _ transform: @noescape (Element) throws -> T
   ) rethrows -> [T] {
     _abstract()
   }
 
-  @warn_unused_result
   internal func _filter(
     _ includeElement: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
@@ -162,26 +158,22 @@ internal class _AnyRandomAccessCollectionBox<Element>
     _abstract()
   }
 
-  @warn_unused_result
   internal func __customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     _abstract()
   }
 
-  @warn_unused_result
   internal func __preprocessingPass<R>(
     _ preprocess: @noescape () throws -> R
   ) rethrows -> R? {
     _abstract()
   }
 
-  @warn_unused_result
   internal func __copyToNativeArrayBuffer() -> _ContiguousArrayStorageBase {
     _abstract()
   }
 
-  @warn_unused_result
   internal func __copyContents(initializing ptr: UnsafeMutablePointer<Element>)
     -> UnsafeMutablePointer<Element> {
     _abstract()
@@ -190,27 +182,22 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   end
 
 %   override = 'override' if Kind != 'Sequence' else ''
-  @warn_unused_result
   internal ${override} func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @warn_unused_result
   internal ${override} func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @warn_unused_result
   internal ${override} func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @warn_unused_result
   internal ${override} func _suffix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @warn_unused_result
   internal func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     isSeparator: @noescape (Element) throws -> Bool
@@ -221,19 +208,16 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   if Kind == 'Collection':
   internal subscript(i: _AnyIndexBox) -> Element { _abstract() }
   
-  @warn_unused_result
   internal func _index(after i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
   
   internal func _formIndex(after i: _AnyIndexBox) { _abstract() }
   
-  @warn_unused_result
   internal func _index(
     _ i: _AnyIndexBox, offsetBy n: IntMax
   ) -> _AnyIndexBox {
     _abstract()
   }
   
-  @warn_unused_result
   internal func _index(
     _ i: _AnyIndexBox, offsetBy n: IntMax, limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
@@ -250,7 +234,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
     _abstract()
   }
   
-  @warn_unused_result
   internal func _distance(
     from start: _AnyIndexBox, to end: _AnyIndexBox
   ) -> IntMax {
@@ -261,13 +244,10 @@ internal class _AnyRandomAccessCollectionBox<Element>
   /*
   var _indices: Indices
 
-  @warn_unused_result
   func prefix(upTo end: Index) -> SubSequence
 
-  @warn_unused_result
   func suffix(from start: Index) -> SubSequence
 
-  @warn_unused_result
   func prefix(through position: Index) -> SubSequence
 
   var isEmpty: Bool { get }
@@ -277,7 +257,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
   // TODO: swift-3-indexing-model: forward the following methods.
   /*
-  @warn_unused_result
   func _customIndexOfEquatableElement(element: Iterator.Element) -> Index??
   */
 
@@ -362,20 +341,17 @@ internal final class _${Kind}Box<
 > : _Any${Kind}Box<S.Iterator.Element> {
   internal typealias Element = S.Iterator.Element
 
-  @warn_unused_result
   internal override func _makeIterator() -> AnyIterator<Element> {
     return AnyIterator(_base.makeIterator())
   }
   internal override var _underestimatedCount: Int {
     return _base.underestimatedCount
   }
-  @warn_unused_result
   internal override func _map<T>(
     _ transform: @noescape (Element) throws -> T
   ) rethrows -> [T] {
     return try _base.map(transform)
   }
-  @warn_unused_result
   internal override func _filter(
     _ includeElement: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
@@ -386,45 +362,36 @@ internal final class _${Kind}Box<
   ) rethrows {
     return try _base.forEach(body)
   }
-  @warn_unused_result
   internal override func __customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     return _base._customContainsEquatableElement(element)
   }
-  @warn_unused_result
   internal override func __preprocessingPass<R>(
     _ preprocess: @noescape () throws -> R
   ) rethrows -> R? {
     return try _base._preprocessingPass(preprocess)
   }
-  @warn_unused_result
   internal override func __copyToNativeArrayBuffer() -> _ContiguousArrayStorageBase {
     return _base._copyToNativeArrayBuffer()._storage
   }
-  @warn_unused_result
   internal override func __copyContents(initializing ptr: UnsafeMutablePointer<Element>)
     -> UnsafeMutablePointer<Element> {
     return _base._copyContents(initializing: ptr)
   }
-  @warn_unused_result
   internal override func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.dropFirst(n))
   }
-  @warn_unused_result
   internal override func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.dropLast(n))
   }
-  @warn_unused_result
   internal override func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.prefix(maxLength))
   }
-  @warn_unused_result
   internal override func _suffix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.suffix(maxLength))
   }
 %   for ResultKind in EqualAndWeakerKinds:
-  @warn_unused_result
   internal override func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     isSeparator: @noescape (Element) throws -> Bool
@@ -472,7 +439,6 @@ internal final class _${Kind}Box<
     )
   }
 
-  @warn_unused_result
   internal override func _index(after position: _AnyIndexBox) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(after: _unbox(position)))
   }
@@ -484,14 +450,12 @@ internal final class _${Kind}Box<
     fatalError("Index type mismatch!")
   }
 
-  @warn_unused_result
   internal override func _index(
     _ i: _AnyIndexBox, offsetBy n: IntMax
   ) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
   }
 
-  @warn_unused_result
   internal override func _index(
     _ i: _AnyIndexBox,
     offsetBy n: IntMax,
@@ -525,7 +489,6 @@ internal final class _${Kind}Box<
     fatalError("Index type mismatch!")
   }
 
-  @warn_unused_result
   internal override func _distance(
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
@@ -542,7 +505,6 @@ internal final class _${Kind}Box<
   }
 
 %     if Kind in ['BidirectionalCollection', 'RandomAccessCollection']:
-  @warn_unused_result
   internal override func _index(before position: _AnyIndexBox) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(before: _unbox(position)))
   }
@@ -622,7 +584,6 @@ extension Any${Kind} {
 %   end
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   public func makeIterator() -> AnyIterator<Element> {
     return _box._makeIterator()
   }
@@ -631,14 +592,12 @@ extension Any${Kind} {
     return _box._underestimatedCount
   }
 
-  @warn_unused_result
   public func map<T>(
     _ transform: @noescape (Element) throws -> T
   ) rethrows -> [T] {
     return try _box._map(transform)
   }
 
-  @warn_unused_result
   public func filter(
     _ includeElement: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
@@ -651,27 +610,22 @@ extension Any${Kind} {
     return try _box._forEach(body)
   }
 
-  @warn_unused_result
   public func dropFirst(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropFirst(n))
   }
 
-  @warn_unused_result
   public func dropLast(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropLast(n))
   }
 
-  @warn_unused_result
   public func prefix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._prefix(maxLength))
   }
 
-  @warn_unused_result
   public func suffix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._suffix(maxLength))
   }
 
-  @warn_unused_result
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
@@ -683,19 +637,16 @@ extension Any${Kind} {
       isSeparator: isSeparator)
   }
 
-  @warn_unused_result
   public func _preprocessingPass<R>(
     _ preprocess: @noescape () throws -> R
   ) rethrows -> R? {
     return try _box.__preprocessingPass(preprocess)
   }
 
-  @warn_unused_result
   public func _copyToNativeArrayBuffer() -> _ContiguousArrayBuffer<Element> {
     return _ContiguousArrayBuffer(self._box.__copyToNativeArrayBuffer())
   }
 
-  @warn_unused_result
   public func _copyContents(initializing ptr: UnsafeMutablePointer<Element>)
     -> UnsafeMutablePointer<Element> {
     return _box.__copyContents(initializing: ptr)
@@ -709,25 +660,18 @@ extension Any${Kind} {
 internal protocol _AnyIndexBox : class {
   var _typeID: ObjectIdentifier { get }
 
-  @warn_unused_result
   func _unbox<T : Comparable>() -> T?
 
-  @warn_unused_result
   func _equal(to rhs: _AnyIndexBox) -> Bool
 
-  @warn_unused_result
   func _notEqual(to rhs: _AnyIndexBox) -> Bool
 
-  @warn_unused_result
   func _less(than rhs: _AnyIndexBox) -> Bool
 
-  @warn_unused_result
   func _lessOrEqual(to rhs: _AnyIndexBox) -> Bool
 
-  @warn_unused_result
   func _greater(than rhs: _AnyIndexBox) -> Bool
 
-  @warn_unused_result
   func _greaterOrEqual(to rhs: _AnyIndexBox) -> Bool
 }
 
@@ -740,7 +684,6 @@ internal final class _IndexBox<
     self._base = _base
   }
 
-  @warn_unused_result
   internal func _unsafeUnbox(_ other: _AnyIndexBox) -> BaseIndex {
     return unsafeDowncast(other, to: _IndexBox.self)._base
   }
@@ -749,37 +692,30 @@ internal final class _IndexBox<
     return Swift._typeID(self)
   }
 
-  @warn_unused_result
   internal func _unbox<T : Comparable>() -> T? {
     return (self as _AnyIndexBox as? _IndexBox<T>)?._base
   }
 
-  @warn_unused_result
   internal func _equal(to rhs: _AnyIndexBox) -> Bool {
     return _base == _unsafeUnbox(rhs)
   }
 
-  @warn_unused_result
   internal func _notEqual(to rhs: _AnyIndexBox) -> Bool {
     return _base != _unsafeUnbox(rhs)
   }
 
-  @warn_unused_result
   internal func _less(than rhs: _AnyIndexBox) -> Bool {
     return _base < _unsafeUnbox(rhs)
   }
 
-  @warn_unused_result
   internal func _lessOrEqual(to rhs: _AnyIndexBox) -> Bool {
     return _base <= _unsafeUnbox(rhs)
   }
 
-  @warn_unused_result
   internal func _greater(than rhs: _AnyIndexBox) -> Bool {
     return _base > _unsafeUnbox(rhs)
   }
 
-  @warn_unused_result
   internal func _greaterOrEqual(to rhs: _AnyIndexBox) -> Bool {
     return _base >= _unsafeUnbox(rhs)
   }
@@ -810,37 +746,31 @@ public struct AnyIndex : Comparable {
 ///
 /// - Precondition: The types of indices wrapped by `lhs` and `rhs` are
 ///   identical.
-@warn_unused_result
 public func == (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
   _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._equal(to: rhs._box)
 }
 
-@warn_unused_result
 public func != (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
   _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._notEqual(to: rhs._box)
 }
 
-@warn_unused_result
 public func < (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
   _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._less(than: rhs._box)
 }
 
-@warn_unused_result
 public func <= (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
   _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._lessOrEqual(to: rhs._box)
 }
 
-@warn_unused_result
 public func > (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
   _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._greater(than: rhs._box)
 }
 
-@warn_unused_result
 public func >= (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
   _precondition(lhs._typeID == rhs._typeID, "base index types differ")
   return lhs._box._greaterOrEqual(to: rhs._box)
@@ -862,7 +792,6 @@ public protocol AnyCollectionProtocol : Collection {
 }
 
 /// Returns `true` iff `lhs` and `rhs` store the same underlying collection.
-@warn_unused_result
 public func === <
   L : AnyCollectionProtocol, R : AnyCollectionProtocol
 >(lhs: L, rhs: R) -> Bool {
@@ -870,7 +799,6 @@ public func === <
 }
 
 /// Returns `false` iff `lhs` and `rhs` store the same underlying collection.
-@warn_unused_result
 public func !== <
   L : AnyCollectionProtocol, R : AnyCollectionProtocol
 >(lhs: L, rhs: R) -> Bool {
@@ -1002,7 +930,6 @@ public struct ${Self}<Element>
     // range check for QoI purposes.
   }
 
-  @warn_unused_result
   public func index(after i: AnyIndex) -> AnyIndex {
     return AnyIndex(_box: _box._index(after: i._box))
   }
@@ -1016,12 +943,10 @@ public struct ${Self}<Element>
     }
   }
 
-  @warn_unused_result
   public func index(_ i: AnyIndex, offsetBy n: IntMax) -> AnyIndex {
     return AnyIndex(_box: _box._index(i._box, offsetBy: n))
   }
 
-  @warn_unused_result
   public func index(
     _ i: AnyIndex,
     offsetBy n: IntMax,
@@ -1055,7 +980,6 @@ public struct ${Self}<Element>
     return false
   }
 
-  @warn_unused_result
   public func distance(from start: AnyIndex, to end: AnyIndex) -> IntMax {
     return _box._distance(from: start._box, to: end._box)
   }

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -113,7 +113,6 @@ public struct LazyFilterIndex<Base : Collection> : Comparable {
   public let base: Base.Index
 }
 
-@warn_unused_result
 public func == <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
@@ -121,7 +120,6 @@ public func == <Base : Collection>(
   return lhs.base == rhs.base
 }
 
-@warn_unused_result
 public func != <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
@@ -129,7 +127,6 @@ public func != <Base : Collection>(
   return lhs.base != rhs.base
 }
 
-@warn_unused_result
 public func < <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
@@ -137,7 +134,6 @@ public func < <Base : Collection>(
   return lhs.base < rhs.base
 }
 
-@warn_unused_result
 public func <= <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
@@ -145,7 +141,6 @@ public func <= <Base : Collection>(
   return lhs.base <= rhs.base
 }
 
-@warn_unused_result
 public func >= <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
@@ -153,7 +148,6 @@ public func >= <Base : Collection>(
   return lhs.base >= rhs.base
 }
 
-@warn_unused_result
 public func > <Base : Collection>(
   lhs: LazyFilterIndex<Base>,
   rhs: LazyFilterIndex<Base>
@@ -227,7 +221,6 @@ public struct ${Self}<
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     var i = i
     formIndex(after: &i)
@@ -245,7 +238,6 @@ public struct ${Self}<
   }
 
 %   if Traversal == 'Bidirectional':
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     var i = i
     formIndex(before: &i)
@@ -306,7 +298,6 @@ extension LazySequenceProtocol {
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
-  @warn_unused_result
   public func filter(
     _ predicate: (Elements.Iterator.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
@@ -328,7 +319,6 @@ extension LazyCollectionProtocol
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
-  @warn_unused_result
   public func filter(
     _ predicate: (Elements.Iterator.Element) -> Bool
   ) -> LazyFilter${collectionForTraversal(Traversal)}<Self.Elements> {

--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -69,7 +69,6 @@ public protocol Integer : _Integer, Strideable {}
 public protocol _SignedInteger : _Integer, SignedNumber {
   /// Represent this number using Swift's widest native signed integer
   /// type.
-  @warn_unused_result
   func toIntMax() -> IntMax
 
   /// Convert from Swift's widest signed integer type, trapping on
@@ -117,7 +116,6 @@ public protocol _DisallowMixedSignArithmetic : _Integer {
 public protocol UnsignedInteger : _DisallowMixedSignArithmetic, Integer {
   /// Represent this number using Swift's widest native unsigned
   /// integer type.
-  @warn_unused_result
   func toUIntMax() -> UIntMax
 
   /// Convert from Swift's widest unsigned integer type, trapping on
@@ -147,7 +145,6 @@ extension UnsignedInteger {
 ///
 ///     func f(_ x: Int32) {}
 ///     func g(_ x: Int64) { f(numericCast(x)) }
-@warn_unused_result
 public func numericCast<
   T : _SignedInteger, U : _SignedInteger
 >(_ x: T) -> U {
@@ -162,7 +159,6 @@ public func numericCast<
 ///
 ///     func f(_ x: UInt32) {}
 ///     func g(_ x: UInt64) { f(numericCast(x)) }
-@warn_unused_result
 public func numericCast<
   T : UnsignedInteger, U : UnsignedInteger
 >(_ x: T) -> U {
@@ -177,7 +173,6 @@ public func numericCast<
 ///
 ///     func f(_ x: UInt32) {}
 ///     func g(_ x: Int64) { f(numericCast(x)) }
-@warn_unused_result
 public func numericCast<
   T : _SignedInteger, U : UnsignedInteger
 >(_ x: T) -> U {
@@ -192,7 +187,6 @@ public func numericCast<
 ///
 ///     func f(_ x: Int32) {}
 ///     func g(_ x: UInt64) { f(numericCast(x)) }
-@warn_unused_result
 public func numericCast<
 T : UnsignedInteger, U : _SignedInteger
 >(_ x: T) -> U {
@@ -673,7 +667,6 @@ public postfix func -- (x: inout ${Self}) -> ${Self} {
 /// Returns the argument and specifies that the value is not negative.
 /// It has only an effect if the argument is a load or call.
 @_transparent
-@warn_unused_result
 public func _assumeNonNegative(_ x: ${Self}) -> ${Self} {
   _sanityCheck(x >= 0)
   return ${Self}(Builtin.assumeNonNegative_${BuiltinName}(x._value))

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -17,7 +17,6 @@ extension LazySequenceProtocol {
   ///     self.map(transform).flatten()
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func flatMap<SegmentOfResult : Sequence>(
     _ transform: (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazySequence<
@@ -33,7 +32,6 @@ extension LazySequenceProtocol {
   ///
   /// - Parameter transform: A closure that accepts an element of this
   /// sequence as its argument and returns an optional value.
-  @warn_unused_result
   public func flatMap<ElementOfResult>(
     _ transform: (Elements.Iterator.Element) -> ElementOfResult?
   ) -> LazyMapSequence<
@@ -52,7 +50,6 @@ extension LazyCollectionProtocol {
   ///     self.map(transform).flatten()
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func flatMap<SegmentOfResult : Collection>(
     _ transform: (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
@@ -70,7 +67,6 @@ extension LazyCollectionProtocol {
   ///
   /// - Parameter transform: A closure that accepts an element of this
   /// collection as its argument and returns an optional value.
-  @warn_unused_result
   public func flatMap<ElementOfResult>(
     _ transform: (Elements.Iterator.Element) -> ElementOfResult?
   ) -> LazyMapCollection<
@@ -93,7 +89,6 @@ extension LazyCollectionProtocol
   ///     self.map(transform).flatten()
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func flatMap<
     SegmentOfResult : Collection
     where SegmentOfResult : BidirectionalCollection

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -124,7 +124,6 @@ extension Sequence where Iterator.Element : Sequence {
   ///   sequence of sequences.
   ///
   /// - SeeAlso: `flatMap(_:)`, `joined(separator:)`
-  @warn_unused_result
   public func flatten() -> FlattenSequence<Self> {
     return FlattenSequence(_base: self)
   }
@@ -136,7 +135,6 @@ extension LazySequenceProtocol
   Iterator.Element : Sequence {
 
   /// A concatenation of the elements of `self`.
-  @warn_unused_result
   public func flatten() -> LazySequence<
     FlattenSequence<Elements>
   > {
@@ -178,7 +176,6 @@ public struct ${Index}<
   internal let _inner: BaseElements.Iterator.Element.Index?
 }
 
-@warn_unused_result
 public func == <BaseElements> (
   lhs: ${Index}<BaseElements>, 
   rhs: ${Index}<BaseElements>
@@ -186,7 +183,6 @@ public func == <BaseElements> (
   return lhs._outer == rhs._outer && lhs._inner == rhs._inner
 }
 
-@warn_unused_result
 public func < <BaseElements> (
   lhs: ${Index}<BaseElements>, 
   rhs: ${Index}<BaseElements>
@@ -284,7 +280,6 @@ public struct ${Collection}<
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     let innerCollection = _base[i._outer]
     let nextInner = innerCollection.index(after: i._inner!)
@@ -306,7 +301,6 @@ public struct ${Collection}<
 
 % if traversal == 'Bidirectional':
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     var prevOuter = i._outer
     if prevOuter == _base.endIndex {
@@ -398,7 +392,6 @@ extension ${collectionForTraversal(traversal)}
   ///   collection of collections.
   ///
   /// - SeeAlso: `flatMap(_:)`, `joined(separator:)`
-  @warn_unused_result
   public func flatten() -> ${Collection}<Self> {
     return ${Collection}(self)
   }
@@ -412,7 +405,6 @@ extension LazyCollectionProtocol
   ${constraints % {'Base': 'Elements.'}},
   Iterator.Element == Elements.Iterator.Element {
   /// A concatenation of the elements of `self`.
-  @warn_unused_result
   public func flatten() -> LazyCollection<${Collection}<Elements>> {
     return ${Collection}(elements).lazy
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -234,7 +234,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// 754 addition operation.
   ///
   /// A default implementation is provided in terms of `add()`.
-  @warn_unused_result
   func adding(_ other: Self) -> Self
 
   /// Replace `self` with the sum of `self` and `other` rounded to a
@@ -242,7 +241,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   mutating func add(_ other: Self)
 
   /// Additive inverse of `self`.  Always exact.
-  @warn_unused_result
   func negated() -> Self
 
   /// Replace `self` with its additive inverse.
@@ -252,7 +250,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// representable value.  The IEEE 754 subtraction operation.
   ///
   /// A default implementation is provided in terms of `subtract()`.
-  @warn_unused_result
   func subtracting(_ other: Self) -> Self
 
   /// Replace `self` with the sum of `self` and the additive inverse of `other`
@@ -263,7 +260,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// IEEE 754 multiply operation.
   ///
   /// A default implementation is provided in terms of `multiply(by:)`.
-  @warn_unused_result
   func multiplied(by other: Self) -> Self
 
   /// Replace `self` with the product of `self` and `other` rounded to a
@@ -274,7 +270,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// IEEE 754 divide operation.
   ///
   /// A default implementation is provided in terms of `divide(by:)`.
-  @warn_unused_result
   func divided(by other: Self) -> Self
 
   /// Replace `self` with the quotient of `self` and `other` rounded to a
@@ -296,7 +291,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// `r` satisfies `-|other|/2 <= r` and `r <= |other|/2`.
   ///
   /// `remainder` is always exact.
-  @warn_unused_result
   func remainder(dividingBy other: Self) -> Self
 
   /// Mutating form of `remainder`.
@@ -312,7 +306,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// of `self/other`.
   ///
   /// `truncatingRemainder` is always exact.
-  @warn_unused_result
   func truncatingRemainder(dividingBy other: Self) -> Self
 
   /// Mutating form of `truncatingRemainder`.
@@ -321,7 +314,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /* TODO: Need to call C sqrt and fma or llvm sqrt and fma intrinsics
    * for these.
   /// Square root of `self`.
-  @warn_unused_result
   func squareRoot() -> Self
 
   /// Mutating form of square root.
@@ -329,7 +321,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
 
   /// `self + lhs*rhs` computed without intermediate rounding.  Implements the
   /// IEEE 754 `fusedMultiplyAdd` operation.
-  @warn_unused_result
   func addingProduct(_ lhs: Self, _ rhs: Self) -> Self
 
   /// Fused multiply-add, accumulating the product of `lhs` and `rhs` to `self`.
@@ -345,7 +336,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// This function is an implementation hook to be used by the free function
   /// min(Self, Self) -> Self so that we get the IEEE 754 behavior with regard
   /// to NaNs.
-  @warn_unused_result
   static func minimum(_ x: Self, _ y: Self) -> Self
 
   /// The maximum of `x` and `y`.  Implements the IEEE 754 `maxNum` operation.
@@ -357,7 +347,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// This function is an implementation hook to be used by the free function
   /// max(Self, Self) -> Self so that we get the IEEE 754 behavior with regard
   /// to NaNs.
-  @warn_unused_result
   static func maximum(_ x: Self, _ y: Self) -> Self
 
   /// Whichever of `x` or `y` has lesser magnitude.  Implements the IEEE 754
@@ -366,7 +355,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// Returns `x` if abs(x) <= abs(y), `y` if abs(y) < abs(x), and whichever of
   /// `x` or `y` is a number if the other is NaN.  The result is NaN
   /// only if both arguments are NaN.
-  @warn_unused_result
   static func minimumMagnitude(_ x: Self, _ y: Self) -> Self
 
   /// Whichever of `x` or `y` has greater magnitude.  Implements the IEEE 754
@@ -375,7 +363,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// Returns `x` if abs(x) >= abs(y), `y` if abs(y) > abs(x), and whichever of
   /// `x` or `y` is a number if the other is NaN.  The result is NaN
   /// only if both arguments are NaN.
-  @warn_unused_result
   static func maximumMagnitude(_ x: Self, _ y: Self) -> Self
 
   /// The least representable value that compares greater than `self`.
@@ -396,7 +383,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   ///
   /// -0 compares equal to +0, and NaN compares not equal to anything,
   /// including itself.
-  @warn_unused_result
   func isEqual(to other: Self) -> Bool
 
   /// IEEE 754 less-than predicate.
@@ -404,7 +390,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// NaN compares not less than anything.  -infinity compares less than
   /// all values except for itself and NaN.  Everything except for NaN and
   /// +infinity compares less than +infinity.
-  @warn_unused_result
   func isLess(than other: Self) -> Bool
 
   /// IEEE 754 less-than-or-equal predicate.
@@ -421,7 +406,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// Note that this predicate does not impose a total order.  The
   /// `isTotallyOrdered` predicate refines this relation so that all values
   /// are totally ordered.
-  @warn_unused_result
   func isLessThanOrEqualTo(_ other: Self) -> Bool
 
   /// True if and only if `self` precedes `other` in the IEEE 754 total order
@@ -431,7 +415,6 @@ public protocol FloatingPoint: Comparable, IntegerLiteralConvertible,
   /// values of type `Self`, including non-canonical encodings, signed zeros,
   /// and NaNs.  Because it is used much less frequently than the usual
   /// comparisons, there is no operator form of this relation.
-  @warn_unused_result
   func isTotallyOrdered(below other: Self) -> Bool
 
   /// True if and only if `self` is normal.
@@ -509,13 +492,11 @@ public enum FloatingPointClassification {
 }
 
 @_transparent
-@warn_unused_result
 public prefix func +<T : FloatingPoint>(x: T) -> T {
   return x
 }
 
 @_transparent
-@warn_unused_result
 public prefix func -<T : FloatingPoint>(x: T) -> T {
   return x.negated()
 }
@@ -531,7 +512,6 @@ binary_arithmetic = [
 
 %for op in binary_arithmetic:
 @_transparent
-@warn_unused_result
 public func ${op[0]}<T : FloatingPoint>(lhs: T, rhs: T) -> T {
   return lhs.${op[1]}(${op[3]+': ' if op[3] else ''}rhs)
 }
@@ -545,38 +525,32 @@ public func ${op[0]}=<T : FloatingPoint>(lhs: inout T, rhs: T) {
 
 /*  TODO: uncomment once implemented.
 @_transparent
-@warn_unused_result
 public func sqrt<T : FloatingPoint>(_ rhs: T) -> T {
   return rhs.squareRoot()
 }
 */
 
 @_transparent
-@warn_unused_result
 public func ==<T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
   return lhs.isEqual(to: rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func < <T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
   return lhs.isLess(than: rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func <= <T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
   return lhs.isLessThanOrEqualTo(rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func > <T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
   return rhs.isLess(than: lhs)
 }
 
 @_transparent
-@warn_unused_result
 public func >= <T : FloatingPoint>(lhs: T, rhs: T) -> Bool {
   return rhs.isLessThanOrEqualTo(lhs)
 }
@@ -686,16 +660,12 @@ public protocol BinaryFloatingPoint: FloatingPoint, FloatLiteralConvertible {
 
   /*  TODO: Implement these once it becomes possible to do so.  (Requires
    *  revised Integer protocol).
-  @warn_unused_result
   func isEqual<Other: BinaryFloatingPoint>(to other: Other) -> Bool
 
-  @warn_unused_result
   func isLess<Other: BinaryFloatingPoint>(than other: Other) -> Bool
 
-  @warn_unused_result
   func isLessThanOrEqualTo<Other: BinaryFloatingPoint>(other: Other) -> Bool
 
-  @warn_unused_result
   func isTotallyOrdered<Other: BinaryFloatingPoint>(below other: Other) -> Bool
   */
 }
@@ -828,7 +798,6 @@ extension BinaryFloatingPoint {
   //  subnormal when converted to the other type.  This is an extremely niche
   //  corner case, however (it cannot occur with the usual IEEE 754 floating-
   //  point types).  Nonetheless, this should be fixed someday.
-  @warn_unused_result
   public func isEqual<Other: BinaryFloatingPoint>(to other: Other) -> Bool {
     if Self.significandBitCount >= Other.significandBitCount {
       return self.isEqual(to: Self(other))
@@ -836,7 +805,6 @@ extension BinaryFloatingPoint {
     return other.isEqual(to: Other(self))
   }
 
-  @warn_unused_result
   public func isLess<Other: BinaryFloatingPoint>(than other: Other) -> Bool {
     if Self.significandBitCount >= Other.significandBitCount {
       return self.isLess(than: Self(other))
@@ -844,7 +812,6 @@ extension BinaryFloatingPoint {
     return Other(self).isLess(than: other)
   }
 
-  @warn_unused_result
   public func isLessThanOrEqualTo<Other: BinaryFloatingPoint>(other: Other) -> Bool {
     if Self.significandBitCount >= Other.significandBitCount {
       return self.isLessThanOrEqualTo(Self(other))
@@ -852,7 +819,6 @@ extension BinaryFloatingPoint {
     return Other(self).isLessThanOrEqualTo(other)
   }
 
-  @warn_unused_result
   public func isTotallyOrdered<Other: BinaryFloatingPoint>(before other: Other) -> Bool {
     if Self.significandBitCount >= Other.significandBitCount {
       return self.totalOrder(with: Self(other))

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -30,7 +30,6 @@ cFuncSuffix2 = {32: 'f', 64: 'd', 80: 'ld'}
 
 /// Returns `true` iff isspace(u) would return nonzero when the current
 /// locale is the C locale.
-@warn_unused_result
 internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
   return "\t\n\u{b}\u{c}\r ".utf16.contains(u)
 }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -539,19 +539,16 @@ extension ${Self}: BinaryFloatingPoint {
   */
 
   @_transparent
-  @warn_unused_result
   public func isEqual(to other: ${Self}) -> Bool {
     return Bool(Builtin.fcmp_oeq_FPIEEE${bits}(self._value, other._value))
   }
 
   @_transparent
-  @warn_unused_result
   public func isLess(than other: ${Self}) -> Bool {
     return Bool(Builtin.fcmp_olt_FPIEEE${bits}(self._value, other._value))
   }
 
   @_transparent
-  @warn_unused_result
   public func isLessThanOrEqualTo(_ other: ${Self}) -> Bool {
     return Bool(Builtin.fcmp_ole_FPIEEE${bits}(self._value, other._value))
   }
@@ -708,20 +705,17 @@ extension ${Self} : Hashable {
 extension ${Self} : AbsoluteValuable {
   /// Returns the absolute value of `x`.
   @_transparent
-  @warn_unused_result
   public static func abs(_ x: ${Self}) -> ${Self} {
     return ${Self}(_bits: Builtin.int_fabs_FPIEEE${bits}(x._value))
   }
 }
 
 @_transparent
-@warn_unused_result
 public prefix func +(x: ${Self}) -> ${Self} {
   return x
 }
 
 @_transparent
-@warn_unused_result
 public prefix func -(x: ${Self}) -> ${Self} {
   return ${Self}(_bits: Builtin.fneg_FPIEEE${bits}(x._value))
 }
@@ -782,25 +776,21 @@ extension ${Self} {
 //  definitions in the standard lib, or both.
 
 @_transparent
-@warn_unused_result
 public func +(lhs: ${Self}, rhs: ${Self}) -> ${Self} {
   return lhs.adding(rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func -(lhs: ${Self}, rhs: ${Self}) -> ${Self} {
   return lhs.subtracting(rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func *(lhs: ${Self}, rhs: ${Self}) -> ${Self} {
   return lhs.multiplied(by: rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func /(lhs: ${Self}, rhs: ${Self}) -> ${Self} {
   return lhs.divided(by: rhs)
 }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -209,21 +209,16 @@ internal protocol _HashStorage {
   var startIndex: Index { get }
   var endIndex: Index { get }
 
-  @warn_unused_result
   func index(after i: Index) -> Index
 
   func formIndex(after i: inout Index)
 
-  @warn_unused_result
   func index(forKey key: Key) -> Index?
 
-  @warn_unused_result
   func assertingGet(_ i: Index) -> SequenceElement
 
-  @warn_unused_result
   func assertingGet(_ key: Key) -> Value
 
-  @warn_unused_result
   func maybeGet(_ key: Key) -> Value?
 
   @discardableResult
@@ -245,7 +240,6 @@ internal protocol _HashStorage {
 
   var count: Int { get }
 
-  @warn_unused_result
   static func fromArray(_ elements: [SequenceElementWithoutLabels]) -> Self
 }
 
@@ -512,7 +506,6 @@ public struct Set<Element : Hashable> :
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     return i.successor()
   }
@@ -535,7 +528,6 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter member: An element to look for in the set.
   /// - Returns: `true` if `member` exists in the set; otherwise, `false`.
-  @warn_unused_result
   public func contains(_ member: Element) -> Bool {
     return _variantStorage.maybeGet(member) != nil
   }
@@ -546,7 +538,6 @@ public struct Set<Element : Hashable> :
   /// - Parameter member: An element to search for in the set.
   /// - Returns: The index of `member` if it exists in the set; otherwise,
   ///   `nil`.
-  @warn_unused_result
   public func index(of member: Element) -> Index? {
     return _variantStorage.index(forKey: member)
   }
@@ -792,7 +783,6 @@ public struct Set<Element : Hashable> :
   ///   must be finite.
   /// - Returns: `true` if the set is a subset of `possibleSuperset`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isSubset<
     S : Sequence where S.Iterator.Element == Element
   >(of possibleSuperset: S) -> Bool {
@@ -821,7 +811,6 @@ public struct Set<Element : Hashable> :
   ///   `possibleStrictSuperset` must be finite.
   /// - Returns: `true` is the set is strict subset of
   ///   `possibleStrictSuperset`; otherwise, `false`.
-  @warn_unused_result
   public func isStrictSubset<
     S : Sequence where S.Iterator.Element == Element
   >(of possibleStrictSuperset: S) -> Bool {
@@ -845,7 +834,6 @@ public struct Set<Element : Hashable> :
   ///   be finite.
   /// - Returns: `true` if the set is a superset of `possibleSubset`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isSuperset<
     S : Sequence where S.Iterator.Element == Element
   >(of possibleSubset: S) -> Bool {
@@ -873,7 +861,6 @@ public struct Set<Element : Hashable> :
   ///   `possibleStrictSubset` must be finite.
   /// - Returns: `true` if the set is a strict superset of
   ///   `possibleStrictSubset`; otherwise, `false`.
-  @warn_unused_result
   public func isStrictSuperset<
     S : Sequence where S.Iterator.Element == Element
   >(of possibleStrictSubset: S) -> Bool {
@@ -894,7 +881,6 @@ public struct Set<Element : Hashable> :
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: `true` if the set has no elements in common with `other`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isDisjoint<
     S : Sequence where S.Iterator.Element == Element
   >(with other: S) -> Bool {
@@ -926,7 +912,6 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set with the unique elements of this set and `other`.
-  @warn_unused_result
   public func union<
     S : Sequence where S.Iterator.Element == Element
   >(_ other: S) -> Set<Element> {
@@ -969,7 +954,6 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set.
-  @warn_unused_result
   public func subtracting<
     S : Sequence where S.Iterator.Element == Element
   >(_ other: S) -> Set<Element> {
@@ -1022,7 +1006,6 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set.
-  @warn_unused_result
   public func intersection<
     S : Sequence where S.Iterator.Element == Element
   >(_ other: S) -> Set<Element> {
@@ -1073,7 +1056,6 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set.
-  @warn_unused_result
   public func symmetricDifference<
     S : Sequence where S.Iterator.Element == Element
   >(_ other: S) -> Set<Element> {
@@ -1121,12 +1103,10 @@ public struct Set<Element : Hashable> :
   // `Sequence` conformance
   //
 
-  @warn_unused_result
   public func _customContainsEquatableElement(_ member: Element) -> Bool? {
     return contains(member)
   }
 
-  @warn_unused_result
   public func _customIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
@@ -1157,7 +1137,6 @@ public struct Set<Element : Hashable> :
 /// a set and some sequence (which may itself be a `Set`).
 ///
 /// (isSubset: lhs ⊂ rhs, isEqual: lhs ⊂ rhs and |lhs| = |rhs|)
-@warn_unused_result
 internal func _compareSets<Element>(_ lhs: Set<Element>, _ rhs: Set<Element>)
   -> (isSubset: Bool, isEqual: Bool) {
   // FIXME(performance): performance could be better if we start by comparing
@@ -1177,7 +1156,6 @@ internal func _compareSets<Element>(_ lhs: Set<Element>, _ rhs: Set<Element>)
 ///   - rhs: Another set.
 /// - Returns: `true` if the `lhs` and `rhs` have the same elements; otherwise,
 ///   `false`.
-@warn_unused_result
 public func == <Element : Hashable>(lhs: Set<Element>, rhs: Set<Element>) -> Bool {
   switch (lhs._variantStorage, rhs._variantStorage) {
   case (.native(let lhsNativeOwner), .native(let rhsNativeOwner)):
@@ -1248,7 +1226,6 @@ public func == <Element : Hashable>(lhs: Set<Element>, rhs: Set<Element>) -> Boo
 }
 
 extension Set : CustomStringConvertible, CustomDebugStringConvertible {
-  @warn_unused_result
   private func makeDescription(isDebug: Bool) -> String {
     var result = isDebug ? "Set([" : "["
     var first = true
@@ -1298,7 +1275,6 @@ internal func _stdlib_NSSet_allObjects(_ nss: _NSSet) ->
 ///
 /// - Precondition: `BaseValue` is a base class or base `@objc`
 ///   protocol (such as `AnyObject`) of `DerivedValue`.
-@warn_unused_result
 public func _setUpCast<DerivedValue, BaseValue>(_ source: Set<DerivedValue>)
   -> Set<BaseValue> {
   _sanityCheck(_isClassOrObjCExistential(BaseValue.self))
@@ -1317,7 +1293,6 @@ public func _setUpCast<DerivedValue, BaseValue>(_ source: Set<DerivedValue>)
 ///
 /// - Precondition: `SwiftValue` is bridged to Objective-C
 ///   and requires non-trivial bridging.
-@warn_unused_result
 public func _setBridgeToObjectiveC<SwiftValue, ObjCValue>(
   _ source: Set<SwiftValue>
 ) -> Set<ObjCValue> {
@@ -1350,7 +1325,6 @@ public func _setBridgeToObjectiveC<SwiftValue, ObjCValue>(
 ///
 /// - Precondition: `DerivedValue` is a subtype of `BaseValue` and both
 ///   are reference types.
-@warn_unused_result
 public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
   -> Set<DerivedValue> {
 
@@ -1377,7 +1351,6 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
 ///
 /// - Precondition: `DerivedValue` is a subtype of `BaseValue` and both
 ///   are reference types.
-@warn_unused_result
 public func _setDownCastConditional<BaseValue, DerivedValue>(
   _ source: Set<BaseValue>
 ) -> Set<DerivedValue>? {
@@ -1399,7 +1372,6 @@ public func _setDownCastConditional<BaseValue, DerivedValue>(
 ///
 /// - Precondition: At least one of `SwiftValue` is a bridged value
 ///   type, and the corresponding `ObjCValue` is a reference type.
-@warn_unused_result
 public func _setBridgeFromObjectiveC<ObjCValue, SwiftValue>(
   _ source: Set<ObjCValue>
 ) -> Set<SwiftValue> {
@@ -1415,7 +1387,6 @@ public func _setBridgeFromObjectiveC<ObjCValue, SwiftValue>(
 ///
 /// - Precondition: At least one of `SwiftValue` is a bridged value
 ///   type, and the corresponding `ObjCValue` is a reference type.
-@warn_unused_result
 public func _setBridgeFromObjectiveCConditional<
   ObjCValue, SwiftValue
 >(
@@ -1723,7 +1694,6 @@ public struct Dictionary<Key : Hashable, Value> :
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     return i.successor()
   }
@@ -1742,7 +1712,6 @@ public struct Dictionary<Key : Hashable, Value> :
   /// - Parameter key: The key to find in the dictionary.
   /// - Returns: The index for `key` and its associated value if `key` is in
   ///   the dictionary; otherwise, `nil`.
-  @warn_unused_result
   @inline(__always)
   public func index(forKey key: Key) -> Index? {
     // Complexity: amortized O(1) for native storage, O(N) when wrapping an
@@ -2073,7 +2042,6 @@ public struct Dictionary<Key : Hashable, Value> :
 
 }
 
-@warn_unused_result
 public func == <Key : Equatable, Value : Equatable>(
   lhs: [Key : Value],
   rhs: [Key : Value]
@@ -2154,7 +2122,6 @@ public func == <Key : Equatable, Value : Equatable>(
   }
 }
 
-@warn_unused_result
 public func != <Key : Equatable, Value : Equatable>(
   lhs: [Key : Value],
   rhs: [Key : Value]
@@ -2163,7 +2130,6 @@ public func != <Key : Equatable, Value : Equatable>(
 }
 
 extension Dictionary : CustomStringConvertible, CustomDebugStringConvertible {
-  @warn_unused_result
   internal func _makeDescription() -> String {
     if count == 0 {
       return "[:]"
@@ -2200,7 +2166,6 @@ extension Dictionary : CustomStringConvertible, CustomDebugStringConvertible {
 #if _runtime(_ObjC)
 /// Equivalent to `NSDictionary.allKeys`, but does not leave objects on the
 /// autorelease pool.
-@warn_unused_result
 internal func _stdlib_NSDictionary_allKeys(_ nsd: _NSDictionary)
     -> _HeapBuffer<Int, AnyObject> {
   let count = nsd.count
@@ -2220,7 +2185,6 @@ internal func _stdlib_NSDictionary_allKeys(_ nsd: _NSDictionary)
 /// - Precondition: `BaseKey` and `BaseValue` are base classes or base `@objc`
 ///   protocols (such as `AnyObject`) of `DerivedKey` and `DerivedValue`,
 ///   respectively.
-@warn_unused_result
 public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
     _ source: Dictionary<DerivedKey, DerivedValue>
 ) -> Dictionary<BaseKey, BaseValue> {
@@ -2246,7 +2210,6 @@ public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
 ///
 /// - Precondition: `SwiftKey` and `SwiftValue` are bridged to Objective-C,
 ///   and at least one of them requires non-trivial bridging.
-@warn_unused_result
 @inline(never)
 @_semantics("stdlib_binary_only")
 public func _dictionaryBridgeToObjectiveC<
@@ -2308,7 +2271,6 @@ public func _dictionaryBridgeToObjectiveC<
 ///
 /// - Precondition: `DerivedKey` is a subtype of `BaseKey`, `DerivedValue` is
 ///   a subtype of `BaseValue`, and all of these types are reference types.
-@warn_unused_result
 public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
   _ source: Dictionary<BaseKey, BaseValue>
 ) -> Dictionary<DerivedKey, DerivedValue> {
@@ -2348,7 +2310,6 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
 ///
 /// - Precondition: `DerivedKey` is a subtype of `BaseKey`, `DerivedValue` is
 ///   a subtype of `BaseValue`, and all of these types are reference types.
-@warn_unused_result
 public func _dictionaryDownCastConditional<
   BaseKey, BaseValue, DerivedKey, DerivedValue
 >(
@@ -2379,7 +2340,6 @@ public func _dictionaryDownCastConditional<
 ///
 /// - Precondition: At least one of `SwiftKey` or `SwiftValue` is a bridged value
 ///   type, and the corresponding `ObjCKey` or `ObjCValue` is a reference type.
-@warn_unused_result
 public func _dictionaryBridgeFromObjectiveC<
   ObjCKey, ObjCValue, SwiftKey, SwiftValue
 >(
@@ -2398,7 +2358,6 @@ public func _dictionaryBridgeFromObjectiveC<
 ///
 /// - Precondition: At least one of `SwiftKey` or `SwiftValue` is a bridged value
 ///   type, and the corresponding `ObjCKey` or `ObjCValue` is a reference type.
-@warn_unused_result
 public func _dictionaryBridgeFromObjectiveCConditional<
   ObjCKey, ObjCValue, SwiftKey, SwiftValue
 >(
@@ -2502,17 +2461,14 @@ internal struct _BitMap {
   internal let bitCount: Int
 
   // Note: We use UInt here to get unsigned math (shifts).
-  @warn_unused_result
   internal static func wordIndex(_ i: UInt) -> UInt {
     return i / UInt._sizeInBits
   }
 
-  @warn_unused_result
   internal static func bitIndex(_ i: UInt) -> UInt {
     return i % UInt._sizeInBits
   }
 
-  @warn_unused_result
   internal static func wordsFor(_ bitCount: Int) -> Int {
     return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
   }
@@ -2523,7 +2479,6 @@ internal struct _BitMap {
   }
 
   internal var numberOfWords: Int {
-    @warn_unused_result
     get {
       return _BitMap.wordsFor(bitCount)
     }
@@ -2536,7 +2491,6 @@ internal struct _BitMap {
   }
 
   internal subscript(i: Int) -> Bool {
-    @warn_unused_result
     get {
       _sanityCheck(i < Int(bitCount) && i >= 0, "index out of bounds")
       let idx = UInt(i)
@@ -2593,7 +2547,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   /// Returns the bytes necessary to store a bit map of 'capacity' bytes and
   /// padding to align the start to word alignment.
-  @warn_unused_result
   internal static func bytesForBitMap(capacity: Int) -> Int {
     let numWords = _BitMap.wordsFor(capacity)
     return numWords * sizeof(UInt) + alignof(UInt)
@@ -2602,7 +2555,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   /// Returns the bytes necessary to store 'capacity' keys and padding to align
   /// the start to the alignment of the 'Key' type assuming a word aligned base
   /// address.
-  @warn_unused_result
   internal static func bytesForKeys(capacity: Int) -> Int {
     let padding = max(0, alignof(Key.self) - alignof(UInt))
     return strideof(Key.self) * capacity + padding
@@ -2614,7 +2566,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   /// alignment of a word.
 
 %if Self == 'Dictionary':
-  @warn_unused_result
   internal static func bytesForValues(capacity: Int) -> Int {
     let maxPrevAlignment = max(alignof(Key.self), alignof(UInt))
     let padding = max(0, alignof(Value.self) - maxPrevAlignment)
@@ -2623,7 +2574,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 %end
 
   internal var buffer: BufferPointer {
-    @warn_unused_result
     get {
       return BufferPointer(self)
     }
@@ -2641,7 +2591,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   @_versioned
   internal var _capacity: Int {
-    @warn_unused_result
     get {
       return _body.capacity
     }
@@ -2652,14 +2601,12 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
     set {
       _body.count = newValue
     }
-    @warn_unused_result
     get {
       return _body.count
     }
   }
 
   internal var _maxLoadFactorInverse : Double {
-    @warn_unused_result
     get {
       return _body.maxLoadFactorInverse
     }
@@ -2667,7 +2614,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
   internal
   var _initializedHashtableEntriesBitMapStorage: UnsafeMutablePointer<UInt> {
-    @warn_unused_result
     get {
       let start = UInt(Builtin.ptrtoint_Word(buffer._elementPointer._rawValue))
       let alignment = UInt(alignof(UInt))
@@ -2678,7 +2624,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
   }
 
   internal var _keys: UnsafeMutablePointer<Key> {
-    @warn_unused_result
     get {
       let start =
           UInt(Builtin.ptrtoint_Word(
@@ -2693,7 +2638,6 @@ final internal class _Native${Self}StorageImpl<${TypeParameters}> :
 
 %if Self == 'Dictionary':
   internal var _values: UnsafeMutablePointer<Value> {
-    @warn_unused_result
     get {
       let start = UInt(Builtin.ptrtoint_Word(_keys._rawValue)) &+
         UInt(_capacity) &* UInt(strideof(Key.self))
@@ -2810,7 +2754,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   @_transparent
   public // @testable
   var capacity: Int {
-    @warn_unused_result
     get {
       let result = buffer._capacity
       _fixLifetime(buffer)
@@ -2821,7 +2764,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   @_versioned
   @_transparent
   internal var count: Int {
-    @warn_unused_result
     get {
       let result = buffer._count
       _fixLifetime(buffer)
@@ -2835,7 +2777,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   @_transparent
   internal var maxLoadFactorInverse: Double {
-    @warn_unused_result
     get {
       let result = buffer._maxLoadFactorInverse
       _fixLifetime(buffer)
@@ -2844,7 +2785,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_versioned
-  @warn_unused_result
   @inline(__always)
   internal func key(at i: Int) -> Key {
     _precondition(i >= 0 && i < capacity)
@@ -2856,7 +2796,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_versioned
-  @warn_unused_result
   internal func isInitializedEntry(at i: Int) -> Bool {
     _precondition(i >= 0 && i < capacity)
     return initializedEntries[i]
@@ -2921,7 +2860,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   @_versioned
   @_transparent
-  @warn_unused_result
   internal func value(at i: Int) -> Value {
     _sanityCheck(isInitializedEntry(at: i))
 
@@ -2950,19 +2888,16 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_versioned
-  @warn_unused_result
   internal func _bucket(_ k: Key) -> Int {
     return _squeezeHashValue(k.hashValue, 0..<capacity)
   }
 
   @_versioned
-  @warn_unused_result
   internal func _index(after bucket: Int) -> Int {
     // Bucket is within 0 and capacity. Therefore adding 1 does not overflow.
     return (bucket &+ 1) & _bucketMask
   }
 
-  @warn_unused_result
   internal func _prev(_ bucket: Int) -> Int {
     // Bucket is not negative. Therefore subtracting 1 does not overflow.
     return (bucket &- 1) & _bucketMask
@@ -2973,7 +2908,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   /// If the key is not present, returns the position where it could be
   /// inserted.
   @_versioned
-  @warn_unused_result
   @inline(__always)
   internal func _find(_ key: Key, startBucket: Int)
     -> (pos: Index, found: Bool) {
@@ -2995,7 +2929,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_transparent
-  @warn_unused_result
   internal static func minimumCapacity(
     minimumCount: Int,
     maxLoadFactorInverse: Double
@@ -3063,7 +2996,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_versioned
-  @warn_unused_result
   internal func index(after i: Index) -> Index {
     return i.successor()
   }
@@ -3074,7 +3006,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_versioned
-  @warn_unused_result
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
     if count == 0 {
@@ -3085,7 +3016,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
     return found ? i : nil
   }
 
-  @warn_unused_result
   internal func assertingGet(_ i: Index) -> SequenceElement {
     _precondition(
       isInitializedEntry(at: i.offset),
@@ -3099,7 +3029,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
 
   }
 
-  @warn_unused_result
   internal func assertingGet(_ key: Key) -> Value {
     let (i, found) = _find(key, startBucket: _bucket(key))
     _precondition(found, "key not found")
@@ -3111,7 +3040,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
   }
 
   @_versioned
-  @warn_unused_result
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
     if count == 0 {
@@ -3161,7 +3089,6 @@ struct _Native${Self}Storage<${TypeParametersDecl}> :
       "don't call mutating methods on _Native${Self}Storage")
   }
 
-  @warn_unused_result
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
     -> _Native${Self}Storage<${TypeParameters}> {
 
@@ -3284,7 +3211,6 @@ internal struct _BridgedNative${Self}Storage {
   }
 
   @_transparent
-  @warn_unused_result
   internal func value(at i: Int) -> AnyObject {
     _sanityCheck(isInitializedEntry(at: i))
     let res = (values + i).pointee
@@ -3293,7 +3219,6 @@ internal struct _BridgedNative${Self}Storage {
   }
 %end
 
-  @warn_unused_result
   internal func assertingGet(_ i: Int) -> SequenceElement {
     _precondition(
       isInitializedEntry(at: i),
@@ -3337,7 +3262,6 @@ final internal class _Native${Self}StorageKeyNSEnumerator<
   //
 
   @objc
-  @warn_unused_result
   internal func nextObject() -> AnyObject? {
     if nextIndex == endIndex {
       return nil
@@ -3438,19 +3362,16 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   }
 
   @objc
-  @warn_unused_result
   internal func member(_ object: AnyObject) -> AnyObject? {
     return bridgingObjectForKey(object)
   }
 
   @objc
-  @warn_unused_result
   internal func objectEnumerator() -> _NSEnumerator {
     return bridgingKeyEnumerator(())
   }
 
   @objc(copyWithZone:)
-  @warn_unused_result
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // Instances of this class should be visible outside of standard library as
     // having `NSSet` type, which is immutable.
@@ -3475,19 +3396,16 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   }
 
   @objc(objectForKey:)
-  @warn_unused_result
   internal func objectFor(_ aKey: AnyObject) -> AnyObject? {
     return bridgingObjectForKey(aKey)
   }
 
   @objc
-  @warn_unused_result
   internal func keyEnumerator() -> _NSEnumerator {
     return bridgingKeyEnumerator(())
   }
 
   @objc(copyWithZone:)
-  @warn_unused_result
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // Instances of this class should be visible outside of standard library as
     // having `NSDictionary` type, which is immutable.
@@ -3512,7 +3430,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   /// The storage for bridged ${Self} elements, if present.
   internal var _bridgedBuffer:
     BridgedNativeStorage.StorageImpl? {
-    @warn_unused_result
     get {
       if let ref = _stdlib_atomicLoadARCRef(object: _heapBufferBridgedPtr) {
         return unsafeDowncast(ref, to: BridgedNativeStorage.StorageImpl.self)
@@ -3541,7 +3458,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     return BridgedNativeStorage(buffer: _bridgedBuffer!)
   }
 
-  @warn_unused_result
   internal func _createBridgedNativeStorage(_ capacity: Int) ->
     BridgedNativeStorage {
     let buffer = BridgedNativeStorage.StorageImpl.create(capacity: capacity)
@@ -3578,7 +3494,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
   // Foundation subclasses (NS${Self}, NSEnumerator), don't access any
   // storage directly, use these functions.
   //
-  @warn_unused_result
   internal func _getBridgedKey(_ i: _Native${Self}Index<${TypeParameters}>) ->
     AnyObject {
     if _fastPath(_isClassOrObjCExistential(Key.self)) {
@@ -3598,7 +3513,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
 %if Self == 'Set':
 
-  @warn_unused_result
   internal func _getBridgedValue(_ i: _Native${Self}Index<${TypeParameters}>) ->
     AnyObject {
     if _fastPath(_isClassOrObjCExistential(Value.self)) {
@@ -3610,7 +3524,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
 
 %elif Self == 'Dictionary':
 
-  @warn_unused_result
   internal func _getBridgedValue(_ i: _Native${Self}Index<${TypeParameters}>)
     -> AnyObject {
     if _fastPath(_isClassOrObjCExistential(Value.self)) {
@@ -3674,7 +3587,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     return nativeStorage.count
   }
 
-  @warn_unused_result
   internal func bridgingObjectForKey(_ aKey: AnyObject)
     -> AnyObject? {
     guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Key.self)
@@ -3688,7 +3600,6 @@ final internal class _Native${Self}StorageOwner<${TypeParametersDecl}>
     return nil
   }
 
-  @warn_unused_result
   internal func bridgingKeyEnumerator() -> _NSEnumerator {
     return _Native${Self}StorageKeyNSEnumerator<${TypeParameters}>(self)
   }
@@ -3756,7 +3667,6 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
   }
 
   @_versioned
-  @warn_unused_result
   internal func index(after i: Index) -> Index {
     return i.successor()
   }
@@ -3767,7 +3677,6 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
   }
 
   @_versioned
-  @warn_unused_result
   internal func index(forKey key: Key) -> Index? {
     // Fast path that does not involve creating an array of all keys.  In case
     // the key is present, this lookup is a penalty for the slow path, but the
@@ -3794,7 +3703,6 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
     return Index(cocoa${Self}, allKeys, keyIndex)
   }
 
-  @warn_unused_result
   internal func assertingGet(_ i: Index) -> SequenceElement {
 %if Self == 'Set':
     let value: Value? = i.allKeys[i.currentKeyIndex]
@@ -3808,7 +3716,6 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
 
   }
 
-  @warn_unused_result
   internal func assertingGet(_ key: Key) -> Value {
 %if Self == 'Set':
     let value: Value? = cocoa${Self}.member(key)
@@ -3821,7 +3728,6 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
 %end
   }
 
-  @warn_unused_result
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
       
@@ -3863,7 +3769,6 @@ internal struct _Cocoa${Self}Storage : _HashStorage {
     return cocoa${Self}.count
   }
 
-  @warn_unused_result
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
     -> _Cocoa${Self}Storage {
 
@@ -3899,7 +3804,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     return _canBeClass(Key.self) == 0 || _canBeClass(Value.self) == 0
   }
 
-  @warn_unused_result
   internal mutating func isUniquelyReferenced() -> Bool {
     if _fastPath(guaranteedNative) {
       return _isUnique_native(&self)
@@ -4073,7 +3977,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   @_versioned
-  @warn_unused_result
   func index(after i: Index) -> Index {
     if _fastPath(guaranteedNative) {
       return ._native(asNative.index(after: i._nativeIndex))
@@ -4097,7 +4000,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
   }
 
   @_versioned
-  @warn_unused_result
   @inline(__always)
   internal func index(forKey key: Key) -> Index? {
     if _fastPath(guaranteedNative) {
@@ -4126,7 +4028,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     }
   }
 
-  @warn_unused_result
   internal func assertingGet(_ i: Index) -> SequenceElement {
     if _fastPath(guaranteedNative) {
       return asNative.assertingGet(i._nativeIndex)
@@ -4154,7 +4055,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     }
   }
 
-  @warn_unused_result
   internal func assertingGet(_ key: Key) -> Value {
     if _fastPath(guaranteedNative) {
       return asNative.assertingGet(key)
@@ -4190,7 +4090,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
 #endif
 
   @_versioned
-  @warn_unused_result
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
     if _fastPath(guaranteedNative) {
@@ -4586,7 +4485,6 @@ internal enum _Variant${Self}Storage<${TypeParametersDecl}> : _HashStorage {
     }
   }
 
-  @warn_unused_result
   internal static func fromArray(_ elements: [SequenceElement])
     -> _Variant${Self}Storage<${TypeParameters}> {
 
@@ -4615,7 +4513,6 @@ internal struct _Native${Self}Index<${TypeParametersDecl}> :
   /// Returns the next consecutive value after `self`.
   ///
   /// - Precondition: The next value is representable.
-  @warn_unused_result
   internal func successor() -> NativeIndex {
     // FIXME: swift-3-indexing-model: remove this method.
     var i = offset + 1
@@ -4703,7 +4600,6 @@ internal struct _Cocoa${Self}Index : Comparable {
   /// Returns the next consecutive value after `self`.
   ///
   /// - Precondition: The next value is representable.
-  @warn_unused_result
   internal func successor() -> _Cocoa${Self}Index {
     // FIXME: swift-3-indexing-model: remove this method.
     _precondition(
@@ -4712,7 +4608,6 @@ internal struct _Cocoa${Self}Index : Comparable {
   }
 }
 
-@warn_unused_result
 internal func ==(lhs: _Cocoa${Self}Index, rhs: _Cocoa${Self}Index) -> Bool {
   _precondition(lhs.cocoa${Self} === rhs.cocoa${Self},
     "cannot compare indexes pointing to different ${Self}s")
@@ -4722,7 +4617,6 @@ internal func ==(lhs: _Cocoa${Self}Index, rhs: _Cocoa${Self}Index) -> Bool {
   return lhs.currentKeyIndex == rhs.currentKeyIndex
 }
 
-@warn_unused_result
 internal func <(lhs: _Cocoa${Self}Index, rhs: _Cocoa${Self}Index) -> Bool {
   _precondition(lhs.cocoa${Self} === rhs.cocoa${Self},
     "cannot compare indexes pointing to different ${Self}s")
@@ -4847,7 +4741,6 @@ public struct ${Self}Index<${TypeParametersDecl}> :
   }
 }
 
-@warn_unused_result
 public func == <${TypeParametersDecl}> (
   lhs: ${Self}Index<${TypeParameters}>,
   rhs: ${Self}Index<${TypeParameters}>
@@ -4870,7 +4763,6 @@ public func == <${TypeParametersDecl}> (
   }
 }
 
-@warn_unused_result
 public func < <${TypeParametersDecl}> (
   lhs: ${Self}Index<${TypeParameters}>,
   rhs: ${Self}Index<${TypeParameters}>
@@ -5146,7 +5038,6 @@ public struct _${Self}Builder<${TypeParametersDecl}> {
   }
 %end
 
-  @warn_unused_result
   public mutating func take() -> ${Self}<${TypeParameters}> {
     _precondition(_actualCount >= 0,
       "cannot take the result twice")
@@ -5182,7 +5073,6 @@ extension ${Self} {
   ///
   /// - Complexity: Averages to O(1) over many calls to `popFirst()`.
 %end
-  @warn_unused_result
   public mutating func popFirst() -> Element? {
     guard !isEmpty else { return nil }
     return remove(at: startIndex)
@@ -5193,7 +5083,6 @@ extension ${Self} {
 
 #if _runtime(_ObjC)
 extension ${Self} {
-  @warn_unused_result
   public func _bridgeToObjectiveCImpl() -> _NS${Self}Core {
     switch _variantStorage {
     case _Variant${Self}Storage.native(let nativeOwner):
@@ -5211,7 +5100,6 @@ extension ${Self} {
     }
   }
 
-  @warn_unused_result
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> ${Self}<${TypeParameters}>? {
@@ -5261,7 +5149,6 @@ extension Set {
   ///   must be finite.
   /// - Returns: `true` if the set is a subset of `possibleSuperset`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isSubset(of other: Set<Element>) -> Bool {
     let (isSubset, isEqual) = _compareSets(self, other)
     return isSubset || isEqual
@@ -5281,7 +5168,6 @@ extension Set {
   /// - Parameter possibleSubset: Another set.
   /// - Returns: `true` if the set is a superset of `possibleSubset`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isSuperset(of other: Set<Element>) -> Bool {
     return other.isSubset(of: self)
   }
@@ -5299,7 +5185,6 @@ extension Set {
   /// - Parameter other: Another set.
   /// - Returns: `true` if the set has no elements in common with `other`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isDisjoint(with other: Set<Element>) -> Bool {
     for member in self {
       if other.contains(member) {
@@ -5322,7 +5207,6 @@ extension Set {
   ///
   /// - Parameter other: Another set.
   /// - Returns: A new set.
-  @warn_unused_result
   public func subtracting(_ other: Set<Element>) -> Set<Element> {
     return self._subtracting(other)
   }
@@ -5344,7 +5228,6 @@ extension Set {
   /// - Parameter possibleStrictSubset: Another set.
   /// - Returns: `true` if the set is a strict superset of
   ///   `possibleStrictSubset`; otherwise, `false`.
-  @warn_unused_result
   public func isStrictSuperset(of other: Set<Element>) -> Bool {
     return self.isSuperset(of: other) && self != other
   }
@@ -5368,7 +5251,6 @@ extension Set {
   /// - Parameter possibleStrictSuperset: Another set.
   /// - Returns: `true` if the set is a strict subset of
   ///   `possibleStrictSuperset`; otherwise, `false`.
-  @warn_unused_result
   public func isStrictSubset(of other: Set<Element>) -> Bool {
     return other.isStrictSuperset(of: self)
   }
@@ -5386,7 +5268,6 @@ extension Set {
   ///
   /// - Parameter other: Another set.
   /// - Returns: A new set.
-  @warn_unused_result
   public func intersection(_ other: Set<Element>) -> Set<Element> {
     var newSet = Set<Element>()
     for member in self {

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -41,7 +41,6 @@ struct _HashingDetail {
 
   @_versioned
   @_transparent
-  @warn_unused_result
   static func getExecutionSeed() -> UInt64 {
     // FIXME: This needs to be a per-execution seed. This is just a placeholder
     // implementation.
@@ -51,7 +50,6 @@ struct _HashingDetail {
 
   @_versioned
   @_transparent
-  @warn_unused_result
   static func hash16Bytes(_ low: UInt64, _ high: UInt64) -> UInt64 {
     // Murmur-inspired hashing.
     let mul: UInt64 = 0x9ddfea08eb382d69
@@ -74,7 +72,6 @@ struct _HashingDetail {
 //
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _mixUInt32(_ value: UInt32) -> UInt32 {
   // Zero-extend to 64 bits, hash, select 32 bits from the hash.
@@ -88,14 +85,12 @@ func _mixUInt32(_ value: UInt32) -> UInt32 {
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _mixInt32(_ value: Int32) -> Int32 {
   return Int32(bitPattern: _mixUInt32(UInt32(bitPattern: value)))
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _mixUInt64(_ value: UInt64) -> UInt64 {
   // Similar to hash_4to8_bytes but using a seed instead of length.
@@ -106,14 +101,12 @@ func _mixUInt64(_ value: UInt64) -> UInt64 {
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _mixInt64(_ value: Int64) -> Int64 {
   return Int64(bitPattern: _mixUInt64(UInt64(bitPattern: value)))
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _mixUInt(_ value: UInt) -> UInt {
 #if arch(i386) || arch(arm)
@@ -124,7 +117,6 @@ func _mixUInt(_ value: UInt) -> UInt {
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _mixInt(_ value: Int) -> Int {
 #if arch(i386) || arch(arm)
@@ -151,7 +143,6 @@ func _mixInt(_ value: Int) -> Int {
 /// hash value does not change anything fundamentally: collisions are still
 /// possible, and it does not prevent malicious users from constructing data
 /// sets that will exhibit pathological collisions.
-@warn_unused_result
 public // @testable
 func _squeezeHashValue(_ hashValue: Int, _ resultRange: Range<Int>) -> Int {
   // Length of a Range<Int> does not fit into an Int, but fits into an UInt.
@@ -174,7 +165,6 @@ func _squeezeHashValue(_ hashValue: Int, _ resultRange: Range<Int>) -> Int {
       UInt(bitPattern: resultRange.lowerBound) &+ unsignedResult)
 }
 
-@warn_unused_result
 public // @testable
 func _squeezeHashValue(_ hashValue: Int, _ resultRange: Range<UInt>) -> UInt {
   let mixedHashValue = UInt(bitPattern: _mixInt(hashValue))

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -13,7 +13,6 @@
 import SwiftShims
 typealias _HeapObject = SwiftShims.HeapObject
 
-@warn_unused_result
 @_silgen_name("swift_bufferAllocate")
 internal func _swift_bufferAllocate(
   bufferType type: AnyClass,
@@ -51,7 +50,6 @@ class _HeapBufferStorage<Value, Element> : NonObjectiveCBase {
     Buffer(self)._value.deinitialize()
   }
 
-  @warn_unused_result
   final func __getInstanceSizeAndAlignMask() -> (Int, Int) {
     return Buffer(self)._allocatedSizeAndAlignMask()
   }
@@ -72,21 +70,18 @@ struct _HeapBuffer<Value, Element> : Equatable {
     return _storage.map { Builtin.castFromNativeObject($0) }
   }
 
-  @warn_unused_result
   internal static func _valueOffset() -> Int {
     return _roundUp(
       sizeof(_HeapObject.self),
       toAlignment: alignof(Value.self))
   }
 
-  @warn_unused_result
   internal static func _elementOffset() -> Int {
     return _roundUp(
       _valueOffset() + sizeof(Value.self),
       toAlignment: alignof(Element.self))
   }
 
-  @warn_unused_result
   internal static func _requiredAlignMask() -> Int {
     // We can't use max here because it can allocate an array.
     let heapAlign = alignof(_HeapObject.self) &- 1
@@ -112,23 +107,19 @@ struct _HeapBuffer<Value, Element> : Equatable {
     return UnsafeMutablePointer(_HeapBuffer._elementOffset() + _address)
   }
 
-  @warn_unused_result
   internal func _allocatedSize() -> Int {
     return _swift_stdlib_malloc_size(_address)
   }
 
-  @warn_unused_result
   internal func _allocatedAlignMask() -> Int {
     return _HeapBuffer._requiredAlignMask()
   }
 
-  @warn_unused_result
   internal func _allocatedSizeAndAlignMask() -> (Int, Int) {
     return (_allocatedSize(), _allocatedAlignMask())
   }
 
   /// Returns the actual number of `Elements` we can possibly store.
-  @warn_unused_result
   internal func _capacity() -> Int {
     return (_allocatedSize() - _HeapBuffer._elementOffset())
       / strideof(Element.self)
@@ -212,18 +203,15 @@ struct _HeapBuffer<Value, Element> : Equatable {
     return _storage!
   }
 
-  @warn_unused_result
   internal static func fromNativeObject(_ x: Builtin.NativeObject) -> _HeapBuffer {
     return _HeapBuffer(nativeStorage: x)
   }
 
-  @warn_unused_result
   public // @testable
   mutating func isUniquelyReferenced() -> Bool {
     return _isUnique(&_storage)
   }
 
-  @warn_unused_result
   public // @testable
   mutating func isUniquelyReferencedOrPinned() -> Bool {
     return _isUniqueOrPinned(&_storage)
@@ -231,7 +219,6 @@ struct _HeapBuffer<Value, Element> : Equatable {
 }
 
 // HeapBuffers are equal when they reference the same buffer
-@warn_unused_result
 public // @testable
 func == <Value, Element> (
   lhs: _HeapBuffer<Value, Element>,

--- a/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
+++ b/stdlib/public/core/ImplicitlyUnwrappedOptional.swift
@@ -64,7 +64,6 @@ extension ImplicitlyUnwrappedOptional : CustomDebugStringConvertible {
 }
 
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _stdlib_ImplicitlyUnwrappedOptional_isSome<Wrapped>
   (_ `self`: Wrapped!) -> Bool {
@@ -73,7 +72,6 @@ func _stdlib_ImplicitlyUnwrappedOptional_isSome<Wrapped>
 }
 
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _stdlib_ImplicitlyUnwrappedOptional_unwrapped<Wrapped>
   (_ `self`: Wrapped!) -> Wrapped {

--- a/stdlib/public/core/Indices.swift.gyb
+++ b/stdlib/public/core/Indices.swift.gyb
@@ -71,7 +71,6 @@ public struct ${Self}<
       endIndex: bounds.upperBound)
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _elements.index(after: i)
@@ -83,7 +82,6 @@ public struct ${Self}<
   }
 
 %     if Traversal in ['Bidirectional', 'RandomAccess']:
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _elements.index(before: i)

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -21,7 +21,6 @@ import SwiftShims
 ///
 /// Standard input is interpreted as `UTF-8`.  Invalid bytes
 /// will be replaced by Unicode [replacement characters](http://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character).
-@warn_unused_result
 public func readLine(strippingNewline: Bool = true) -> String? {
   var linePtrVar: UnsafeMutablePointer<CChar>? = nil
   var readBytes = swift_stdlib_readLine_stdin(&linePtrVar)

--- a/stdlib/public/core/IntegerArithmetic.swift.gyb
+++ b/stdlib/public/core/IntegerArithmetic.swift.gyb
@@ -45,13 +45,11 @@ public protocol IntegerArithmetic : _IntegerArithmetic, Comparable {
 % for name, op, Action, result in integerBinaryOps:
   /// ${Action} `lhs` and `rhs`, returning ${result} and trapping in case of
   /// arithmetic overflow (except in -Ounchecked builds).
-  @warn_unused_result
   func ${op} (lhs: Self, rhs: Self) -> Self
 % end
   
   /// Explicitly convert to `IntMax`, trapping on overflow (except in
   /// -Ounchecked builds).
-  @warn_unused_result
   func toIntMax() -> IntMax
 }
 
@@ -59,7 +57,6 @@ public protocol IntegerArithmetic : _IntegerArithmetic, Comparable {
 /// ${Action} `lhs` and `rhs`, returning ${result} and trapping in case of
 /// arithmetic overflow (except in -Ounchecked builds).
 @_transparent
-@warn_unused_result
 public func ${op} <T : _IntegerArithmetic>(lhs: T, rhs: T) -> T {
   return _overflowChecked(T.${name}WithOverflow(lhs, rhs))
 }
@@ -67,7 +64,6 @@ public func ${op} <T : _IntegerArithmetic>(lhs: T, rhs: T) -> T {
 % if (op != '/') and (op != '%'):
 /// ${Action} `lhs` and `rhs`, silently discarding any overflow.
 @_transparent
-@warn_unused_result
 public func &${op} <T : _IntegerArithmetic>(lhs: T, rhs: T) -> T {
   return T.${name}WithOverflow(lhs, rhs).0
 }
@@ -97,11 +93,9 @@ public func ${op}= <T : _IntegerArithmetic>(lhs: inout T, rhs: T) {
 /// - `-(-x) == x`
 public protocol SignedNumber : Comparable, IntegerLiteralConvertible {
   /// Returns the result of negating `x`.
-  @warn_unused_result
   prefix func - (x: Self) -> Self
 
   /// Returns the difference between `lhs` and `rhs`.
-  @warn_unused_result
   func - (lhs: Self, rhs: Self) -> Self
   
   // Do not use this operator directly; call abs(x) instead
@@ -140,7 +134,6 @@ public func ~> <T : SignedNumber>(x:T,_:(_Abs, ())) -> T {
 /// A type that supports an "absolute value" function.
 public protocol AbsoluteValuable : SignedNumber {
   /// Returns the absolute value of `x`.
-  @warn_unused_result
   static func abs(_ x: Self) -> Self
 }
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -175,7 +175,6 @@ extension Sequence where Iterator.Element : Sequence {
   /// - Returns: The joined sequence of elements.
   ///
   /// - SeeAlso: `flatten()`
-  @warn_unused_result
   public func joined<
     Separator : Sequence
     where

--- a/stdlib/public/core/LazyCollection.swift.gyb
+++ b/stdlib/public/core/LazyCollection.swift.gyb
@@ -130,7 +130,6 @@ extension ${Self} : ${TraversalCollection} {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(after i: Base.Index) -> Base.Index {
     return _base.index(after: i)
   }
@@ -183,13 +182,11 @@ extension ${Self} : ${TraversalCollection} {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: Base.IndexDistance) -> Index {
     return _base.index(i, offsetBy: n)
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: Base.IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -197,14 +194,12 @@ extension ${Self} : ${TraversalCollection} {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
     return _base.distance(from:start, to: end)
   }
 
 %   if Traversal != 'Forward':
 
-  @warn_unused_result
   public func index(before i: Base.Index) -> Base.Index {
     return _base.index(before: i)
   }

--- a/stdlib/public/core/Map.swift.gyb
+++ b/stdlib/public/core/Map.swift.gyb
@@ -99,7 +99,6 @@ public struct ${Self}<
   public var startIndex: Base.Index { return _base.startIndex }
   public var endIndex: Base.Index { return _base.endIndex }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index { return _base.index(after: i) }
 
   public func formIndex(after i: inout Index) {
@@ -107,7 +106,6 @@ public struct ${Self}<
   }
 
 %   if Traversal in ['Bidirectional', 'RandomAccess']:
-  @warn_unused_result
   public func index(before i: Index) -> Index { return _base.index(before: i) }
 
   public func formIndex(before i: inout Index) {
@@ -162,19 +160,16 @@ public struct ${Self}<
   public var last: Element? { return _base.last.map(_transform) }
 %   end
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: Base.IndexDistance) -> Index {
     return _base.index(i, offsetBy: n)
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: Base.IndexDistance, limitedBy limit: Index
   ) -> Index? {
     return _base.index(i, offsetBy: n, limitedBy: limit)
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> Base.IndexDistance {
     return _base.distance(from: start, to: end)
   }
@@ -209,7 +204,6 @@ extension LazySequenceProtocol {
   /// Returns a `LazyMapSequence` over this `Sequence`.  The elements of
   /// the result are computed lazily, each time they are read, by
   /// calling `transform` function on a base element.
-  @warn_unused_result
   public func map<U>(
     _ transform: (Elements.Iterator.Element) -> U
   ) -> LazyMapSequence<Self.Elements, U> {
@@ -227,7 +221,6 @@ extension LazyCollectionProtocol
   /// Returns a `LazyMapCollection` over this `Collection`.  The elements of
   /// the result are computed lazily, each time they are read, by
   /// calling `transform` function on a base element.
-  @warn_unused_result
   public func map<U>(
     _ transform: (Elements.Iterator.Element) -> U
   ) -> LazyMap${collectionForTraversal(Traversal)}<Self.Elements, U> {

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -139,12 +139,10 @@ public struct Mirror {
     case dictionary, `set`
   }
 
-  @warn_unused_result
   static func _noSuperclassMirror() -> Mirror? { return nil }
 
   /// Returns the legacy mirror representing the part of `subject`
   /// corresponding to the superclass of `staticSubclass`.
-  @warn_unused_result
   internal static func _legacyMirror(
     _ subject: AnyObject, asClass targetSuperclass: AnyClass) -> _Mirror? {
     
@@ -164,7 +162,6 @@ public struct Mirror {
     return nil
   }
   
-  @warn_unused_result
   internal static func _superclassIterator<Subject : Any>(
     _ subject: Subject, _ ancestorRepresentation: AncestorRepresentation
   ) -> () -> Mirror? {
@@ -443,7 +440,6 @@ extension Mirror {
   /// this function is suitable for exploring the structure of a
   /// `Mirror` in a REPL or playground, but don't expect it to be
   /// efficient.
-  @warn_unused_result
   public func descendant(
     _ first: MirrorPath, _ rest: MirrorPath...
   ) -> Any? {
@@ -490,7 +486,6 @@ extension Mirror.DisplayStyle {
   }
 }
 
-@warn_unused_result
 internal func _isClassSuperMirror(_ t: Any.Type) -> Bool {
 #if  _runtime(_ObjC)
   return t == _ClassSuperMirror.self || t == _ObjCSuperMirror.self
@@ -500,7 +495,6 @@ internal func _isClassSuperMirror(_ t: Any.Type) -> Bool {
 }
 
 extension _Mirror {
-  @warn_unused_result
   internal func _superMirror() -> _Mirror? {
     if self.count > 0 {
       let childMirror = self[0].1

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -15,7 +15,6 @@
 // FIXME: Once we have an FFI interface, make these have proper function bodies
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _countLeadingZeros(_ value: Int64) -> Int64 {
     return Int64(Builtin.int_ctlz_Int64(value._value, false._value))
@@ -23,7 +22,6 @@ func _countLeadingZeros(_ value: Int64) -> Int64 {
 
 /// Returns if `x` is a power of 2.
 @_transparent
-@warn_unused_result
 public // @testable
 func _isPowerOf2(_ x: UInt) -> Bool {
   if x == 0 {
@@ -36,7 +34,6 @@ func _isPowerOf2(_ x: UInt) -> Bool {
 
 /// Returns if `x` is a power of 2.
 @_transparent
-@warn_unused_result
 public // @testable
 func _isPowerOf2(_ x: Int) -> Bool {
   if x <= 0 {
@@ -78,7 +75,6 @@ public func _getTypeName(_ type: Any.Type, qualified: Bool)
   -> (UnsafePointer<UInt8>, Int)
 
 /// Returns the demangled qualified name of a metatype.
-@warn_unused_result
 public // @testable
 func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
   let (stringPtr, count) = _getTypeName(type, qualified: qualified)
@@ -94,7 +90,6 @@ func _getTypeByMangledName(
 
 /// Lookup a class given a name. Until the demangled encoding of type
 /// names is stabilized, this is limited to top-level class names (Foo.bar).
-@warn_unused_result
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let components = name.characters.split{$0 == "."}.map(String.init)
@@ -134,7 +129,6 @@ func _typeByName(_ name: String) -> Any.Type? {
 ///      floorLog2(9) == floorLog2(15) == 3
 ///
 /// TODO: Implement version working on Int instead of Int64.
-@warn_unused_result
 @_transparent
 public // @testable
 func _floorLog2(_ x: Int64) -> Int {

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -157,7 +157,6 @@ public protocol MutableIndexable : Indexable {
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
-  @warn_unused_result
   func index(after i: Index) -> Index
 
   /// Replaces the given index with its successor.

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -144,7 +144,6 @@ extension OptionSet {
   /// - Parameter other: An option set.
   /// - Returns: A new option set made up of the elements contained in this
   ///   set, in `other`, or in both.
-  @warn_unused_result
   public func union(_ other: Self) -> Self {
     var r: Self = Self(rawValue: self.rawValue)
     r.formUnion(other)
@@ -171,7 +170,6 @@ extension OptionSet {
   /// - Parameter other: An option set.
   /// - Returns: A new option set with only the elements contained in both this
   ///   set and `other`.
-  @warn_unused_result
   public func intersection(_ other: Self) -> Self {
     var r = Self(rawValue: self.rawValue)
     r.formIntersection(other)
@@ -184,7 +182,6 @@ extension OptionSet {
   /// - Parameter other: An option set.
   /// - Returns: A new option set with only the elements contained in either
   ///   this set or `other`, but not in both.
-  @warn_unused_result
   public func symmetricDifference(_ other: Self) -> Self {
     var r = Self(rawValue: self.rawValue)
     r.formSymmetricDifference(other)
@@ -214,7 +211,6 @@ extension OptionSet where Element == Self {
   /// - Parameter member: The element to look for in the option set.
   /// - Returns: `true` if the option set contains `member`; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func contains(_ member: Self) -> Bool {
     return self.isSuperset(of: member)
   }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -156,7 +156,6 @@ public enum Optional<Wrapped> : NilLiteralConvertible {
   /// - Parameter f: A closure that takes the unwrapped value of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @warn_unused_result
   public func map<U>(_ f: @noescape (Wrapped) throws -> U) rethrows -> U? {
     switch self {
     case .some(let y):
@@ -184,7 +183,6 @@ public enum Optional<Wrapped> : NilLiteralConvertible {
   /// - Parameter f: A closure that takes the unwrapped value of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @warn_unused_result
   public func flatMap<U>(_ f: @noescape (Wrapped) throws -> U?) rethrows -> U? {
     switch self {
     case .some(let y):
@@ -287,14 +285,12 @@ extension Optional : CustomReflectable {
 }
 
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _stdlib_Optional_isSome<Wrapped>(_ `self`: Wrapped?) -> Bool {
   return `self` != nil
 }
 
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _stdlib_Optional_unwrapped<Wrapped>(_ `self`: Wrapped?) -> Wrapped {
   switch `self` {
@@ -313,7 +309,6 @@ func _diagnoseUnexpectedNilOptional() {
     "unexpectedly found nil while unwrapping an Optional value")
 }
 
-@warn_unused_result
 public func == <T: Equatable> (lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -325,7 +320,6 @@ public func == <T: Equatable> (lhs: T?, rhs: T?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func != <T : Equatable> (lhs: T?, rhs: T?) -> Bool {
   return !(lhs == rhs)
 }
@@ -340,7 +334,6 @@ public struct _OptionalNilComparisonType : NilLiteralConvertible {
   }
 }
 @_transparent
-@warn_unused_result
 public func ~= <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   switch rhs {
   case .some(_):
@@ -352,7 +345,6 @@ public func ~= <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
 
 // Enable equality comparisons against the nil literal, even if the
 // element type isn't equatable
-@warn_unused_result
 public func == <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   switch lhs {
   case .some(_):
@@ -362,7 +354,6 @@ public func == <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   }
 }
 
-@warn_unused_result
 public func != <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   switch lhs {
   case .some(_):
@@ -372,7 +363,6 @@ public func != <T>(lhs: T?, rhs: _OptionalNilComparisonType) -> Bool {
   }
 }
 
-@warn_unused_result
 public func == <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   switch rhs {
   case .some(_):
@@ -382,7 +372,6 @@ public func == <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func != <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   switch rhs {
   case .some(_):
@@ -392,7 +381,6 @@ public func != <T>(lhs: _OptionalNilComparisonType, rhs: T?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func < <T : Comparable> (lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -404,7 +392,6 @@ public func < <T : Comparable> (lhs: T?, rhs: T?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -414,7 +401,6 @@ public func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func <= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -424,7 +410,6 @@ public func <= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func >= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -467,7 +452,6 @@ public func >= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
 ///   - defaultValue: A value to use as a default. `defaultValue` is the same
 ///     type as the `Wrapped` type of `optional`.
 @_transparent
-@warn_unused_result
 public func ?? <T> (optional: T?, defaultValue: @autoclosure () throws -> T)
     rethrows -> T {
   switch optional {
@@ -521,7 +505,6 @@ public func ?? <T> (optional: T?, defaultValue: @autoclosure () throws -> T)
 ///   - defaultValue: A value to use as a default. `defaultValue` and
 ///     `optional` have the same type.
 @_transparent
-@warn_unused_result
 public func ?? <T> (optional: T?, defaultValue: @autoclosure () throws -> T?)
     rethrows -> T? {
   switch optional {

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -23,7 +23,6 @@ public protocol _Pointer {
 
 /// Derive a pointer argument from a convertible pointer type.
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertPointerToPointerArgument<
   FromPointer : _Pointer,
@@ -34,7 +33,6 @@ func _convertPointerToPointerArgument<
 
 /// Derive a pointer argument from the address of an inout parameter.
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertInOutToPointerArgument<
   ToPointer : _Pointer
@@ -47,7 +45,6 @@ func _convertInOutToPointerArgument<
 /// This always produces a non-null pointer, even if the array doesn't have any
 /// storage.
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertConstArrayToPointerArgument<
   FromElement,
@@ -70,7 +67,6 @@ func _convertConstArrayToPointerArgument<
 ///
 /// This always produces a non-null pointer, even if the array's length is 0.
 @_transparent
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertMutableArrayToPointerArgument<
   FromElement,
@@ -87,7 +83,6 @@ func _convertMutableArrayToPointerArgument<
 }
 
 /// Derive a UTF-8 pointer argument from a value string parameter.
-@warn_unused_result
 public // COMPILER_INTRINSIC
 func _convertConstStringToUTF8PointerArgument<
   ToPointer : _Pointer

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -369,7 +369,6 @@ public typealias AnyClass = AnyObject.Type
 /// instance (in other words, are identical pointers).
 ///
 /// - SeeAlso: `Equatable`, `==`
-@warn_unused_result
 public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -384,7 +383,6 @@ public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   }
 }
 
-@warn_unused_result
 public func !== (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   return !(lhs === rhs)
 }
@@ -540,7 +538,6 @@ public protocol Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @warn_unused_result
   func == (lhs: Self, rhs: Self) -> Bool
 }
 
@@ -555,7 +552,6 @@ public protocol Equatable {
 /// - Parameters:
 ///   - lhs: A value to compare.
 ///   - rhs: Another value to compare.
-@warn_unused_result
 public func != <T : Equatable>(lhs: T, rhs: T) -> Bool {
   return !(lhs == rhs)
 }
@@ -573,7 +569,6 @@ public func != <T : Equatable>(lhs: T, rhs: T) -> Bool {
 /// - Parameters:
 ///   - lhs: A value to compare.
 ///   - rhs: Another value to compare.
-@warn_unused_result
 public func > <T : Comparable>(lhs: T, rhs: T) -> Bool {
   return rhs < lhs
 }
@@ -587,7 +582,6 @@ public func > <T : Comparable>(lhs: T, rhs: T) -> Bool {
 /// - Parameters:
 ///   - lhs: A value to compare.
 ///   - rhs: Another value to compare.
-@warn_unused_result
 public func <= <T : Comparable>(lhs: T, rhs: T) -> Bool {
   return !(rhs < lhs)
 }
@@ -603,7 +597,6 @@ public func <= <T : Comparable>(lhs: T, rhs: T) -> Bool {
 ///   - rhs: Another value to compare.
 /// - Returns: `true` if `lhs` is greater than or equal to `rhs`; otherwise,
 ///   `false`.
-@warn_unused_result
 public func >= <T : Comparable>(lhs: T, rhs: T) -> Bool {
   return !(lhs < rhs)
 }
@@ -743,7 +736,6 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @warn_unused_result
   func < (lhs: Self, rhs: Self) -> Bool
 
   /// Returns a Boolean value indicating whether the value of the first
@@ -752,7 +744,6 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @warn_unused_result
   func <= (lhs: Self, rhs: Self) -> Bool
 
   /// Returns a Boolean value indicating whether the value of the first
@@ -761,7 +752,6 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @warn_unused_result
   func >= (lhs: Self, rhs: Self) -> Bool
 
   /// Returns a Boolean value indicating whether the value of the first
@@ -770,7 +760,6 @@ public protocol Comparable : Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @warn_unused_result
   func > (lhs: Self, rhs: Self) -> Bool
 }
 
@@ -883,7 +872,6 @@ public protocol BitwiseOperations {
   ///     // Prints "0"
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   func & (lhs: Self, rhs: Self) -> Self
 
   /// Returns the union of bits set in the two arguments.
@@ -903,7 +891,6 @@ public protocol BitwiseOperations {
   ///     // Prints "5"
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   func | (lhs: Self, rhs: Self) -> Self
 
   /// Returns the bits that are set in exactly one of the two arguments.
@@ -924,7 +911,6 @@ public protocol BitwiseOperations {
   ///     // Prints "5"
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   func ^ (lhs: Self, rhs: Self) -> Self
 
   /// Returns the inverse of the bits set in the argument.
@@ -944,7 +930,6 @@ public protocol BitwiseOperations {
   ///     let allOnes = ~UInt8.allZeros   // 0b11111111
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   prefix func ~ (x: Self) -> Self
 
   /// The empty bitset.
@@ -1087,7 +1072,6 @@ public protocol Hashable : Equatable {
 
 // Equatable types can be matched in patterns by value equality.
 @_transparent
-@warn_unused_result
 public func ~= <T : Equatable> (a: T, b: T) -> Bool {
   return a == b
 }

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -140,7 +140,6 @@ extension RandomAccessIndexable {
   ///   the method returns `nil`.
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -189,7 +188,6 @@ where Index : Strideable,
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     return _validityChecked(i.advanced(by: 1))
   }
@@ -199,7 +197,6 @@ where Index : Strideable,
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     return _validityChecked(i.advanced(by: -1))
   }
@@ -230,7 +227,6 @@ where Index : Strideable,
   ///   - If `n > 0`, `n <= self.distance(from: i, to: self.endIndex)`
   ///   - If `n < 0`, `n >= self.distance(from: i, to: self.startIndex)`
   /// - Complexity: O(1)
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: Index.Stride) -> Index {
     return _validityChecked(i.advanced(by: n))
   }
@@ -244,7 +240,6 @@ where Index : Strideable,
   /// - Returns: The distance between `start` and `end`.
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> Index.Stride {
     return start.distance(to: end)
   }

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -115,7 +115,6 @@ public struct CountableRange<
     return upperBound
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     // FIXME: swift-3-indexing-model: tests.
     _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
@@ -123,7 +122,6 @@ public struct CountableRange<
     return i.advanced(by: 1)
   }
 
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check i: should allow `endIndex`.
     //_failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
@@ -131,13 +129,11 @@ public struct CountableRange<
     return i.advanced(by: -1)
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     // FIXME: swift-3-indexing-model: tests.
     return i.advanced(by: n)
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     // FIXME: swift-3-indexing-model: tests.
     return start.distance(to: end)
@@ -182,7 +178,6 @@ public struct CountableRange<
     self.upperBound = bounds.upper
   }
 
-  @warn_unused_result
   public func _customContainsEquatableElement(_ element: Element) -> Bool? {
     return lowerBound <= element && element < upperBound
   }
@@ -344,7 +339,6 @@ public struct Range<
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func contains(_ element: Bound) -> Bool {
     return lowerBound <= element && element < upperBound
   }
@@ -436,7 +430,6 @@ extension ${Self}
   /// - Parameter other: A range to check for elements in common.
   /// - Returns: `true` if this range and `other` have at least one element in
   ///   common; otherwise, `false`.
-  @warn_unused_result
   @inline(__always)
   public func overlaps(_ other: ${OtherSelf}<Bound>) -> Bool {
     return (!other.isEmpty && self.contains(other.lowerBound))
@@ -469,7 +462,6 @@ extension ${Self} {
   ///
   /// - Parameter limits: The range to clamp the bounds of this range.
   /// - Returns: A new range clamped to the bounds of `limits`.
-  @warn_unused_result
   @inline(__always)
   public func clamped(to limits: ${Self}) -> ${Self} {
     return ${Self}(
@@ -511,14 +503,12 @@ extension ${Self} : CustomReflectable {
 
 extension ${Self} : Equatable {}
 
-@warn_unused_result
 public func == <Bound>(lhs: ${Self}<Bound>, rhs: ${Self}<Bound>) -> Bool {
   return
     lhs.lowerBound == rhs.lowerBound &&
     lhs.upperBound == rhs.upperBound
 }
 
-@warn_unused_result
 public func ~= <Bound> (pattern: ${Self}<Bound>, value: Bound) -> Bool {
   return pattern.contains(value)
 }
@@ -564,7 +554,6 @@ extension ${Self} where Bound : _Strideable, Bound.Stride : SignedInteger {
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-@warn_unused_result
 public func ..< <Bound : Comparable> (minimum: Bound, maximum: Bound)
   -> Range<Bound> {
   _precondition(minimum <= maximum,
@@ -585,7 +574,6 @@ public func ..< <Bound : Comparable> (minimum: Bound, maximum: Bound)
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-@warn_unused_result
 // WORKAROUND rdar://25214598 - should be just Bound : Strideable
 public func ..< <
   Bound : _Strideable where Bound : Comparable, Bound.Stride : Integer

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -486,14 +486,12 @@ public protocol RangeReplaceableCollection
   /// want to replace the default implementation.
   ///
   /// - Returns: A non-nil value if the operation was performed.
-  @warn_unused_result
   mutating func _customRemoveLast() -> Iterator.Element?
 
   /// Customization point for `removeLast(_:)`.  Implement this function if you
   /// want to replace the default implementation.
   ///
   /// - Returns: `true` if the operation was performed.
-  @warn_unused_result
   mutating func _customRemoveLast(_ n: Int) -> Bool
 
   /// Removes and returns the first element of the collection.
@@ -956,12 +954,10 @@ extension RangeReplaceableCollection
 % end
 
 extension RangeReplaceableCollection {
-  @warn_unused_result
   public mutating func _customRemoveLast() -> Iterator.Element? {
     return nil
   }
 
-  @warn_unused_result
   public mutating func _customRemoveLast(_ n: Int) -> Bool {
     return false
   }
@@ -972,14 +968,12 @@ extension RangeReplaceableCollection
   Self : BidirectionalCollection,
   SubSequence == Self {
 
-  @warn_unused_result
   public mutating func _customRemoveLast() -> Iterator.Element? {
     let element = last!
     self = self[startIndex..<index(before: endIndex)]
     return element
   }
 
-  @warn_unused_result
   public mutating func _customRemoveLast(_ n: Int) -> Bool {
     self = self[startIndex..<index(endIndex, offsetBy: numericCast(-n))]
     return true
@@ -1107,7 +1101,6 @@ extension RangeReplaceableCollection
 /// - Parameters:
 ///   - lhs: A range-replaceable collection.
 ///   - rhs: A collection or finite sequence.
-@warn_unused_result
 public func +<
     C : RangeReplaceableCollection,
     S : Sequence
@@ -1138,7 +1131,6 @@ public func +<
 /// - Parameters:
 ///   - lhs: A collection or finite sequence.
 ///   - rhs: A range-replaceable collection.
-@warn_unused_result
 public func +<
   C : RangeReplaceableCollection,
   S : Sequence
@@ -1169,7 +1161,6 @@ public func +<
 /// - Parameters:
 ///   - lhs: A range-replaceable collection.
 ///   - rhs: Another range-replaceable collection.
-@warn_unused_result
 public func +<
   RRC1 : RangeReplaceableCollection,
   RRC2 : RangeReplaceableCollection

--- a/stdlib/public/core/Reflection.swift
+++ b/stdlib/public/core/Reflection.swift
@@ -18,7 +18,6 @@ public protocol _Reflectable {
   // corresponding change to Reflection.cpp.
 
   /// Returns a mirror that reflects `self`.
-  @warn_unused_result
   func _getMirror() -> _Mirror
 }
 
@@ -52,12 +51,10 @@ public struct ObjectIdentifier : Hashable, Comparable {
   }
 }
 
-@warn_unused_result
 public func <(lhs: ObjectIdentifier, rhs: ObjectIdentifier) -> Bool {
   return UInt(lhs) < UInt(rhs)
 }
 
-@warn_unused_result
 public func ==(x: ObjectIdentifier, y: ObjectIdentifier) -> Bool {
   return Bool(Builtin.cmp_eq_RawPointer(x._value, y._value))
 }
@@ -134,7 +131,6 @@ public protocol _Mirror {
 /// An entry point that can be called from C++ code to get the summary string
 /// for an arbitrary object. The memory pointed to by "out" is initialized with
 /// the summary string.
-@warn_unused_result
 @_silgen_name("swift_getSummary")
 public // COMPILER_INTRINSIC
 func _getSummary<T>(_ out: UnsafeMutablePointer<String>, x: T) {
@@ -145,7 +141,6 @@ func _getSummary<T>(_ out: UnsafeMutablePointer<String>, x: T) {
 /// `_Reflectable`, invoke its `_getMirror()` method; otherwise, fall back
 /// to an implementation in the runtime that structurally reflects values
 /// of any type.
-@warn_unused_result
 @_silgen_name("swift_reflectAny")
 internal func _reflect<T>(_ x: T) -> _Mirror
 
@@ -410,7 +405,6 @@ struct _OpaqueMirror : _Mirror {
   var disposition: _MirrorDisposition { return .aggregate }
 }
 
-@warn_unused_result
 @_silgen_name("swift_TupleMirror_count")
 func _getTupleCount(_: _MagicMirrorData) -> Int
 
@@ -422,7 +416,6 @@ func _getTupleCount(_: _MagicMirrorData) -> Int
 // ABI rules on most platforms.  Therefore, we make this function generic,
 // which has the disadvantage of passing the String type metadata as an
 // extra argument, but does force the string to be returned indirectly.
-@warn_unused_result
 @_silgen_name("swift_TupleMirror_subscript")
 func _getTupleChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 
@@ -443,11 +436,9 @@ internal struct _TupleMirror : _Mirror {
   var disposition: _MirrorDisposition { return .tuple }
 }
 
-@warn_unused_result
 @_silgen_name("swift_StructMirror_count")
 func _getStructCount(_: _MagicMirrorData) -> Int
 
-@warn_unused_result
 @_silgen_name("swift_StructMirror_subscript")
 func _getStructChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 
@@ -471,15 +462,12 @@ struct _StructMirror : _Mirror {
   var disposition: _MirrorDisposition { return .`struct` }
 }
 
-@warn_unused_result
 @_silgen_name("swift_EnumMirror_count")
 func _getEnumCount(_: _MagicMirrorData) -> Int
 
-@warn_unused_result
 @_silgen_name("swift_EnumMirror_subscript")
 func _getEnumChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 
-@warn_unused_result
 @_silgen_name("swift_EnumMirror_caseName")
 func _swift_EnumMirror_caseName(
     _ data: _MagicMirrorData) -> UnsafePointer<CChar>
@@ -512,11 +500,9 @@ struct _EnumMirror : _Mirror {
   var disposition: _MirrorDisposition { return .`enum` }
 }
 
-@warn_unused_result
 @_silgen_name("swift_ClassMirror_count")
 func _getClassCount(_: _MagicMirrorData) -> Int
 
-@warn_unused_result
 @_silgen_name("swift_ClassMirror_subscript")
 func _getClassChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
 

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -28,7 +28,6 @@ public struct ReversedIndex<Base : Collection> : Comparable {
   public let base: Base.Index
 }
 
-@warn_unused_result
 public func == <Base : Collection>(
   lhs: ReversedIndex<Base>,
   rhs: ReversedIndex<Base>
@@ -36,7 +35,6 @@ public func == <Base : Collection>(
   return lhs.base == rhs.base
 }
 
-@warn_unused_result
 public func < <Base : Collection>(
   lhs: ReversedIndex<Base>,
   rhs: ReversedIndex<Base>
@@ -92,23 +90,19 @@ public struct ReversedCollection<
     return ReversedIndex(_base.startIndex)
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     return ReversedIndex(_base.index(before: i.base))
   }
 
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     return ReversedIndex(_base.index(after: i.base))
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
     return ReversedIndex(_base.index(i.base, offsetBy: -n))
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -116,7 +110,6 @@ public struct ReversedCollection<
     return _base.index(i.base, offsetBy: -n, limitedBy: limit.base).map { ReversedIndex($0) }
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     return _base.distance(from: end.base, to: start.base)
   }
@@ -146,7 +139,6 @@ public struct ReversedRandomAccessIndex<
   public let base: Base.Index
 }
 
-@warn_unused_result
 public func == <Base : Collection>(
   lhs: ReversedRandomAccessIndex<Base>,
   rhs: ReversedRandomAccessIndex<Base>
@@ -154,7 +146,6 @@ public func == <Base : Collection>(
   return lhs.base == rhs.base
 }
 
-@warn_unused_result
 public func < <Base : Collection>(
   lhs: ReversedRandomAccessIndex<Base>,
   rhs: ReversedRandomAccessIndex<Base>
@@ -205,24 +196,20 @@ public struct ReversedRandomAccessCollection<
     return ReversedRandomAccessIndex(_base.startIndex)
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     return ReversedRandomAccessIndex(_base.index(before: i.base))
   }
 
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     return ReversedRandomAccessIndex(_base.index(after: i.base))
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     // FIXME: swift-3-indexing-model: `-n` can trap on Int.min.
     // FIXME: swift-3-indexing-model: tests.
     return ReversedRandomAccessIndex(_base.index(i.base, offsetBy: -n))
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -231,7 +218,6 @@ public struct ReversedRandomAccessCollection<
     return _base.index(i.base, offsetBy: -n, limitedBy: limit.base).map { Index($0) }
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     // FIXME: swift-3-indexing-model: tests.
     return _base.distance(from: end.base, to: start.base)
@@ -275,7 +261,6 @@ extension BidirectionalCollection {
   ///     // Prints "sdrawkcaB"
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func reversed() -> ReversedCollection<Self> {
     return ReversedCollection(_base: self)
   }
@@ -309,7 +294,6 @@ extension RandomAccessCollection {
   ///     // Prints "[7, 5, 3]"
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func reversed() -> ReversedRandomAccessCollection<Self> {
     return ReversedRandomAccessCollection(_base: self)
   }
@@ -323,7 +307,6 @@ extension LazyCollectionProtocol
   /// Returns the elements of `self` in reverse order.
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func reversed() -> LazyBidirectionalCollection<
     ReversedCollection<Elements>
   > {
@@ -339,7 +322,6 @@ extension LazyCollectionProtocol
   /// Returns the elements of `self` in reverse order.
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func reversed() -> LazyRandomAccessCollection<
     ReversedRandomAccessCollection<Elements>
   > {

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -21,7 +21,6 @@ import SwiftShims
 //===----------------------------------------------------------------------===//
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _stdlib_atomicCompareExchangeStrongPtrImpl(
   object target: UnsafeMutablePointer<OpaquePointer?>,
@@ -65,7 +64,6 @@ func _stdlib_atomicCompareExchangeStrongPtrImpl(
 /// compare-and-exchange instruction will operate on the writeback buffer, and
 /// you will get a *race* while doing writeback into shared memory.
 @_transparent
-@warn_unused_result
 public // @testable
 func _stdlib_atomicCompareExchangeStrongPtr<T>(
   object target: UnsafeMutablePointer<UnsafeMutablePointer<T>>,
@@ -99,7 +97,6 @@ func _stdlib_atomicInitializeARCRef(
 
 % for bits in [ 32, 64 ]:
 
-@warn_unused_result
 @_transparent
 public // @testable
 func _stdlib_atomicCompareExchangeStrongUInt${bits}(
@@ -113,7 +110,6 @@ func _stdlib_atomicCompareExchangeStrongUInt${bits}(
   return Bool(won)
 }
 
-@warn_unused_result
 @_transparent
 public // @testable
 func _stdlib_atomicCompareExchangeStrongInt${bits}(
@@ -143,7 +139,6 @@ func _swift_stdlib_atomicStoreInt${bits}(
     desired: UInt${bits}(bitPattern: desired))
 }
 
-@warn_unused_result
 public // @testable
 func _swift_stdlib_atomicLoadUInt${bits}(
   object target: UnsafeMutablePointer<UInt${bits}>) -> UInt${bits} {
@@ -152,7 +147,6 @@ func _swift_stdlib_atomicLoadUInt${bits}(
   return UInt${bits}(value)
 }
 
-@warn_unused_result
 func _swift_stdlib_atomicLoadInt${bits}(
   object target: UnsafeMutablePointer<Int${bits}>) -> Int${bits} {
   return Int${bits}(bitPattern:
@@ -175,7 +169,6 @@ func _swift_stdlib_atomicFetch${operation}UInt${bits}(
 }
 
 // Warning: no overflow checking.
-@warn_unused_result
 func _swift_stdlib_atomicFetch${operation}Int${bits}(
   object target: UnsafeMutablePointer<Int${bits}>,
   operand: Int${bits}) -> Int${bits} {
@@ -188,7 +181,6 @@ func _swift_stdlib_atomicFetch${operation}Int${bits}(
 
 % end
 
-@warn_unused_result
 func _stdlib_atomicCompareExchangeStrongInt(
   object target: UnsafeMutablePointer<Int>,
   expected: UnsafeMutablePointer<Int>,
@@ -221,7 +213,6 @@ func _swift_stdlib_atomicStoreInt(
 }
 
 @_transparent
-@warn_unused_result
 public func _swift_stdlib_atomicLoadInt(
   object target: UnsafeMutablePointer<Int>) -> Int {
 #if arch(i386) || arch(arm)
@@ -235,7 +226,6 @@ public func _swift_stdlib_atomicLoadInt(
 #endif
 }
 
-@warn_unused_result
 @_transparent
 public // @testable
 func _swift_stdlib_atomicLoadPtrImpl(
@@ -246,7 +236,6 @@ func _swift_stdlib_atomicLoadPtrImpl(
 }
 
 @_transparent
-@warn_unused_result
 public // @testable
 func _stdlib_atomicLoadARCRef(
   object target: UnsafeMutablePointer<AnyObject?>
@@ -293,7 +282,6 @@ public final class _stdlib_AtomicInt {
     return _swift_stdlib_atomicStoreInt(object: _valuePtr, desired: desired)
   }
 
-  @warn_unused_result
   public func load() -> Int {
     return _swift_stdlib_atomicLoadInt(object: _valuePtr)
   }
@@ -310,7 +298,6 @@ public final class _stdlib_AtomicInt {
   }
 % end
 
-  @warn_unused_result
   public func compareExchange(expected: inout Int, desired: Int) -> Bool {
     var expectedVar = expected
     let result = _stdlib_atomicCompareExchangeStrongInt(
@@ -353,7 +340,6 @@ internal struct _Buffer72 {
 #if !os(Windows) && (arch(i386) || arch(x86_64))
 % end
 
-@warn_unused_result
 @_silgen_name("swift_float${bits}ToString")
 func _float${bits}ToStringImpl(
   _ buffer: UnsafeMutablePointer<UTF8.CodeUnit>,
@@ -361,7 +347,6 @@ func _float${bits}ToStringImpl(
   _ debug: Bool
 ) -> UInt
 
-@warn_unused_result
 func _float${bits}ToString(_ value: Float${bits}, debug: Bool) -> String {
 
   if value.isInfinite {
@@ -392,7 +377,6 @@ func _float${bits}ToString(_ value: Float${bits}, debug: Bool) -> String {
 
 % end
 
-@warn_unused_result
 @_silgen_name("swift_int64ToString")
 func _int64ToStringImpl(
   _ buffer: UnsafeMutablePointer<UTF8.CodeUnit>,
@@ -400,7 +384,6 @@ func _int64ToStringImpl(
   _ radix: Int64, _ uppercase: Bool
 ) -> UInt
 
-@warn_unused_result
 func _int64ToString(
   _ value: Int64, radix: Int64 = 10, uppercase: Bool = false
 ) -> String {
@@ -431,14 +414,12 @@ func _int64ToString(
   }
 }
 
-@warn_unused_result
 @_silgen_name("swift_uint64ToString")
 func _uint64ToStringImpl(
   _ buffer: UnsafeMutablePointer<UTF8.CodeUnit>,
   _ bufferLength: UInt, _ value: UInt64, _ radix: Int64, _ uppercase: Bool
 ) -> UInt
 
-@warn_unused_result
 public // @testable
 func _uint64ToString(
     _ value: UInt64, radix: Int64 = 10, uppercase: Bool = false
@@ -470,7 +451,6 @@ func _uint64ToString(
   }
 }
 
-@warn_unused_result
 func _rawPointerToString(_ value: Builtin.RawPointer) -> String {
   var result = _uint64ToString(
     UInt64(

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -206,7 +206,6 @@ public protocol IteratorProtocol {
   ///
   /// - Returns: The next element in the underlying sequence if a next element
   ///   exists; otherwise, `nil`.
-  @warn_unused_result
   mutating func next() -> Element?
 }
 
@@ -349,7 +348,6 @@ public protocol Sequence {
   // repeatedly slicing them in a loop.
 
   /// Returns an iterator over the elements of this sequence.
-  @warn_unused_result
   func makeIterator() -> Iterator
 
   /// A value less than or equal to the number of elements in
@@ -375,7 +373,6 @@ public protocol Sequence {
   ///   value of the same or of a different type.
   /// - Returns: An array containing the transformed elements of this
   ///   sequence.
-  @warn_unused_result
   func map<T>(
     _ transform: @noescape (Iterator.Element) throws -> T
   ) rethrows -> [T]
@@ -395,7 +392,6 @@ public protocol Sequence {
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
   /// - Returns: An array of the elements that `includeElement` allowed.
-  @warn_unused_result
   func filter(
     _ includeElement: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [Iterator.Element]
@@ -454,7 +450,6 @@ public protocol Sequence {
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements to drop from
   ///   the beginning of the sequence.
-  @warn_unused_result
   func dropFirst(_ n: Int) -> SubSequence
 
   /// Returns a subsequence containing all but the specified number of final
@@ -474,7 +469,6 @@ public protocol Sequence {
   ///   sequence. `n` must be greater than or equal to zero.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @warn_unused_result
   func dropLast(_ n: Int) -> SubSequence
 
   /// Returns a subsequence, up to the specified maximum length, containing
@@ -493,7 +487,6 @@ public protocol Sequence {
   ///   `maxLength` must be greater than or equal to zero.
   /// - Returns: A subsequence starting at the beginning of this sequence
   ///   with at most `maxLength` elements.
-  @warn_unused_result
   func prefix(_ maxLength: Int) -> SubSequence
 
   /// Returns a subsequence, up to the given maximum length, containing the
@@ -515,7 +508,6 @@ public protocol Sequence {
   ///   at most `maxLength` elements.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @warn_unused_result
   func suffix(_ maxLength: Int) -> SubSequence
 
   /// Returns the longest possible subsequences of the sequence, in order, that
@@ -562,7 +554,6 @@ public protocol Sequence {
   ///   - isSeparator: A closure that returns `true` if its argument should be
   ///     used to split the sequence; otherwise, `false`.
   /// - Returns: An array of subsequences, split from this sequence's elements.
-  @warn_unused_result
   func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     isSeparator: @noescape (Iterator.Element) throws -> Bool
@@ -579,7 +570,6 @@ public protocol Sequence {
     where: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element?
 
-  @warn_unused_result
   func _customContainsEquatableElement(
     _ element: Iterator.Element
   ) -> Bool?
@@ -724,7 +714,6 @@ extension Sequence {
   ///   value of the same or of a different type.
   /// - Returns: An array containing the transformed elements of this
   ///   sequence.
-  @warn_unused_result
   public func map<T>(
     _ transform: @noescape (Iterator.Element) throws -> T
   ) rethrows -> [T] {
@@ -760,7 +749,6 @@ extension Sequence {
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
   /// - Returns: An array of the elements that `includeElement` allowed.
-  @warn_unused_result
   public func filter(
     _ includeElement: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [Iterator.Element] {
@@ -794,7 +782,6 @@ extension Sequence {
   /// - Parameter maxLength: The maximum number of elements to return. The
   ///   value of `maxLength` must be greater than or equal to zero.
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @warn_unused_result
   public func suffix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
     _precondition(maxLength >= 0, "Can't take a suffix of negative length from a sequence")
     if maxLength == 0 { return AnySequence([]) }
@@ -867,7 +854,6 @@ extension Sequence {
   ///   - isSeparator: A closure that returns `true` if its argument should be
   ///     used to split the sequence; otherwise, `false`.
   /// - Returns: An array of subsequences, split from this sequence's elements.
-  @warn_unused_result
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
@@ -929,7 +915,6 @@ extension Sequence {
     return nil
   }
 
-  @warn_unused_result
   public func _customContainsEquatableElement(
     _ element: Iterator.Element
   ) -> Bool? {
@@ -1045,7 +1030,6 @@ extension Sequence where Iterator.Element : Equatable {
   ///     start or end of the sequence. If `true`, only nonempty subsequences
   ///     are returned. The default value is `true`.
   /// - Returns: An array of subsequences, split from this sequence's elements.
-  @warn_unused_result
   public func split(
     separator: Iterator.Element,
     maxSplits: Int = Int.max,
@@ -1081,7 +1065,6 @@ extension Sequence where
   ///   elements.
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   public func dropFirst(_ n: Int) -> AnySequence<Iterator.Element> {
     _precondition(n >= 0, "Can't drop a negative number of elements from a sequence")
     if n == 0 { return AnySequence(self) }
@@ -1104,7 +1087,6 @@ extension Sequence where
   /// - Parameter n: The number of elements to drop off the end of the
   ///   sequence. `n` must be greater than or equal to zero.
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @warn_unused_result
   public func dropLast(_ n: Int) -> AnySequence<Iterator.Element> {
     _precondition(n >= 0, "Can't drop a negative number of elements from a sequence")
     if n == 0 { return AnySequence(self) }
@@ -1149,7 +1131,6 @@ extension Sequence where
   ///   with at most `maxLength` elements.
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func prefix(_ maxLength: Int) -> AnySequence<Iterator.Element> {
     _precondition(maxLength >= 0, "Can't take a prefix of negative length from a sequence")
     if maxLength == 0 {
@@ -1171,7 +1152,6 @@ extension Sequence {
   ///     // Prints "[2, 3, 4, 5]"
   ///
   /// - Complexity: O(1)
-  @warn_unused_result
   public func dropFirst() -> SubSequence { return dropFirst(1) }
 
   /// Returns a subsequence containing all but the last element of the sequence.
@@ -1183,7 +1163,6 @@ extension Sequence {
   ///     // Prints "[1, 2, 3, 4]"
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
-  @warn_unused_result
   public func dropLast() -> SubSequence  { return dropLast(1) }
 }
 

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -117,7 +117,6 @@ ${orderingExplanation}
   ///
   /// - SeeAlso: `min(isOrderedBefore:)`
 %   end
-  @warn_unused_result
   public func min(
 %   if preds:
     isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
@@ -170,7 +169,6 @@ ${orderingExplanation}
   ///
   /// - SeeAlso: `max(isOrderedBefore:)`
 %   end
-  @warn_unused_result
   public func max(
 %   if preds:
     isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
@@ -238,7 +236,6 @@ ${equivalenceExplanation}
   ///
   /// - SeeAlso: `starts(with:isEquivalent:)`
 %   end
-  @warn_unused_result
   public func starts<
     PossiblePrefix : Sequence where PossiblePrefix.${GElement} == ${GElement}
   >(
@@ -313,7 +310,6 @@ ${equivalenceExplanation}
   ///
   /// - SeeAlso: `elementsEqual(_:isEquivalent:)`
 %   end
-  @warn_unused_result
   public func elementsEqual<
     OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
   >(
@@ -397,7 +393,6 @@ ${orderingExplanation}
   ///   perform localized comparison.
   /// - SeeAlso: `lexicographicallyPrecedes(_:isOrderedBefore:)`
 %   end
-  @warn_unused_result
   public func lexicographicallyPrecedes<
     OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
   >(
@@ -449,7 +444,6 @@ extension Sequence where Iterator.Element : Equatable {
   /// - Parameter element: The element to find in the sequence.
   /// - Returns: `true` if the element was found in the sequence; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func contains(_ element: ${GElement}) -> Bool {
     if let result = _customContainsEquatableElement(element) {
       return result
@@ -500,7 +494,6 @@ extension Sequence {
   ///   the passed element represents a match.
   /// - Returns: `true` if the sequence contains an element that satisfies
   ///   `predicate`; otherwise, `false`.
-  @warn_unused_result
   public func contains(
     _ predicate: @noescape (${GElement}) throws -> Bool
   ) rethrows -> Bool {
@@ -547,7 +540,6 @@ extension Sequence {
   ///     in the next call of the `combine` closure or returned to the
   ///     caller.
   /// - Returns: The final accumulated value.
-  @warn_unused_result
   public func reduce<T>(
     _ initial: T, combine: @noescape (T, ${GElement}) throws -> T
   ) rethrows -> T {
@@ -573,7 +565,6 @@ extension Sequence {
   ///
   /// - Returns: An array containing the elements of this sequence in
   ///   reverse order.
-  @warn_unused_result
   public func reversed() -> [${GElement}] {
     // FIXME(performance): optimize to 1 pass?  But Array(self) can be
     // optimized to a memcpy() sometimes.  Those cases are usually collections,
@@ -619,7 +610,6 @@ extension Sequence {
   /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
   ///   and *n* is the length of the result.
   /// - SeeAlso: `flatten()`, `map(_:)`
-  @warn_unused_result
   public func flatMap<SegmentOfResult : Sequence>(
     _ transform: @noescape (${GElement}) throws -> SegmentOfResult
   ) rethrows -> [SegmentOfResult.${GElement}] {
@@ -656,7 +646,6 @@ extension Sequence {
   ///
   /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
   ///   and *n* is the length of the result.
-  @warn_unused_result
   public func flatMap<ElementOfResult>(
     _ transform: @noescape (${GElement}) throws -> ElementOfResult?
   ) rethrows -> [ElementOfResult] {

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -66,7 +66,6 @@ extension Sequence
   ///   value of the same or of a different type.
   /// - Returns: An array containing the transformed elements of this
   ///   sequence.
-  @warn_unused_result
   public func map<T>(
     _ transform: @noescape (Base.Iterator.Element) throws -> T
   ) rethrows -> [T] {
@@ -88,7 +87,6 @@ extension Sequence
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
   /// - Returns: An array of the elements that `includeElement` allowed.
-  @warn_unused_result
   public func filter(
     _ includeElement: @noescape (Base.Iterator.Element) throws -> Bool
   ) rethrows -> [Base.Iterator.Element] {

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -89,7 +89,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   ///
   /// - Parameter member: An element to look for in the set.
   /// - Returns: `true` if `member` exists in the set; otherwise, `false`.
-  @warn_unused_result
   func contains(_ member: Element) -> Bool
 
   /// Returns a new set with the elements of both this and the given set.
@@ -116,7 +115,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   /// - Note: if this set and `other` contain elements that are equal but
   ///   distinguishable (e.g. via `===`), which of these elements is present
   ///   in the result is unspecified.
-  @warn_unused_result
   func union(_ other: Self) -> Self
   
   /// Returns a new set with the elements that are common to both this set and
@@ -136,7 +134,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   /// - Note: if this set and `other` contain elements that are equal but
   ///   distinguishable (e.g. via `===`), which of these elements is present
   ///   in the result is unspecified.
-  @warn_unused_result
   func intersection(_ other: Self) -> Self
 
   /// Returns a new set with the elements that are either in this set or in the
@@ -152,7 +149,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: A new set.
-  @warn_unused_result
   func symmetricDifference(_ other: Self) -> Self
 
   /// Inserts the given element in the set if it is not already present.
@@ -293,7 +289,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: A new set.
-  @warn_unused_result
   func subtracting(_ other: Self) -> Self
 
   /// Returns a Boolean value that indicates whether the set is a subset of
@@ -309,7 +304,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
-  @warn_unused_result
   func isSubset(of other: Self) -> Bool
 
   /// Returns a Boolean value that indicates whether the set has no members in
@@ -325,7 +319,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set has no elements in common with `other`;
   ///   otherwise, `false`.
-  @warn_unused_result
   func isDisjoint(with other: Self) -> Bool
 
   /// Returns a Boolean value that indicates whether the set is a superset of
@@ -342,7 +335,6 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a superset of `possibleSubset`;
   ///   otherwise, `false`.
-  @warn_unused_result
   func isSuperset(of other: Self) -> Bool
 
   /// A Boolean value that indicates whether the set has no elements.
@@ -448,7 +440,6 @@ extension SetAlgebra {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
-  @warn_unused_result
   public func isSubset(of other: Self) -> Bool {
     return self.intersection(other) == self
   }
@@ -467,7 +458,6 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a superset of `other`; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func isSuperset(of other: Self) -> Bool {
     return other.isSubset(of: self)
   }
@@ -485,7 +475,6 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set has no elements in common with `other`;
   ///   otherwise, `false`.
-  @warn_unused_result
   public func isDisjoint(with other: Self) -> Bool {
     return self.intersection(other).isEmpty
   }
@@ -503,7 +492,6 @@ extension SetAlgebra {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: A new set.
-  @warn_unused_result
   public func subtracting(_ other: Self) -> Self {
     return self.intersection(self.symmetricDifference(other))
   }
@@ -530,7 +518,6 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a strict superset of `other`; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func isStrictSuperset(of other: Self) -> Bool {
     return self.isSuperset(of: other) && self != other
   }
@@ -554,7 +541,6 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a strict subset of `other`; otherwise,
   ///   `false`.
-  @warn_unused_result
   public func isStrictSubset(of other: Self) -> Bool {
     return other.isStrictSuperset(of: self)
   }

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -17,7 +17,6 @@
 #if _runtime(_ObjC)
 import SwiftShims
 
-@warn_unused_result
 internal func _makeSwiftNSFastEnumerationState()
    -> _SwiftNSFastEnumerationState {
   return _SwiftNSFastEnumerationState(

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -168,7 +168,6 @@ public struct ${Self}<Base : ${BaseRequirements}>
   // We can't do it right now because we don't have enough
   // constraints on the Base.Indices type in this context.
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(after: i)
@@ -180,7 +179,6 @@ public struct ${Self}<Base : ${BaseRequirements}>
   }
 
 %     if Traversal in ['Bidirectional', 'RandomAccess']:
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(before: i)
@@ -192,13 +190,11 @@ public struct ${Self}<Base : ${BaseRequirements}>
   }
 %     end
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(i, offsetBy: n)
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -206,7 +202,6 @@ public struct ${Self}<Base : ${BaseRequirements}>
     return _base.index(i, offsetBy: n, limitedBy: limit)
   }
 
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     // FIXME: swift-3-indexing-model: range check.
     return _base.distance(from: start, to: end)

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -133,7 +133,6 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
 
   //===--- Non-essential bits ---------------------------------------------===//
 
-  @warn_unused_result
   public mutating func requestUniqueMutableBackingBuffer(
     minimumCapacity: Int
   ) -> NativeBuffer? {
@@ -163,12 +162,10 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
     return nil
   }
 
-  @warn_unused_result
   public mutating func isMutableAndUniquelyReferenced() -> Bool {
     return _hasNativeBuffer && isUniquelyReferenced()
   }
 
-  @warn_unused_result
   public mutating func isMutableAndUniquelyReferencedOrPinned() -> Bool {
     return _hasNativeBuffer && isUniquelyReferencedOrPinned()
   }
@@ -176,7 +173,6 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
   /// If this buffer is backed by a `_ContiguousArrayBuffer`
   /// containing the same number of elements as `self`, return it.
   /// Otherwise, return `nil`.
-  @warn_unused_result
   public func requestNativeBuffer() -> _ContiguousArrayBuffer<Element>? {
     _invariantCheck()
     if _fastPath(_hasNativeBuffer && nativeBuffer.count == count) {
@@ -239,18 +235,15 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
     return count
   }
 
-  @warn_unused_result
   mutating func isUniquelyReferenced() -> Bool {
     return isUniquelyReferencedNonObjC(&owner)
   }
 
-  @warn_unused_result
   mutating func isUniquelyReferencedOrPinned() -> Bool {
     return isUniquelyReferencedOrPinnedNonObjC(&owner)
   }
 
   @_versioned
-  @warn_unused_result
   func getElement(_ i: Int) -> Element {
     _sanityCheck(i >= startIndex, "negative slice index is out of range")
     _sanityCheck(i < endIndex, "slice index out of range")

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -35,7 +35,6 @@ public protocol ${Self} : ${Conformance} {
   /// If `Stride` conforms to `Integer`, then `self.advanced(by: x) == other`.
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   func distance(to other: Self) -> Stride
 
   /// Returns a `Self` `x` such that `self.distance(to: x)` approximates `n`.
@@ -43,7 +42,6 @@ public protocol ${Self} : ${Conformance} {
   /// If `Stride` conforms to `Integer`, then `self.distance(to: x) == n`.
   ///
   /// - Complexity: O(1).
-  @warn_unused_result
   func advanced(by n: Stride) -> Self
 
   associatedtype _DisabledRangeIndex = _DisabledRangeIndex_
@@ -60,22 +58,18 @@ public func == <T : Strideable>(x: T, y: T) -> Bool {
   return x.distance(to: y) == 0
 }
 
-@warn_unused_result
 public func + <T : Strideable>(lhs: T, rhs: T.Stride) -> T {
   return lhs.advanced(by: rhs)
 }
 
-@warn_unused_result
 public func + <T : Strideable>(lhs: T.Stride, rhs: T) -> T {
   return rhs.advanced(by: lhs)
 }
 
-@warn_unused_result
 public func - <T : Strideable>(lhs: T, rhs: T.Stride) -> T {
   return lhs.advanced(by: -rhs)
 }
 
-@warn_unused_result
 public func - <T : Strideable>(lhs: T, rhs: T) -> T.Stride {
   return rhs.distance(to: lhs)
 }
@@ -181,7 +175,6 @@ public struct StrideTo<Element : Strideable> : Sequence, CustomReflectable {
 /// Returns the sequence of values (`self`, `self + stride`, `self +
 /// stride + stride`, ... *last*) where *last* is the last value in
 /// the progression that is less than `end`.
-@warn_unused_result
 public func stride<T : Strideable>(
   from start: T, to end: T, by stride: T.Stride
 ) -> StrideTo<T> {
@@ -250,7 +243,6 @@ public struct StrideThrough<
 /// the progression less than or equal to `end`.
 ///
 /// - Note: There is no guarantee that `end` is an element of the sequence.
-@warn_unused_result
 public func stride<T : Strideable>(
   from start: T, through end: T, by stride: T.Stride
 ) -> StrideThrough<T> {

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -124,7 +124,6 @@ public struct String {
 }
 
 extension String {
-  @warn_unused_result
   public // @testable
   static func _fromWellFormedCodeUnitSequence<
     Encoding: UnicodeCodec, Input: Collection
@@ -135,7 +134,6 @@ extension String {
     return String._fromCodeUnitSequence(encoding, input: input)!
   }
 
-  @warn_unused_result
   public // @testable
   static func _fromCodeUnitSequence<
     Encoding: UnicodeCodec, Input: Collection
@@ -153,7 +151,6 @@ extension String {
     }
   }
 
-  @warn_unused_result
   public // @testable
   static func _fromCodeUnitSequenceWithRepair<
     Encoding: UnicodeCodec, Input: Collection
@@ -271,7 +268,6 @@ extension String : CustomDebugStringConvertible {
 extension String {
   /// Returns the number of code units occupied by this string
   /// in the given encoding.
-  @warn_unused_result
   func _encodedLength<
     Encoding: UnicodeCodec
   >(_ encoding: Encoding.Type) -> Int {
@@ -325,7 +321,6 @@ public func _stdlib_compareNSStringDeterministicUnicodeCollationPointer(
 extension String : Equatable {
 }
 
-@warn_unused_result
 public func ==(lhs: String, rhs: String) -> Bool {
   if lhs._core.isASCII && rhs._core.isASCII {
     if lhs._core.count != rhs._core.count {
@@ -354,7 +349,6 @@ extension String {
   ///   0027  ; [*02F8.0020.0002] # APOSTROPHE
   ///
   /// - Precondition: Both `self` and `rhs` are ASCII strings.
-  @warn_unused_result
   public // @testable
   func _compareASCII(_ rhs: String) -> Int {
     var compare = Int(_swift_stdlib_memcmp(
@@ -370,7 +364,6 @@ extension String {
 #endif
 
   /// Compares two strings with the Unicode Collation Algorithm.
-  @warn_unused_result
   @inline(never)
   @_semantics("stdlib_binary_only") // Hide the CF/ICU dependency
   public  // @testable
@@ -418,7 +411,6 @@ extension String {
 #endif
   }
 
-  @warn_unused_result
   public  // @testable
   func _compareString(_ rhs: String) -> Int {
 #if _runtime(_ObjC)
@@ -432,7 +424,6 @@ extension String {
   }
 }
 
-@warn_unused_result
 public func <(lhs: String, rhs: String) -> Bool {
   return lhs._compareString(rhs) < 0
 }
@@ -459,11 +450,9 @@ extension String {
 }
 
 #if _runtime(_ObjC)
-@warn_unused_result
 @_silgen_name("swift_stdlib_NSStringHashValue")
 func _stdlib_NSStringHashValue(_ str: AnyObject, _ isASCII: Bool) -> Int
 
-@warn_unused_result
 @_silgen_name("swift_stdlib_NSStringHashValuePointer")
 func _stdlib_NSStringHashValuePointer(_ str: OpaquePointer, _ isASCII: Bool) -> Int
 #endif
@@ -512,7 +501,6 @@ extension String : Hashable {
   }
 }
 
-@warn_unused_result
 @effects(readonly)
 @_semantics("string.concat")
 public func + (lhs: String, rhs: String) -> String {
@@ -569,7 +557,6 @@ extension Sequence where Iterator.Element == String {
   /// - Parameter separator: A string to insert between each of the elements
   ///   in this sequence.
   /// - Returns: A single, concatenated string.
-  @warn_unused_result
   public func joined(separator: String) -> String {
     var result = ""
 
@@ -613,15 +600,12 @@ extension Sequence where Iterator.Element == String {
 }
 
 #if _runtime(_ObjC)
-@warn_unused_result
 @_silgen_name("swift_stdlib_NSStringLowercaseString")
 func _stdlib_NSStringLowercaseString(_ str: AnyObject) -> _CocoaString
 
-@warn_unused_result
 @_silgen_name("swift_stdlib_NSStringUppercaseString")
 func _stdlib_NSStringUppercaseString(_ str: AnyObject) -> _CocoaString
 #else
-@warn_unused_result
 internal func _nativeUnicodeLowercaseString(_ str: String) -> String {
   var buffer = _StringBuffer(
     capacity: str._core.count, initialSize: str._core.count, elementWidth: 2)
@@ -645,7 +629,6 @@ internal func _nativeUnicodeLowercaseString(_ str: String) -> String {
   return String(_storage: buffer)
 }
 
-@warn_unused_result
 internal func _nativeUnicodeUppercaseString(_ str: String) -> String {
   var buffer = _StringBuffer(
     capacity: str._core.count, initialSize: str._core.count, elementWidth: 2)

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -83,7 +83,6 @@ public struct _StringBuffer {
       = ((_storage._capacity() - capacityBump) << 1) + elementShift
   }
 
-  @warn_unused_result
   static func fromCodeUnits<
     Input : Collection, // Sequence?
     Encoding : UnicodeCodec
@@ -181,7 +180,6 @@ public struct _StringBuffer {
   // reserveCapacity on String and subsequently use that capacity, in
   // two separate phases.  Operations with one-phase growth should use
   // "grow()," below.
-  @warn_unused_result
   func hasCapacity(
     _ cap: Int, forSubRange r: Range<UnsafePointer<_RawByte>>
   ) -> Bool {

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -113,7 +113,6 @@ extension String.CharacterView : BidirectionalCollection {
 
     /// Returns the length of the first extended grapheme cluster in UTF-16
     /// code units.
-    @warn_unused_result
     @inline(never)
     internal static func _measureExtendedGraphemeClusterForward(
         from start: UnicodeScalarView.Index
@@ -155,7 +154,6 @@ extension String.CharacterView : BidirectionalCollection {
 
     /// Returns the length of the previous extended grapheme cluster in UTF-16
     /// code units.
-    @warn_unused_result
     @inline(never)
     internal static func _measureExtendedGraphemeClusterBackward(
         from end: UnicodeScalarView.Index
@@ -218,7 +216,6 @@ extension String.CharacterView : BidirectionalCollection {
   /// Returns the next consecutive position after `i`.
   ///
   /// - Precondition: The next position is valid.
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     _precondition(i._base != i._base._viewEndIndex, "cannot increment endIndex")
     return Index(_base: i._endBase)
@@ -227,7 +224,6 @@ extension String.CharacterView : BidirectionalCollection {
   /// Returns the previous consecutive position before `i`.
   ///
   /// - Precondition: The previous position is valid.
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check i?
     _precondition(i._base != i._base._viewStartIndex,

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -97,7 +97,6 @@ public struct _StringCore {
   /// storage.  Caveats: The string must have contiguous storage; the
   /// element may be 1 or 2 bytes wide, depending on elementWidth; the
   /// result may be null if the string is empty.
-  @warn_unused_result
   func _pointer(toElementAt n: Int) -> OpaquePointer {
     _sanityCheck(hasContiguousStorage && n >= 0 && n <= count)
     return OpaquePointer(
@@ -296,7 +295,6 @@ public struct _StringCore {
 
   /// Get the Nth UTF-16 Code Unit stored.
   @_versioned
-  @warn_unused_result
   func _nthContiguous(_ position: Int) -> UTF16.CodeUnit {
     let p =
         UnsafeMutablePointer<UInt8>(_pointer(toElementAt: position)._rawValue)
@@ -382,7 +380,6 @@ public struct _StringCore {
   /// - Note: If unsuccessful because of insufficient space in an
   ///   existing buffer, the suggested new capacity will at least double
   ///   the existing buffer's storage.
-  @warn_unused_result
   mutating func _claimCapacity(
     _ newSize: Int, minElementWidth: Int) -> (Int, OpaquePointer?) {
     if _fastPath((nativeBuffer != nil) && elementWidth >= minElementWidth) {
@@ -416,7 +413,6 @@ public struct _StringCore {
   /// Effectively appends garbage to the String until it has newSize
   /// UTF-16 code units.  Returns a pointer to the garbage code units;
   /// you must immediately copy valid data into that storage.
-  @warn_unused_result
   mutating func _growBuffer(
     _ newSize: Int, minElementWidth: Int
   ) -> OpaquePointer {
@@ -555,7 +551,6 @@ public struct _StringCore {
   /// represented as pure ASCII.
   ///
   /// - Complexity: O(N) in the worst case.
-  @warn_unused_result
   func isRepresentableAsASCII() -> Bool {
     if _slowPath(!hasContiguousStorage) {
       return false

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -68,7 +68,6 @@ extension String.Index {
   /// to `self`.
   ///
   /// - Precondition: `self` is an element of `String(utf8).indices`.
-  @warn_unused_result
   public func samePosition(
     in utf8: String.UTF8View
   ) -> String.UTF8View.Index {
@@ -79,7 +78,6 @@ extension String.Index {
   /// to `self`.
   ///
   /// - Precondition: `self` is an element of `String(utf16).indices`.
-  @warn_unused_result
   public func samePosition(
     in utf16: String.UTF16View
   ) -> String.UTF16View.Index {
@@ -90,7 +88,6 @@ extension String.Index {
   /// to `self`.
   ///
   /// - Precondition: `self` is an element of `String(unicodeScalars).indices`.
-  @warn_unused_result
   public func samePosition(
     in unicodeScalars: String.UnicodeScalarView
   ) -> String.UnicodeScalarView.Index {

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -38,7 +38,6 @@ extension String {
     return _split(separator: "\n")
   }
   
-  @warn_unused_result
   public func _split(separator: UnicodeScalar) -> [String] {
     let scalarSlices = unicodeScalars.split { $0 == separator }
     return scalarSlices.map { String($0) }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -29,25 +29,21 @@ extension String {
   public var endIndex: Index { return characters.endIndex }
 
     // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     return characters.index(after: i)
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     return characters.index(before: i)
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     return characters.index(i, offsetBy: n)
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -55,7 +51,6 @@ extension String {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     return characters.distance(from: start, to: end)
   }
@@ -75,12 +70,10 @@ extension String {
   }
 }
 
-@warn_unused_result
 public func == (lhs: String.Index, rhs: String.Index) -> Bool {
   return lhs._base == rhs._base
 }
 
-@warn_unused_result
 public func < (lhs: String.Index, rhs: String.Index) -> Bool {
   return lhs._base < rhs._base
 }

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -59,28 +59,24 @@ extension String {
     }
 
     // TODO: swift-3-indexing-model - add docs
-    @warn_unused_result
     public func index(after i: Index) -> Index {
       // FIXME: swift-3-indexing-model: range check i?
       return Index(_offset: _unsafePlus(i._offset, 1))
     }
 
     // TODO: swift-3-indexing-model - add docs
-    @warn_unused_result
     public func index(before i: Index) -> Index {
       // FIXME: swift-3-indexing-model: range check i?
       return Index(_offset: _unsafeMinus(i._offset, 1))
     }
 
     // TODO: swift-3-indexing-model - add docs
-    @warn_unused_result
     public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
       // FIXME: swift-3-indexing-model: range check i?
       return Index(_offset: i._offset.advanced(by: n))
     }
 
     // TODO: swift-3-indexing-model - add docs
-    @warn_unused_result
     public func index(
       _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
     ) -> Index? {
@@ -93,13 +89,11 @@ extension String {
     }
 
     // TODO: swift-3-indexing-model - add docs
-    @warn_unused_result
     public func distance(from start: Index, to end: Index) -> IndexDistance {
       // FIXME: swift-3-indexing-model: range check start and end?
       return start._offset.distance(to: end._offset)
     }
 
-    @warn_unused_result
     func _internalIndex(at i: Int) -> Int {
       return _core.startIndex + _offset + i
     }
@@ -231,14 +225,12 @@ extension String {
 
 // FIXME: swift-3-indexing-model: add complete set of forwards for Comparable 
 //        assuming String.UTF8View.Index continues to exist
-@warn_unused_result
 public func == (
   lhs: String.UTF16View.Index, rhs: String.UTF16View.Index
 ) -> Bool {
   return lhs._offset == rhs._offset
 }
 
-@warn_unused_result
 public func < (
   lhs: String.UTF16View.Index, rhs: String.UTF16View.Index
 ) -> Bool {
@@ -293,7 +285,6 @@ extension String.UTF16View.Index {
   ///
   /// - Precondition: `self` is an element of
   ///   `String(utf8)!.utf16.indices`.
-  @warn_unused_result
   public func samePosition(
     in utf8: String.UTF8View
   ) -> String.UTF8View.Index? {
@@ -305,7 +296,6 @@ extension String.UTF16View.Index {
   ///
   /// - Precondition: `self` is an element of
   ///   `String(unicodeScalars).utf16.indices`.
-  @warn_unused_result
   public func samePosition(
     in unicodeScalars: String.UnicodeScalarView
   ) -> String.UnicodeScalarIndex? {
@@ -316,7 +306,6 @@ extension String.UTF16View.Index {
   /// to `self`, or if no such position exists, `nil`.
   ///
   /// - Precondition: `self` is an element of `characters.utf16.indices`.
-  @warn_unused_result
   public func samePosition(
     in characters: String
   ) -> String.Index? {
@@ -379,7 +368,6 @@ extension String.UTF16View.Indices : BidirectionalCollection {
       endIndex: bounds.upperBound)
   }
 
-  @warn_unused_result
   public func index(after i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _elements.index(after: i)
@@ -390,7 +378,6 @@ extension String.UTF16View.Indices : BidirectionalCollection {
     _elements.formIndex(after: &i)
   }
 
-  @warn_unused_result
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _elements.index(before: i)
@@ -401,13 +388,11 @@ extension String.UTF16View.Indices : BidirectionalCollection {
     _elements.formIndex(before: &i)
   }
 
-  @warn_unused_result
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     // FIXME: swift-3-indexing-model: range check i?
     return _elements.index(i, offsetBy: n)
   }
 
-  @warn_unused_result
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -416,7 +401,6 @@ extension String.UTF16View.Indices : BidirectionalCollection {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @warn_unused_result
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     // FIXME: swift-3-indexing-model: range check start and end?
     return _elements.distance(from: start, to: end)

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -32,7 +32,6 @@ extension _StringCore {
   /// and the second element contains the encoded UTF-8 starting in its
   /// low byte.  Any unused high bytes in the result will be set to
   /// 0xFF.
-  @warn_unused_result
   func _encodeSomeUTF8(from i: Int) -> (Int, _UTF8Chunk) {
     _sanityCheck(i <= count)
 
@@ -62,7 +61,6 @@ extension _StringCore {
 
   /// Helper for `_encodeSomeUTF8`, above.  Handles the case where the
   /// storage is contiguous UTF-16.
-  @warn_unused_result
   func _encodeSomeContiguousUTF16AsUTF8(from i: Int) -> (Int, _UTF8Chunk) {
     _sanityCheck(elementWidth == 2)
     _sanityCheck(_baseAddress != nil)
@@ -74,7 +72,6 @@ extension _StringCore {
 #if _runtime(_ObjC)
   /// Helper for `_encodeSomeUTF8`, above.  Handles the case where the
   /// storage is non-contiguous UTF-16.
-  @warn_unused_result
   func _encodeSomeNonContiguousUTF16AsUTF8(from i: Int) -> (Int, _UTF8Chunk) {
     _sanityCheck(elementWidth == 2)
     _sanityCheck(_baseAddress == nil)
@@ -190,7 +187,6 @@ extension String {
     /// Returns the next consecutive position after `i`.
     ///
     /// - Precondition: The next position is representable.
-    @warn_unused_result
     public func index(after i: Index) -> Index {
       // FIXME: swift-3-indexing-model: range check i?
       let currentUnit = UTF8.CodeUnit(truncatingBitPattern: i._buffer)
@@ -307,7 +303,6 @@ extension String {
 
 // FIXME: swift-3-indexing-model: add complete set of forwards for Comparable 
 //        assuming String.UTF8View.Index continues to exist
-@warn_unused_result
 public func == (
   lhs: String.UTF8View.Index,
   rhs: String.UTF8View.Index
@@ -344,7 +339,6 @@ public func == (
   while true
 }
 
-@warn_unused_result
 public func < (
   lhs: String.UTF8View.Index,
   rhs: String.UTF8View.Index
@@ -414,7 +408,6 @@ extension String.UTF8View.Index {
   /// to `self`, or if no such position exists, `nil`.
   ///
   /// - Precondition: `self` is an element of `String(utf16)!.utf8.indices`.
-  @warn_unused_result
   public func samePosition(
     in utf16: String.UTF16View
   ) -> String.UTF16View.Index? {
@@ -426,7 +419,6 @@ extension String.UTF8View.Index {
   ///
   /// - Precondition: `self` is an element of
   ///   `String(unicodeScalars).utf8.indices`.
-  @warn_unused_result
   public func samePosition(
     in unicodeScalars: String.UnicodeScalarView
   ) -> String.UnicodeScalarIndex? {
@@ -437,7 +429,6 @@ extension String.UTF8View.Index {
   /// to `self`, or if no such position exists, `nil`.
   ///
   /// - Precondition: `self` is an element of `characters.utf8.indices`.
-  @warn_unused_result
   public func samePosition(
     in characters: String
   ) -> String.Index? {

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@warn_unused_result
 public func == (
   lhs: String.UnicodeScalarView.Index,
   rhs: String.UnicodeScalarView.Index
@@ -18,7 +17,6 @@ public func == (
   return lhs._position == rhs._position
 }
 
-@warn_unused_result
 public func < (
   lhs: String.UnicodeScalarView.Index,
   rhs: String.UnicodeScalarView.Index
@@ -95,7 +93,6 @@ extension String {
     /// Returns the next consecutive location after `i`.
     ///
     /// - Precondition: The next location exists.
-    @warn_unused_result
     public func index(after i: Index) -> Index {
       var scratch = _ScratchIterator(_core, i._position)
       var decoder = UTF16()
@@ -106,7 +103,6 @@ extension String {
     /// Returns the previous consecutive location before `i`.
     ///
     /// - Precondition: The previous location exists.
-    @warn_unused_result
     public func index(before i: Index) -> Index {
       var i = i._position-1
       let codeUnit = _core[i]
@@ -210,7 +206,6 @@ extension String {
     /// this sequence.
     ///
     /// - Complexity: O(1).
-    @warn_unused_result
     public func makeIterator() -> Iterator {
       return Iterator(_core)
     }
@@ -363,7 +358,6 @@ extension String.UnicodeScalarIndex {
   /// to `self`.
   ///
   /// - Precondition: `self` is an element of `String(utf8)!.indices`.
-  @warn_unused_result
   public func samePosition(in utf8: String.UTF8View) -> String.UTF8View.Index {
     return String.UTF8View.Index(self, within: utf8)
   }
@@ -372,7 +366,6 @@ extension String.UnicodeScalarIndex {
   /// to `self`.
   ///
   /// - Precondition: `self` is an element of `String(utf16)!.indices`.
-  @warn_unused_result
   public func samePosition(
     in utf16: String.UTF16View
   ) -> String.UTF16View.Index {
@@ -384,7 +377,6 @@ extension String.UnicodeScalarIndex {
   ///
   /// - Precondition: `self` is an element of
   ///   `characters.unicodeScalars.indices`.
-  @warn_unused_result
   public func samePosition(in characters: String) -> String.Index? {
     return String.Index(self, within: characters)
   }

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -20,7 +20,6 @@
 
 /// Returns `true` iff each component of `lhs` is equal to the corresponding
 /// component of `rhs`.
-@warn_unused_result
 public func == <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool {
   guard lhs.0 == rhs.0 else { return false }
   /*tail*/ return (
@@ -32,7 +31,6 @@ public func == <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool 
 
 /// Returns `true` iff any component of `lhs` is not equal to the corresponding
 /// component of `rhs`.
-@warn_unused_result
 public func != <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool {
   guard lhs.0 == rhs.0 else { return true }
   /*tail*/ return (
@@ -51,7 +49,6 @@ public func != <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool 
 /// Given two tuples `(a1, a2, ..., aN)` and `(b1, b2, ..., bN)`, the
 /// first tuple is `${op}${opeq}` the second tuple iff `a1 ${op} b1` or
 /// (`a1 == b1` and `(a2, ..., aN) ${op}${opeq} (b2, ..., bN)`).
-@warn_unused_result
 public func ${op}${opeq} <${comparableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool {
   if lhs.0 != rhs.0 { return lhs.0 ${op}${opeq} rhs.0 }
   /*tail*/ return (

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -199,7 +199,6 @@ public struct UTF8 : UnicodeCodec {
   /// - Requires: There is at least one used byte in `buffer`, and the unused
   ///   space in `buffer` is filled with some value not matching the UTF-8
   ///   continuation byte form (`0b10xxxxxx`).
-  @warn_unused_result
   public // @testable
   static func _decodeOne(_ buffer: UInt32) -> (result: UInt32?, length: UInt8) {
     // Note the buffer is read least significant byte first: [ #3 #2 #1 #0 ].
@@ -318,7 +317,6 @@ public struct UTF8 : UnicodeCodec {
 
   /// Returns `true` if `byte` is a continuation byte of the form
   /// `0b10xxxxxx`.
-  @warn_unused_result
   public static func isContinuation(_ byte: CodeUnit) -> Bool {
     return byte & 0b11_00__0000 == 0b10_00__0000
   }
@@ -571,7 +569,6 @@ public func transcode<
 ///
 /// Returns the index of the first unhandled code unit and the UTF-8 data
 /// that was encoded.
-@warn_unused_result
 internal func _transcodeSomeUTF16AsUTF8<
   Input : Collection
   where
@@ -666,10 +663,8 @@ internal func _transcodeSomeUTF16AsUTF8<
 /// representation.
 public // @testable
 protocol _StringElement {
-  @warn_unused_result
   static func _toUTF16CodeUnit(_: Self) -> UTF16.CodeUnit
 
-  @warn_unused_result
   static func _fromUTF16CodeUnit(_ utf16: UTF16.CodeUnit) -> Self
 }
 
@@ -703,7 +698,6 @@ extension UTF8.CodeUnit : _StringElement {
 
 extension UTF16 {
   /// Returns the number of code units required to encode `x`.
-  @warn_unused_result
   public static func width(_ x: UnicodeScalar) -> Int {
     return x.value <= 0xFFFF ? 1 : 2
   }
@@ -712,7 +706,6 @@ extension UTF16 {
   /// `x`.
   ///
   /// - Precondition: `width(x) == 2`.
-  @warn_unused_result
   public static func leadSurrogate(_ x: UnicodeScalar) -> UTF16.CodeUnit {
     _precondition(width(x) == 2)
     return UTF16.CodeUnit((x.value - 0x1_0000) >> (10 as UInt32)) + 0xD800
@@ -722,7 +715,6 @@ extension UTF16 {
   /// `x`.
   ///
   /// - Precondition: `width(x) == 2`.
-  @warn_unused_result
   public static func trailSurrogate(_ x: UnicodeScalar) -> UTF16.CodeUnit {
     _precondition(width(x) == 2)
     return UTF16.CodeUnit(
@@ -730,12 +722,10 @@ extension UTF16 {
     ) + 0xDC00
   }
 
-  @warn_unused_result
   public static func isLeadSurrogate(_ x: CodeUnit) -> Bool {
     return 0xD800...0xDBFF ~= x
   }
 
-  @warn_unused_result
   public static func isTrailSurrogate(_ x: CodeUnit) -> Bool {
     return 0xDC00...0xDFFF ~= x
   }
@@ -767,7 +757,6 @@ extension UTF16 {
   /// If `repairIllFormedSequences` is `true`, the function always succeeds.
   /// If it is `false`, `nil` is returned if an ill-formed code unit sequence is
   /// found in `input`.
-  @warn_unused_result
   public static func transcodedLength<
     Encoding : UnicodeCodec, Input : IteratorProtocol
     where Encoding.CodeUnit == Input.Element

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -78,7 +78,6 @@ public struct UnicodeScalar :
   ///
   /// - parameter forceASCII: If `true`, forces most values into a numeric
   ///   representation.
-  @warn_unused_result
   public func escaped(asASCII forceASCII: Bool) -> String {
     func lowNibbleAsHex(_ v: UInt32) -> String {
       let nibble = v & 15
@@ -218,12 +217,10 @@ extension UInt64 {
 extension UnicodeScalar : Comparable, Equatable {
 }
 
-@warn_unused_result
 public func ==(lhs: UnicodeScalar, rhs: UnicodeScalar) -> Bool {
   return lhs.value == rhs.value
 }
 
-@warn_unused_result
 public func <(lhs: UnicodeScalar, rhs: UnicodeScalar) -> Bool {
   return lhs.value < rhs.value
 }
@@ -268,7 +265,6 @@ extension UnicodeScalar.UTF16View : RandomAccessCollection {
 }
 
 /// Returns c as a UTF16.CodeUnit.  Meant to be used as _ascii16("x").
-@warn_unused_result
 public // SPI(SwiftExperimental)
 func _ascii16(_ c: UnicodeScalar) -> UTF16.CodeUnit {
   _sanityCheck(c.value >= 0 && c.value <= 0x7F, "not ASCII")

--- a/stdlib/public/core/UnicodeTrie.swift.gyb
+++ b/stdlib/public/core/UnicodeTrie.swift.gyb
@@ -145,37 +145,31 @@ struct _UnicodeGraphemeClusterBreakPropertyTrie {
   }
 
   @_transparent
-  @warn_unused_result
   func _getBMPFirstLevelIndex(_ cp: UInt32) -> Int {
     return Int(cp >> ${BMPFirstLevelIndexBits})
   }
 
   @_transparent
-  @warn_unused_result
   func _getBMPDataOffset(_ cp: UInt32) -> Int {
     return Int(cp & ((1 << ${BMPDataOffsetBits}) - 1))
   }
 
   @_transparent
-  @warn_unused_result
   func _getSuppFirstLevelIndex(_ cp: UInt32) -> Int {
     return Int(cp >> (${SuppSecondLevelIndexBits} + ${SuppDataOffsetBits}))
   }
 
   @_transparent
-  @warn_unused_result
   func _getSuppSecondLevelIndex(_ cp: UInt32) -> Int {
     return Int((cp >> ${SuppDataOffsetBits}) &
         ((1 << ${SuppSecondLevelIndexBits}) - 1))
   }
 
   @_transparent
-  @warn_unused_result
   func _getSuppDataOffset(_ cp: UInt32) -> Int {
     return Int(cp & ((1 << ${SuppDataOffsetBits}) - 1))
   }
 
-  @warn_unused_result
   func getPropertyRawValue(
       _ codePoint: UInt32
   ) -> _GraphemeClusterBreakPropertyRawValue {
@@ -204,7 +198,6 @@ struct _UnicodeGraphemeClusterBreakPropertyTrie {
     }
   }
 
-  @warn_unused_result
   public // @testable
   func getPropertyValue(
       _ codePoint: UInt32
@@ -223,7 +216,6 @@ internal struct _UnicodeExtendedGraphemeClusterSegmenter {
 
   /// Returns `true` if there is always a grapheme cluster break after a code
   /// point with a given `Grapheme_Cluster_Break` property value.
-  @warn_unused_result
   func isBoundaryAfter(_ gcb: _GraphemeClusterBreakPropertyRawValue) -> Bool {
     let ruleRow = _noBoundaryRulesMatrix[Int(gcb.rawValue)]
     return ruleRow == 0
@@ -231,7 +223,6 @@ internal struct _UnicodeExtendedGraphemeClusterSegmenter {
 
   /// Returns `true` if there is a grapheme cluster break between code points
   /// with given `Grapheme_Cluster_Break` property values.
-  @warn_unused_result
   func isBoundary(
       _ gcb1: _GraphemeClusterBreakPropertyRawValue,
       _ gcb2: _GraphemeClusterBreakPropertyRawValue

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -29,7 +29,6 @@ public struct Unmanaged<Instance : AnyObject> {
   ///
   ///     let str: CFString = Unmanaged.fromOpaque(ptr).takeUnretainedValue()
   @_transparent
-  @warn_unused_result
   public static func fromOpaque(_ value: OpaquePointer) -> Unmanaged {
     return Unmanaged(_private: unsafeBitCast(value, to: Instance.self))
   }
@@ -41,7 +40,6 @@ public struct Unmanaged<Instance : AnyObject> {
   /// does not know the ownership rules for, but you know that the
   /// API expects you to pass the object at +1.
   @_transparent
-  @warn_unused_result
   public static func passRetained(_ value: Instance) -> Unmanaged {
     return Unmanaged(_private: value).retain()
   }
@@ -56,7 +54,6 @@ public struct Unmanaged<Instance : AnyObject> {
   ///     CFArraySetValueAtIndex(.passUnretained(array), i,
   ///                            .passUnretained(object))
   @_transparent
-  @warn_unused_result
   public static func passUnretained(_ value: Instance) -> Unmanaged {
     return Unmanaged(_private: value)
   }
@@ -66,7 +63,6 @@ public struct Unmanaged<Instance : AnyObject> {
   ///
   /// This is useful when a function returns an unmanaged reference
   /// and you know that you're not responsible for releasing the result.
-  @warn_unused_result
   public func takeUnretainedValue() -> Instance {
     return _value
   }
@@ -76,7 +72,6 @@ public struct Unmanaged<Instance : AnyObject> {
   ///
   /// This is useful when a function returns an unmanaged reference
   /// and you know that you're responsible for releasing the result.
-  @warn_unused_result
   public func takeRetainedValue() -> Instance {
     let result = _value
     release()

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -126,7 +126,6 @@ public struct ${Self}<Pointee>
   /// instances of `Pointee`.
   ///
   /// - Postcondition: The pointee is allocated, but not initialized.
-  @warn_unused_result
   public init(allocatingCapacity count: Int) {
     let size = strideof(Pointee.self) * count
     self._rawValue =
@@ -193,7 +192,6 @@ public struct ${Self}<Pointee>
   /// - Precondition: The pointee is initialized.
   ///
   /// - Postcondition: The memory is uninitialized.
-  @warn_unused_result
   public func move() -> Pointee {
     return Builtin.take(_rawValue)
   }
@@ -481,7 +479,6 @@ extension ${Self} : CustomPlaygroundQuickLookable {
 }
 
 @_transparent
-@warn_unused_result
 public func == <Pointee>(
   lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>
 ) -> Bool {
@@ -489,33 +486,28 @@ public func == <Pointee>(
 }
 
 @_transparent
-@warn_unused_result
 public func < <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
   return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
 }
 
 @_transparent
-@warn_unused_result
 public func + <Pointee>(lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
   return ${Self}(Builtin.gep_Word(
     lhs._rawValue, (rhs &* strideof(Pointee.self))._builtinWordValue))
 }
 
 @_transparent
-@warn_unused_result
 public func + <Pointee>(lhs: Int,
            rhs: ${Self}<Pointee>) -> ${Self}<Pointee> {
   return rhs + lhs
 }
 
 @_transparent
-@warn_unused_result
 public func - <Pointee>(lhs: ${Self}<Pointee>, rhs: Int) -> ${Self}<Pointee> {
   return lhs + -rhs
 }
 
 @_transparent
-@warn_unused_result
 public func - <Pointee>(lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Int {
   return
     Int(Builtin.sub_Word(Builtin.ptrtoint_Word(lhs._rawValue),
@@ -579,7 +571,6 @@ extension ${Self} {
 }
 
 extension Int {
-  @warn_unused_result
   public init<U>(bitPattern: ${Self}<U>?) {
     if let bitPattern = bitPattern {
       self = Int(Builtin.ptrtoint_Word(bitPattern._rawValue))
@@ -590,7 +581,6 @@ extension Int {
 }
 
 extension UInt {
-  @warn_unused_result
   public init<U>(bitPattern: ${Self}<U>?) {
     if let bitPattern = bitPattern {
       self = UInt(Builtin.ptrtoint_Word(bitPattern._rawValue))

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -95,7 +95,6 @@ internal func _withVaList<R>(
 ///   `withVaList`, but occasionally (i.e. in a `class` initializer) you
 ///   may find that the language rules don't allow you to use
 /// `withVaList` as intended.
-@warn_unused_result
 public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
   let builder = _VaListBuilder()
   for a in args {
@@ -108,7 +107,6 @@ public func getVaList(_ args: [CVarArg]) -> CVaListPointer {
 }
 #endif
 
-@warn_unused_result
 public func _encodeBitsAsWords<T : CVarArg>(_ x: T) -> [Int] {
   let result = [Int](
     repeating: 0,
@@ -313,7 +311,6 @@ final internal class _VaListBuilder {
     appendWords(arg._cVarArgEncoding)
   }
 
-  @warn_unused_result
   func va_list() -> CVaListPointer {
     // Use Builtin.addressof to emphasize that we are deliberately escaping this
     // pointer and assuming it is safe to do so.
@@ -351,13 +348,11 @@ final internal class _VaListBuilder {
     }
   }
 
-  @warn_unused_result
   func rawSizeAndAlignment(_ wordCount: Int) -> (Builtin.Word, Builtin.Word) {
     return ((wordCount * strideof(Int.self))._builtinWordValue,
       requiredAlignmentInBytes._builtinWordValue)
   }
 
-  @warn_unused_result
   func allocStorage(wordCount: Int) -> UnsafeMutablePointer<Int> {
     let (rawSize, rawAlignment) = rawSizeAndAlignment(wordCount)
     let rawStorage = Builtin.allocRaw(rawSize, rawAlignment)
@@ -429,7 +424,6 @@ final internal class _VaListBuilder {
     }
   }
 
-  @warn_unused_result
   func va_list() -> CVaListPointer {
     header.reg_save_area = storage._baseAddress
     header.overflow_arg_area


### PR DESCRIPTION
I kept the one on `sorted()`, because that one requires a less trivial change.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
