### PR TITLE
Allow nested names in @available(*, renamed:"...").

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -834,7 +834,7 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
   auto parseBaseName = [&](StringRef text) -> bool {
     // Split the text into context name and base name.
     StringRef contextName, baseName;
-    std::tie(contextName, baseName) = text.split('.');
+    std::tie(contextName, baseName) = text.rsplit('.');
     if (baseName.empty()) {
       baseName = contextName;
       contextName = StringRef();
@@ -842,14 +842,26 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
       return true;
     }
 
+    auto isValidIdentifier = [](StringRef text) -> bool {
+      return Lexer::isIdentifier(text) && text != "_";
+    };
+
     // Make sure we have an identifier for the base name.
-    if (!Lexer::isIdentifier(baseName) || baseName == "_")
+    if (!isValidIdentifier(baseName))
       return true;
 
-    // If we have a context, make sure it is an identifier.
-    if (!contextName.empty() &&
-        (!Lexer::isIdentifier(contextName) || contextName == "_"))
-      return true;
+    // If we have a context, make sure it is an identifier, or a series of
+    // dot-separated identifiers.
+    // FIXME: What about generic parameters?
+    if (!contextName.empty()) {
+      StringRef first;
+      StringRef rest = contextName;
+      do {
+        std::tie(first, rest) = rest.split('.');
+        if (!isValidIdentifier(first))
+          return true;
+      } while (!rest.empty());
+    }
 
     // Record the results.
     result.ContextName = contextName;

--- a/test/APINotes/Inputs/broken-modules/BrokenAPINotes.apinotes
+++ b/test/APINotes/Inputs/broken-modules/BrokenAPINotes.apinotes
@@ -12,3 +12,5 @@ Functions:
     SwiftName: 'getter:ZXSpectrum.misnamedRegister(self:)'
   - Name: ZXSpectrumSetMisnamedRegister
     SwiftName: 'setter:ZXSpectrum.misnamedRegister(self:newValue:)'
+  - Name: ZXSpectrumHelperReset
+    SwiftName: 'ZXSpectrum.Helper.reset()'

--- a/test/APINotes/Inputs/broken-modules/BrokenAPINotes.h
+++ b/test/APINotes/Inputs/broken-modules/BrokenAPINotes.h
@@ -9,3 +9,4 @@ void ZXSpectrumSetRegister(ZXSpectrum *self, int which, unsigned char newValue);
 unsigned char ZXSpectrumGetMisnamedRegister(const ZXSpectrum *self, int which);
 void ZXSpectrumSetMisnamedRegister(ZXSpectrum *self, int which, unsigned char newValue);
 
+void ZXSpectrumHelperReset(void);

--- a/test/APINotes/broken-swift-name.swift
+++ b/test/APINotes/broken-swift-name.swift
@@ -21,4 +21,6 @@ func testBrokenSwiftName(x: inout ZXSpectrum) {
   ZXSpectrumGetMisnamedRegister(&x, 0)
   // TODO: Conservative validation in Clang doesn't reject the API name here
   // ZXSpectrumSetMisnamedRegister(&x, 0, 1)
+
+  ZXSpectrumHelperReset()
 }

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -127,9 +127,6 @@ let _: Int
 @available(*, renamed: "bad name") // expected-error{{'renamed' argument of 'available' attribute must be an operator, identifier, or full function name, optionally prefixed by a type name}}
 let _: Int
 
-@available(*, renamed: "Overly.Nested.Name") // expected-error{{'renamed' argument of 'available' attribute must be an operator, identifier, or full function name, optionally prefixed by a type name}}
-let _: Int
-
 @available(*, renamed: "_") // expected-error{{'renamed' argument of 'available' attribute must be an operator, identifier, or full function name, optionally prefixed by a type name}}
 let _: Int
 
@@ -249,6 +246,8 @@ func testOperators(x: DummyType, y: DummyType) {
 func unavailableMember() {} // expected-note {{here}}
 @available(*, deprecated, renamed: "DummyType.bar")
 func deprecatedMember() {}
+@available(*, unavailable, renamed: "DummyType.Inner.foo")
+func unavailableNestedMember() {} // expected-note {{here}}
 
 @available(*, unavailable, renamed: "DummyType.Foo")
 struct UnavailableType {} // expected-note {{here}}
@@ -258,6 +257,7 @@ typealias DeprecatedType = Int
 func testGlobalToMembers() {
   unavailableMember() // expected-error {{'unavailableMember()' has been renamed to 'DummyType.foo'}} {{3-20=DummyType.foo}}
   deprecatedMember() // expected-warning {{'deprecatedMember()' is deprecated: renamed to 'DummyType.bar'}} expected-note {{use 'DummyType.bar' instead}} {{3-19=DummyType.bar}}
+  unavailableNestedMember() // expected-error {{'unavailableNestedMember()' has been renamed to 'DummyType.Inner.foo'}} {{3-26=DummyType.Inner.foo}}
   let x: UnavailableType? = nil // expected-error {{'UnavailableType' has been renamed to 'DummyType.Foo'}} {{10-25=DummyType.Foo}}
   _ = x
   let y: DeprecatedType? = nil // expected-warning {{'DeprecatedType' is deprecated: renamed to 'DummyType.Bar'}} expected-note {{use 'DummyType.Bar' instead}} {{10-24=DummyType.Bar}}
@@ -303,6 +303,8 @@ func unavailableMultiNewlyUnnamed(a: Int, b: Int) {} // expected-note {{here}}
 
 @available(*, unavailable, renamed: "Int.init(other:)")
 func unavailableInit(a: Int) {} // expected-note 2 {{here}}
+@available(*, unavailable, renamed: "Foo.Bar.init(other:)")
+func unavailableNestedInit(a: Int) {} // expected-note 2 {{here}}
 
 
 func testArgNames() {
@@ -329,6 +331,10 @@ func testArgNames() {
   unavailableInit(a: 0) // expected-error {{'unavailableInit(a:)' has been replaced by 'Int.init(other:)'}} {{3-18=Int}} {{19-20=other}}
   let fn = unavailableInit // expected-error {{'unavailableInit(a:)' has been replaced by 'Int.init(other:)'}} {{12-27=Int.init}}
   fn(a: 1)
+
+  unavailableNestedInit(a: 0) // expected-error {{'unavailableNestedInit(a:)' has been replaced by 'Foo.Bar.init(other:)'}} {{3-24=Foo.Bar}} {{25-26=other}}
+  let fn2 = unavailableNestedInit // expected-error {{'unavailableNestedInit(a:)' has been replaced by 'Foo.Bar.init(other:)'}} {{13-34=Foo.Bar.init}}
+  fn2(a: 1)
 }
 
 @available(*, unavailable, renamed: "shinyLabeledArguments()")
@@ -368,6 +374,9 @@ func deprecatedInstance(a: Int) {}
 @available(*, deprecated, renamed: "Int.foo(self:)", message: "blah")
 func deprecatedInstanceMessage(a: Int) {}
 
+@available(*, unavailable, renamed: "Foo.Bar.foo(self:)")
+func unavailableNestedInstance(a: Int) {} // expected-note {{here}}
+
 func testRenameInstance() {
   unavailableInstance(a: 0) // expected-error{{'unavailableInstance(a:)' has been replaced by instance method 'Int.foo()'}} {{3-22=0.foo}} {{23-27=}}
   unavailableInstanceUnlabeled(0) // expected-error{{'unavailableInstanceUnlabeled' has been replaced by instance method 'Int.foo()'}} {{3-31=0.foo}} {{32-33=}}
@@ -380,6 +389,8 @@ func testRenameInstance() {
   unavailableInstanceMessage(a: 0) // expected-error{{'unavailableInstanceMessage(a:)' has been replaced by instance method 'Int.foo()': blah}} {{3-29=0.foo}} {{30-34=}}
   deprecatedInstance(a: 0) // expected-warning{{'deprecatedInstance(a:)' is deprecated: replaced by instance method 'Int.foo()'}} expected-note{{use 'Int.foo()' instead}} {{3-21=0.foo}} {{22-26=}}
   deprecatedInstanceMessage(a: 0) // expected-warning{{'deprecatedInstanceMessage(a:)' is deprecated: blah}} expected-note{{use 'Int.foo()' instead}} {{3-28=0.foo}} {{29-33=}}
+
+  unavailableNestedInstance(a: 0) // expected-error{{'unavailableNestedInstance(a:)' has been replaced by instance method 'Foo.Bar.foo()'}} {{3-28=0.foo}} {{29-33=}}
 }
 
 @available(*, unavailable, renamed: "Int.shinyLabeledArguments(self:)")


### PR DESCRIPTION
This can be used as QoI for things like `NSASCIIStringEncoding`, which is going to canonically be `String.Encoding.ascii` if/when [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md) is accepted.

We can't actually handle this in `NS_SWIFT_NAME` (that is, we can't _import_ something onto a nested type), but that's okay: we already have stricter limitations on `NS_SWIFT_NAME` enforced by Clang.

rdar://problem/26352374

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
