### PR TITLE
[swift-3.0-preview-1-branch][stdlib] Fix _writeBackMutableSlice error messages

### DIFF
--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -39,9 +39,9 @@ internal func _writeBackMutableSlice<
 
   _precondition(
     selfElementIndex == selfElementsEndIndex,
-    "Cannot replace a slice of a MutableCollection with a slice of a larger size")
+    "Cannot replace a slice of a MutableCollection with a slice of a smaller size")
   _precondition(
     newElementIndex == newElementsEndIndex,
-    "Cannot replace a slice of a MutableCollection with a slice of a smaller size")
+    "Cannot replace a slice of a MutableCollection with a slice of a larger size")
 }
 

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -588,6 +588,26 @@ CollectionTypeTests.test("subscript(_: Range<Index>)/writeback") {
     [ 1, 2, 3, 4, 5, 0, -1, -2, -3, -4 ], collection)
 }
 
+CollectionTypeTests.test("subscript(_: Range<Index>)/defaultImplementation/sliceTooLarge")
+  .crashOutputMatches("Cannot replace a slice of a MutableCollection with a slice of a larger size")
+  .code {
+  var x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  expectCrashLater()
+  x.withUnsafeMutableBufferPointer { buffer in
+    buffer[2..<4] = buffer[4..<8]
+  }
+}
+
+CollectionTypeTests.test("subscript(_: Range<Index>)/defaultImplementation/sliceTooSmall")
+  .crashOutputMatches("Cannot replace a slice of a MutableCollection with a slice of a smaller size")
+  .code {
+  var x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  expectCrashLater()
+  x.withUnsafeMutableBufferPointer { buffer in
+    buffer[2..<6] = buffer[6..<8]
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // isEmpty
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
- Explanation: error messages produced by the default implementation of `MutableCollection.subscript().set` were not correct.  The error detection was correct, just the message text was wrong.
- Scope of the issue: most `MutableCollection` implementations.
- Risk: low, only changes the error message.
- Reviewed by: @gribozavr.
- Testing: new regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
