### PR TITLE
[stdlib] Fix the `String.decodeCString` for UTF16 and UTF32

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -138,7 +138,7 @@ extension String {
     guard let cString = cString else {
       return nil
     }
-    let len = Int(_swift_stdlib_strlen(UnsafePointer(cString)))
+    let len = encoding._nullCodeUnitOffset(in: cString)
     let buffer = UnsafeBufferPointer<Encoding.CodeUnit>(
       start: cString, count: len)
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1252,5 +1252,35 @@ StringTests.test("String.append(_: Character)") {
   }
 }
 
-runAllTests()
+internal func decodeCString<
+  C : UnicodeCodec
+  where
+  C.CodeUnit : UnsignedInteger
+>(_ s: String, as codec: C.Type)
+  -> (result: String, repairsMade: Bool)? {
+  let units = s.unicodeScalars.map({ $0.value }) + [0]
+  return units.map({ C.CodeUnit(numericCast($0)) }).withUnsafeBufferPointer {
+    String.decodeCString($0.baseAddress, as: C.self)
+  }
+}
 
+StringTests.test("String.decodeCString/UTF8") {
+  let actual = decodeCString("foobar", as: UTF8.self)
+  expectFalse(actual!.repairsMade)
+  expectEqual("foobar", actual!.result)
+}
+
+StringTests.test("String.decodeCString/UTF16") {
+  let actual = decodeCString("foobar", as: UTF16.self)
+  expectFalse(actual!.repairsMade)
+  expectEqual("foobar", actual!.result)
+}
+
+StringTests.test("String.decodeCString/UTF32") {
+  let actual = decodeCString("foobar", as: UTF32.self)
+  expectFalse(actual!.repairsMade)
+  expectEqual("foobar", actual!.result)
+}
+
+
+runAllTests()

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/Unicode.swift
+// RUN: %S/../../utils/line-directive %t/Unicode.swift -- %target-build-swift %t/Unicode.swift -o %t/a.out -Xfrontend -disable-objc-attr-requires-foundation-module
+// RUN: %S/../../utils/line-directive %t/Unicode.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
@@ -2460,6 +2462,32 @@ StringTests.test("StreamableConformance") {
     expectEqual(expected, actual)
   }
 }
+
+let nullOffsetTests = [
+  (input: "\0", expected: 0),
+  (input: "a\0", expected: 1),
+  (input: "foobar\0", expected: 6)
+]
+
+let NullCodeUnitOffsetTests = TestSuite("NullCodeUnitOffsetTests")
+
+% for (Encoding, View) in [
+%   ('UTF8', 'utf8'),
+%   ('UTF16', 'utf16'),
+%   ('UTF32', 'unicodeScalars.map{ $0.value }')
+% ]:
+
+NullCodeUnitOffsetTests.test("${Encoding}._nullCodeUnitOffset(in:)") {
+  for test in nullOffsetTests {
+    let actual = Array(test.input.${View})
+      .withUnsafeBufferPointer { p in
+        ${Encoding}._nullCodeUnitOffset(in: p.baseAddress!)
+      }
+    expectEqual(test.expected, actual)
+  }
+}
+
+% end
 
 runAllTests()
 


### PR DESCRIPTION
- Explanation: `String.decodeCSstring` method was introduced while we were reviewing the Standard Library and applying the new API naming guidelines to it, and it's implementation has always contained this bug.
- Scope of Issue: This method did not exist before Swift 3, so nobody has had a chance to use it yet.
- Origination: Bug in the original implementation.
- Risk: None.
- Reviewed By: Dmitri Gribenko (https://github.com/apple/swift/pull/2681)
- Testing: Unit tests included in the patch itself + ran the whole test suite.
- Directions for QA: N/A

rdar://problem/26423201
