### PR TITLE
[Import as Member] Print full context in fixit

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1284,14 +1284,15 @@ namespace {
 
     /// Mark the given declaration as the Swift 2 variant of a Swift 3
     /// declaration with the given name.
-    static void markAsSwift2Variant(Decl *decl, ImportedName swift3Name) {
+    void markAsSwift2Variant(Decl *decl, ImportedName swift3Name,
+                             DeclContext *newDC = nullptr) {
       ASTContext &ctx = decl->getASTContext();
 
       llvm::SmallString<64> renamed;
       {
         // Render a swift_name string.
         llvm::raw_svector_ostream os(renamed);
-        swift3Name.printSwiftName(os);
+        Impl.printSwiftName(swift3Name, os);
       }
 
       auto attr = AvailableAttr::createUnconditional(

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -907,9 +907,6 @@ public:
       }
     }
 
-    /// Print this imported name as a string suitable for the swift_name
-    /// attribute.
-    void printSwiftName(llvm::raw_ostream &os) const;
   };
 
   /// Flags that control the import of names in importFullName.
@@ -937,6 +934,9 @@ public:
   Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
                              const clang::MacroInfo *macro,
                              clang::ASTContext &clangCtx);
+
+  /// Print an imported name as a string suitable for the swift_name attribute.
+  void printSwiftName(ImportedName, llvm::raw_ostream &os);
 
   /// Retrieve the property type as determined by the given accessor.
   static clang::QualType

--- a/test/IDE/Inputs/custom-modules/Newtype.h
+++ b/test/IDE/Inputs/custom-modules/Newtype.h
@@ -94,3 +94,11 @@ extern MyABIOldTypeNS getMyABIOldTypeNS(void);
 extern void takeMyABINewTypeNonNullNS(__nonnull MyABINewTypeNS);
 extern void takeMyABIOldTypeNonNullNS(__nonnull MyABIOldTypeNS);
 
+// Nested types
+typedef struct {int i;} NSSomeContext;
+
+typedef NSString *NSSomeContextName __attribute((swift_newtype(struct)))
+__attribute((swift_name("NSSomeContext.Name")));
+
+extern const NSSomeContextName NSMyContextName;
+

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -91,6 +91,52 @@
 // PRINT-NEXT:  }
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
+//
+// PRINT-NEXT:  struct MyABINewType : RawRepresentable, _SwiftNewtypeWrapper {
+// PRINT-NEXT:    init(_ rawValue: CFString)
+// PRINT-NEXT:    init(rawValue: CFString)
+// PRINT-NEXT:    let rawValue: CFString
+// PRINT-NEXT:  }
+// PRINT-NEXT:  typealias MyABIOldType = CFString
+// PRINT-NEXT:  extension MyABINewType {
+// PRINT-NEXT:    static let global: MyABINewType!
+// PRINT-NEXT:  }
+// PRINT-NEXT:  let kMyABIOldTypeGlobal: MyABIOldType!
+// PRINT-NEXT:  func getMyABINewType() -> MyABINewType!
+// PRINT-NEXT:  func getMyABIOldType() -> MyABIOldType!
+// PRINT-NEXT:  func takeMyABINewType(_: MyABINewType!)
+// PRINT-NEXT:  func takeMyABIOldType(_: MyABIOldType!)
+// PRINT-NEXT:  func takeMyABINewTypeNonNull(_: MyABINewType)
+// PRINT-NEXT:  func takeMyABIOldTypeNonNull(_: MyABIOldType)
+// PRINT-NEXT:  struct MyABINewTypeNS : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
+// PRINT-NEXT:    init(_ rawValue: String)
+// PRINT-NEXT:    init(rawValue: String)
+// PRINT-NEXT:    var _rawValue: NSString
+// PRINT-NEXT:    var rawValue: String { get }
+// PRINT-NEXT:  }
+// PRINT-NEXT:  typealias MyABIOldTypeNS = NSString
+// PRINT-NEXT:  func getMyABINewTypeNS() -> MyABINewTypeNS!
+// PRINT-NEXT:  func getMyABIOldTypeNS() -> String!
+// PRINT-NEXT:  func takeMyABINewTypeNonNullNS(_: MyABINewTypeNS)
+// PRINT-NEXT:  func takeMyABIOldTypeNonNullNS(_: String)
+//
+// PRINT-NEXT:  struct NSSomeContext {
+// PRINT-NEXT:    var i: Int32
+// PRINT-NEXT:    init()
+// PRINT-NEXT:    init(i: Int32)
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension NSSomeContext {
+// PRINT-NEXT:    struct Name : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, Comparable, _ObjectiveCBridgeable {
+// PRINT-NEXT:      init(_ rawValue: String)
+// PRINT-NEXT:      init(rawValue: String)
+// PRINT-NEXT:      var _rawValue: NSString
+// PRINT-NEXT:      var rawValue: String { get }
+// PRINT-NEXT:    }
+// PRINT-NEXT:  }
+// PRINT-NEXT:  extension NSSomeContext.Name {
+// PRINT-NEXT:    static let myContextName: NSSomeContext.Name
+// PRINT-NEXT:  }
+
 import Newtype
 
 func tests() {
@@ -128,4 +174,10 @@ func testConformances(ed: ErrorDomain) {
   acceptHashable(ed)
   acceptComparable(ed)
   acceptObjectiveCBridgeable(ed)
+}
+
+func testFixit() {
+	let _ = NSMyContextName
+	  // expected-error@-1{{'NSMyContextName' has been renamed to 'NSSomeContext.Name.myContextName'}}
+
 }

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -178,6 +178,5 @@ func testConformances(ed: ErrorDomain) {
 
 func testFixit() {
 	let _ = NSMyContextName
-	  // expected-error@-1{{'NSMyContextName' has been renamed to 'NSSomeContext.Name.myContextName'}}
-
+	  // expected-error@-1{{'NSMyContextName' has been renamed to 'NSSomeContext.Name.myContextName'}} {{10-25=NSSomeContext.Name.myContextName}}
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
[Import as Member] Print full context in fixit

Due to swift_name and swift_newtype, we are frequently importing onto
different contexts. This was confusing the fixit logic for unavailable
swift2 names, as we were trying to use Clang names when the Swift name
might be totally different (and even a nested type). This change has a
two-fold effect:

1) Globals who are imported onto swift_newtype-ed typedefs should be
   considered ImportAsMember.
2) When printing out the name of an ImportAsMember Swift 3 decl, we
   need to print out a fully qualified context, which also uses the
   Swift names, not the Clang names.
```
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Due to swift_name and swift_newtype, we are frequently importing onto
different contexts. This was confusing the fixit logic for unavailable
swift2 names, as we were trying to use Clang names when the Swift name
might be totally different (and even a nested type). This change has a
two-fold effect:

1) Globals who are imported onto swift_newtype-ed typedefs should be
   considered ImportAsMember.
2) When printing out the name of an ImportAsMember Swift 3 decl, we
   need to print out a fully qualified context, which also uses the
   Swift names, not the Clang names.
