### PR TITLE
[swift-3.0-preview-1-branch] [stdlib] Add String.subscript(_: ClosedRange<Index>)

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -89,6 +89,14 @@ extension String {
   public subscript(bounds: Range<Index>) -> String {
     return String(characters[bounds])
   }
+
+  /// Accesses the text in the given range.
+  ///
+  /// - Complexity: O(*n*) if the underlying string is bridged from
+  ///   Objective-C, where *n* is the length of the string; otherwise, O(1).
+  public subscript(bounds: ClosedRange<Index>) -> String {
+    return String(characters[bounds])
+  }
 }
 
 @warn_unused_result

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -205,6 +205,22 @@ StringTests.test("ForeignIndexes/subscript(Index)/OutOfBoundsTrap") {
   acceptor[i]
 }
 
+StringTests.test("String/subscript(_:Range)") {
+  let s = "foobar"
+  let from = s.startIndex
+  let to = s.index(before: s.endIndex)
+  let actual = s[from..<to]
+  expectEqual("fooba", actual)
+}
+
+StringTests.test("String/subscript(_:ClosedRange)") {
+  let s = "foobar"
+  let from = s.startIndex
+  let to = s.index(before: s.endIndex)
+  let actual = s[from...to]
+  expectEqual(s, actual)
+}
+
 StringTests.test("ForeignIndexes/subscript(Range)/OutOfBoundsTrap/1") {
   let donor = "abcdef"
   let acceptor = "uvw"


### PR DESCRIPTION
Fixes [SR-1596](https://bugs.swift.org/browse/SR-1596).

• Explanation: New collections introduce two distinct range types for half-open and closed ranges. String type, even though it is not a collection, provides `subscript(_: Range<Index>)`. What it does not provide, is the `subscript(_: ClosedRange<Ingex>)`. This change fixes this ommision.
• Scope of Issue: Purely additive change that will enable more uses.
• Origination: Implementing this subscript was overlooked while porting the standard library to the new collection indexing model.
• Risk: Minimal.
• Reviewed By: Dmitri Gribenko
• Testing: Unit tests, REPL
• Directions for QA: N/A
