### PR TITLE
IRGen: Fix Clang type conversion to map Swift.Bool to _Bool instead o…

### DIFF
--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -740,7 +740,9 @@ clang::CanQualType ClangTypeConverter::convert(IRGenModule &IGM, CanType type) {
       // FIXME: Handle _Bool and DarwinBoolean.
       auto &ctx = IGM.getClangASTContext();
       auto &TI = ctx.getTargetInfo();
-      if (TI.useSignedCharForObjCBool()) {
+      // FIXME: Figure out why useSignedCharForObjCBool() returns
+      // 'true' on Linux
+      if (IGM.ObjCInterop && TI.useSignedCharForObjCBool()) {
         return ctx.SignedCharTy;
       }
     }


### PR DESCRIPTION
rdar://problem/26444628

Please don't merge -- still needs tests (and might be the wrong approach)
