### PR TITLE
[build-script] never expand install prefix as relative path

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -919,6 +919,11 @@ function get_host_install_prefix() {
         local host_install_prefix="${INSTALL_PREFIX}"
     fi
 
+    # Should always begin with a '/'; otherwise CMake will expand it as a relative path from the build folder.
+    if [[ "${host_install_prefix:0:1}" != "/" ]]; then
+        host_install_prefix="/${host_install_prefix}"
+    fi
+
     echo "${host_install_prefix}/" # Should always end in a '/'; it's a directory.
 }
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

If the install prefix doesn't begin with a leading `/`, CMake will expand it as a relative path from the build directory. This leads to strange install trees, where swift, llvm and llbuild (the products which install with CMake) get placed in, for example:
`destdir/Spring/Projects/3rdParty/OpenSource/Apple/build/Ninja-ReleaseAssert/swift-macosx-x86_64/swift-3.0.xctoolchain/usr/bin/swift`

instead of:
`destdir/swift-3.0.xctoolchain/usr/bin/swift`

with a parameter: `--install-prefix=swift-3.0.xctoolchain/usr`

This fixes a regression from https://github.com/apple/swift/pull/2497. Previously we `os.path.abspath`-ed the install-prefix in `build-script`, which looked like it could have even been the cause of the strange trees. So now there's also a comment to explain why we're doing this.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
