### PR TITLE
Disable this test when lto is enabled.

### DIFF
--- a/test/Driver/static-stdlib.swift
+++ b/test/Driver/static-stdlib.swift
@@ -1,5 +1,6 @@
 // Statically link a "hello world" program
 // XFAIL: linux
+// XFAIL: lto
 // REQUIRES: static_stdlib
 print("hello world!")
 // RUN: rm -rf %t && mkdir %t

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -26,6 +26,11 @@ if "@SWIFT_ASAN_BUILD@" == "TRUE":
 else:
     config.available_features.add('no_asan')
 
+if '@SWIFT_ENABLE_LTO@' == 'TRUE':
+    config.available_features.add('lto')
+else:
+    config.available_features.add('no_lto')
+
 if "@LLVM_ENABLE_ASSERTIONS@" == "TRUE":
     config.available_features.add('asserts')
 else:


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Right now when we enable lto in swift, we lto the runtime and the compiler. In
the case where we are making dylibs for the runtime this is great, we get better
performance.

On the other hand, there is a bug now that makes it so that the static
libswiftCore also gets the lto bitcode. We do not want users to take this
potential compile time hit from ltoing that archive.

I have not had time to look into this issue yet, so I am xfailing this test when
LTO is enabled.

rdar://26281388
