### PR TITLE
[stdlib] Fix the `String.decodeCString` for UTF16 and UTF32

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -137,7 +137,7 @@ extension String {
     guard let cString = cString else {
       return nil
     }
-    let len = encoding._nullCodeUnitOffset(cString)
+    let len = encoding._nullCodeUnitOffset(in: cString)
     let buffer = UnsafeBufferPointer<Encoding.CodeUnit>(
       start: cString, count: len)
 

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -137,7 +137,7 @@ extension String {
     guard let cString = cString else {
       return nil
     }
-    let len = Int(_swift_stdlib_strlen(UnsafePointer(cString)))
+    let len = encoding._nullCodeUnitOffset(cString)
     let buffer = UnsafeBufferPointer<Encoding.CodeUnit>(
       start: cString, count: len)
 

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftShims
 
 // Conversions between different Unicode encodings.  Note that UTF-16 and
 // UTF-32 decoding are *not* currently resilient to erroneous data.
@@ -132,6 +133,12 @@ public protocol UnicodeCodec {
     _ input: UnicodeScalar,
     sendingOutputTo processCodeUnit: @noescape (CodeUnit) -> Void
   )
+
+  /// Searches for the first occurrence of a `CodeUnit` that is equal to 0.
+  ///
+  /// Is an equivalent of `strlen` for C-strings.
+  /// - Complexity: O(n)
+  static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int
 }
 
 /// A codec for translating between Unicode scalar values and UTF-8 code
@@ -427,6 +434,10 @@ public struct UTF8 : UnicodeCodec {
   /// - Returns: `true` if `byte` is a continuation byte; otherwise, `false`.
   public static func isContinuation(_ byte: CodeUnit) -> Bool {
     return byte & 0b11_00__0000 == 0b10_00__0000
+  }
+
+  public static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int {
+    return Int(_swift_stdlib_strlen(UnsafePointer(input)))
   }
 }
 
@@ -1146,6 +1157,24 @@ extension UnicodeScalar {
     _sanityCheck(value <= 0x10FFFF, "value is outside of Unicode codespace")
 
     self._value = value
+  }
+}
+
+extension UnicodeCodec where CodeUnit : UnsignedInteger {
+  public static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int {
+    var input = input
+    var length = 0
+    while input.pointee != 0 {
+      input = input.successor()
+      length += 1
+    }
+    return length
+  }
+}
+
+extension UnicodeCodec {
+  public static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int {
+    fatalError("_nullCodeUnitOffset implementation should be provided")
   }
 }
 

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -138,7 +138,7 @@ public protocol UnicodeCodec {
   ///
   /// Is an equivalent of `strlen` for C-strings.
   /// - Complexity: O(n)
-  static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int
+  static func _nullCodeUnitOffset(in input: UnsafePointer<CodeUnit>) -> Int
 }
 
 /// A codec for translating between Unicode scalar values and UTF-8 code
@@ -436,7 +436,7 @@ public struct UTF8 : UnicodeCodec {
     return byte & 0b11_00__0000 == 0b10_00__0000
   }
 
-  public static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int {
+  public static func _nullCodeUnitOffset(in input: UnsafePointer<CodeUnit>) -> Int {
     return Int(_swift_stdlib_strlen(UnsafePointer(input)))
   }
 }
@@ -1161,11 +1161,9 @@ extension UnicodeScalar {
 }
 
 extension UnicodeCodec where CodeUnit : UnsignedInteger {
-  public static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int {
-    var input = input
+  public static func _nullCodeUnitOffset(in input: UnsafePointer<CodeUnit>) -> Int {
     var length = 0
-    while input.pointee != 0 {
-      input = input.successor()
+    while input[length] != 0 {
       length += 1
     }
     return length
@@ -1173,8 +1171,8 @@ extension UnicodeCodec where CodeUnit : UnsignedInteger {
 }
 
 extension UnicodeCodec {
-  public static func _nullCodeUnitOffset(_ input: UnsafePointer<CodeUnit>) -> Int {
-    fatalError("_nullCodeUnitOffset implementation should be provided")
+  public static func _nullCodeUnitOffset(in input: UnsafePointer<CodeUnit>) -> Int {
+    fatalError("_nullCodeUnitOffset(in:) implementation should be provided")
   }
 }
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1252,5 +1252,35 @@ StringTests.test("String.append(_: Character)") {
   }
 }
 
-runAllTests()
+internal func decodeCString<
+  C : UnicodeCodec
+  where
+  C.CodeUnit : UnsignedInteger
+>(_ s: String, as codec: C.Type)
+  -> (result: String, repairsMade: Bool)? {
+  let units = s.unicodeScalars.map({ $0.value }) + [0]
+  return units.map({ C.CodeUnit(numericCast($0)) }).withUnsafeBufferPointer {
+    String.decodeCString($0.baseAddress, as: C.self)
+  }
+}
 
+StringTests.test("String.decodeCString/UTF8") {
+  let actual = decodeCString("foobar", as: UTF8.self)
+  expectFalse(actual!.repairsMade)
+  expectEqual("foobar", actual!.result)
+}
+
+StringTests.test("String.decodeCString/UTF16") {
+  let actual = decodeCString("foobar", as: UTF16.self)
+  expectFalse(actual!.repairsMade)
+  expectEqual("foobar", actual!.result)
+}
+
+StringTests.test("String.decodeCString/UTF32") {
+  let actual = decodeCString("foobar", as: UTF32.self)
+  expectFalse(actual!.repairsMade)
+  expectEqual("foobar", actual!.result)
+}
+
+
+runAllTests()

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -2477,11 +2477,11 @@ let NullCodeUnitOffsetTests = TestSuite("NullCodeUnitOffsetTests")
 %   ('UTF32', 'unicodeScalars.map{ $0.value }')
 % ]:
 
-NullCodeUnitOffsetTests.test("${Encoding}._nullCodeUnitOffset") {
+NullCodeUnitOffsetTests.test("${Encoding}._nullCodeUnitOffset(in:)") {
   for test in nullOffsetTests {
     let actual = Array(test.input.${View})
       .withUnsafeBufferPointer { p in
-        ${Encoding}._nullCodeUnitOffset(p.baseAddress!)
+        ${Encoding}._nullCodeUnitOffset(in: p.baseAddress!)
       }
     expectEqual(test.expected, actual)
   }

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -1,7 +1,6 @@
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out
-// RUN: %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/Unicode.swift
+// RUN: %S/../../utils/line-directive %t/Unicode.swift -- %target-build-swift %t/Unicode.swift -o %t/a.out -Xfrontend -disable-objc-attr-requires-foundation-module
+// RUN: %S/../../utils/line-directive %t/Unicode.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import SwiftPrivate
@@ -2463,6 +2462,32 @@ StringTests.test("StreamableConformance") {
 }
 
 #endif // _runtime(_ObjC)
+
+let nullOffsetTests = [
+  (input: "\0", expected: 0),
+  (input: "a\0", expected: 1),
+  (input: "foobar\0", expected: 6)
+]
+
+let NullCodeUnitOffsetTests = TestSuite("NullCodeUnitOffsetTests")
+
+% for (Encoding, View) in [
+%   ('UTF8', 'utf8'),
+%   ('UTF16', 'utf16'),
+%   ('UTF32', 'unicodeScalars.map{ $0.value }')
+% ]:
+
+NullCodeUnitOffsetTests.test("${Encoding}._nullCodeUnitOffset") {
+  for test in nullOffsetTests {
+    let actual = Array(test.input.${View})
+      .withUnsafeBufferPointer { p in
+        ${Encoding}._nullCodeUnitOffset(p.baseAddress!)
+      }
+    expectEqual(test.expected, actual)
+  }
+}
+
+% end
 
 runAllTests()
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Essentially the problem was that `strlen` is not the right way of
obtaining a length of anything but null-terminated UTF-8 sequence of
characters. Other encodings require alternative mechanisms.
#### Resolved bug number: ([SR-1578](https://bugs.swift.org/browse/SR-1578))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
