### PR TITLE
[stdlib] Fix _writeBackMutableSlice error messages

### DIFF
--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -39,9 +39,9 @@ internal func _writeBackMutableSlice<
 
   _precondition(
     selfElementIndex == selfElementsEndIndex,
-    "Cannot replace a slice of a MutableCollection with a slice of a larger size")
+    "Cannot replace a slice of a MutableCollection with a slice of a smaller size")
   _precondition(
     newElementIndex == newElementsEndIndex,
-    "Cannot replace a slice of a MutableCollection with a slice of a smaller size")
+    "Cannot replace a slice of a MutableCollection with a slice of a larger size")
 }
 

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -112,7 +112,7 @@ struct MinimalCollectionWith${Implementation}Filter<Element>
   }
 
   func filter(
-    @noescape _ transform: (Element) throws -> Bool
+    _ transform: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
     MinimalCollectionWithCustomFilter.timesFilterWasCalled += 1
     return try _data.filter(transform)
@@ -126,7 +126,7 @@ struct MinimalCollectionWith${Implementation}Filter<Element>
 
 func callStaticCollectionFilter(
   _ sequence: MinimalCollectionWithDefaultFilter<OpaqueValue<Int>>,
-  @noescape includeElement: (OpaqueValue<Int>) -> Bool
+  includeElement: @noescape (OpaqueValue<Int>) -> Bool
 ) -> [OpaqueValue<Int>] {
   var result = sequence.filter(includeElement)
   expectType([OpaqueValue<Int>].self, &result)
@@ -135,7 +135,7 @@ func callStaticCollectionFilter(
 
 func callStaticCollectionFilter(
   _ sequence: MinimalCollectionWithCustomFilter<OpaqueValue<Int>>,
-  @noescape includeElement: (OpaqueValue<Int>) -> Bool
+  includeElement: @noescape (OpaqueValue<Int>) -> Bool
 ) -> [OpaqueValue<Int>] {
   var result = sequence.filter(includeElement)
   expectType([OpaqueValue<Int>].self, &result)
@@ -144,7 +144,7 @@ func callStaticCollectionFilter(
 
 func callGenericCollectionFilter<S : Collection>(
   _ sequence: S,
-  @noescape includeElement: (S.Iterator.Element) -> Bool
+  includeElement: @noescape (S.Iterator.Element) -> Bool
 ) -> [S.Iterator.Element] {
   var result = sequence.filter(includeElement)
   expectType(Array<S.Iterator.Element>.self, &result)
@@ -249,7 +249,7 @@ struct MinimalCollectionWith${Implementation}Map<Element>
   }
 
   func map<T>(
-    @noescape _ transform: (Element) throws -> T
+    _ transform: @noescape (Element) throws -> T
   ) rethrows -> [T] {
     MinimalCollectionWithCustomMap.timesMapWasCalled += 1
     return try _data.map(transform)
@@ -263,7 +263,7 @@ struct MinimalCollectionWith${Implementation}Map<Element>
 
 func callStaticCollectionMap<T>(
   _ collection: MinimalCollectionWithDefaultMap<OpaqueValue<Int>>,
-  @noescape transform: (OpaqueValue<Int>) -> T
+  transform: @noescape (OpaqueValue<Int>) -> T
 ) -> [T] {
   var result = collection.map(transform)
   expectType([T].self, &result)
@@ -272,7 +272,7 @@ func callStaticCollectionMap<T>(
 
 func callStaticCollectionMap<T>(
   _ collection: MinimalCollectionWithCustomMap<OpaqueValue<Int>>,
-  @noescape transform: (OpaqueValue<Int>) -> T
+  transform: @noescape (OpaqueValue<Int>) -> T
 ) -> [T] {
   var result = collection.map(transform)
   expectType([T].self, &result)
@@ -281,7 +281,7 @@ func callStaticCollectionMap<T>(
 
 func callGenericCollectionMap<C : Collection, T>(
   _ collection: C,
-  @noescape transform: (C.Iterator.Element) -> T
+  transform: @noescape (C.Iterator.Element) -> T
 ) -> [T] {
   var result = collection.map(transform)
   expectType([T].self, &result)
@@ -750,7 +750,7 @@ CollectionTypeTests.test("index(of:)/ContinueSearch") {
 
 CollectionTypeTests.test("Collection/split/dispatch") {
   var tester = CollectionLog.dispatchTester([OpaqueValue(1)])
-  tester.split { $0.value == 1 }
+  _ = tester.split { $0.value == 1 }
   expectCustomizable(tester, tester.log.split)
 }
 
@@ -760,7 +760,7 @@ CollectionTypeTests.test("Collection/split/dispatch") {
 
 CollectionTypeTests.test("Collection/prefix(through:)/dispatch") {
   var tester = CollectionLog.dispatchTester([1, 2, 3].map(OpaqueValue.init))
-  tester.prefix(through: 1)
+  _ = tester.prefix(through: 1)
   expectCustomizable(tester, tester.log.prefixThrough)
 }
 
@@ -770,7 +770,7 @@ CollectionTypeTests.test("Collection/prefix(through:)/dispatch") {
 
 CollectionTypeTests.test("Collection/prefix(upTo:)/dispatch") {
   var tester = CollectionLog.dispatchTester([OpaqueValue(1)])
-  tester.prefix(upTo: 1)
+  _ = tester.prefix(upTo: 1)
   expectCustomizable(tester, tester.log.prefixUpTo)
 }
 
@@ -780,7 +780,7 @@ CollectionTypeTests.test("Collection/prefix(upTo:)/dispatch") {
 
 CollectionTypeTests.test("Collection/suffix(from:)/dispatch") {
   var tester = CollectionLog.dispatchTester([1, 2, 3].map(OpaqueValue.init))
-  tester.suffix(from: 1)
+  _ = tester.suffix(from: 1)
   expectCustomizable(tester, tester.log.suffixFrom)
 }
 

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -588,6 +588,26 @@ CollectionTypeTests.test("subscript(_: Range<Index>)/writeback") {
     [ 1, 2, 3, 4, 5, 0, -1, -2, -3, -4 ], collection)
 }
 
+CollectionTypeTests.test("subscript(_: Range<Index>)/defaultImplementation/sliceTooLarge")
+  .crashOutputMatches("Cannot replace a slice of a MutableCollection with a slice of a larger size")
+  .code {
+  var x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  expectCrashLater()
+  x.withUnsafeMutableBufferPointer { buffer in
+    buffer[2..<4] = buffer[4..<8]
+  }
+}
+
+CollectionTypeTests.test("subscript(_: Range<Index>)/defaultImplementation/sliceTooSmall")
+  .crashOutputMatches("Cannot replace a slice of a MutableCollection with a slice of a smaller size")
+  .code {
+  var x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  expectCrashLater()
+  x.withUnsafeMutableBufferPointer { buffer in
+    buffer[2..<6] = buffer[6..<8]
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // isEmpty
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

The error messages in the `_writeBackMutableSlice` function are reversed. For example:

``` swift
var a = Array(1...20)
a.withUnsafeMutableBufferPointer { buffer in
    buffer[4...15] = buffer[2...3]
}
// fatal error: Cannot replace a slice of a MutableCollection with a slice of a larger size
```
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
