### PR TITLE
[swiftc] Add test case for crash triggered in swift::Type::transform(…)

### DIFF
--- a/validation-test/compiler_crashers/28300-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28300-swift-type-transform.swift
@@ -1,0 +1,15 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class S<T{
+class A{
+func g:d
+var d={
+class B:A class e:B{
+func g


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/Support/Casting.h:95: static bool llvm::isa_impl_cl<swift::SILFunctionType, const swift::TypeBase *>::doit(const From *) [To = swift::SILFunctionType, From = const swift::TypeBase *]: Assertion `Val && "isa<> used on a null pointer"' failed.
9  swift           0x000000000110ad94 swift::Type::transform(llvm::function_ref<swift::Type (swift::Type)>) const + 36
10 swift           0x000000000110cec8 swift::TypeBase::getTypeOfMember(swift::ModuleDecl*, swift::Type, swift::DeclContext const*) + 136
17 swift           0x0000000000ea0566 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
20 swift           0x0000000000f060c4 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
21 swift           0x0000000000f3094c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
22 swift           0x0000000000e8e211 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
23 swift           0x0000000000e8f2c7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
24 swift           0x0000000000e8f4db swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
26 swift           0x0000000000e9bc19 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 4153
27 swift           0x00000000010f23ac swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2652
28 swift           0x00000000010f0c45 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2469
29 swift           0x0000000000edaf5b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
32 swift           0x0000000000f0b99e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
34 swift           0x0000000000f0c9a4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
35 swift           0x0000000000f0b890 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
37 swift           0x0000000000ed7dfe swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
44 swift           0x0000000000ea0566 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
45 swift           0x0000000000ec3812 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 994
46 swift           0x0000000000c585e9 swift::CompilerInstance::performSema() + 3289
48 swift           0x00000000007d6f4f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
49 swift           0x00000000007a2f58 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28300-swift-type-transform.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28300-swift-type-transform-f3fdad.o
1.  While type-checking 'S' at validation-test/compiler_crashers/28300-swift-type-transform.swift:10:1
2.  While resolving type d at [validation-test/compiler_crashers/28300-swift-type-transform.swift:12:8 - line:12:8] RangeText="d"
3.  While type-checking expression at [validation-test/compiler_crashers/28300-swift-type-transform.swift:13:7 - line:15:6] RangeText="{
4.  While type-checking 'e' at validation-test/compiler_crashers/28300-swift-type-transform.swift:14:11
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
