### PR TITLE
Disable typealiases in protocols and add frontend flag to re-enable.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -771,6 +771,8 @@ ERROR(expected_close_after_else_directive,none,
       "further conditions after #else are unreachable", ())
 
 /// Associatedtype Statement
+WARNING(typealias_in_protocol_deprecated,none,
+      "use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead", ())
 ERROR(typealias_inside_protocol_without_type,none,
       "typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement", ())
 ERROR(associatedtype_outside_protocol,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -157,6 +157,9 @@ namespace swift {
     /// Enable the Swift 3 migration via Fix-Its.
     bool Swift3Migration = false;
 
+    /// Enable typealiases in protocols.
+    bool EnableProtocolTypealiases = false;
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -341,4 +341,7 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def group_info_path : Separate<["-"], "group-info-path">,
   HelpText<"The path to collect the group information of the compiled module">;
 
+def enable_protocol_typealiases: Flag<["-"], "enable-protocol-typealiases">,
+  HelpText<"Enable typealiases inside protocol declarations">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -772,6 +772,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.InferImportAsMember |= Args.hasArg(OPT_enable_infer_import_as_member);
 
   Opts.EnableThrowWithoutTry |= Args.hasArg(OPT_enable_throw_without_try);
+  Opts.EnableProtocolTypealiases |= Args.hasArg(OPT_enable_protocol_typealiases);
 
   if (auto A = Args.getLastArg(OPT_enable_objc_attr_requires_foundation_module,
                                OPT_disable_objc_attr_requires_foundation_module)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2175,7 +2175,12 @@ ParserStatus Parser::parseDecl(ParseDeclOptions Flags,
       break;
     }
     case tok::kw_typealias:
-      DeclResult = parseDeclTypeAlias(Flags, Attributes);
+      if (Flags.contains(PD_InProtocol) &&
+          !Context.LangOpts.EnableProtocolTypealiases) {
+        DeclResult = parseDeclAssociatedType(Flags, Attributes);
+      } else {
+        DeclResult = parseDeclTypeAlias(Flags, Attributes);
+      }
       Status = DeclResult;
       break;
     case tok::kw_associatedtype:
@@ -3028,7 +3033,10 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
   // ask us to fix up leftover Swift 2 code intending to be an associatedtype.
   if (Tok.is(tok::kw_typealias)) {
     AssociatedTypeLoc = consumeToken(tok::kw_typealias);
-    diagnose(AssociatedTypeLoc, diag::typealias_inside_protocol_without_type)
+    auto diagnosis = Context.LangOpts.EnableProtocolTypealiases ?
+      diag::typealias_inside_protocol_without_type :
+      diag::typealias_in_protocol_deprecated;
+    diagnose(AssociatedTypeLoc, diagnosis)
         .fixItReplace(AssociatedTypeLoc, "associatedtype");
   } else {
     AssociatedTypeLoc = consumeToken(tok::kw_associatedtype);

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -173,7 +173,7 @@ struct C<a : B> : B { // expected-error {{type 'C<a>' does not conform to protoc
 
 // SR-511
 protocol sr511 {
-  typealias Foo // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}} 
+  typealias Foo // expected-warning {{use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead}} 
 }
 
 associatedtype Foo = Int // expected-error {{associated types can only be defined in a protocol; define a type or introduce a 'typealias' to satisfy an associated type requirement}}

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-parse-verify-swift
+// RUN: %target-parse-verify-swift -enable-protocol-typealiases
 
 typealias rgb = Int32 // expected-note {{declared here}}
 var rgb : rgb? // expected-error {{invalid redeclaration of 'rgb'}}
@@ -29,7 +29,6 @@ struct MyType<TyA, TyB> {
 
 protocol P {
   associatedtype X<T>  // expected-error {{associated types may not have a generic parameter list}}
-  
   typealias Y<T>       // expected-error {{expected '=' in typealias declaration}}
 }
 
@@ -150,7 +149,7 @@ extension C<T> {}  // expected-error {{use of undeclared type 'T'}}
 extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
 
 
-// Allow typealias inside protocol, but don't allow it in where clauses (at least not yet)
+// Allow typealias inside protocol
 protocol Col {
   associatedtype Elem
   var elem: Elem { get }

--- a/validation-test/compiler_crashers/28268-swift-type-transform.swift
+++ b/validation-test/compiler_crashers/28268-swift-type-transform.swift
@@ -6,8 +6,5 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-protocol A{
-typealias B<a>:A
-enum S<T where B<Int>:d
-typealias d
+var:{protocol a{struct A:a
+typealias e=A.e

--- a/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
+++ b/validation-test/compiler_crashers_fixed/28288-swift-genericparamlist-getsubstitutionmap.swift
@@ -6,5 +6,8 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -parse
-var:{protocol a{struct A:a
-typealias e=A.e
+// REQUIRES: asserts
+protocol A{
+typealias B<a>:A
+enum S<T where B<Int>:d
+typealias d


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Goes back to Swift 2.2 behavior of treating the 'typealias' keyword inside a protocol as a deprecated form of an associatedtype. To get the newer (but still partly buggy) behavior of treating it as an actual typealias, add "-Xfrontend -enable-protocol-typealiases" to the compile invocation.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
