### PR TITLE
Swift 3 imported protocol alias 26304496

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1276,7 +1276,7 @@ namespace {
 
       // FIXME: We cannot currently handle generic types.
       if (auto generic = dyn_cast<GenericTypeDecl>(typeDecl)) {
-        if (generic->getGenericSignature())
+        if (generic->getGenericSignature() && !isa<ProtocolDecl>(typeDecl))
           return nullptr;
       }
 

--- a/test/ClangModules/swift2_warnings.swift
+++ b/test/ClangModules/swift2_warnings.swift
@@ -92,4 +92,4 @@ class X : NSDocument {
   }
 }
 
-func makeCopy<T: NSCopying>(thing: T) {} // expected-error {{'NSCopying' has been renamed to 'Copying'}} {{18-27=Copying}} 
+func makeCopy<T: NSWobbling>(thing: T) {} // expected-error {{'NSWobbling' has been renamed to 'Wobbling'}} {{18-28=Wobbling}} 

--- a/test/ClangModules/swift2_warnings.swift
+++ b/test/ClangModules/swift2_warnings.swift
@@ -91,3 +91,5 @@ class X : NSDocument {
     return url
   }
 }
+
+func makeCopy<T: NSCopying>(thing: T) {} // expected-error {{'NSCopying' has been renamed to 'Copying'}} {{18-27=Copying}} 


### PR DESCRIPTION
Protocols have the implicit Self generic parameter, which was
preventing this type alias from getting created, so some renamed
imported protocols for Swift 3 weren't emitting the expected
diagnostics and fix-its.

rdar://problem/26304496
