### PR TITLE
AddSwift.cmake: Install into resource dir based on TARGET_LIBRARY

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1224,7 +1224,7 @@ function(add_swift_library name)
         message(FATAL_ERROR "internal error: the variable should be non-empty")
       endif()
 
-      if(SWIFTLIB_IS_STDLIB)
+      if(SWIFTLIB_TARGET_LIBRARY)
         if(SWIFTLIB_SHARED)
           set(resource_dir "swift")
           set(file_permissions


### PR DESCRIPTION
not IS_STDLIB. There are other non-stdlib libraries that can go
into the platform resource directory, such as libswiftRemoteMirror.dylib.

rdar://problem/26435454
