### PR TITLE
SwiftRemoteMirror: Fix crash emitting capture descriptors involving i…

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1120,10 +1120,6 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
     argConventions.push_back(ParameterConvention::Direct_Unowned);
   }
 
-  // For capture descriptors, we need to know where the capture list begins
-  // in the lowered SIL type of the callee.
-  unsigned firstCaptureIndex = origType->getNumSILArguments() - params.size();
-
   // Collect the type infos for the context parameters.
   for (auto param : params) {
     SILType argType = param.getSILType();
@@ -1305,8 +1301,7 @@ void irgen::emitFunctionPartialApplication(IRGenFunction &IGF,
 
   auto descriptor = IGF.IGM.getAddrOfCaptureDescriptor(SILFn, origType,
                                                        substType, subs,
-                                                       layout,
-                                                       firstCaptureIndex);
+                                                       layout);
 
   llvm::Value *data;
   if (layout.isKnownEmpty()) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -629,8 +629,7 @@ public:
                                              CanSILFunctionType origCalleeType,
                                              CanSILFunctionType substCalleeType,
                                              ArrayRef<Substitution> subs,
-                                             HeapLayout &layout,
-                                             unsigned firstCaptureIndex);
+                                             HeapLayout &layout);
   std::string getBuiltinTypeMetadataSectionName();
   std::string getFieldTypeMetadataSectionName();
   std::string getAssociatedTypeMetadataSectionName();


### PR DESCRIPTION
When emitting capture descriptors for functions with a smaller number of parameters
than SIL parameters, the compiler can crash indexing into the heap layout's element
types, because the capture index underflows to UINT_MAX.

rdar://problem/26404583
