### PR TITLE
[SR-1639][SourceKit] Link SwiftLang libraries to sourcekitd

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -16,5 +16,8 @@ endif()
 
 add_sourcekit_library(sourcekitdAPI
   ${sourcekitdAPI_sources}
-  DEPENDS SourceKitSupport
+  DEPENDS
+      SourceKitSupport SourceKitSwiftLang
+      # Clang dependencies, required by SourceKitSwiftLang
+      clangFormat clangToolingCore clangDriver
 )


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

When building SourceKit on Linux, sourcekitdAPI would not be linked to SourceKitSwiftLang, which caused the following symbols to be undefined:
- `SourceKit::LangSupport::SynthesizedUSRSeparator`
- `SourceKit::LangSupport::createSwiftLangSupport(SourceKit::Context&)`

Link SourceKitSwiftLang to resolve these symbols.
#### ~~Resolved~~ Related bug number: ([SR-1639](https://bugs.swift.org/browse/SR-1639))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
