### PR TITLE
[swift-3.0-preview-1-branch] @available attribute for .Some and .None

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -531,3 +531,15 @@ public func ?? <T> (optional: T?, defaultValue: @autoclosure () throws -> T?)
     return try defaultValue()
   }
 }
+
+extension Optional {
+  @available(*, unavailable, renamed: "none")
+  public static var None: Optional<Wrapped> {
+    Builtin.unreachable()
+  }
+  @available(*, unavailable, renamed: "some")
+  public static func Some(_: Wrapped) -> Optional<Wrapped> {
+    Builtin.unreachable()
+  }
+
+}


### PR DESCRIPTION
• Explanation: Optional cases were renamed to .some() and .none according to the new API naming guidelines, but the fixits for old cases .Some() and .None were never provided.
• Scope of Issue: All the code using Optional cases explicitly.
• Origination: Introduced while applying API naming guidelines to the standard library.
• Risk: Minimal.
• Reviewed By:  Dmitri Gribenko
• Testing: tried to use in the REPL
• Directions for QA:  N/A
