### PR TITLE
[sema] When the error is "cannot convert value of type <integer> to expected argument type <RawRepresentable>" add a fixit.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3096,6 +3096,11 @@ static bool isIntegerToStringIndexConversion(Type fromType, Type toType,
   return false;
 }
 
+/// Attempts to add a fixit to correct the compiler error.
+///
+/// Corrects the error is "cannot convert value of type <integer> to expected
+/// argument type <RawRepresentable>", by adding a fixit that constructs the
+/// raw-representable type from the value. This helps with SDK changes.
 static void tryConversionFixit(InFlightDiagnostic &diag,
                                ConstraintSystem *CS,
                                Diag<Type, Type> diagID,
@@ -3119,7 +3124,7 @@ static void tryConversionFixit(InFlightDiagnostic &diag,
 
   // When the error is "cannot convert value of type <integer> to expected
   // argument type <RawRepresentable>", add a fixit that constructs the
-  // raw-representable type from the value. This helps with SDK changes.
+  // raw-representable type from the value.
 
   if (!isIntegerType(exprType))
     return;
@@ -3384,6 +3389,7 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
 
   InFlightDiagnostic diag = diagnose(expr->getLoc(), diagID, exprType, contextualType);
   diag.highlight(expr->getSourceRange());
+  // Attempt to add a fixit for the error.
   tryConversionFixit(diag, CS, diagID, exprType, contextualType, expr);
   return true;
 }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3096,6 +3096,63 @@ static bool isIntegerToStringIndexConversion(Type fromType, Type toType,
   return false;
 }
 
+static void tryConversionFixit(InFlightDiagnostic &diag,
+                               ConstraintSystem *CS,
+                               Diag<Type, Type> diagID,
+                               Type exprType,
+                               Type contextualType,
+                               Expr *expr) {
+  if (!CS || !expr || !exprType || !contextualType)
+    return;
+  if (diagID.ID != diag::cannot_convert_argument_value.ID)
+    return;
+
+  auto integerType =
+    CS->TC.getProtocol(SourceLoc(),
+                       KnownProtocolKind::IntegerLiteralConvertible);
+  if (!integerType) return;
+
+  auto isIntegerType = [&](Type ty) -> bool {
+    return CS->TC.conformsToProtocol(exprType, integerType, CS->DC,
+                                     ConformanceCheckFlags::InExpression);
+  };
+
+  // When the error is "cannot convert value of type <integer> to expected
+  // argument type <RawRepresentable>", add a fixit that constructs the
+  // raw-representable type from the value. This helps with SDK changes.
+
+  if (!isIntegerType(exprType))
+    return;
+
+  auto rawReprType =
+    CS->TC.getProtocol(SourceLoc(), KnownProtocolKind::RawRepresentable);
+  if (!rawReprType) return;
+
+  ProtocolConformance *rawReprConformance;
+  if (!CS->TC.conformsToProtocol(contextualType, rawReprType, CS->DC,
+                                 ConformanceCheckFlags::InExpression,
+                                 &rawReprConformance))
+    return;
+
+  Type rawTy = ProtocolConformance::getTypeWitnessByName(contextualType,
+                                                      rawReprConformance,
+                                  CS->getASTContext().getIdentifier("RawValue"),
+                                                      &CS->TC);
+  if (!rawTy || !isIntegerType(rawTy))
+    return;
+
+  std::string convWrapBefore = contextualType.getString();
+  convWrapBefore += "(rawValue: ";
+  std::string convWrapAfter = ")";
+  if (rawTy->getCanonicalType() != exprType->getCanonicalType()) {
+    convWrapBefore += rawTy->getString();
+    convWrapBefore += "(";
+    convWrapAfter += ")";
+  }
+  SourceRange exprRange = expr->getSourceRange();
+  diag.fixItInsert(exprRange.Start, convWrapBefore);
+  diag.fixItInsertAfter(exprRange.End, convWrapAfter);
+}
 
 bool FailureDiagnosis::diagnoseContextualConversionError() {
   // If the constraint system has a contextual type, then we can test to see if
@@ -3325,8 +3382,9 @@ bool FailureDiagnosis::diagnoseContextualConversionError() {
         diagID = diag::noescape_functiontype_mismatch;
     }
 
-  diagnose(expr->getLoc(), diagID, exprType, contextualType)
-    .highlight(expr->getSourceRange());
+  InFlightDiagnostic diag = diagnose(expr->getLoc(), diagID, exprType, contextualType);
+  diag.highlight(expr->getSourceRange());
+  tryConversionFixit(diag, CS, diagID, exprType, contextualType, expr);
   return true;
 }
 

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -31,6 +31,18 @@ func supported() -> MyMask {
   return Int(MyMask.Bingo.rawValue)
 }
 
+struct MyEventMask2 : OptionSet {
+  init(rawValue: UInt64) {}
+  var rawValue: UInt64 { return 0 }
+}
+func sendIt(_: MyEventMask2) {}
+func testMask1(a: Int) {
+  sendIt(a)
+}
+func testMask2(a: UInt64) {
+  sendIt(a)
+}
+
 func goo(var e : ErrorProtocol) {
 }
 func goo2(var e: ErrorProtocol) {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -31,6 +31,18 @@ func supported() -> MyMask {
   return MyMask.Bingo
 }
 
+struct MyEventMask2 : OptionSet {
+  init(rawValue: UInt64) {}
+  var rawValue: UInt64 { return 0 }
+}
+func sendIt(_: MyEventMask2) {}
+func testMask1(a: Int) {
+  sendIt(MyEventMask2(rawValue: UInt64(a)))
+}
+func testMask2(a: UInt64) {
+  sendIt(MyEventMask2(rawValue: a))
+}
+
 func goo(e : ErrorProtocol) {
     var e = e
 }


### PR DESCRIPTION
#### What's in this pull request?

When the error is "cannot convert value of type <integer> to expected argument type <RawRepresentable>" there is a change to add a fixit. The fixit constructs the raw-representable type from the value. This helps with SDK changes.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26478127

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
