### PR TITLE
[SourceKit] Conditionally use in-proc for repl

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -1,6 +1,12 @@
+if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
+  set(SOURCEKITD_REPL_DEPEND sourcekitdInProc)
+else()
+  set(SOURCEKITD_REPL_DEPEND sourcekitd)
+endif()
+
 add_sourcekit_executable(sourcekitd-repl
   sourcekitd-repl.cpp
-  DEPENDS sourcekitd edit
+  DEPENDS ${SOURCEKITD_REPL_DEPEND} edit
   COMPONENT_DEPENDS support
 )
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Most SourceKit build products are linked against either sourcekitd (which uses XPC) or sourcekitdInProc (which does not) based on the `SWIFT_SOURCEKIT_USE_INPROC_LIBRARY` CMake option. Adapt `sourcekitd-repl` to fit this established pattern.

/cc @akyrtzi
#### ~~Resolved~~ Related bug number: ([SR-710](https://bugs.swift.org/browse/SR-710))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
