### PR TITLE
Adding tests for replaceSubrange overloads for range types

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
@@ -23,6 +23,7 @@ add_swift_library(swiftStdlibCollectionUnittest SHARED IS_STDLIB
   CheckSequenceType.swift
   LoggingWrappers.swift.gyb
   MinimalCollections.swift.gyb
+  RangeSelection.swift
   ../../public/core/WriteBackMutableSlice.swift
 
   SWIFT_MODULE_DEPENDS StdlibUnittest

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -516,7 +516,7 @@ Int64 distances.
 %         # Only generating MinimalRandomAccessCollectionWithStrideableIndex
 %         if not StrideableIndex or (
 %           StrideableIndex and Traversal == 'RandomAccess' and
-%           not Mutable and not RangeReplaceable):
+%           not Mutable):
 
 /// A minimal implementation of `Collection` with extra checks.
 public struct ${Self}<T> : ${SelfProtocols} {

--- a/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
+++ b/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
@@ -1,0 +1,81 @@
+//===--- RangeSelection.swift.gyb ----------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2016 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import StdlibUnittest
+
+public enum RangeSelection {
+  case emptyRange
+  case leftEdge
+  case rightEdge
+  case middle
+  case leftHalf
+  case rightHalf
+  case offsets(Int, Int)
+
+  public func range<C : Collection>(in c: C) -> Range<C.Index> {
+    switch self {
+      case .emptyRange: return c.endIndex..<c.endIndex
+      case .leftEdge: return c.startIndex..<c.startIndex
+      case .rightEdge: return c.endIndex..<c.endIndex
+      case .middle:
+        let start = c.index(c.startIndex, offsetBy: c.count / 4)
+        let end = c.index(c.startIndex, offsetBy: 3 * c.count / 4 + 1)
+        return start..<end
+      case .leftHalf:
+        let start = c.startIndex
+        let end = c.index(start, offsetBy: c.count / 2)
+        return start..<end
+      case .rightHalf:
+        let start = c.index(c.startIndex, offsetBy: c.count / 2)
+        let end = c.endIndex
+        return start..<end
+      case let .offsets(lowerBound, upperBound):
+        let start = c.index(c.startIndex, offsetBy: numericCast(lowerBound))
+        let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))
+        return start..<end
+    }
+  }
+
+  public func countableRange<C : Collection>(in c: C) -> CountableRange<C.Index> {
+    return CountableRange(range(in: c))
+  }
+
+  public func closedRange<C : Collection>(in c: C) -> ClosedRange<C.Index> {
+    switch self {
+      case .emptyRange: fatalError("Closed range cannot be empty")
+      case .leftEdge: return c.startIndex...c.startIndex
+      case .rightEdge:
+        let beforeEnd = c.index(c.startIndex, offsetBy: c.count - 1)
+        return beforeEnd...beforeEnd
+      case .middle:
+        let start = c.index(c.startIndex, offsetBy: c.count / 4)
+        let end = c.index(c.startIndex, offsetBy: 3 * c.count / 4)
+        return start...end
+      case .leftHalf:
+        let start = c.startIndex
+        let end = c.index(start, offsetBy: c.count / 2 - 1)
+        return start...end
+      case .rightHalf:
+        let start = c.index(c.startIndex, offsetBy: c.count / 2)
+        let beforeEnd = c.index(c.startIndex, offsetBy: c.count - 1)
+        return start...beforeEnd
+      case let .offsets(lowerBound, upperBound):
+        let start = c.index(c.startIndex, offsetBy: numericCast(lowerBound))
+        let end = c.index(c.startIndex, offsetBy: numericCast(upperBound))
+        return start...end
+    }
+  }
+
+  public func countableClosedRange<C : Collection>(in c: C) -> CountableClosedRange<C.Index> {
+    return CountableClosedRange(closedRange(in: c))
+  }
+}

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -903,7 +903,6 @@ extension RangeReplaceableCollection
     _ subrange: ${Range}<Index>,
     with newElements: C
   ) where C : Collection, C.Iterator.Element == Iterator.Element {
-    // FIXME: swift-3-indexing-model: tests.
     self.replaceSubrange(_makeHalfOpen(subrange), with: newElements)
   }
 

--- a/validation-test/stdlib/RangeReplaceable.swift.gyb
+++ b/validation-test/stdlib/RangeReplaceable.swift.gyb
@@ -81,6 +81,37 @@ RangeReplaceableTestSuite.test("removeAll/dispatch") {
   expectCustomizable(tester, tester.log.removeAll)
 }
 
+RangeReplaceableTestSuite.test("replaceSubrange/countableRange") {
+  for test in replaceRangeTests {
+    var c = 
+      MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.collection)
+    let rangeToReplace = test.rangeSelection.countableRange(in: c)
+    let newElements =
+      MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.newElements)
+    c.replaceSubrange(rangeToReplace, with: newElements)
+    expectEqualSequence(
+      test.expected,
+      c.map { $0.value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+RangeReplaceableTestSuite.test("replaceSubrange/countableClosedRange") {
+  for test in replaceRangeTests {
+    guard let closedExpected = test.closedExpected else { continue }
+    var c = 
+      MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.collection)
+    let rangeToReplace = test.rangeSelection.countableClosedRange(in: c)
+    let newElements =
+      MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.newElements)
+    c.replaceSubrange(rangeToReplace, with: newElements)
+    expectEqualSequence(
+      closedExpected,
+      c.map { $0.value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
 RangeReplaceableTestSuite.test("reserveCapacity/dispatch") {
   var tester = RangeReplaceableCollectionLog.dispatchTester(Array<Int>())
   tester.reserveCapacity(10)


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->

Tests for `RangeReplaceableCollection`'s new `replaceSubrange()` overloads, for use with the new ranges.

EDIT: Tests all run and pass successfully, this PR can be merged at any time.

@gribozavr 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
