### PR TITLE
[Type checker] Make sure that the omit-needless-words logic validates decls

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1867,6 +1867,12 @@ public:
                                               ConstructorDecl *ctorDecl,
                                               bool SuppressDiagnostics);
 
+  /// Attempt to omit needless words from the name of the given declaration.
+  Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
+
+  /// Attempt to omit needless words from the name of the given declaration.
+  Optional<Identifier> omitNeedlessWords(VarDecl *var);
+
   /// Check for needless words in the name of the given function/constructor.
   void checkOmitNeedlessWords(AbstractFunctionDecl *afd);
 
@@ -1916,12 +1922,6 @@ public:
   /// The unescaped message to display to the user.
   const StringRef Message;
 };
-
-/// Attempt to omit needless words from the name of the given declaration.
-Optional<DeclName> omitNeedlessWords(AbstractFunctionDecl *afd);
-
-/// Attempt to omit needless words from the name of the given declaration.
-Optional<Identifier> omitNeedlessWords(VarDecl *var);
 
 } // end namespace swift
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Per the commit message, this ensures that the omit-needless-words logic (which now applies for near-miss checking of @objc optional requirements) validates a declaration before it looks at its type. This eliminates crashes in hard-to-reproduce-in-the-small test cases.
#### Resolved bug number: (rdar://problem/26413181)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… decls.

With the introduction of near-miss checking for optional @objc
protocol requirements, the omit-needless-words logic within the type
checker started being applied to arbitrary declarations that might not
have been type-checked, leading to crashes in various multi-file
scenarios that I wasn't able to reduce down to a sensible test
case. Make sure these declarations get type-checked, fixing
rdar://problem/26413181.
