### PR TITLE
Pass libdispatch source and build directories to Swift PM

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1522,6 +1522,10 @@ function set_swiftpm_bootstrap_command() {
     LLBUILD_BIN="$(build_directory_bin ${LOCAL_HOST} llbuild)/swift-build-tool"
     if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
         FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
+        if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+            LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
+            LIBDISPATCH_BUILD_ARGS="--libdispatch-source-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
+        fi
         if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
             XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
         fi
@@ -1544,6 +1548,10 @@ function set_swiftpm_bootstrap_command() {
     if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
         swiftpm_bootstrap_command+=(
             --foundation="${FOUNDATION_BUILD_DIR}/Foundation")
+        if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+            swiftpm_bootstrap_command+=(
+                $LIBDISPATCH_BUILD_ARGS)
+        fi
         if [[ ! "${SKIP_BUILD_XCTEST}" ]] ; then
             swiftpm_bootstrap_command+=(
                 --xctest="${XCTEST_BUILD_DIR}")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

The new dependency between Swift Package Manager and Foundation means that there's a compilation failure if Dispatch is built into Foundation.

This passes the libdispatch source and build directories to Swift PM build script to that it can add them to the import paths.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

N/A

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
