### PR TITLE
Add Process.environment as a [String:String] dictionary

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -311,6 +311,7 @@ SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
   SILParameterInfo params[] = {
     SILParameterInfo(Int32Ty, ParameterConvention::Direct_Unowned),
     SILParameterInfo(PtrPtrInt8Ty, ParameterConvention::Direct_Unowned),
+    SILParameterInfo(PtrPtrInt8Ty, ParameterConvention::Direct_Unowned),
   };
 
   CanSILFunctionType topLevelType = SILFunctionType::get(nullptr, extInfo,
@@ -1121,6 +1122,8 @@ static void emitTopLevelProlog(SILGenFunction &gen, SILLocation loc) {
                                   entry, FnTy->getParameters()[0].getSILType());
   auto argv = new (gen.F.getModule()) SILArgument(
                                   entry, FnTy->getParameters()[1].getSILType());
+  auto envp = new (gen.F.getModule()) SILArgument(
+                                  entry, FnTy->getParameters()[2].getSILType());
 
   // If the standard library provides a _stdlib_didEnterMain intrinsic, call it
   // first thing.
@@ -1128,6 +1131,7 @@ static void emitTopLevelProlog(SILGenFunction &gen, SILLocation loc) {
     ManagedValue params[] = {
       ManagedValue::forUnmanaged(argc),
       ManagedValue::forUnmanaged(argv),
+      ManagedValue::forUnmanaged(envp),
     };
     (void) gen.emitApplyOfLibraryIntrinsic(loc, didEnterMain, {}, params,
                                            SGFContext());

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -45,6 +45,9 @@ __swift_uint64_t _swift_stdlib_HashingDetail_fixedSeedOverride;
 extern SWIFT_RUNTIME_STDLIB_INTERFACE
 void *_swift_stdlib_ProcessArguments;
 
+extern SWIFT_RUNTIME_STDLIB_INTERFACE
+void *_swift_stdlib_ProcessEnvironment;
+
 #ifdef __cplusplus
 }} // extern "C", namespace swift
 #endif

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -44,6 +44,9 @@ __swift_uint64_t swift::_swift_stdlib_HashingDetail_fixedSeedOverride = 0;
 /// Backing storage for Swift.Process.arguments.
 void *swift::_swift_stdlib_ProcessArguments = nullptr;
 
+/// Backing storage for Swift.Process.environment.
+void *swift::_swift_stdlib_ProcessEnvironment = nullptr;
+
 namespace llvm { namespace hashing { namespace detail {
   // An extern variable expected by LLVM's hashing templates. We don't link any
   // LLVM libs into the runtime, so define this here.


### PR DESCRIPTION
#### What's in this pull request?

Implemented `Process.environment` that takes it's values from the third parameter to the C main function (`environ`). `Process.environment` is a dictionary `[String:String]` of all defined environment variables. It does not update when the process executes a `setenv` system call.
#### Resolved bug number: ([SR-1636](https://bugs.swift.org/browse/SR-1636))

Probably related: [SR-1396](https://bugs.swift.org/browse/SR-1396)

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
