### PR TITLE
[Sema] Exclude Bad Synthesized Constructors from Member Lookup

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -2297,7 +2297,7 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
           .highlight(baseRange).highlight(nameLoc.getSourceRange());
       } else {
         // Otherwise the static member lookup was invalid because it was
-        // called on an instance
+        // called on an instance.
         diagnose(loc, diag::could_not_use_type_member_on_instance,
                  baseObjTy, memberName)
           .highlight(baseRange).highlight(nameLoc.getSourceRange());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2935,7 +2935,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       result.markErrorAlreadyDiagnosed();
       return;
     }
-
+    
     // FIXME: Deal with broken recursion
     if (!cand->getInterfaceType())
       return;
@@ -2961,8 +2961,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       }
     }
 
-    // See if we have an instance method, instance member or static method,
-    // and check if it can be accessed on our base type.
+    // See if we have an instance method, instance member, static method,
+    // or constructor, and check if it can be accessed on our base type.
     if (cand->isInstanceMember()) {
       if ((isa<FuncDecl>(cand) && !hasInstanceMethods) ||
           (!isa<FuncDecl>(cand) && !hasInstanceMembers)) {
@@ -2972,6 +2972,11 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
       
     } else {
       if (!hasStaticMembers) {
+        if (cand->isImplicit() && isa<ConstructorDecl>(cand)) {
+          result.markErrorAlreadyDiagnosed();
+          return;
+        }
+        
         result.addUnviable(cand, MemberLookupResult::UR_TypeMemberOnInstance);
         return;
       }

--- a/test/Sema/diag_invalid_synthesized_init_proto_conformance.swift
+++ b/test/Sema/diag_invalid_synthesized_init_proto_conformance.swift
@@ -1,0 +1,15 @@
+// RUN: %target-parse-verify-swift
+
+protocol P {
+  init()
+}
+
+class C : P { // expected-error {{initializer requirement 'init()' can only be satisfied by a `required` initializer in non-final class 'C'}}
+  // No further errors.
+}
+
+class B : C {
+  init(i: Int) {}
+}
+
+class D : B {}


### PR DESCRIPTION
#### What's in this pull request?

@slavapestov's provided file illustrates a diagnostics issue caused by member lookup searching for synthesized constructors and assuming they were just general member lookup failures.  This patch amends that logic by excluding bad synthesized constructors from the lookup set and marking the previous error as the correct diagnosis for this case.
#### Resolved bug number: ([SR-1571](https://bugs.swift.org/browse/SR-1571))

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

There are probably more robust ways to solve this, but in general it is
not OK to include synthesized constructors in the lookup member set here.  In
the case of classes, you wind up with a different double-diagnostic about the protocol
override and a bogus availability error.  For structs, conformance errors
(if any) are already handled up the chain like classes.
