### PR TITLE
Don't emit @objc Fix-Its or diagnostics where @objc inference would do the right job

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2141,6 +2141,10 @@ public:
   /// first slot.
   Optional<ObjCSelector> getObjCRuntimeName() const;
 
+  /// Determine whether the given declaration can infer @objc, or the
+  /// Objective-C name, if used to satisfy the given requirement.
+  bool canInferObjCFromRequirement(ValueDecl *requirement);
+
   SourceLoc getNameLoc() const { return NameLoc; }
   SourceLoc getLoc() const { return NameLoc; }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2699,6 +2699,13 @@ ERROR(objc_override_property_name_mismatch,none,
       "Objective-C property has a different name from the "
       "property it overrides (%0 vs. %1)", (Identifier, Identifier))
 
+ERROR(objc_ambiguous_inference,none,
+      "ambiguous inference of Objective-C name for %0 %1 (%2 vs %3)",
+      (DescriptiveDeclKind, DeclName, ObjCSelector, ObjCSelector))
+NOTE(objc_ambiguous_inference_candidate,none,
+     "%0 (in protocol %1) provides Objective-C name %2",
+     (DeclName, DeclName, ObjCSelector))
+
 ERROR(nonlocal_bridged_to_objc,none,
       "conformance of %0 to %1 can only be written in module %2",
       (Identifier, Identifier, Identifier))

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2478,8 +2478,9 @@ bool ASTContext::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
       fixDeclarationName(diag, conflicts[0], req->getFullName());
 
       // Fix the '@objc' attribute, if needed.
-      fixDeclarationObjCName(diag, conflicts[0], req->getObjCRuntimeName(),
-                             /*ignoreImpliedName=*/true);
+      if (!conflicts[0]->canInferObjCFromRequirement(req))
+        fixDeclarationObjCName(diag, conflicts[0], req->getObjCRuntimeName(),
+                               /*ignoreImpliedName=*/true);
     }
 
     // @nonobjc will silence this warning.

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -41,8 +41,8 @@ namespace {
     bool mayAppear = false;
       
     // This is true if a '{{none}}' is present to mark that there should be no
-    // fixits at all.
-    bool noFixitsMayAppear = false;
+    // extra fixits.
+    bool noExtraFixitsMayAppear = false;
 
     // This is the raw input buffer for the message text, the part in the
     // {{...}}
@@ -364,7 +364,7 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
       
       // Special case for specifying no fixits should appear.
       if (FixItStr == "none") {
-        Expected.noFixitsMayAppear = true;
+        Expected.noExtraFixitsMayAppear = true;
         continue;
       }
         
@@ -459,6 +459,9 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
       if (!checkForFixIt(fixit, FoundDiagnostic, InputFile))
         IncorrectFixit = fixit.StartLoc;
     }
+
+    bool matchedAllFixIts =
+      expected.Fixits.size() == FoundDiagnostic.getFixIts().size();
     
     // If we have any expected fixits that didn't get matched, then they are
     // wrong.  Replace the failed fixit with what actually happened.
@@ -476,8 +479,8 @@ bool DiagnosticVerifier::verifyFile(unsigned BufferID,
         addError(IncorrectFixit,
                  "expected fix-it not seen; actual fix-its: " + actual, fix);
       }
-    } else if (expected.noFixitsMayAppear &&
-               !FoundDiagnostic.getFixIts().empty() &&
+    } else if (expected.noExtraFixitsMayAppear &&
+               !matchedAllFixIts &&
                !expected.mayAppear) {
       // If there was no fixit specification, but some were produced, add a
       // fixit to add them in.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2296,18 +2296,42 @@ static void inferObjCName(TypeChecker &tc, ValueDecl *decl) {
   // When no override determined the Objective-C name, look for
   // requirements for which this declaration is a witness.
   Optional<ObjCSelector> requirementObjCName;
+  ValueDecl *firstReq = nullptr;
   for (auto req : tc.findWitnessedObjCRequirements(decl,
                                                    /*onlyFirst=*/false)) {
     // If this is the first requirement, take its name.
     if (!requirementObjCName) {
       requirementObjCName = req->getObjCRuntimeName();
+      firstReq = req;
       continue;
     }
 
     // If this requirement has a different name from one we've seen,
-    // bail out and let protocol-conformance diagnostics handle this.
-    if (*requirementObjCName != *req->getObjCRuntimeName())
-      return;
+    // note the ambiguity.
+    if (*requirementObjCName != *req->getObjCRuntimeName()) {
+      tc.diagnose(decl, diag::objc_ambiguous_inference,
+                  decl->getDescriptiveKind(), decl->getFullName(),
+                  *requirementObjCName, *req->getObjCRuntimeName());
+      
+      // Note the candidates and what Objective-C names they provide.
+      auto diagnoseCandidate = [&](ValueDecl *req) {
+        auto proto = cast<ProtocolDecl>(req->getDeclContext());
+        auto diag = tc.diagnose(decl,
+                                diag::objc_ambiguous_inference_candidate,
+                                req->getFullName(),
+                                proto->getFullName(),
+                                *req->getObjCRuntimeName());
+        fixDeclarationObjCName(diag, decl, req->getObjCRuntimeName());
+      };
+      diagnoseCandidate(firstReq);
+      diagnoseCandidate(req);
+
+      // Suggest '@nonobjc' to suppress this error, and not try to
+      // infer @objc for anything.
+      tc.diagnose(decl, diag::optional_req_near_match_nonobjc, true)
+        .fixItInsert(decl->getAttributeInsertionLoc(false), "@nonobjc ");
+      break;
+    }
   }
 
   // If we have a name, install it via an @objc attribute.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3653,6 +3653,7 @@ void ConformanceChecker::checkConformance() {
 
       // Objective-C checking for @objc requirements.
       if (requirement->isObjC() &&
+          requirement->getFullName() == witness->getFullName() &&
           !requirement->getAttrs().isUnavailable(TC.Context)) {
         // The witness must also be @objc.
         if (!witness->isObjC()) {

--- a/test/ClangModules/objc_parse.swift
+++ b/test/ClangModules/objc_parse.swift
@@ -265,7 +265,7 @@ func classAnyObject(_ obj: NSObject) {
 class Wobbler : NSWobbling { // expected-note{{candidate has non-matching type '()'}}
   @objc func wobble() { }
 
-  func returnMyself() -> Self { return self } // expected-error{{non-'@objc' method 'returnMyself()' does not satisfy requirement of '@objc' protocol 'NSWobbling'}}{{3-3=@objc }}
+  func returnMyself() -> Self { return self } // expected-error{{non-'@objc' method 'returnMyself()' does not satisfy requirement of '@objc' protocol 'NSWobbling'}}{{none}}
   // expected-error@-1{{method cannot be an implementation of an @objc requirement because its result type cannot be represented in Objective-C}}
 }
 

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -10,7 +10,7 @@
 class C1a : P1 {
   @objc func doSomething(a: Int, c: Double) { }
   // expected-warning@-1{{instance method 'doSomething(a:c:)' nearly matches optional requirement 'doSomething(a:b:)' of protocol 'P1'}}
-  // expected-note@-2{{rename to 'doSomething(a:b:)' to satisfy this requirement}}{{34-34=b }}{{8-8=(doSomethingWithA:b:)}}
+  // expected-note@-2{{rename to 'doSomething(a:b:)' to satisfy this requirement}}{{34-34=b }}{{none}}
   // expected-note@-3{{move 'doSomething(a:c:)' to an extension to silence this warning}}
   // expected-note@-4{{make 'doSomething(a:c:)' private to silence this warning}}{{9-9=private }}
 }
@@ -28,7 +28,7 @@ class C1c {
 extension C1c : P1 {
   func doSomething(a: Int, c: Double) { }
   // expected-warning@-1{{instance method 'doSomething(a:c:)' nearly matches optional requirement 'doSomething(a:b:)' of protocol 'P1'}}
-  // expected-note@-2{{rename to 'doSomething(a:b:)' to satisfy this requirement}}{{28-28=b }}{{3-3=@objc(doSomethingWithA:b:) }}
+  // expected-note@-2{{rename to 'doSomething(a:b:)' to satisfy this requirement}}{{28-28=b }}{{none}}
   // expected-note@-3{{move 'doSomething(a:c:)' to another extension to silence this warning}}
   // expected-note@-4{{make 'doSomething(a:c:)' private to silence this warning}}{{3-3=private }}
 }
@@ -87,7 +87,7 @@ class C4a : P4 {
 class C5a : P5 {
   func method(_: Int, for someClass: SomeClass, dividing double: Double) { }
   // expected-warning@-1{{instance method 'method(_:for:dividing:)' nearly matches optional requirement 'methodWithInt(_:forSomeClass:dividingDouble:)' of protocol 'P5'}}
-  // expected-note@-2{{rename to 'methodWithInt(_:forSomeClass:dividingDouble:)' to satisfy this requirement}}{{3-3=@objc(methodWithInt:forSomeClass:dividingDouble:) }}{{8-14=methodWithInt}}{{23-26=forSomeClass}}{{49-57=dividingDouble}}
+  // expected-note@-2{{rename to 'methodWithInt(_:forSomeClass:dividingDouble:)' to satisfy this requirement}}{{8-14=methodWithInt}}{{23-26=forSomeClass}}{{49-57=dividingDouble}}{{none}}
   // expected-note@-3{{move 'method(_:for:dividing:)' to an extension to silence this warning}}
   // expected-note@-4{{make 'method(_:for:dividing:)' private to silence this warning}}{{3-3=private }}
 }
@@ -100,7 +100,7 @@ class C5a : P5 {
 class C6a : P6 {
   func methodWithInt(_: Int, forSomeClass: SomeClass, dividingDouble: Double) { }
   // expected-warning@-1{{instance method 'methodWithInt(_:forSomeClass:dividingDouble:)' nearly matches optional requirement 'method(_:for:dividing:)' of protocol 'P6'}}
-  // expected-note@-2{{rename to 'method(_:for:dividing:)' to satisfy this requirement}}{{3-3=@objc(method:for:dividing:) }}{{8-21=method}}{{30-30=for }}{{55-55=dividing }}
+  // expected-note@-2{{rename to 'method(_:for:dividing:)' to satisfy this requirement}}{{8-21=method}}{{30-30=for }}{{55-55=dividing }}{{none}}
   // expected-note@-3{{move 'methodWithInt(_:forSomeClass:dividingDouble:)' to an extension to silence this warning}}
   // expected-note@-4{{make 'methodWithInt(_:forSomeClass:dividingDouble:)' private to silence this warning}}{{3-3=private }}
 }

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -130,6 +130,19 @@ class C4b : P4 {
 // Don't infer when there is an ambiguity.
 class C4_5a : P4, P5 {
   func method(x: Int, y: Int) { }
-  // expected-error@-1{{Objective-C method 'methodWithX:y:' provided by method 'method(x:y:)' does not match the requirement's selector ('foo:bar:')}}
-  // expected-error@-2{{Objective-C method 'methodWithX:y:' provided by method 'method(x:y:)' does not match the requirement's selector ('wibble:wobble:')}}
+  // expected-error@-1{{ambiguous inference of Objective-C name for instance method 'method(x:y:)' ('foo:bar:' vs 'wibble:wobble:')}}
+  // expected-note@-2{{'method(x:y:)' (in protocol 'P4') provides Objective-C name 'foo:bar:'}}{{3-3=@objc(foo:bar:) }}
+  // expected-note@-3{{'method(x:y:)' (in protocol 'P5') provides Objective-C name 'wibble:wobble:'}}{{3-3=@objc(wibble:wobble:) }}
+  // expected-note@-4{{add '@nonobjc' to silence this error}}{{3-3=@nonobjc }}
+  // expected-error@-5{{Objective-C method 'foo:bar:' provided by method 'method(x:y:)' does not match the requirement's selector ('wibble:wobble:')}}
+}
+
+// Don't complain about a selector mismatch in cases where the
+// selector will be inferred.
+@objc protocol P6 {
+  func doSomething(_ sender: AnyObject?) // expected-note{{requirement 'doSomething' declared here}}
+}
+
+class C6a : P6 {
+  func doSomething(sender: AnyObject?) { } // expected-error{{method 'doSomething(sender:)' has different argument names from those required by protocol 'P6' ('doSomething')}}{{20-20=_ }}{{none}}
 }

--- a/test/decl/protocol/req/optional.swift
+++ b/test/decl/protocol/req/optional.swift
@@ -117,7 +117,7 @@ extension C6 : P1 {
 @objc class C8 : P2 { // expected-note{{class 'C8' declares conformance to protocol 'P2' here}}
   func objcMethod(int x: Int) { } // expected-error{{Objective-C method 'objcMethodWithInt:' provided by method 'objcMethod(int:)' conflicts with optional requirement method 'method(y:)' in protocol 'P2'}}
   // expected-note@-1{{add '@nonobjc' to silence this error}}{{3-3=@nonobjc }}
-  // expected-note@-2{{rename method to match requirement 'method(y:)'}}{{3-3=@objc(objcMethodWithInt:) }}{{8-18=method}}{{19-22=y}}
+  // expected-note@-2{{rename method to match requirement 'method(y:)'}}{{8-18=method}}{{19-22=y}}{{none}}
 }
 
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

In a number of cases, we weren't taking @objc inference into account when emitting other diagnostics. For example, a near-miss diagnostic for an @objc optional requirement would fix the Swift name and also provide a Fix-It that adds @objc(the-objc-name), even in cases where the @objc(the-objc-name) was redundant boilerplate due to inference.
#### Resolved bug number: (rdar://problem/26518216)

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
