### PR TITLE
Reflection fixes for closures and imported types (3.0)

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -104,14 +104,25 @@ struct FieldRecordIterator {
 };
 
 enum class FieldDescriptorKind : uint16_t {
+  // Swift nominal types.
   Struct,
   Class,
   Enum,
+
+  // A Swift opaque protocol. There are no fields, just a record for the
+  // type itself.
   Protocol,
+
+  // A Swift class-bound protocol.
   ClassProtocol,
+
+  // An Objective-C protocol, which may be imported or defined in Swift.
   ObjCProtocol,
-  ObjCClass,
-  Imported
+
+  // An Objective-C class, which may be imported or defined in Swift.
+  // In the former case, field type metadata is not emitted, and
+  // must be obtained from the Objective-C runtime.
+  ObjCClass
 };
 
 // Field descriptors contain a collection of field records for a single

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -773,7 +773,7 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
                     classTI.getLayout(*this, selfType),
                     classTI.getClassLayout(*this, selfType));
   emitNestedTypeDecls(D->getMembers());
-  emitReflectionMetadata(D);
+  emitFieldMetadataRecord(D);
 }
 
 namespace {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2053,6 +2053,8 @@ llvm::Constant *IRGenModule::emitProtocolConformances() {
 
   SmallVector<llvm::Constant*, 8> elts;
   for (auto *conformance : ProtocolConformances) {
+    emitAssociatedTypeMetadataRecord(conformance);
+
     auto descriptorRef = getAddrOfLLVMVariableOrGOTEquivalent(
                   LinkEntity::forProtocolDescriptor(conformance->getProtocol()),
                   getPointerAlignment(), ProtocolDescriptorStructTy);
@@ -2755,7 +2757,6 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 }
 
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
-  emitAssociatedTypeMetadataRecord(ext);
   emitNestedTypeDecls(ext->getMembers());
 
   // Generate a category if the extension either introduces a

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5562,7 +5562,7 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
   emitEnumMetadata(*this, theEnum);
   emitNestedTypeDecls(theEnum->getMembers());
-  emitReflectionMetadata(theEnum);
+  emitFieldMetadataRecord(theEnum);
 }
 
 void irgen::emitSwitchAddressOnlyEnumDispatch(IRGenFunction &IGF,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1386,7 +1386,7 @@ public:
 
   /// Allocate a box of the given type.
   virtual OwnedAddress
-  allocate(IRGenFunction &IGF, SILType boxedType,
+  allocate(IRGenFunction &IGF, SILType boxedType, SILType boxedInterfaceType,
            const llvm::Twine &name) const = 0;
 
   /// Deallocate an uninitialized box.
@@ -1404,7 +1404,7 @@ public:
   EmptyBoxTypeInfo(IRGenModule &IGM) : BoxTypeInfo(IGM) {}
 
   OwnedAddress
-  allocate(IRGenFunction &IGF, SILType boxedType,
+  allocate(IRGenFunction &IGF, SILType boxedType, SILType boxedInterfaceType,
            const llvm::Twine &name) const override {
     return OwnedAddress(IGF.getTypeInfo(boxedType).getUndefAddress(),
                         IGF.IGM.RefCountedNull);
@@ -1429,7 +1429,7 @@ public:
   NonFixedBoxTypeInfo(IRGenModule &IGM) : BoxTypeInfo(IGM) {}
 
   OwnedAddress
-  allocate(IRGenFunction &IGF, SILType boxedType,
+  allocate(IRGenFunction &IGF, SILType boxedType, SILType boxedInterfaceType,
            const llvm::Twine &name) const override {
     auto &ti = IGF.getTypeInfo(boxedType);
     // Use the runtime to allocate a box of the appropriate size.
@@ -1470,14 +1470,15 @@ public:
   {}
 
   OwnedAddress
-  allocate(IRGenFunction &IGF, SILType boxedType, const llvm::Twine &name)
+  allocate(IRGenFunction &IGF, SILType boxedType, SILType boxedInterfaceType,
+           const llvm::Twine &name)
   const override {
     // Allocate a new object using the layout.
 
-    auto nullCaptureDescriptor
-      = llvm::ConstantPointerNull::get(IGF.IGM.CaptureDescriptorPtrTy);
+    auto boxDescriptor = IGF.IGM.getAddrOfBoxDescriptor(
+        boxedInterfaceType.getSwiftRValueType());
     llvm::Value *allocation = IGF.emitUnmanagedAlloc(layout, name,
-                                                     nullCaptureDescriptor);
+                                                     boxDescriptor);
     Address rawAddr = project(IGF, allocation, boxedType);
     return {rawAddr, allocation};
   }
@@ -1586,9 +1587,13 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
 
 OwnedAddress
 irgen::emitAllocateBox(IRGenFunction &IGF, CanSILBoxType boxType,
+                       CanSILBoxType boxInterfaceType,
                        const llvm::Twine &name) {
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
-  return boxTI.allocate(IGF, boxType->getBoxedAddressType(), name);
+  return boxTI.allocate(IGF,
+                        boxType->getBoxedAddressType(),
+                        boxInterfaceType->getBoxedAddressType(),
+                        name);
 }
 
 void irgen::emitDeallocateBox(IRGenFunction &IGF,

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -116,8 +116,12 @@ void emitDeallocatePartialClassInstance(IRGenFunction &IGF,
                                         llvm::Value *alignMask);
 
 /// Allocate a boxed value.
+///
+/// The interface type is required for emitting reflection metadata.
 OwnedAddress
-emitAllocateBox(IRGenFunction &IGF, CanSILBoxType boxType,
+emitAllocateBox(IRGenFunction &IGF,
+                CanSILBoxType boxType,
+                CanSILBoxType boxInterfaceType,
                 const llvm::Twine &name);
 
 /// Deallocate a box whose value is uninitialized.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5690,7 +5690,7 @@ void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
   var->setConstant(true);
   var->setInitializer(init);
 
-  emitReflectionMetadata(protocol);
+  emitFieldMetadataRecord(protocol);
 }
 
 /// \brief Load a reference to the protocol descriptor for the given protocol.

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -819,7 +819,6 @@ IRGenModule::getAddrOfBoxDescriptor(CanType BoxedType) {
   if (!IRGen.Opts.EnableReflectionMetadata)
     return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);
 
-  llvm::SetVector<CanType> BuiltinTypes;
   BoxDescriptorBuilder builder(*this, BuiltinTypes, BoxedType);
 
   auto var = builder.emit();
@@ -838,7 +837,6 @@ IRGenModule::getAddrOfCaptureDescriptor(SILFunction &Caller,
   if (!IRGen.Opts.EnableReflectionMetadata)
     return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);
 
-  llvm::SetVector<CanType> BuiltinTypes;
   CaptureDescriptorBuilder builder(*this, BuiltinTypes, Caller,
                                    OrigCalleeType, SubstCalleeType, Subs,
                                    Layout);

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -240,12 +240,17 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
       return false;
     };
 
+    Conformance->forEachTypeWitness(/*resolver*/ nullptr, collectTypeWitness);
+
+    // If there are no associated types, don't bother emitting any
+    // metadata.
+    if (AssociatedTypes.empty())
+      return;
+
     addTypeRef(ModuleContext, ConformingType);
 
     auto ProtoTy = Conformance->getProtocol()->getDeclaredType();
     addTypeRef(ModuleContext, ProtoTy->getCanonicalType());
-
-    Conformance->forEachTypeWitness(/*resolver*/ nullptr, collectTypeWitness);
 
     addConstantInt32(AssociatedTypes.size());
     addConstantInt32(AssociatedTypeRecordSize);

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -830,7 +830,7 @@ irgen::getPhysicalStructMemberAccessStrategy(IRGenModule &IGM,
 void IRGenModule::emitStructDecl(StructDecl *st) {
   emitStructMetadata(*this, st);
   emitNestedTypeDecls(st->getMembers());
-  emitReflectionMetadata(st);
+  emitFieldMetadataRecord(st);
 }
 
 namespace {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -617,6 +617,8 @@ public:
                                 llvm::Function *fn);
   llvm::Constant *emitProtocolConformances();
   llvm::Constant *emitTypeMetadataRecords();
+
+  // Remote reflection metadata
   void emitReflectionMetadata(const NominalTypeDecl *Decl);
   void emitAssociatedTypeMetadataRecord(const NominalTypeDecl *Decl);
   void emitAssociatedTypeMetadataRecord(const ExtensionDecl *Ext);
@@ -628,7 +630,8 @@ public:
                                              CanSILFunctionType origCalleeType,
                                              CanSILFunctionType substCalleeType,
                                              ArrayRef<Substitution> subs,
-                                             HeapLayout &layout);
+                                             const HeapLayout &layout);
+  llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
   std::string getBuiltinTypeMetadataSectionName();
   std::string getFieldTypeMetadataSectionName();
   std::string getAssociatedTypeMetadataSectionName();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -717,6 +717,9 @@ public:
   /// Imported classes referenced by types in this module when emitting
   /// reflection metadata.
   llvm::SetVector<ClassDecl *> ImportedClasses;
+  /// Imported protocols referenced by types in this module when emitting
+  /// reflection metadata.
+  llvm::SetVector<ProtocolDecl *> ImportedProtocols;
 
   llvm::Constant *getAddrOfStringForTypeRef(StringRef Str);
   llvm::Constant *getAddrOfFieldName(StringRef Name);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -730,9 +730,7 @@ public:
                                              const HeapLayout &layout);
   llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
 
-  void emitReflectionMetadata(const NominalTypeDecl *Decl);
-  void emitAssociatedTypeMetadataRecord(const NominalTypeDecl *Decl);
-  void emitAssociatedTypeMetadataRecord(const ExtensionDecl *Ext);
+  void emitAssociatedTypeMetadataRecord(const ProtocolConformance *Conformance);
   void emitFieldMetadataRecord(const NominalTypeDecl *Decl);
   void emitBuiltinReflectionMetadata();
   std::string getBuiltinTypeMetadataSectionName();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -618,27 +618,6 @@ public:
   llvm::Constant *emitProtocolConformances();
   llvm::Constant *emitTypeMetadataRecords();
 
-  // Remote reflection metadata
-  void emitReflectionMetadata(const NominalTypeDecl *Decl);
-  void emitAssociatedTypeMetadataRecord(const NominalTypeDecl *Decl);
-  void emitAssociatedTypeMetadataRecord(const ExtensionDecl *Ext);
-  void emitFieldMetadataRecord(const NominalTypeDecl *Decl);
-  void emitBuiltinReflectionMetadata();
-  llvm::Constant *getAddrOfStringForTypeRef(StringRef Str);
-  llvm::Constant *getAddrOfFieldName(StringRef Name);
-  llvm::Constant *getAddrOfCaptureDescriptor(SILFunction &caller,
-                                             CanSILFunctionType origCalleeType,
-                                             CanSILFunctionType substCalleeType,
-                                             ArrayRef<Substitution> subs,
-                                             const HeapLayout &layout);
-  llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
-  std::string getBuiltinTypeMetadataSectionName();
-  std::string getFieldTypeMetadataSectionName();
-  std::string getAssociatedTypeMetadataSectionName();
-  std::string getCaptureDescriptorMetadataSectionName();
-  std::string getReflectionStringsSectionName();
-  std::string getReflectionTypeRefSectionName();
-
   llvm::Constant *getOrCreateHelperFunction(StringRef name,
                                             llvm::Type *resultType,
                                             ArrayRef<llvm::Type*> paramTypes,
@@ -690,9 +669,6 @@ private:
   SmallVector<NormalProtocolConformance *, 4> ProtocolConformances;
   /// List of nominal types to generate type metadata records for.
   SmallVector<CanType, 4> RuntimeResolvableTypes;
-  /// Builtin types referenced by types in this module when emitting
-  /// reflection metadata.
-  llvm::SetVector<CanType> BuiltinTypes;
   /// List of ExtensionDecls corresponding to the generated
   /// categories.
   SmallVector<ExtensionDecl*, 4> ObjCCategoryDecls;
@@ -732,6 +708,36 @@ private:
   void emitGlobalLists();
   void emitAutolinkInfo();
   void cleanupClangCodeGenMetadata();
+
+//--- Remote reflection metadata --------------------------------------------
+public:
+  /// Builtin types referenced by types in this module when emitting
+  /// reflection metadata.
+  llvm::SetVector<CanType> BuiltinTypes;
+  /// Imported classes referenced by types in this module when emitting
+  /// reflection metadata.
+  llvm::SetVector<ClassDecl *> ImportedClasses;
+
+  llvm::Constant *getAddrOfStringForTypeRef(StringRef Str);
+  llvm::Constant *getAddrOfFieldName(StringRef Name);
+  llvm::Constant *getAddrOfCaptureDescriptor(SILFunction &caller,
+                                             CanSILFunctionType origCalleeType,
+                                             CanSILFunctionType substCalleeType,
+                                             ArrayRef<Substitution> subs,
+                                             const HeapLayout &layout);
+  llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
+
+  void emitReflectionMetadata(const NominalTypeDecl *Decl);
+  void emitAssociatedTypeMetadataRecord(const NominalTypeDecl *Decl);
+  void emitAssociatedTypeMetadataRecord(const ExtensionDecl *Ext);
+  void emitFieldMetadataRecord(const NominalTypeDecl *Decl);
+  void emitBuiltinReflectionMetadata();
+  std::string getBuiltinTypeMetadataSectionName();
+  std::string getFieldTypeMetadataSectionName();
+  std::string getAssociatedTypeMetadataSectionName();
+  std::string getCaptureDescriptorMetadataSectionName();
+  std::string getReflectionStringsSectionName();
+  std::string getReflectionTypeRefSectionName();
 
 //--- Runtime ---------------------------------------------------------------
 public:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3589,7 +3589,11 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
 # endif
 
   auto boxTy = i->getType().castTo<SILBoxType>();
-  OwnedAddress boxWithAddr = emitAllocateBox(*this, boxTy, DbgName);
+  auto boxInterfaceTy = cast<SILBoxType>(
+      CurSILFn->mapTypeOutOfContext(boxTy)
+          ->getCanonicalType());
+  OwnedAddress boxWithAddr = emitAllocateBox(*this, boxTy, boxInterfaceTy,
+                                             DbgName);
   setLoweredBox(i, boxWithAddr);
 
   if (IGM.DebugInfo && Decl) {

--- a/test/Reflection/Inputs/ObjectiveCTypes.swift
+++ b/test/Reflection/Inputs/ObjectiveCTypes.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 
 public class OC : NSObject {
   public let nsObject: NSObject
@@ -26,7 +27,7 @@ public class GenericOC<T> : NSObject {
 public class HasObjCClasses {
   let url = NSURL()
   let integer = NSInteger()
-  let rect = NSRect(x: 0, y: 1, width: 2, height: 3)
+  let rect = CGRect(x: 0, y: 1, width: 2, height: 3)
 }
 
 public func closureHasObjCClasses(b: NSBundle, c: NSCoding) -> () -> () {

--- a/test/Reflection/Inputs/ObjectiveCTypes.swift
+++ b/test/Reflection/Inputs/ObjectiveCTypes.swift
@@ -26,6 +26,7 @@ public class GenericOC<T> : NSObject {
 public class HasObjCClasses {
   let url = NSURL()
   let integer = NSInteger()
+  let rect = NSRect(x: 0, y: 1, width: 2, height: 3)
 }
 
 public func closureHasObjCClasses(b: NSBundle) -> () -> () {

--- a/test/Reflection/Inputs/ObjectiveCTypes.swift
+++ b/test/Reflection/Inputs/ObjectiveCTypes.swift
@@ -28,3 +28,6 @@ public class HasObjCClasses {
   let integer = NSInteger()
 }
 
+public func closureHasObjCClasses(b: NSBundle) -> () -> () {
+  return { _ = b }
+}

--- a/test/Reflection/Inputs/ObjectiveCTypes.swift
+++ b/test/Reflection/Inputs/ObjectiveCTypes.swift
@@ -29,6 +29,6 @@ public class HasObjCClasses {
   let rect = NSRect(x: 0, y: 1, width: 2, height: 3)
 }
 
-public func closureHasObjCClasses(b: NSBundle) -> () -> () {
-  return { _ = b }
+public func closureHasObjCClasses(b: NSBundle, c: NSCoding) -> () -> () {
+  return { _ = b; _ = c }
 }

--- a/test/Reflection/Inputs/ObjectiveCTypes.swift
+++ b/test/Reflection/Inputs/ObjectiveCTypes.swift
@@ -2,26 +2,15 @@ import Foundation
 import CoreGraphics
 
 public class OC : NSObject {
-  public let nsObject: NSObject
-  public let nsString: NSString
-  public let cfString: CFString
-  public let aBlock: @convention(block) () -> ()
-  public init(nsObject: NSObject, nsString: NSString, cfString: CFString,
-              aBlock: @convention(block) () -> ()) {
-    self.nsObject = nsObject
-    self.nsString = nsString
-    self.cfString = cfString
-    self.aBlock = aBlock
-  }
+  public let nsObject: NSObject = NSObject()
+  public let nsString: NSString = ""
+  public let cfString: CFString = ""
+  public let aBlock: @convention(block) () -> () = {}
+  public let ocnss: GenericOC<NSString> = GenericOC()
+  public let occfs: GenericOC<CFString> = GenericOC()
 }
 
 public class GenericOC<T> : NSObject {
-  public let ocnss: GenericOC<NSString>
-  public let occfs: GenericOC<CFString>
-  public init(nss: GenericOC<NSString>, cfs: GenericOC<CFString>) {
-    self.ocnss = nss
-    self.occfs = cfs
-  }
 }
 
 public class HasObjCClasses {

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -1,0 +1,39 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift %s -emit-module -emit-library -module-name capture_descriptors -o %t/capture_descriptors.%target-dylib-extension
+// RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors.%target-dylib-extension | FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// CHECK:      CAPTURE DESCRIPTORS:
+// CHECK-NEXT: ====================
+
+class C<T> {}
+
+sil_vtable C {}
+
+sil @make_some_boxes : $@convention(thin) <T> () -> () {
+  %a = alloc_box $Int
+  %b = alloc_box $(Int, Int)
+  %c = alloc_box $C<T>
+  %result = tuple ()
+  return %result : $()
+}
+
+// CHECK:      - Capture types:
+// CHECK-NEXT: (struct Swift.Int)
+// CHECK-NEXT: - Metadata sources:
+
+// CHECK:      - Capture types:
+// CHECK-NEXT: (tuple
+// CHECK-NEXT:   (struct Swift.Int)
+// CHECK-NEXT:   (struct Swift.Int))
+// CHECK-NEXT: - Metadata sources:
+
+// CHECK:      - Capture types:
+// CHECK-NEXT: (bound_generic_class capture_descriptors.C
+// CHECK-NEXT:   (generic_type_parameter depth=0 index=0))
+// CHECK-NEXT: - Metadata sources:

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -30,6 +30,12 @@ bb0(%i: $Int, %p: $@thick P.Type):
   return %c : $@callee_owned () -> ()
 }
 
+// This is the descriptor for '@box Int' above
+
+// CHECK:      - Capture types:
+// CHECK-NEXT: (struct Swift.Int)
+// CHECK-NEXT: - Metadata sources:
+
 // CHECK:      - Capture types:
 // CHECK-NEXT: (struct Swift.Int)
 // CHECK-NEXT: (sil_box
@@ -59,6 +65,12 @@ bb0:
   dealloc_stack %i : $*Int
   return %c : $@callee_owned () -> ()
 }
+
+// This is the descriptor for '@box String' above
+
+// CHECK:      - Capture types:
+// CHECK-NEXT: (struct Swift.String)
+// CHECK-NEXT: - Metadata sources:
 
 // CHECK:      - Capture types:
 // CHECK-NEXT: (struct Swift.Int)

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -582,15 +582,10 @@
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
-// CHECK: - TypesToReflect.Box : Swift.AnyObject
-// CHECK: - TypesToReflect.C : Swift.AnyObject
-// CHECK: - TypesToReflect.C1 : Swift.AnyObject
 // CHECK: - TypesToReflect.C1 : TypesToReflect.ClassBoundP
 // CHECK: typealias Inner = A
 // CHECK: (generic_type_parameter depth=0 index=0)
 
-// CHECK: - TypesToReflect.C2 : Swift.AnyObject
-// CHECK: - TypesToReflect.C3 : Swift.AnyObject
 // CHECK: - TypesToReflect.C4 : TypesToReflect.P1
 // CHECK: typealias Inner = A
 // CHECK: (generic_type_parameter depth=0 index=0)

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -594,14 +594,6 @@
 // CHECK: typealias Outer = A
 // CHECK: (generic_type_parameter depth=0 index=0)
 
-// CHECK: - TypesToReflect.C4 : TypesToReflect.P1
-// CHECK: typealias Inner = A
-// CHECK: (generic_type_parameter depth=0 index=0)
-
-// CHECK: - TypesToReflect.C4 : TypesToReflect.P2
-// CHECK: typealias Outer = A
-// CHECK: (generic_type_parameter depth=0 index=0)
-
 // CHECK: - TypesToReflect.S4 : TypesToReflect.P1
 // CHECK: typealias Inner = A
 // CHECK: (generic_type_parameter depth=0 index=0)
@@ -609,29 +601,6 @@
 // CHECK: - TypesToReflect.S4 : TypesToReflect.P2
 // CHECK: typealias Outer = A
 // CHECK: (generic_type_parameter depth=0 index=0)
-
-// CHECK: - TypesToReflect.S4 : TypesToReflect.P1
-// CHECK: typealias Inner = A
-// CHECK: (generic_type_parameter depth=0 index=0)
-
-// CHECK: - TypesToReflect.S4 : TypesToReflect.P2
-// CHECK: typealias Outer = A
-// CHECK: (generic_type_parameter depth=0 index=0)
-
-// CHECK: - TypesToReflect.E4 : TypesToReflect.P1
-// CHECK: typealias Inner = A
-// CHECK: (generic_type_parameter depth=0 index=0)
-
-// CHECK: - TypesToReflect.E4 : TypesToReflect.P2
-// CHECK: typealias Outer = B
-// CHECK: (generic_type_parameter depth=0 index=1)
-
-// CHECK: - TypesToReflect.E4 : TypesToReflect.P3
-// CHECK: typealias First = A
-// CHECK: (generic_type_parameter depth=0 index=0)
-
-// CHECK: typealias Second = B
-// CHECK: (generic_type_parameter depth=0 index=1)
 
 // CHECK: - TypesToReflect.E4 : TypesToReflect.P1
 // CHECK: typealias Inner = A

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -18,15 +18,6 @@
 // CHECK-32: mcsbf: __C.MyCStructWithBitfields
 // CHECK-32: (struct __C.MyCStructWithBitfields)
 
-// CHECK-32: __C.MyCStruct
-// CHECK-32: -------------
-// CHECK-32: __C.MyCEnum
-// CHECK-32: -----------
-// CHECK-32: __C.MyCUnion
-// CHECK-32: ------------
-// CHECK-32: __C.MyCStructWithBitfields
-// CHECK-32: --------------------------
-
 // CHECK-32: ASSOCIATED TYPES:
 // CHECK-32: =================
 
@@ -82,15 +73,6 @@
 
 // CHECK-64: mcsbf: __C.MyCStructWithBitfields
 // CHECK-64: (struct __C.MyCStructWithBitfields)
-
-// CHECK-64: __C.MyCStruct
-// CHECK-64: -------------
-// CHECK-64: __C.MyCEnum
-// CHECK-64: -----------
-// CHECK-64: __C.MyCUnion
-// CHECK-64: ------------
-// CHECK-64: __C.MyCStructWithBitfields
-// CHECK-64: --------------------------
 
 // CHECK-64: ASSOCIATED TYPES:
 // CHECK-64: =================

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -45,6 +45,8 @@
 // CHECK: ---------------
 // CHECK: __ObjC.NSURL
 // CHECK: ------------
+// CHECK: __ObjC.NSCoding
+// CHECK: ---------------
 
 // CHECK: ASSOCIATED TYPES:
 // CHECK: =================
@@ -70,6 +72,23 @@
 // CHECK: - Capture types:
 // CHECK: (function
 // CHECK:   (tuple))
+// CHECK: - Metadata sources:
+
+// CHECK: - Capture types:
+// CHECK: (struct Swift.StaticString)
+// CHECK: (struct Swift.StaticString)
+// CHECK: (struct Swift.UInt)
+// CHECK: (struct Swift.UInt)
+// CHECK: - Metadata sources:
+
+// CHECK: - Capture types:
+// CHECK: (function
+// CHECK:   (tuple))
+// CHECK: - Metadata sources:
+
+// CHECK: - Capture types:
+// CHECK: (class __ObjC.NSBundle)
+// CHECK: (protocol __ObjC.NSCoding)
 // CHECK: - Metadata sources:
 
 // CHECK: - Capture types:

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -28,17 +28,11 @@
 // CHECK-32: BUILTIN TYPES:
 // CHECK-32: ==============
 
-// CHECK-32: - __ObjC.NSBundle:
-// CHECK-32: Size: 4
-// CHECK-32: Alignment: 4
-// CHECK-32: Stride: 4
-// CHECK-32: NumExtraInhabitants: 4096
-
-// CHECK-32: - __ObjC.NSURL:
-// CHECK-32: Size: 4
-// CHECK-32: Alignment: 4
-// CHECK-32: Stride: 4
-// CHECK-32: NumExtraInhabitants: 4096
+// CHECK-32: - __C.CGRect:
+// CHECK-32: Size: 32
+// CHECK-32: Alignment: 8
+// CHECK-32: Stride: 32
+// CHECK-32: NumExtraInhabitants: 0
 
 // CHECK-32: CAPTURE DESCRIPTORS:
 // CHECK-32: ====================
@@ -108,17 +102,11 @@
 // CHECK-64: BUILTIN TYPES:
 // CHECK-64: ==============
 
-// CHECK-64: - __ObjC.NSBundle:
-// CHECK-64: Size: 8
+// CHECK-64: - __C.CGRect:
+// CHECK-64: Size: 32
 // CHECK-64: Alignment: 8
-// CHECK-64: Stride: 8
-// CHECK-64: NumExtraInhabitants: 2147483647
-
-// CHECK-64: - __ObjC.NSURL:
-// CHECK-64: Size: 8
-// CHECK-64: Alignment: 8
-// CHECK-64: Stride: 8
-// CHECK-64: NumExtraInhabitants: 2147483647
+// CHECK-64: Stride: 32
+// CHECK-64: NumExtraInhabitants: 0
 
 // CHECK-64: CAPTURE DESCRIPTORS:
 // CHECK-64: ====================

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -20,8 +20,6 @@
 // CHECK: (function convention=block
 // CHECK:   (tuple))
 
-// CHECK: TypesToReflect.GenericOC
-// CHECK: ------------------------
 // CHECK: ocnss: TypesToReflect.GenericOC<__ObjC.NSString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
 // CHECK:   (class __ObjC.NSString))
@@ -29,6 +27,9 @@
 // CHECK: occfs: TypesToReflect.GenericOC<__ObjC.CFString>
 // CHECK: (bound_generic_class TypesToReflect.GenericOC
 // CHECK:   (class __ObjC.CFString))
+
+// CHECK: TypesToReflect.GenericOC
+// CHECK: ------------------------
 
 // CHECK: TypesToReflect.HasObjCClasses
 // CHECK: -----------------------------
@@ -60,65 +61,16 @@
 // CHECK-32: Stride: 16
 // CHECK-32: NumExtraInhabitants: 0
 
+// CHECK-64: - __C.CGRect:
 // CHECK-64: Size: 32
 // CHECK-64: Alignment: 8
 // CHECK-64: Stride: 32
 // CHECK-64: NumExtraInhabitants: 0
 
-// CHECK: CAPTURE DESCRIPTORS:
-// CHECK: ====================
-// CHECK: - Capture types:
-// CHECK: (struct Swift.StaticString)
-// CHECK: (struct Swift.StaticString)
-// CHECK: (struct Swift.UInt)
-// CHECK: (struct Swift.UInt)
-// CHECK: - Metadata sources:
+// CHECK:      CAPTURE DESCRIPTORS:
+// CHECK-NEXT: ====================
 
-// CHECK: - Capture types:
-// CHECK: (function
-// CHECK:   (tuple))
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (struct Swift.StaticString)
-// CHECK: (struct Swift.StaticString)
-// CHECK: (struct Swift.UInt)
-// CHECK: (struct Swift.UInt)
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (function
-// CHECK:   (tuple))
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (class __ObjC.NSBundle)
-// CHECK: (protocol __ObjC.NSCoding)
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (struct Swift.StaticString)
-// CHECK: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK:   (struct Swift.UInt8))
-// CHECK: (struct Swift.UInt)
-// CHECK: (struct Swift.UInt)
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (function
-// CHECK:   (tuple))
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK:   (struct Swift.UInt8))
-// CHECK: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK:   (struct Swift.UInt8))
-// CHECK: (struct Swift.UInt)
-// CHECK: (struct Swift.UInt)
-// CHECK: - Metadata sources:
-
-// CHECK: - Capture types:
-// CHECK: (function
-// CHECK:   (tuple))
-// CHECK: - Metadata sources:
+// CHECK:      - Capture types:
+// CHECK-NEXT: (class __ObjC.NSBundle)
+// CHECK-NEXT: (protocol __ObjC.NSCoding)
+// CHECK-NEXT: - Metadata sources:

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
 // REQUIRES: objc_interop
 
 // CHECK: FIELDS:
@@ -54,11 +54,16 @@
 // CHECK: BUILTIN TYPES:
 // CHECK: ==============
 
-// CHECK: - __C.CGRect:
-// CHECK: Size: 32
-// CHECK: Alignment: 8
-// CHECK: Stride: 32
-// CHECK: NumExtraInhabitants: 0
+// CHECK-32: - __C.CGRect:
+// CHECK-32: Size: 16
+// CHECK-32: Alignment: 4
+// CHECK-32: Stride: 16
+// CHECK-32: NumExtraInhabitants: 0
+
+// CHECK-64: Size: 32
+// CHECK-64: Alignment: 8
+// CHECK-64: Stride: 32
+// CHECK-64: NumExtraInhabitants: 0
 
 // CHECK: CAPTURE DESCRIPTORS:
 // CHECK: ====================

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -1,151 +1,100 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift %S/Inputs/ObjectiveCTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/libTypesToReflect.%target-dylib-extension
-// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-reflection-dump -binary-filename %t/libTypesToReflect.%target-dylib-extension | FileCheck %s --check-prefix=CHECK
 // REQUIRES: objc_interop
 
-// CHECK-32: FIELDS:
-// CHECK-32: =======
-// CHECK-32: TypesToReflect.OC
-// CHECK-32: -----------------
-// CHECK-32: TypesToReflect.GenericOC
-// CHECK-32: ------------------------
-// CHECK-32: TypesToReflect.HasObjCClasses
-// CHECK-32: -----------------------------
-// CHECK-32: url: __ObjC.NSURL
-// CHECK-32: (class __ObjC.NSURL)
+// CHECK: FIELDS:
+// CHECK: =======
+// CHECK: TypesToReflect.OC
+// CHECK: -----------------
+// CHECK: nsObject: __ObjC.NSObject
+// CHECK: (class __ObjC.NSObject)
 
-// CHECK-32: integer: Swift.Int
-// CHECK-32: (struct Swift.Int)
+// CHECK: nsString: __ObjC.NSString
+// CHECK: (class __ObjC.NSString)
 
-// CHECK-32: __ObjC.NSBundle
-// CHECK-32: ---------------
-// CHECK-32: __ObjC.NSURL
-// CHECK-32: ------------
+// CHECK: cfString: __ObjC.CFString
+// CHECK: (class __ObjC.CFString)
 
-// CHECK-32: ASSOCIATED TYPES:
-// CHECK-32: =================
+// CHECK: aBlock: @convention(block) () -> ()
+// CHECK: (function convention=block
+// CHECK:   (tuple))
 
-// CHECK-32: BUILTIN TYPES:
-// CHECK-32: ==============
+// CHECK: TypesToReflect.GenericOC
+// CHECK: ------------------------
+// CHECK: ocnss: TypesToReflect.GenericOC<__ObjC.NSString>
+// CHECK: (bound_generic_class TypesToReflect.GenericOC
+// CHECK:   (class __ObjC.NSString))
 
-// CHECK-32: - __C.CGRect:
-// CHECK-32: Size: 32
-// CHECK-32: Alignment: 8
-// CHECK-32: Stride: 32
-// CHECK-32: NumExtraInhabitants: 0
+// CHECK: occfs: TypesToReflect.GenericOC<__ObjC.CFString>
+// CHECK: (bound_generic_class TypesToReflect.GenericOC
+// CHECK:   (class __ObjC.CFString))
 
-// CHECK-32: CAPTURE DESCRIPTORS:
-// CHECK-32: ====================
-// CHECK-32: - Capture types:
-// CHECK-32: (struct Swift.StaticString)
-// CHECK-32: (struct Swift.StaticString)
-// CHECK-32: (struct Swift.UInt)
-// CHECK-32: (struct Swift.UInt)
-// CHECK-32: - Metadata sources:
+// CHECK: TypesToReflect.HasObjCClasses
+// CHECK: -----------------------------
+// CHECK: url: __ObjC.NSURL
+// CHECK: (class __ObjC.NSURL)
 
-// CHECK-32: - Capture types:
-// CHECK-32: (function
-// CHECK-32:   (tuple))
-// CHECK-32: - Metadata sources:
+// CHECK: integer: Swift.Int
+// CHECK: (struct Swift.Int)
 
-// CHECK-32: - Capture types:
-// CHECK-32: (struct Swift.StaticString)
-// CHECK-32: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK-32:   (struct Swift.UInt8))
-// CHECK-32: (struct Swift.UInt)
-// CHECK-32: (struct Swift.UInt)
-// CHECK-32: - Metadata sources:
+// CHECK: rect: __C.CGRect
+// CHECK: (struct __C.CGRect)
 
-// CHECK-32: - Capture types:
-// CHECK-32: (function
-// CHECK-32:   (tuple))
-// CHECK-32: - Metadata sources:
+// CHECK: __ObjC.NSBundle
+// CHECK: ---------------
+// CHECK: __ObjC.NSURL
+// CHECK: ------------
 
-// CHECK-32: - Capture types:
-// CHECK-32: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK-32:   (struct Swift.UInt8))
-// CHECK-32: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK-32:   (struct Swift.UInt8))
-// CHECK-32: (struct Swift.UInt)
-// CHECK-32: (struct Swift.UInt)
-// CHECK-32: - Metadata sources:
+// CHECK: ASSOCIATED TYPES:
+// CHECK: =================
 
-// CHECK-32: - Capture types:
-// CHECK-32: (function
-// CHECK-32:   (tuple))
-// CHECK-32: - Metadata sources:
+// CHECK: BUILTIN TYPES:
+// CHECK: ==============
 
+// CHECK: - __C.CGRect:
+// CHECK: Size: 32
+// CHECK: Alignment: 8
+// CHECK: Stride: 32
+// CHECK: NumExtraInhabitants: 0
 
-// CHECK-64: FIELDS:
-// CHECK-64: =======
-// CHECK-64: TypesToReflect.OC
-// CHECK-64: -----------------
-// CHECK-64: TypesToReflect.GenericOC
-// CHECK-64: ------------------------
-// CHECK-64: TypesToReflect.HasObjCClasses
-// CHECK-64: -----------------------------
-// CHECK-64: url: __ObjC.NSURL
-// CHECK-64: (class __ObjC.NSURL)
+// CHECK: CAPTURE DESCRIPTORS:
+// CHECK: ====================
+// CHECK: - Capture types:
+// CHECK: (struct Swift.StaticString)
+// CHECK: (struct Swift.StaticString)
+// CHECK: (struct Swift.UInt)
+// CHECK: (struct Swift.UInt)
+// CHECK: - Metadata sources:
 
-// CHECK-64: integer: Swift.Int
-// CHECK-64: (struct Swift.Int)
+// CHECK: - Capture types:
+// CHECK: (function
+// CHECK:   (tuple))
+// CHECK: - Metadata sources:
 
-// CHECK-64: __ObjC.NSBundle
-// CHECK-64: ------------
+// CHECK: - Capture types:
+// CHECK: (struct Swift.StaticString)
+// CHECK: (bound_generic_struct Swift.UnsafeBufferPointer
+// CHECK:   (struct Swift.UInt8))
+// CHECK: (struct Swift.UInt)
+// CHECK: (struct Swift.UInt)
+// CHECK: - Metadata sources:
 
-// CHECK-64: __ObjC.NSURL
-// CHECK-64: ------------
+// CHECK: - Capture types:
+// CHECK: (function
+// CHECK:   (tuple))
+// CHECK: - Metadata sources:
 
-// CHECK-64: ASSOCIATED TYPES:
-// CHECK-64: =================
+// CHECK: - Capture types:
+// CHECK: (bound_generic_struct Swift.UnsafeBufferPointer
+// CHECK:   (struct Swift.UInt8))
+// CHECK: (bound_generic_struct Swift.UnsafeBufferPointer
+// CHECK:   (struct Swift.UInt8))
+// CHECK: (struct Swift.UInt)
+// CHECK: (struct Swift.UInt)
+// CHECK: - Metadata sources:
 
-// CHECK-64: BUILTIN TYPES:
-// CHECK-64: ==============
-
-// CHECK-64: - __C.CGRect:
-// CHECK-64: Size: 32
-// CHECK-64: Alignment: 8
-// CHECK-64: Stride: 32
-// CHECK-64: NumExtraInhabitants: 0
-
-// CHECK-64: CAPTURE DESCRIPTORS:
-// CHECK-64: ====================
-// CHECK-64: - Capture types:
-// CHECK-64: (struct Swift.StaticString)
-// CHECK-64: (struct Swift.StaticString)
-// CHECK-64: (struct Swift.UInt)
-// CHECK-64: (struct Swift.UInt)
-// CHECK-64: - Metadata sources:
-
-// CHECK-64: - Capture types:
-// CHECK-64: (function
-// CHECK-64:   (tuple))
-// CHECK-64: - Metadata sources:
-
-// CHECK-64: - Capture types:
-// CHECK-64: (struct Swift.StaticString)
-// CHECK-64: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK-64:   (struct Swift.UInt8))
-// CHECK-64: (struct Swift.UInt)
-// CHECK-64: (struct Swift.UInt)
-// CHECK-64: - Metadata sources:
-
-// CHECK-64: - Capture types:
-// CHECK-64: (function
-// CHECK-64:   (tuple))
-// CHECK-64: - Metadata sources:
-
-// CHECK-64: - Capture types:
-// CHECK-64: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK-64:   (struct Swift.UInt8))
-// CHECK-64: (bound_generic_struct Swift.UnsafeBufferPointer
-// CHECK-64:   (struct Swift.UInt8))
-// CHECK-64: (struct Swift.UInt)
-// CHECK-64: (struct Swift.UInt)
-// CHECK-64: - Metadata sources:
-
-// CHECK-64: - Capture types:
-// CHECK-64: (function
-// CHECK-64:   (tuple))
-// CHECK-64: - Metadata sources:
-
+// CHECK: - Capture types:
+// CHECK: (function
+// CHECK:   (tuple))
+// CHECK: - Metadata sources:

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -17,6 +17,8 @@
 // CHECK-32: integer: Swift.Int
 // CHECK-32: (struct Swift.Int)
 
+// CHECK-32: __ObjC.NSBundle
+// CHECK-32: ---------------
 // CHECK-32: __ObjC.NSURL
 // CHECK-32: ------------
 
@@ -25,6 +27,12 @@
 
 // CHECK-32: BUILTIN TYPES:
 // CHECK-32: ==============
+
+// CHECK-32: - __ObjC.NSBundle:
+// CHECK-32: Size: 4
+// CHECK-32: Alignment: 4
+// CHECK-32: Stride: 4
+// CHECK-32: NumExtraInhabitants: 4096
 
 // CHECK-32: - __ObjC.NSURL:
 // CHECK-32: Size: 4
@@ -88,6 +96,9 @@
 // CHECK-64: integer: Swift.Int
 // CHECK-64: (struct Swift.Int)
 
+// CHECK-64: __ObjC.NSBundle
+// CHECK-64: ------------
+
 // CHECK-64: __ObjC.NSURL
 // CHECK-64: ------------
 
@@ -96,6 +107,12 @@
 
 // CHECK-64: BUILTIN TYPES:
 // CHECK-64: ==============
+
+// CHECK-64: - __ObjC.NSBundle:
+// CHECK-64: Size: 8
+// CHECK-64: Alignment: 8
+// CHECK-64: Stride: 8
+// CHECK-64: NumExtraInhabitants: 2147483647
 
 // CHECK-64: - __ObjC.NSURL:
 // CHECK-64: Size: 8

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -22,21 +22,6 @@
 
 // CHECK-32: ASSOCIATED TYPES:
 // CHECK-32: =================
-// CHECK-32: - TypesToReflect.OC : Swift.AnyObject
-// CHECK-32: - TypesToReflect.OC : __ObjC.NSObjectProtocol
-// CHECK-32: - TypesToReflect.OC : Swift.Equatable
-// CHECK-32: - TypesToReflect.OC : Swift.Hashable
-// CHECK-32: - TypesToReflect.OC : Swift.CVarArg
-// CHECK-32: - TypesToReflect.OC : Swift.CustomStringConvertible
-// CHECK-32: - TypesToReflect.OC : Swift.CustomDebugStringConvertible
-// CHECK-32: - TypesToReflect.GenericOC : Swift.AnyObject
-// CHECK-32: - TypesToReflect.GenericOC : __ObjC.NSObjectProtocol
-// CHECK-32: - TypesToReflect.GenericOC : Swift.Equatable
-// CHECK-32: - TypesToReflect.GenericOC : Swift.Hashable
-// CHECK-32: - TypesToReflect.GenericOC : Swift.CVarArg
-// CHECK-32: - TypesToReflect.GenericOC : Swift.CustomStringConvertible
-// CHECK-32: - TypesToReflect.GenericOC : Swift.CustomDebugStringConvertible
-// CHECK-32: - TypesToReflect.HasObjCClasses : Swift.AnyObject
 
 // CHECK-32: BUILTIN TYPES:
 // CHECK-32: ==============
@@ -108,21 +93,6 @@
 
 // CHECK-64: ASSOCIATED TYPES:
 // CHECK-64: =================
-// CHECK-64: - TypesToReflect.OC : Swift.AnyObject
-// CHECK-64: - TypesToReflect.OC : __ObjC.NSObjectProtocol
-// CHECK-64: - TypesToReflect.OC : Swift.Equatable
-// CHECK-64: - TypesToReflect.OC : Swift.Hashable
-// CHECK-64: - TypesToReflect.OC : Swift.CVarArg
-// CHECK-64: - TypesToReflect.OC : Swift.CustomStringConvertible
-// CHECK-64: - TypesToReflect.OC : Swift.CustomDebugStringConvertible
-// CHECK-64: - TypesToReflect.GenericOC : Swift.AnyObject
-// CHECK-64: - TypesToReflect.GenericOC : __ObjC.NSObjectProtocol
-// CHECK-64: - TypesToReflect.GenericOC : Swift.Equatable
-// CHECK-64: - TypesToReflect.GenericOC : Swift.Hashable
-// CHECK-64: - TypesToReflect.GenericOC : Swift.CVarArg
-// CHECK-64: - TypesToReflect.GenericOC : Swift.CustomStringConvertible
-// CHECK-64: - TypesToReflect.GenericOC : Swift.CustomDebugStringConvertible
-// CHECK-64: - TypesToReflect.HasObjCClasses : Swift.AnyObject
 
 // CHECK-64: BUILTIN TYPES:
 // CHECK-64: ==============

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -33,16 +33,36 @@ func concrete(x: Int, y: Any) {
 // CHECK-64-NEXT:       (field name=_value offset=0
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0)))))
 
-  // FIXME: Need @box reflection -- here the context is a single boxed value
+  // Here the context is a single boxed value
   reflect(function: {print(y)})
 // CHECK:         Type reference:
 // CHECK-NEXT:    (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: <null type info>
+// CHECK-32-NEXT: (closure_context size=28 alignment=4 stride=28 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field offset=12
+// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=value offset=8
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1)))))
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: <null type info>
+// CHECK-64-NEXT: (closure_context size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field offset=16
+// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=value offset=16
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
 }
 
 concrete(x: 10, y: true)

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -1,6 +1,10 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-run %target-swift-reflection-test %t/functions | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// FIXME: Should not require objc_interop -- please put Objective-C-specific
+// testcases in functions_objc.swift
+
 // REQUIRES: objc_interop
 
 /*

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -6,14 +6,14 @@
 import SwiftReflectionTest
 import Foundation
 
-func capturesImportedClass(x: Int, n: NSURL, r: NSRect) {
-  reflect(function: {print(x); print(n); print(r)})
+func capturesImportedTypes(x: Int, n: NSURL, r: NSRect, c: NSCoding) {
+  reflect(function: {print(x); print(n); print(r); print(c)})
 
 // CHECK-32:      Type reference:
 // CHECK-32-NEXT: (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=56 alignment=8 stride=56 num_extra_inhabitants=0
+// CHECK-32-NEXT: (closure_context size=60 alignment=8 stride=60 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
@@ -21,13 +21,15 @@ func capturesImportedClass(x: Int, n: NSURL, r: NSRect) {
 // CHECK-32-NEXT:   (field offset=16
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:   (field offset=24
-// CHECK-32-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0)))
+// CHECK-32-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0))
+// CHECK-32-NEXT:   (field offset=56
+// CHECK-32-NEXT:     (reference kind=strong refcounting=unknown)))
 
 // CHECK-64:      Type reference:
 // CHECK-64-NEXT: (builtin Builtin.NativeObject)
 
 // CHECK-64:      Type info:
-// CHECK-64-NEXT: (closure_context size=64 alignment=8 stride=64 num_extra_inhabitants=0
+// CHECK-64-NEXT: (closure_context size=72 alignment=8 stride=72 num_extra_inhabitants=0
 // CHECK-64-NEXT:   (field offset=16
 // CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=_value offset=0
@@ -35,9 +37,11 @@ func capturesImportedClass(x: Int, n: NSURL, r: NSRect) {
 // CHECK-64-NEXT:   (field offset=24
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:   (field offset=32
-// CHECK-64-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0)))
+// CHECK-64-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0))
+// CHECK-64-NEXT:   (field offset=64
+// CHECK-64-NEXT:     (reference kind=strong refcounting=unknown)))
 }
 
-capturesImportedClass(x: 10, n: NSURL(), r: NSRect(x: 1, y: 2, width: 3, height: 4))
+capturesImportedTypes(x: 10, n: NSURL(), r: NSRect(x: 1, y: 2, width: 3, height: 4), c: "" as NSString)
 
 doneReflecting()

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -1,0 +1,43 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
+// RUN: %target-run %target-swift-reflection-test %t/functions | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_interop
+
+import SwiftReflectionTest
+import Foundation
+
+func capturesImportedClass(x: Int, n: NSURLX, r: NSRect) {
+  reflect(function: {print(x); print(n); print(r)})
+
+// CHECK-32:      Type reference:
+// CHECK-32-NEXT: (builtin Builtin.NativeObject)
+
+// CHECK-32:      Type info:
+// CHECK-32-NEXT: (closure_context size=56 alignment=8 stride=56 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field offset=12
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
+// CHECK-32-NEXT:   (field offset=16
+// CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
+// CHECK-32-NEXT:   (field offset=24
+// CHECK-32-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0)))
+
+// CHECK-64:      Type reference:
+// CHECK-64-NEXT: (builtin Builtin.NativeObject)
+
+// CHECK-64:      Type info:
+// CHECK-64-NEXT: (closure_context size=64 alignment=8 stride=64 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0))))
+// CHECK-64-NEXT:   (field offset=24
+// CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
+// CHECK-64-NEXT:   (field offset=32
+// CHECK-64-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0)))
+}
+
+capturesImportedClass(x: 10, n: NSURL(), r: NSRect(x: 1, y: 2, width: 3, height: 4))
+
+doneReflecting()

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -5,24 +5,25 @@
 
 import SwiftReflectionTest
 import Foundation
+import CoreGraphics
 
-func capturesImportedTypes(x: Int, n: NSURL, r: NSRect, c: NSCoding) {
+func capturesImportedTypes(x: Int, n: NSURL, r: CGRect, c: NSCoding) {
   reflect(function: {print(x); print(n); print(r); print(c)})
 
 // CHECK-32:      Type reference:
 // CHECK-32-NEXT: (builtin Builtin.NativeObject)
 
 // CHECK-32:      Type info:
-// CHECK-32-NEXT: (closure_context size=60 alignment=8 stride=60 num_extra_inhabitants=0
+// CHECK-32-NEXT: (closure_context size=40 alignment=4 stride=40 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field offset=12
 // CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=_value offset=0
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0))))
 // CHECK-32-NEXT:   (field offset=16
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
-// CHECK-32-NEXT:   (field offset=24
-// CHECK-32-NEXT:     (builtin size=32 alignment=8 stride=32 num_extra_inhabitants=0))
-// CHECK-32-NEXT:   (field offset=56
+// CHECK-32-NEXT:   (field offset=20
+// CHECK-32-NEXT:     (builtin size=16 alignment=4 stride=16 num_extra_inhabitants=0))
+// CHECK-32-NEXT:   (field offset=36
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown)))
 
 // CHECK-64:      Type reference:
@@ -42,6 +43,6 @@ func capturesImportedTypes(x: Int, n: NSURL, r: NSRect, c: NSCoding) {
 // CHECK-64-NEXT:     (reference kind=strong refcounting=unknown)))
 }
 
-capturesImportedTypes(x: 10, n: NSURL(), r: NSRect(x: 1, y: 2, width: 3, height: 4), c: "" as NSString)
+capturesImportedTypes(x: 10, n: NSURL(), r: CGRect(x: 1, y: 2, width: 3, height: 4), c: "" as NSString)
 
 doneReflecting()

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -6,7 +6,7 @@
 import SwiftReflectionTest
 import Foundation
 
-func capturesImportedClass(x: Int, n: NSURLX, r: NSRect) {
+func capturesImportedClass(x: Int, n: NSURL, r: NSRect) {
   reflect(function: {print(x); print(n); print(r)})
 
 // CHECK-32:      Type reference:


### PR DESCRIPTION
This patch series fixes some problems with remote reflection:
- We now emit the right metadata for mutable captures, or captures of fixed-size but address-only types, such as existentials
- Fix for missing field metadata when a Swift class inherits from NSObject or some other Objective-C class
- Fix a crash when emitting reflection metadata for an imported generic Objective-C class
- Emit metadata for imported Objective-C protocols, allowing types containing these to be reflected

The patch series is a bit on the large side but I discussed the changes in detail with @bitjammer and he is OK with it.

rdar://problem/26314060
rdar://problem/26498484
