### PR TITLE
[build-script] use explicit build/test list between build-script and build-script-impl

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1338,6 +1338,7 @@ details of the setups of other systems or automated environments.""")
             "--install-symroot", os.path.abspath(args.install_symroot)
         ]
 
+    # Decide which products to build.
     if args.skip_build:
         build_script_impl_args += ["--skip-build-cmark",
                                    "--skip-build-llvm",
@@ -1357,29 +1358,42 @@ details of the setups of other systems or automated environments.""")
     if not args.build_swiftpm:
         build_script_impl_args += ["--skip-build-swiftpm"]
 
-    if args.skip_build_linux:
-        build_script_impl_args += ["--skip-build-linux"]
-    if args.skip_build_freebsd:
-        build_script_impl_args += ["--skip-build-freebsd"]
-    if args.skip_build_cygwin:
-        build_script_impl_args += ["--skip-build-cygwin"]
-    if args.skip_build_osx:
-        build_script_impl_args += ["--skip-build-osx"]
-    if args.skip_build_ios_device:
-        build_script_impl_args += ["--skip-build-ios-device"]
-    if args.skip_build_ios_simulator:
-        build_script_impl_args += ["--skip-build-ios-simulator"]
-    if args.skip_build_tvos_device:
-        build_script_impl_args += ["--skip-build-tvos-device"]
-    if args.skip_build_tvos_simulator:
-        build_script_impl_args += ["--skip-build-tvos-simulator"]
-    if args.skip_build_watchos_device:
-        build_script_impl_args += ["--skip-build-watchos-device"]
-    if args.skip_build_watchos_simulator:
-        build_script_impl_args += ["--skip-build-watchos-simulator"]
-    if args.skip_build_android:
-        build_script_impl_args += ["--skip-build-android"]
+    # Decide which stdlib targets to build,
+    # by taking all of the configured stdlib-deployment-targets
+    # and subtracting the skipped ones.
 
+    skipped_targets = []
+    if args.skip_build_linux:
+        skipped_targets += StdlibDeploymentTarget.Linux.allArchs
+    if args.skip_build_freebsd:
+        skipped_targets += StdlibDeploymentTarget.FreeBSD.allArchs
+    if args.skip_build_cygwin:
+        skipped_targets += StdlibDeploymentTarget.Cygwin.allArchs
+    if args.skip_build_osx:
+        skipped_targets += StdlibDeploymentTarget.OSX.allArchs
+    if args.skip_build_ios_device:
+        skipped_targets += StdlibDeploymentTarget.iOS.allArchs
+    if args.skip_build_ios_simulator:
+        skipped_targets += StdlibDeploymentTarget.iOSSimulator.allArchs
+    if args.skip_build_tvos_device:
+        skipped_targets += StdlibDeploymentTarget.AppleTV.allArchs
+    if args.skip_build_tvos_simulator:
+        skipped_targets += StdlibDeploymentTarget.AppleTVSimulator.allArchs
+    if args.skip_build_watchos_device:
+        skipped_targets += StdlibDeploymentTarget.AppleWatch.allArchs
+    if args.skip_build_watchos_simulator:
+        skipped_targets += StdlibDeploymentTarget.AppleWatchSimulator.allArchs
+    if args.skip_build_android:
+        skipped_targets += StdlibDeploymentTarget.Android.allArchs
+
+    build_stdlib_deployment_targets = [
+        x for x in args.stdlib_deployment_targets
+        if x not in skipped_targets]
+
+    build_script_impl_args += ["--build-stdlib-deployment-targets",
+                               " ".join(build_stdlib_deployment_targets)]
+
+    # Decide which products to test
     if not args.test and not args.long_test:
         build_script_impl_args += ["--skip-test-swift"]
     if not args.test:
@@ -1390,26 +1404,45 @@ details of the setups of other systems or automated environments.""")
                                    "--skip-test-xctest",
                                    "--skip-test-foundation",
                                    "--skip-test-libdispatch"]
+
+    # Decide which stdlib targets to test,
+    # by taking all of the configured stdlib-deployment-targets
+    # and subtracting the skipped ones.
+
+    skip_test_tgts = []
     if args.skip_test_linux:
-        build_script_impl_args += ["--skip-test-linux"]
+        skip_test_tgts += StdlibDeploymentTarget.Linux.allArchs
     if args.skip_test_freebsd:
-        build_script_impl_args += ["--skip-test-freebsd"]
+        skip_test_tgts += StdlibDeploymentTarget.FreeBSD.allArchs
     if args.skip_test_cygwin:
-        build_script_impl_args += ["--skip-test-cygwin"]
+        skip_test_tgts += StdlibDeploymentTarget.Cygwin.allArchs
     if args.skip_test_osx:
-        build_script_impl_args += ["--skip-test-osx"]
+        skip_test_tgts += StdlibDeploymentTarget.OSX.allArchs
     if args.skip_test_ios_host:
-        build_script_impl_args += ["--skip-test-ios-host"]
+        skip_test_tgts += StdlibDeploymentTarget.iOS.allArchs
     if args.skip_test_ios_simulator:
-        build_script_impl_args += ["--skip-test-ios-simulator"]
+        skip_test_tgts += StdlibDeploymentTarget.iOSSimulator.allArchs
     if args.skip_test_tvos_host:
-        build_script_impl_args += ["--skip-test-tvos-host"]
+        skip_test_tgts += StdlibDeploymentTarget.AppleTV.allArchs
     if args.skip_test_tvos_simulator:
-        build_script_impl_args += ["--skip-test-tvos-simulator"]
+        skip_test_tgts += StdlibDeploymentTarget.AppleTVSimulator.allArchs
     if args.skip_test_watchos_host:
-        build_script_impl_args += ["--skip-test-watchos-host"]
+        skip_test_tgts += StdlibDeploymentTarget.AppleWatch.allArchs
     if args.skip_test_watchos_simulator:
-        build_script_impl_args += ["--skip-test-watchos-simulator"]
+        skip_test_tgts += StdlibDeploymentTarget.AppleWatchSimulator.allArchs
+
+    # FIXME: Do the tests work for Android?
+    skip_test_tgts += StdlibDeploymentTarget.Android.allArchs
+
+    # Set the test list by taking all of the configured
+    # stdlib-deployment-targets and subtracting the skipped ones.
+
+    test_stdlib_deployment_targets = [
+        x for x in args.stdlib_deployment_targets
+        if x not in skip_test_tgts]
+    build_script_impl_args += ["--test-stdlib-deployment-targets",
+                               " ".join(test_stdlib_deployment_targets)]
+
     if args.build_runtime_with_host_compiler:
         build_script_impl_args += ["--build-runtime-with-host-compiler"]
     if args.validation_test:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -105,17 +105,6 @@ KNOWN_SETTINGS=(
     skip-build-cmark            ""               "set to skip building CommonMark"
     skip-build-llvm             ""               "set to skip building LLVM/Clang"
     skip-build-swift            ""               "set to skip building Swift"
-    skip-build-linux            ""               "set to skip building Swift stdlibs for Linux"
-    skip-build-freebsd          ""               "set to skip building Swift stdlibs for FreeBSD"
-    skip-build-cygwin           ""               "set to skip building Swift stdlibs for Cygwin"
-    skip-build-osx              ""               "set to skip building Swift stdlibs for OSX"
-    skip-build-ios-device       ""               "set to skip building Swift stdlibs for iOS devices (i.e. build simulators only)"
-    skip-build-ios-simulator    ""               "set to skip building Swift stdlibs for iOS simulators (i.e. build devices only)"
-    skip-build-tvos-device      ""               "set to skip building Swift stdlibs for tvOS devices (i.e. build simulators only)"
-    skip-build-tvos-simulator   ""               "set to skip building Swift stdlibs for tvOS simulators (i.e. build devices only)"
-    skip-build-watchos-device   ""               "set to skip building Swift stdlibs for Apple watchOS devices (i.e. build simulators only)"
-    skip-build-watchos-simulator ""              "set to skip building Swift stdlibs for Apple watchOS simulators (i.e. build devices only)"
-    skip-build-android          ""               "set to skip building Swift stdlibs for Android"
     skip-build-lldb             ""               "set to skip building LLDB"
     skip-build-llbuild          ""               "set to skip building llbuild"
     skip-build-swiftpm          ""               "set to skip building swiftpm"
@@ -131,16 +120,6 @@ KNOWN_SETTINGS=(
     skip-test-xctest            ""               "set to skip testing xctest"
     skip-test-foundation        ""               "set to skip testing foundation"
     skip-test-libdispatch       ""               "set to skip testing libdispatch"
-    skip-test-linux             ""               "set to skip testing Swift stdlibs for Linux"
-    skip-test-freebsd           ""               "set to skip testing Swift stdlibs for FreeBSD"
-    skip-test-cygwin            ""               "set to skip testing Swift stdlibs for Cygwin"
-    skip-test-osx               ""               "set to skip testing Swift stdlibs for OSX"
-    skip-test-ios-simulator     ""               "set to skip testing Swift stdlibs for iOS simulators (i.e. test devices only)"
-    skip-test-ios-host          ""               "set to skip testing the host parts of the iOS toolchain"
-    skip-test-tvos-simulator    ""               "set to skip testing Swift stdlibs for tvOS simulators (i.e. test devices only)"
-    skip-test-tvos-host         ""               "set to skip testing the host parts of the tvOS toolchain"
-    skip-test-watchos-simulator  ""              "set to skip testing Swift stdlibs for Apple watchOS simulators (i.e. test devices only)"
-    skip-test-watchos-host      ""               "set to skip testing the host parts of the watchOS toolchain"
     validation-test             "0"              "set to run the validation test suite"
     long-test                   "0"              "set to run the long test suite"
     skip-test-benchmarks        ""               "set to skip running Swift Benchmark Suite"
@@ -181,7 +160,8 @@ KNOWN_SETTINGS=(
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
     host-target                 ""               "The host target. LLVM, Clang, and Swift will be built for this target. The built LLVM and Clang will be used to compile Swift for the cross-compilation targets. **This argument is required**"
     stdlib-deployment-targets   ""               "space-separated list of targets to configure the Swift standard library to be compiled or cross-compiled for"
-    build-stdlib-deployment-targets "all"        "space-separated list that filters which of the configured targets to build the Swift standard library for, or 'all'"
+    build-stdlib-deployment-targets "all"        "space-separated list that determines which of the configured targets to build the Swift standard library for, or 'all'"
+    test-stdlib-deployment-targets  "all"        "space-separated list that determines which of the configured targets to build the Swift standard library tests for, or 'all'"
     cross-compile-hosts         ""               "space-separated list of targets to cross-compile host Swift tools for"
     cross-compile-with-host-tools  ""            "set to use the clang we build for the host to then build the cross-compile hosts"
     cross-compile-install-prefixes      ""       "semicolon-separated list of install prefixes to use for the cross-compiled hosts. The list expands, so if there are more cross-compile hosts than prefixes, unmatched hosts use the last prefix in the list"
@@ -1096,91 +1076,73 @@ function calculate_targets_for_host() {
     for stdlib_deployment_target in "${stdlib_targets[@]}"; do
         local swift_sdk=
         local is_in_build_list=$(should_build_stdlib_target ${stdlib_deployment_target} ${host})
-        local build_for_this_target=1
-        local test_this_target=1
+        local test_this_target=
         local test_host_only=
-        local build_benchmark_this_target=
-        local test_benchmark_this_target=
+        local supports_benchmarks=
 
         case ${stdlib_deployment_target} in
             linux-*)
                 swift_sdk="LINUX"
-                build_for_this_target=$(not ${SKIP_BUILD_LINUX})
                 test_this_target=$(not ${SKIP_TEST_LINUX})
                 ;;
             freebsd-*)
                 swift_sdk="FREEBSD"
-                build_for_this_target=$(not ${SKIP_BUILD_FREEBSD})
                 test_this_target=$(not ${SKIP_TEST_FREEBSD})
                 ;;
             cygwin-*)
                 swift_sdk="CYGWIN"
-                build_for_this_target=$(not ${SKIP_BUILD_CYGWIN})
                 test_this_target=$(not ${SKIP_TEST_CYGWIN})
                 ;;
             macosx-*)
                 swift_sdk="OSX"
-                build_for_this_target=$(not ${SKIP_BUILD_OSX})
                 test_this_target=$(not ${SKIP_TEST_OSX})
-                build_benchmark_this_target=$(not ${SKIP_BUILD_OSX})
-                test_benchmark_this_target=$(not ${SKIP_BUILD_OSX})
+                supports_benchmarks=1
                 ;;
             iphoneos-*)
                 swift_sdk="IOS"
-                build_for_this_target=$(not ${SKIP_BUILD_IOS_DEVICE})
                 if [[ ! "${SKIP_TEST_IOS_HOST}" ]] ; then
                     test_host_only=1
-                else
-                    test_this_target=
+                    test_this_target=1
                 fi
-                build_benchmark_this_target=$(not ${SKIP_BUILD_IOS_DEVICE})
+                supports_benchmarks=1
 
                 # Never build iOS armv7s benchmarks.
                 if [[ "${stdlib_deployment_target}" == "iphoneos-armv7s" ]]; then
-                    build_benchmark_this_target=
+                    supports_benchmarks=
                 fi
                 ;;
             iphonesimulator-*)
                 swift_sdk="IOS_SIMULATOR"
-                build_for_this_target=$(not ${SKIP_BUILD_IOS_SIMULATOR})
                 test_this_target=$(not ${SKIP_TEST_IOS_SIMULATOR})
                 ;;
             appletvos-*)
                 swift_sdk="TVOS"
-                build_for_this_target=$(not ${SKIP_BUILD_TVOS_DEVICE})
                 if [[ ! "${SKIP_TEST_TVOS_HOST}" ]] ; then
                     test_host_only=1
-                else
-                    test_this_target=
+                    test_this_target=1
                 fi
-                build_benchmark_this_target=$(not ${SKIP_BUILD_TVOS_DEVICE})
+                supports_benchmarks=1
                 ;;
             appletvsimulator-*)
                 swift_sdk="TVOS_SIMULATOR"
-                build_for_this_target=$(not ${SKIP_BUILD_TVOS_SIMULATOR})
                 test_this_target=$(not ${SKIP_TEST_TVOS_SIMULATOR})
                 ;;
             watchos-*)
                 swift_sdk="WATCHOS"
-                build_for_this_target=$(not ${SKIP_BUILD_WATCHOS_DEVICE})
                 if [[ ! "${SKIP_TEST_WATCHOS_HOST}" ]] ; then
                     test_host_only=1
-                else
-                    test_this_target=
+                    test_this_target=1
                 fi
-                build_benchmark_this_target=$(not ${SKIP_BUILD_WATCHOS_DEVICE})
+                supports_benchmarks=1
                 ;;
             watchsimulator-*)
                 swift_sdk="WATCHOS_SIMULATOR"
-                build_for_this_target=$(not ${SKIP_BUILD_WATCHOS_SIMULATOR})
                 test_this_target=$(not ${SKIP_TEST_WATCHOS_SIMULATOR})
                 ;;
             android-*)
                 swift_sdk="ANDROID"
-                build_for_this_target=$(not ${SKIP_BUILD_ANDROID})
                 # FIXME: Allow Android host tests to be enabled/disabled by the
                 #        build script.
-                test_this_target=
                 ;;
             *)
                 echo "Unknown compiler deployment target: ${stdlib_deployment_target}"
@@ -1190,7 +1152,7 @@ function calculate_targets_for_host() {
 
         SWIFT_SDKS+=("${swift_sdk}")
 
-        if [[ "${build_for_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
+        if [[ "${is_in_build_list}" ]]; then
 
             if [[ "${BUILD_SWIFT_STDLIB_UNITTEST_EXTRA}" == "1" ]] ; then
                 SWIFT_STDLIB_TARGETS+=("swift-stdlib-${stdlib_deployment_target}")
@@ -1201,34 +1163,34 @@ function calculate_targets_for_host() {
                     SWIFT_STDLIB_TARGETS+=("swift-test-stdlib-${stdlib_deployment_target}")
                 fi
             fi
-        fi
-        if [[ "${build_benchmark_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
-            SWIFT_BENCHMARK_TARGETS+=("swift-benchmark-${stdlib_deployment_target}")
-            if [[ $(not ${SKIP_TEST_BENCHMARK}) ]] ; then
-              SWIFT_RUN_BENCHMARK_TARGETS+=("check-swift-benchmark-${stdlib_deployment_target}")
+            if [[ "${supports_benchmarks}" ]]; then
+                SWIFT_BENCHMARK_TARGETS+=("swift-benchmark-${stdlib_deployment_target}")
+                if [[ $(not ${SKIP_TEST_BENCHMARK}) ]] ; then
+                  SWIFT_RUN_BENCHMARK_TARGETS+=("check-swift-benchmark-${stdlib_deployment_target}")
+                fi
             fi
-        fi
-        if [[ "${test_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
-            test_target_suffix=""
-            if [[ -n "${test_host_only}" ]] ; then
-                test_target_suffix="-non-executable"
-            fi
+            if [[ "${test_this_target}" ]]; then
+                test_target_suffix=""
+                if [[ -n "${test_host_only}" ]] ; then
+                    test_target_suffix="-non-executable"
+                fi
 
-            test_subset_target_suffix=""
-            if [[ "${VALIDATION_TEST}" == "1" ]] ; then
-                if [[ "${LONG_TEST}" == "1" ]] ; then
-                    test_subset_target_suffix="-all"
+                test_subset_target_suffix=""
+                if [[ "${VALIDATION_TEST}" == "1" ]] ; then
+                    if [[ "${LONG_TEST}" == "1" ]] ; then
+                        test_subset_target_suffix="-all"
+                    else
+                        test_subset_target_suffix="-validation"
+                    fi
                 else
-                    test_subset_target_suffix="-validation"
+                    if [[ "${LONG_TEST}" == "1" ]] ; then
+                        test_subset_target_suffix="-only_long"
+                    fi
                 fi
-            else
-                if [[ "${LONG_TEST}" == "1" ]] ; then
-                    test_subset_target_suffix="-only_long"
+                SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}${test_target_suffix}-${stdlib_deployment_target}")
+                if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" ]] ; then
+                    SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}-optimize-${stdlib_deployment_target}")
                 fi
-            fi
-            SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}${test_target_suffix}-${stdlib_deployment_target}")
-            if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" ]] ; then
-                SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}-optimize-${stdlib_deployment_target}")
             fi
         fi
     done


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Instead of having lots of different `skip-[platform]` and `skip-test-[platform]` flags for every stdlib SDK, use an explicit list of targets to build and test.

There are no outward-facing changes. The build and test list are calculated from the same `- - ios`, etc flags as they are today. This only affects how `build-script` tells `build-script-impl` which targets to build/test. It simplifies stdlib target calculation, and gives us the opportunity to override it with more granular options (e.g. just building one stdlib deployment target, not a whole SDK, or just building tests for one target).
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

(and appropriate test flags) with an explicit build and test list.
