### PR TITLE
[swift-3.0-preview-1][stdlib] Dictionary, Set: stop overallocating the bitmap

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2514,7 +2514,7 @@ internal struct _BitMap {
 
   @warn_unused_result
   internal static func wordsFor(_ bitCount: Int) -> Int {
-    return bitCount + Int._sizeInBytes - 1 / Int._sizeInBytes
+    return (bitCount + Int._sizeInBits - 1) / Int._sizeInBits
   }
 
   internal init(storage: UnsafeMutablePointer<UInt>, bitCount: Int) {


### PR DESCRIPTION
- Explanation: The 'sizeInWords(forSizeInBits:)' function was supposed to return the size in words, but returned the size in bits, overallocating the bitmap by a factor of 32 or 64, depending on the platform.
- Scope of Issue: All uses of Dictionary and Set are affected.
- Risk: low risk.  I studied the code carefully, and added tests for confidence.
- Reviewed By: TBD.
- Testing: checked that existing tests don't break.  I also added directed tests on the master branch, but that required refactoring some Dictionary internals to be testable.  (https://github.com/apple/swift/pull/2528)  I decided not to propose the refactoring for the preview-1 branch, and only backported the correctness fix.

rdar://problem/26271578

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
