### PR TITLE
[SR-1594] Provide a better diagnostic for nil comparisons.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -130,8 +130,12 @@ ERROR(expression_too_complex,none,
       "expression was too complex to be solved in reasonable time; "
       "consider breaking up the expression into distinct sub-expressions", ())
 
-ERROR(comparison_with_nil_illegal,none,
-      "value of type %0 can never be nil, comparison isn't allowed",
+ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,
+      "value of type %0 cannot be compared by reference; "
+      "did you mean to compare by value?",
+      (Type))
+ERROR(value_type_comparison_with_nil_illegal,none,
+      "type %0 is not optional, value can never be nil",
       (Type))
 
 ERROR(cannot_match_expr_pattern_with_value,none,

--- a/test/ClangModules/nullability.swift
+++ b/test/ClangModules/nullability.swift
@@ -6,16 +6,16 @@ import CoreCooling
 
 func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   var ao1: AnyObject = sc.methodA(osc)
-  if sc.methodA(osc) == nil { } // expected-error{{value of type 'AnyObject' can never be nil, comparison isn't allowed}}
+  if sc.methodA(osc) == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
 
   var ao2: AnyObject = sc.methodB(nil)
-  if sc.methodA(osc) == nil { } // expected-error{{value of type 'AnyObject' can never be nil, comparison isn't allowed}}
+  if sc.methodA(osc) == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
 
   var ao3: AnyObject = sc.property // expected-error{{value of optional type 'AnyObject?' not unwrapped; did you mean to use '!' or '?'?}} {{35-35=!}}
   var ao3_ok: AnyObject? = sc.property // okay
 
   var ao4: AnyObject = sc.methodD()
-  if sc.methodD() == nil { } // expected-error{{value of type 'AnyObject' can never be nil, comparison isn't allowed}}
+  if sc.methodD() == nil { } // expected-error{{type 'AnyObject' is not optional, value can never be nil}}
 
   sc.methodE(sc)
   sc.methodE(osc) // expected-error{{value of optional type 'SomeClass?' not unwrapped; did you mean to use '!' or '?'?}} {{17-17=!}}
@@ -31,7 +31,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let ci: CInt = 1
   var sc2 = SomeClass(int: ci)
   var sc2a: SomeClass = sc2
-  if sc2 == nil { } // expected-error{{value of type 'SomeClass' can never be nil, comparison isn't allowed}}
+  if sc2 == nil { } // expected-error{{type 'SomeClass' is not optional, value can never be nil}}
 
   var sc3 = SomeClass(double: 1.5)
   if sc3 == nil { } // okay
@@ -39,7 +39,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
 
   var sc4 = sc.returnMe()
   var sc4a: SomeClass = sc4
-  if sc4 == nil { } // expected-error{{value of type 'SomeClass' can never be nil, comparison isn't allowed}}
+  if sc4 == nil { } // expected-error{{type 'SomeClass' is not optional, value can never be nil}}
 }
 
 // Nullability with CF types.

--- a/test/ClangModules/objc_failable_inits.swift
+++ b/test/ClangModules/objc_failable_inits.swift
@@ -7,7 +7,7 @@ import Foundation
 func testDictionary() {
   // -[NSDictionary init] returns non-nil.
   var dictNonOpt = NSDictionary()
-  if dictNonOpt == nil { } // expected-error{{value of type 'NSDictionary' can never be nil, comparison isn't allowed}}
+  if dictNonOpt == nil { } // expected-error{{type 'NSDictionary' is not optional, value can never be nil}}
 }
 
 func testString() throws {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -213,7 +213,7 @@ class r20201968C {
 
 // <rdar://problem/21459429> QoI: Poor compilation error calling assert
 func r21459429(_ a : Int) {
-  assert(a != nil, "ASSERT COMPILATION ERROR") // expected-error {{value of type 'Int' can never be nil, comparison isn't allowed}}
+  assert(a != nil, "ASSERT COMPILATION ERROR") // expected-error {{type 'Int' is not optional, value can never be nil}}
 }
 
 
@@ -590,7 +590,7 @@ func r21684487() {
 func r18397777(_ d : r21447318?) {
   let c = r21447318()
 
-  if c != nil { // expected-error {{value of type 'r21447318' can never be nil, comparison isn't allowed}}
+  if c != nil { // expected-error {{type 'r21447318' is not optional, value can never be nil}}
   }
   
   if d {  // expected-error {{optional type 'r21447318?' cannot be used as a boolean; test for '!= nil' instead}} {{6-6=(}} {{7-7= != nil)}}
@@ -762,6 +762,19 @@ func overloadSetResultType(_ a : Int, b : Int) -> Int {
 func r21523291(_ bytes : UnsafeMutablePointer<UInt8>) {
   let i = 42   // expected-note {{change 'let' to 'var' to make it mutable}}
   let r = bytes[i++]  // expected-error {{cannot pass immutable value as inout argument: 'i' is a 'let' constant}}
+}
+
+
+// SR-1594: Wrong error description when using === on non-class types
+class SR1594 {
+  func sr1594(bytes : UnsafeMutablePointer<Int>, _ i : Int?) {
+    _ = (i === nil) // expected-error {{value of type 'Int?' cannot be compared by reference; did you mean to compare by value?}} {{12-15===}}
+    _ = (bytes === nil) // expected-error {{type 'UnsafeMutablePointer<Int>' is not optional, value can never be nil}}
+    _ = (self === nil) // expected-error {{type 'SR1594' is not optional, value can never be nil}}
+    _ = (i !== nil) // expected-error {{value of type 'Int?' cannot be compared by reference; did you mean to compare by value?}} {{12-15=!=}}
+    _ = (bytes !== nil) // expected-error {{type 'UnsafeMutablePointer<Int>' is not optional, value can never be nil}}
+    _ = (self !== nil) // expected-error {{type 'SR1594' is not optional, value can never be nil}}
+  }
 }
 
 

--- a/test/expr/cast/nil_value_to_optional.swift
+++ b/test/expr/cast/nil_value_to_optional.swift
@@ -5,8 +5,8 @@ var f = false
 
 func markUsed<T>(_ t: T) {}
 
-markUsed(t != nil) // expected-error {{value of type 'Bool' can never be nil, comparison isn't allowed}}
-markUsed(f != nil) // expected-error {{value of type 'Bool' can never be nil, comparison isn't allowed}}
+markUsed(t != nil) // expected-error {{type 'Bool' is not optional, value can never be nil}}
+markUsed(f != nil) // expected-error {{type 'Bool' is not optional, value can never be nil}}
 
 class C : Equatable {}
 
@@ -15,7 +15,7 @@ func == (lhs: C, rhs: C) -> Bool {
 }
 
 func test(_ c: C) {
-  if c == nil {} // expected-error {{value of type 'C' can never be nil, comparison isn't allowed}}
+  if c == nil {} // expected-error {{type 'C' is not optional, value can never be nil}}
 }
 
 class D {}
@@ -24,6 +24,6 @@ var d = D()
 var dopt: D? = nil
 var diuopt: D! = nil
 
-_ = d == nil // expected-error{{value of type 'D' can never be nil, comparison isn't allowed}}
+_ = d == nil // expected-error{{type 'D' is not optional, value can never be nil}}
 _ = dopt == nil
 _ = diuopt == nil

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -682,10 +682,10 @@ func invalidDictionaryLiteral() {
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
-Int.self == nil // expected-error {{value of type 'Int.Type' can never be nil, comparison isn't allowed}}
+Int.self == nil // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
 nil == Int.self // expected-error {{binary operator '==' cannot be applied to operands}}
 // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists}}
-Int.self != nil // expected-error {{value of type 'Int.Type' can never be nil, comparison isn't allowed}}
+Int.self != nil // expected-error {{type 'Int.Type' is not optional, value can never be nil}}
 nil != Int.self // expected-error {{binary operator '!=' cannot be applied to operands}}
 // expected-note @-1 {{overloads for '!=' exist with these partially matching parameter lists}}
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Comparisons to nil are already suspect, but the diagnostic about it applied only to types with reference semantics, which `Int?` in the linked SR most certainly does not have.  This patch differentiates the error for types with reference and value semantics.
#### Resolved bug number: ([SR-1594](https://bugs.swift.org/browse/SR-1594))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
