### PR TITLE
SR-1476: Disambiguate NSObjectController API

### DIFF
--- a/apinotes/AppKit.apinotes
+++ b/apinotes/AppKit.apinotes
@@ -1,6 +1,14 @@
 ---
 Name: AppKit
 Classes:
+- Name: NSObjectController
+  Methods:
+  - Selector: 'remove:'
+    SwiftName: 'remove(sender:)'
+    MethodKind: Instance
+  - Selector: 'removeObject:'
+    SwiftName: 'remove(object:)'
+    MethodKind: Instance
 - Name: NSCell
   Methods:
   - Selector: 'initImageCell:'

--- a/test/ClangModules/AppKit_test.swift
+++ b/test/ClangModules/AppKit_test.swift
@@ -4,6 +4,16 @@
 
 import AppKit
 
+class MyController {
+  init() {
+    let arrayController = NSArrayController()
+    let object = "test" as NSString
+    arrayController.remove(sender: object)
+    arrayController.remove(object: object)
+    arrayController.remove(object) // expected-error {{'remove' has been renamed to 'remove(sender:)'}}
+  }
+}
+
 class MyDocument : NSDocument {
   override func read(from URL: NSURL, ofType type: String) throws {
     try super.read(from: URL, ofType: type)
@@ -36,4 +46,3 @@ class MyView : NSView {
     // expected-note@-2 {{use 'Swift.' to reference the global function}} {{5-5=Swift.}}
   }
 }
-

--- a/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
@@ -300,3 +300,16 @@ typedef NSPoint *NSPointPointer;
 - (void)addRect:(NSRect)rect;
 + (void)conjureRect:(NSRect)rect;
 @end
+
+@interface NSController : NSObject
+@end
+
+@interface NSObjectController : NSController
+- (void)removeObject:(nonnull id)object;
+- (void)remove:(nullable id)sender;
+@end
+
+@interface NSArrayController : NSObjectController
+- (void)removeObject:(nonnull id)object;
+- (void)remove:(nullable id)sender;
+@end


### PR DESCRIPTION
#### What's in this pull request?

This pull request adds an APInote for AppKit to disambiguate the imported API for NSObjectController / NSArrayController. `-[NSObjectController remove:]` and `-[NSObjectController removeObject:]` map to `NSObjectController.remove(_ sender: AnyObject?)`and `NSObjectController.remove(_ object: AnyObject)` which makes it hard to call the right method.

This PR changes the imported API as follows:
`-[NSObjectController remove:]` -> `NSObjectController.remove(sender:)`
`-[NSObjectController removeObject:]` -> `NSObjectController.remove(object:)`
#### Resolved bug number: ([SR-1476](https://bugs.swift.org/browse/SR-1476))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This PR adds parameter labels to -[NSObjectController remove:] and -[NSObjectController removeObject:] to disambiguate them on the Swift side.
