### PR TITLE
IRGen: Don't emit externally available witness tables.

### DIFF
--- a/test/IRGen/existential_metatypes.sil
+++ b/test/IRGen/existential_metatypes.sil
@@ -19,6 +19,9 @@ extension Float : Kindable {
   public var kind: Int { get }
 }
 
+// CHECK: @_TWPSi21existential_metatypes8KindableS_ = external global i8*, align 8
+// CHECK: @_TWPSf21existential_metatypes8KindableS_ = external global i8*, align 8
+
 sil @int_kind_getter : $@convention(method) (Int) -> Int {
 bb0(%0 : $Int):
   %2 = integer_literal $Builtin.Int64, 0
@@ -62,7 +65,7 @@ bb0:
   %1 = metatype $@thin Int.Type
   %2 = metatype $@thick Int.Type
   %3 = init_existential_metatype %2 : $@thick Int.Type, $@thick Kindable.Type
-  // CHECK-NEXT: store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @_TWPSi21existential_metatypes8KindableS_, i32 0, i32 0), i8*** [[T0]], align 8
+  // CHECK-NEXT: store i8** @_TWPSi21existential_metatypes8KindableS_, i8*** [[T0]], align 8
   store %3 to %0 : $*@thick Kindable.Type
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { %swift.type*, i8** }, { %swift.type*, i8** }* [[V]], i32 0, i32 0
   // CHECK-NEXT: store %swift.type* @_TMSf, %swift.type** [[T0]], align 8
@@ -70,7 +73,7 @@ bb0:
   %5 = metatype $@thin Float.Type
   %6 = metatype $@thick Float.Type
   %7 = init_existential_metatype %6 : $@thick Float.Type, $@thick Kindable.Type
-  // CHECK-NEXT: store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @_TWPSf21existential_metatypes8KindableS_, i32 0, i32 0), i8*** [[T0]], align 8
+  // CHECK-NEXT: store i8** @_TWPSf21existential_metatypes8KindableS_, i8*** [[T0]], align 8
   store %7 to %0 : $*@thick Kindable.Type
   %9 = tuple ()
   // CHECK-NEXT: bitcast

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -36,6 +36,7 @@ struct Conformer: Q, QQ {
   func qMethod() {}
 }
 
+// CHECK: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@_TWPV39sil_witness_tables_external_conformance17ExternalConformerS_9ExternalPS_]] = external global i8*, align 8
 // CHECK: [[CONFORMER_Q_WITNESS_TABLE:@_TWPV18sil_witness_tables9ConformerS_1QS_]] = hidden constant [2 x i8*] [
 // CHECK:   i8* bitcast ([4 x i8*]* [[CONFORMER_P_WITNESS_TABLE:@_TWPV18sil_witness_tables9ConformerS_1PS_]] to i8*),
 // CHECK:   i8* bitcast (void (%V18sil_witness_tables9Conformer*, %swift.type*, i8**)* @_TTWV18sil_witness_tables9ConformerS_1QS_FS1_7qMethod{{.*}} to i8*)
@@ -47,7 +48,6 @@ struct Conformer: Q, QQ {
 // CHECK:   i8* bitcast (void (%V18sil_witness_tables9Conformer*, %swift.type*, i8**)* @_TTWV18sil_witness_tables9ConformerS_1PS_FS1_14instanceMethod{{.*}} to i8*)
 // CHECK: ]
 // CHECK: [[CONFORMER2_P_WITNESS_TABLE:@_TWPV18sil_witness_tables10Conformer2S_1PS_]] = hidden constant [4 x i8*]
-// CHECK: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@_TWPV39sil_witness_tables_external_conformance17ExternalConformerS_9ExternalPS_]] = available_externally constant [0 x i8*]
 
 struct Conformer2: Q {
   typealias Assoc = AssocConformer
@@ -66,7 +66,7 @@ func erasure(c c: Conformer) -> QQ {
 
 // CHECK-LABEL: define hidden void @_TF18sil_witness_tables15externalErasureFT1cV39sil_witness_tables_external_conformance17ExternalConformer_PS0_9ExternalP_(%P39sil_witness_tables_external_conformance9ExternalP_* noalias nocapture sret)
 // CHECK:         [[WITNESS_TABLE_ADDR:%.*]] = getelementptr inbounds %P39sil_witness_tables_external_conformance9ExternalP_, %P39sil_witness_tables_external_conformance9ExternalP_* %0, i32 0, i32 2
-// CHECK-NEXT:    store i8** getelementptr inbounds ([0 x i8*], [0 x i8*]* [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE]], i32 0, i32 0), i8*** %2, align 8
+// CHECK-NEXT:    store i8** [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE]], i8*** %2, align 8
 func externalErasure(c c: ExternalConformer) -> ExternalP {
   return c
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

It can end up in having duplicate sumbols for generated associated type metadata access functions. rdar://problem/26360504
Also, it is not a big benefit for LLVM to emit such witness tables.
