### PR TITLE
[swift_newtype] Structs have label-less init

### DIFF
--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -33,6 +33,12 @@ extern const MyFloat globalFloat;
 extern const MyFloat kPI;
 extern const MyFloat kVersion;
 
+typedef int MyInt __attribute((swift_newtype(struct)));
+extern const MyInt kMyIntZero;
+extern const MyInt kMyIntOne;
+extern const int kRawInt;
+extern void takesMyInt(MyInt);
+
 typedef NSString * NSURLResourceKey __attribute((swift_newtype(struct)));
 extern NSURLResourceKey const NSURLIsRegularFileKey;
 extern NSURLResourceKey const NSURLIsDirectoryKey;

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 
 // PRINT-LABEL: struct ErrorDomain : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
+// PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
@@ -36,11 +37,13 @@
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct IUONewtype : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
+// PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct MyFloat : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
+// PRINT-NEXT:    init(_ rawValue: Float)
 // PRINT-NEXT:    init(rawValue: Float)
 // PRINT-NEXT:    let rawValue: Float
 // PRINT-NEXT:  }
@@ -49,6 +52,18 @@
 // PRINT-NEXT:    static let PI: MyFloat
 // PRINT-NEXT:    static let version: MyFloat
 // PRINT-NEXT:  }
+//
+// PRINT-LABEL: struct MyInt : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
+// PRINT-NEXT:    init(_ rawValue: Int32)
+// PRINT-NEXT:    init(rawValue: Int32)
+// PRINT-NEXT:    let rawValue: Int32
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension MyInt {
+// PRINT-NEXT:    static let zero: MyInt!
+// PRINT-NEXT:    static let one: MyInt!
+// PRINT-NEXT:  }
+// PRINT-NEXT:  let kRawInt: Int32
+// PRINT-NEXT:  func takesMyInt(_: MyInt!)
 //
 // PRINT-LABEL: extension NSURLResourceKey {
 // PRINT-NEXT:    static let isRegularFileKey: NSURLResourceKey
@@ -65,6 +80,7 @@
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
 // PRINT-LABEL: struct CFNewType : RawRepresentable, _SwiftNewtypeWrapper {
+// PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
 // PRINT-NEXT:  }

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -2,6 +2,7 @@
 // RUN: mkdir -p %t
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t -I %S/../IDE/Inputs/custom-modules) %s -emit-ir -enable-swift-newtype | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t -I %S/../IDE/Inputs/custom-modules) %s -emit-ir -enable-swift-newtype -O | FileCheck %s -check-prefix=OPT
 import CoreFoundation
 import Foundation
 import Newtype
@@ -99,4 +100,33 @@ public func compareABIs() {
   //
   // CHECK: declare void @takeMyABINewTypeNonNullNS(%0*)
   // CHECK: declare void @takeMyABIOldTypeNonNullNS(%0*)
+}
+
+// OPT-LABEL: define i1 @_TF7newtype12compareInitsFT_Sb
+public func compareInits() -> Bool {
+  let mf = MyInt(rawValue: 1)
+  let mfNoLabel = MyInt(1)
+  let res = mf.rawValue == MyInt.one.rawValue 
+        && mfNoLabel.rawValue == MyInt.one.rawValue
+  // OPT:  [[ONE:%.*]] = load i32, i32* @kMyIntOne, align 4
+  // OPT-NEXT: [[COMP:%.*]] = icmp eq i32 [[ONE]], 1
+
+  takesMyInt(mf)
+  takesMyInt(mfNoLabel)
+  takesMyInt(MyInt(rawValue: kRawInt))
+  takesMyInt(MyInt(kRawInt))
+  // OPT: tail call void @takesMyInt(i32 1)
+  // OPT-NEXT: tail call void @takesMyInt(i32 1)
+  // OPT-NEXT: [[RAWINT:%.*]] = load i32, i32* @kRawInt, align 4
+  // OPT-NEXT: tail call void @takesMyInt(i32 [[RAWINT]])
+  // OPT-NEXT: tail call void @takesMyInt(i32 [[RAWINT]])
+
+  return res
+  // OPT-NEXT: ret i1 [[COMP]]
+}
+
+// CHECK-LABEL: anchor
+// OPT-LABEL: anchor
+public func anchor() -> Bool {
+  return false
 }

--- a/test/Interpreter/SDK/autolinking.swift
+++ b/test/Interpreter/SDK/autolinking.swift
@@ -14,7 +14,7 @@
 // This is specifically testing autolinking for immediate mode. Please do not
 // change it to use %target-build/%target-run
 // REQUIRES: swift_interpreter
-// REQUIRES: macosx
+// REQUIRES: OS=macosx
 
 
 import Darwin

--- a/test/Interpreter/import_as_member.swift
+++ b/test/Interpreter/import_as_member.swift
@@ -5,7 +5,7 @@
 // RUN: %target-run %t/a.out | FileCheck %s
 
 // REQUIRES: swift_interpreter
-// REQUIRES: macosx
+// REQUIRES: OS=macosx
 
 import ImportAsMember
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
Adds an unlabeled rawValue init for swift_newtype(struct), which
expresses the extensibility theme better.  This makes the use and
creation of new instances of that type more succinct.
swift_newtype(enum) still requires the explicit label, as it is
non-extensible.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Adds an unlabeled rawValue init for swift_newtype(struct), which
expresses the extensibility theme better.  This makes the use and
creation of new instances of that type more succinct.
swift_newtype(enum) still requires the explicit label, as it is
non-extensible.
