### PR TITLE
[SR-1397][AST] Stop looking into inner nominal decls for outer constructors

### DIFF
--- a/test/decl/class/constructor_search_outer.swift
+++ b/test/decl/class/constructor_search_outer.swift
@@ -1,0 +1,45 @@
+// RUN: %target-parse-verify-swift
+
+class A {
+  init() {}
+}
+
+class B {
+  init() {}
+    
+  convenience init(x: ()) {
+    class C: A {
+      override init() { // No error
+        super.init()
+      }
+    }
+      
+    class D: A {
+      convenience init(x: ()) {
+        class DI : A {
+          override init() { // No error
+            super.init()
+          }
+        }
+
+        self.init()
+      }
+
+      override init() { // No error
+        class DI : A {
+          override init() { // No error
+            super.init()
+          }
+        }
+        super.init()
+      }
+    }
+
+    struct E {
+      init() {} // No error
+    }
+ 
+    self.init()
+  }
+}
+


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

We were walking way too far searching for constructor decls and accidentally assuming every inner class declaration's constructors were a part of the outer class here.  Because valid constructors only exist in the outermost context, we will simply not walk into nominal decls.
#### Resolved bug number: ([SR-1397](https://bugs.swift.org/browse/SR-1397))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
