### PR TITLE
SR-1417: Add non-optional overloads of XCTAssertEqual and XCTAssertNotEqual

### DIFF
--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -238,7 +238,7 @@ public func XCTAssertFalse(_ expression: @autoclosure () throws -> Boolean, _ me
   }
 }
 
-public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Void {
+public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Void {
   let assertionType = _XCTAssertionType.equal
   
   // evaluate each expression exactly once
@@ -252,12 +252,15 @@ public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws 
   
   switch result {
   case .success:
-    if expressionValue1Optional != expressionValue2Optional {
+    let expressionValue1: T = expressionValue1Optional!
+    let expressionValue2: T = expressionValue2Optional!
+
+    if expressionValue1 != expressionValue2 {
       // TODO: @auto_string expression1
       // TODO: @auto_string expression2
       
-      let expressionValueStr1 = "\(expressionValue1Optional)"
-      let expressionValueStr2 = "\(expressionValue2Optional)"
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
       
       _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
     }
@@ -271,6 +274,41 @@ public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws 
   case .failedWithUnknownException:
     _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
   }
+}
+
+public func XCTAssertEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Void {
+    let assertionType = _XCTAssertionType.equal
+
+    // evaluate each expression exactly once
+    var expressionValue1Optional: T?
+    var expressionValue2Optional: T?
+
+    let result = _XCTRunThrowableBlock {
+        expressionValue1Optional = try expression1()
+        expressionValue2Optional = try expression2()
+    }
+
+    switch result {
+    case .success:
+        if expressionValue1Optional != expressionValue2Optional {
+            // TODO: @auto_string expression1
+            // TODO: @auto_string expression2
+
+            let expressionValueStr1 = "\(expressionValue1Optional)"
+            let expressionValueStr2 = "\(expressionValue2Optional)"
+
+            _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+        }
+
+    case .failedWithError(let error):
+        _XCTRegisterFailure(false, "XCTAssertEqual failed: threw error \"\(error)\"", message, file, line)
+
+    case .failedWithException(_, _, let reason):
+        _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+
+    case .failedWithUnknownException:
+        _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+    }
 }
 
 // FIXME: Due to <rdar://problem/16768059> we need overrides of XCTAssertEqual for:
@@ -431,7 +469,7 @@ public func XCTAssertEqual<T, U : Equatable>(_ expression1: @autoclosure () thro
   }
 }
 
-public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Void {
+public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Void {
   let assertionType = _XCTAssertionType.notEqual
   
   // evaluate each expression exactly once
@@ -445,12 +483,15 @@ public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () thro
   
   switch result {
   case .success:
-    if expressionValue1Optional == expressionValue2Optional {
+    let expressionValue1: T = expressionValue1Optional!
+    let expressionValue2: T = expressionValue2Optional!
+
+    if expressionValue1 == expressionValue2 {
       // TODO: @auto_string expression1
       // TODO: @auto_string expression2
       
-      let expressionValueStr1 = "\(expressionValue1Optional)"
-      let expressionValueStr2 = "\(expressionValue2Optional)"
+      let expressionValueStr1 = "\(expressionValue1)"
+      let expressionValueStr2 = "\(expressionValue2)"
       
       _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
     }
@@ -464,6 +505,41 @@ public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () thro
   case .failedWithUnknownException:
     _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
   }
+}
+
+public func XCTAssertNotEqual<T : Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Void {
+    let assertionType = _XCTAssertionType.notEqual
+
+    // evaluate each expression exactly once
+    var expressionValue1Optional: T?
+    var expressionValue2Optional: T?
+
+    let result = _XCTRunThrowableBlock {
+        expressionValue1Optional = try expression1()
+        expressionValue2Optional = try expression2()
+    }
+
+    switch result {
+    case .success:
+        if expressionValue1Optional == expressionValue2Optional {
+            // TODO: @auto_string expression1
+            // TODO: @auto_string expression2
+
+            let expressionValueStr1 = "\(expressionValue1Optional)"
+            let expressionValueStr2 = "\(expressionValue2Optional)"
+
+            _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 0, expressionValueStr1 as NSString, expressionValueStr2 as NSString), message, file, line)
+        }
+
+    case .failedWithError(let error):
+        _XCTRegisterFailure(false, "XCTAssertNotEqual failed: threw error \"\(error)\"", message, file, line)
+
+    case .failedWithException(_, _, let reason):
+        _XCTRegisterFailure(false, _XCTFailureDescription(assertionType, 1, reason as NSString), message, file, line)
+
+    case .failedWithUnknownException:
+        _XCTRegisterFailure(true, _XCTFailureDescription(assertionType, 2), message, file, line)
+    }
 }
 
 // FIXME: Due to <rdar://problem/16768059> we need overrides of XCTAssertNotEqual for:

--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -44,6 +44,38 @@ XCTestTestSuite.test("exceptions") {
   expectFalse(testRun.hasSucceeded)
 }
 
+XCTestTestSuite.test("XCTAssertEqual/Optional<T>") {
+  class AssertEqualOptionalTestCase: XCTestCase {
+    dynamic func test_whenOptionalsAreEqual_passes() {
+      XCTAssertEqual(Optional(1),Optional(1))
+    }
+
+    dynamic func test_whenOptionalsAreNotEqual_fails() {
+      XCTAssertEqual(Optional(1),Optional(2))
+    }
+  }
+
+  let passingTestCase = AssertEqualOptionalTestCase(selector: #selector(AssertEqualOptionalTestCase.test_whenOptionalsAreEqual_passes))
+  execute(passingTestCase.run)
+  let passingTestRun = passingTestCase.testRun!
+  expectEqual(1, passingTestRun.testCaseCount)
+  expectEqual(1, passingTestRun.executionCount)
+  expectEqual(0, passingTestRun.failureCount)
+  expectEqual(0, passingTestRun.unexpectedExceptionCount)
+  expectEqual(0, passingTestRun.totalFailureCount)
+  expectTrue(passingTestRun.hasSucceeded)
+
+  let failingTestCase = AssertEqualOptionalTestCase(selector: #selector(AssertEqualOptionalTestCase.test_whenOptionalsAreNotEqual_fails))
+  execute(failingTestCase.run)
+  let failingTestRun = failingTestCase.testRun!
+  expectEqual(1, failingTestRun.testCaseCount)
+  expectEqual(1, failingTestRun.executionCount)
+  expectEqual(1, failingTestRun.failureCount)
+  expectEqual(0, failingTestRun.unexpectedExceptionCount)
+  expectEqual(1, failingTestRun.totalFailureCount)
+  expectFalse(failingTestRun.hasSucceeded)
+}
+
 XCTestTestSuite.test("XCTAssertEqual/Array<T>") {
   class AssertEqualArrayTestCase: XCTestCase {
     dynamic func test_whenArraysAreEqual_passes() {


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This is https://github.com/apple/swift/pull/2551 updated to include a more comprehensive test that the failure message produced by the newly introduced overload is working as-desired.

From @nsalmoria's original pull request:

> Previously, the only version of the functions that accepted values was the one that implicitly wraps them into Optionals. This generated a confusing error message when the assert failed. Having a separate overload that accepts non-optional types ensures that the correct description is printed when the assert fails.
> 
> Example:
> XCTAssertEqual(1, 2, "message")
> 
> Previous error:
> XCTAssertEqual failed: ("Optional(1)") is not equal to ("Optional(2)") - message
> 
> New error:
> XCTAssertEqual failed: ("1") is not equal to ("2") - message

CC @modocache @mike-ferris-apple 
#### Resolved bug number: ([SR-1417](https://bugs.swift.org/browse/SR-1417))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
