### PR TITLE
[SR-1594][Sema] Add specific diagnostic for using reference equality with nil.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -133,6 +133,8 @@ ERROR(expression_too_complex,none,
 ERROR(comparison_with_nil_illegal,none,
       "value of type %0 can never be nil, comparison isn't allowed",
       (Type))
+ERROR(reference_comparison_with_nil_illegal,none,
+      "cannot check reference equality of nil; use normal comparison instead", ())
 
 ERROR(cannot_match_expr_pattern_with_value,none,
       "expression pattern of type %0 cannot match values of type %1",

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4311,8 +4311,15 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
     if (isa<NilLiteralExpr>(rhsExpr->getValueProvidingExpr()) &&
         !isUnresolvedOrTypeVarType(lhsType)) {
       if (isNameOfStandardComparisonOperator(overloadName)) {
-        diagnose(callExpr->getLoc(), diag::comparison_with_nil_illegal, lhsType)
-          .highlight(lhsExpr->getSourceRange());
+        if (lhsType->getAnyOptionalObjectType() &&
+            (overloadName == "===" || overloadName == "!==")) {
+          diagnose(callExpr->getLoc(), diag::reference_comparison_with_nil_illegal)
+            .fixItReplace(callExpr->getFn()->getSourceRange(),
+                          overloadName.substr(0,2));
+        } else {
+          diagnose(callExpr->getLoc(), diag::comparison_with_nil_illegal, lhsType)
+            .highlight(lhsExpr->getSourceRange());
+        }
         return true;
       }
     }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -764,4 +764,7 @@ func r21523291(_ bytes : UnsafeMutablePointer<UInt8>) {
   let r = bytes[i++]  // expected-error {{cannot pass immutable value as inout argument: 'i' is a 'let' constant}}
 }
 
-
+// SR-1594 wrong error description when using === on comparison to nil
+func sr1594(a: Int?) {
+  _ = a === nil // expected-error {{cannot check reference equality of nil; use normal comparison instead}}{{9-12===}}
+}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

A new diagnostic and fixit for replacing `=== nil` (and `!== nil`) with `== nil` (`!= nil`).
#### Resolved bug number: ([SR-1594](https://bugs.swift.org/browse/SR-1594))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
