### PR TITLE
[SR-1628] Run swift-integration-tests in a sandboxed directory.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2500,7 +2500,8 @@ if [[ "${INSTALLABLE_PACKAGE}" ]] ; then
     if [[ "${TEST_INSTALLABLE_PACKAGE}" ]] ; then
         PKG_TESTS_SOURCE_DIR="${WORKSPACE}/swift-integration-tests"
         PKG_TESTS_SANDBOX_PARENT="$(build_directory swift_package_sandbox none)"
-
+        PKG_TESTS_TEMPS="${PKG_TESTS_SANDBOX_PARENT}"/"tests"
+        
         if [[ "$(uname -s)" == "Darwin" ]] ; then
             PKG_TESTS_SANDBOX="${PKG_TESTS_SANDBOX_PARENT}"/"${TOOLCHAIN_PREFIX}"
         else # Linux
@@ -2518,7 +2519,7 @@ if [[ "${INSTALLABLE_PACKAGE}" ]] ; then
         popd
 
         (cd "${PKG_TESTS_SOURCE_DIR}" &&
-                python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param filecheck="${FILECHECK_EXECUTABLE_PATH}")
+                python "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param filecheck="${FILECHECK_EXECUTABLE_PATH}" --param test-exec-root="${PKG_TESTS_TEMPS}")
         { set +x; } 2>/dev/null
     fi
 fi


### PR DESCRIPTION
#### What's in this pull request?

```
[SR-1628] Run swift-integration-tests in a sandboxed directory.

 - This should fix possible issues with the test outputs being in a shared
   directory on CI machines running concurrent builds.

 - https://bugs.swift.org/browse/SR-1628
```
#### Resolved bug number: ([SR-1628](https://bugs.swift.org/browse/SR-1628))

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- This should fix possible issues with the test outputs being in a shared
  directory on CI machines running concurrent builds.
- https://bugs.swift.org/browse/SR-1628
