### PR TITLE
[stdlib] @available attributes for intervals

### DIFF
--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -613,3 +613,12 @@ extension Range {
     Builtin.unreachable()
   }
 }
+
+@available(*, unavailable, message: "IntervalType has been removed in Swift 3. Use ranges instead.")
+public typealias IntervalType = Void
+
+@available(*, unavailable, renamed: "Range")
+public struct HalfOpenInterval<Bound> {}
+
+@available(*, unavailable, renamed: "ClosedRange")
+public struct ClosedInterval<Bound> {}


### PR DESCRIPTION
- Explanation: `IntervalType` protocol as well as `HalfOpenInterval` and `ClosedInterval` types have been removed from the standard library in favor of ranges. However no guidance is provided for the existing code that uses those removed types. This patch provides the necessary `@available` attributes.
- Scope of Issue: Purely additive.
- Origination: Omission during the new collections indexing model implementation.
- Risk: None
- Reviewed By: Dmitri Gribenko
- Testing: tested in REPL
- Directions for QA: N/A
