### PR TITLE
[swift-3.0-preview-1-branch] [stdlib] implement reverse() as proposed in SE-0078

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -686,6 +686,20 @@ if resiliencyChecks.subscriptOnOutOfBoundsIndicesBehavior != .none {
 }
 
 //===----------------------------------------------------------------------===//
+// reverse()
+//===----------------------------------------------------------------------===//
+
+self.test("\(testNamePrefix).reverse()") {
+  for test in reverseTests {
+    var c = makeWrappedCollection(test.sequence.map(OpaqueValue.init))
+    c.reverse()
+    expectEqual(
+      test.expected, c.map { extractValue($0).value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+//===----------------------------------------------------------------------===//
 
   } // addMutableBidirectionalCollectionTests
 

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -1,4 +1,4 @@
-//===--- Reverse.swift - Lazy sequence reversal ---------------------------===//
+//===--- Reverse.swift - Sequence and collection reversal -----------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -9,6 +9,28 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+extension MutableCollection where Self : BidirectionalCollection {
+  /// Reverses the elements of the collection in place.
+  ///
+  ///     var characters: [Character] = ["C", "a", "f", "é"]
+  ///     characters.reverse()
+  ///     print(cafe.characters)
+  ///     // Prints "["é", "f", "a", "C"]
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of elements in the
+  ///   collection.
+  public mutating func reverse() {
+    if isEmpty { return }
+    var f = startIndex
+    var l = index(before: endIndex)
+    while f < l {
+      swap(&self[f], &self[l])
+      formIndex(after: &f)
+      formIndex(before: &l)
+    }
+  }
+}
 
 // FIXME(ABI)(compiler limitation): we should have just one type,
 // `ReversedCollection`, that has conditional conformances to


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

• Explanation: This change adds a mutating `reverse()` method for the `BidirectionalCollection`, based on the Core Team review of [SE-0078](https://github.com/apple/swift-evolution/blob/master/proposals/0078-rotate-algorithm.md)
• Scope of Issue: Purely additive.
• Origination: Based on the Core Team feedback to the proposal linked above.
• Risk: None.
• Reviewed By: Max Moiseev (originally implemented by Dmitri Gribenko)
• Testing: Unit tests (included in the patch)
• Directions for QA: N/A

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
