### PR TITLE
[swift-3.0-preview-1-branch][stdlib] Provide migration hint for AnyTraversalIndex types

### DIFF
--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -1129,3 +1129,8 @@ extension AnyCollectionProtocol {
     Builtin.unreachable()
   }
 }
+
+% for Traversal in TRAVERSALS:
+@available(*, unavailable, renamed: "AnyIndex")
+public typealias Any${Traversal}Index = AnyIndex
+% end


### PR DESCRIPTION
- Explanation: Migration aids for the `AnyForwardIndex`, `AnyBidirectionalIndex`, and `AnyRandomAccessIndex` types were omitted. This change adds an `@available` attribute for each removed type that forwards to the new `AnyIndex`.
- Scope of Issue: Aids the migration of Swift 2.2 code that uses existential indices.
- Risk: None. The new type aliases will provide migration hints but will not be usable in new code.
- Reviewed By: Dmitri Gribenko
- Testing: Checked that existing tests don't break and checked in the REPL that the correct replacement type is suggested.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
