### PR TITLE
Make sure TSan does not report false positives on IRGened code

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1225,6 +1225,11 @@ createInPlaceMetadataInitializationFunction(IRGenModule &IGM,
   if (IGM.DebugInfo)
     IGM.DebugInfo->emitArtificialFunction(IGF, fn);
 
+  // Skip instrumentation when building for TSan to avoid false positives.
+  // The syncronization for this happens in the Runtime and we do not see it.
+  if (IGM.IRGen.Opts.Sanitize == SanitizerKind::Thread)
+    fn->removeFnAttr(llvm::Attribute::SanitizeThread);
+
   // Emit the initialization.
   llvm::Value *relocatedMetadata = initialize(IGF, metadata);
 
@@ -1279,7 +1284,10 @@ emitInPlaceTypeMetadataAccessFunctionBody(IRGenFunction &IGF,
   // We can just load the cache now.
   // TODO: this should be consume-ordered when LLVM supports it.
   Address cacheAddr = Address(cacheVariable, IGF.IGM.getPointerAlignment());
-  llvm::Value *relocatedMetadata = IGF.Builder.CreateLoad(cacheAddr);
+  llvm::LoadInst *relocatedMetadata = IGF.Builder.CreateLoad(cacheAddr);
+  // Make this barrier explicit when building for TSan to avoid false positives.
+  if (IGF.IGM.IRGen.Opts.Sanitize == SanitizerKind::Thread)
+    relocatedMetadata->setOrdering(llvm::AtomicOrdering::Acquire);
 
   // emitLazyCacheAccessFunction will see that the value was loaded from
   // the guard variable and skip the redundant store back.
@@ -2880,6 +2888,12 @@ namespace {
       f->setAttributes(IGM.constructInitialAttributes());
       
       IRGenFunction IGF(IGM, f);
+
+      // Skip instrumentation when building for TSan to avoid false positives.
+      // The syncronization for this happens in the Runtime and we do not see it.
+      if (IGM.IRGen.Opts.Sanitize == SanitizerKind::Thread)
+        f->removeFnAttr(llvm::Attribute::SanitizeThread);
+
       if (IGM.DebugInfo)
         IGM.DebugInfo->emitArtificialFunction(IGF, f);
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1341,7 +1341,9 @@ emitReturnOfCheckedLoadFromCache(IRGenFunction &IGF, Address destTable,
 
   // Load and check whether it was null.
   auto cachedResult = IGF.Builder.CreateLoad(cache);
-  // FIXME: cachedResult->setOrdering(Consume);
+  // TODO: When LLVM supports Consume, we should use it here.
+  if (IGF.IGM.IRGen.Opts.Sanitize == SanitizerKind::Thread)
+    cachedResult->setOrdering(llvm::AtomicOrdering::Acquire);
   auto cacheIsEmpty = IGF.Builder.CreateIsNull(cachedResult);
   llvm::BasicBlock *fetchBB = IGF.createBasicBlock("fetch");
   llvm::BasicBlock *contBB = IGF.createBasicBlock("cont");

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -573,3 +573,31 @@ public func consumeCPU(units amountOfWork: Int) {
     }
   }
 }
+
+internal struct ClosureBasedRaceTest : RaceTestWithPerTrialData {
+  static var thread: () -> () = {}
+
+  class RaceData {}
+  typealias ThreadLocalData = Void
+  typealias Observation = Void
+
+  func makeRaceData() -> RaceData { return RaceData() }
+  func makeThreadLocalData() -> Void { return Void() }
+
+  func thread1(
+    _ raceData: RaceData, _ threadLocalData: inout ThreadLocalData
+  ) {
+    ClosureBasedRaceTest.thread()
+  }
+
+  func evaluateObservations(
+    _ observations: [Observation],
+    _ sink: (RaceTestObservationEvaluation) -> Void
+  ) {}
+}
+
+public func runRaceTest(trials: Int, threads: Int? = nil, body: () -> ()) {
+  ClosureBasedRaceTest.thread = body
+  runRaceTest(ClosureBasedRaceTest.self, trials: trials, threads: threads)
+}
+

--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -2,6 +2,7 @@
 // RUN: not env ASAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: asan_runtime
 // XFAIL: linux
 
 // Test AddressSanitizer execution end-to-end.

--- a/test/Sanitizers/asan.swift
+++ b/test/Sanitizers/asan.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swiftc_driver %s -g -sanitize=address -o %t_tsan-binary
+// RUN: not env ASAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// XFAIL: linux
+
+// Test AddressSanitizer execution end-to-end.
+
+var a = UnsafeMutablePointer<Int>(allocatingCapacity: 1)
+a.initialize(with: 5)
+a.deinitialize(count: 1)
+a.deallocateCapacity(1)
+print(a.pointee)
+a.deinitialize(count: 1)
+a.deallocateCapacity(1)
+
+// CHECK: AddressSanitizer: heap-use-after-free

--- a/test/Sanitizers/tsan-type-metadata.swift
+++ b/test/Sanitizers/tsan-type-metadata.swift
@@ -1,0 +1,88 @@
+// RUN: %target-build-swift -sanitize=thread %s -o %t_binary
+// RUN: TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
+
+// We expect not to report any races on this testcase.
+
+// This test excercises accesses to type metadata, which uses lockless
+// syncronization in the runtime that is relied upon by the direct accesses in the IR.
+// We have to make sure TSan does not see the acesses to the metadata from the IR.
+// Otherwise, it will report a race.
+
+// Generic classes.
+private class KeyWrapper<T: Hashable> {
+  let value: T
+
+  init(_ value: T) {
+    self.value = value
+  }
+  func present() {
+    print("Key: \(value)")
+  }
+}
+private class ValueWrapper<T> {
+  let value: T
+  init(_ value: T) {
+    self.value = value
+  }
+  func present() {
+    print("Value: \(value)")
+  }
+}
+
+// Concrete a class that inherits a generic base.
+class Base<T> {
+  var first, second: T
+  required init(x: T) {
+    first = x
+    second = x
+  }
+  func present() {
+    print("\(self.dynamicType) \(T.self) \(first) \(second)")
+  }
+}
+class SuperDerived: Derived {
+}
+class Derived: Base<String> {
+  var third: String
+  required init(x: String) {
+    third = x
+    super.init(x: x)
+  }
+  override func present() {
+    super.present()
+    print("...and \(third)")
+  }
+}
+func presentBase<T>(_ base: Base<T>) {
+  base.present()
+}
+func presentDerived(_ derived: Derived) {
+  derived.present()
+}
+
+public func testMetadata<Key: Hashable, Value>(_ key: Key, _ value: Value) {
+  let wrappedKey = KeyWrapper(key)
+  wrappedKey.present()
+  ValueWrapper(value).present()
+  presentBase(SuperDerived(x: "two"))
+  presentBase(Derived(x: "two"))
+  presentBase(Base(x: "two"))
+  presentBase(Base(x: 2))
+  presentDerived(Derived(x: "two"))
+}
+
+// Execute concurrently.
+import StdlibUnittest
+var RaceTestSuite = TestSuite("t")
+
+RaceTestSuite.test("test_metadata") {
+  runRaceTest(trials: 1) {
+    testMetadata(4, 4)
+  }
+}
+
+runAllTests()

--- a/test/Sanitizers/tsan-type-metadata.swift
+++ b/test/Sanitizers/tsan-type-metadata.swift
@@ -4,6 +4,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
+// REQUIRES: tsan_runtime
 
 // We expect not to report any races on this testcase.
 

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
+// REQUIRES: tsan_runtime
 // XFAIL: linux
 
 // Test ThreadSanitizer execution end-to-end.

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swiftc_driver %s -g -sanitize=thread -o %t_tsan-binary
+// RUN: not env TSAN_OPTIONS=abort_on_error=0 %target-run %t_tsan-binary 2>&1 | FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64
+// XFAIL: linux
+
+// Test ThreadSanitizer execution end-to-end.
+
+import Darwin
+var user_interactive_thread: pthread_t? = nil
+var user_interactive_thread2: pthread_t? = nil
+var racey_x: Int;
+
+pthread_create(&user_interactive_thread, nil, { _ in
+    print("pthread ran")
+    racey_x = 5;
+
+    return nil
+}, nil)
+
+pthread_create(&user_interactive_thread2, nil, { _ in
+    print("pthread2 ran")
+    racey_x = 6;
+
+    return nil
+}, nil)
+
+// CHECK: ThreadSanitizer: data race

--- a/test/Sanitizers/witness_table_lookup.swift
+++ b/test/Sanitizers/witness_table_lookup.swift
@@ -1,0 +1,57 @@
+// RUN: %target-build-swift -sanitize=thread %s -o %t_binary
+// RUN: TSAN_OPTIONS=ignore_interceptors_accesses=1:halt_on_error=1 %t_binary
+// REQUIRES: executable_test
+// REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
+
+// Check taht TSan does not report spurious races in witness table lookup.
+
+func consume(_ x: Any) {}
+protocol Q {
+  associatedtype QA
+  func deduceQA() -> QA
+  static func foo()
+}
+extension Q {
+  func deduceQA() -> Int { return 0 }
+}
+protocol Q2 {
+  associatedtype Q2A
+  func deduceQ2A() -> Q2A
+}
+extension Q2 {
+  func deduceQ2A() -> Int { return 0 }
+}
+protocol P {
+  associatedtype E : Q, Q2
+}
+struct B<T : Q> : Q, Q2 {
+  static func foo() { consume(self.dynamicType) }
+}
+struct A<T : Q where T : Q2> : P {
+  typealias E = B<T>
+  let value: T
+}
+func foo<T : P>(_ t: T) {
+  T.E.foo()
+}
+struct EasyType : Q, Q2 {
+    static func foo() { consume(self.dynamicType) }
+}
+extension Int : Q, Q2 {
+  static func foo() { consume(self.dynamicType) }
+}
+
+// Execute concurrently.
+import StdlibUnittest
+var RaceTestSuite = TestSuite("t")
+
+RaceTestSuite.test("test_metadata") {
+  runRaceTest(trials: 1) {
+    foo(A<Int>(value: 5))
+    foo(A<Int>(value: Int()))
+    foo(A<EasyType>(value: EasyType()))
+  }
+}
+
+runAllTests()

--- a/test/Sanitizers/witness_table_lookup.swift
+++ b/test/Sanitizers/witness_table_lookup.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
+// REQUIRES: tsan_runtime
 
 // Check taht TSan does not report spurious races in witness table lookup.
 

--- a/validation-test/StdlibUnittest/RaceTest.swift
+++ b/validation-test/StdlibUnittest/RaceTest.swift
@@ -92,6 +92,16 @@ RaceTestSuite.test("fails") {
 // CHECK: stdout>>> Failure: 1 times
 // CHECK: stdout>>> Failure (65534): 3 times
 // CHECK: [     FAIL ] Race.fails
+
+RaceTestSuite.test("closure") {
+  let count = _stdlib_AtomicInt(0)
+  runRaceTest(trials: 10) {
+    _ = count.fetchAndAdd(1)
+  }
+  expectNotEqual(0, count.load())
+}
+// CHECK: [ RUN      ] Race.closure
+// CHECK: [       OK ] Race.closure
 // CHECK: Race: Some tests failed, aborting
 
 runAllTests()


### PR DESCRIPTION
Address rdar://problem/26427107 TSan reports false positives on Swift code

TSan does not see all of the synchronization happening in the runtime since the runtime is not instrumented. Due to tight interplay between the runtime and the generated code, we report false positives when metadata or witness tables are accessed on certain types.

Fix these false positives by modifying the IRGen to hide writes in some cases and exposing stronger barriers in others.

Additionally, now that we have compiler-rt, add basic sanitizer tests.
