### PR TITLE
[IDE/completion] Hide clang decls that are marked as 'swift_private', from the code-completion results.

### DIFF
--- a/test/IDE/Inputs/header.h
+++ b/test/IDE/Inputs/header.h
@@ -13,3 +13,5 @@ void doSomethingInHead(int arg);
 @interface BaseInHead(SomeCategory)
 -(void)doItInCategory;
 @end
+
+void function_as_swift_private(void) __attribute__((swift_private));

--- a/test/IDE/complete_with_header_import.swift
+++ b/test/IDE/complete_with_header_import.swift
@@ -5,6 +5,7 @@
 
 func foo() {
   #^TOP^#
+  // CHECK-TOP-NOT: function_as_swift_private
   // CHECK-TOP: Decl[FreeFunction]/OtherModule[__ObjC]:     doSomethingInHead({#(arg): Int32#})[#Void#]{{; name=.+$}}
 }
 


### PR DESCRIPTION
#### What's in this pull request?

<!-- Description about pull request. -->

Changes to hide clang decls that are marked as 'swift_private', from the code-completion results.
These are not intended to be visible.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26533313

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
