### PR TITLE
[FixCode] Add fix-its for mismatched integer types.

### DIFF
--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -104,3 +104,11 @@ class SubTest2 : Test2 {
 }
 Test2().instMeth(0)
 Test2().instMeth2(0, p2:1)
+
+func recit(_: Int32) {}
+func ftest3(_ fd: CInt) {
+  recit(UInt(fd))
+}
+func ftest4(_ fd: UInt) {
+  recit(fd)
+}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -107,3 +107,11 @@ class SubTest2 : Test2 {
 }
 Test2().instMeth(0)
 Test2().instMeth2(0, p2:1)
+
+func recit(_: Int32) {}
+func ftest3(_ fd: CInt) {
+  recit(fd)
+}
+func ftest4(_ fd: UInt) {
+  recit(Int32(fd))
+}


### PR DESCRIPTION
#### What's in this pull request?

Adds fixits for:
     - Passing an integer with the right type but which is getting wrapped with a different integer type unnecessarily. The fixit removes the cast.
     - Passing an integer but expecting different integer type. The fixit adds a wrapping cast.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26570815

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
