### PR TITLE
Correct renaming fix-its for trailing closures, disable them for operators

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1006,9 +1006,19 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
                                      InFlightDiagnostic &diag,
                                      SourceRange referenceRange,
                                      const AvailableAttr *attr,
-                                     const CallExpr *CE) {
+                                     const ApplyExpr *call) {
   ParsedDeclName parsed = swift::parseDeclName(attr->Rename);
   if (!parsed)
+    return;
+
+  bool originallyWasKnownOperatorExpr = false;
+  if (call) {
+    originallyWasKnownOperatorExpr =
+        isa<BinaryExpr>(call) ||
+        isa<PrefixUnaryExpr>(call) ||
+        isa<PostfixUnaryExpr>(call);
+  }
+  if (parsed.isOperator() != originallyWasKnownOperatorExpr)
     return;
 
   SourceManager &sourceMgr = TC.Context.SourceMgr;
@@ -1018,7 +1028,7 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
     // We can only do a good job with the fix-it if we have the whole call
     // expression.
     // FIXME: Should we be validating the ContextName in some way?
-    if (!CE)
+    if (!dyn_cast_or_null<CallExpr>(call))
       return;
 
     unsigned selfIndex = parsed.SelfIndex.getValue();
@@ -1026,7 +1036,7 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
     SourceLoc removeRangeStart;
     SourceLoc removeRangeEnd;
 
-    const Expr *argExpr = CE->getArg();
+    const Expr *argExpr = call->getArg();
     if (auto args = dyn_cast<TupleExpr>(argExpr)) {
       size_t numElementsWithinParens = args->getNumElements();
       numElementsWithinParens -= args->hasTrailingClosure();
@@ -1115,21 +1125,22 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
       selfReplace.push_back(')');
     selfReplace.push_back('.');
     selfReplace += parsed.BaseName;
-    diag.fixItReplace(CE->getFn()->getSourceRange(), selfReplace);
+    diag.fixItReplace(call->getFn()->getSourceRange(), selfReplace);
 
     if (!parsed.isPropertyAccessor())
       diag.fixItRemoveChars(removeRangeStart, removeRangeEnd);
 
     // Continue on to diagnose any argument label renames.
 
-  } else if (parsed.BaseName == TC.Context.Id_init.str() && CE) {
+  } else if (parsed.BaseName == TC.Context.Id_init.str() &&
+             dyn_cast_or_null<CallExpr>(call)) {
     // For initializers, replace with a "call" of the context type...but only
     // if we know we're doing a call (rather than a first-class reference).
     if (parsed.isMember()) {
-      diag.fixItReplace(CE->getFn()->getSourceRange(), parsed.ContextName);
+      diag.fixItReplace(call->getFn()->getSourceRange(), parsed.ContextName);
 
     } else {
-      auto *dotCall = dyn_cast<DotSyntaxCallExpr>(CE->getFn());
+      auto *dotCall = dyn_cast<DotSyntaxCallExpr>(call->getFn());
       if (!dotCall)
         return;
 
@@ -1151,10 +1162,10 @@ void swift::fixItAvailableAttrRename(TypeChecker &TC,
     diag.fixItReplace(referenceRange, baseReplace);
   }
 
-  if (!CE)
+  if (!dyn_cast_or_null<CallExpr>(call))
     return;
 
-  const Expr *argExpr = CE->getArg();
+  const Expr *argExpr = call->getArg();
   if (parsed.IsGetter) {
     diag.fixItRemove(argExpr->getSourceRange());
     return;
@@ -1297,7 +1308,7 @@ void TypeChecker::diagnoseDeprecated(SourceRange ReferenceRange,
                                      const DeclContext *ReferenceDC,
                                      const AvailableAttr *Attr,
                                      DeclName Name,
-                                     const CallExpr *CE) {
+                                     const ApplyExpr *Call) {
   // We match the behavior of clang to not report deprecation warnings
   // inside declarations that are themselves deprecated on all deployment
   // targets.
@@ -1354,7 +1365,7 @@ void TypeChecker::diagnoseDeprecated(SourceRange ReferenceRange,
     auto renameDiag = diagnose(ReferenceRange.Start,
                                diag::note_deprecated_rename,
                                newName);
-    fixItAvailableAttrRename(*this, renameDiag, ReferenceRange, Attr, CE);
+    fixItAvailableAttrRename(*this, renameDiag, ReferenceRange, Attr, Call);
   }
 }
 
@@ -1407,11 +1418,11 @@ void TypeChecker::diagnoseUnavailableOverride(ValueDecl *override,
 bool TypeChecker::diagnoseExplicitUnavailability(const ValueDecl *D,
                                                  SourceRange R,
                                                  const DeclContext *DC,
-                                                 const CallExpr *CE) {
+                                                 const ApplyExpr *call) {
   return diagnoseExplicitUnavailability(D, R, DC,
                                         [=](InFlightDiagnostic &diag) {
     fixItAvailableAttrRename(*this, diag, R, AvailableAttr::isUnavailable(D),
-                             CE);
+                             call);
   });
 }
 
@@ -1546,7 +1557,7 @@ public:
 
     if (auto DR = dyn_cast<DeclRefExpr>(E))
       diagAvailability(DR->getDecl(), DR->getSourceRange(),
-                       getEnclosingCallExpr());
+                       getEnclosingApplyExpr());
     if (auto MR = dyn_cast<MemberRefExpr>(E)) {
       walkMemberRef(MR);
       return skipChildren();
@@ -1554,11 +1565,11 @@ public:
     if (auto OCDR = dyn_cast<OtherConstructorDeclRefExpr>(E))
       diagAvailability(OCDR->getDecl(),
                        OCDR->getConstructorLoc().getSourceRange(),
-                       getEnclosingCallExpr());
+                       getEnclosingApplyExpr());
     if (auto DMR = dyn_cast<DynamicMemberRefExpr>(E))
       diagAvailability(DMR->getMember().getDecl(),
                        DMR->getNameLoc().getSourceRange(),
-                       getEnclosingCallExpr());
+                       getEnclosingApplyExpr());
     if (auto DS = dyn_cast<DynamicSubscriptExpr>(E))
       diagAvailability(DS->getMember().getDecl(), DS->getSourceRange());
     if (auto S = dyn_cast<SubscriptExpr>(E)) {
@@ -1586,12 +1597,12 @@ public:
 
 private:
   bool diagAvailability(const ValueDecl *D, SourceRange R,
-                        const CallExpr *CE = nullptr);
+                        const ApplyExpr *call = nullptr);
   bool diagnoseIncDecRemoval(const ValueDecl *D, SourceRange R,
                              const AvailableAttr *Attr);
 
-  /// Walks up from a potential callee to the enclosing CallExpr.
-  const CallExpr *getEnclosingCallExpr() const {
+  /// Walks up from a potential callee to the enclosing ApplyExpr.
+  const ApplyExpr *getEnclosingApplyExpr() const {
     ArrayRef<const Expr *> parents = ExprStack;
     assert(!parents.empty() && "must be called while visiting an expression");
     size_t idx = parents.size() - 1;
@@ -1606,7 +1617,7 @@ private:
              isa<ForceValueExpr>(parents[idx]) || // f!(a)
              isa<BindOptionalExpr>(parents[idx])); // f?(a)
 
-    auto *call = dyn_cast<CallExpr>(parents[idx]);
+    auto *call = dyn_cast<ApplyExpr>(parents[idx]);
     if (!call || call->getFn() != parents[idx+1])
       return nullptr;
     return call;
@@ -1723,7 +1734,7 @@ private:
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
 bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
-                                          const CallExpr *CE) {
+                                          const ApplyExpr *call) {
   if (!D)
     return false;
 
@@ -1731,12 +1742,12 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
     if (diagnoseIncDecRemoval(D, R, attr))
       return true;
 
-  if (TC.diagnoseExplicitUnavailability(D, R, DC, CE))
+  if (TC.diagnoseExplicitUnavailability(D, R, DC, call))
     return true;
 
   // Diagnose for deprecation
   if (const AvailableAttr *Attr = TypeChecker::getDeprecated(D)) {
-    TC.diagnoseDeprecated(R, DC, Attr, D->getFullName(), CE);
+    TC.diagnoseDeprecated(R, DC, Attr, D->getFullName(), call);
   }
 
   if (TC.getLangOpts().DisableAvailabilityChecking)

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -22,8 +22,8 @@
 
 namespace swift {
   class AbstractFunctionDecl;
+  class ApplyExpr;
   class AvailableAttr;
-  class CallExpr;
   class DeclContext;
   class Expr;
   class InFlightDiagnostic;
@@ -61,13 +61,13 @@ bool diagnoseArgumentLabelError(TypeChecker &TC, const Expr *expr,
                                 InFlightDiagnostic *existingDiag = nullptr);
 
 /// Emit fix-its to rename the base name at \p referenceRange based on the
-/// "renamed" argument in \p attr. If \p CE is provided, the argument labels
+/// "renamed" argument in \p attr. If \p call is provided, the argument labels
 /// will also be updated.
 void fixItAvailableAttrRename(TypeChecker &TC,
                               InFlightDiagnostic &diag,
                               SourceRange referenceRange,
                               const AvailableAttr *attr,
-                              const CallExpr *CE);
+                              const ApplyExpr *call);
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1608,7 +1608,7 @@ public:
   bool diagnoseExplicitUnavailability(const ValueDecl *D,
                                       SourceRange R,
                                       const DeclContext *DC,
-                                      const CallExpr *CE);
+                                      const ApplyExpr *call);
 
   /// Emit a diagnostic for references to declarations that have been
   /// marked as unavailable, either through "unavailable" or "obsoleted:".
@@ -1821,7 +1821,7 @@ public:
                           const DeclContext *ReferenceDC,
                           const AvailableAttr *Attr,
                           DeclName Name,
-                          const CallExpr *CE);
+                          const ApplyExpr *Call);
   /// @}
 
   /// If LangOptions::DebugForbidTypecheckPrefix is set and the given decl

--- a/test/ClangModules/attr-swift_name_renaming.swift
+++ b/test/ClangModules/attr-swift_name_renaming.swift
@@ -37,7 +37,7 @@ func test() {
   // This particular instance method mapping previously caused a crash because
   // of the trailing closure.
   acceptsClosure(Foo(), test) // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-25=}} {{25-25=closure: }}
-  acceptsClosure(Foo()) {} // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-25=}}
+  acceptsClosure(Foo()) {} // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-23=}}
 
   Foo().accepts(closure: test)
   Foo().accepts() {}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -479,6 +479,19 @@ func testRenameSetters() {
   unavailableSetInstancePropertyInout(a: &x, b: 2) // expected-error{{'unavailableSetInstancePropertyInout(a:b:)' has been replaced by property 'Int.prop'}} {{3-38=x.prop}} {{38-49= = }} {{50-51=}}
 }
 
+@available(*, unavailable, renamed: "Int.foo(self:execute:)")
+func trailingClosure(_ value: Int, fn: () -> Void) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:bar:execute:)")
+func trailingClosureArg(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(bar:self:execute:)")
+func trailingClosureArg2(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
+
+func testInstanceTrailingClosure() {
+  trailingClosure(0) {} // expected-error {{'trailingClosure(_:fn:)' has been replaced by instance method 'Int.foo(execute:)'}} {{3-18=0.foo}} {{19-20=}}
+  trailingClosureArg(0, 1) {} // expected-error {{'trailingClosureArg(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-21=0.foo}} {{22-25=}} {{25-25=bar: }}
+  trailingClosureArg2(0, 1) {} // expected-error {{'trailingClosureArg2(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-22=1.foo}} {{23-23=bar: }} {{24-27=}}
+}
+
 extension Int {
   @available(*, unavailable, renamed: "init(other:)")
   @discardableResult

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -492,6 +492,39 @@ func testInstanceTrailingClosure() {
   trailingClosureArg2(0, 1) {} // expected-error {{'trailingClosureArg2(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-22=1.foo}} {{23-23=bar: }} {{24-27=}}
 }
 
+@available(*, unavailable, renamed: "+")
+func add(_ value: Int, _ other: Int) {} // expected-note {{here}}
+
+infix operator *** {}
+@available(*, unavailable, renamed: "add")
+func ***(value: (), other: ()) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:_:)")
+func ***(value: Int, other: Int) {} // expected-note {{here}}
+
+prefix operator *** {}
+@available(*, unavailable, renamed: "add")
+prefix func ***(value: Int?) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:)")
+prefix func ***(value: Int) {} // expected-note {{here}}
+
+postfix operator *** {}
+@available(*, unavailable, renamed: "add")
+postfix func ***(value: Int?) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:)")
+postfix func ***(value: Int) {} // expected-note {{here}}
+
+func testOperators() {
+  add(0, 1) // expected-error {{'add' has been renamed to '+'}} {{none}}
+  () *** () // expected-error {{'***' has been renamed to 'add'}} {{none}}
+  0 *** 1 // expected-error {{'***' has been replaced by instance method 'Int.foo(_:)'}} {{none}}
+
+  ***nil // expected-error {{'***' has been renamed to 'add'}} {{none}}
+  ***0 // expected-error {{'***' has been replaced by instance method 'Int.foo()'}} {{none}}
+  
+  nil*** // expected-error {{'***' has been renamed to 'add'}} {{none}}
+  0*** // expected-error {{'***' has been replaced by instance method 'Int.foo()'}} {{none}}
+}
+
 extension Int {
   @available(*, unavailable, renamed: "init(other:)")
   @discardableResult


### PR DESCRIPTION
Pull request for testing purposes / parking while CI is red.

rdar://problem/26305887

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
