### PR TITLE
Reannotate compiler crashes according to current compiler behavior

### DIFF
--- a/validation-test/IDE/crashers/011-swift-lookupvisibledecls.swift
+++ b/validation-test/IDE/crashers/011-swift-lookupvisibledecls.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-enum S<T where g:A{struct T enum S:#^A^#

--- a/validation-test/IDE/crashers_fixed/011-swift-lookupvisibledecls.swift
+++ b/validation-test/IDE/crashers_fixed/011-swift-lookupvisibledecls.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+enum S<T where g:A{struct T enum S:#^A^#

--- a/validation-test/compiler_crashers/00429-vtable.swift
+++ b/validation-test/compiler_crashers/00429-vtable.swift
@@ -5,7 +5,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -parse
+// RUN: not --crash %target-swift-frontend %s -parse
+// XFAIL: linux
 }
 struct S {
 static let i: B<Q<T where A"""


### PR DESCRIPTION
1 improvement, 1 regression.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
