### PR TITLE
[stdlib] Documentation consistency for OptionSet initializers

### DIFF
--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -115,11 +115,10 @@ public protocol OptionSet : SetAlgebra, RawRepresentable {
   ///     print(extraOptions.isStrictSuperset(of: .all))
   ///     // Prints "true"
   ///
-  /// - Parameter rawValue: The raw value of the option set to create.
-  /// - Returns: A new option set with the given raw value. Each bit of the raw
-  ///   value potentially represents an element of the option set, though raw
-  ///   values may include bits that are not defined as distinct values of the
-  ///   `OptionSet` type.
+  /// - Parameter rawValue: The raw value of the option set to create. Each bit
+  ///   of `rawValue` potentially represents an element of the option set,
+  ///   though raw values may include bits that are not defined as distinct
+  ///   values of the `OptionSet` type.
   init(rawValue: RawValue)
 }
 
@@ -319,8 +318,6 @@ extension OptionSet where RawValue : BitwiseOperations {
   /// Creates an empty option set.
   ///
   /// This initializer creates an option set with a raw value of zero.
-  ///
-  /// - Returns: An option set that contains no elements.
   public init() {
     self.init(rawValue: .allZeros)
   }

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -5580,7 +5580,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "init()",
         key.usr: "s:FesRxs9OptionSetwx8RawValues17BitwiseOperationsrS_cFT_x::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:FesRxs9OptionSetwx8RawValues17BitwiseOperationsrS_cFT_x",
-        key.doc.full_as_xml: "<Function><Name>init()</Name><USR>s:FesRxs9OptionSetwx8RawValues17BitwiseOperationsrS_cFT_x</USR><Declaration>convenience init()</Declaration><Abstract><Para>Creates an empty option set.</Para></Abstract><ResultDiscussion><Para>An option set that contains no elements.</Para></ResultDiscussion><Discussion><Para>This initializer creates an option set with a raw value of zero.</Para></Discussion></Function>",
+        key.doc.full_as_xml: "<Function><Name>init()</Name><USR>s:FesRxs9OptionSetwx8RawValues17BitwiseOperationsrS_cFT_x</USR><Declaration>convenience init()</Declaration><Abstract><Para>Creates an empty option set.</Para></Abstract><Discussion><Para>This initializer creates an option set with a raw value of zero.</Para></Discussion></Function>",
         key.offset: 1933,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This removes the `- Returns` field from a couple initializers in the `OptionSet` protocol. It includes an updated fixture for `SourceKit/DocSupport/doc_clang_module.swift`, which depends on the modified documentation.
#### Resolved bug number: n/a

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

This includes an updated fixture for `SourceKit/DocSupport/
doc_clang_module.swift', which depends on the OptionSet documentation.
