### PR TITLE
rdar://problem/26396895 Clang importer: Fix the 'self' type of imported ObjC generic members.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3630,16 +3630,16 @@ namespace {
       // Add the implicit 'self' parameter patterns.
       SmallVector<ParameterList *, 4> bodyParams;
       auto selfVar =
-        ParamDecl::createUnboundSelf(SourceLoc(), dc, /*isStatic*/!isInstance);
+        ParamDecl::createSelf(SourceLoc(), dc, /*isStatic*/!isInstance);
       bodyParams.push_back(ParameterList::createWithoutLoc(selfVar));
-      Type selfInterfaceType;
+      Type selfContextType;
       if (dc->getAsProtocolOrProtocolExtensionContext()) {
-        selfInterfaceType = dc->getProtocolSelf()->getArchetype();
+        selfContextType = dc->getProtocolSelf()->getArchetype();
       } else {
-        selfInterfaceType = dc->getDeclaredInterfaceType();
+        selfContextType = dc->getDeclaredTypeInContext();
       }
       if (!isInstance) {
-        selfInterfaceType = MetatypeType::get(selfInterfaceType);
+        selfContextType = MetatypeType::get(selfContextType);
       }
 
       SpecialMethodKind kind = SpecialMethodKind::Regular;
@@ -3722,7 +3722,7 @@ namespace {
       }
 
       // Add the 'self' parameter to the function type.
-      type = FunctionType::get(selfInterfaceType, type);
+      type = FunctionType::get(selfContextType, type);
 
       if (auto proto = dyn_cast<ProtocolDecl>(dc)) {
         std::tie(type, interfaceType)

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -37,6 +37,21 @@ public func genericPropertyOnAnyObject(o: AnyObject, b: Bool) -> AnyObject?? {
   return o.propertyThing
 }
 
+protocol ThingHolder {
+  associatedtype Thing
+
+  init!(thing: Thing!)
+  func thing() -> Thing?
+  func arrayOfThings() -> [Thing]
+  func setArrayOfThings(_: [Thing])
+  static func classThing() -> Thing?
+
+  var propertyThing: Thing? { get set }
+  var propertyArrayOfThings: [Thing]? { get set }
+}
+
+extension GenericClass: ThingHolder {}
+
 // CHECK-LABEL: sil @_TF21objc_imported_generic26genericPropertyOnAnyObject
 // CHECK:         dynamic_method_br %4 : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
 // CHECK:       bb1({{%.*}} : $@convention(objc_method) (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):


### PR DESCRIPTION
A variable was called `selfInterfaceType` even though it was inconsistently set to a contextual Self archetype for protocols, and an interface type for nominal types, and the one place we used the type expected to work with contextual types. Fixes rdar://problem/26396895.
