### PR TITLE
[Parser] Don't report AttrsRequiringFoundation in inactive config block

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2291,9 +2291,11 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
   }
 
   if (auto SF = CurDeclContext->getParentSourceFile()) {
-    for (auto Attr : Attributes) {
-      if (isa<ObjCAttr>(Attr) || isa<DynamicAttr>(Attr))
-        SF->AttrsRequiringFoundation.insert({Attr->getKind(), Attr});
+    if (!getScopeInfo().isInactiveConfigBlock()) {
+      for (auto Attr : Attributes) {
+        if (isa<ObjCAttr>(Attr) || isa<DynamicAttr>(Attr))
+          SF->AttrsRequiringFoundation.insert({Attr->getKind(), Attr});
+      }
     }
   }
 

--- a/test/Sema/objc_attr_requires_module_3.swift
+++ b/test/Sema/objc_attr_requires_module_3.swift
@@ -1,0 +1,43 @@
+// RUN: %target-build-swift -parse %s -Xfrontend -verify
+
+class TestClass1 {
+#if false
+  @objc func testMethod() {} // OK, in inactive block
+#endif
+}
+
+#if false
+class TestClass2 {
+  @objc func testMethod() {} // OK, in inactive block
+}
+#endif
+
+#if false
+class TestClass3 {
+#if true
+  @objc func testMethod() {} // OK, in inactive block
+#endif
+}
+#endif
+
+#if false
+#if true
+class TestClass4 {
+  @objc func testMethod() {} // OK, in inactive block
+}
+#endif
+#endif
+
+class TestClass5 {
+#if true
+  // pass
+#else
+  @objc func testMethod() {} // OK, in inactive block
+#endif
+}
+
+#if true
+class TestClass6 {
+  @objc func testMethod() {} // expected-error {{@objc attribute used without importing module 'Foundation'}}
+}
+#endif

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -6,7 +6,7 @@
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
 // RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Array -Xfrontend -disable-access-control; \
 // RUN: else \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Array -Xfrontend -disable-objc-attr-requires-foundation-module -Xfrontend -disable-access-control; \
+// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Array -Xfrontend -disable-access-control; \
 // RUN: fi
 // RUN: %S/../../utils/line-directive %t/main.swift -- %target-run %t/Array
 // REQUIRES: executable_test

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -6,7 +6,7 @@
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
 // RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Dictionary -Xfrontend -disable-access-control; \
 // RUN: else \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Dictionary -Xfrontend -disable-access-control -Xfrontend -disable-objc-attr-requires-foundation-module; \
+// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Dictionary -Xfrontend -disable-access-control; \
 // RUN: fi
 //
 // RUN: %S/../../utils/line-directive %t/main.swift -- %target-run %t/Dictionary

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -6,7 +6,7 @@
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
 // RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Set -Xfrontend -disable-access-control; \
 // RUN: else \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Set -Xfrontend -disable-access-control -Xfrontend -disable-objc-attr-requires-foundation-module; \
+// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Set -Xfrontend -disable-access-control; \
 // RUN: fi
 //
 // RUN: %S/../../utils/line-directive %t/main.swift -- %target-run %t/Set

--- a/validation-test/stdlib/Unicode.swift
+++ b/validation-test/stdlib/Unicode.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out -Xfrontend -disable-objc-attr-requires-foundation-module
+// RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 


### PR DESCRIPTION
#### What's in this pull request?

In Linux, compiling this used to emit an error:

``` swift
#if os(OSX)
import Foundation
@objc class Foo: NSObject { }
#else
class Foo { }
#endif
```

```
error: @objc attribute used without importing module 'Foundation'
@objc class Foo: NSObject { }
~^~~~
```

While we can silence it with `-disable-objc-attr-requires-foundation-module` option,
Entirely disabling this diagnosis is not safe for us.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
