### PR TITLE
Don't allow unavailable-in-current-Swift declarations to shadow outer decls

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -391,6 +391,8 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
   if (IsKnownNonCascading)
     isCascadingUse = false;
 
+  SmallVector<UnqualifiedLookupResult, 4> UnavailableInnerResults;
+
   // Never perform local lookup for operators.
   if (Name.isOperator()) {
     if (!isCascadingUse.hasValue()) {
@@ -565,9 +567,25 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
         }
 
         if (FoundAny) {
-          if (DebugClient)
-            filterForDiscriminator(Results, DebugClient);
-          return;
+          // Predicate that determines whether a lookup result should
+          // be unavailable except as a last-ditch effort.
+          auto unavailableLookupResult =
+            [&](const UnqualifiedLookupResult &result) {
+            return result.getValueDecl()->getAttrs()
+                     .isUnavailableInCurrentSwift();
+          };
+
+          // If all of the results we found are unavailable, keep looking.
+          if (std::all_of(Results.begin(), Results.end(),
+                          unavailableLookupResult)) {
+            UnavailableInnerResults.append(Results.begin(), Results.end());
+            Results.clear();
+            FoundAny = false;
+          } else {
+            if (DebugClient)
+              filterForDiscriminator(Results, DebugClient);
+            return;
+          }
         }
 
         // Check the generic parameters if our context is a generic type or
@@ -640,6 +658,14 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
   // If we've found something, we're done.
   if (!Results.empty())
     return;
+
+  // If we still haven't found anything, but we do have some
+  // declarations that are "unavailable in the current Swift", drop
+  // those in.
+  if (!UnavailableInnerResults.empty()) {
+    Results = std::move(UnavailableInnerResults);
+    return;
+  }
 
   if (!Name.isSimpleName())
     return;

--- a/test/ClangModules/swift2_warnings.swift
+++ b/test/ClangModules/swift2_warnings.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import ImportAsMember.A
+import AppKit
 
 func testOldTypeNames() {
   var ps: NSPostingStyle? // expected-error{{'NSPostingStyle' has been renamed to 'PostingStyle'}}{{11-25=PostingStyle}}
@@ -76,4 +77,17 @@ func testImportAsMember() {
 
   IAMStruct1SetRadius(iam1, 3.14159)
   // expected-error@-1{{'IAMStruct1SetRadius' has been replaced by property 'Struct1.radius'}}{{3-22=iam1.radius}} {{22-29= = }} {{36-37=}}
+}
+
+// rdar://problem/26236989
+class X : NSDocument {
+  func test(url: URL) {
+  }
+  func test2() {
+    let url = URL(string: "ABC")
+    self.url = url!
+  }
+  func getTheURL() -> URL {
+    return url
+  }
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/AppKit.h
@@ -300,3 +300,7 @@ typedef NSPoint *NSPointPointer;
 - (void)addRect:(NSRect)rect;
 + (void)conjureRect:(NSRect)rect;
 @end
+
+@interface NSDocument (URL)
+@property (copy,nonnull) NSURL *URL;
+@end


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This pull request fixes a problem where unavailable-in-current-Swift declarations imported with the Swift 2 names (for quality-of-implementation results) can shadow declarations with the Swift 3 names, causing valid Swift 3 code to be rejected and require excessive qualification.
#### Resolved bug number: rdar://problem/26370846)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…o shadow available ones.

The unavailable-in-current-Swift declarations introduced by the Clang
importer to help with migrating Swift 2.x code to Swift 3's naming
cause problems with unqualified name lookup when they shadow, e.g.,
types. The biggest problem in practice is with "URL", which is a
common Cocoa property name (in Swift 2) that becomes "url" in Swift 3,
but the old name conflicts with the Foundation value type "URL".

Fixes rdar://problem/26236989.
