### PR TITLE
Don't look for near-miss witnesses for unavailable requirements.

### DIFF
--- a/test/ClangModules/Inputs/protocol-member-renaming.h
+++ b/test/ClangModules/Inputs/protocol-member-renaming.h
@@ -1,0 +1,13 @@
+@import ObjectiveC;
+
+@interface Foo : NSObject
+@end
+
+@protocol FooDelegate
+- (void)foo:(Foo *)foo willConsumeObject:(id)obj __attribute__((swift_name("foo(_:willConsume:)")));
+@end
+
+@protocol OptionalButUnavailable
+@optional
+- (void)doTheThing:(id)thingToDoItWith __attribute__((unavailable));
+@end

--- a/test/ClangModules/protocol-member-renaming.swift
+++ b/test/ClangModules/protocol-member-renaming.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -parse -import-objc-header %S/Inputs/protocol-member-renaming.h -verify %s
+
+// REQUIRES: objc_interop
+
+class Modern : NSObject, FooDelegate {
+  func foo(_ foo: Foo, willConsume object: AnyObject) {}
+}
+
+class PreMigration : NSObject, FooDelegate {
+  func foo(_ foo: Foo, willConsumeObject object: AnyObject) {}
+  // expected-error@-1 {{'foo(_:willConsumeObject:)' has been renamed to 'foo(_:willConsume:)'}} {{24-41=willConsume}}
+  // expected-error@-2 {{method 'foo(_:willConsumeObject:)' has different argument names from those required by protocol 'FooDelegate' ('foo(_:willConsume:)')}} {{24-41=willConsume}}
+}
+
+class OptionalButUnavailableImpl : OptionalButUnavailable {
+  // Note the argument label that causes this not to match the requirement.
+  func doTheThing(object: AnyObject) {} // no-warning
+}


### PR DESCRIPTION
- **Explanation:** We use unavailable requirements as migration hints, but conformance checking would try a little too hard to actually satisfy them, even though they wouldn't actually be used. This led to errors about the _new_ name not matching the _old_ name.
- **Scope:** Every Objective-C delegate protocol where the "omit needless words" heuristic has changed a method cannot be conformed to in Swift. (Oops.)
- **Issue:** rdar://problem/26313044 and [SR-1514](https://bugs.swift.org/browse/SR-1514) (and dups). Reviewed by @DougGregor.
- **Risk:** Very low. We skip emitting diagnostics about unavailable requirements in more cases, but any crashes/miscompiles resulting from this would already have been possible. User experience will not degrade either.
- **Testing:** Added compiler regression tests, verified that the test case in the Radar now works. The SRs have several more test cases as well.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
