### PR TITLE
rdar://problem/26371959 AST/SILGen: Consider bridgeable value types to be bridgeable when bound to generic parameters.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2141,6 +2141,10 @@ getForeignRepresentable(Type type, ForeignLanguage language,
              nullptr };
   }
 
+  // In Objective-C, type parameters are always objects.
+  if (type->isTypeParameter() && language == ForeignLanguage::ObjectiveC)
+    return { ForeignRepresentableKind::Object, nullptr };
+
   auto nominal = type->getAnyNominal();
   if (!nominal)
     return failure();

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1040,9 +1040,6 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     };
 
     {
-      GenericContextScope genericScope(SGM.Types,
-                                       foreignFnTy->getGenericSignature());
-
       for (unsigned nativeParamIndex : indices(params)) {
         // Bring the parameter to +1.
         auto paramValue = params[nativeParamIndex];

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -54,6 +54,21 @@ entry:
   return undef : $()
 }
 
+sil @_TToFC27objc_generic_class_metadata8SubclasscfT5thingGSQCSo8NSString__GSQS0__ : $@convention(objc_method) (ImplicitlyUnwrappedOptional<NSString>, @owned Subclass) -> @owned ImplicitlyUnwrappedOptional<Subclass> {
+entry(%0: $ImplicitlyUnwrappedOptional<NSString>, %1: $Subclass):
+  unreachable
+}
+
+sil @_TToFC27objc_generic_class_metadata8SubclasscfT13arrayOfThingsGSaCSo8NSString__GSQS0__ : $@convention(objc_method) (NSArray, @owned Subclass) -> @owned ImplicitlyUnwrappedOptional<Subclass> {
+entry(%0: $NSArray, %1: $Subclass):
+  unreachable
+}
+
+sil @_TToFC27objc_generic_class_metadata8SubclasscfT_S0_ : $@convention(objc_method) (@owned Subclass) -> @owned Subclass {
+entry(%0: $Subclass):
+  unreachable
+}
+
 // CHECK-LABEL: define linkonce_odr hidden %swift.type* @_TMaCSo12GenericClass()
 // CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
 // CHECK:         call %objc_class* @rt_swift_getInitializedObjCClass(%objc_class* [[T0]])

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -2,16 +2,19 @@
 
 @interface GenericClass<T> : NSObject
 - (id)initWithThing:(T)thing;
+- (id)initWithArrayOfThings:(NSArray<T> *__nonnull)things;
 - (void)dealloc;
 - (__nullable T)thing;
 - (int)count;
 + (__nullable T)classThing;
 - (__nonnull NSArray<T> *)arrayOfThings;
+- (void)setArrayOfThings:(NSArray<T> *__nonnull)things;
 
 - (T __nonnull)objectAtIndexedSubscript:(uint16_t)i;
 - (void)setObject:(T __nonnull)object atIndexedSubscript:(uint16_t)i;
 
 @property (nonatomic) __nullable T propertyThing;
+@property (nonatomic) __nullable NSArray<T> *propertyArrayOfThings;
 @end
 
 @interface GenericClass<T> (Private)

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -40,3 +40,18 @@ public func genericPropertyOnAnyObject(o: AnyObject, b: Bool) -> AnyObject?? {
 // CHECK-LABEL: sil @_TF21objc_imported_generic26genericPropertyOnAnyObject
 // CHECK:         dynamic_method_br %4 : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
 // CHECK:       bb1({{%.*}} : $@convention(objc_method) (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
+
+// CHECK-LABEL: sil @_TF21objc_imported_generic20arraysOfGenericParam
+public func arraysOfGenericParam<T: AnyObject>(y: Array<T>) {
+  // CHECK:         function_ref {{@_TFCSo12GenericClassCfT13arrayOfThings.*}} : $@convention(method) <τ_0_0 where τ_0_0 : AnyObject> (@owned Array<τ_0_0>, @thick GenericClass<τ_0_0>.Type) -> @owned ImplicitlyUnwrappedOptional<GenericClass<τ_0_0>>
+  let x = GenericClass<T>(arrayOfThings: y)!
+  // CHECK:         class_method [volatile] {{%.*}} : $GenericClass<T>, #GenericClass.setArrayOfThings!1.foreign {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : AnyObject> (NSArray, GenericClass<τ_0_0>) -> ()
+  x.setArrayOfThings(y)
+  // CHECK:         class_method [volatile] {{%.*}} : $GenericClass<T>, #GenericClass.propertyArrayOfThings!getter.1.foreign {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : AnyObject> (GenericClass<τ_0_0>) -> @autoreleased Optional<NSArray>
+  _ = x.propertyArrayOfThings
+  // CHECK:         class_method [volatile] {{%.*}} : $GenericClass<T>, #GenericClass.propertyArrayOfThings!setter.1.foreign {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : AnyObject> (Optional<NSArray>, GenericClass<τ_0_0>) -> ()
+  x.propertyArrayOfThings = y
+}
+
+// CHECK-LABEL: sil shared [thunk] @_TTOFCSo12GenericClasscfT13arrayOfThings
+// CHECK:         class_method [volatile] {{%.*}} : $GenericClass<T>, #GenericClass.init!initializer.1.foreign {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : AnyObject> (NSArray, @owned GenericClass<τ_0_0>) -> @owned ImplicitlyUnwrappedOptional<GenericClass<τ_0_0>>


### PR DESCRIPTION
We were failing to bridge Array<T> parameters in the signatures of Objective-C generics when their NSArray<T> \* type in ObjC depended on generic parameters. This partially fixes rdar://problem/26371959, though IRGen still needs a fix to get us all the way through (which @rjmccall is working on).

(@DougGregor did all the work here, I'm just testing and CCC-ing.)
