### PR TITLE
Import swift_newtype'd types via their (bridged) underlying type when used in collections.

### DIFF
--- a/test/IDE/Inputs/custom-modules/NewtypeObjC.h
+++ b/test/IDE/Inputs/custom-modules/NewtypeObjC.h
@@ -1,0 +1,16 @@
+@import Foundation;
+
+typedef NSString *_Nonnull SNTClosedEnum __attribute((swift_newtype(enum)))
+__attribute((swift_name("ClosedEnum")));
+
+extern const SNTClosedEnum SNTFirstClosedEntryEnum;
+extern const SNTClosedEnum SNTSecondEntry;
+extern const SNTClosedEnum SNTClosedEnumThirdEntry;
+
+@interface GenericClassA<T> : NSObject
+@end
+
+@interface UsesGenericClassA : NSObject
+-(void)takeEnumValues:(nonnull GenericClassA<SNTClosedEnum> *)values;
+-(void)takeEnumValuesArray:(nonnull NSArray<SNTClosedEnum> *)values;
+@end

--- a/test/IDE/Inputs/custom-modules/module.map
+++ b/test/IDE/Inputs/custom-modules/module.map
@@ -16,6 +16,11 @@ module Newtype {
   header "Newtype.h"
 }
 
+module NewtypeObjC {
+  header "NewtypeObjC.h"
+  export *
+}
+
 module ImportAsMember {
   export *
 

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -85,7 +85,7 @@ func tests() {
 	fooErr.process()
 	Food().process() // expected-error{{value of type 'Food' has no member 'process'}}
 
-	let thirdEnum = ClosedEnum.thirdEntry!
+	let thirdEnum = ClosedEnum.thirdEntry
 	thirdEnum.process()
 	  // expected-error@-1{{value of type 'ClosedEnum' has no member 'process'}}
 

--- a/test/IDE/newtype_objc.swift
+++ b/test/IDE/newtype_objc.swift
@@ -1,0 +1,21 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: %build-clang-importer-objc-overlays
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk-nosource) -I %t -I %S/Inputs/custom-modules -print-module -source-filename %s -module-to-print=NewtypeObjC -enable-swift-newtype > %t.printed.NewtypeObjC.txt
+// RUN: FileCheck %s -check-prefix=PRINT -strict-whitespace < %t.printed.NewtypeObjC.txt
+// RUN: %target-parse-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t -enable-swift-newtype %s
+
+// REQUIRES: objc_interop
+
+// PRINT: class UsesGenericClassA : NSObject {
+// PRINT:   func takeEnumValues(_ values: GenericClassA<NSString>)
+// PRINT:   func takeEnumValuesArray(_ values: [ClosedEnum])
+// PRINT: }
+
+import NewtypeObjC
+
+func useSpecializationOverNewtypes(a: UsesGenericClassA) {
+  let gca = GenericClassA<NSString>()
+  a.takeEnumValues(gca)
+}


### PR DESCRIPTION
rdar://problem/26340353
