### PR TITLE
Fix type checking performance regression for variables annotated with desugared array types

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1193,8 +1193,12 @@ namespace {
           baseTy = baseTy->getLValueOrInOutObjectType();
         }
         
-        if (auto arraySliceTy = dyn_cast<ArraySliceType>(baseTy.getPointer())) {
-          baseTy = arraySliceTy->getDesugaredType();
+        if (CS.isArrayType(baseTy.getPointer())) {
+
+          if (auto arraySliceTy = 
+                dyn_cast<ArraySliceType>(baseTy.getPointer())) {
+            baseTy = arraySliceTy->getDesugaredType();
+          }
           
           auto indexExpr = subscriptExpr->getIndex();
           

--- a/test/expr/edge-contraction/array_base_optimization.swift
+++ b/test/expr/edge-contraction/array_base_optimization.swift
@@ -1,0 +1,9 @@
+// RUN: %target-parse-verify-swift
+
+var fa2: Array<Double> = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+print("six has the value [\(fa2[0]), \(fa2[1]), \(fa2[2]), \(fa2[3]), \(fa2[4]), \(fa2[5])]")
+
+var threeDoubles = Array(repeating: 0.0, count: 3)
+var anotherThreeDoubles = Array(repeating: 2.5, count: 3)
+var sixDoubles: [Double] = threeDoubles + anotherThreeDoubles
+print("six has the value [\(sixDoubles[0]), \(sixDoubles[1]), \(sixDoubles[2]), \(sixDoubles[3]), \(sixDoubles[4]), \(sixDoubles[5])]")


### PR DESCRIPTION
When generating constraints for subscript expressions, look beyond array
slice types when deciding whether or not to create a fresh type variable
for the array's base expression. 

(pushed to master as 39e7c77a, rdar://problem/26392320)
