### PR TITLE
[Core Graphics] Fix apinotes for CGPathCreateMutableCopy

### DIFF
--- a/apinotes/CoreGraphics.apinotes
+++ b/apinotes/CoreGraphics.apinotes
@@ -430,9 +430,9 @@ Functions:
 - Name: CGPathCreateCopyByTransformingPath
   SwiftName: CGPathRef.copy(self:using:)
 - Name: CGPathCreateMutableCopy
-  SwiftName: CGMutablePathRef.copy(self:)
+  SwiftName: CGPathRef.mutableCopy(self:)
 - Name: CGPathCreateMutableCopyByTransformingPath
-  SwiftName: CGMutablePathRef.copy(self:using:)
+  SwiftName: CGPathRef.mutableCopy(self:using:)
 - Name: CGPathEqualToPath
   SwiftName: CGPathRef.equalTo(self:_:)
 - Name: CGPathGetPathBoundingBox


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

CGPathCreateMutableCopy and CGPathCreateMutableCopyByTransformingPath
have 'self' type of CGPath, and thus must be imported as members of
CGPath proper, not CGMutablePath. Does so by following common naming
conventions for producing mutable copies.

rdar://problem/26339788
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

CGPathCreateMutableCopy and CGPathCreateMutableCopyByTransformingPath
have 'self' type of CGPath, and thus must be imported as members of
CGPath proper, not CGMutablePath. Does so by following common naming
conventions for producing mutable copies.
