### PR TITLE
Fix renaming fix-it when trailing closures are present.

### DIFF
--- a/test/ClangModules/attr-swift_name_renaming.swift
+++ b/test/ClangModules/attr-swift_name_renaming.swift
@@ -37,7 +37,7 @@ func test() {
   // This particular instance method mapping previously caused a crash because
   // of the trailing closure.
   acceptsClosure(Foo(), test) // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-25=}} {{25-25=closure: }}
-  acceptsClosure(Foo()) {} // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-25=}}
+  acceptsClosure(Foo()) {} // expected-error {{'acceptsClosure' has been replaced by instance method 'Foo.accepts(closure:)'}} {{3-17=(Foo()).accepts}} {{18-23=}}
 
   Foo().accepts(closure: test)
   Foo().accepts() {}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -479,6 +479,19 @@ func testRenameSetters() {
   unavailableSetInstancePropertyInout(a: &x, b: 2) // expected-error{{'unavailableSetInstancePropertyInout(a:b:)' has been replaced by property 'Int.prop'}} {{3-38=x.prop}} {{38-49= = }} {{50-51=}}
 }
 
+@available(*, unavailable, renamed: "Int.foo(self:execute:)")
+func trailingClosure(_ value: Int, fn: () -> Void) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(self:bar:execute:)")
+func trailingClosureArg(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
+@available(*, unavailable, renamed: "Int.foo(bar:self:execute:)")
+func trailingClosureArg2(_ value: Int, _ other: Int, fn: () -> Void) {} // expected-note {{here}}
+
+func testInstanceTrailingClosure() {
+  trailingClosure(0) {} // expected-error {{'trailingClosure(_:fn:)' has been replaced by instance method 'Int.foo(execute:)'}} {{3-18=0.foo}} {{19-20=}}
+  trailingClosureArg(0, 1) {} // expected-error {{'trailingClosureArg(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-21=0.foo}} {{22-25=}} {{25-25=bar: }}
+  trailingClosureArg2(0, 1) {} // expected-error {{'trailingClosureArg2(_:_:fn:)' has been replaced by instance method 'Int.foo(bar:execute:)'}} {{3-22=1.foo}} {{23-23=bar: }} {{24-27=}}
+}
+
 extension Int {
   @available(*, unavailable, renamed: "init(other:)")
   @discardableResult


### PR DESCRIPTION
- **Explanation:** The fix-its for a function now imported as a member are incorrect if there’s a trailing closure, because “the end of the TupleExpr” isn’t the same location as “the close paren”.
- **Scope:** Poor fix-its for dispatch_sync and dispatch_async (and others, but those will by far be the most common).
- **Issue:** rdar://problem/26305887. Reviewed by @DougGregor.
- **Risk:** Low. This only affects diagnostic code, and should not be any more unsafe than the existing code.
- **Testing:** Added compiler regression tests, verified that the fix-it for the original test case is correct.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
