### PR TITLE
Handle unavailable and deprecated symbols in code-completion

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -535,11 +535,9 @@ public:
   };
 
   enum NotRecommendedReason {
-
     Redundant,
-
     TypeMismatch,
-
+    Deprecated,
     NoReason,
   };
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -780,6 +780,9 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
 
   if (!CurrentModule)
     CurrentModule = D->getModuleContext();
+
+  if (D->getAttrs().getDeprecated(D->getASTContext()))
+    setNotRecommended(CodeCompletionResult::Deprecated);
 }
 
 StringRef CodeCompletionContext::copyString(StringRef Str) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1914,9 +1914,10 @@ public:
   }
 
   void addVarDeclRef(const VarDecl *VD, DeclVisibilityKind Reason) {
-    if (!VD->hasName())
-      return;
-    if (!VD->isUserAccessible())
+    if (!VD->hasName() ||
+        !VD->isUserAccessible() ||
+        (VD->hasAccessibility() && !VD->isAccessibleFrom(CurrDeclContext)) ||
+        AvailableAttr::isUnavailable(VD))
       return;
 
     StringRef Name = VD->getName().get();
@@ -2483,7 +2484,9 @@ public:
   void addEnumElementRef(const EnumElementDecl *EED,
                          DeclVisibilityKind Reason,
                          bool HasTypeContext) {
-    if (!EED->hasName())
+    if (!EED->hasName() ||
+        (EED->hasAccessibility() && !EED->isAccessibleFrom(CurrDeclContext)) ||
+        AvailableAttr::isUnavailable(EED))
       return;
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -62,6 +62,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_3 | FileCheck %s -check-prefix=IN_FOR_EACH_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_4 | FileCheck %s -check-prefix=IN_FOR_EACH_3
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPRECATED_1 | FileCheck %s -check-prefix=DEPRECATED_1
+
 //
 // Test code completion at the beginning of expr-postfix.
 //
@@ -455,3 +457,20 @@ func testInForEach4(arg: Int) {
   }
   let after = 4
 }
+
+@available(*, deprecated)
+struct Deprecated {
+  @available(*, deprecated)
+  func testDeprecated() {
+    @available(*, deprecated) let local = 1
+    @available(*, deprecated) func f() {}
+
+    #^DEPRECATED_1^#
+  }
+}
+// DEPRECATED_1: Begin completions
+// DEPRECATED_1-DAG: Decl[LocalVar]/Local/NotRecommended: local[#Int#];
+// DEPRECATED_1-DAG: Decl[FreeFunction]/Local/NotRecommended: f()[#Void#];
+// DEPRECATED_1-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: testDeprecated()[#Void#];
+// DEPRECATED_1-DAG: Decl[Struct]/CurrModule/NotRecommended: Deprecated[#Deprecated#];
+// DEPRECATED_1: End completions

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -104,6 +104,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=HAS_THROWING -code-completion-keywords=false | FileCheck %s -check-prefix=HAS_THROWING
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOC_TYPE1 -code-completion-keywords=false | FileCheck %s -check-prefix=ASSOC_TYPE1
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPRECATED_1 -code-completion-keywords=false | FileCheck %s -check-prefix=DEPRECATED_1
+
 @objc
 class TagPA {}
 @objc
@@ -496,3 +498,13 @@ class C1 : P1 {
 // ASSOC_TYPE1: Begin completions, 2 items
 // ASSOC_TYPE1: Decl[AssociatedType]/Super:         typealias T2 = {#(Type)#}; name=T2 = Type
 // ASSOC_TYPE1: Decl[AssociatedType]/Super:         typealias T3 = {#(Type)#}; name=T3 = Type
+
+class Deprecated1 {
+  @available(*, deprecated)
+  func deprecated() {}
+}
+
+class Deprecated2 : Deprecated1 {
+  override func #^DEPRECATED_1^#
+}
+// DEPRECATED_1: Decl[InstanceMethod]/Super/NotRecommended: deprecated() {|};

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -34,6 +34,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_29 | FileCheck %s -check-prefix=UNRESOLVED_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_30 | FileCheck %s -check-prefix=UNRESOLVED_2
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_AVAIL_1 | FileCheck %s -check-prefix=ENUM_AVAIL_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPTIONS_AVAIL_1 | FileCheck %s -check-prefix=OPTIONS_AVAIL_1
+
 enum SomeEnum1 {
   case South
   case North
@@ -66,6 +69,17 @@ struct SomeOptions2 : OptionSet {
   static let Option4 = SomeOptions2(rawValue: 1 << 1)
   static let Option5 = SomeOptions2(rawValue: 1 << 2)
   static let Option6 = SomeOptions2(rawValue: 1 << 3)
+}
+
+enum EnumAvail1 {
+  case aaa
+  @available(*, unavailable) case AAA
+}
+
+struct OptionsAvail1 : OptionSet {
+  let rawValue: Int
+  static let aaa = OptionsAvail1(rawValue: 1 << 0)
+  @available(*, unavailable) static let AAA = OptionsAvail1(rawValue: 1 << 0)
 }
 
 func OptionSetTaker1(Op : SomeOptions1) {}
@@ -232,3 +246,17 @@ let TopLevelVar1 = OptionSetTaker7([.#^UNRESOLVED_28^#], Op2: [.Option4])
 let TopLevelVar2 = OptionSetTaker1([.#^UNRESOLVED_29^#])
 
 let TopLevelVar3 = OptionSetTaker7([.Option1], Op2: [.#^UNRESOLVED_30^#])
+
+func testAvail1(x: EnumAvail1) {
+  testAvail1(.#^ENUM_AVAIL_1^#)
+}
+// ENUM_AVAIL_1: Begin completions
+// ENUM_AVAIL_1-NEXT: Decl[EnumElement]/ExprSpecific:     aaa[#EnumAvail1#];
+// ENUM_AVAIL_1-NEXT: End completions
+
+func testAvail2(x: OptionsAvail1) {
+  testAvail2(.#^OPTIONS_AVAIL_1^#)
+}
+// OPTIONS_AVAIL_1: Begin completions
+// OPTIONS_AVAIL_1_NEXT: Decl[StaticVar]/CurrNominal:        aaa[#OptionsAvail1#];
+// OPTIONS_AVAIL_1_NEXT: End completions

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -74,12 +74,14 @@ struct SomeOptions2 : OptionSet {
 enum EnumAvail1 {
   case aaa
   @available(*, unavailable) case AAA
+  @available(*, deprecated) case BBB
 }
 
 struct OptionsAvail1 : OptionSet {
   let rawValue: Int
   static let aaa = OptionsAvail1(rawValue: 1 << 0)
   @available(*, unavailable) static let AAA = OptionsAvail1(rawValue: 1 << 0)
+  @available(*, deprecated) static let BBB = OptionsAvail1(rawValue: 1 << 1)
 }
 
 func OptionSetTaker1(Op : SomeOptions1) {}
@@ -250,13 +252,19 @@ let TopLevelVar3 = OptionSetTaker7([.Option1], Op2: [.#^UNRESOLVED_30^#])
 func testAvail1(x: EnumAvail1) {
   testAvail1(.#^ENUM_AVAIL_1^#)
 }
-// ENUM_AVAIL_1: Begin completions
-// ENUM_AVAIL_1-NEXT: Decl[EnumElement]/ExprSpecific:     aaa[#EnumAvail1#];
-// ENUM_AVAIL_1-NEXT: End completions
+// ENUM_AVAIL_1: Begin completions, 2 items
+// ENUM_AVAIL_1-NOT: AAA
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific:     aaa[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific/NotRecommended: BBB[#EnumAvail1#];
+// ENUM_AVAIL_1-NOT: AAA
+// ENUM_AVAIL_1: End completions
 
 func testAvail2(x: OptionsAvail1) {
   testAvail2(.#^OPTIONS_AVAIL_1^#)
 }
-// OPTIONS_AVAIL_1: Begin completions
-// OPTIONS_AVAIL_1_NEXT: Decl[StaticVar]/CurrNominal:        aaa[#OptionsAvail1#];
-// OPTIONS_AVAIL_1_NEXT: End completions
+// OPTIONS_AVAIL_1: Begin completions, 2 items
+// ENUM_AVAIL_1-NOT: AAA
+// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal:        aaa[#OptionsAvail1#];
+// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/NotRecommended: BBB[#OptionsAvail1#];
+// ENUM_AVAIL_1-NOT: AAA
+// OPTIONS_AVAIL_1: End completions

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -170,6 +170,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPEALIAS_1 | FileCheck %s -check-prefix=GENERIC_TYPEALIAS_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPEALIAS_2 | FileCheck %s -check-prefix=GENERIC_TYPEALIAS_2
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEPRECATED_1 | FileCheck %s -check-prefix=DEPRECATED_1
+
 // Test code completion of expressions that produce a value.
 
 struct FooStruct {
@@ -1882,3 +1884,11 @@ func testGenericTypealias2() {
   Enclose.#^GENERIC_TYPEALIAS_2^#
 }
 // GENERIC_TYPEALIAS_2: Decl[TypeAlias]/CurrNominal:        MyPair[#(T, T)#];
+
+struct Deprecated {
+  @available(*, deprecated)
+  func deprecated(x: Deprecated) {
+    x.#^DEPRECATED_1^#
+  }
+}
+// DEPRECATED_1: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecated({#x: Deprecated#})[#Void#];


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This merge fixes two issues in Swift3, both covered by rdar://problem/26335424.
1. Unavailable symbols incorrectly show up in unresolved-member code-completions like "foo(.<here>)"
2. Deprecated symbols are not being marked "not recommended"

These are particularly egregious after API renaming, where we end up showing both the old names, the new names, and sometimes also a deprecated old name.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/26335424

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
