### PR TITLE
[build-script] Modularize argparse types

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -16,8 +16,6 @@ import multiprocessing
 import os
 import pipes
 import platform
-import re
-import shlex
 import sys
 
 # FIXME: Instead of modifying the system path in order to enable imports from
@@ -40,6 +38,7 @@ from SwiftBuildSupport import (
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
 
 # E402 means module level import not at top of file
+from swift_build_support import arguments  # noqa (E402)
 from swift_build_support.toolchain import host_toolchain  # noqa (E402)
 import swift_build_support.debug      # noqa (E402)
 from swift_build_support import migration  # noqa (E402)
@@ -50,50 +49,6 @@ import swift_build_support.targets    # noqa (E402)
 from swift_build_support.cmake import CMake  # noqa (E402)
 from swift_build_support.workspace import Workspace  # noqa(E402)
 from swift_build_support.workspace import compute_build_subdir  # noqa(E402)
-
-
-# A strict parser for bools (unlike Python's `bool()`, where
-# `bool('False')` is `True`).
-#
-# This function can be passed as `type=` argument to argparse to parse values
-# passed to command line arguments.
-def argparse_bool(string):
-    if string in ['0', 'false', 'False']:
-        return False
-    if string in ['1', 'true', 'True']:
-        return True
-    raise argparse.ArgumentTypeError("%r is not a boolean value" % string)
-
-
-# Parse and split shell arguments string into a list of shell arguments.
-# Recognize `,` as a separator as well as white spaces.
-# string: -BAR="foo bar" -BAZ='foo,bar',-QUX 42
-# into
-# ['-BAR=foo bar', '-BAZ=foo,bar', "-QUX", "42"]
-def argparse_shell_split(string):
-    lex = shlex.shlex(string, posix=True)
-    lex.whitespace_split = True
-    lex.whitespace += ','
-    return list(lex)
-
-
-# Parse version string and split into a tuple of strings (major, minor, patch)
-# Support only "MAJOR.MINOR.PATCH" format.
-def argparse_clang_compiler_version(string):
-    m = re.match(r'([0-9]*)\.([0-9]*)\.([0-9]*)', string)
-    if m is not None:
-        return m.group(1, 2, 3)
-    raise argparse.ArgumentTypeError(
-        "%r is invalid version value. must be 'MAJOR.MINOR.PATCH'" % string)
-
-
-# Check the string is executable path string.
-# Convert it to absolute path.
-def argparse_executable(string):
-    if os.access(string, os.X_OK):
-        return os.path.abspath(string)
-    raise argparse.ArgumentTypeError(
-        "%r is not executable" % string)
 
 
 # Main entry point for the preset mode.
@@ -591,7 +546,7 @@ details of the setups of other systems or automated environments.""")
         help="test Swift after building",
         metavar="BOOL",
         nargs='?',
-        type=argparse_bool,
+        type=arguments.type.bool,
         default=False,
         const=True)
     run_tests_group.add_argument(
@@ -605,7 +560,7 @@ details of the setups of other systems or automated environments.""")
         help="run the validation test suite (implies --test)",
         metavar="BOOL",
         nargs='?',
-        type=argparse_bool,
+        type=arguments.type.bool,
         default=False,
         const=True)
     run_tests_group.add_argument(
@@ -619,7 +574,7 @@ details of the setups of other systems or automated environments.""")
         help="run the test suite in optimized mode too (implies --test)",
         metavar="BOOL",
         nargs='?',
-        type=argparse_bool,
+        type=arguments.type.bool,
         default=False,
         const=True)
     run_tests_group.add_argument(
@@ -627,7 +582,7 @@ details of the setups of other systems or automated environments.""")
         help="run the long test suite",
         metavar="BOOL",
         nargs='?',
-        type=argparse_bool,
+        type=arguments.type.bool,
         default=False,
         const=True)
     run_tests_group.add_argument(
@@ -860,7 +815,7 @@ details of the setups of other systems or automated environments.""")
         "--cmake",
         help="the path to a CMake executable that will be used to build "
              "Swift",
-        type=argparse_executable,
+        type=arguments.type.executable,
         metavar="PATH")
     parser.add_argument(
         "--show-sdks",
@@ -916,13 +871,13 @@ details of the setups of other systems or automated environments.""")
         "--host-cc",
         help="the absolute path to CC, the 'clang' compiler for the host "
              "platform. Default is auto detected.",
-        type=argparse_executable,
+        type=arguments.type.executable,
         metavar="PATH")
     parser.add_argument(
         "--host-cxx",
         help="the absolute path to CXX, the 'clang++' compiler for the host "
              "platform. Default is auto detected.",
-        type=argparse_executable,
+        type=arguments.type.executable,
         metavar="PATH")
     parser.add_argument(
         "--distcc",
@@ -939,7 +894,7 @@ details of the setups of other systems or automated environments.""")
     parser.add_argument(
         "--clang-compiler-version",
         help="string that indicates a compiler version for Clang",
-        type=argparse_clang_compiler_version,
+        type=arguments.type.clang_compiler_version,
         metavar="MAJOR.MINOR.PATCH")
 
     parser.add_argument(
@@ -969,7 +924,7 @@ details of the setups of other systems or automated environments.""")
              "separated options '-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp'. Can be "
              "called multiple times to add multiple such options.",
         action="append",
-        type=argparse_shell_split,
+        type=arguments.type.shell_split,
         default=[])
 
     parser.add_argument(
@@ -977,7 +932,7 @@ details of the setups of other systems or automated environments.""")
         help="arguments to the build tool. This would be prepended to the "
              "default argument that is '-j8' when CMake generator is "
              "\"Ninja\".",
-        type=argparse_shell_split,
+        type=arguments.type.shell_split,
         default=[])
 
     parser.add_argument(
@@ -985,7 +940,7 @@ details of the setups of other systems or automated environments.""")
         help="print the commands executed during the build",
         metavar="BOOL",
         nargs='?',
-        type=argparse_bool,
+        type=arguments.type.bool,
         default=False,
         const=True)
 

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -93,7 +93,7 @@ def type_executable(string):
 
     Convert it to absolute path.
     """
-    if os.access(string, os.X_OK):
+    if os.path.isfile(string) and os.access(string, os.X_OK):
         return os.path.abspath(string)
     raise argparse.ArgumentTypeError(
         "%r is not executable" % string)

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -78,7 +78,7 @@ def type_clang_compiler_version(string):
 
     Support only "MAJOR.MINOR.PATCH" format.
     """
-    m = re.match(r'([0-9]*)\.([0-9]*)\.([0-9]*)', string)
+    m = re.match(r'^([0-9]+)\.([0-9]+)\.([0-9]+)$', string)
     if m is not None:
         return m.group(1, 2, 3)
     raise argparse.ArgumentTypeError(

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -1,0 +1,101 @@
+# swift_build_support/arguments.py ------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+"""
+argparse suppliments
+"""
+# ----------------------------------------------------------------------------
+
+from __future__ import absolute_import
+
+import argparse
+import os
+import re
+import shlex
+
+__all__ = [
+    "type"
+]
+
+
+class _Registry(object):
+    pass
+
+
+def _register(registry, name, value):
+    setattr(registry, name, value)
+
+
+type = _Registry()
+
+
+def type_bool(string):
+    """
+    A strict parser for bools
+
+    unlike Python's `bool()`, where `bool('False')` is `True`
+    This function can be passed as `type=` argument to argparse to parse values
+    passed to command line arguments.
+    """
+    if string in ['0', 'false', 'False']:
+        return False
+    if string in ['1', 'true', 'True']:
+        return True
+    raise argparse.ArgumentTypeError("%r is not a boolean value" % string)
+
+_register(type, 'bool', type_bool)
+
+
+def type_shell_split(string):
+    """
+    Parse and split shell arguments string into a list of shell arguments.
+
+    Recognize `,` as a separator as well as white spaces.
+    string: -BAR="foo bar" -BAZ='foo,bar',-QUX 42
+    into
+    ['-BAR=foo bar', '-BAZ=foo,bar', "-QUX", "42"]
+    """
+    lex = shlex.shlex(string, posix=True)
+    lex.whitespace_split = True
+    lex.whitespace += ','
+    return list(lex)
+
+_register(type, 'shell_split', type_shell_split)
+
+
+def type_clang_compiler_version(string):
+    """
+    Parse version string and split into a tuple of strings
+    (major, minor, patch)
+
+    Support only "MAJOR.MINOR.PATCH" format.
+    """
+    m = re.match(r'([0-9]*)\.([0-9]*)\.([0-9]*)', string)
+    if m is not None:
+        return m.group(1, 2, 3)
+    raise argparse.ArgumentTypeError(
+        "%r is invalid version value. must be 'MAJOR.MINOR.PATCH'" % string)
+
+_register(type, 'clang_compiler_version', type_clang_compiler_version)
+
+
+def type_executable(string):
+    """
+    Check the string is executable path string.
+
+    Convert it to absolute path.
+    """
+    if os.access(string, os.X_OK):
+        return os.path.abspath(string)
+    raise argparse.ArgumentTypeError(
+        "%r is not executable" % string)
+
+_register(type, 'executable', type_executable)

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -1,0 +1,83 @@
+# tests/arguments.py --------------------------------------------*- python -*-
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+import argparse
+import os
+import sys
+import unittest
+
+from swift_build_support.arguments import type as argtype
+
+
+class ArgumentsTypeTestCase(unittest.TestCase):
+
+    def test_bool(self):
+        self.assertTrue(argtype.bool("1"))
+        self.assertTrue(argtype.bool("true"))
+        self.assertTrue(argtype.bool("True"))
+
+        self.assertFalse(argtype.bool("0"))
+        self.assertFalse(argtype.bool("false"))
+        self.assertFalse(argtype.bool("False"))
+
+        self.assertRaises(argparse.ArgumentTypeError, argtype.bool, 'foobar')
+        self.assertRaises(argparse.ArgumentTypeError, argtype.bool, 'TRUE')
+        self.assertRaises(argparse.ArgumentTypeError, argtype.bool, 'FALSE')
+
+    def test_shell_split(self):
+        self.assertEqual(
+            argtype.shell_split("-BAR=\"foo bar\" -BAZ='foo,bar',-QUX $baz"),
+            ['-BAR=foo bar', '-BAZ=foo,bar', '-QUX', '$baz'])
+
+    def test_clang_compiler_version(self):
+        self.assertEqual(
+            argtype.clang_compiler_version('1.23.456'),
+            ("1", "23", "456"))
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.clang_compiler_version,
+            "ver1.2.3")
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.clang_compiler_version,
+            "1.beta2.3")
+        self.assertEqual(
+            argtype.clang_compiler_version("1.2.preview3"),
+            ("1", "2", ""))
+        self.assertEqual(
+            argtype.clang_compiler_version("1.2.3-rc4"),
+            ("1", "2", "3"))
+
+    def test_executable(self):
+        python = sys.executable
+        self.assertTrue(os.path.isabs(argtype.executable(python)))
+
+        # On this test directory, specifying "../../build-script-impl" returns
+        # absolute path of build-script-impl
+        impl = os.path.join("..", "..", "build-script-impl")
+        cwd = os.getcwd()
+        os.chdir(os.path.dirname(__file__))
+        self.assertTrue(os.path.isabs(argtype.executable(impl)))
+        os.chdir(cwd)
+
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.executable, __file__)  # this file is not executable
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.executable, os.path.dirname(__file__))
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.executable, "/bin/example-command-not-exist")
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.executable, "../example-command-not-exist")

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -50,12 +50,18 @@ class ArgumentsTypeTestCase(unittest.TestCase):
             argparse.ArgumentTypeError,
             argtype.clang_compiler_version,
             "1.beta2.3")
-        self.assertEqual(
-            argtype.clang_compiler_version("1.2.preview3"),
-            ("1", "2", ""))
-        self.assertEqual(
-            argtype.clang_compiler_version("1.2.3-rc4"),
-            ("1", "2", "3"))
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.clang_compiler_version,
+            "1.2.preview3")
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.clang_compiler_version,
+            "1.2.3-rc4")
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            argtype.clang_compiler_version,
+            "1..2")
 
     def test_executable(self):
         python = sys.executable


### PR DESCRIPTION
#### What's in this pull request?

Modularize argparse type functions in `build-script` into `swift_build_support.arguments` module.
Added some tests.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
