### PR TITLE
Fixed line continuation error in CMakeLists.txt. Updated REPL warning…

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -137,8 +137,7 @@ runcmd(COMMAND "xcrun" "-toolchain" "${SWIFT_DARWIN_XCRUN_TOOLCHAIN}" "-f" "clan
 # You have to delete CMakeCache.txt in the swift build to force a
 # reconfiguration.
 set(SWIFT_EXTRA_BENCH_CONFIGS CACHE STRING
-    "A semicolon separated list of benchmark configurations. \
-Available configurations: <Optlevel>_SINGLEFILE, <Optlevel>_MULTITHREADED")
+    "A semicolon separated list of benchmark configurations. Available configurations: <Optlevel>_SINGLEFILE, <Optlevel>_MULTITHREADED")
 
 # Syntax for an optset:  <optimization-level>_<configuration>
 #    where "_<configuration>" is optional.

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -984,7 +984,8 @@ public:
     if (llvm::sys::Process::StandardInIsUserInput())
       llvm::outs() <<
           "***  You are running Swift's integrated REPL,  ***\n"
-          "***  intended for testing purposes only.       ***\n"
+          "***  intended for compiler and stdlib          ***\n"
+          "***  development and testing purposes only.    ***\n"
           "***  The full REPL is built as part of LLDB.   ***\n"
           "***  Type ':help' for assistance.              ***\n";
   }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Pull request includes:
- Fixed line continuation error in CMakeLists.txt. 
- Updated REPL warning for compiler and stdlib development use recommendations per [recommendation by Jordan Rose](http://twitter.com/UINT_MIN/status/737768933323735040).

cc @jrose-apple

<!-- Description about pull request. -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… for compiler and stdlib development use recommendations
