### PR TITLE
[swift-3.0-preview-1-branch] [stdlib] Add missing @available attributes

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -407,3 +407,14 @@ public func ... <
   return CountableClosedRange(uncheckedBounds: (lower: minimum, upper: maximum))
 }
 
+extension ClosedRange {
+  @available(*, unavailable, renamed: "lowerBound")
+  public var startIndex: Bound {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "upperBound")
+  public var endIndex: Bound {
+    Builtin.unreachable()
+  }
+}

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -401,3 +401,10 @@ internal struct _TeeStream<
 
 @available(*, unavailable, renamed: "OutputStream")
 public typealias OutputStreamType = OutputStream
+
+extension Streamable {
+  @available(*, unavailable, renamed: "write(to:)")
+  public func writeTo<Target : OutputStream>(target: inout Target) {
+    Builtin.unreachable()
+  }
+}

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -601,3 +601,15 @@ public func ..< <
 // swift-3-indexing-model: this is not really a proper rename
 @available(*, unavailable, renamed: "IndexingIterator")
 public struct RangeGenerator<Bound> {}
+
+extension Range {
+  @available(*, unavailable, renamed: "lowerBound")
+  public var startIndex: Bound {
+    Builtin.unreachable()
+  }
+
+  @available(*, unavailable, renamed: "upperBound")
+  public var endIndex: Bound {
+    Builtin.unreachable()
+  }
+}


### PR DESCRIPTION
• Explanation: Quite a few methods/properties were renamed during both the application of new naming guidelines, as well as the implementation of the new collections indexing model. Some of the fixit's were missing. This update adds 3 missing @available attributes.
• Scope of Issue: Purely additive change that will improve user experience.
• Origination: Overlooked while applying API naming guidelines and implementing the new indexing model.
• Risk: None.
• Reviewed By:  Dmitri Gribenko
• Testing: tried in REPL, expected diagnostics were issued.
• Directions for QA:  N/A

rdar://problem/26399436
