### PR TITLE
Ignore label fixits when picking-up fixits for migration invocation

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -557,6 +557,11 @@ private:
     // Do not add a semi as it is wrong in most cases during migration
     if (Info.ID == diag::statement_same_line_without_semi.ID)
       return false;
+    // The following interact badly with the swift migrator, they are undoing
+    // migration of arguments to preserve the no-label for first argument.
+    if (Info.ID == diag::witness_argument_name_mismatch.ID ||
+      Info.ID == diag::missing_argument_labels.ID)
+      return false;
 
     if (Kind == DiagnosticKind::Error)
       return true;

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -64,3 +64,15 @@ func ftest1() {
 }
 
 func ftest2(x x: Int -> Int) {}
+
+protocol SomeProt {
+  func protMeth(p: Int)
+}
+class Test2 : SomeProt {
+  func protMeth(_ p: Int)
+
+  func instMeth(p: Int)
+  func instMeth2(p: Int, p2: Int)
+}
+Test2().instMeth(0)
+Test2().instMeth2(0, p2:1)

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -69,10 +69,10 @@ protocol SomeProt {
   func protMeth(p: Int)
 }
 class Test2 : SomeProt {
-  func protMeth(_ p: Int)
+  func protMeth(_ p: Int) {}
 
-  func instMeth(p: Int)
-  func instMeth2(p: Int, p2: Int)
+  func instMeth(p: Int) {}
+  func instMeth2(p: Int, p2: Int) {}
 }
 Test2().instMeth(0)
 Test2().instMeth2(0, p2:1)

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -67,3 +67,15 @@ func ftest1() {
 }
 
 func ftest2(x: (Int) -> Int) {}
+
+protocol SomeProt {
+  func protMeth(p: Int)
+}
+class Test2 : SomeProt {
+  func protMeth(_ p: Int)
+
+  func instMeth(p: Int)
+  func instMeth2(p: Int, p2: Int)
+}
+Test2().instMeth(0)
+Test2().instMeth2(0, p2:1)

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -72,10 +72,10 @@ protocol SomeProt {
   func protMeth(p: Int)
 }
 class Test2 : SomeProt {
-  func protMeth(_ p: Int)
+  func protMeth(_ p: Int) {}
 
-  func instMeth(p: Int)
-  func instMeth2(p: Int, p2: Int)
+  func instMeth(p: Int) {}
+  func instMeth2(p: Int, p2: Int) {}
 }
 Test2().instMeth(0)
 Test2().instMeth2(0, p2:1)


### PR DESCRIPTION
#### What's in this pull request?

When the migrator is invoking the compiler to pick-up fixits, the fixits for argument labels are messing with the migration.

They are undoing migration of arguments to preserve the no-label for first argument.
For example, if you have this in a different file than the currently migrated one:

```
class Test {
  func instMeth(p: Int) {}
}

```

and there is this call in the migrated file:

`Test().instMeth(0)
`
then there will be a fixit to add the label:

`Test().instMeth(p: 0)
`
But we don’t want that, the migrator is going to add underscore to the function to preserve the no-label for the first parameter and the caller will not need to change (and adding the label will end up causing a compiler error).

The fix here is that when the migrator is calling the compiler in the special mode for migration fixits, we are going to ignore fixits for errors related to argument labels.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26457709
Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
