### PR TITLE
[don't merge] Map opened archetypes to the instructions defining them.

### DIFF
--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -1,0 +1,149 @@
+//===- SILOpenedArchetypeTracker.h - Track opened archetypes  ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
+#define SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
+
+#include "swift/SIL/Notifications.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILFunction.h"
+
+namespace swift {
+
+/// SILOpenedArchetypesTracker is a helper class that can be used to create
+/// and maintain a mapping from opened archetypes to instructions
+/// defining them, e.g. open_existential_ref, open_existential_addr,
+/// open_existential_metatype.
+///
+/// This information is useful for representing and maintaining the
+/// dependencies of instructions on opened archetypes they are using.
+class SILOpenedArchetypesTracker : public DeleteNotificationHandler {
+public:
+  typedef llvm::DenseMap<Type, SILValue> OpenedArchetypeDefsMap;
+  // Re-use pre-populated map if available.
+  SILOpenedArchetypesTracker(const SILFunction &F,
+                             SILOpenedArchetypesTracker &Tracker)
+      : F(F), OpenedArchetypeDefs(Tracker.OpenedArchetypeDefs) { }
+
+  // Re-use pre-populated map if available.
+  SILOpenedArchetypesTracker(const SILFunction &F,
+                             OpenedArchetypeDefsMap &OpenedArchetypeDefs)
+      : F(F), OpenedArchetypeDefs(OpenedArchetypeDefs) { }
+
+  // Use its own local map if no pre-populated map is provided.
+  SILOpenedArchetypesTracker(const SILFunction &F)
+      : F(F), OpenedArchetypeDefs(LocalOpenedArchetypeDefs) { }
+
+
+  const SILFunction &getFunction() { return F; }
+
+  void addOpenedArchetypeDef(Type archetype, SILValue Def) {
+    assert(!getOpenedArchetypeDef(archetype) &&
+           "There can be only one definition of an opened archetype");
+    OpenedArchetypeDefs[archetype] = Def;
+  }
+
+  void removeOpenedArchetypeDef(Type archetype, SILValue Def) {
+    auto FoundDef = getOpenedArchetypeDef(archetype);
+    assert(FoundDef &&
+           "Opened archetype definition is not registered in SILFunction");
+    if (FoundDef == Def)
+      OpenedArchetypeDefs.erase(archetype);
+  }
+
+  SILValue getOpenedArchetypeDef(Type archetype) const {
+    return OpenedArchetypeDefs.lookup(archetype);
+  }
+
+  const OpenedArchetypeDefsMap &getOpenedArchetypeDefs() {
+    return OpenedArchetypeDefs;
+  }
+
+  // Register archetypes opened by a given instruction.
+  // Can be used to incrementally populate the mapping, e.g.
+  // if it is done when performing a scan of all instructions
+  // inside a function.
+  void registerOpenedArchetypes(const SILInstruction *I) {
+    assert((!I->getParent() || I->getFunction() == &F) &&
+           "Instruction does not belong to a proper SILFunction");
+    if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
+        isa<OpenExistentialBoxInst>(I)) {
+      auto Ty = I->getType().getSwiftRValueType();
+      assert(Ty->isOpenedExistential() && "Type should be an opened archetype");
+      addOpenedArchetypeDef(Ty, I);
+    } else if (isa<OpenExistentialMetatypeInst>(I)) {
+      SILType InstanceTy = I->getType();
+      while (isa<AnyMetatypeType>(InstanceTy.getSwiftRValueType())) {
+        InstanceTy = InstanceTy.getMetatypeInstanceType(I->getModule());
+      }
+      auto Ty = InstanceTy.getSwiftRValueType();
+      assert(Ty->isOpenedExistential() && "Type should be an opened archetype");
+      addOpenedArchetypeDef(Ty, I);
+    }
+  }
+
+  // Unregister archetypes opened by a given instruction.
+  // Should be only called when this instruction is to be removed.
+  void unregisterOpenedArchetypes(const SILInstruction *I) {
+    assert(I->getFunction() == &F &&
+           "Instruction does not belong to a proper SILFunction");
+    if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
+        isa<OpenExistentialBoxInst>(I)) {
+      auto Ty = I->getType().getSwiftRValueType();
+      assert(Ty->isOpenedExistential() && "Type should be an opened archetype");
+      removeOpenedArchetypeDef(Ty, I);
+    } else if (isa<OpenExistentialMetatypeInst>(I)) {
+      SILType InstanceTy = I->getType();
+      while (isa<AnyMetatypeType>(InstanceTy.getSwiftRValueType())) {
+        InstanceTy = InstanceTy.getMetatypeInstanceType(I->getModule());
+      }
+      auto Ty = InstanceTy.getSwiftRValueType();
+      assert(Ty->isOpenedExistential() && "Type should be an opened archetype");
+      removeOpenedArchetypeDef(Ty, I);
+    }
+  }
+
+  // Pre-populate the map by scanning the whole function for any
+  // instructions creating new opened archetypes.
+  void collectOpenedArchetypesOfFunction() {
+    for (auto FI = F.begin(), FE = F.end(); FI != FE; ++FI) {
+      for (auto I = FI->begin(), E = FI->end(); I != E; ++I) {
+        registerOpenedArchetypes(&*I);
+      }
+    }
+  }
+
+  // Handling of instruction removal notifications.
+  bool needsNotifications() { return true; }
+
+  void handleDeleteNotification(swift::ValueBase *Value) {
+    if (auto I = dyn_cast<SILInstruction>(Value))
+      if (I->getFunction() == &F)
+        unregisterOpenedArchetypes(I);
+  }
+
+  virtual ~SILOpenedArchetypesTracker() {
+    // Unregister the handler.
+    F.getModule().removeDeleteNotificationHandler(this);
+  }
+
+private:
+  const SILFunction &F;
+  /// Mapping from opened archetypes to their definitions
+  OpenedArchetypeDefsMap &OpenedArchetypeDefs;
+  // Local map to be used if no other map was provided in the
+  // constructor.
+  OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
+};
+
+} // end swift namespace
+#endif

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -47,10 +47,12 @@ public:
 
   SILInliner(SILFunction &To, SILFunction &From, InlineKind IKind,
              TypeSubstitutionMap &ContextSubs, ArrayRef<Substitution> ApplySubs,
-             CloneCollector::CallbackType Callback =nullptr)
-    : TypeSubstCloner<SILInliner>(To, From, ContextSubs, ApplySubs, true),
-    IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
-    Callback(Callback) {
+             SILOpenedArchetypesTracker &OpenedArchetypes,
+             CloneCollector::CallbackType Callback = nullptr)
+      : TypeSubstCloner<SILInliner>(To, From, ContextSubs, ApplySubs,
+                                    OpenedArchetypes, true),
+        IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
+        Callback(Callback) {
   }
 
   /// inlineFunction - This method inlines a callee function, assuming that it

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -14,6 +14,7 @@
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/SILVTable.h"
 #include "swift/SIL/Dominance.h"
@@ -100,6 +101,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   Module *M;
   const SILFunction &F;
   Lowering::TypeConverter &TC;
+  SILOpenedArchetypesTracker OpenedArchetypes;
   const SILInstruction *CurInstruction = nullptr;
   DominanceInfo *Dominance = nullptr;
   bool SingleFunction = true;
@@ -414,7 +416,7 @@ public:
 
   SILVerifier(const SILFunction &F, bool SingleFunction=true)
     : M(F.getModule().getSwiftModule()), F(F), TC(F.getModule().Types),
-      Dominance(nullptr), SingleFunction(SingleFunction) {
+      OpenedArchetypes(F), Dominance(nullptr), SingleFunction(SingleFunction) {
     if (F.isExternalDeclaration())
       return;
       
@@ -440,17 +442,18 @@ public:
   }
 
   void visitSILArgument(SILArgument *arg) {
-    checkLegalType(arg->getFunction(), arg);
+    checkLegalType(arg->getFunction(), arg, nullptr);
   }
 
   void visitSILInstruction(SILInstruction *I) {
     CurInstruction = I;
+    OpenedArchetypes.registerOpenedArchetypes(I);
     checkSILInstruction(I);
 
     // Check the SILLLocation attached to the instruction.
     checkInstructionsSILLocation(I);
 
-    checkLegalType(I->getFunction(), I);
+    checkLegalType(I->getFunction(), I, I);
   }
 
   void checkSILInstruction(SILInstruction *I) {
@@ -515,7 +518,7 @@ public:
 
       // Make sure that if operand is generic that its primary archetypes match
       // the function context.
-      checkLegalType(I->getFunction(), operand.get());
+      checkLegalType(I->getFunction(), operand.get(), I);
     }
   }
 
@@ -562,14 +565,14 @@ public:
 
   /// Check that the types of this value producer are all legal in the function
   /// context in which it exists.
-  void checkLegalType(SILFunction *F, ValueBase *value) {
+  void checkLegalType(SILFunction *F, ValueBase *value, SILInstruction *I) {
     if (SILType type = value->getType()) {
-      checkLegalType(F, type);
+      checkLegalType(F, type, I);
     }
   }
 
   /// Check that the given type is a legal SIL value.
-  void checkLegalType(SILFunction *F, SILType type) {
+  void checkLegalType(SILFunction *F, SILType type, SILInstruction *I) {
     auto rvalueType = type.getSwiftRValueType();
     require(!isa<LValueType>(rvalueType),
             "l-value types are not legal in SIL");
@@ -583,6 +586,14 @@ public:
       require(isArchetypeValidInFunction(A, F),
               "Operand is of an ArchetypeType that does not exist in the "
               "Caller's generic param list.");
+      if (auto OpenedA = getOpenedArchetype(t.getCanonicalTypeOrNull())) {
+        auto Def = OpenedArchetypes.getOpenedArchetypeDef(OpenedA);
+        require (Def, "Opened archetype should be registered in SILFunction");
+        require(I == nullptr || Def == I ||
+                Dominance->properlyDominates(cast<SILInstruction>(Def), I),
+                "Use of an opened archetype should be dominated by a "
+                "definition of this opened archetype");
+      }
     });
   }
 
@@ -685,8 +696,19 @@ public:
       auto *A = Sub.getReplacement()->getAs<ArchetypeType>();
       if (!A)
         continue;
-      require(isArchetypeValidInFunction(A, site.getInstruction()->getFunction()),
-              "Archetype to be substituted must be valid in function.");
+      require(
+          isArchetypeValidInFunction(A, site.getInstruction()->getFunction()),
+          "Archetype to be substituted must be valid in function.");
+      if (auto OpenedA = getOpenedArchetype(
+              Sub.getReplacement().getCanonicalTypeOrNull())) {
+        auto Def = OpenedArchetypes.getOpenedArchetypeDef(OpenedA);
+        require(Def, "Opened archetype should be registered in SILFunction");
+        require(Def == site.getInstruction() ||
+                Dominance->properlyDominates(cast<SILInstruction>(Def),
+                                             site.getInstruction()),
+                "Use of an opened archetype should be dominated by a "
+                "definition of this opened archetype");
+      }
     }
 
     // Then make sure that we have a type that can be substituted for the
@@ -1646,7 +1668,7 @@ public:
             "method's Self parameter should be constrained by protocol");
 
     auto lookupType = AMI->getLookupType();
-    if (isOpenedArchetype(lookupType))
+    if (getOpenedArchetype(lookupType))
       require(AMI->hasOperand(), "Must have an opened existential operand");
     if (isa<ArchetypeType>(lookupType) || lookupType->isAnyExistentialType()) {
       require(AMI->getConformance().isAbstract(),
@@ -1662,12 +1684,14 @@ public:
     }
   }
 
-  bool isOpenedArchetype(CanType t) {
+  ArchetypeType *getOpenedArchetype(CanType t) {
     ArchetypeType *archetype = dyn_cast<ArchetypeType>(t);
     if (!archetype)
-      return false;
+      return nullptr;
 
-    return !archetype->getOpenedExistentialType().isNull();
+    if (!archetype->getOpenedExistentialType().isNull())
+      return archetype;
+    return nullptr;
   }
 
   // Get the expected type of a dynamic method reference.
@@ -1809,8 +1833,12 @@ public:
     require(OEI->getType().isAddress(),
             "open_existential_addr result must be an address");
 
-    require(isOpenedArchetype(OEI->getType().getSwiftRValueType()),
+    auto archetype = getOpenedArchetype(OEI->getType().getSwiftRValueType());
+    require(archetype,
         "open_existential_addr result must be an opened existential archetype");
+    require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
+            "Archetype opened by open_existential_addr should be registered in "
+            "SILFunction");
   }
 
   void checkOpenExistentialRefInst(OpenExistentialRefInst *OEI) {
@@ -1827,8 +1855,12 @@ public:
     require(OEI->getType().isObject(),
             "open_existential_ref result must be an address");
 
-    require(isOpenedArchetype(resultInstanceTy),
-            "open_existential_ref result must be an opened existential");
+    auto archetype = getOpenedArchetype(resultInstanceTy);
+    require(archetype,
+        "open_existential_ref result must be an opened existential archetype");
+    require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
+            "Archetype opened by open_existential_ref should be registered in "
+            "SILFunction");
   }
 
   void checkOpenExistentialBoxInst(OpenExistentialBoxInst *OEI) {
@@ -1845,8 +1877,12 @@ public:
     require(OEI->getType().isAddress(),
             "open_existential_box result must be an address");
 
-    require(isOpenedArchetype(resultInstanceTy),
-            "open_existential_box result must be an opened existential");
+    auto archetype = getOpenedArchetype(resultInstanceTy);
+    require(archetype,
+        "open_existential_box result must be an opened existential archetype");
+    require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
+            "Archetype opened by open_existential_box should be registered in "
+            "SILFunction");
   }
 
   void checkOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *I) {
@@ -1886,11 +1922,15 @@ public:
     require(operandInstTy.isExistentialType(),
             "ill-formed existential metatype in open_existential_metatype "
             "operand");
-    require(isOpenedArchetype(resultInstTy),
-            "open_existential_metatype result must be an opened existential "
-            "metatype");
+    auto archetype = getOpenedArchetype(resultInstTy);
+    require(archetype, "open_existential_metatype result must be an opened "
+                       "existential metatype");
+    require(
+        OpenedArchetypes.getOpenedArchetypeDef(archetype) == I,
+        "Archetype opened by open_existential_metatype should be registered in "
+        "SILFunction");
   }
-  
+
   void checkAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {
     SILType exType = AEBI->getExistentialType();
     require(exType.isObject(),
@@ -3064,6 +3104,22 @@ public:
     }
   }
 
+  void verifyOpenedArchetypes(SILFunction *F) {
+    assert(&OpenedArchetypes.getFunction() == F &&
+           "Wrong SILFunction provided to verifyOpenedArchetypes");
+    // Check that definitions of all opened archetypes from
+    // OpenedArchetypesDefs are existing instructions
+    // belonging to the function F.
+    for (auto KV: OpenedArchetypes.getOpenedArchetypeDefs()) {
+      require(getOpenedArchetype(KV.first.getCanonicalTypeOrNull()),
+              "Only opened archetypes should be registered in SILFunction");
+      auto Def = cast<SILInstruction>(KV.second);
+      require(Def->getFunction() == F, 
+              "Definition of every registered opened archetype should be an"
+              " existing instruction in a current SILFunction");
+    }
+  }
+
   void visitSILBasicBlock(SILBasicBlock *BB) {
     // Make sure that each of the successors/predecessors of this basic block
     // have this basic block in its predecessor/successor list.
@@ -3138,6 +3194,7 @@ public:
     verifyEpilogBlocks(F);
     verifyStackHeight(F);
     verifyBranches(F);
+    verifyOpenedArchetypes(F);
     SILVisitor::visitSILFunction(F);
   }
 

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -7,6 +7,20 @@ protocol CP : class {
   func f() -> Self
 }
 
+protocol P2 {
+  var c: Int32 { get }
+}
+
+extension P2 {
+  func s() -> Int32
+}
+
+struct L {
+  var start: Int32 { get }
+  @sil_stored let o: P2
+  init(o: P2)
+}
+
 sil @plus : $@convention(thin) (Int64, Int64) -> Int64
 sil @fromLiteral : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int64
 
@@ -845,3 +859,47 @@ sil shared [transparent] @identity_closure : $@convention(thin) (Builtin.Int8) -
 bb0(%0 : $Builtin.Int8):
   return %0 : $Builtin.Int8
 }
+
+sil [transparent] @P2_s : $@convention(method) <Self where Self : P2> (@in_guaranteed Self) -> Int32 {
+bb0(%0 : $*Self):
+  %2 = alloc_stack $Self
+  copy_addr %0 to [initialization] %2 : $*Self
+  %4 = witness_method $Self, #P2.c!getter.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  %5 = apply %4<Self>(%2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  destroy_addr %2 : $*Self
+  %7 = integer_literal $Builtin.Int32, 1
+  %8 = struct_extract %5 : $Int32, #Int32._value
+  %9 = integer_literal $Builtin.Int1, -1
+  %10 = builtin "sadd_with_overflow_Int32"(%8 : $Builtin.Int32, %7 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %11 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 0
+  %12 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %12 : $Builtin.Int1
+  %14 = struct $Int32 (%11 : $Builtin.Int32)
+  dealloc_stack %2 : $*Self
+  return %14 : $Int32
+}
+
+// Check that P2_s call can be properly inlined and the resulting witness_method instruction
+// uses the opned archetype from the caller.
+// CHECK-LABEL: sil hidden @L_start
+// CHECK: open_existential_addr{{.*}}$*@[[OPENED_ARCHETYPE:opened\("[A-Z0-9-]+"\) P2]]
+// CHECK: witness_method $@[[OPENED_ARCHETYPE]], #P2.c!getter.1, %{{[0-9]+}} : $*@[[OPENED_ARCHETYPE]]
+// CHECK: return
+sil hidden @L_start : $@convention(method) (@in_guaranteed L) -> Int32 {
+bb0(%0 : $*L):
+  %2 = struct_element_addr %0 : $*L, #L.o
+  %3 = alloc_stack $P2
+  copy_addr %2 to [initialization] %3 : $*P2
+  %5 = open_existential_addr %3 : $*P2 to $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2
+  %6 = function_ref @P2_s : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  %7 = apply %6<@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2>(%5) : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  destroy_addr %5 : $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2
+  deinit_existential_addr %3 : $*P2
+  dealloc_stack %3 : $*P2
+  return %7 : $Int32
+}
+
+sil_default_witness_table hidden P2 {
+  no_default
+}
+

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -142,8 +142,8 @@ lookup2:
   %23 = alloc_box $Optional<() -> ()>
   %24 = load %21a : $*AnyObject
   strong_retain %24 : $AnyObject
-  %26 = open_existential_ref %24 : $AnyObject to $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject
-  %27 = unchecked_ref_cast %26 : $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
+  %26 = open_existential_ref %24 : $AnyObject to $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject
+  %27 = unchecked_ref_cast %26 : $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
   dynamic_method_br %27 : $Builtin.UnknownObject, #X.f!1.foreign, bb1, bb2
 
 bb1(%8 : $@convention(objc_method) (Builtin.UnknownObject) -> ()):


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This is an alternative implementation of opened archetypes mapping, based on some comments from PR https://github.com/apple/swift/pull/2707
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Introduce a helper class SILOpenedArchetypesTracker for creating and maintaining such mappings.

These mappings are constructed on demand and used by SILCloner, sil-inliner, sil-verifier and other optimizer passes to properly handle opened archetypes.
