### PR TITLE
[swiftc] Add test case for crash triggered in swift::GenericSignature::getSubstitutionMap(…)

### DIFF
--- a/validation-test/compiler_crashers/28296-swift-genericsignature-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers/28296-swift-genericsignature-getsubstitutionmap.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class a<g{let C{class d<T where g:a{class a{func e{class A:a}}}protocol a{{{{}}}typealias a


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:139: const T &llvm::ArrayRef<swift::Substitution>::front() const [T = swift::Substitution]: Assertion `!empty()' failed.
8  swift           0x00000000010cc8a6 swift::GenericSignature::getSubstitutionMap(llvm::ArrayRef<swift::Substitution>) const + 566
9  swift           0x0000000000f1d41a swift::createDesignatedInitOverride(swift::TypeChecker&, swift::ClassDecl*, swift::ConstructorDecl*, swift::DesignatedInitKind) + 266
10 swift           0x0000000000ea60a7 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 3095
13 swift           0x0000000000e9fe76 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
16 swift           0x0000000000f0465a swift::TypeChecker::typeCheckFunctionBodyUntil(swift::FuncDecl*, swift::SourceLoc) + 346
17 swift           0x0000000000f044be swift::TypeChecker::typeCheckAbstractFunctionBodyUntil(swift::AbstractFunctionDecl*, swift::SourceLoc) + 46
18 swift           0x0000000000f05083 swift::TypeChecker::typeCheckAbstractFunctionBody(swift::AbstractFunctionDecl*) + 179
20 swift           0x0000000000ec3221 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1249
21 swift           0x0000000000c58a39 swift::CompilerInstance::performSema() + 3289
23 swift           0x00000000007d6d6f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
24 swift           0x00000000007a2db8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28296-swift-genericsignature-getsubstitutionmap.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28296-swift-genericsignature-getsubstitutionmap-92b81d.o
1.  While type-checking 'e' at validation-test/compiler_crashers/28296-swift-genericsignature-getsubstitutionmap.swift:10:45
2.  While type-checking 'A' at validation-test/compiler_crashers/28296-swift-genericsignature-getsubstitutionmap.swift:10:52
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
