### PR TITLE
Fix passing XFAIL-ed test on Linux

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -430,6 +430,7 @@ for target in config.targets_to_build.split():
 # Add the run target CPU, OS, and pointer size as features.
 config.available_features.add("CPU=" + run_cpu)
 config.available_features.add("OS=" + run_os)
+config.available_features.add("PLATFORM=" + platform.system())
 config.available_features.add("PTRSIZE=" + run_ptrsize)
 
 if run_cpu == "i386" or run_cpu == "x86_64":

--- a/validation-test/compiler_crashers_fixed/00429-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00429-vtable.swift
@@ -9,7 +9,7 @@
 
 // REQUIRES: asserts
 // SR-1584
-// XFAIL: *
+// XFAIL: PLATFORM=Darwin
 
 }
 struct S {


### PR DESCRIPTION
- Add a PLATFORM key to the lit.cfg
- Use it for the XFAIL line in 00429-vtable.swift
