### PR TITLE
SwiftRemoteMirror: Turn on reflection metadata by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,14 +234,6 @@ option(SWIFT_STDLIB_ENABLE_RESILIENCE
     "Build the standard libraries and overlays with resilience enabled; see docs/LibraryEvolution.rst"
     FALSE)
 
-option(SWIFT_STDLIB_ENABLE_REFLECTION_METADATA
-    "Build the standard libraries and overlays with remote reflection metadata; see docs/proposals/RemoteMirrors.rst"
-    TRUE)
-
-option(SWIFT_STDLIB_ENABLE_REFLECTION_NAMES
-    "Build the standard libraries and overlays with remote reflection names; see docs/proposals/RemoteMirrors.rst"
-    FALSE)
-
 option(SWIFT_STDLIB_SIL_SERIALIZE_ALL
     "Build the standard libraries and overlays serializing all method bodies"
     TRUE)

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -226,14 +226,6 @@ function(_compile_swift_files dependency_target_out_var_name)
     list(APPEND swift_flags "-Xfrontend" "-enable-resilience")
   endif()
 
-  if(SWIFT_STDLIB_ENABLE_REFLECTION_METADATA AND SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-Xfrontend" "-enable-reflection-metadata")
-  endif()
-
-  if(SWIFT_STDLIB_ENABLE_REFLECTION_NAMES AND SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-Xfrontend" "-enable-reflection-names")
-  endif()
-
   if(SWIFT_EMIT_SORTED_SIL_OUTPUT)
     list(APPEND swift_flags "-Xfrontend" "-emit-sorted-sil")
   endif()

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -168,7 +168,7 @@ public:
                    EmitStackPromotionChecks(false), GenerateProfile(false),
                    PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
                    HasValueNamesSetting(false), ValueNames(false),
-                   EnableReflectionMetadata(false), EnableReflectionNames(false),
+                   EnableReflectionMetadata(true), EnableReflectionNames(true),
                    UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
                    CmdArgs()
                    {}

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -193,11 +193,11 @@ def disable_llvm_value_names : Flag<["-"], "disable-llvm-value-names">,
 def enable_llvm_value_names : Flag<["-"], "enable-llvm-value-names">,
   HelpText<"Add names to local values in LLVM IR">;
 
-def enable_reflection_metadata : Flag<["-"], "enable-reflection-metadata">,
-  HelpText<"Enable emission of reflection metadata for nominal types">;
+def disable_reflection_metadata : Flag<["-"], "disable-reflection-metadata">,
+  HelpText<"Disable emission of reflection metadata for nominal types">;
 
-def enable_reflection_names : Flag<["-"], "enable-reflection-names">,
-  HelpText<"Enable emission of names of stored properties and enum cases in"
+def disable_reflection_names : Flag<["-"], "disable-reflection-names">,
+  HelpText<"Disable emission of names of stored properties and enum cases in"
            "reflection metadata">;
 
 def stack_promotion_checks : Flag<["-"], "emit-stack-promotion-checks">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1266,11 +1266,13 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.Sanitize = parseSanitizerArgValues(A, Triple, Diags);
   }
 
-  if (Args.hasArg(OPT_enable_reflection_metadata)) {
-    Opts.EnableReflectionMetadata = true;
-    if (Args.hasArg(OPT_enable_reflection_names)) {
-      Opts.EnableReflectionNames = true;
-    }
+  if (Args.hasArg(OPT_disable_reflection_metadata)) {
+    Opts.EnableReflectionMetadata = false;
+    Opts.EnableReflectionNames = false;
+  }
+
+  if (Args.hasArg(OPT_disable_reflection_names)) {
+    Opts.EnableReflectionNames = false;
   }
 
   return false;

--- a/stdlib/private/SwiftReflectionTest/CMakeLists.txt
+++ b/stdlib/private/SwiftReflectionTest/CMakeLists.txt
@@ -1,10 +1,6 @@
-set(swift_reflection_test_compile_flags
-  "-Xfrontend" "-enable-reflection-names")
-
 add_swift_library(swiftSwiftReflectionTest SHARED IS_STDLIB
   SwiftReflectionTest.swift
   SWIFT_MODULE_DEPENDS Darwin
-  SWIFT_COMPILE_FLAGS ${swift_reflection_test_compile_flags}
   INSTALL_IN_COMPONENT stdlib-experimental)
 
 foreach(SDK ${SWIFT_SDKS})

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -4,7 +4,7 @@
 
 // -- partial_apply context metadata
 
-// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy.1, i8** null, %swift.type { i64 64 }, i32 16, i8* null }
+// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 64 }, i32 16, i8* bitcast (<{ i32, i32, i32, i32 }>* @"\01l__swift3_capture_descriptor" to i8*) }
 
 func a(i i: Int) -> (Int) -> Int {
   return { x in i }

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -enable-reflection-metadata -enable-reflection-names -emit-ir %s | FileCheck %s
-// RUN: %target-swift-frontend -enable-reflection-metadata -emit-ir %s | FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
-// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
+// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+// RUN: %target-swift-frontend -disable-reflection-names -emit-ir %s | FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
+// RUN: %target-swift-frontend -disable-reflection-metadata -emit-ir %s | FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
 
 // STRIP_REFLECTION_NAMES_DAG: {{.*}}swift3_reflect
 // STRIP_REFLECTION_NAMES_DAG: {{.*}}swift3_fieldmd

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -o %t/capture_descriptors.%target-dylib-extension
+// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors.%target-dylib-extension | FileCheck %s
 
 sil_stage canonical

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -o %t/libTypesToReflect.%target-dylib-extension
+// RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s
 
 // CHECK: FIELDS:

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -o %t/libTypesToReflect.%target-dylib-extension -I %S/Inputs
+// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension -I %S/Inputs
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // CHECK-32: FIELDS:

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -o %t/libTypesToReflect.%target-dylib-extension
+// RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -o %t/libTypesToReflect.%target-dylib-extension
+// RUN: %target-build-swift %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect.%target-dylib-extension
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension -binary-filename %platform-module-dir/libswiftCore.%target-dylib-extension -dump-type-lowering < %s | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 V12TypeLowering11BasicStruct
@@ -8,66 +8,66 @@ V12TypeLowering11BasicStruct
 // CHECK-64-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field name=i1 offset=0
 // CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))
 // CHECK-64-NEXT:   (field name=i2 offset=2
 // CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))
 // CHECK-64-NEXT:   (field name=i3 offset=4
 // CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
 // CHECK-64-NEXT:   (field name=bi1 offset=8
 // CHECK-64-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=value offset=0
 // CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:           (field name=_value offset=0
 // CHECK-64-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
 // CHECK-64-NEXT:   (field name=bi2 offset=10
 // CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=value offset=0
 // CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:           (field name=_value offset=0
 // CHECK-64-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-64-NEXT:   (field name=bi3 offset=12
 // CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=value offset=0
 // CHECK-64-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:           (field name=_value offset=0
 // CHECK-64-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))))
 
 // CHECK-32: (struct TypeLowering.BasicStruct)
 // CHECK-32-NEXT: (struct size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field name=i1 offset=0
 // CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))
 // CHECK-32-NEXT:   (field name=i2 offset=2
 // CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))
 // CHECK-32-NEXT:   (field name=i3 offset=4
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
 // CHECK-32-NEXT:   (field name=bi1 offset=8
 // CHECK-32-NEXT:     (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=value offset=0
 // CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:           (field name=_value offset=0
 // CHECK-32-NEXT:             (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:   (field name=bi2 offset=10
 // CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=value offset=0
 // CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:           (field name=_value offset=0
 // CHECK-32-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:   (field name=bi3 offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=value offset=0
 // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:           (field name=_value offset=0
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))))
 
 V12TypeLowering15AssocTypeStruct
@@ -79,13 +79,13 @@ V12TypeLowering15AssocTypeStruct
 // CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64-NEXT:           (field name=value offset=0
 // CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-64-NEXT:               (field offset=0
+// CHECK-64-NEXT:               (field name=_value offset=0
 // CHECK-64-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-64-NEXT:       (field name=b offset=2
 // CHECK-64-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64-NEXT:           (field name=value offset=0
 // CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-64-NEXT:               (field offset=0
+// CHECK-64-NEXT:               (field name=_value offset=0
 // CHECK-64-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
 // CHECK-64-NEXT:       (field name=c offset=4
 // CHECK-64-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0
@@ -93,13 +93,13 @@ V12TypeLowering15AssocTypeStruct
 // CHECK-64-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64-NEXT:               (field name=value offset=0
 // CHECK-64-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-64-NEXT:                   (field offset=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
 // CHECK-64-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-64-NEXT:           (field offset=2
 // CHECK-64-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-64-NEXT:               (field name=value offset=0
 // CHECK-64-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-64-NEXT:                   (field offset=0
+// CHECK-64-NEXT:                   (field name=_value offset=0
 // CHECK-64-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0)))))))))))
 
 // CHECK-32:     (struct TypeLowering.AssocTypeStruct)
@@ -110,13 +110,13 @@ V12TypeLowering15AssocTypeStruct
 // CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32-NEXT:           (field name=value offset=0
 // CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-32-NEXT:               (field offset=0
+// CHECK-32-NEXT:               (field name=_value offset=0
 // CHECK-32-NEXT:                 (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:       (field name=b offset=2
 // CHECK-32-NEXT:         (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32-NEXT:           (field name=value offset=0
 // CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-32-NEXT:               (field offset=0
+// CHECK-32-NEXT:               (field name=_value offset=0
 // CHECK-32-NEXT:                 (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:       (field name=c offset=4
 // CHECK-32-NEXT:         (tuple size=3 alignment=2 stride=4 num_extra_inhabitants=0
@@ -124,13 +124,13 @@ V12TypeLowering15AssocTypeStruct
 // CHECK-32-NEXT:             (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32-NEXT:               (field name=value offset=0
 // CHECK-32-NEXT:                 (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-32-NEXT:                   (field offset=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
 // CHECK-32-NEXT:                     (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:           (field offset=2
 // CHECK-32-NEXT:             (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
 // CHECK-32-NEXT:               (field name=value offset=0
 // CHECK-32-NEXT:                 (struct size=1 alignment=1 stride=1 num_extra_inhabitants=0
-// CHECK-32-NEXT:                   (field offset=0
+// CHECK-32-NEXT:                   (field name=_value offset=0
 // CHECK-32-NEXT:                     (builtin size=1 alignment=1 stride=1 num_extra_inhabitants=0)))))))))))
 
 TGV12TypeLowering3BoxVs5Int16_Vs5Int32_
@@ -149,11 +149,11 @@ TGV12TypeLowering3BoxVs5Int16_Vs5Int32_
 // CHECK-64-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=value offset=0
 // CHECK-64-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-64-NEXT:           (field offset=0
+// CHECK-64-NEXT:           (field name=_value offset=0
 // CHECK-64-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-64-NEXT:   (field offset=4
 // CHECK-64-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
 
 // CHECK-32-NEXT: (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=0
@@ -161,11 +161,11 @@ TGV12TypeLowering3BoxVs5Int16_Vs5Int32_
 // CHECK-32-NEXT:     (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=value offset=0
 // CHECK-32-NEXT:         (struct size=2 alignment=2 stride=2 num_extra_inhabitants=0
-// CHECK-32-NEXT:           (field offset=0
+// CHECK-32-NEXT:           (field name=_value offset=0
 // CHECK-32-NEXT:             (builtin size=2 alignment=2 stride=2 num_extra_inhabitants=0))))))
 // CHECK-32-NEXT:   (field offset=4
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
 
 

--- a/test/Reflection/typeref_lowering_imported.swift
+++ b/test/Reflection/typeref_lowering_imported.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -I %S/Inputs -o %t/libTypesToReflect
+// RUN: %target-build-swift %S/Inputs/ImportedTypes.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -I %S/Inputs -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/Reflection/typeref_lowering_objc.swift
+++ b/test/Reflection/typeref_lowering_objc.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift %S/Inputs/TypeLoweringObjectiveC.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -o %t/libTypesToReflect
+// RUN: %target-build-swift %S/Inputs/TypeLoweringObjectiveC.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/libTypesToReflect
 // RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect -binary-filename %platform-module-dir/libswiftCore.dylib -dump-type-lowering < %s | FileCheck %s
 
 // REQUIRES: objc_interop

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -77,8 +77,6 @@ KNOWN_SETTINGS=(
     llvm-enable-lto             "0"              "enable LTO compilation of LLVM/Clang."
     swift-stdlib-build-type     "Debug"          "the CMake build variant for Swift"
     swift-stdlib-enable-assertions "1"           "enable assertions in Swift"
-    swift-stdlib-enable-reflection-metadata "1"  "build the Swift stdlib and overlays with remote reflection metadata"
-    swift-stdlib-enable-reflection-names "0"     "build the Swift stdlib and overlays with names of struct stored properties and enum cases"
     swift-stdlib-enable-resilience "0"           "build the Swift stdlib and overlays with resilience enabled"
     swift-stdlib-sil-serialize-all "1"           "build the Swift stdlib and overlays with all method bodies serialized"
     lldb-build-type             "Debug"          "the CMake build variant for LLDB"
@@ -1635,8 +1633,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARG
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")
                     -DSWIFT_STDLIB_BUILD_TYPE:STRING="${SWIFT_STDLIB_BUILD_TYPE}"
                     -DSWIFT_STDLIB_ASSERTIONS:BOOL=$(true_false "${SWIFT_STDLIB_ENABLE_ASSERTIONS}")
-                    -DSWIFT_STDLIB_ENABLE_REFLECTION_METADATA:BOOL=$(true_false "${SWIFT_STDLIB_ENABLE_REFLECTION_METADATA}")
-                    -DSWIFT_STDLIB_ENABLE_REFLECTION_NAMES:BOOL=$(true_false "${SWIFT_STDLIB_ENABLE_REFLECTION_NAMES}")
                     -DSWIFT_STDLIB_ENABLE_RESILIENCE:BOOL=$(true_false "${SWIFT_STDLIB_ENABLE_RESILIENCE}")
                     -DSWIFT_STDLIB_SIL_SERIALIZE_ALL:BOOL=$(true_false "${SWIFT_STDLIB_SIL_SERIALIZE_ALL}")
                     -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${native_llvm_tools_path}"

--- a/validation-test/Reflection/example.swift
+++ b/validation-test/Reflection/example.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -lswiftSwiftReflectionTest %s -o %t/example
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/example
 // RUN: %target-run %target-swift-reflection-test %t/example | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
@@ -47,45 +47,45 @@ reflect(object: mc)
 // CHECK-64: Reflecting an object.
 // CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_class example.MyClass
-// CHECK-64:   (class example.Container)
-// CHECK-64:   (class example.Container))
+// CHECK-64:        Type reference:
+// CHECK-64:        (bound_generic_class example.MyClass
+// CHECK-64-NEXT:   (class example.Container)
+// CHECK-64-NEXT:   (class example.Container))
 
-// CHECK-64: Type info:
-// CHECK-64: (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
-// CHECK-64:   (field name=f offset=16
-// CHECK-64:     (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants=0
-// CHECK-64:       (field name=function offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=context offset=8
-// CHECK-64:         (reference kind=strong refcounting=native))))
-// CHECK-64:   (field name=x offset=32
-// CHECK-64:     (reference kind=strong refcounting=native))
-// CHECK-64:   (field name=y offset=40
-// CHECK-64:     (reference kind=strong refcounting=native)))
+// CHECK-64:        Type info:
+// CHECK-64:        (class_instance size=48 alignment=16 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=f offset=16
+// CHECK-64-NEXT:     (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=function offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=context offset=8
+// CHECK-64-NEXT:         (reference kind=strong refcounting=native))))
+// CHECK-64-NEXT:   (field name=x offset=32
+// CHECK-64-NEXT:     (reference kind=strong refcounting=native))
+// CHECK-64-NEXT:   (field name=y offset=40
+// CHECK-64-NEXT:     (reference kind=strong refcounting=native)))
 
 
 // CHECK-32: Reflecting an object.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class example.MyClass
-// CHECK-32:   (class example.Container)
-// CHECK-32:   (class example.Container))
+// CHECK-32:      Type reference:
+// CHECK-32:      (bound_generic_class example.MyClass
+// CHECK-32-NEXT:   (class example.Container)
+// CHECK-32-NEXT:   (class example.Container))
 
-// CHECK-32: Type info:
-// CHECK-32: (class_instance size=28 alignment=16 stride=32 num_extra_inhabitants=0
-// CHECK-32:   (field name=f offset=12
-// CHECK-32:     (thick_function size=8 alignment=4 stride=8 num_extra_inhabitants=0
-// CHECK-32:       (field name=function offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=context offset=4
-// CHECK-32:         (reference kind=strong refcounting=native))))
-// CHECK-32:   (field name=x offset=20
-// CHECK-32:     (reference kind=strong refcounting=native))
-// CHECK-32:   (field name=y offset=24
-// CHECK-32:     (reference kind=strong refcounting=native)))
+// CHECK-32:      Type info:
+// CHECK-32:      (class_instance size=28 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=f offset=12
+// CHECK-32-NEXT:     (thick_function size=8 alignment=4 stride=8 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=function offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=context offset=4
+// CHECK-32-NEXT:         (reference kind=strong refcounting=native))))
+// CHECK-32-NEXT:   (field name=x offset=20
+// CHECK-32-NEXT:     (reference kind=strong refcounting=native))
+// CHECK-32-NEXT:   (field name=y offset=24
+// CHECK-32-NEXT:     (reference kind=strong refcounting=native)))
 
 reflect(any: mc)
 
@@ -93,19 +93,19 @@ reflect(any: mc)
 // CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-64: Type reference:
 // CHECK-64: (bound_generic_class example.MyClass
-// CHECK-64:   (class example.Container)
-// CHECK-64:   (class example.Container))
+// CHECK-64-NEXT:   (class example.Container)
+// CHECK-64-NEXT:   (class example.Container))
 
 // CHECK-64: Type info:
 // CHECK-64: (reference kind=strong refcounting=native)
 
 
-// CHECK-32: Reflecting an existential.
-// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class example.MyClass
-// CHECK-32:   (class example.Container)
-// CHECK-32:   (class example.Container))
+// CHECK-32:      Reflecting an existential.
+// CHECK-32:      Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32:      Type reference:
+// CHECK-32-NEXT: (bound_generic_class example.MyClass
+// CHECK-32-NEXT:   (class example.Container)
+// CHECK-32-NEXT:   (class example.Container))
 
 // CHECK-32: Type info:
 // CHECK-32: (reference kind=strong refcounting=native)

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -lswiftSwiftReflectionTest %s -o %t/existentials
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/existentials
 // RUN: %target-run %target-swift-reflection-test %t/existentials | FileCheck %s --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
@@ -58,19 +58,19 @@ reflect(any: mc)
 
 // CHECK-64: Reflecting an existential.
 // CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_class existentials.MyClass
-// CHECK-64:   (struct Swift.Int)
-// CHECK-64:   (struct Swift.Int))
+// CHECK-64:         Type reference:
+// CHECK-64:         (bound_generic_class existentials.MyClass
+// CHECK-64-NEXT:    (struct Swift.Int)
+// CHECK-64-NEXT:    (struct Swift.Int))
 // CHECK-64: Type info:
 // CHECK-64: (reference kind=strong refcounting=native)
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_class existentials.MyClass
-// CHECK-32:   (struct Swift.Int)
-// CHECK-32:   (struct Swift.Int))
+// CHECK-32:        Type reference:
+// CHECK-32:        (bound_generic_class existentials.MyClass
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.Int))
 // CHECK-32: Type info:
 // CHECK-32: (reference kind=strong refcounting=native)
 
@@ -80,47 +80,49 @@ reflect(any: smallStruct)
 
 // CHECK-64: Reflecting an existential.
 // CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_struct existentials.MyStruct
-// CHECK-64:   (struct Swift.Int)
-// CHECK-64:   (struct Swift.Int)
-// CHECK-64:   (struct Swift.Int))
-// CHECK-64: Type info:
-// CHECK-64: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64:   (field name=x offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=y offset=8
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:   (field name=z offset=16
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+// CHECK-64:        Type reference:
+// CHECK-64:        (bound_generic_struct existentials.MyStruct
+// CHECK-64-NEXT:   (struct Swift.Int)
+// CHECK-64-NEXT:   (struct Swift.Int)
+// CHECK-64-NEXT:   (struct Swift.Int))
+
+// CHECK-64:        Type info:
+// CHECK-64:        (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=x offset=0
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:   (field name=y offset=8
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:   (field name=z offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_struct existentials.MyStruct
-// CHECK-32:   (struct Swift.Int)
-// CHECK-32:   (struct Swift.Int)
-// CHECK-32:   (struct Swift.Int))
-// CHECK-32: Type info:
-// CHECK-32: (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32:   (field name=x offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:   (field name=y offset=4
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:   (field name=z offset=8
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+// CHECK-32:        Type reference:
+// CHECK-32:        (bound_generic_struct existentials.MyStruct
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.Int))
+
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=x offset=0
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:   (field name=y offset=4
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:   (field name=z offset=8
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
 
 // This value will be copied into a heap buffer, with a
 // pointer to it in the existential.
@@ -129,125 +131,125 @@ reflect(any: largeStruct)
 
 // CHECK-64: Reflecting an existential.
 // CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-64: Type reference:
-// CHECK-64: (bound_generic_struct existentials.MyStruct
-// CHECK-64:   (tuple
-// CHECK-64:     (struct Swift.Int)
-// CHECK-64:     (struct Swift.Int)
-// CHECK-64:     (struct Swift.Int))
-// CHECK-64:   (tuple
-// CHECK-64:     (struct Swift.Int)
-// CHECK-64:     (struct Swift.Int)
-// CHECK-64:     (struct Swift.Int))
-// CHECK-64:   (tuple
-// CHECK-64:     (struct Swift.Int)
-// CHECK-64:     (struct Swift.Int)
-// CHECK-64:     (struct Swift.Int)))
+// CHECK-64:        Type reference:
+// CHECK-64:        (bound_generic_struct existentials.MyStruct
+// CHECK-64-NEXT:   (tuple
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int))
+// CHECK-64-NEXT:   (tuple
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int))
+// CHECK-64-NEXT:   (tuple
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)))
 // CHECK-64: Type info:
-// CHECK-64: (struct size=72 alignment=8 stride=72 num_extra_inhabitants=0
-// CHECK-64:   (field name=x offset=0
-// CHECK-64:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:       (field offset=8
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:       (field offset=16
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))))
-// CHECK-64:   (field name=y offset=24
-// CHECK-64:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:       (field offset=8
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:       (field offset=16
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))))
-// CHECK-64:   (field name=z offset=48
-// CHECK-64:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:       (field offset=8
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
-// CHECK-64:       (field offset=16
-// CHECK-64:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:           (field offset=0
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))))
+// CHECK-64-NEXT: (struct size=72 alignment=8 stride=72 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=x offset=0
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:       (field offset=8
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:       (field offset=16
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:   (field name=y offset=24
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:       (field offset=8
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:       (field offset=16
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))))
+// CHECK-64-NEXT:   (field name=z offset=48
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:       (field offset=8
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:       (field offset=16
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))))
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
-// CHECK-32: Type reference:
-// CHECK-32: (bound_generic_struct existentials.MyStruct
-// CHECK-32:   (tuple
-// CHECK-32:     (struct Swift.Int)
-// CHECK-32:     (struct Swift.Int)
-// CHECK-32:     (struct Swift.Int))
-// CHECK-32:   (tuple
-// CHECK-32:     (struct Swift.Int)
-// CHECK-32:     (struct Swift.Int)
-// CHECK-32:     (struct Swift.Int))
-// CHECK-32:   (tuple
-// CHECK-32:     (struct Swift.Int)
-// CHECK-32:     (struct Swift.Int)
-// CHECK-32:     (struct Swift.Int)))
-// CHECK-32: Type info:
-// CHECK-32: (struct size=36 alignment=4 stride=36 num_extra_inhabitants=0
-// CHECK-32:   (field name=x offset=0
-// CHECK-32:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:       (field offset=4
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:       (field offset=8
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))))
-// CHECK-32:   (field name=y offset=12
-// CHECK-32:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:       (field offset=4
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:       (field offset=8
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))))
-// CHECK-32:   (field name=z offset=24
-// CHECK-32:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:       (field offset=4
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
-// CHECK-32:       (field offset=8
-// CHECK-32:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:           (field offset=0
-// CHECK-32:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))))
+// CHECK-32:        Type reference:
+// CHECK-32:        (bound_generic_struct existentials.MyStruct
+// CHECK-32-NEXT:   (tuple
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int))
+// CHECK-32-NEXT:   (tuple
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int))
+// CHECK-32-NEXT:   (tuple
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)))
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=36 alignment=4 stride=36 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=x offset=0
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:       (field offset=4
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:       (field offset=8
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:   (field name=y offset=12
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:       (field offset=4
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:       (field offset=8
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))))
+// CHECK-32-NEXT:   (field name=z offset=24
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:       (field offset=4
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:       (field offset=8
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))))
 
 var he = HasError(singleError: MyError(), errorInComposition: MyError(), customError: MyCustomError(), customErrorInComposition: MyCustomError())
 reflect(any: he)
@@ -257,104 +259,104 @@ reflect(any: he)
 // CHECK-64: Type reference:
 // CHECK-64: (struct existentials.HasError)
 
-// CHECK-64: Type info:
-// CHECK-64: (struct size=144 alignment=8 stride=144 num_extra_inhabitants=0
-// CHECK-64:   (field name=singleError offset=0
-// CHECK-64:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
-// CHECK-64:       (field name=error offset=0
-// CHECK-64:         (reference kind=strong refcounting=unknown))))
-// CHECK-64:   (field name=errorInComposition offset=8
-// CHECK-64:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
-// CHECK-64:       (field name=value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=value offset=8
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=value offset=16
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=wtable offset=32
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=wtable offset=40
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64:   (field name=customError offset=56
-// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
-// CHECK-64:       (field name=value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=value offset=8
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=value offset=16
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=wtable offset=32
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64:   (field name=customErrorInComposition offset=96
-// CHECK-64:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
-// CHECK-64:       (field name=value offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=value offset=8
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=value offset=16
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=wtable offset=32
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
-// CHECK-64:       (field name=wtable offset=40
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
+// CHECK-64:        Type info:
+// CHECK-64:        (struct size=144 alignment=8 stride=144 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=singleError offset=0
+// CHECK-64-NEXT:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647
+// CHECK-64-NEXT:       (field name=error offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
+// CHECK-64-NEXT:   (field name=errorInComposition offset=8
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=16
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=wtable offset=32
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=wtable offset=40
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
+// CHECK-64-NEXT:   (field name=customError offset=56
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=16
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=wtable offset=32
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
+// CHECK-64-NEXT:   (field name=customErrorInComposition offset=96
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=16
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=wtable offset=32
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=wtable offset=40
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
 
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32: Type reference:
 // CHECK-32: (struct existentials.HasError)
 
-// CHECK-32: Type info:
-// CHECK-32: (struct size=72 alignment=4 stride=72 num_extra_inhabitants=0
-// CHECK-32:   (field name=singleError offset=0
-// CHECK-32:     (error_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
-// CHECK-32:       (field name=error offset=0
-// CHECK-32:         (reference kind=strong refcounting=unknown))))
-// CHECK-32:   (field name=errorInComposition offset=4
-// CHECK-32:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
-// CHECK-32:       (field name=value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=value offset=4
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=value offset=8
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=metadata offset=12
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=wtable offset=16
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=wtable offset=20
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32:   (field name=customError offset=28
-// CHECK-32:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
-// CHECK-32:       (field name=value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=value offset=4
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=value offset=8
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=metadata offset=12
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=wtable offset=16
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32:   (field name=customErrorInComposition offset=48
-// CHECK-32:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
-// CHECK-32:       (field name=value offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=value offset=4
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=value offset=8
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=metadata offset=12
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=wtable offset=16
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
-// CHECK-32:       (field name=wtable offset=20
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=72 alignment=4 stride=72 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=singleError offset=0
+// CHECK-32-NEXT:     (error_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
+// CHECK-32-NEXT:       (field name=error offset=0
+// CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))))
+// CHECK-32-NEXT:   (field name=errorInComposition offset=4
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=8
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=wtable offset=16
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=wtable offset=20
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
+// CHECK-32-NEXT:   (field name=customError offset=28
+// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=8
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=wtable offset=16
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
+// CHECK-32-NEXT:   (field name=customErrorInComposition offset=48
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=8
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=wtable offset=16
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=wtable offset=20
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
 
 reflect(error: MyError())
 
@@ -363,23 +365,23 @@ reflect(error: MyError())
 // CHECK-64: Type reference:
 // CHECK-64: (struct existentials.MyError)
 
-// CHECK-64: Type info:
-// CHECK-64: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:   (field name=i offset=0
-// CHECK-64:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64:       (field offset=0
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
+// CHECK-64:        Type info:
+// CHECK-64:        (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=i offset=0
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
 
 // CHECK-32: Reflecting an error existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32: Type reference:
 // CHECK-32: (struct existentials.MyError)
 
-// CHECK-32: Type info:
-// CHECK-32: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:   (field name=i offset=0
-// CHECK-32:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32:       (field offset=0
-// CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=i offset=0
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
 
 doneReflecting()

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %target-build-swift -Xfrontend -enable-reflection-metadata -Xfrontend -enable-reflection-names -lswiftSwiftReflectionTest %s -o %t/functions
-// RUN: %target-run %target-swift-reflection-test %t/functions 2>&1 | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
+// RUN: %target-run %target-swift-reflection-test %t/functions | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop
 
 /*
@@ -23,14 +23,14 @@ func concrete(x: Int, y: Any) {
 // CHECK-32-NEXT: (closure_context size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
 
 // CHECK-64:      Type info:
 // CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field offset=16
 // CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
 
   // FIXME: Need @box reflection -- here the context is a single boxed value
@@ -61,14 +61,14 @@ func generic<T : P, U, V : C>(x: T, y: U, z: V, i: Int) {
 // CHECK-32-NEXT: (closure_context size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
-// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0)))))
 
 // CHECK-64:      Type info:
 // CHECK-64-NEXT: (closure_context size=24 alignment=8 stride=24 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field offset=16
 // CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
-// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
 
   reflect(function: {print(x); print(y); print(z)})


### PR DESCRIPTION
Flip the enable flags to disable and make these IRGen options
true by default.

rdar://problem/26206547
