### PR TITLE
[swiftc] Add test case for crash triggered in swift::namelookup::lookupVisibleDeclsInModule(…)

### DIFF
--- a/validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
+++ b/validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct a{var f={H:{}}}init


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2152: swift::Type swift::ValueDecl::getType() const: Assertion `hasType() && "declaration has no type set yet"' failed.
11 swift           0x00000000010e805d swift::namelookup::lookupVisibleDeclsInModule(swift::ModuleDecl*, llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::NLKind, swift::namelookup::ResolutionKind, swift::LazyResolver*, swift::DeclContext const*, llvm::ArrayRef<std::pair<llvm::ArrayRef<std::pair<swift::Identifier, swift::SourceLoc> >, swift::ModuleDecl*> >) + 1101
12 swift           0x00000000010cdc12 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1730
13 swift           0x0000000000ed9684 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
14 swift           0x0000000000e85b78 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3864
16 swift           0x000000000104b5b3 swift::Expr::walk(swift::ASTWalker&) + 19
17 swift           0x0000000000e86397 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
18 swift           0x0000000000e8cd52 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
21 swift           0x0000000000f034f4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
22 swift           0x0000000000f2dd2c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
23 swift           0x0000000000e8cdf1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
24 swift           0x0000000000e8dea7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
25 swift           0x0000000000e8e0bb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
27 swift           0x0000000000e9a7f9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 4153
28 swift           0x0000000000f1a87d swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 413
29 swift           0x0000000000ea49d6 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1526
32 swift           0x0000000000e9edc6 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
33 swift           0x0000000000ec0b32 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 994
34 swift           0x0000000000c57d19 swift::CompilerInstance::performSema() + 3289
36 swift           0x00000000007d6a5f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
37 swift           0x00000000007a2aa8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28295-swift-namelookup-lookupvisibledeclsinmodule-623be6.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift:10:16 - line:10:21] RangeText="{H:{}}"
3.  While type-checking expression at [validation-test/compiler_crashers/28295-swift-namelookup-lookupvisibledeclsinmodule.swift:10:17 - line:10:17] RangeText="H"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
