### PR TITLE
[swiftc] Add test case for crash triggered in swift::ArchetypeBuilder::addSuperclassRequirement(…)

### DIFF
--- a/validation-test/compiler_crashers/28294-swift-archetypebuilder-addsuperclassrequirement.swift
+++ b/validation-test/compiler_crashers/28294-swift-archetypebuilder-addsuperclassrequirement.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+func a{
+struct B<a{
+protocol A{
+typealias e:AnyObject,b}
+class b:T
+class T


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/Module.cpp:922: Optional<swift::ProtocolConformanceRef> swift::ModuleDecl::lookupConformance(swift::Type, swift::ProtocolDecl *, swift::LazyResolver *): Assertion `inheritedConformance && "We already found the inherited conformance"' failed.
11 swift           0x0000000000fd0afc swift::ArchetypeBuilder::addSuperclassRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::Type, swift::RequirementSource) + 188
14 swift           0x0000000000fd260f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
15 swift           0x0000000000fd062a swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
16 swift           0x0000000000fd09b7 swift::ArchetypeBuilder::addConformanceRequirement(swift::ArchetypeBuilder::PotentialArchetype*, swift::ProtocolDecl*, swift::RequirementSource, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 471
19 swift           0x0000000000fd260f swift::ArchetypeBuilder::visitInherited(llvm::ArrayRef<swift::TypeLoc>, llvm::function_ref<bool (swift::Type, swift::SourceLoc)>) + 175
20 swift           0x0000000000fd062a swift::ArchetypeBuilder::addAbstractTypeParamRequirements(swift::AbstractTypeParamDecl*, swift::ArchetypeBuilder::PotentialArchetype*, swift::RequirementSource::Kind, llvm::SmallPtrSetImpl<swift::ProtocolDecl*>&) + 426
21 swift           0x0000000000fd0455 swift::ArchetypeBuilder::addGenericParameterRequirements(swift::GenericTypeParamDecl*) + 165
22 swift           0x0000000000ed4b17 swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 375
23 swift           0x0000000000ed6217 swift::TypeChecker::validateGenericSignature(swift::GenericParamList*, swift::DeclContext*, swift::GenericSignature*, std::function<bool (swift::ArchetypeBuilder&)>, bool&) + 135
24 swift           0x0000000000ed65b6 swift::TypeChecker::validateGenericTypeSignature(swift::GenericTypeDecl*) + 102
25 swift           0x0000000000e99e1e swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1630
30 swift           0x0000000000e9edc6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000f0217a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
34 swift           0x0000000000f01fde swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
35 swift           0x0000000000f02ba3 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
37 swift           0x0000000000ec0c31 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1249
38 swift           0x0000000000c57d19 swift::CompilerInstance::performSema() + 3289
40 swift           0x00000000007d6a5f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
41 swift           0x00000000007a2aa8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28294-swift-archetypebuilder-addsuperclassrequirement.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28294-swift-archetypebuilder-addsuperclassrequirement-c14518.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28294-swift-archetypebuilder-addsuperclassrequirement.swift:10:1
2.  While type-checking 'B' at validation-test/compiler_crashers/28294-swift-archetypebuilder-addsuperclassrequirement.swift:11:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
