### PR TITLE
[build-script] use explicit build/test list between build-script and build-script-impl

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1136,98 +1136,49 @@ details of the setups of other systems or automated environments.""")
             platform.system() != "Darwin"):
         args.build_foundation = True
 
-    # Propagate global --skip-build
-    if args.skip_build:
-        args.skip_build_linux = True
-        args.skip_build_freebsd = True
-        args.skip_build_cygwin = True
-        args.skip_build_osx = True
-        args.skip_build_ios = True
-        args.skip_build_tvos = True
-        args.skip_build_watchos = True
-        args.skip_build_android = True
-        args.skip_build_benchmarks = True
-        args.build_lldb = False
-        args.build_llbuild = False
-        args.build_swiftpm = False
-        args.build_xctest = False
-        args.build_foundation = False
-        args.build_libdispatch = False
-
-    # --skip-{ios,tvos,watchos} or --skip-build-{ios,tvos,watchos} are
-    # merely shorthands for --skip-build-{**os}-{device,simulator}
-    if not args.ios or args.skip_build_ios:
-        args.skip_build_ios_device = True
-        args.skip_build_ios_simulator = True
-
-    if not args.tvos or args.skip_build_tvos:
-        args.skip_build_tvos_device = True
-        args.skip_build_tvos_simulator = True
-
-    if not args.watchos or args.skip_build_watchos:
-        args.skip_build_watchos_device = True
-        args.skip_build_watchos_simulator = True
-
-    if not args.android or args.skip_build_android:
-        args.skip_build_android = True
-
     # --validation-test implies --test.
     if args.validation_test:
+        args.test = True
+
+    # --long-test implies --test.
+    if args.long_test:
         args.test = True
 
     # --test-optimized implies --test.
     if args.test_optimized:
         args.test = True
 
-    # If none of tests specified skip swift stdlib test on all platforms
-    if not args.test and not args.validation_test and not args.long_test:
-        args.skip_test_linux = True
-        args.skip_test_freebsd = True
-        args.skip_test_cygwin = True
-        args.skip_test_osx = True
-        args.skip_test_ios = True
-        args.skip_test_tvos = True
-        args.skip_test_watchos = True
+    # Expand iOS skip_build/test arguments for both device and simulator.
+    if args.skip_build_ios:
+        args.skip_build_ios_device = True
+        args.skip_build_ios_simulator = True
 
-    # --skip-test-ios is merely a shorthand for host and simulator tests.
+    if args.skip_build_tvos:
+        args.skip_build_tvos_device = True
+        args.skip_build_tvos_simulator = True
+
+    if args.skip_build_watchos:
+        args.skip_build_watchos_device = True
+        args.skip_build_watchos_simulator = True
+
     if args.skip_test_ios:
         args.skip_test_ios_host = True
         args.skip_test_ios_simulator = True
-    # --skip-test-tvos is merely a shorthand for host and simulator tests.
+
     if args.skip_test_tvos:
         args.skip_test_tvos_host = True
         args.skip_test_tvos_simulator = True
-    # --skip-test-watchos is merely a shorthand for host and simulator tests.
+
     if args.skip_test_watchos:
         args.skip_test_watchos_host = True
         args.skip_test_watchos_simulator = True
 
-    # --skip-build-{ios,tvos,watchos}-{device,simulator} implies
-    # --skip-test-{ios,tvos,watchos}-{host,simulator}
-    if args.skip_build_ios_device:
-        args.skip_test_ios_host = True
-    if args.skip_build_ios_simulator:
-        args.skip_test_ios_simulator = True
-
-    if args.skip_build_tvos_device:
-        args.skip_test_tvos_host = True
-    if args.skip_build_tvos_simulator:
-        args.skip_test_tvos_simulator = True
-
-    if args.skip_build_watchos_device:
-        args.skip_test_watchos_host = True
-    if args.skip_build_watchos_simulator:
-        args.skip_test_watchos_simulator = True
-
-    if not args.host_test:
-        args.skip_test_ios_host = True
-        args.skip_test_tvos_host = True
-        args.skip_test_watchos_host = True
-
     if args.build_subdir is None:
         args.build_subdir = compute_build_subdir(args)
 
-    # Add optional stdlib-deployment-targets
+    # Configure additional selected stdlib-deployment-targets
+    # (we do not need to configure iOS targets, they are part of the default
+    # list).
     if args.android:
         args.stdlib_deployment_targets.append(
             StdlibDeploymentTarget.Android.armv7)
@@ -1338,10 +1289,61 @@ details of the setups of other systems or automated environments.""")
             "--install-symroot", os.path.abspath(args.install_symroot)
         ]
 
+    # Create the build target list.
+    #
+    # Take all of the configured stdlib-deployment-targets
+    # and subtract any we've been told to skip.
+
+    skipped_targets = []
+    if args.skip_build_linux:
+        skipped_targets += StdlibDeploymentTarget.Linux.allArchs
+    if args.skip_build_freebsd:
+        skipped_targets += StdlibDeploymentTarget.FreeBSD.allArchs
+    if args.skip_build_cygwin:
+        skipped_targets += StdlibDeploymentTarget.Cygwin.allArchs
+    if args.skip_build_android:
+        skipped_targets += StdlibDeploymentTarget.Android.allArchs
+    if args.skip_build_osx:
+        skipped_targets += StdlibDeploymentTarget.OSX.allArchs
+
+    # iOS targets are special: they are configured by default, but only built
+    # if the appropriate '--ios'/'--tvos'/... flag is given.
+    if args.skip_build_ios_device or not args.ios:
+        skipped_targets += StdlibDeploymentTarget.iOS.allArchs
+    if args.skip_build_ios_simulator or not args.ios:
+        skipped_targets += StdlibDeploymentTarget.iOSSimulator.allArchs
+    if args.skip_build_tvos_device or not args.tvos:
+        skipped_targets += StdlibDeploymentTarget.AppleTV.allArchs
+    if args.skip_build_tvos_simulator or not args.tvos:
+        skipped_targets += StdlibDeploymentTarget.AppleTVSimulator.allArchs
+    if args.skip_build_watchos_device or not args.watchos:
+        skipped_targets += StdlibDeploymentTarget.AppleWatch.allArchs
+    if args.skip_build_watchos_simulator or not args.watchos:
+        skipped_targets += StdlibDeploymentTarget.AppleWatchSimulator.allArchs
+
+    build_stdlib_deployment_targets = [
+        x for x in args.stdlib_deployment_targets
+        if x not in skipped_targets]
+
+    if args.skip_build or len(build_stdlib_deployment_targets) == 0:
+        build_stdlib_deployment_targets = ['none']
+
+    build_script_impl_args += ["--build-stdlib-deployment-targets",
+                               " ".join(build_stdlib_deployment_targets)]
+
+    # Decide which products to build.
     if args.skip_build:
         build_script_impl_args += ["--skip-build-cmark",
                                    "--skip-build-llvm",
                                    "--skip-build-swift"]
+        args.skip_build_benchmarks = True
+        args.build_lldb = False
+        args.build_llbuild = False
+        args.build_swiftpm = False
+        args.build_xctest = False
+        args.build_foundation = False
+        args.build_libdispatch = False
+
     if args.skip_build_benchmarks:
         build_script_impl_args += ["--skip-build-benchmarks"]
     if not args.build_foundation:
@@ -1357,29 +1359,46 @@ details of the setups of other systems or automated environments.""")
     if not args.build_swiftpm:
         build_script_impl_args += ["--skip-build-swiftpm"]
 
-    if args.skip_build_linux:
-        build_script_impl_args += ["--skip-build-linux"]
-    if args.skip_build_freebsd:
-        build_script_impl_args += ["--skip-build-freebsd"]
-    if args.skip_build_cygwin:
-        build_script_impl_args += ["--skip-build-cygwin"]
-    if args.skip_build_osx:
-        build_script_impl_args += ["--skip-build-osx"]
-    if args.skip_build_ios_device:
-        build_script_impl_args += ["--skip-build-ios-device"]
-    if args.skip_build_ios_simulator:
-        build_script_impl_args += ["--skip-build-ios-simulator"]
-    if args.skip_build_tvos_device:
-        build_script_impl_args += ["--skip-build-tvos-device"]
-    if args.skip_build_tvos_simulator:
-        build_script_impl_args += ["--skip-build-tvos-simulator"]
-    if args.skip_build_watchos_device:
-        build_script_impl_args += ["--skip-build-watchos-device"]
-    if args.skip_build_watchos_simulator:
-        build_script_impl_args += ["--skip-build-watchos-simulator"]
-    if args.skip_build_android:
-        build_script_impl_args += ["--skip-build-android"]
+    # Create the test target list.
+    #
+    # Take all of the stdlib-deployment-targets that we're actually building,
+    # and subtract any we've been told to skip.
 
+    skip_test_tgts = []
+    if args.skip_test_linux:
+        skip_test_tgts += StdlibDeploymentTarget.Linux.allArchs
+    if args.skip_test_freebsd:
+        skip_test_tgts += StdlibDeploymentTarget.FreeBSD.allArchs
+    if args.skip_test_cygwin:
+        skip_test_tgts += StdlibDeploymentTarget.Cygwin.allArchs
+    if args.skip_test_osx:
+        skip_test_tgts += StdlibDeploymentTarget.OSX.allArchs
+    if args.skip_test_ios_simulator:
+        skip_test_tgts += StdlibDeploymentTarget.iOSSimulator.allArchs
+    if args.skip_test_tvos_simulator:
+        skip_test_tgts += StdlibDeploymentTarget.AppleTVSimulator.allArchs
+    if args.skip_test_watchos_simulator:
+        skip_test_tgts += StdlibDeploymentTarget.AppleWatchSimulator.allArchs
+    if args.skip_test_ios_host or not args.host_test:
+        skip_test_tgts += StdlibDeploymentTarget.iOS.allArchs
+    if args.skip_test_tvos_host or not args.host_test:
+        skip_test_tgts += StdlibDeploymentTarget.AppleTV.allArchs
+    if args.skip_test_watchos_host or not args.host_test:
+        skip_test_tgts += StdlibDeploymentTarget.AppleWatch.allArchs
+
+    # The tests do not work on Android yet.
+    skip_test_tgts += StdlibDeploymentTarget.Android.allArchs
+
+    if args.test:
+        test_deployment_targets = [
+            x for x in build_stdlib_deployment_targets
+            if x not in skip_test_tgts]
+
+        if len(test_deployment_targets) > 0:
+            build_script_impl_args += ["--test-stdlib-deployment-targets",
+                                       " ".join(test_deployment_targets)]
+
+    # Decide which products to test
     if not args.test and not args.long_test:
         build_script_impl_args += ["--skip-test-swift"]
     if not args.test:
@@ -1390,26 +1409,7 @@ details of the setups of other systems or automated environments.""")
                                    "--skip-test-xctest",
                                    "--skip-test-foundation",
                                    "--skip-test-libdispatch"]
-    if args.skip_test_linux:
-        build_script_impl_args += ["--skip-test-linux"]
-    if args.skip_test_freebsd:
-        build_script_impl_args += ["--skip-test-freebsd"]
-    if args.skip_test_cygwin:
-        build_script_impl_args += ["--skip-test-cygwin"]
-    if args.skip_test_osx:
-        build_script_impl_args += ["--skip-test-osx"]
-    if args.skip_test_ios_host:
-        build_script_impl_args += ["--skip-test-ios-host"]
-    if args.skip_test_ios_simulator:
-        build_script_impl_args += ["--skip-test-ios-simulator"]
-    if args.skip_test_tvos_host:
-        build_script_impl_args += ["--skip-test-tvos-host"]
-    if args.skip_test_tvos_simulator:
-        build_script_impl_args += ["--skip-test-tvos-simulator"]
-    if args.skip_test_watchos_host:
-        build_script_impl_args += ["--skip-test-watchos-host"]
-    if args.skip_test_watchos_simulator:
-        build_script_impl_args += ["--skip-test-watchos-simulator"]
+
     if args.build_runtime_with_host_compiler:
         build_script_impl_args += ["--build-runtime-with-host-compiler"]
     if args.validation_test:
@@ -1421,6 +1421,7 @@ details of the setups of other systems or automated environments.""")
     if not args.test_optimized:
         build_script_impl_args += ["--skip-test-optimized"]
 
+    # Other arguments
     if args.android:
         build_script_impl_args += [
             "--android-ndk", args.android_ndk,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -105,17 +105,6 @@ KNOWN_SETTINGS=(
     skip-build-cmark            ""               "set to skip building CommonMark"
     skip-build-llvm             ""               "set to skip building LLVM/Clang"
     skip-build-swift            ""               "set to skip building Swift"
-    skip-build-linux            ""               "set to skip building Swift stdlibs for Linux"
-    skip-build-freebsd          ""               "set to skip building Swift stdlibs for FreeBSD"
-    skip-build-cygwin           ""               "set to skip building Swift stdlibs for Cygwin"
-    skip-build-osx              ""               "set to skip building Swift stdlibs for OSX"
-    skip-build-ios-device       ""               "set to skip building Swift stdlibs for iOS devices (i.e. build simulators only)"
-    skip-build-ios-simulator    ""               "set to skip building Swift stdlibs for iOS simulators (i.e. build devices only)"
-    skip-build-tvos-device      ""               "set to skip building Swift stdlibs for tvOS devices (i.e. build simulators only)"
-    skip-build-tvos-simulator   ""               "set to skip building Swift stdlibs for tvOS simulators (i.e. build devices only)"
-    skip-build-watchos-device   ""               "set to skip building Swift stdlibs for Apple watchOS devices (i.e. build simulators only)"
-    skip-build-watchos-simulator ""              "set to skip building Swift stdlibs for Apple watchOS simulators (i.e. build devices only)"
-    skip-build-android          ""               "set to skip building Swift stdlibs for Android"
     skip-build-lldb             ""               "set to skip building LLDB"
     skip-build-llbuild          ""               "set to skip building llbuild"
     skip-build-swiftpm          ""               "set to skip building swiftpm"
@@ -131,16 +120,6 @@ KNOWN_SETTINGS=(
     skip-test-xctest            ""               "set to skip testing xctest"
     skip-test-foundation        ""               "set to skip testing foundation"
     skip-test-libdispatch       ""               "set to skip testing libdispatch"
-    skip-test-linux             ""               "set to skip testing Swift stdlibs for Linux"
-    skip-test-freebsd           ""               "set to skip testing Swift stdlibs for FreeBSD"
-    skip-test-cygwin            ""               "set to skip testing Swift stdlibs for Cygwin"
-    skip-test-osx               ""               "set to skip testing Swift stdlibs for OSX"
-    skip-test-ios-simulator     ""               "set to skip testing Swift stdlibs for iOS simulators (i.e. test devices only)"
-    skip-test-ios-host          ""               "set to skip testing the host parts of the iOS toolchain"
-    skip-test-tvos-simulator    ""               "set to skip testing Swift stdlibs for tvOS simulators (i.e. test devices only)"
-    skip-test-tvos-host         ""               "set to skip testing the host parts of the tvOS toolchain"
-    skip-test-watchos-simulator  ""              "set to skip testing Swift stdlibs for Apple watchOS simulators (i.e. test devices only)"
-    skip-test-watchos-host      ""               "set to skip testing the host parts of the watchOS toolchain"
     validation-test             "0"              "set to run the validation test suite"
     long-test                   "0"              "set to run the long test suite"
     skip-test-benchmarks        ""               "set to skip running Swift Benchmark Suite"
@@ -181,7 +160,8 @@ KNOWN_SETTINGS=(
     darwin-install-extract-symbols ""            "whether to extract symbols with dsymutil during installations"
     host-target                 ""               "The host target. LLVM, Clang, and Swift will be built for this target. The built LLVM and Clang will be used to compile Swift for the cross-compilation targets. **This argument is required**"
     stdlib-deployment-targets   ""               "space-separated list of targets to configure the Swift standard library to be compiled or cross-compiled for"
-    build-stdlib-deployment-targets "all"        "space-separated list that filters which of the configured targets to build the Swift standard library for, or 'all'"
+    build-stdlib-deployment-targets "all"        "space-separated list that determines which of the configured targets to build the Swift standard library for, or 'all' (default) or 'none'"
+    test-stdlib-deployment-targets   "none"      "space-separated list that determines which of the configured targets to build the Swift standard library tests for, or 'all' or 'none' (default)"
     cross-compile-hosts         ""               "space-separated list of targets to cross-compile host Swift tools for"
     cross-compile-with-host-tools  ""            "set to use the clang we build for the host to then build the cross-compile hosts"
     cross-compile-install-prefixes      ""       "semicolon-separated list of install prefixes to use for the cross-compiled hosts. The list expands, so if there are more cross-compile hosts than prefixes, unmatched hosts use the last prefix in the list"
@@ -973,8 +953,11 @@ function get_stdlib_targets_for_host() {
 function should_build_stdlib_target() {
     local stdlib_target=$1
     local host=$2
+
     if [[ "${BUILD_STDLIB_DEPLOYMENT_TARGETS}" == "all" ]]; then
         echo 1
+    elif [[ "${BUILD_STDLIB_DEPLOYMENT_TARGETS}" == "none" ]]; then
+        return
     else
         # Only build the stdlib targets in 'build-stdlib-deployment-targets'
         local build_list=($BUILD_STDLIB_DEPLOYMENT_TARGETS)
@@ -986,6 +969,31 @@ function should_build_stdlib_target() {
         # As with 'stdlib-deployment-targets', 'build-stdlib-deployment-targets'
         # only applies to the LOCAL_HOST. For cross-tools hosts, always allow
         # their one-and-only stdlib-target to build.
+        if [[ $(is_cross_tools_host ${host}) ]] && [[ "${stdlib_target}" == "${host}" ]]; then
+            echo 1
+        fi
+    fi
+}
+
+function should_test_stdlib_target() {
+    local stdlib_target=$1
+    local host=$2
+
+    if [[ "${TEST_STDLIB_DEPLOYMENT_TARGETS}" == "all" ]]; then
+        echo 1
+    elif [[ "${TEST_STDLIB_DEPLOYMENT_TARGETS}" == "none" ]]; then
+        return
+    else
+        # Only test the stdlib targets in 'test-stdlib-deployment-targets'
+        local test_list=($TEST_STDLIB_DEPLOYMENT_TARGETS)
+        for t in "${test_list[@]}"; do
+            if [[ "${t}" == "${stdlib_target}" ]]; then
+                echo 1
+            fi
+        done
+        # As with 'stdlib-deployment-targets', 'test-stdlib-deployment-targets'
+        # only applies to the LOCAL_HOST. For cross-tools hosts, always test
+        # their one-and-only stdlib-target.
         if [[ $(is_cross_tools_host ${host}) ]] && [[ "${stdlib_target}" == "${host}" ]]; then
             echo 1
         fi
@@ -1096,91 +1104,61 @@ function calculate_targets_for_host() {
     for stdlib_deployment_target in "${stdlib_targets[@]}"; do
         local swift_sdk=
         local is_in_build_list=$(should_build_stdlib_target ${stdlib_deployment_target} ${host})
-        local build_for_this_target=1
-        local test_this_target=1
+        local is_in_test_list=$(should_test_stdlib_target ${stdlib_deployment_target} ${host})
         local test_host_only=
-        local build_benchmark_this_target=
-        local test_benchmark_this_target=
+        local supports_benchmarks=
 
         case ${stdlib_deployment_target} in
             linux-*)
                 swift_sdk="LINUX"
-                build_for_this_target=$(not ${SKIP_BUILD_LINUX})
-                test_this_target=$(not ${SKIP_TEST_LINUX})
                 ;;
             freebsd-*)
                 swift_sdk="FREEBSD"
-                build_for_this_target=$(not ${SKIP_BUILD_FREEBSD})
-                test_this_target=$(not ${SKIP_TEST_FREEBSD})
                 ;;
             cygwin-*)
                 swift_sdk="CYGWIN"
-                build_for_this_target=$(not ${SKIP_BUILD_CYGWIN})
-                test_this_target=$(not ${SKIP_TEST_CYGWIN})
                 ;;
             macosx-*)
                 swift_sdk="OSX"
-                build_for_this_target=$(not ${SKIP_BUILD_OSX})
-                test_this_target=$(not ${SKIP_TEST_OSX})
-                build_benchmark_this_target=$(not ${SKIP_BUILD_OSX})
-                test_benchmark_this_target=$(not ${SKIP_BUILD_OSX})
+                supports_benchmarks=1
                 ;;
             iphoneos-*)
                 swift_sdk="IOS"
-                build_for_this_target=$(not ${SKIP_BUILD_IOS_DEVICE})
-                if [[ ! "${SKIP_TEST_IOS_HOST}" ]] ; then
+                if [[ "${is_in_test_list}" ]] ; then
                     test_host_only=1
-                else
-                    test_this_target=
                 fi
-                build_benchmark_this_target=$(not ${SKIP_BUILD_IOS_DEVICE})
+                supports_benchmarks=1
 
                 # Never build iOS armv7s benchmarks.
                 if [[ "${stdlib_deployment_target}" == "iphoneos-armv7s" ]]; then
-                    build_benchmark_this_target=
+                    supports_benchmarks=
                 fi
                 ;;
             iphonesimulator-*)
                 swift_sdk="IOS_SIMULATOR"
-                build_for_this_target=$(not ${SKIP_BUILD_IOS_SIMULATOR})
-                test_this_target=$(not ${SKIP_TEST_IOS_SIMULATOR})
                 ;;
             appletvos-*)
                 swift_sdk="TVOS"
-                build_for_this_target=$(not ${SKIP_BUILD_TVOS_DEVICE})
-                if [[ ! "${SKIP_TEST_TVOS_HOST}" ]] ; then
+                if [[ "${is_in_test_list}" ]] ; then
                     test_host_only=1
-                else
-                    test_this_target=
                 fi
-                build_benchmark_this_target=$(not ${SKIP_BUILD_TVOS_DEVICE})
+                supports_benchmarks=1
                 ;;
             appletvsimulator-*)
                 swift_sdk="TVOS_SIMULATOR"
-                build_for_this_target=$(not ${SKIP_BUILD_TVOS_SIMULATOR})
-                test_this_target=$(not ${SKIP_TEST_TVOS_SIMULATOR})
                 ;;
             watchos-*)
                 swift_sdk="WATCHOS"
-                build_for_this_target=$(not ${SKIP_BUILD_WATCHOS_DEVICE})
-                if [[ ! "${SKIP_TEST_WATCHOS_HOST}" ]] ; then
+                if [[ "${is_in_test_list}" ]] ; then
                     test_host_only=1
-                else
-                    test_this_target=
                 fi
-                build_benchmark_this_target=$(not ${SKIP_BUILD_WATCHOS_DEVICE})
+                supports_benchmarks=1
                 ;;
             watchsimulator-*)
                 swift_sdk="WATCHOS_SIMULATOR"
-                build_for_this_target=$(not ${SKIP_BUILD_WATCHOS_SIMULATOR})
-                test_this_target=$(not ${SKIP_TEST_WATCHOS_SIMULATOR})
                 ;;
             android-*)
                 swift_sdk="ANDROID"
-                build_for_this_target=$(not ${SKIP_BUILD_ANDROID})
-                # FIXME: Allow Android host tests to be enabled/disabled by the
-                #        build script.
-                test_this_target=
                 ;;
             *)
                 echo "Unknown compiler deployment target: ${stdlib_deployment_target}"
@@ -1190,7 +1168,7 @@ function calculate_targets_for_host() {
 
         SWIFT_SDKS+=("${swift_sdk}")
 
-        if [[ "${build_for_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
+        if [[ "${is_in_build_list}" ]]; then
 
             if [[ "${BUILD_SWIFT_STDLIB_UNITTEST_EXTRA}" == "1" ]] ; then
                 SWIFT_STDLIB_TARGETS+=("swift-stdlib-${stdlib_deployment_target}")
@@ -1201,34 +1179,34 @@ function calculate_targets_for_host() {
                     SWIFT_STDLIB_TARGETS+=("swift-test-stdlib-${stdlib_deployment_target}")
                 fi
             fi
-        fi
-        if [[ "${build_benchmark_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
-            SWIFT_BENCHMARK_TARGETS+=("swift-benchmark-${stdlib_deployment_target}")
-            if [[ $(not ${SKIP_TEST_BENCHMARK}) ]] ; then
-              SWIFT_RUN_BENCHMARK_TARGETS+=("check-swift-benchmark-${stdlib_deployment_target}")
+            if [[ "${supports_benchmarks}" ]]; then
+                SWIFT_BENCHMARK_TARGETS+=("swift-benchmark-${stdlib_deployment_target}")
+                if [[ $(not ${SKIP_TEST_BENCHMARK}) ]] ; then
+                  SWIFT_RUN_BENCHMARK_TARGETS+=("check-swift-benchmark-${stdlib_deployment_target}")
+                fi
             fi
-        fi
-        if [[ "${test_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
-            test_target_suffix=""
-            if [[ -n "${test_host_only}" ]] ; then
-                test_target_suffix="-non-executable"
-            fi
+            if [[ "${is_in_test_list}" ]]; then
+                test_target_suffix=""
+                if [[ -n "${test_host_only}" ]] ; then
+                    test_target_suffix="-non-executable"
+                fi
 
-            test_subset_target_suffix=""
-            if [[ "${VALIDATION_TEST}" == "1" ]] ; then
-                if [[ "${LONG_TEST}" == "1" ]] ; then
-                    test_subset_target_suffix="-all"
+                test_subset_target_suffix=""
+                if [[ "${VALIDATION_TEST}" == "1" ]] ; then
+                    if [[ "${LONG_TEST}" == "1" ]] ; then
+                        test_subset_target_suffix="-all"
+                    else
+                        test_subset_target_suffix="-validation"
+                    fi
                 else
-                    test_subset_target_suffix="-validation"
+                    if [[ "${LONG_TEST}" == "1" ]] ; then
+                        test_subset_target_suffix="-only_long"
+                    fi
                 fi
-            else
-                if [[ "${LONG_TEST}" == "1" ]] ; then
-                    test_subset_target_suffix="-only_long"
+                SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}${test_target_suffix}-${stdlib_deployment_target}")
+                if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" ]] ; then
+                    SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}-optimize-${stdlib_deployment_target}")
                 fi
-            fi
-            SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}${test_target_suffix}-${stdlib_deployment_target}")
-            if [[ $(not ${SKIP_TEST_OPTIMIZED}) && ! -n "${test_host_only}" ]] ; then
-                SWIFT_TEST_TARGETS+=("check-swift${test_subset_target_suffix}-optimize-${stdlib_deployment_target}")
             fi
         fi
     done
@@ -1446,6 +1424,8 @@ function set_swiftpm_bootstrap_command() {
 #
 # Start with native deployment targets because the resulting tools are used during cross-compilation.
 
+echo "=============================="
+echo -e "Building the Swift compiler for: ${ALL_HOSTS[@]}"
 
 for host in "${ALL_HOSTS[@]}"; do
 
@@ -1453,15 +1433,23 @@ for host in "${ALL_HOSTS[@]}"; do
 
     set_build_options_for_host $host
 
-    echo "Building the standard library for: ${SWIFT_STDLIB_TARGETS[@]}"
+    # Print a summary of the calculated targets
+    configured_targets=(`echo $(get_stdlib_targets_for_host ${host})`)
+    echo "=============================="
+    echo "* Host target: ${host}"
+    echo "* Standard Library targets:"
+    echo -e "    - Configured         [${#configured_targets[@]}]:\t ${configured_targets[@]}"
+    echo -e "    - Build targets      [${#SWIFT_STDLIB_TARGETS[@]}]:\t ${SWIFT_STDLIB_TARGETS[@]}"
+    echo -e "    - Benchmark targets  [${#SWIFT_BENCHMARK_TARGETS[@]}]:\t ${SWIFT_BENCHMARK_TARGETS[@]}"
     if [[ "${SWIFT_TEST_TARGETS[@]}" ]] && ! [[ "${SKIP_TEST_SWIFT}" ]]; then
-        echo "Running Swift tests for: ${SWIFT_TEST_TARGETS[@]}"
+    echo -e "* Running tests for      [${#SWIFT_TEST_TARGETS[@]}]:\t ${SWIFT_TEST_TARGETS[@]}"
     fi
     if ! [[ "${SKIP_TEST_BENCHMARKS}" ]] &&
        [[ "${SWIFT_RUN_BENCHMARK_TARGETS[@]}" ]] &&
        ! [[ "${SKIP_TEST_BENCHMARK}" ]]; then
-        echo "Running Swift benchmarks for: ${SWIFT_RUN_BENCHMARK_TARGETS[@]}"
+    echo -e "* Running benchmarks for [${#SWIFT_RUN_BENCHMARK_TARGETS[@]}]:\t ${SWIFT_RUN_BENCHMARK_TARGETS[@]}"
     fi
+    echo "=============================="
 
     case "${COMPILER_VENDOR}" in
         none)
@@ -1671,7 +1659,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if [[ ! "${SKIP_BUILD_ANDROID}" ]]; then
+                # FIXME: Need a better test to see if we're building for Android
+                if [[ "$(should_build_stdlib_target 'android-armv7' ${host})" ]]; then
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DSWIFT_ANDROID_NDK_PATH:STRING="${ANDROID_NDK}"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1659,19 +1659,46 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                # FIXME: Need a better test to see if we're building for Android
-                if [[ "$(should_build_stdlib_target 'android-armv7' ${host})" ]]; then
-                    cmake_options=(
-                        "${cmake_options[@]}"
-                        -DSWIFT_ANDROID_NDK_PATH:STRING="${ANDROID_NDK}"
-                        -DSWIFT_ANDROID_NDK_GCC_VERSION:STRING="${ANDROID_NDK_GCC_VERSION}"
-                        -DSWIFT_ANDROID_SDK_PATH:STRING="${ANDROID_NDK}/platforms/android-${ANDROID_API_LEVEL}/arch-arm"
-                        -DSWIFT_ANDROID_ICU_UC:STRING="${ANDROID_ICU_UC}"
-                        -DSWIFT_ANDROID_ICU_UC_INCLUDE:STRING="${ANDROID_ICU_UC_INCLUDE}"
-                        -DSWIFT_ANDROID_ICU_I18N:STRING="${ANDROID_ICU_I18N}"
-                        -DSWIFT_ANDROID_ICU_I18N_INCLUDE:STRING="${ANDROID_ICU_I18N_INCLUDE}"
-                    )
-                fi
+                # Configure every cross-compiled stdlib-deployment-target.
+                # That is, every stdlib-deployment-target where (Target != Host).
+
+                configured_targets=(`echo $(get_stdlib_targets_for_host ${host})`)
+                for stdlib_deployment_target in "${configured_targets[@]}"; do
+
+                    # We don't need to configure host's sysroot/toolchain etc
+                    if [[ "${stdlib_deployment_target}" == "${host}" ]]; then
+                        continue
+                    fi
+                    if [[ ! "$(should_build_stdlib_target ${stdlib_deployment_target} ${host})" ]]; then
+                        continue
+                    fi
+
+                    case ${stdlib_deployment_target} in
+                        # We don't need to set up any variables to cross-compile the stdlib for Darwin targets.
+                        # 'xcrun' will detect everything on the CMake side.
+                        macosx-* | iphone* | appletv* | watch* )
+                            continue
+                            ;;
+                        # android-armv7 is the only other cross-compilable stdlib target we support right now.
+                        # Set sysroot/toolchain-related variables.
+                        android-armv7)
+                            cmake_options=(
+                                "${cmake_options[@]}"
+                                -DSWIFT_ANDROID_NDK_PATH:STRING="${ANDROID_NDK}"
+                                -DSWIFT_ANDROID_NDK_GCC_VERSION:STRING="${ANDROID_NDK_GCC_VERSION}"
+                                -DSWIFT_ANDROID_SDK_PATH:STRING="${ANDROID_NDK}/platforms/android-${ANDROID_API_LEVEL}/arch-arm"
+                                -DSWIFT_ANDROID_ICU_UC:STRING="${ANDROID_ICU_UC}"
+                                -DSWIFT_ANDROID_ICU_UC_INCLUDE:STRING="${ANDROID_ICU_UC_INCLUDE}"
+                                -DSWIFT_ANDROID_ICU_I18N:STRING="${ANDROID_ICU_I18N}"
+                                -DSWIFT_ANDROID_ICU_I18N_INCLUDE:STRING="${ANDROID_ICU_I18N_INCLUDE}"
+                            )
+                            ;;
+                        *)
+                            echo "Unsupported stdlib-deployment-target to cross-compile: ${stdlib_deployment_target}"
+                            exit 1
+                            ;;
+                    esac
+                done
 
                 native_llvm_tools_path=""
                 native_clang_tools_path=""


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Instead of having lots of different skip-[platform] and skip-test-[platform] flags for every stdlib SDK, use an explicit list of targets to build and test.

There are no outward-facing changes (besides a more verbose and obvious configuration message). The build and test list are calculated from the same `--ios`, etc flags as they are today. This only affects how `build-script` tells `build-script-impl` which targets to build/test. It simplifies stdlib target calculation, and gives us the opportunity to override it with more granular options (e.g. just building one stdlib deployment target, not a whole SDK, or just building tests for one target).

Reopened from #2780 
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

(and appropriate test flags) with an explicit build and test list.

Made configuration message more visible and obvious
