### PR TITLE
[IDE/format] Disable the sibling check for dictionary/array literal e…

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -536,12 +536,26 @@ class FormatWalker : public SourceEntityWalker {
 
       // Array/Dictionary elements are siblings to align with each other.
       if (auto AE = dyn_cast_or_null<CollectionExpr>(Node.dyn_cast<Expr *>())) {
-        SourceLoc LBracketLoc = AE->getLBracketLoc();
+        // The following check ends-up creating too much indentation,
+        // for example:
+        //   let something = [
+        //                       a
+        //   ]
+        //
+        // Disabling the check gets us back to the Swift2.2 behavior:
+        //   let something = [
+        //       a
+        //   ]
+        //
+        // FIXME: We are going to revisit the behavior and the indentation we
+        // want for dictionary/array literals.
+        //
+        /* SourceLoc LBracketLoc = AE->getLBracketLoc();
         if (isTargetImmediateAfter(LBracketLoc) &&
             !sameLineWithTarget(LBracketLoc)) {
           FoundSibling = LBracketLoc;
           NeedExtraIndentation = true;
-        }
+        }*/
         for (unsigned I = 0, N = AE->getNumElements(); I < N;  I ++) {
           addPair(AE->getElement(I)->getEndLoc(),
                   FindAlignLoc(AE->getElement(I)->getStartLoc()), tok::comma);

--- a/test/SourceKit/CodeFormat/indent-basic.swift
+++ b/test/SourceKit/CodeFormat/indent-basic.swift
@@ -40,5 +40,5 @@ x
 // CHECK: key.sourcetext: "    "
 // CHECK: key.sourcetext: "}"
 //                        "foo(a: ["
-// CHECK: key.sourcetext: "           3: 3"
+// CHECK: key.sourcetext: "    3: 3"
 // CHECK: key.sourcetext: "    x"


### PR DESCRIPTION
#### What's in this pull request?

This reverts an indentation change, that was creating too much indentation for common cases with array/dictionary literals and effectively going back to Swift 2.2. behavior.

For example, the following:

```
   let something = [
                       a
   ]

```

Will go back to:

```
   let something = [
       a
   ]

```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26433192

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
