### PR TITLE
Turn off typealiases in protocols.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -771,6 +771,8 @@ ERROR(expected_close_after_else_directive,none,
       "further conditions after #else are unreachable", ())
 
 /// Associatedtype Statement
+WARNING(typealias_in_protocol_deprecated,none,
+      "use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead", ())
 ERROR(typealias_inside_protocol_without_type,none,
       "typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement", ())
 ERROR(associatedtype_outside_protocol,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2175,7 +2175,11 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
       break;
     }
     case tok::kw_typealias:
-      DeclResult = parseDeclTypeAlias(Flags, Attributes);
+      if (Flags.contains(PD_InProtocol)) {
+        DeclResult = parseDeclAssociatedType(Flags, Attributes);
+      } else {
+        DeclResult = parseDeclTypeAlias(Flags, Attributes);
+      }
       Status = DeclResult;
       break;
     case tok::kw_associatedtype:
@@ -3021,7 +3025,7 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
   // ask us to fix up leftover Swift 2 code intending to be an associatedtype.
   if (Tok.is(tok::kw_typealias)) {
     AssociatedTypeLoc = consumeToken(tok::kw_typealias);
-    diagnose(AssociatedTypeLoc, diag::typealias_inside_protocol_without_type)
+    diagnose(AssociatedTypeLoc, diag::typealias_in_protocol_deprecated)
         .fixItReplace(AssociatedTypeLoc, "associatedtype");
   } else {
     AssociatedTypeLoc = consumeToken(tok::kw_associatedtype);

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -173,7 +173,7 @@ struct C<a : B> : B { // expected-error {{type 'C<a>' does not conform to protoc
 
 // SR-511
 protocol sr511 {
-  typealias Foo // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}} 
+  typealias Foo // expected-warning {{use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead}} 
 }
 
 associatedtype Foo = Int // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}}

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -29,8 +29,8 @@ struct MyType<TyA, TyB> {
 
 protocol P {
   associatedtype X<T>  // expected-error {{associated types may not have a generic parameter list}}
-  
-  typealias Y<T>       // expected-error {{expected '=' in typealias declaration}}
+// FIXME Disabled until typealiases in protocols are entirely fixed
+//  typealias Y<T>       // fixme-error {{expected '=' in typealias declaration}}
 }
 
 typealias basicTypealias = Int
@@ -148,6 +148,8 @@ extension C<Int> {}  // expected-error {{constrained extension must be declared 
 
 
 // Allow typealias inside protocol, but don't allow it in where clauses (at least not yet)
+// FIXME Disabled until typealiases in protocols are entirely fixed
+/*
 protocol Col {
   associatedtype Elem
   var elem: Elem { get }
@@ -227,23 +229,23 @@ protocol P2 {
     associatedtype B
 }
 
-func go3<T : P1, U : P2 where T.F == U.B>(_ x: T) -> U { // expected-error {{typealias 'F' is too complex to be used as a generic constraint; use an associatedtype instead}} expected-error {{'F' is not a member type of 'T'}}
+func go3<T : P1, U : P2 where T.F == U.B>(_ x: T) -> U { // fixme-error {{typealias 'F' is too complex to be used as a generic constraint; use an associatedtype instead}} fixme-error {{'F' is not a member type of 'T'}}
 }
 
 // Specific diagnosis for things that look like Swift 2.x typealiases
 protocol P3 {
-  typealias T // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
-  typealias U : P2 // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
+  typealias T // fixme-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
+  typealias U : P2 // fixme-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
   
-  associatedtype V : P2 = // expected-error {{expected type in associatedtype declaration}}
+  associatedtype V : P2 = // fixme-error {{expected type in associatedtype declaration}}
 }
 
 // Test for not crashing on self and recursive aliases
 protocol P4 {
   typealias X = Self
-  typealias Y = Self.Y // expected-error {{type alias 'Y' circularly references itself}}
+  typealias Y = Self.Y // fixme-error {{type alias 'Y' circularly references itself}}
   
   func getSelf() -> X
 }
-
+*/
 

--- a/validation-test/compiler_crashers/28268-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28268-swift-type-transform.swift
@@ -6,8 +6,5 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-protocol A{
-typealias B<a>:A
-enum S<T where B<Int>:d
-typealias d
+var:{protocol a{struct A:a
+typealias e=A.e

--- a/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
@@ -6,5 +6,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -parse
-var:{protocol a{struct A:a
-typealias e=A.e
+// REQUIRES: asserts
+protocol A{
+typealias B<a>:A
+enum S<T where B<Int>:d
+typealias d


### PR DESCRIPTION
#### What's in this pull request?

Turn off typealiases in protocols.

Since there still are some holes in this feature, and I haven't had time to
fill them lately: Go back to the 2.2 behavior of treating 'typealias' keyword
in protocols as an associated type, and emit a deprecation warning.

Commented out tests specifically for typealiases in protocols for now, and
random validation tests that crash or not based on whether keyword is interpreted as associatedtype or typealias updated.
