### PR TITLE
debug_value instructions should not block analysis of static initializers

### DIFF
--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -129,6 +129,7 @@ static bool analyzeStaticInitializer(SILFunction *F, SILInstruction *&Val,
       if (I.getKind() != ValueKind::ReturnInst &&
           I.getKind() != ValueKind::StructInst &&
           I.getKind() != ValueKind::TupleInst &&
+          I.getKind() != ValueKind::DebugValueInst &&
           I.getKind() != ValueKind::IntegerLiteralInst &&
           I.getKind() != ValueKind::FloatLiteralInst)
         return false;

--- a/test/SILOptimizer/globalopt_let_propagation.swift
+++ b/test/SILOptimizer/globalopt_let_propagation.swift
@@ -36,6 +36,13 @@ struct IntWrapper4 {
   let val2: IntWrapper1
 }
 
+// Test with an initializer, where a SIL debug_value instruction might block
+// analysis of the initializer and inhibit optimization of the let.
+struct IntWrapper5 {
+  let val: Int
+  init(val: Int) { self.val = val }
+  static let Five = IntWrapper5(val: 5)
+}
 
 var PROP1: Double {
    return PI
@@ -307,11 +314,12 @@ public func test_static_struct_let_wrapped_int() -> Int {
 // CHECK: bb0:
 // CHECK-NOT: global_addr
 // CHECK: integer_literal
+// CHECK-NOT: global_addr
 // CHECK: struct
 // CHECK: return
 @inline(never)
 public func test_static_struct_let_struct_wrapped_multiple_ints() -> Int {
-  return B.IW4.val.val.val + B.IW4.val2.val + 1
+  return B.IW4.val.val.val + B.IW4.val2.val + IntWrapper5.Five.val + 1
 }
 
 // Test accessing multiple Int fields wrapped into multiple structs, where each struct may have
@@ -320,11 +328,12 @@ public func test_static_struct_let_struct_wrapped_multiple_ints() -> Int {
 // CHECK: bb0:
 // CHECK-NOT: global_addr
 // CHECK: integer_literal
+// CHECK-NOT: global_addr
 // CHECK: struct
 // CHECK: return
 @inline(never)
 public func test_static_class_let_struct_wrapped_multiple_ints() -> Int {
-  return C.IW4.val.val.val + C.IW4.val2.val + 1
+  return C.IW4.val.val.val + C.IW4.val2.val + IntWrapper5.Five.val + 1
 }
 
 // Test accessing multiple Int fields wrapped into multiple tuples, where each tuple may have


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

The analyzeStaticInitializer function has a list of specific SIL instructions that it expects to see in static initializers. Anything unexpected blocks the analysis and inhibits optimizations, such as propagating global let variables. Add debug_value instructions to that list so that they do not inhibit optimizations.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/26411312

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
