### PR TITLE
[Clang importer] Handle unavailable designated inits w/ available convenience inits

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1655,30 +1655,7 @@ static bool hasErrorMethodNameCollision(ClangImporter::Implementation &importer,
   // been marked NS_SWIFT_UNAVAILABLE, because it's actually marked unavailable,
   // or because it was deprecated before our API sunset. We can handle
   // "conflicts" where one form is unavailable.
-  // FIXME: Somewhat duplicated from Implementation::importAttributes.
-  clang::AvailabilityResult availability = conflict->getAvailability();
-  if (availability != clang::AR_Unavailable &&
-      importer.DeprecatedAsUnavailableFilter) {
-    for (auto *attr : conflict->specific_attrs<clang::AvailabilityAttr>()) {
-      if (attr->getPlatform()->getName() == "swift") {
-        availability = clang::AR_Unavailable;
-        break;
-      }
-      if (importer.PlatformAvailabilityFilter &&
-          !importer.PlatformAvailabilityFilter(attr->getPlatform()->getName())){
-        continue;
-      }
-      clang::VersionTuple version = attr->getDeprecated();
-      if (version.empty())
-        continue;
-      if (importer.DeprecatedAsUnavailableFilter(version.getMajor(),
-                                                 version.getMinor())) {
-        availability = clang::AR_Unavailable;
-        break;
-      }
-    }
-  }
-  return availability != clang::AR_Unavailable;
+  return !importer.isUnavailableInSwift(conflict);
 }
 
 /// Determine the optionality of the given Objective-C method.
@@ -2822,7 +2799,8 @@ auto ClangImporter::Implementation::importFullName(
         (isa<clang::TypeDecl>(D) ||
          (isa<clang::ObjCInterfaceDecl>(D) &&
           !hasOrInheritsSwiftBridgeAttr(cast<clang::ObjCInterfaceDecl>(D))) ||
-         isa<clang::ObjCProtocolDecl>(D))) {
+         isa<clang::ObjCProtocolDecl>(D)) &&
+        !isUnavailableInSwift(D)) {
       // Find the original declaration, from which we can determine
       // the owning module.
       const clang::Decl *owningD = D->getCanonicalDecl();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3886,6 +3886,14 @@ namespace {
                                CtorInitializerKind kind) {
       CtorInitializerKind existingKind = existingCtor->getInitKind();
 
+      // If one constructor is unavailable in Swift and the other is
+      // not, keep the available one.
+      bool existingIsUnavailable =
+        existingCtor->getAttrs().isUnavailable(Impl.SwiftContext);
+      bool newIsUnavailable = Impl.isUnavailableInSwift(objcMethod);
+      if (existingIsUnavailable != newIsUnavailable)
+        return existingIsUnavailable;
+
       // If the new kind is the same as the existing kind, stick with
       // the existing constructor.
       if (existingKind == kind)
@@ -6195,6 +6203,35 @@ void ClangImporter::Implementation::importAttributes(
   if (ClangDecl->hasAttr<clang::PureAttr>()) {
     MappedDecl->getAttrs().add(new (C) EffectsAttr(EffectsKind::ReadOnly));
   }
+}
+
+bool ClangImporter::Implementation::isUnavailableInSwift(
+    const clang::Decl *decl) {
+  // FIXME: Somewhat duplicated from importAttributes(), but this is a
+  // more direct path.
+  if (decl->getAvailability() == clang::AR_Unavailable) return true;
+
+  // Apply the deprecated-as-unavailable filter.
+  if (!DeprecatedAsUnavailableFilter) return false;
+
+  for (auto *attr : decl->specific_attrs<clang::AvailabilityAttr>()) {
+    if (attr->getPlatform()->getName() == "swift")
+      return true;
+
+    if (PlatformAvailabilityFilter &&
+        !PlatformAvailabilityFilter(attr->getPlatform()->getName())){
+      continue;
+    }
+
+    clang::VersionTuple version = attr->getDeprecated();
+    if (version.empty())
+      continue;
+    if (DeprecatedAsUnavailableFilter(version.getMajor(),
+                                      version.getMinor()))
+      return true;
+  }
+
+  return false;
 }
 
 Decl *

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1101,6 +1101,10 @@ public:
                             bool isStatic,
                             ClangNode ClangN);
 
+  /// Determine whether the given declaration is considered
+  /// 'unavailable' in Swift.
+  bool isUnavailableInSwift(const clang::Decl *decl);
+
   /// \brief Add "Unavailable" annotation to the swift declaration.
   void markUnavailable(ValueDecl *decl, StringRef unavailabilityMsg);
 

--- a/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
+++ b/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
@@ -19,4 +19,17 @@ __attribute__((swift_name("SomeClass.applyOptions(self:_:)")))
 void IAMSomeClassApplyOptions(IAMSomeClass * _Nonnull someClass, 
                               IAMSomeClassOptions options);
 
+@interface UnavailableDefaultInit : NSObject
+-(instancetype)init __attribute__((availability(swift,unavailable)));
+@end
+
+@interface UnavailableDefaultInitSub : UnavailableDefaultInit
+@end
+
+__attribute__((swift_name("UnavailableDefaultInit.init()")))
+UnavailableDefaultInit * _Nonnull MakeUnavailableDefaultInit(void);
+
+__attribute__((swift_name("UnavailableDefaultInitSub.init()")))
+UnavailableDefaultInitSub * _Nonnull MakeUnavailableDefaultInitSub(void);
+
 #endif

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -69,3 +69,9 @@ FooErr.mutateSomeStaticState()
 let someClassOpts: SomeClass.Options = .fuzzyDice
 let someClass = SomeClass(value: 3.14159)
 someClass.applyOptions(someClassOpts)
+
+class SomeSub : UnavailableDefaultInitSub { }
+
+// Handle default initializers.
+let udi1 = UnavailableDefaultInit()
+let udis1 = UnavailableDefaultInitSub()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This brings the fix for rdar://problem/26238032, which concerns problems with an unavailable, inherited designated initializer making an imported-as-member convenience factory initializer unusable.
#### Resolved bug number: (rdar://problem/26238032)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…rride an available import-as-member-init.

More generally, an unavailable initializer shouldn't stomp on an
available initializer, because it's possible that (for example) a
designated initializer will be unavailable but a factory initializer
will be available, so one still construct objects of that type.
Fixes rdar://problem/26238032.
