### PR TITLE
New type 3.0

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -64,13 +64,34 @@ namespace inferred_attributes {
 }
 }
 
+namespace {
+enum class MakeStructRawValuedFlags {
+  /// whether to also create an unlabeled init
+  MakeUnlabeledValueInit = 0x01,
+
+  /// whether the raw value should be a let
+  IsLet = 0x02,
+
+  /// whether to mark the rawValue as implicit
+  IsImplicit = 0x04,
+};
+using MakeStructRawValuedOptions = OptionSet<MakeStructRawValuedFlags>;
+}
+
+static MakeStructRawValuedOptions
+getDefaultMakeStructRawValuedOptions() {
+  MakeStructRawValuedOptions opts;
+  opts -= MakeStructRawValuedFlags::MakeUnlabeledValueInit; // default off
+  opts |= MakeStructRawValuedFlags::IsLet;                  // default on
+  opts |= MakeStructRawValuedFlags::IsImplicit;             // default on
+  return opts;
+}
 
 static bool isInSystemModule(DeclContext *D) {
   if (cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule())
     return true;
   return false;
 }
-
 
 /// Create a typedpattern(namedpattern(decl))
 static Pattern *createTypedNamedPattern(VarDecl *decl) {
@@ -1413,9 +1434,12 @@ namespace {
       if (!isBridged) {
         // Simple, our stored type is equivalent to our computed
         // type.
+        auto options = getDefaultMakeStructRawValuedOptions();
+        if (unlabeledCtor)
+          options |= MakeStructRawValuedFlags::MakeUnlabeledValueInit;
+
         makeStructRawValued(structDecl, storedUnderlyingType,
-                            synthesizedProtocols, protocols,
-                            /*makeUnlabeledValueInit=*/unlabeledCtor);
+                            synthesizedProtocols, protocols, options);
       } else {
         // We need to make a stored rawValue or storage type, and a
         // computed one of bridged type.
@@ -1715,9 +1739,6 @@ namespace {
     /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
     /// \param protocols the protocols to make this struct conform to
     /// \param setterAccessibility the accessibility of the raw value's setter
-    /// \param isLet whether the raw value should be a let
-    /// \param makeUnlabeledValueInit whether to also create an unlabeled init
-    /// \param isImplicit whether to mark the rawValue as implicit
     ///
     /// This will perform most of the work involved in making a new Swift struct
     /// be backed by a raw value. This will populated derived protocols and
@@ -1725,29 +1746,30 @@ namespace {
     /// create the inits parameterized over a raw value
     ///
     void makeStructRawValued(
-        StructDecl *structDecl,
-        Type underlyingType,
+        StructDecl *structDecl, Type underlyingType,
         ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
         ArrayRef<ProtocolDecl *> protocols,
-        bool makeUnlabeledValueInit = false,
-        Accessibility setterAccessibility = Accessibility::Private,
-        bool isLet = true,
-        bool isImplicit = true) {
+        MakeStructRawValuedOptions options =
+            getDefaultMakeStructRawValuedOptions(),
+        Accessibility setterAccessibility = Accessibility::Private) {
       auto &cxt = Impl.SwiftContext;
       addProtocolsToStruct(structDecl, synthesizedProtocolAttrs, protocols);
 
       // Create a variable to store the underlying value.
       VarDecl *var;
       PatternBindingDecl *patternBinding;
-      std::tie(var, patternBinding) =
-          createVarWithPattern(cxt, structDecl, cxt.Id_rawValue, underlyingType,
-                               isLet, isImplicit, setterAccessibility);
+      std::tie(var, patternBinding) = createVarWithPattern(
+          cxt, structDecl, cxt.Id_rawValue, underlyingType,
+          options.contains(MakeStructRawValuedFlags::IsLet),
+          options.contains(MakeStructRawValuedFlags::IsImplicit),
+          setterAccessibility);
 
       structDecl->setHasDelayedMembers();
 
       // Create constructors to initialize that value from a value of the
       // underlying type.
-      if (makeUnlabeledValueInit)
+      if (options.contains(
+              MakeStructRawValuedFlags::MakeUnlabeledValueInit))
         structDecl->addMember(createValueConstructor(
             structDecl, var,
             /*wantCtorParamNames=*/false,
@@ -2214,12 +2236,16 @@ namespace {
         ProtocolDecl *protocols[]
           = {cxt.getProtocol(KnownProtocolKind::RawRepresentable),
              cxt.getProtocol(KnownProtocolKind::Equatable)};
+
+        auto options = getDefaultMakeStructRawValuedOptions();
+        options |= MakeStructRawValuedFlags::MakeUnlabeledValueInit;
+        options -= MakeStructRawValuedFlags::IsLet;
+        options -= MakeStructRawValuedFlags::IsImplicit;
+
         makeStructRawValued(structDecl, underlyingType,
                             {KnownProtocolKind::RawRepresentable}, protocols,
-                            /*makeUnlabeledValueInit=*/true,
-                            /*setterAccessibility=*/Accessibility::Public,
-                            /*isLet=*/false,
-                            /*isImplicit=*/false);
+                            options,
+                            /*setterAccessibility=*/Accessibility::Public);
 
         result = structDecl;
         break;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1312,11 +1312,20 @@ namespace {
     Decl *importSwiftNewtype(const clang::TypedefNameDecl *decl,
                              clang::SwiftNewtypeAttr *newtypeAttr,
                              DeclContext *dc, Identifier name) {
+      // The only (current) difference between swift_newtype(struct) and
+      // swift_newtype(enum), until we can get real enum support, is that enums
+      // have no un-labeld inits(). This is because enums are to be considered
+      // closed, and if constructed from a rawValue, should be very explicit.
+      bool unlabeledCtor = false;
+
       switch (newtypeAttr->getNewtypeKind()) {
       case clang::SwiftNewtypeAttr::NK_Enum:
-      // TODO: import as closed enum instead
-      // For now, fall through and treat as a struct
+        unlabeledCtor = false;
+        // TODO: import as closed enum instead
+        break;
+
       case clang::SwiftNewtypeAttr::NK_Struct:
+        unlabeledCtor = true;
         break;
       // No other cases yet
       }
@@ -1405,13 +1414,15 @@ namespace {
         // Simple, our stored type is equivalent to our computed
         // type.
         makeStructRawValued(structDecl, storedUnderlyingType,
-                            synthesizedProtocols, protocols);
+                            synthesizedProtocols, protocols,
+                            /*makeUnlabeledValueInit=*/unlabeledCtor);
       } else {
         // We need to make a stored rawValue or storage type, and a
         // computed one of bridged type.
         makeStructRawValuedWithBridge(structDecl, storedUnderlyingType,
                                       computedPropertyUnderlyingType,
-                                      synthesizedProtocols, protocols);
+                                      synthesizedProtocols, protocols,
+                                      /*makeUnlabeledValueInit=*/unlabeledCtor);
       }
 
       Impl.ImportedDecls[{decl->getCanonicalDecl(), useSwift2Name}] =
@@ -1718,9 +1729,9 @@ namespace {
         Type underlyingType,
         ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
         ArrayRef<ProtocolDecl *> protocols,
+        bool makeUnlabeledValueInit = false,
         Accessibility setterAccessibility = Accessibility::Private,
         bool isLet = true,
-        bool makeUnlabeledValueInit = false,
         bool isImplicit = true) {
       auto &cxt = Impl.SwiftContext;
       addProtocolsToStruct(structDecl, synthesizedProtocolAttrs, protocols);
@@ -1765,14 +1776,12 @@ namespace {
     /// over a bridged type that will cast to the stored type, as appropriate.
     ///
     void makeStructRawValuedWithBridge(
-        StructDecl *structDecl,
-        Type storedUnderlyingType,
-        Type bridgedType,
+        StructDecl *structDecl, Type storedUnderlyingType, Type bridgedType,
         ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-        ArrayRef<ProtocolDecl *> protocols) {
+        ArrayRef<ProtocolDecl *> protocols,
+        bool makeUnlabeledValueInit = false) {
       auto &cxt = Impl.SwiftContext;
-      addProtocolsToStruct(structDecl, synthesizedProtocolAttrs,
-                           protocols);
+      addProtocolsToStruct(structDecl, synthesizedProtocolAttrs, protocols);
 
       auto storedVarName = cxt.getIdentifier("_rawValue");
       auto computedVarName = cxt.Id_rawValue;
@@ -1786,19 +1795,17 @@ namespace {
 
       //
       // Create a computed value variable
-      auto computedVar = new (cxt) VarDecl(/*static*/ false,
-                                           /*IsLet*/ false,
-                                           SourceLoc(), computedVarName,
-                                           bridgedType, structDecl);
+      auto computedVar =
+          new (cxt) VarDecl(/*static*/ false,
+                            /*IsLet*/ false, SourceLoc(), computedVarName,
+                            bridgedType, structDecl);
       computedVar->setImplicit();
       computedVar->setAccessibility(Accessibility::Public);
       computedVar->setSetterAccessibility(Accessibility::Private);
 
       // Create the getter for the computed value variable.
-      auto computedVarGetter = makeNewtypeBridgedRawValueGetter(Impl,
-                                                                structDecl,
-                                                                computedVar,
-                                                                storedVar);
+      auto computedVarGetter = makeNewtypeBridgedRawValueGetter(
+          Impl, structDecl, computedVar, storedVar);
 
       // Create a pattern binding to describe the variable.
       Pattern *computedVarPattern = createTypedNamedPattern(computedVar);
@@ -1806,26 +1813,52 @@ namespace {
           cxt, SourceLoc(), StaticSpellingKind::None, SourceLoc(),
           computedVarPattern, nullptr, structDecl);
 
-      auto init = createValueConstructor(structDecl, computedVar,
-                                         /*wantCtorParamNames=*/true,
+      auto init = createRawValueBridgingConstructor(
+          structDecl, computedVar, storedVar,
+          /*wantLabel*/ true, !Impl.hasFinishedTypeChecking());
+
+      ConstructorDecl *unlabeledCtor = nullptr;
+      if (makeUnlabeledValueInit)
+        unlabeledCtor = createRawValueBridgingConstructor(
+            structDecl, computedVar, storedVar,
+            /*wantLabel*/ false, !Impl.hasFinishedTypeChecking());
+
+      structDecl->setHasDelayedMembers();
+      if (unlabeledCtor)
+        structDecl->addMember(unlabeledCtor);
+      structDecl->addMember(init);
+      structDecl->addMember(storedPatternBinding);
+      structDecl->addMember(storedVar);
+      structDecl->addMember(computedPatternBinding);
+      structDecl->addMember(computedVar);
+      structDecl->addMember(computedVarGetter);
+    }
+
+    /// Create a rawValue-ed constructor that bridges to its underlying storage.
+    ConstructorDecl *createRawValueBridgingConstructor(
+        StructDecl *structDecl, VarDecl *computedRawValue,
+        VarDecl *storedRawValue, bool wantLabel, bool wantBody) {
+      auto &cxt = Impl.SwiftContext;
+      auto init = createValueConstructor(structDecl, computedRawValue,
+                                         /*wantCtorParamNames=*/wantLabel,
                                          /*wantBody=*/false);
       // Insert our custom init body
-      if (!Impl.hasFinishedTypeChecking()) {
+      if (wantBody) {
         auto selfDecl = init->getParameterList(0)->get(0);
 
         // Construct left-hand side.
         Expr *lhs = new (cxt) DeclRefExpr(selfDecl, DeclNameLoc(),
                                           /*Implicit=*/true);
-        lhs = new (cxt) MemberRefExpr(lhs, SourceLoc(), storedVar,
+        lhs = new (cxt) MemberRefExpr(lhs, SourceLoc(), storedRawValue,
                                       DeclNameLoc(), /*Implicit=*/true);
 
         // Construct right-hand side.
         // FIXME: get the parameter from the init, and plug it in here.
         auto rhs = new (cxt)
-            CoerceExpr(new (cxt) DeclRefExpr(
-                        init->getParameterList(1)->get(0), 
-                        DeclNameLoc(),
-                        /*Implicit=*/true), {}, {nullptr, storedUnderlyingType});
+            CoerceExpr(new (cxt) DeclRefExpr(init->getParameterList(1)->get(0),
+                                             DeclNameLoc(),
+                                             /*Implicit=*/true),
+                       {}, {nullptr, storedRawValue->getType()});
 
         // Add assignment.
         auto assign = new (cxt) AssignExpr(lhs, SourceLoc(), rhs,
@@ -1834,13 +1867,7 @@ namespace {
         init->setBody(body);
       }
 
-      structDecl->setHasDelayedMembers();
-      structDecl->addMember(init);
-      structDecl->addMember(storedPatternBinding);
-      structDecl->addMember(storedVar);
-      structDecl->addMember(computedPatternBinding);
-      structDecl->addMember(computedVar);
-      structDecl->addMember(computedVarGetter);
+      return init;
     }
 
     /// \brief Create a constructor that initializes a struct from its members.
@@ -2189,9 +2216,9 @@ namespace {
              cxt.getProtocol(KnownProtocolKind::Equatable)};
         makeStructRawValued(structDecl, underlyingType,
                             {KnownProtocolKind::RawRepresentable}, protocols,
+                            /*makeUnlabeledValueInit=*/true,
                             /*setterAccessibility=*/Accessibility::Public,
                             /*isLet=*/false,
-                            /*makeUnlabeledValueInit=*/true,
                             /*isImplicit=*/false);
 
         result = structDecl;

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -33,6 +33,12 @@ extern const MyFloat globalFloat;
 extern const MyFloat kPI;
 extern const MyFloat kVersion;
 
+typedef int MyInt __attribute((swift_newtype(struct)));
+extern const MyInt kMyIntZero;
+extern const MyInt kMyIntOne;
+extern const int kRawInt;
+extern void takesMyInt(MyInt);
+
 typedef NSString * NSURLResourceKey __attribute((swift_newtype(struct)));
 extern NSURLResourceKey const NSURLIsRegularFileKey;
 extern NSURLResourceKey const NSURLIsDirectoryKey;

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -7,6 +7,7 @@
 // REQUIRES: objc_interop
 
 // PRINT-LABEL: struct ErrorDomain : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
+// PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
@@ -36,11 +37,13 @@
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct IUONewtype : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
+// PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var _rawValue: NSString
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:  }
 // PRINT-NEXT:  struct MyFloat : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
+// PRINT-NEXT:    init(_ rawValue: Float)
 // PRINT-NEXT:    init(rawValue: Float)
 // PRINT-NEXT:    let rawValue: Float
 // PRINT-NEXT:  }
@@ -49,6 +52,18 @@
 // PRINT-NEXT:    static let PI: MyFloat
 // PRINT-NEXT:    static let version: MyFloat
 // PRINT-NEXT:  }
+//
+// PRINT-LABEL: struct MyInt : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable {
+// PRINT-NEXT:    init(_ rawValue: Int32)
+// PRINT-NEXT:    init(rawValue: Int32)
+// PRINT-NEXT:    let rawValue: Int32
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension MyInt {
+// PRINT-NEXT:    static let zero: MyInt!
+// PRINT-NEXT:    static let one: MyInt!
+// PRINT-NEXT:  }
+// PRINT-NEXT:  let kRawInt: Int32
+// PRINT-NEXT:  func takesMyInt(_: MyInt!)
 //
 // PRINT-LABEL: extension NSURLResourceKey {
 // PRINT-NEXT:    static let isRegularFileKey: NSURLResourceKey
@@ -65,6 +80,7 @@
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
 // PRINT-LABEL: struct CFNewType : RawRepresentable, _SwiftNewtypeWrapper {
+// PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
 // PRINT-NEXT:  }

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -117,7 +117,7 @@ public func compareInits() -> Bool {
   takesMyInt(MyInt(kRawInt))
   // OPT: tail call void @takesMyInt(i32 1)
   // OPT-NEXT: tail call void @takesMyInt(i32 1)
-  // OPT-NEXT: [[RAWINT:%.*]] = load i32, i32* @kRawInt, align 4
+  // OPT-NEXT: [[RAWINT:%.*]] = load i32, i32*{{.*}} @kRawInt{{.*}}, align 4
   // OPT-NEXT: tail call void @takesMyInt(i32 [[RAWINT]])
   // OPT-NEXT: tail call void @takesMyInt(i32 [[RAWINT]])
 

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -108,7 +108,7 @@ public func compareInits() -> Bool {
   let mfNoLabel = MyInt(1)
   let res = mf.rawValue == MyInt.one.rawValue 
         && mfNoLabel.rawValue == MyInt.one.rawValue
-  // OPT:  [[ONE:%.*]] = load i32, i32* @kMyIntOne, align 4
+  // OPT:  [[ONE:%.*]] = load i32, i32*{{.*}}@kMyIntOne{{.*}}, align 4
   // OPT-NEXT: [[COMP:%.*]] = icmp eq i32 [[ONE]], 1
 
   takesMyInt(mf)

--- a/test/IRGen/newtype.swift
+++ b/test/IRGen/newtype.swift
@@ -2,6 +2,7 @@
 // RUN: mkdir -p %t
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t -I %S/../IDE/Inputs/custom-modules) %s -emit-ir -enable-swift-newtype | FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t -I %S/../IDE/Inputs/custom-modules) %s -emit-ir -enable-swift-newtype -O | FileCheck %s -check-prefix=OPT
 import CoreFoundation
 import Foundation
 import Newtype
@@ -99,4 +100,33 @@ public func compareABIs() {
   //
   // CHECK: declare void @takeMyABINewTypeNonNullNS(%0*) #0
   // CHECK: declare void @takeMyABIOldTypeNonNullNS(%0*) #0
+}
+
+// OPT-LABEL: define i1 @_TF7newtype12compareInitsFT_Sb
+public func compareInits() -> Bool {
+  let mf = MyInt(rawValue: 1)
+  let mfNoLabel = MyInt(1)
+  let res = mf.rawValue == MyInt.one.rawValue 
+        && mfNoLabel.rawValue == MyInt.one.rawValue
+  // OPT:  [[ONE:%.*]] = load i32, i32* @kMyIntOne, align 4
+  // OPT-NEXT: [[COMP:%.*]] = icmp eq i32 [[ONE]], 1
+
+  takesMyInt(mf)
+  takesMyInt(mfNoLabel)
+  takesMyInt(MyInt(rawValue: kRawInt))
+  takesMyInt(MyInt(kRawInt))
+  // OPT: tail call void @takesMyInt(i32 1)
+  // OPT-NEXT: tail call void @takesMyInt(i32 1)
+  // OPT-NEXT: [[RAWINT:%.*]] = load i32, i32* @kRawInt, align 4
+  // OPT-NEXT: tail call void @takesMyInt(i32 [[RAWINT]])
+  // OPT-NEXT: tail call void @takesMyInt(i32 [[RAWINT]])
+
+  return res
+  // OPT-NEXT: ret i1 [[COMP]]
+}
+
+// CHECK-LABEL: anchor
+// OPT-LABEL: anchor
+public func anchor() -> Bool {
+  return false
 }

--- a/test/Interpreter/SDK/autolinking.swift
+++ b/test/Interpreter/SDK/autolinking.swift
@@ -14,7 +14,7 @@
 // This is specifically testing autolinking for immediate mode. Please do not
 // change it to use %target-build/%target-run
 // REQUIRES: swift_interpreter
-// REQUIRES: macosx
+// REQUIRES: OS=macosx
 
 
 import Darwin

--- a/test/Interpreter/import_as_member.swift
+++ b/test/Interpreter/import_as_member.swift
@@ -5,7 +5,7 @@
 // RUN: %target-run %t/a.out | FileCheck %s
 
 // REQUIRES: swift_interpreter
-// REQUIRES: macosx
+// REQUIRES: OS=macosx
 
 import ImportAsMember
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Swift 3.0 preview 1 for https://github.com/apple/swift/pull/2654

Adds an unlabeled rawValue init for swift_newtype(struct), which
expresses the extensibility theme better.  This makes the use and
creation of new instances of that type more succinct.
swift_newtype(enum) still requires the explicit label, as it is
non-extensible.

rdar://problem/26299529
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
