### PR TITLE
Ignore fixits for adding objc(selector) when doing migration, and fixits for mismatch label in overridden method

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -563,6 +563,11 @@ private:
       Info.ID == diag::missing_argument_labels.ID ||
       Info.ID == diag::override_argument_name_mismatch.ID)
       return false;
+    // This also interacts badly with the swift migrator, it unnecessary adds
+    // @objc(selector) attributes triggered by the mismatched label changes.
+    if (Info.ID == diag::objc_witness_selector_mismatch.ID ||
+        Info.ID == diag::witness_non_objc.ID)
+      return false;
 
     if (Kind == DiagnosticKind::Error)
       return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -560,7 +560,8 @@ private:
     // The following interact badly with the swift migrator, they are undoing
     // migration of arguments to preserve the no-label for first argument.
     if (Info.ID == diag::witness_argument_name_mismatch.ID ||
-      Info.ID == diag::missing_argument_labels.ID)
+      Info.ID == diag::missing_argument_labels.ID ||
+      Info.ID == diag::override_argument_name_mismatch.ID)
       return false;
 
     if (Kind == DiagnosticKind::Error)

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -86,5 +86,8 @@ class Test2 : SomeProt {
   func instMeth(p: Int) {}
   func instMeth2(p: Int, p2: Int) {}
 }
+class SubTest2 : Test2 {
+  override func instMeth(_ p: Int) {}
+}
 Test2().instMeth(0)
 Test2().instMeth2(0, p2:1)

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -80,11 +80,18 @@ func ftest2(x x: Int -> Int) {}
 protocol SomeProt {
   func protMeth(p: Int)
 }
-class Test2 : SomeProt {
+@objc protocol SomeObjCProt {
+  func objcprotMeth(p: Int)
+}
+class Test2 : SomeProt, SomeObjCProt {
   func protMeth(_ p: Int) {}
 
   func instMeth(p: Int) {}
   func instMeth2(p: Int, p2: Int) {}
+  func objcprotMeth(_ p: Int) {}
+}
+@objc class Test3 : SomeObjCProt {
+  func objcprotMeth(_ p: Int) {}
 }
 class SubTest2 : Test2 {
   override func instMeth(_ p: Int) {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -83,11 +83,18 @@ func ftest2(x: (Int) -> Int) {}
 protocol SomeProt {
   func protMeth(p: Int)
 }
-class Test2 : SomeProt {
+@objc protocol SomeObjCProt {
+  func objcprotMeth(p: Int)
+}
+class Test2 : SomeProt, SomeObjCProt {
   func protMeth(_ p: Int) {}
 
   func instMeth(p: Int) {}
   func instMeth2(p: Int, p2: Int) {}
+  func objcprotMeth(_ p: Int) {}
+}
+@objc class Test3 : SomeObjCProt {
+  func objcprotMeth(_ p: Int) {}
 }
 class SubTest2 : Test2 {
   override func instMeth(_ p: Int) {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -89,5 +89,8 @@ class Test2 : SomeProt {
   func instMeth(p: Int) {}
   func instMeth2(p: Int, p2: Int) {}
 }
+class SubTest2 : Test2 {
+  override func instMeth(_ p: Int) {}
+}
 Test2().instMeth(0)
 Test2().instMeth2(0, p2:1)


### PR DESCRIPTION
#### What's in this pull request?

When picking-up fixits for migration ignore the fixits for adding @objc(selector).

These interact badly with the swift migrator, they are triggered by label mismatches in pre-migrated code.

We also don't generally need them since we do inference for the most common cases. The case where the inference may not work is un-idiomatic and rare (you would have the conforming method in the class but the protocol would show up in an extension in a different file instead of in the class.

Also ignore another diagnostic that is ‘correcting’ argument labels
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26508866

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
