### PR TITLE
[PrintAsObjC] Fix handling of swift_name and swift_newtype

### DIFF
--- a/test/PrintAsObjC/Inputs/newtype.h
+++ b/test/PrintAsObjC/Inputs/newtype.h
@@ -1,0 +1,5 @@
+// This file is meant to be used with the mock SDK, not the real one.
+#import <Foundation.h>
+
+typedef NSString *StructLikeStringWrapper __attribute__((swift_newtype(struct)));
+typedef NSString *EnumLikeStringWrapper __attribute__((swift_newtype(enum)));

--- a/test/PrintAsObjC/Inputs/swift_name.h
+++ b/test/PrintAsObjC/Inputs/swift_name.h
@@ -1,0 +1,22 @@
+// This file is meant to be used with the mock SDK, not the real one.
+#import <Foundation.h>
+
+#define SWIFT_NAME(x) __attribute__((swift_name(#x)))
+
+typedef NSString *ABCStringAlias SWIFT_NAME(ZZStringAlias);
+struct ABCPoint {
+  int x;
+  int y;
+} SWIFT_NAME(ZZPoint);
+enum ABCAlignment {
+  ABCAlignmentLeft,
+  ABCAlignmentRight
+} SWIFT_NAME(ZZAlignment);
+
+SWIFT_NAME(ZZClass)
+@interface ABCClass : NSObject
+@end
+
+SWIFT_NAME(ZZProto)
+@protocol ABCProto
+@end

--- a/test/PrintAsObjC/newtype.swift
+++ b/test/PrintAsObjC/newtype.swift
@@ -1,0 +1,44 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -enable-swift-newtype -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/newtype.h -enable-swift-newtype -parse-as-library %t/newtype.swiftmodule -parse -emit-objc-header-path %t/newtype.h
+
+// RUN: FileCheck %s < %t/newtype.h
+
+// RUN: %check-in-clang %t/newtype.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/newtype.h
+
+import Foundation
+
+// CHECK-LABEL: @interface TestEnumLike : NSObject
+class TestEnumLike : NSObject {
+  // CHECK: - (void)takesNewtype:(EnumLikeStringWrapper _Nonnull)a;
+  func takesNewtype(_ a: EnumLikeStringWrapper) {}
+  // CHECK: - (void)takesNewtypeArray:(NSArray<EnumLikeStringWrapper> * _Nonnull)a;
+  func takesNewtypeArray(_ a: [EnumLikeStringWrapper]) {}
+  // CHECK: - (void)takesNewtypeDictionary:(NSDictionary<EnumLikeStringWrapper, EnumLikeStringWrapper> * _Nonnull)a;
+  func takesNewtypeDictionary(_ a: [EnumLikeStringWrapper: EnumLikeStringWrapper]) {}
+}
+// CHECK: @end
+
+// CHECK-LABEL: @interface TestStructLike : NSObject
+class TestStructLike : NSObject {
+  // CHECK: - (void)takesNewtype:(StructLikeStringWrapper _Nonnull)a;
+  func takesNewtype(_ a: StructLikeStringWrapper) {}
+  // CHECK: - (void)takesNewtypeArray:(NSArray<StructLikeStringWrapper> * _Nonnull)a;
+  func takesNewtypeArray(_ a: [StructLikeStringWrapper]) {}
+  // CHECK: - (void)takesNewtypeDictionary:(NSDictionary<StructLikeStringWrapper, StructLikeStringWrapper> * _Nonnull)a;
+  func takesNewtypeDictionary(_ a: [StructLikeStringWrapper: StructLikeStringWrapper]) {}
+}
+// CHECK: @end
+

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -1,0 +1,33 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: rm -rf %t && mkdir %t
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -emit-module -o %t %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -import-objc-header %S/Inputs/swift_name.h -parse-as-library %t/swift_name.swiftmodule -parse -emit-objc-header-path %t/swift_name.h
+
+// RUN: FileCheck %s < %t/swift_name.h
+// RUN: %check-in-clang %t/swift_name.h
+
+import Foundation
+
+// CHECK-LABEL: @interface Test : NSObject
+// CHECK-NEXT: - (NSArray<ABCStringAlias> * _Nonnull)makeArray:(ABCStringAlias _Nonnull)_;
+// CHECK-NEXT: - (void)usePoint:(struct ABCPoint)_;
+// CHECK-NEXT: - (void)useAlignment:(enum ABCAlignment)_;
+// CHECK-NEXT: - (NSArray<id <ABCProto>> * _Nonnull)useObjects:(ABCClass * _Nonnull)_;
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: @end
+class Test : NSObject {
+  func makeArray(_: ZZStringAlias) -> [ZZStringAlias] { return [] }
+  func usePoint(_: ZZPoint) {}
+  func useAlignment(_: ZZAlignment) {}
+  func useObjects(_: ZZClass) -> [ZZProto] { return [] }
+}


### PR DESCRIPTION
A typedef with the `swift_newtype` attribute is imported as a struct wrapping the underlying type instead of just a typealias. If the underlying type is a bridged type (like String), the newtype struct is bridged as well. However, we don't want to use that type when bridging back to Objective-C, because
1. Objective-C header generation is done too late to fill out the _ObjectiveCBridgeable conformance for the type, so if it wasn't type-checked then the conformance won't have the original type in it.
2. There's a perfectly good typedef we should be using anyway.

Just use the type as written in Objective-C (instead of crashing).

Also, make sure we use the C name for the type rather than the Swift name. Previously this part of the compiler assumed that any imported struct or enum would have the same name as it does in C, which is no longer true.

rdar://problem/26372925

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
