### PR TITLE
[SR-237][build-script] Migrate Ninja build to Python

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -18,7 +18,6 @@ import pipes
 import platform
 import re
 import shlex
-import shutil
 import sys
 
 # FIXME: Instead of modifying the system path in order to enable imports from
@@ -31,7 +30,6 @@ from SwiftBuildSupport import (
     HOME,
     SWIFT_BUILD_ROOT,
     SWIFT_SOURCE_ROOT,
-    WorkingDirectory,
     check_call,
     get_all_preset_names,
     get_preset_options,
@@ -45,6 +43,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 from swift_build_support.toolchain import host_toolchain  # noqa (E402)
 import swift_build_support.debug      # noqa (E402)
 from swift_build_support import migration  # noqa (E402)
+from swift_build_support import shell  # noqa (E402)
 import swift_build_support.tar        # noqa (E402)
 import swift_build_support.targets    # noqa (E402)
 from swift_build_support.cmake import CMake  # noqa (E402)
@@ -1200,8 +1199,9 @@ details of the setups of other systems or automated environments.""")
         source_root=SWIFT_SOURCE_ROOT,
         build_root=os.path.join(SWIFT_BUILD_ROOT, args.build_subdir))
 
-    if args.clean and os.path.isdir(workspace.build_root):
-        shutil.rmtree(workspace.build_root)
+    # Clean build_dir if requested.
+    if args.clean:
+        shell.rmtree(workspace.build_root)
 
     cmake = CMake(args=args,
                   toolchain=toolchain)
@@ -1411,7 +1411,7 @@ details of the setups of other systems or automated environments.""")
         # it is archiving. To stay safe, we change working directories, then
         # run `tar` without the leading '/' (we remove it ourselves to keep
         # `tar` from emitting a warning).
-        with WorkingDirectory(args.install_symroot):
+        with shell.pushd(args.install_symroot):
             swift_build_support.tar.tar(source=prefix.lstrip('/'),
                                         destination=args.symbols_package)
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -43,6 +43,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 from swift_build_support.toolchain import host_toolchain  # noqa (E402)
 import swift_build_support.debug      # noqa (E402)
 from swift_build_support import migration  # noqa (E402)
+from swift_build_support import products  # noqa (E402)
 from swift_build_support import shell  # noqa (E402)
 import swift_build_support.tar        # noqa (E402)
 import swift_build_support.targets    # noqa (E402)
@@ -392,6 +393,10 @@ details of the setups of other systems or automated environments.""")
         help="build libdispatch",
         action="store_true",
         dest="build_libdispatch")
+    projects_group.add_argument(
+        "--build-ninja",
+        help="build the Ninja tool",
+        action="store_true")
 
     extra_actions_group = parser.add_argument_group(
         title="Extra actions to perform before or in addition to building")
@@ -938,6 +943,27 @@ details of the setups of other systems or automated environments.""")
         metavar="MAJOR.MINOR.PATCH")
 
     parser.add_argument(
+        "--darwin-deployment-version-osx",
+        help="minimum deployment target version for OS X",
+        metavar="MAJOR.MINOR",
+        default="10.9")
+    parser.add_argument(
+        "--darwin-deployment-version-ios",
+        help="minimum deployment target version for iOS",
+        metavar="MAJOR.MINOR",
+        default="7.0")
+    parser.add_argument(
+        "--darwin-deployment-version-tvos",
+        help="minimum deployment target version for tvOS",
+        metavar="MAJOR.MINOR",
+        default="9.0")
+    parser.add_argument(
+        "--darwin-deployment-version-watchos",
+        help="minimum deployment target version for watchOS",
+        metavar="MAJOR.MINOR",
+        default="2.0")
+
+    parser.add_argument(
         "--extra-cmake-options",
         help="Pass through extra options to CMake in the form of comma "
              "separated options '-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp'. Can be "
@@ -1097,6 +1123,11 @@ details of the setups of other systems or automated environments.""")
     if args.cmake_generator is None:
         args.cmake_generator = "Ninja"
 
+    ninja_required = (
+        args.cmake_generator == 'Ninja' or args.build_foundation)
+    if ninja_required and toolchain.ninja is None:
+        args.build_ninja = True
+
     # SwiftPM and XCTest have a dependency on Foundation.
     # On OS X, Foundation is built automatically using xcodebuild.
     # On Linux, we must ensure that it is built manually.
@@ -1199,9 +1230,41 @@ details of the setups of other systems or automated environments.""")
         source_root=SWIFT_SOURCE_ROOT,
         build_root=os.path.join(SWIFT_BUILD_ROOT, args.build_subdir))
 
-    # Clean build_dir if requested.
+    if args.build_ninja:
+        if not os.path.exists(workspace.source_dir("ninja")):
+            print_with_argv0("Can't find source directory for ninja "
+                             "(tried %s)" % (workspace.source_dir("ninja")))
+            return 1
+
+    # Unset environment variables that might affect how tools behave.
+    for v in [
+            'MAKEFLAGS',
+            'SDKROOT',
+            'MACOSX_DEPLOYMENT_TARGET',
+            'IPHONEOS_DEPLOYMENT_TARGET',
+            'TVOS_DEPLOYMENT_TARGET',
+            'WATCHOS_DEPLOYMENT_TARGET']:
+        os.environ.pop(v, None)
+
+    if args.show_sdks:
+        swift_build_support.debug.print_xcodebuild_versions()
+
+    # Clean build direcotry if requested.
     if args.clean:
         shell.rmtree(workspace.build_root)
+
+    # Create build directory.
+    shell.makedirs(workspace.build_root)
+
+    # Build ninja if required.
+    if args.build_ninja:
+        ninja_build = products.Ninja(
+            args=args,
+            toolchain=toolchain,
+            source_dir=workspace.source_dir("ninja"),
+            build_dir=workspace.build_dir("build", "ninja"))
+        ninja_build.do_build()
+        toolchain.ninja = ninja_build.ninja_bin_path
 
     cmake = CMake(args=args,
                   toolchain=toolchain)
@@ -1216,6 +1279,14 @@ details of the setups of other systems or automated environments.""")
         "--host-cc", toolchain.cc,
         "--host-cxx", toolchain.cxx,
         "--darwin-xcrun-toolchain", args.darwin_xcrun_toolchain,
+        "--darwin-deployment-version-osx=%s" % (
+            args.darwin_deployment_version_osx),
+        "--darwin-deployment-version-ios=%s" % (
+            args.darwin_deployment_version_ios),
+        "--darwin-deployment-version-tvos=%s" % (
+            args.darwin_deployment_version_tvos),
+        "--darwin-deployment-version-watchos=%s" % (
+            args.darwin_deployment_version_watchos),
         "--cmake", toolchain.cmake,
         "--cmark-build-type", args.cmark_build_variant,
         "--llvm-build-type", args.llvm_build_variant,
@@ -1237,6 +1308,8 @@ details of the setups of other systems or automated environments.""")
             pipes.quote(arg) for arg in cmake.build_args()),
     ]
 
+    if toolchain.ninja:
+        build_script_impl_args += ["--ninja-bin=%s" % toolchain.ninja]
     if args.distcc:
         build_script_impl_args += [
             "--distcc",
@@ -1256,8 +1329,6 @@ details of the setups of other systems or automated environments.""")
         build_script_impl_args += [
             "--install-symroot", os.path.abspath(args.install_symroot)
         ]
-    if args.cmake_generator == 'Ninja' and toolchain.ninja is None:
-        build_script_impl_args += ["--build-ninja"]
 
     if args.skip_build:
         build_script_impl_args += ["--skip-build-cmark",
@@ -1380,19 +1451,6 @@ details of the setups of other systems or automated environments.""")
         ]
 
     build_script_impl_args += args.build_script_impl_args
-
-    # Unset environment variables that might affect how tools behave.
-    for v in [
-            'MAKEFLAGS',
-            'SDKROOT',
-            'MACOSX_DEPLOYMENT_TARGET',
-            'IPHONEOS_DEPLOYMENT_TARGET',
-            'TVOS_DEPLOYMENT_TARGET',
-            'WATCHOS_DEPLOYMENT_TARGET']:
-        os.environ.pop(v, None)
-
-    if args.show_sdks:
-        swift_build_support.debug.print_xcodebuild_versions()
 
     check_call([build_script_impl] + build_script_impl_args,
                disable_sleep=True)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -60,7 +60,7 @@ KNOWN_SETTINGS=(
     host-cc                     ""               "the path to CC, the 'clang' compiler for the host platform. **This argument is required**"
     host-cxx                    ""               "the path to CXX, the 'clang++' compiler for the host platform. **This argument is required**"
     darwin-xcrun-toolchain      "default"        "the name of the toolchain to use on Darwin"
-    build-ninja                 ""               "build the Ninja tool"
+    ninja-bin                   ""               "the path to Ninja tool"
     cmark-build-type            "Debug"          "the CMake build variant for CommonMark (Debug, RelWithDebInfo, Release, MinSizeRel).  Defaults to Debug."
     lldb-extra-cmake-args       ""               "extra command line args to pass to lldb cmake"
     lldb-extra-xcodebuild-args  ""               "extra command line args to pass to lldb xcodebuild"
@@ -1258,43 +1258,6 @@ function set_swiftpm_bootstrap_command() {
     fi
 }
 
-mkdir -p "${BUILD_DIR}"
-
-#
-# Build Ninja
-#
-if [[ "${BUILD_NINJA}" ]] ; then
-    build_dir=$(build_directory build ninja)
-    if [ ! -f "${build_dir}/ninja" ] ; then
-        if [ ! -d "${NINJA_SOURCE_DIR}" ] ; then
-          echo "Can't find source directory for ninja (tried ${NINJA_SOURCE_DIR})"
-          exit 1
-        fi
-
-        # Ninja can only be built in-tree.  Copy the source tree to the build
-        # directory.
-        set -x
-        rm -rf "${build_dir}"
-        cp -r "${NINJA_SOURCE_DIR}" "${build_dir}"
-        if [[ $(uname -s) == "Darwin" ]]; then
-          (cd "${build_dir}" && \
-            env CXX=$(xcrun --sdk macosx -find clang++) \
-                CFLAGS="-isysroot $(xcrun --sdk macosx --show-sdk-path) -mmacosx-version-min=${DARWIN_DEPLOYMENT_VERSION_OSX}" \
-                LDFLAGS="-mmacosx-version-min=${DARWIN_DEPLOYMENT_VERSION_OSX}" \
-                python ./configure.py --bootstrap)
-          { set +x; } 2>/dev/null
-        else
-          (cd "${build_dir}" && python ./configure.py --bootstrap)
-          { set +x; } 2>/dev/null
-        fi
-    fi
-    NINJA_BIN="${build_dir}/ninja"
-    COMMON_CMAKE_OPTIONS=(
-        "${COMMON_CMAKE_OPTIONS[@]}"
-        -DCMAKE_MAKE_PROGRAM=${NINJA_BIN}
-    )
-fi
-
 #
 # Configure and build each product
 #
@@ -1809,7 +1772,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARG
                 SWIFT_BIN="$(build_directory_bin ${deployment_target} swift)/swift"
                 SWIFT_BUILD_PATH="$(build_directory ${deployment_target} swift)"
                 LLVM_BIN="$(build_directory_bin ${deployment_target} llvm)"
-                NINJA_BIN="ninja"
 
                 # Staging: require opt-in for building with dispatch
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
@@ -1821,11 +1783,6 @@ for deployment_target in "${HOST_TARGET}" "${CROSS_COMPILE_TOOLS_DEPLOYMENT_TARG
                     SWIFT_USE_LINKER="-fuse-ld=gold"
                 fi
 
-                if [[ "${BUILD_NINJA}" ]]; then
-                    NINJA_BUILD_DIR=$(build_directory build ninja)
-                    NINJA_BIN="${NINJA_BUILD_DIR}/ninja"
-                fi
-                
                 set -x
                 pushd "${FOUNDATION_SOURCE_DIR}"
                 SWIFTC="${SWIFTC_BIN}" CLANG="${LLVM_BIN}"/clang SWIFT="${SWIFT_BIN}" \

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -113,6 +113,9 @@ class CMake(object):
             define("LLVM_VERSION_MINOR:STRING", minor)
             define("LLVM_VERSION_PATCH:STRING", patch)
 
+        if args.build_ninja and args.cmake_generator == 'Ninja':
+            define('CMAKE_MAKE_PROGRAM', toolchain.ninja)
+
         return options
 
     def build_args(self):

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -1,0 +1,17 @@
+# swift_build_support/products/__init__.py ----------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from .ninja import Ninja
+
+__all__ = [
+    'Ninja',
+]

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -1,0 +1,63 @@
+# swift_build_support/producsts/ninja.py ------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+"""
+Ninja build
+"""
+# ----------------------------------------------------------------------------
+
+import os.path
+import platform
+import sys
+
+from .. import shell
+from .. import cache_util
+
+
+class Ninja(object):
+
+    def __init__(self, args, toolchain, source_dir, build_dir):
+        self.args = args
+        self.toolchain = toolchain
+        self.source_dir = source_dir
+        self.build_dir = build_dir
+
+    @cache_util.reify
+    def ninja_bin_path(self):
+        return os.path.join(self.build_dir, 'ninja')
+
+    def do_build(self):
+        if os.path.exists(self.ninja_bin_path):
+            return
+
+        env = None
+        if platform.system() == "Darwin":
+            from .. import xcrun
+            sysroot = xcrun.sdk_path("macosx")
+            osx_version_min = self.args.darwin_deployment_version_osx
+            assert sysroot is not None
+            env = [
+                ("CXX", self.toolchain.cxx),
+                ("CFLAGS", (
+                    "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
+                ).format(sysroot=sysroot, osx_version=osx_version_min)),
+                ("LDFLAGS", (
+                    "-mmacosx-version-min={osx_version}"
+                ).format(osx_version=osx_version_min)),
+            ]
+
+        # Ninja can only be built in-tree.  Copy the source tree to the build
+        # directory.
+        shell.rmtree(self.build_dir)
+        shell.copytree(self.source_dir, self.build_dir)
+        with shell.pushd(self.build_dir):
+            shell.call([sys.executable, 'configure.py', '--bootstrap'],
+                       env=env)

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -1,0 +1,98 @@
+# swift_build_support/shell.py ----------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+"""
+Centralized command line and file system interface for the build script.
+"""
+# ----------------------------------------------------------------------------
+
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+import sys
+import pipes
+from contextlib import contextmanager
+
+dry_run = False
+
+
+def _quote(arg):
+    return pipes.quote(str(arg))
+
+
+def _coerce_dry_run(dry_run_override):
+    if dry_run_override is None:
+        return dry_run
+    else:
+        return dry_run_override
+
+
+def _print_command(dry_run, command, env=None, prompt="+ "):
+    output = []
+    if env is not None:
+        output += ['env'] + [_quote("%s=%s" % (k, v)) for k, v in env]
+    output += [_quote(arg) for arg in command]
+    file = None
+    if not dry_run:
+        file = sys.stderr
+    print(prompt + ' '.join(output), file=file)
+
+
+def call(command, stderr=None, env=None, dry_run=None):
+    dry_run = _coerce_dry_run(dry_run)
+    _print_command(dry_run, command, env=env)
+    if dry_run:
+        return
+    _env = None
+    if env is not None:
+        _env = dict(os.environ)
+        _env.update(env)
+    subprocess.check_call(command, env=_env, stderr=stderr)
+
+
+@contextmanager
+def pushd(path, dry_run=None):
+    dry_run = _coerce_dry_run(dry_run)
+    old_dir = os.getcwd()
+    _print_command(dry_run, ["pushd", path])
+    if not dry_run:
+        os.chdir(path)
+    yield
+    _print_command(dry_run, ["popd"])
+    if not dry_run:
+        os.chdir(old_dir)
+
+
+def makedirs(path, dry_run=None):
+    dry_run = _coerce_dry_run(dry_run)
+    _print_command(dry_run, ['mkdir', '-p', path])
+    if dry_run:
+        return
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+
+def rmtree(path, dry_run=None):
+    dry_run = _coerce_dry_run(dry_run)
+    _print_command(dry_run, ['rm', '-rf', path])
+    if dry_run:
+        return
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+
+def copytree(src, dest, dry_run=None):
+    dry_run = _coerce_dry_run(dry_run)
+    _print_command(dry_run, ['cp', '-r', src, dest])
+    if dry_run:
+        return
+    shutil.copytree(src, dest)

--- a/utils/swift_build_support/swift_build_support/tar.py
+++ b/utils/swift_build_support/swift_build_support/tar.py
@@ -8,8 +8,12 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+from __future__ import absolute_import
+
 import platform
 import subprocess
+
+from . import shell
 
 
 def tar(source, destination):
@@ -28,4 +32,4 @@ def tar(source, destination):
     # Capture stderr output such as 'tar: Failed to open ...'. We'll detect
     # these cases using the exit code, which should cause 'check_call' to
     # raise.
-    subprocess.check_call(args + [source], stderr=subprocess.PIPE)
+    shell.call(args + [source], stderr=subprocess.PIPE)

--- a/utils/swift_build_support/swift_build_support/xcrun.py
+++ b/utils/swift_build_support/swift_build_support/xcrun.py
@@ -43,3 +43,18 @@ def find(tool, sdk=None, toolchain=None):
         return str(out.rstrip().decode())
     except subprocess.CalledProcessError:
         return None
+
+
+@cache_util.cached
+def sdk_path(sdk):
+    """
+    Return the path string for given SDK, according to `xcrun --show-sdk-path`.
+
+    If `xcrun --show-sdk-path` cannot find the SDK, return None.
+    """
+    command = ['xcrun', '--sdk', sdk, '--show-sdk-path']
+    try:
+        out = subprocess.check_output(command)
+        return str(out.rstrip().decode())
+    except subprocess.CalledProcessError:
+        return None

--- a/utils/swift_build_support/tests/products/__init__.py
+++ b/utils/swift_build_support/tests/products/__init__.py
@@ -1,0 +1,10 @@
+# tests/products/__init__.py ------------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -1,0 +1,113 @@
+# tests/products/test_ninja.py ----------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import unittest
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+from swift_build_support import xcrun
+from swift_build_support.products import Ninja
+from swift_build_support.toolchain import host_toolchain
+from swift_build_support.workspace import Workspace
+
+
+class NinjaTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Setup workspace
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp())
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp())
+        os.makedirs(os.path.join(tmpdir1, 'ninja'))
+
+        self.workspace = Workspace(source_root=tmpdir1,
+                                   build_root=tmpdir2)
+
+        # Setup toolchain
+        self.toolchain = host_toolchain()
+        self.toolchain.cc = '/path/to/cc'
+        self.toolchain.cxx = '/path/to/cxx'
+
+        # Setup args
+        self.args = argparse.Namespace(
+            build_ninja=True,
+            darwin_deployment_version_osx="10.9")
+
+        # Setup shell
+        shell.dry_run = True
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def tearDown(self):
+        shutil.rmtree(self.workspace.build_root)
+        shutil.rmtree(self.workspace.source_root)
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        shell.dry_run = False
+        self.workspace = None
+        self.toolchain = None
+        self.args = None
+
+    def test_ninja_bin_path(self):
+        ninja_build = Ninja(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+
+        self.assertEqual(ninja_build.ninja_bin_path, '/path/to/build/ninja')
+
+    def test_do_build(self):
+        ninja_build = Ninja(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir=self.workspace.source_dir('ninja'),
+            build_dir=self.workspace.build_dir('build', 'ninja'))
+
+        ninja_build.do_build()
+
+        expect_env = ""
+        if platform.system() == "Darwin":
+            expect_env = (
+                "env "
+                "CXX={cxx} "
+                "'CFLAGS=-isysroot {sysroot} -mmacosx-version-min=10.9' "
+                "LDFLAGS=-mmacosx-version-min=10.9 "
+            ).format(
+                cxx=self.toolchain.cxx,
+                sysroot=xcrun.sdk_path('macosx')
+            )
+
+        self.assertEqual(self.stdout.getvalue(), """\
++ rm -rf {build_dir}
++ cp -r {source_dir} {build_dir}
++ pushd {build_dir}
++ {expect_env}{python} configure.py --bootstrap
++ popd
+""".format(
+            source_dir=os.path.join(self.workspace.source_root, 'ninja'),
+            build_dir=os.path.join(self.workspace.build_root, 'ninja-build'),
+            expect_env=expect_env,
+            python=sys.executable))

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -1,0 +1,152 @@
+# tests/test_shell.py -------------------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+# ----------------------------------------------------------------------------
+
+import unittest
+import sys
+import os
+import os.path
+import shutil
+import tempfile
+try:
+    # py2
+    from StringIO import StringIO
+except ImportError:
+    # py3
+    from io import StringIO
+
+from swift_build_support import shell
+
+
+class ShellTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = os.path.realpath(tempfile.mkdtemp())
+        self._orig_stdout = sys.stdout
+        self._orig_stderr = sys.stderr
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+
+    def tearDown(self):
+        sys.stdout = self._orig_stdout
+        sys.stderr = self._orig_stderr
+        if os.path.exists(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
+
+    def test_call(self):
+        shell.dry_run = False
+        foo_file = os.path.join(self.tmpdir, 'foo.txt')
+        bar_file = os.path.join(self.tmpdir, 'bar.txt')
+
+        with open(foo_file, 'w') as f:
+            f.write("Hello Swift")
+
+        shell.call(['cp', foo_file, bar_file])
+
+        with open(bar_file, 'r') as f:
+            self.assertEqual(f.read(), "Hello Swift")
+
+        self.assertEqual(self.stdout.getvalue(), "")
+        self.assertEqual(self.stderr.getvalue(), '''\
++ cp {foo_file} {bar_file}
+'''.format(foo_file=foo_file, bar_file=bar_file))
+
+    def test_rmtree(self):
+        shell.dry_run = False
+        path = os.path.join(self.tmpdir, 'foo', 'bar')
+        shell.makedirs(path)
+
+        self.assertTrue(os.path.isdir(path))
+
+        shell.rmtree(os.path.join(path))
+        self.assertFalse(
+            os.path.exists(os.path.join(path)))
+        self.assertTrue(
+            os.path.exists(os.path.join(self.tmpdir, 'foo')))
+
+        self.assertEqual(self.stdout.getvalue(), "")
+        self.assertEqual(self.stderr.getvalue(), '''\
++ mkdir -p {path}
++ rm -rf {path}
+'''.format(path=path))
+
+    def test_pushd(self):
+        shell.dry_run = False
+        basedir = os.getcwd()
+
+        with shell.pushd(self.tmpdir):
+            self.assertEqual(os.getcwd(), self.tmpdir)
+        self.assertEqual(os.getcwd(), basedir)
+
+        # pushd inside pushd
+        with shell.pushd(self.tmpdir):
+            self.assertEqual(os.getcwd(), self.tmpdir)
+            shell.makedirs('foo')
+            with shell.pushd('foo'):
+                self.assertEqual(os.getcwd(),
+                                 os.path.join(self.tmpdir, 'foo'))
+            self.assertEqual(os.getcwd(), self.tmpdir)
+        self.assertEqual(os.getcwd(), basedir)
+
+        # cd inside pushd
+        with shell.pushd(self.tmpdir):
+            os.chdir('foo')
+            self.assertEqual(os.getcwd(), os.path.join(self.tmpdir, 'foo'))
+            os.chdir('..')
+            self.assertEqual(os.getcwd(), self.tmpdir)
+            shell.rmtree('foo')
+        self.assertEqual(os.getcwd(), basedir)
+
+        self.assertEqual(self.stdout.getvalue(), "")
+        self.assertEqual(self.stderr.getvalue(), '''\
++ pushd {tmpdir}
++ popd
++ pushd {tmpdir}
++ mkdir -p foo
++ pushd foo
++ popd
++ popd
++ pushd {tmpdir}
++ rm -rf foo
++ popd
+'''.format(tmpdir=self.tmpdir))
+
+    def test_dry_run(self):
+        shell.dry_run = True
+
+        basedir = os.getcwd()
+        foobar_dir = os.path.join(self.tmpdir, 'foo', 'bar')
+
+        shell.makedirs(foobar_dir)
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, 'foo')))
+        self.assertFalse(os.path.exists(foobar_dir))
+
+        with shell.pushd(foobar_dir):
+            self.assertEqual(os.getcwd(), basedir)
+            shell.call(['touch', 'testfile'])
+            self.assertFalse(os.path.exists(
+                os.path.join(foobar_dir, 'testfile')))
+
+        self.assertEqual(os.getcwd(), basedir)
+
+        shell.rmtree(self.tmpdir)
+        self.assertTrue(os.path.exists(self.tmpdir))
+
+        self.assertEqual(self.stdout.getvalue(), '''\
++ mkdir -p {foobar_dir}
++ pushd {foobar_dir}
++ touch testfile
++ popd
++ rm -rf {tmpdir}
+'''.format(foobar_dir=foobar_dir, tmpdir=self.tmpdir))
+        self.assertEqual(self.stderr.getvalue(), "")
+        self.dry_run = False

--- a/utils/swift_build_support/tests/test_xcrun.py
+++ b/utils/swift_build_support/tests/test_xcrun.py
@@ -28,6 +28,13 @@ class XCRunTestCase(unittest.TestCase):
                                    sdk='macosx',
                                    toolchain='default').endswith('/clang'))
 
+    def test_sdk_path(self):
+        # Unknown SDK
+        self.assertIsNone(xcrun.sdk_path('not-a-sdk'))
+
+        # Available SDK
+        self.assertIsNotNone(xcrun.sdk_path('macosx'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### What's in this pull request?

More work on [[SR-237] Merge `build-script-impl` into `build-script`](https://bugs.swift.org/browse/SR-237).

Migrate Ninja build to Python.
Also, some functional changes:
- In OS X, use user configurable `toolchain.cxx` instead of `xcrun --find clang++` to build Ninja.
- When the system installed Ninja is not found, try to build Ninja if `--foundation` is requested as well as `cmake_generator == "Ninja"`.
- To build Foundation, even without `--build-ninja`, use `build-script` detected Ninja path instead of just `ninja`,  because the system installed Ninja can be named `ninja-build`.
- Added debug trace output for commands used in `build-script`
  - Clean build directory `rm -rf {build_root}`
  - Create build directory `mkdir -p {build_root}`
  - Archive symbols package: `tar -c -z -f ...`
- Possible regression:
  - [Existence check of products source directories](https://github.com/apple/swift/blob/7218c41e6012b9cbbb247454485436d8f6cb9531/utils/build-script-impl#L850-L878) has been postponed until after Ninja was built.
  - [Report stdlib targets](https://github.com/apple/swift/blob/7218c41e6012b9cbbb247454485436d8f6cb9531/utils/build-script-impl#L1047-L1056), e.g. `Building the standard library for: ...`, after Ninja was built.
    (Depends #2497)

Please tell me if these changes are unacceptable.

Migrated impl args:
`--build-ninja`
`--darwin-deployment-version-{osx,ios,tvos,watchos}`

Removed impl args:
`--build-ninja`: Not used in `build-script-impl` anymore

Added impl args:
`--ninja-bin`: To propagate just built `ninja` path to `build-script-impl`
## 

To make it testable, cherry-picked (and enhanced) dry-runnable shell interface from #2241.
#### Resolved bug number: (Partially [SR-237](https://bugs.swift.org/browse/SR-237))

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
