### PR TITLE
Don't embed bitcode in libSwiftRemoteMirror.dylib

### DIFF
--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_swift_library(swiftRemoteMirror SHARED TARGET_LIBRARY
+add_swift_library(swiftRemoteMirror SHARED TARGET_LIBRARY DONT_EMBED_BITCODE
   SwiftRemoteMirror.cpp
   LINK_LIBRARIES swiftReflection
   INSTALL_IN_COMPONENT stdlib)


### PR DESCRIPTION
It's not necessary and contributes to bloat in the dylib.

rdar://problem/26396488
