### PR TITLE
Sema: Don't warn on casts that change an ObjC generic's parameters.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2255,7 +2255,7 @@ public:
   bool isObjC() const {
     return getAttrs().hasAttribute<ObjCAttr>();
   }
-
+  
   void setIsObjC(bool Value);
 
   /// Is this declaration marked with 'final'?
@@ -3342,6 +3342,13 @@ public:
   static bool classof(const IterableDeclContext *C) {
     auto NTD = dyn_cast<NominalTypeDecl>(C);
     return NTD && classof(NTD);
+  }
+  
+  /// Returns true if the decl uses the Objective-C generics model.
+  ///
+  /// This is true of imported Objective-C classes.
+  bool usesObjCGenericsModel() const {
+    return isObjC() && hasClangNode() && isGenericContext();
   }
 };
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2219,10 +2219,18 @@ public:
               "upcast operand must be a class or class metatype instance");
       CanType opInstTy(UI->getOperand()->getType().castTo<MetatypeType>()
                          ->getInstanceType());
-      require(instTy->getClassOrBoundGenericClass(),
+      auto instClass = instTy->getClassOrBoundGenericClass();
+      require(instClass,
               "upcast must convert a class metatype to a class metatype");
-      require(instTy->isExactSuperclassOf(opInstTy, nullptr),
-              "upcast must cast to a superclass or an existential metatype");
+      
+      if (instClass->usesObjCGenericsModel()) {
+        require(instClass->getDeclaredTypeInContext()
+                  ->isBindableToSuperclassOf(opInstTy, nullptr),
+                "upcast must cast to a superclass or an existential metatype");
+      } else {
+        require(instTy->isExactSuperclassOf(opInstTy, nullptr),
+                "upcast must cast to a superclass or an existential metatype");
+      }
       return;
     }
 
@@ -2245,10 +2253,18 @@ public:
           FromTy.getSwiftRValueType().getAnyOptionalObjectType());
     }
 
-    require(ToTy.getClassOrBoundGenericClass(),
+    auto ToClass = ToTy.getClassOrBoundGenericClass();
+    require(ToClass,
             "upcast must convert a class instance to a class type");
-    require(ToTy.isExactSuperclassOf(FromTy),
-            "upcast must cast to a superclass");
+      if (ToClass->usesObjCGenericsModel()) {
+        require(ToClass->getDeclaredTypeInContext()
+                  ->isBindableToSuperclassOf(FromTy.getSwiftRValueType(),
+                                             nullptr),
+                "upcast must cast to a superclass or an existential metatype");
+      } else {
+        require(ToTy.isExactSuperclassOf(FromTy),
+                "upcast must cast to a superclass or an existential metatype");
+      }
   }
 
   void checkIsNonnullInst(IsNonnullInst *II) {

--- a/test/ClangModules/objc_bridging_generics.swift
+++ b/test/ClangModules/objc_bridging_generics.swift
@@ -308,3 +308,11 @@ class SwiftConcreteSubclassC<T>: GenericClass<NSString> {
   override func arrayOfThings() -> [NSString] {}
 }
 
+// FIXME: Some generic ObjC APIs rely on covariance. We don't handle this well
+// in Swift yet, but ensure we don't emit spurious warnings when
+// `as!` is used to force types to line up.
+func foo(x: GenericClass<NSMutableString>) {
+  let x2 = x as! GenericClass<NSString>
+  takeGenericClass(x2)
+  takeGenericClass(unsafeBitCast(x, to: GenericClass<NSString>.self))
+}

--- a/test/SILOptimizer/cast_folding_objc_generics.swift
+++ b/test/SILOptimizer/cast_folding_objc_generics.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -O -emit-sil %s | FileCheck %s
+// REQUIRES: objc_interop
+
+import objc_generics
+
+// CHECK-LABEL: sil [noinline] @_TF26cast_folding_objc_generics26testObjCGenericParamChange
+// CHECK:         upcast
+// CHECK-NOT:     int_trap
+@inline(never)
+public func testObjCGenericParamChange(_ a: GenericClass<NSMutableString>) -> GenericClass<NSString> {
+  return a as! GenericClass<NSString>
+}
+
+// CHECK-LABEL: sil [noinline] @_TF26cast_folding_objc_generics34testObjCGenericParamChangeSubclass
+// CHECK:         unconditional_checked_cast
+// CHECK-NOT:     int_trap
+@inline(never)
+public func testObjCGenericParamChangeSubclass(_ a: GenericClass<NSMutableString>) -> GenericSubclass<NSString> {
+  return a as! GenericSubclass<NSString>
+}
+
+// CHECK-LABEL: sil [noinline] @_TF26cast_folding_objc_generics36testObjCGenericParamChangeSuperclass
+// CHECK:         upcast
+// CHECK-NOT:     int_trap
+@inline(never)
+public func testObjCGenericParamChangeSuperclass(_ a: GenericSubclass<NSMutableString>) -> GenericClass<NSString> {
+  return a as! GenericClass<NSString>
+}

--- a/test/SILOptimizer/cast_folding_objc_no_foundation.swift
+++ b/test/SILOptimizer/cast_folding_objc_no_foundation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil %s | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -O -emit-sil %s | FileCheck %s
 // REQUIRES: objc_interop
 
 // Note: no 'import Foundation'


### PR DESCRIPTION
Some ObjC generic APIs rely on covariance, and until we devise a systematic solution for SR-1522, you need to force-cast to get the types to line up in cases like this:

```
func foo(x: GenericClass<NSMutableString>) {
  let x2 = x as! GenericClass<NSString>
  takeGenericClassOfNSString(x2)
}
```

We currently raise a "cast will never succeed" warning, which is wrong because the dynamic cast can't even check the generic parameters. Suppress this warning. Fixes rdar://problem/26398265.
