### PR TITLE
Bring back RC identity cache

### DIFF
--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -453,6 +453,11 @@ SILValue RCIdentityFunctionInfo::getRCIdentityRootInner(SILValue V,
 }
 
 SILValue RCIdentityFunctionInfo::getRCIdentityRoot(SILValue V) {
+  // Do we have it in the RCCache ?
+  auto Iter = RCCache.find(V);
+  if (Iter != RCCache.end())
+    return Iter->second;
+
   SILValue Root = getRCIdentityRootInner(V, 0);
   VisitedArgs.clear();
 
@@ -460,7 +465,12 @@ SILValue RCIdentityFunctionInfo::getRCIdentityRoot(SILValue V) {
   if (!Root)
     return V;
 
-  return Root;
+  // Make sure the cache does not grow too big.
+  if (RCCache.size() > MaxRCIdentityCacheSize)
+    RCCache.clear();
+
+  // Return and cache it.
+  return RCCache[V] = Root;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Transforms/RetainReleaseCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/RetainReleaseCodeMotion.cpp
@@ -224,16 +224,9 @@ protected:
   /// we compute the genset and killset.
   llvm::SmallPtrSet<SILBasicBlock *, 8> InterestBlocks;
 
-  /// An RC-identity cache.
-  /// TODO: this should be cached in RCIdentity analysis.
-  llvm::DenseMap<SILValue, SILValue> RCCache;
-
   /// Return the rc-identity root of the SILValue.
   SILValue getRCRoot(SILValue R) {
-    auto Iter = RCCache.find(R);
-    if (Iter != RCCache.end())
-      return Iter->second;
-     return RCCache[R] = RCFI->getRCIdentityRoot(R);
+     return RCFI->getRCIdentityRoot(R);
   }
 
   /// Return the rc-identity root of the RC instruction, i.e.


### PR DESCRIPTION
Bring back rc identity cache. This takes off 0.7% of the 27.7% of the time we spent in SILoptimizer when building Stdlib.
