### PR TITLE
[swiftc] Add test case for crash triggered in swift::NameAliasType::getSinglyDesugaredType()

### DIFF
--- a/validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift
+++ b/validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A{typealias e:a
+let a=c


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/include/swift/AST/Decl.h:2463: swift::Type swift::TypeAliasDecl::getUnderlyingType() const: Assertion `!UnderlyingTy.getType().isNull() && "getting invalid underlying type"' failed.
8  swift           0x0000000001106262 swift::NameAliasType::getSinglyDesugaredType() + 146
9  swift           0x00000000011022e6 swift::TypeBase::getCanonicalType() + 486
10 swift           0x00000000011023fe swift::TypeBase::getCanonicalType() + 766
11 swift           0x00000000010eeb47 swift::removeShadowedDecls(llvm::SmallVectorImpl<swift::ValueDecl*>&, swift::ModuleDecl const*, swift::LazyResolver*) + 311
16 swift           0x00000000010d0c86 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1174
17 swift           0x0000000000edc344 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
18 swift           0x0000000000e86f78 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3864
20 swift           0x000000000104e623 swift::Expr::walk(swift::ASTWalker&) + 19
21 swift           0x0000000000e87797 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
22 swift           0x0000000000e8e152 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
23 swift           0x0000000000e8f2a7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
24 swift           0x0000000000e8f4bb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
26 swift           0x0000000000e9bbf9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 4153
27 swift           0x00000000010f220c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2652
28 swift           0x00000000010f0aa5 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2469
29 swift           0x0000000000edaf3b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
32 swift           0x0000000000f0b97e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
34 swift           0x0000000000f0c984 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
35 swift           0x0000000000f0b870 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
38 swift           0x0000000000e9b001 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
43 swift           0x0000000000ea0546 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
44 swift           0x0000000000ec37f2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 994
45 swift           0x0000000000c58c79 swift::CompilerInstance::performSema() + 3289
47 swift           0x00000000007d6eef swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
48 swift           0x00000000007a2ef8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28298-swift-namealiastype-getsinglydesugaredtype-defc2e.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift:10:1
2.  While type-checking 'e' at validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift:10:9
3.  While resolving type a at [validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift:10:21 - line:10:21] RangeText="a"
4.  While type-checking expression at [validation-test/compiler_crashers/28298-swift-namealiastype-getsinglydesugaredtype.swift:11:7 - line:11:7] RangeText="c"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
