### PR TITLE
Make the shadowing logic more conservative about typealias declaratio…

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -154,17 +154,17 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
     // types well.
     CanType signature;
 
-    // FIXME: Egregious hack to avoid failing when there are no declared types.
-    if (!decl->hasType() || isa<TypeAliasDecl>(decl) || isa<AbstractTypeParamDecl>(decl)) {
-      // FIXME: Pass this down instead of getting it from the ASTContext.
-      if (typeResolver && !decl->isBeingTypeChecked())
-        typeResolver->resolveDeclSignature(decl);
-      if (!decl->hasType())
+    if (typeResolver)
+      typeResolver->resolveDeclSignature(decl);
+
+    if (!decl->hasType())
+      continue;
+    if (auto aliasType = dyn_cast<TypeAliasDecl>(decl))
+      if (!aliasType->hasUnderlyingType())
         continue;
-      if (auto assocType = dyn_cast<AssociatedTypeDecl>(decl))
-        if (!assocType->getArchetype())
-          continue;
-    }
+    if (auto assocType = dyn_cast<AssociatedTypeDecl>(decl))
+      if (!assocType->getArchetype())
+        continue;
     
     // If the decl is currently being validated, this is likely a recursive
     // reference and we'll want to skip ahead so as to avoid having its type

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -154,7 +154,7 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
     // types well.
     CanType signature;
 
-    if (typeResolver)
+    if (typeResolver && !decl->isBeingTypeChecked())
       typeResolver->resolveDeclSignature(decl);
 
     if (!decl->hasType())

--- a/validation-test/compiler_crashers_fixed/00429-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00429-vtable.swift
@@ -6,11 +6,6 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -parse
-
-// REQUIRES: asserts
-// SR-1584
-// XFAIL: objc_interop
-
 }
 struct S {
 static let i: B<Q<T where A"""


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Fix a validation test by making the name-shadowing logic more conservative about typealias declarations.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-1584](https://bugs.swift.org/browse/SR-1584))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…ns that lack an underlying type.
