### PR TITLE
Fix more broken API notes caught by manual inspection.

### DIFF
--- a/apinotes/TVMLKit.apinotes
+++ b/apinotes/TVMLKit.apinotes
@@ -32,10 +32,10 @@ Classes:
     SwiftName: children
   Methods:
   - Selector: 'dispatchEventOfType:canBubble:cancellable:extraInfo:completion:'
-    SwiftName: 'dispatchEvent(type:canBubble:cancellable:extraInfo:completion:Bool):)'
+    SwiftName: 'dispatchEvent(type:canBubble:cancellable:extraInfo:completion:)'
     MethodKind: Instance
   - Selector: 'dispatchEventWithName:canBubble:cancellable:extraInfo:completion:'
-    SwiftName: 'dispatchEvent(name:canBubble:cancellable:extraInfo:completion:Bool):)'
+    SwiftName: 'dispatchEvent(name:canBubble:cancellable:extraInfo:completion:)'
     MethodKind: Instance
 - Name: TVViewElementStyle
   Methods:


### PR DESCRIPTION
- **Explanation:** We had busted apinotes for two methods in TVMLKit, resulting in those methods not being imported. We’ve since updated the compiler to just ignore invalid `swift_name` attributes rather than drop the API, so the failure mode isn’t as bad, but we should still get this right with the rest of our “Swift 3 modernization” changes.
- **Scope:** Just these two methods.
- **Issue:** rdar://problem/26403143. Reviewed by @bitjammer.
- **Risk:** Very low. It’s really no different from any other apinotes, and since the methods weren’t showing up at all for a while it’s unlikely anyone using the latest Swift compilers is relying on them.
- **Testing:** Verified that the methods imported correctly in the integrated REPL, which they previously hadn’t.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
