### PR TITLE
[asan] Do not run sanitizers on the ASan bot

### DIFF
--- a/test/Sanitizers/lit.local.cfg
+++ b/test/Sanitizers/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'no_asan' not in config.available_features:
+    config.unsupported = True


### PR DESCRIPTION
This should fix the Swift ASan buildbot failure.
