### PR TITLE
utils: require gold on Linux targets

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1218,6 +1218,11 @@ std::string toolchains::GenericUnix::getDefaultLinker() const {
     // final executables, as such, unless specified, we default to gold
     // linker.
     return "gold";
+  case llvm::Triple::x86_64:
+  case llvm::Triple::ppc64:
+  case llvm::Triple::ppc64le:
+    // BFD linker has issues wrt relocations against protected symbols.
+    return "gold";
   default:
     // Otherwise, use the default BFD linker.
     return "";

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -325,6 +325,7 @@ function set_deployment_target_based_options() {
 
     case ${deployment_target} in
         linux-x86_64)
+            USE_GOLD_LINKER=1
             SWIFT_HOST_VARIANT_ARCH="x86_64"
             ;;
         linux-armv6)
@@ -346,9 +347,11 @@ function set_deployment_target_based_options() {
             SWIFT_HOST_VARIANT_ARCH="x86_64"
             ;;
         linux-powerpc64)
+            USE_GOLD_LINKER=1
             SWIFT_HOST_VARIANT_ARCH="powerpc64"
             ;;
         linux-powerpc64le)
+            USE_GOLD_LINKER=1
             SWIFT_HOST_VARIANT_ARCH="powerpc64le"
             ;;
         cygwin-x86_64)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Given the discussion on swift-dev, and no opposition, swift the linux targets to
using gold by default.
