### PR TITLE
SourceKit: Fix Object literals in syntax map

### DIFF
--- a/include/swift/Parse/Tokens.def
+++ b/include/swift/Parse/Tokens.def
@@ -38,12 +38,6 @@
 #define POUND_KEYWORD(kw)
 #endif
 
-/// POUND_NORMAL_KEYWORD(kw)
-///   Keywords except object and config keywords in the #foo namespace.
-#ifndef POUND_NORMAL_KEYWORD
-#define POUND_NORMAL_KEYWORD(kw) POUND_KEYWORD(kw)
-#endif
-
 /// POUND_OBJECT_LITERAL(kw, desc, proto)
 ///   Every keyword in the #foo namespace representing an object literal.
 #ifndef POUND_OBJECT_LITERAL
@@ -227,7 +221,6 @@ POUND_KEYWORD(dsohandle)
 #undef SIL_KEYWORD
 #undef PUNCTUATOR
 #undef POUND_KEYWORD
-#undef POUND_NORMAL_KEYWORD
 #undef POUND_OBJECT_LITERAL
 #undef POUND_OLD_OBJECT_LITERAL
 #undef POUND_CONFIG

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -59,7 +59,6 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
   std::vector<SyntaxNode> Nodes;
   SourceLoc AttrLoc;
   SourceLoc UnaryMinusLoc;
-  auto LiteralStartLoc = Optional<SourceLoc>();
   for (unsigned I = 0, E = Tokens.size(); I != E; ++I) {
     auto &Tok = Tokens[I];
     SyntaxNodeKind Kind;
@@ -83,34 +82,23 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
       Loc = Tok.getLoc();
       Length = Tok.getLength();
 
-      if (LiteralStartLoc.hasValue() && Length.hasValue()) {
-        Kind = SyntaxNodeKind::ObjectLiteral;
-        Nodes.emplace_back(Kind, CharSourceRange(SM, LiteralStartLoc.getValue(),
-          Tok.getRange().getEnd()));
-        LiteralStartLoc = Optional<SourceLoc>();
-        continue;
-      }
-
       switch(Tok.getKind()) {
 #define KEYWORD(X) case tok::kw_##X: Kind = SyntaxNodeKind::Keyword; break;
 #include "swift/Parse/Tokens.def"
 #undef KEYWORD
 
-#define POUND_NORMAL_KEYWORD(Name) case tok::pound_##Name:
+#define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg) \
+      case tok::pound_##Name:
 #define POUND_OBJECT_LITERAL(Name, Desc, Proto) case tok::pound_##Name:
-#define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg) case tok::pound_##Name:
-#include "swift/Parse/Tokens.def"    
+#include "swift/Parse/Tokens.def"
+        Kind = SyntaxNodeKind::ObjectLiteral;
+        break;
+
+#define POUND_OBJECT_LITERAL(Name, Desc, Proto)
+#define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg)
+#define POUND_KEYWORD(Name) case tok::pound_##Name:
+#include "swift/Parse/Tokens.def"
         Kind = SyntaxNodeKind::Keyword;
-        break;
-
-#define POUND_CONFIG(Name) case tok::pound_##Name:
-#include "swift/Parse/Tokens.def"    
-        Kind = SyntaxNodeKind::BuildConfigKeyword;
-        break;
-
-      case tok::pound_line:
-        Kind = Tok.isAtStartOfLine() ? SyntaxNodeKind::BuildConfigKeyword :
-                                       SyntaxNodeKind::Keyword;
         break;
       case tok::identifier:
         if (Tok.getText().startswith("<#"))

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -3,12 +3,12 @@
 // XFAIL: broken_std_regex
 
 #line 17 "abc.swift"
-// CHECK: <#kw>#line</#kw> <int>17</int> <str>"abc.swift"</str>
+// CHECK: <kw>#line</kw> <int>17</int> <str>"abc.swift"</str>
 
 @available(iOS 8.0, OSX 10.10, *)
 // CHECK: <attr-builtin>@available</attr-builtin>(<kw>iOS</kw> <float>8.0</float>, <kw>OSX</kw> <float>10.10</float>, *)
 func foo() {
-// CHECK: <kw>if</kw> <#kw>#available</#kw> (<kw>OSX</kw> <float>10.10</float>, <kw>iOS</kw> <float>8.01</float>, *) {<kw>let</kw> <kw>_</kw> = <str>"iOS"</str>}
+// CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> <float>10.10</float>, <kw>iOS</kw> <float>8.01</float>, *) {<kw>let</kw> <kw>_</kw> = <str>"iOS"</str>}
   if #available (OSX 10.10, iOS 8.01, *) {let _ = "iOS"}
 }
 
@@ -261,7 +261,7 @@ func test3(o: AnyObject) {
 
 // CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
-  // CHECK: <kw>if</kw> <#kw>#available</#kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
+  // CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
 
 // CHECK: <kw>class</kw> MySubClass : <type>MyCls</type> {

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -467,10 +467,25 @@ _ = -3.1e-5
 
 /** aaa
 
-
  - returns: something
  */
 // CHECK:  - <doc-comment-field>returns</doc-comment-field>: something
+
+let filename = #file
+// CHECK: <kw>let</kw> filename = <kw>#file</kw>
+let line = #line
+// CHECK: <kw>let</kw> line = <kw>#line</kw>
+let column = #column
+// CHECK: <kw>let</kw> column = <kw>#column</kw>
+let function = #function
+// CHECK: <kw>let</kw> function = <kw>#function</kw>
+
+let image = #imageLiteral(resourceName: "cloud.png")
+// CHECK: <kw>let</kw> image = <object-literal>#imageLiteral(resourceName: "cloud.png")</object-literal>
+let file = #fileLiteral(resourceName: "cloud.png")
+// CHECK: <kw>let</kw> file = <object-literal>#fileLiteral(resourceName: "cloud.png")</object-literal>
+let black = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
+// CHECK: <kw>let</kw> black = <object-literal>#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)</object-literal>
 
 "--\"\(x) --"
 // CHECK: <str>"--\"</str>\<anchor>(</anchor>x<anchor>)</anchor><str> --"</str>

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
@@ -4,3 +4,4 @@
 let image = #imageLiteral(resourceName: "cloud.png")
 let color = #colorLiteral(red: 1, blue: 0, green: 1, alpha: 1)
 let file = #fileLiteral(resourceName: "test.txt")
+

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
@@ -1,4 +1,6 @@
 // RUN: %sourcekitd-test -req=syntax-map %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
-let x = #Cloud(tube: true)
+let image = #imageLiteral(resourceName: "cloud.png")
+let color = #colorLiteral(red: 1, blue: 0, green: 1, alpha: 1)
+let file = #fileLiteral(resourceName: "test.txt")

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 139,
+  key.length: 278,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -21,55 +21,102 @@
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 116,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.objectliteral,
+      key.offset: 124,
+      key.length: 13
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 138,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 152,
+      key.length: 11
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 165,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 169,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.objectliteral,
+      key.offset: 177,
+      key.length: 13
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 191,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 196,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 121,
-      key.length: 5
+      key.offset: 199,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 205,
+      key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 127,
-      key.length: 4
+      key.offset: 208,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 215,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 218,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 225,
+      key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 133,
+      key.offset: 228,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 232,
       key.length: 4
-    }
-  ],
-  key.diagnostics: [
-    {
-      key.line: 4,
-      key.column: 8,
-      key.filepath: syntaxmap-object-literals.swift,
-      key.severity: source.diagnostic.severity.error,
-      key.description: "consecutive statements on a line must be separated by ';'",
-      key.diagnostic_stage: source.diagnostic.stage.swift.parse,
-      key.fixits: [
-        {
-          key.offset: 119,
-          key.length: 0,
-          key.sourcetext: ";"
-        }
-      ]
     },
     {
-      key.line: 4,
-      key.column: 9,
-      key.filepath: syntaxmap-object-literals.swift,
-      key.severity: source.diagnostic.severity.error,
-      key.description: "expected initial value after '='",
-      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+      key.kind: source.lang.swift.syntaxtype.objectliteral,
+      key.offset: 239,
+      key.length: 12
     },
     {
-      key.line: 4,
-      key.column: 9,
-      key.filepath: syntaxmap-object-literals.swift,
-      key.severity: source.diagnostic.severity.error,
-      key.description: "expected expression",
-      key.diagnostic_stage: source.diagnostic.stage.swift.parse
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 252,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 266,
+      key.length: 10
     }
   ]
 }

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 278,
+  key.length: 279,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -26,17 +26,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
       key.offset: 124,
-      key.length: 13
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 138,
-      key.length: 12
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 152,
-      key.length: 11
+      key.length: 40
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
@@ -51,47 +41,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
       key.offset: 177,
-      key.length: 13
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 191,
-      key.length: 3
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 196,
-      key.length: 1
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 199,
-      key.length: 4
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 205,
-      key.length: 1
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 208,
-      key.length: 5
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 215,
-      key.length: 1
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 218,
-      key.length: 5
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 225,
-      key.length: 1
+      key.length: 50
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
@@ -106,17 +56,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
       key.offset: 239,
-      key.length: 12
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 252,
-      key.length: 12
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 266,
-      key.length: 10
+      key.length: 38
     }
   ]
 }

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
@@ -1,0 +1,10 @@
+// RUN: %sourcekitd-test -req=syntax-map %s | %sed_clean > %t.response
+// RUN: diff -u %s.response %t.response
+
+let fn = #function
+let f = #file
+let l = #line
+let c = #column
+
+if #available(iOS 9.0, *) {}
+

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
@@ -1,0 +1,97 @@
+{
+  key.offset: 0,
+  key.length: 206,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.syntaxmap: [
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 0,
+      key.length: 71
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 71,
+      key.length: 40
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 112,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 116,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 121,
+      key.length: 9
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 131,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 135,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 139,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 145,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 149,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 153,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 159,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 163,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 167,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 176,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 179,
+      key.length: 10
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 190,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 194,
+      key.length: 3
+    }
+  ]
+}


### PR DESCRIPTION
Includes some clean up and new tests to make sure object literals show up properly in the syntax map.

rdar://problem/26451674
