### PR TITLE
Check value casts are to non-foreign types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -665,8 +665,12 @@ ERROR(init_not_instance_member,none,
       "a new object of the same dynamic type", ())
 ERROR(super_initializer_not_in_initializer,none,
       "'super.init' cannot be called outside of an initializer", ())
+
 WARNING(isa_is_always_true,none, "'%0' test is always true",
         (StringRef))
+WARNING(isa_is_foreign_check,none,
+      "'is' test is always true because %0 is a Core Foundation type",
+      (Type))
 WARNING(conditional_downcast_coercion,none,
       "conditional cast from %0 to %1 always succeeds",
       (Type, Type))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2857,12 +2857,20 @@ namespace {
         tc.diagnose(expr->getLoc(), diag::isa_is_always_true, "is");
         expr->setCastKind(castKind);
         break;
+      case CheckedCastKind::ValueCast:
+        // Check the cast target is a non-foreign type
+        if (auto cls = toType->getAs<ClassType>()) {
+          if (cls->getDecl()->isForeign()) {
+            tc.diagnose(expr->getLoc(), diag::isa_is_foreign_check, toType);
+          }
+        }
+        expr->setCastKind(castKind);
+        break;
       case CheckedCastKind::ArrayDowncast:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::DictionaryDowncastBridged:
       case CheckedCastKind::SetDowncast:
       case CheckedCastKind::SetDowncastBridged:
-      case CheckedCastKind::ValueCast:
       case CheckedCastKind::BridgeFromObjectiveC:
         // Valid checks.
         expr->setCastKind(castKind);

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -148,4 +148,8 @@ func tuple_splat2(_ q : (a : Int, b : Int)) {
   tuple_splat2(1, b: 2)    // expected-error {{extra argument 'b' in call}}
 }
 
+// SR-1612: Type comparison of foreign types is always true.
+func is_foreign(a: AnyObject) -> Bool {
+  return a is CGColor // expected-warning {{'is' test is always true because 'CGColor' is a Core Foundation type}}
+}
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Emits a warning when `is` casts are used with foreign types per the discussion on the attached SR.
#### Resolved bug number: ([SR-1612](https://bugs.swift.org/browse/SR-1612))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
