### PR TITLE
Use COMPONENT_DEPENDS instead of LINK_LIBRARIES when linking against …

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -4,9 +4,10 @@ add_swift_executable(swift
   autolink_extract_main.cpp
   modulewrap_main.cpp
   LINK_LIBRARIES
-    LLVMDebugInfoCodeView
     swiftDriver
     swiftFrontendTool
+  COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 target_link_libraries(swift edit)

--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -2,7 +2,8 @@ add_swift_executable(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
   LINK_LIBRARIES
     swiftASTSectionImporter swiftFrontend swiftClangImporter
-    LLVMDebugInfoCodeView
+  COMPONENT_DEPENDS
+    DebugInfoCodeView
     )
 
 swift_install_in_component(testsuite-tools

--- a/tools/sil-extract/CMakeLists.txt
+++ b/tools/sil-extract/CMakeLists.txt
@@ -6,7 +6,8 @@ add_swift_executable(sil-extract
     swiftSILOptimizer
     swiftSerialization
     swiftClangImporter
-    LLVMDebugInfoCodeView
+  COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 swift_install_in_component(tools

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -5,7 +5,8 @@ add_swift_executable(sil-opt
     swiftIRGen
     swiftSILGen
     swiftSILOptimizer
-    LLVMDebugInfoCodeView
+  COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 swift_install_in_component(tools

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -6,7 +6,8 @@ add_swift_executable(swift-ide-test
     swiftDriver
     swiftFrontend
     swiftIDE
-    LLVMDebugInfoCodeView
+  COMPONENT_DEPENDS
+    DebugInfoCodeView
 )
 
 # If libxml2 is available, make it available for swift-ide-test.

--- a/tools/swift-llvm-opt/CMakeLists.txt
+++ b/tools/swift-llvm-opt/CMakeLists.txt
@@ -11,7 +11,8 @@ add_swift_executable(swift-llvm-opt
   clangBasic
   clangCodeGen
 
-  LLVMDebugInfoCodeView
+  COMPONENT_DEPENDS
+  DebugInfoCodeView
 )
 
 swift_install_in_component(tools


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

We were earlier incorrectly using LINK_LIBRARIES instead of COMPONENT_DEPENDS to link against LLVM. This commit changes master-next to use COMPONENT_DEPENDS.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…llvm libraries.
