### PR TITLE
NSPersistentStoreCoordinator apinote. Add -performBlockAndWait:

### DIFF
--- a/apinotes/CoreData.apinotes
+++ b/apinotes/CoreData.apinotes
@@ -120,6 +120,9 @@ Classes:
   - Selector: 'importStoreWithIdentifier:fromExternalRecordsDirectory:toURL:options:withType:error:'
     SwiftName: 'importStore(withIdentifier:fromExternalRecordsDirectoryAt:to:options:ofType:)'
     MethodKind: Instance
+  - Selector: 'performBlockAndWait:'
+    SwiftName: 'performAndWait(_:)'
+    MethodKind: Instance
 - Name: NSSaveChangesRequest
   Methods:
   - Selector: 'initWithInsertedObjects:updatedObjects:deletedObjects:lockedObjects:'


### PR DESCRIPTION
#### What's in this pull request?

Like NSManagedObjectContext, NSPersistentStoreCoordinator provides a
performBlockAndWait method that should be mapped to performAndWait(_ block:).

This simple change adds the missing apinote to NSPersistentStoreCoordinator class.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
