### PR TITLE
[SR-1490][stdlib] Implement SE-0076: pointer copying from immutable UnsafePointer 

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -207,11 +207,11 @@ public struct ${Self}<Pointee>
   ///
   /// - Precondition: The `Pointee`s at `self..<self + count` and
   ///   `source..<source + count` are initialized.
-  public func assignFrom(_ source: ${Self}, count: Int) {
+  public func assignFrom(_ source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.assignFrom with negative count")
     _debugPrecondition(
-      self < source || self >= source + count,
+      UnsafePointer(self) < source || UnsafePointer(self) >= source + count,
       "assignFrom non-following overlapping range; use assignBackwardFrom")
     for i in 0..<count {
       self[i] = source[i]
@@ -232,11 +232,11 @@ public struct ${Self}<Pointee>
   ///
   /// - Precondition: The `Pointee`s at `self..<self + count` and
   ///   `source..<source + count` are initialized.
-  public func assignBackwardFrom(_ source: ${Self}, count: Int) {
+  public func assignBackwardFrom(_ source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.assignBackwardFrom with negative count")
     _debugPrecondition(
-      source < self || source >= self + count,
+      source < UnsafePointer(self) || source >= UnsafePointer(self) + count,
       "${Self}.assignBackwardFrom non-preceding overlapping range; use assignFrom instead")
     var i = count-1
     while i >= 0 {
@@ -324,11 +324,12 @@ public struct ${Self}<Pointee>
   ///
   /// - Postcondition: The `Pointee`s at `self..<self + count` and
   ///   `source..<source + count` are initialized.
-  public func initializeFrom(_ source: ${Self}, count: Int) {
+  public func initializeFrom(_ source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
       count >= 0, "${Self}.initializeFrom with negative count")
     _debugPrecondition(
-      self + count <= source || source + count <= self,
+      UnsafePointer(self) + count <= source || 
+      source + count <= UnsafePointer(self),
       "${Self}.initializeFrom non-following overlapping range")
     Builtin.copyArray(
       Pointee.self, self._rawValue, source._rawValue, count._builtinWordValue)

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -188,9 +188,9 @@ class Missile {
 }
 
 func checkPointerCorrectness(_ check: Check,
+  _ withMissiles: Bool = false,
   _ f: (UnsafeMutablePointer<Missile>) ->
-    (UnsafeMutablePointer<Missile>, count: Int) -> Void,
-  _ withMissiles: Bool = false) {
+    (UnsafeMutablePointer<Missile>, count: Int) -> Void) {
   let ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 4)
   switch check {
   case .RightOverlap:
@@ -235,9 +235,23 @@ func checkPointerCorrectness(_ check: Check,
   }
 }
 
-let checkPtr: (((UnsafeMutablePointer<Missile>) ->
-  (UnsafeMutablePointer<Missile>, count: Int) -> Void), Bool) -> (Check) -> Void
-  = { (f, m) in return { checkPointerCorrectness($0, f, m) } }
+func checkPtr(
+  _ f: ((UnsafeMutablePointer<Missile>) -> (UnsafeMutablePointer<Missile>, count: Int) -> Void), 
+  _ m: Bool
+) -> (Check) -> Void {
+  return { checkPointerCorrectness($0, m, f) }
+}
+
+func checkPtr(
+  _ f: ((UnsafeMutablePointer<Missile>) -> (UnsafePointer<Missile>, count: Int) -> Void), 
+  _ m: Bool
+) -> (Check) -> Void {
+  return {
+    checkPointerCorrectness($0, m) { destPtr in 
+      return { f(destPtr)(UnsafeMutablePointer($0), count: $1) }
+    } 
+  }
+}
 
 UnsafeMutablePointerTestSuite.test("moveInitializeBackwardFrom") {
   let check = checkPtr(UnsafeMutablePointer.moveInitializeBackwardFrom, false)
@@ -321,6 +335,41 @@ UnsafeMutablePointerTestSuite.test("initializeFrom.Right") {
     check(Check.RightOverlap)
   }
 }
+
+UnsafeMutablePointerTestSuite.test("initializeFrom/immutable") {  
+  var ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 3)
+  defer {
+    ptr.deinitialize(count: 3)
+    ptr.deallocateCapacity(3)
+  }
+  let source = (0..<3).map(Missile.init)
+  source.withUnsafeBufferPointer { bufferPtr in
+    ptr.initializeFrom(bufferPtr.baseAddress!, count: 3)
+    expectEqual(0, ptr[0].number)
+    expectEqual(1, ptr[1].number)
+    expectEqual(2, ptr[2].number)
+  }
+}
+
+% for assign in ['assignFrom', 'assignBackwardFrom']:
+
+UnsafeMutablePointerTestSuite.test("${assign}/immutable") {  
+  var ptr = UnsafeMutablePointer<Missile>(allocatingCapacity: 2)
+  defer {
+    ptr.deinitialize(count: 2)
+    ptr.deallocateCapacity(2)
+  }
+  ptr.initialize(with: Missile(1))
+  (ptr + 1).initialize(with: Missile(2))
+  let source = (3..<5).map(Missile.init)
+  source.withUnsafeBufferPointer { bufferPtr in
+    ptr.${assign}(bufferPtr.baseAddress!, count: 2)
+    expectEqual(3, ptr[0].number)
+    expectEqual(4, ptr[1].number)
+  }
+}
+
+% end
 
 UnsafePointerTestSuite.test("customMirror") {
   // Ensure that the custom mirror works properly, including when the raw value


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Implementation of SE-0076. Converts `assignFrom`, `assignBackwardsFrom` and `initializeFrom` to take `UnsafePointer`.

The implementation differs from the original proposal, as per the discussion in the Jira bug.

The added tests are not intended to test the functionality itself, only ensure that the functions can be used with an immutable pointer. Actual functionality is still covered by the existing tests.

`checkPtr` grew up to be a Real Function™ in order to provide an overload that performs the mutable/immutable conversion (since the member function reference doesn't get magic compiler conversion of the pointer type.)
#### Resolved bug number: ([SR-1490](https://bugs.swift.org/browse/SR-1490))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes the functions to take immutable UP instead
of adding overloads, per comments in bug
