### PR TITLE
[Parse] Improve diagnostics in inheritance clauses

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -652,6 +652,8 @@ ERROR(expected_langle_protocol,PointsToFirstBadToken,
       "expected '<' in protocol composition type", ())
 ERROR(expected_rangle_protocol,PointsToFirstBadToken,
       "expected '>' to complete protocol composition type", ())
+ERROR(disallowed_protocol_composition,PointsToFirstBadToken,
+      "protocol composition is neither allowed nor needed here", ())
 
 //------------------------------------------------------------------------------
 // Pattern parsing diagnostics

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2524,6 +2524,28 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
       continue;
     }
 
+    // Provide a nice error if protocol composition is used.
+    if (Tok.is(tok::kw_protocol) && startsWithLess(peekToken())) {
+      auto compositionResult = parseTypeComposition();
+      Status |= compositionResult;
+      if (auto composition = compositionResult.getPtrOrNull()) {
+        // Record the protocols inside the composition.
+        Inherited.append(composition->getProtocols().begin(),
+                         composition->getProtocols().end());
+
+        // Provide fixits to remove the composition, leaving the types intact.
+        auto angleRange = composition->getAngleBrackets();
+        diagnose(composition->getProtocolLoc(),
+                 diag::disallowed_protocol_composition)
+            .fixItRemove({composition->getProtocolLoc(), angleRange.Start})
+            .fixItRemove(startsWithGreater(L->getTokenAt(angleRange.End))
+                             ? angleRange.End
+                             : SourceLoc());
+      }
+
+      continue;
+    }
+
     // Parse the inherited type (which must be a protocol).
     ParserResult<TypeRepr> Ty = parseTypeIdentifier();
     Status |= Ty;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -299,6 +299,12 @@ ParserResult<IdentTypeRepr> Parser::parseTypeIdentifier() {
     }
 
     diagnose(Tok, diag::expected_identifier_for_type);
+
+    // If there is a keyword at the start of a new line, we won't want to
+    // skip it as a recovery but rather keep it.
+    if (Tok.isKeyword() && !Tok.isAtStartOfLine())
+      consumeToken();
+
     return nullptr;
   }
 

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -24,11 +24,19 @@ protocol Q : A { } // expected-error{{non-class type 'Q' cannot inherit from cla
 // Extension inheriting a class
 extension C : A { } // expected-error{{extension of type 'C' cannot inherit from class 'A'}}
 
+// Keywords in inheritance clauses
+struct S2 : struct { } // expected-error{{expected identifier for type name}}
+
+// Protocol composition in inheritance clauses
+struct S3 : P, protocol<P> { } // expected-error{{duplicate inheritance from 'P'}}
+                               // expected-error@-1{{protocol composition is neither allowed nor needed here}}{{16-25=}}{{26-27=}}
+struct S4 : protocol< { } // expected-error{{expected identifier for type name}}
+                          // expected-error@-1{{protocol composition is neither allowed nor needed here}}{{13-23=}}
 
 class GenericBase<T> {}
 
 class GenericSub<T> : GenericBase<T> {} // okay
-	
+
 class InheritGenericParam<T> : T {} // expected-error {{inheritance from non-protocol, non-class type 'T'}}
 class InheritBody : T { // expected-error {{use of undeclared type 'T'}}
 	typealias T = A

--- a/validation-test/compiler_crashers_fixed/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
+++ b/validation-test/compiler_crashers_fixed/28235-swift-archetypebuilder-addsametyperequirementtoconcrete.swift
@@ -5,10 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-struct S:P{var f:a
-var _=f
-struct a{}
-}
-{
-}protocol P{protocol a:var f:a
+// RUN: not %target-swift-frontend %s -parse
+struct c:protocol A{associatedtype f{}func g:B
+class B<T where f.h:b,f=c

--- a/validation-test/compiler_crashers_fixed/28274-swift-valuedecl-isinstancemember.swift
+++ b/validation-test/compiler_crashers_fixed/28274-swift-valuedecl-isinstancemember.swift
@@ -5,6 +5,10 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-struct c:protocol A{associatedtype f{}func g:B
-class B<T where f.h:b,f=c
+// RUN: not %target-swift-frontend %s -parse
+struct S:P{var f:a
+var _=f
+struct a{}
+}
+{
+}protocol P{protocol a:var f:a


### PR DESCRIPTION
#### What's in this pull request?

Improve the diagnostics emitted when parsing an inheritance clause.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Before, a keyword in an inheritance clause would lead to a long list of errors
not really showing what was wrong.
A special case is added to handle protocol composition; in inheritance clauses
the protocols don't have to be composed with 'protocol<>'.
