### PR TITLE
[stdlib][NFC] Use UInt${bits} instead of ${RawSignificand} to initialize float with bit pattern

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -215,12 +215,14 @@ extension ${Self}: BinaryFloatingPoint {
               exponentBitPattern: UInt,
               significandBitPattern: ${RawSignificand}) {
     let signShift = ${Self}.significandBitCount + ${Self}.exponentBitCount
-    let sign = ${RawSignificand}(sign == .minus ? 1 : 0)
-    let exponent = ${RawSignificand}(exponentBitPattern &
-      ${Self}._infinityExponent)
-    let significand = significandBitPattern & ${Self}._significandMask
-    self.init(bitPattern: sign << ${RawSignificand}(signShift) |
-      exponent << ${RawSignificand}(${Self}.significandBitCount) |
+    let sign = UInt${bits}(sign == .minus ? 1 : 0)
+    let exponent = UInt${bits}(
+      exponentBitPattern & ${Self}._infinityExponent)
+    let significand = UInt${bits}(
+      significandBitPattern & ${Self}._significandMask)
+    self.init(bitPattern:
+      sign << UInt${bits}(signShift) |
+      exponent << UInt${bits}(${Self}.significandBitCount) |
       significand)
   }
 


### PR DESCRIPTION
#### What's in this pull request?

Semantically, `init(bitPattern: UInt${bits})` is more relevant
than `init(bitPattern: ${RawSignificand})`

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
