### PR TITLE
[SR-1165][apinotes] Avoid duplicate `XCTest.run()`

### DIFF
--- a/apinotes/XCTest.apinotes
+++ b/apinotes/XCTest.apinotes
@@ -1,0 +1,14 @@
+---
+Name: XCTest
+Classes:
+- Name: XCTest
+  Methods:
+  # The abstract base class XCTest declares a (deprecated) method
+  # `-[XCTest run]`. If left to the standard name conversion rules, this
+  # conflicts with `-[XCTest runTest]`. Here we explicitly convert `-runTest`
+  # as `XCTest.runTest()`. See https://bugs.swift.org/browse/SR-1165 for
+  # details.
+  - Selector: 'runTest'
+    SwiftName: 'runTest()'
+    MethodKind: Instance
+

--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -20,11 +20,6 @@ var XCTestTestSuite = TestSuite("XCTest")
 //       as dynamic. Objective-C XCTest uses runtime introspection to
 //       instantiate an NSInvocation with the given selector.
 
-
-func execute(_ run: () -> ()) {
-  run()
-}
-
 XCTestTestSuite.test("exceptions") {
   class ExceptionTestCase: XCTestCase {
     dynamic func test_raises() {
@@ -33,7 +28,7 @@ XCTestTestSuite.test("exceptions") {
   }
 
   let testCase = ExceptionTestCase(selector: #selector(ExceptionTestCase.test_raises))
-  execute(testCase.run)
+  testCase.runTest()
   let testRun = testCase.testRun!
 
   expectEqual(1, testRun.testCaseCount)
@@ -58,7 +53,7 @@ XCTestTestSuite.test("XCTAssertEqual/Array<T>") {
   }
 
   let passingTestCase = AssertEqualArrayTestCase(selector: #selector(AssertEqualArrayTestCase.test_whenArraysAreEqual_passes))
-  execute(passingTestCase.run)
+  passingTestCase.runTest()
   let passingTestRun = passingTestCase.testRun!
   expectEqual(1, passingTestRun.testCaseCount)
   expectEqual(1, passingTestRun.executionCount)
@@ -68,7 +63,7 @@ XCTestTestSuite.test("XCTAssertEqual/Array<T>") {
   expectTrue(passingTestRun.hasSucceeded)
 
   let failingTestCase = AssertEqualArrayTestCase(selector: #selector(AssertEqualArrayTestCase.test_whenArraysAreNotEqual_fails))
-  execute(failingTestCase.run)
+  failingTestCase.runTest()
   let failingTestRun = failingTestCase.testRun!
   expectEqual(1, failingTestRun.testCaseCount)
   expectEqual(1, failingTestRun.executionCount)
@@ -92,7 +87,7 @@ XCTestTestSuite.test("XCTAssertEqual/Dictionary<T, U>") {
   }
 
   let passingTestCase = AssertEqualDictionaryTestCase(selector: #selector(AssertEqualDictionaryTestCase.test_whenDictionariesAreEqual_passes))
-  execute(passingTestCase.run)
+  passingTestCase.runTest()
   let passingTestRun = passingTestCase.testRun!
   expectEqual(1, passingTestRun.testCaseCount)
   expectEqual(1, passingTestRun.executionCount)
@@ -102,7 +97,7 @@ XCTestTestSuite.test("XCTAssertEqual/Dictionary<T, U>") {
   expectTrue(passingTestRun.hasSucceeded)
 
   let failingTestCase = AssertEqualDictionaryTestCase(selector: #selector(AssertEqualDictionaryTestCase.test_whenDictionariesAreNotEqual_fails))
-  execute(failingTestCase.run)
+  failingTestCase.runTest()
   let failingTestRun = failingTestCase.testRun!
   expectEqual(1, failingTestRun.testCaseCount)
   expectEqual(1, failingTestRun.executionCount)
@@ -136,7 +131,7 @@ XCTestTestSuite.test("XCTAssertThrowsError") {
     // Try success case
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_throws))
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)
@@ -151,7 +146,7 @@ XCTestTestSuite.test("XCTAssertThrowsError") {
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_throws))
         testCase.doThrow = false
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)
@@ -167,7 +162,7 @@ XCTestTestSuite.test("XCTAssertThrowsError") {
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_throws))
         testCase.errorCode = 23
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)
@@ -201,7 +196,7 @@ XCTestTestSuite.test("XCTAsserts with throwing expressions") {
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
         testCase.doThrow = false
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)
@@ -215,7 +210,7 @@ XCTestTestSuite.test("XCTAsserts with throwing expressions") {
     // Now try when the expression throws
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)
@@ -248,7 +243,7 @@ XCTestTestSuite.test("Test methods that wind up throwing") {
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
         testCase.doThrow = false
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)
@@ -262,7 +257,7 @@ XCTestTestSuite.test("Test methods that wind up throwing") {
     // Now try when the expression throws
     do {
         let testCase = ErrorTestCase(selector: #selector(ErrorTestCase.test_withThrowing))
-        execute(testCase.run)
+        testCase.runTest()
         let testRun = testCase.testRun!
         
         expectEqual(1, testRun.testCaseCount)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The abstract base class XCTest declares a (deprecated) method `-[XCTest run]`. If left to the standard name conversion rules, this conflicts with `-[XCTest runTest]`. Here we explicitly convert `-runTest` as `XCTest.runTest()`. See https://bugs.swift.org/browse/SR-1165 for details.

/cc @milseman
#### Resolved bug number: ([SR-1165](https://bugs.swift.org/browse/SR-1165))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
