### PR TITLE
[CodeCompletion] Apply filter rules directly to inner results

### DIFF
--- a/test/SourceKit/CodeComplete/Inputs/filter-rules/hideInnerOp.json
+++ b/test/SourceKit/CodeComplete/Inputs/filter-rules/hideInnerOp.json
@@ -1,0 +1,7 @@
+[
+  {
+    key.kind: source.codecompletion.identifier,
+    key.hide: 1,
+    key.names: [".", "?.", "("]
+  }
+]

--- a/test/SourceKit/CodeComplete/Inputs/filter-rules/showOp.json
+++ b/test/SourceKit/CodeComplete/Inputs/filter-rules/showOp.json
@@ -1,0 +1,16 @@
+[
+  {
+    key.kind: source.codecompletion.everything,
+    key.hide: 1
+  },
+  {
+    key.kind: source.codecompletion.identifier,
+    key.hide: 0,
+    key.names: ["local", ".", "="]
+  },
+  {
+    key.kind: source.codecompletion.module,
+    key.hide: 0,
+    key.names: ["Swift"]
+  }
+]

--- a/test/SourceKit/CodeComplete/complete_filter_rules.swift
+++ b/test/SourceKit/CodeComplete/complete_filter_rules.swift
@@ -85,3 +85,99 @@ func testShowSpecific01() {
 // SHOW_SPECIFIC_1-NEXT:   myFunFunction1()
 // SHOW_SPECIFIC_1-NEXT: ]
 }
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showSpecific.json -tok=HIDE_OP_1 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP
+func testHideOp1() {
+  var local = 1
+  #^HIDE_OP_1,local^#
+}
+// HIDE_OP-NOT: .
+// HIDE_OP-NOT: =
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showSpecific.json -tok=HIDE_OP_2 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP -allow-empty
+func testHideOp2() {
+  var local = 1
+  local#^HIDE_OP_2^#
+}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showOp.json -tok=SHOW_OP_1 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=SHOW_OP_1
+func testShowOp1() {
+  var local = 1
+  #^SHOW_OP_1,local^#
+}
+// SHOW_OP_1: local.{{$}}
+// SHOW_OP_1: local={{$}}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showOp.json -tok=SHOW_OP_2 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=SHOW_OP_2
+func testShowOp2() {
+  var local = 1
+  local#^SHOW_OP_2^#
+}
+// SHOW_OP_2: {{^}}.{{$}}
+// SHOW_OP_2: {{^}}={{$}}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showOp.json -tok=HIDE_OP_3 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP
+func testHideOp3() {
+  let local = TestHideName()
+  // Implicitly hidden because we hide all the members.
+  #^HIDE_OP_3,local^#
+}
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showOp.json -tok=HIDE_OP_4 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP -allow-empty
+func testHideOp4() {
+  let local = TestHideName()
+  // Implicitly hidden because we hide all the members.
+  local#^HIDE_OP_4^#
+}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showOp.json -tok=SHOW_OP_3 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=SHOW_OP_1
+func testShowOp3() {
+  var local = 1
+  #^SHOW_OP_3,local^#
+}
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/showOp.json -tok=SHOW_OP_4 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=SHOW_OP_2
+func testShowOp4() {
+  var local = 1
+  local#^SHOW_OP_4^#
+}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideInnerOp.json -tok=HIDE_OP_5 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP_5 -allow-empty
+func testHideOp5() {
+  var local = 1
+  #^HIDE_OP_5,local^#
+}
+// HIDE_OP_5-NOT: local.{{$}}
+// HIDE_OP_5-NOT: local?.
+// HIDE_OP_5-NOT: local(
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideInnerOp.json -tok=HIDE_OP_6 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP_5 -allow-empty
+func testHideOp6() {
+  var local: Int? = 1
+  #^HIDE_OP_6,local^#
+}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideInnerOp.json -tok=HIDE_OP_7 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP_5 -allow-empty
+func testHideOp7() {
+  struct local {}
+  #^HIDE_OP_7,local^#
+}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideInnerOp.json -tok=HIDE_OP_8 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP_8 -allow-empty
+func testHideOp8() {
+  var local = 1
+  local#^HIDE_OP_8^#
+}
+// HIDE_OP_8-NOT: {{^}}.{{$}}
+// HIDE_OP_8-NOT: {{^}}?.
+// HIDE_OP_8-NOT: {{^}}(
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideInnerOp.json -tok=HIDE_OP_9 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP_8 -allow-empty
+func testHideOp9() {
+  var local: Int? = 1
+  local#^HIDE_OP_9^#
+}
+
+// RUN: %complete-test -filter-rules=%S/Inputs/filter-rules/hideInnerOp.json -tok=HIDE_OP_10 %s -- -F %S/../Inputs/libIDE-mock-sdk | FileCheck %s -check-prefix=HIDE_OP_8 -allow-empty
+func testHideOp10() {
+  struct local {}
+  local#^HIDE_OP_10^#
+}

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -234,6 +234,10 @@ struct FilterRules {
   llvm::StringMap<bool> hideByName;
 
   bool hideCompletion(Completion *completion) const;
+  bool hideCompletion(SwiftResult *completion,
+                      StringRef name,
+                      void *customKind = nullptr) const;
+  bool hideName(StringRef name) const;
 };
 
 } // end namespace CodeCompletion

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -447,10 +447,21 @@ static bool isHighPriorityKeyword(CodeCompletionKeywordKind kind) {
   }
 }
 
-bool FilterRules::hideCompletion(Completion *completion) const {
+bool FilterRules::hideName(StringRef name) const {
+  auto I = hideByName.find(name);
+  if (I != hideByName.end())
+      return I->getValue();
+  return hideAll;
+}
 
-  if (!completion->getName().empty()) {
-    auto I = hideByName.find(completion->getName());
+bool FilterRules::hideCompletion(Completion *completion) const {
+  return hideCompletion(completion, completion->getName(), completion->getCustomKind());
+}
+
+bool FilterRules::hideCompletion(SwiftResult *completion, StringRef name, void *customKind) const {
+
+  if (!name.empty()) {
+    auto I = hideByName.find(name);
     if (I != hideByName.end())
       return I->getValue();
   }
@@ -468,7 +479,7 @@ bool FilterRules::hideCompletion(Completion *completion) const {
     break;
   }
   case Completion::Pattern: {
-    if (completion->hasCustomKind()) {
+    if (customKind) {
       // FIXME: individual custom completions
       if (hideCustomCompletions)
         return true;


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Apply filter rules directly to inner results and don't try to filter the extended results.  Once the results are extended with the common prefix they will not match identifier filter rules, which will create differences between completions depending on whether they had a filter text or were a postfix expression.  Also, allow filtering by name directly on the inner operator name for inner operators.
#### Resolved bug number: [rdar://problem/26312235](rdar://problem/26312235)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
