### PR TITLE
[build-script] Simplify usage message of build-script

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -171,6 +171,10 @@ def main_preset():
 def main_normal():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        usage="""
+  %(prog)s [-h | --help] [OPTION ...]
+  %(prog)s --preset=NAME [SUBSTITUTION ...]
+""",
         description="""
 Use this tool to build, test, and prepare binary distribution archives of Swift
 and related tools.


### PR DESCRIPTION
#### What's in this pull request?

The usage message of `build-script` is becoming insanely long, therefore useless:
<details>
<summary>

Full usage</summary>



```
usage: build-script [-h] [--host-target HOST_TARGET]
                    [--stdlib-deployment-targets [STDLIB_DEPLOYMENT_TARGETS [STDLIB_DEPLOYMENT_TARGETS ...]]]
                    [-l] [-b] [-p] [--xctest] [--foundation] [--libdispatch]
                    [--build-ninja] [-c] [--export-compile-commands]
                    [--symbols-package PATH] [-d | -r | -R] [--debug-llvm]
                    [--debug-swift] [--debug-swift-stdlib] [--debug-lldb]
                    [--debug-cmark] [--debug-foundation] [--debug-libdispatch]
                    [--assertions | --no-assertions] [--cmark-assertions]
                    [--llvm-assertions] [--no-llvm-assertions]
                    [--swift-assertions] [--no-swift-assertions]
                    [--swift-stdlib-assertions] [--no-swift-stdlib-assertions]
                    [--lldb-assertions] [--no-lldb-assertions] [-x] [-m] [-e]
                    [-t] [--test [BOOL]] [-T] [--validation-test [BOOL]] [-o]
                    [--test-optimized [BOOL]] [--long-test [BOOL]]
                    [--host-test] [-B] [--skip-test-osx] [--skip-test-linux]
                    [--skip-test-freebsd] [--skip-test-cygwin]
                    [--build-runtime-with-host-compiler] [-S]
                    [--skip-build-linux] [--skip-build-freebsd]
                    [--skip-build-cygwin] [--skip-build-osx]
                    [--skip-build-ios] [--skip-build-ios-device]
                    [--skip-build-ios-simulator] [--skip-build-tvos]
                    [--skip-build-tvos-device] [--skip-build-tvos-simulator]
                    [--skip-build-watchos] [--skip-build-watchos-device]
                    [--skip-build-watchos-simulator] [--skip-build-android]
                    [--skip-build-benchmarks] [--skip-test-ios]
                    [--skip-test-ios-simulator] [--skip-test-ios-host]
                    [--skip-test-tvos] [--skip-test-tvos-simulator]
                    [--skip-test-tvos-host] [--skip-test-watchos]
                    [--skip-test-watchos-simulator] [--skip-test-watchos-host]
                    [-i] [--skip-ios] [--tvos] [--skip-tvos] [--watchos]
                    [--skip-watchos] [--android]
                    [--swift-analyze-code-coverage {false,not-merged,merged}]
                    [--build-subdir PATH] [--install-prefix PATH]
                    [--install-symroot PATH] [-j BUILD_JOBS]
                    [--darwin-xcrun-toolchain DARWIN_XCRUN_TOOLCHAIN]
                    [--cmake PATH] [--show-sdks]
                    [--extra-swift-args EXTRA_SWIFT_ARGS] [--android-ndk PATH]
                    [--android-api-level ANDROID_API_LEVEL]
                    [--android-ndk-gcc-version {4.8,4.9}]
                    [--android-icu-uc PATH] [--android-icu-uc-include PATH]
                    [--android-icu-i18n PATH]
                    [--android-icu-i18n-include PATH] [--host-cc PATH]
                    [--host-cxx PATH] [--distcc] [--enable-asan]
                    [--enable-ubsan]
                    [--clang-compiler-version MAJOR.MINOR.PATCH]
                    [--darwin-deployment-version-osx MAJOR.MINOR]
                    [--darwin-deployment-version-ios MAJOR.MINOR]
                    [--darwin-deployment-version-tvos MAJOR.MINOR]
                    [--darwin-deployment-version-watchos MAJOR.MINOR]
                    [--extra-cmake-options EXTRA_CMAKE_OPTIONS]
                    [--build-args BUILD_ARGS] [--verbose-build [BOOL]]
```

</details>

This PR simplify that to:

```
usage: 
  build-script [-h | --help] [OPTION ...]
  build-script --preset=NAME [SUBSTITUTION ...]
```

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
