### PR TITLE
Allow update-checkout to switch to master/stable

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -39,6 +39,20 @@ REPOSITORIES = {
     'swift-integration-tests': 'apple/swift-integration-tests',
 }
 
+MASTER_BRANCHES = {
+    'llvm': 'stable',
+    'clang': 'stable',
+    'swift': 'master',
+    'lldb': 'master',
+    'cmark': 'master',
+    'llbuild': 'master',
+    'swiftpm': 'master',
+    'swift-corelibs-xctest': 'master',
+    'swift-corelibs-foundation': 'master',
+    'swift-corelibs-libdispatch': 'master',
+    'swift-integration-tests': 'master',
+}
+
 NEXT_BRANCHES = {
     'llvm': 'stable-next',
     'clang': 'stable-next',
@@ -110,7 +124,9 @@ def obtain_additional_swift_sources(
                     check_call(['git', 'clone', '--recursive', remote,
                                 dir_name])
                 if branch:
-                    if branch == "stable-next" or branch == "master-next":
+                    if branch == "master" or branch == "stable":
+                        repo_branch = MASTER_BRANCHES[dir_name]
+                    elif branch == "stable-next" or branch == "master-next":
                         repo_branch = NEXT_BRANCHES[dir_name]
                     elif branch == "swift-3.0-branch" or \
                             branch == "swift-3.0-preview-1-branch":
@@ -169,7 +185,9 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
             print("--- Skipping '" + dir_name + "' ---")
             continue
         if branch:
-            if branch == "stable-next" or branch == "master-next":
+            if branch == "master" or branch == "stable":
+                repo_branch = MASTER_BRANCHES[dir_name]
+            elif branch == "stable-next" or branch == "master-next":
                 repo_branch = NEXT_BRANCHES[dir_name]
             elif branch == "swift-3.0-branch" or \
                     branch == "swift-3.0-preview-1-branch":

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -47,6 +47,7 @@ MASTER_BRANCHES = {
     'cmark': 'master',
     'llbuild': 'master',
     'swiftpm': 'master',
+    'compiler-rt': 'stable',
     'swift-corelibs-xctest': 'master',
     'swift-corelibs-foundation': 'master',
     'swift-corelibs-libdispatch': 'master',
@@ -61,6 +62,7 @@ NEXT_BRANCHES = {
     'cmark': 'master',
     'llbuild': 'master',
     'swiftpm': 'master',
+    'compiler-rt': 'stable-next',
     'swift-corelibs-xctest': 'master',
     'swift-corelibs-foundation': 'master',
     'swift-corelibs-libdispatch': 'master',
@@ -75,11 +77,11 @@ SWIFT_3_0_PREVIEW_1_BRANCHES = {
     'cmark': 'swift-3.0-preview-1-branch',
     'llbuild': 'swift-3.0-preview-1-branch',
     'swiftpm': 'swift-3.0-preview-1-branch',
+    'compiler-rt': 'swift-3.0-branch',
     'swift-corelibs-xctest': 'swift-3.0-preview-1-branch',
     'swift-corelibs-foundation': 'swift-3.0-preview-1-branch',
     'swift-corelibs-libdispatch': 'swift-3.0-preview-1-branch',
     'swift-integration-tests': 'swift-3.0-preview-1-branch',
-    'compiler-rt': 'swift-3.0-branch',
 }
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This lets you switch back to the "latest" branch of all supporting repos by providing `master` or `stable` as the destination branch. Some use `master` (swift, llbuild) and some use `stable` (clang, llvm) so trying to switch to either of those via the script fails.

```
$ utils/update-checkout --branch master
```
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->
