### PR TITLE
[SIL] Don't assume we always have an associated DeclContext. (#2730)

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2304,9 +2304,11 @@ static bool isNullableTypeInC(SILModule &M, Type ty) {
     return true;
 
   // Other types like UnsafePointer can also be nullable.
+  const DeclContext *DC = M.getAssociatedContext();
+  if (!DC)
+    DC = M.getSwiftModule();
   ty = OptionalType::get(ty);
-  return ty->isTriviallyRepresentableIn(ForeignLanguage::C,
-                                        M.getAssociatedContext());
+  return ty->isTriviallyRepresentableIn(ForeignLanguage::C, DC);
 }
 
 /// Determine whether the given declaration returns a non-optional object that

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -217,8 +217,7 @@ protected:
     // If a vtable or witness table (method) is only visible in another module
     // it can be accessed inside that module and we don't see this access.
     // We hit this case e.g. if a table is imported from the stdlib.
-    if (decl->getDeclContext()->getParentModule() !=
-        Module->getAssociatedContext()->getParentModule())
+    if (decl->getDeclContext()->getParentModule() != Module->getSwiftModule())
       return true;
 
     return false;

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -338,7 +338,7 @@ static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
 // be analyzed by this pass.
 static bool mayHaveUnknownUses(VarDecl *Property, SILModule *Module) {
   if (Property->getDeclContext()->getParentModule() !=
-      Module->getAssociatedContext()->getParentModule()) {
+      Module->getSwiftModule()) {
     DEBUG(llvm::dbgs() << "Property " << *Property
                        << " is defined in a different module\n");
     // We don't see the bodies of initializers from a different module

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1817,6 +1817,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // serialize everything.
   // FIXME: Resilience: could write out vtable for fragile classes.
   const DeclContext *assocDC = SILMod->getAssociatedContext();
+  assert(assocDC && "cannot serialize SIL without an associated DeclContext");
   for (const SILVTable &vt : SILMod->getVTables()) {
     if (ShouldSerializeAll &&
         vt.getClass()->isChildContextOf(assocDC))

--- a/test/Interpreter/SDK/Cocoa_repl.swift
+++ b/test/Interpreter/SDK/Cocoa_repl.swift
@@ -18,3 +18,14 @@ extension CGRect: Q {
 
 (CGRect() as Any as! Q).foo()
 // CHECK: (0.0, 0.0, 0.0, 0.0)
+
+// Test the "mayLieAboutNonOptionalReturn" hack for both imported and
+// non-imported types.
+struct Empty {}
+let _: Optional = Empty()
+// CHECK: Optional(REPL.Empty())
+let _: Optional = CGPoint.zero
+// CHECK: Optional((0.0, 0.0))
+let _: Optional = NSString.availableStringEncodings()
+// CHECK: Optional(0x{{[0-9a-fA-F]+}})
+


### PR DESCRIPTION
- **Explanation:** A recently-changed bit of handling for imported methods “lying” about returning non-nullable pointers would crash in the integrated REPL.
- **Scope:** Only the integrated REPL.
- **Issue:** rdar://problem/26476281. Reviewed by @jckarter.
- **Risk:** Low. Adds fallbacks or uses safer constructs in some code paths.
- **Testing:** Added a compiler regression test.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
