### PR TITLE
[SE-0081][stdlib] Apply tail style "where" clause to stdlib

### DIFF
--- a/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
+++ b/stdlib/internal/SwiftExperimental/SwiftExperimental.swift
@@ -63,51 +63,44 @@ infix operator ⊇ { associativity left precedence 130 }
 infix operator ⊉ { associativity left precedence 130 }
 
 /// - Returns: The relative complement of `lhs` with respect to `rhs`.
-public func ∖ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Set<T> {
+public func ∖ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Set<T>
+  where S.Iterator.Element == T {
   return lhs.subtracting(rhs)
 }
 
 /// Assigns the relative complement between `lhs` and `rhs` to `lhs`.
-public func ∖= <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: inout Set<T>, rhs: S) {
+public func ∖= <T, S: Sequence>(lhs: inout Set<T>, rhs: S)
+  where S.Iterator.Element == T {
   lhs.subtract(rhs)
 }
 
 /// - Returns: The union of `lhs` and `rhs`.
-public func ∪ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Set<T> {
+public func ∪ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Set<T>
+  where S.Iterator.Element == T {
   return lhs.union(rhs)
 }
 
 /// Assigns the union of `lhs` and `rhs` to `lhs`.
-public func ∪= <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: inout Set<T>, rhs: S) {
+public func ∪= <T, S: Sequence>(lhs: inout Set<T>, rhs: S)
+  where S.Iterator.Element == T {
   lhs.formUnion(rhs)
 }
 
 /// - Returns: The intersection of `lhs` and `rhs`.
-public func ∩ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Set<T> {
+public func ∩ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Set<T>
+  where S.Iterator.Element == T {
   return lhs.intersection(rhs)
 }
 
 /// Assigns the intersection of `lhs` and `rhs` to `lhs`.
-public func ∩= <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: inout Set<T>, rhs: S) {
+public func ∩= <T, S: Sequence>(lhs: inout Set<T>, rhs: S)
+  where S.Iterator.Element == T {
   lhs.formIntersection(rhs)
 }
 
 /// - Returns: A set with elements in `lhs` or `rhs` but not in both.
-public func ⨁ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Set<T> {
+public func ⨁ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Set<T>
+  where S.Iterator.Element == T {
   return lhs.symmetricDifference(rhs)
 }
 
@@ -129,57 +122,49 @@ public func ∉ <T>(x: T, rhs: Set<T>) -> Bool {
 }
 
 /// - Returns: True if `lhs` is a strict subset of `rhs`.
-public func ⊂ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊂ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return lhs.isStrictSubset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is not a strict subset of `rhs`.
-public func ⊄ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊄ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return !lhs.isStrictSubset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is a subset of `rhs`.
-public func ⊆ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊆ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return lhs.isSubset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is not a subset of `rhs`.
-public func ⊈ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊈ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return !lhs.isSubset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is a strict superset of `rhs`.
-public func ⊃ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊃ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return lhs.isStrictSuperset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is not a strict superset of `rhs`.
-public func ⊅ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊅ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return !lhs.isStrictSuperset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is a superset of `rhs`.
-public func ⊇ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊇ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return lhs.isSuperset(of: rhs)
 }
 
 /// - Returns: True if `lhs` is not a superset of `rhs`.
-public func ⊉ <
-  T, S: Sequence where S.Iterator.Element == T
-  >(lhs: Set<T>, rhs: S) -> Bool {
+public func ⊉ <T, S: Sequence>(lhs: Set<T>, rhs: S) -> Bool
+  where S.Iterator.Element == T {
   return !lhs.isSuperset(of: rhs)
 }

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift.gyb
@@ -52,20 +52,19 @@ public struct CollectionMisuseResiliencyChecks {
 /// - Precondition: ${'''`endIndex` is reachable from all
 ///   elements of `instances`.''' if inc == 'inc' else '''all
 ///   elements of `instances` are reachable from `startIndex`.'''}
-public func check${inc.capitalize()}rementable<
-  Instances : Collection,
-  BaseCollection : ${protocol}
-  where
-  Instances.Iterator.Element == BaseCollection.Index,
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+public func check${inc.capitalize()}rementable<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection: BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   ${end}Index: Instances.Iterator.Element, ${TRACE}
-) {
+) where
+  Instances : Collection,
+  BaseCollection : ${protocol},
+  Instances.Iterator.Element == BaseCollection.Index,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
+
   checkEquatable(instances, oracle: equalityOracle, ${trace})
   for i in instances {
     if i != ${end}Index {
@@ -82,15 +81,7 @@ public func check${inc.capitalize()}rementable<
 }
 %end
 
-internal func _checkIncrementalAdvance<
-  Instances : Collection,
-  BaseCollection : Indexable
-  where
-  Instances.Iterator.Element == BaseCollection.Index,
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+internal func _checkIncrementalAdvance<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection : BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
@@ -98,7 +89,13 @@ internal func _checkIncrementalAdvance<
   sign: BaseCollection.IndexDistance, // 1 or -1
   next: (Instances.Iterator.Element) -> Instances.Iterator.Element,
   ${TRACE}
-) {
+) where
+  Instances : Collection,
+  BaseCollection : Indexable,
+  Instances.Iterator.Element == BaseCollection.Index,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
   for i in instances {
     let d: BaseCollection.IndexDistance = sign > 0 ?
       baseCollection.distance(from: i, to: limit) :
@@ -124,20 +121,19 @@ internal func _checkIncrementalAdvance<
 ///
 /// - Precondition: `endIndex` is reachable from all elements of
 ///   `instances`
-public func checkForwardIndex<
-  Instances : Collection,
-  BaseCollection : Indexable
-  where
-  Instances.Iterator.Element == BaseCollection.Index,
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+public func checkForwardIndex<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection: BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   endIndex: Instances.Iterator.Element, ${TRACE}
-) {
+) where
+  Instances : Collection,
+  BaseCollection : Indexable,
+  Instances.Iterator.Element == BaseCollection.Index,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
+
   checkIncrementable(instances, of: baseCollection,
     equalityOracle: equalityOracle, endIndex: endIndex, ${trace})
 
@@ -153,22 +149,21 @@ public func checkForwardIndex<
 /// - Precondition:
 ///   - all elements of `instances` are reachable from `startIndex`.
 ///   - `endIndex` is reachable from all elements of `instances`.
-public func checkBidirectionalIndex<
-  Instances: Collection,
-  BaseCollection : BidirectionalIndexable
-  where
-  Instances.Iterator.Element == BaseCollection.Index,
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+public func checkBidirectionalIndex<Instances, BaseCollection>(
   _ instances: Instances,
   of baseCollection: BaseCollection,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   startIndex: Instances.Iterator.Element,
   endIndex: Instances.Iterator.Element,
   ${TRACE}
-) {
+) where
+  Instances: Collection,
+  BaseCollection : BidirectionalIndexable,
+  Instances.Iterator.Element == BaseCollection.Index,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
+
   checkForwardIndex(instances, of: baseCollection,
     equalityOracle: equalityOracle, endIndex: endIndex)
 
@@ -189,18 +184,7 @@ public func checkBidirectionalIndex<
 /// - Precondition:
 ///   - all elements of `instances` are reachable from `startIndex`.
 ///   - `endIndex` is reachable from all elements of `instances`.
-public func checkRandomAccessIndex<
-  Instances : Collection,
-  Distances : Collection,
-  BaseCollection : RandomAccessIndexable
-  where
-  Instances.Iterator.Element == BaseCollection.Index,
-  Distances.Iterator.Element == BaseCollection.IndexDistance,
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index,
-  Distances.Indices.Iterator.Element == Distances.Index
->(
+public func checkRandomAccessIndex<Instances, Distances, BaseCollection>(
   _ instances: Instances, distances: Distances,
   of baseCollection: BaseCollection,
   distanceOracle:
@@ -210,7 +194,17 @@ public func checkRandomAccessIndex<
   startIndex: Instances.Iterator.Element,
   endIndex: Instances.Iterator.Element,
   ${TRACE}
-) {
+) where
+  Instances : Collection,
+  Distances : Collection,
+  BaseCollection : RandomAccessIndexable,
+  Instances.Iterator.Element == BaseCollection.Index,
+  Distances.Iterator.Element == BaseCollection.IndexDistance,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index,
+  Distances.Indices.Iterator.Element == Distances.Index {
+
   checkBidirectionalIndex(instances, of: baseCollection,
     equalityOracle: { distanceOracle($0, $1) == 0 },
     startIndex: startIndex, endIndex: endIndex, ${trace})
@@ -225,18 +219,7 @@ public func checkRandomAccessIndex<
 // Copies what checkStrideable is doing, but instead of calling
 // advanced(by:) and distance(to:) on an Strideable's,
 // calls corresponding methods on a base collection.
-public func checkAdvancesAndDistances<
-  Instances : Collection,
-  Distances : Collection,
-  BaseCollection : Indexable
-  where
-  Instances.Iterator.Element == BaseCollection.Index,
-  Distances.Iterator.Element == BaseCollection.IndexDistance,
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index,
-  Distances.Indices.Iterator.Element == Distances.Index
->(
+public func checkAdvancesAndDistances<Instances, Distances, BaseCollection>(
   _ instances: Instances, distances: Distances,
   of baseCollection: BaseCollection,
   distanceOracle:
@@ -244,7 +227,17 @@ public func checkAdvancesAndDistances<
   advanceOracle:
     (Instances.Index, Distances.Index) -> Instances.Iterator.Element,
   ${TRACE}
-) {
+) where
+  Instances : Collection,
+  Distances : Collection,
+  BaseCollection : Indexable,
+  Instances.Iterator.Element == BaseCollection.Index,
+  Distances.Iterator.Element == BaseCollection.IndexDistance,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index,
+  Distances.Indices.Iterator.Element == Distances.Index {
+
   checkComparable(
     instances,
     oracle: {
@@ -281,15 +274,15 @@ public func checkAdvancesAndDistances<
 
 public func check${Traversal}Collection<
   ${genericParam}, C : ${TraversalCollection}
-  where
-  C.Iterator.Element == ${Element},
-  C.Indices.Iterator.Element == C.Index
 >(
   _ expected: ${Expected}, _ collection: C,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) {
+) where
+  C.Iterator.Element == ${Element},
+  C.Indices.Iterator.Element == C.Index {
+
   // A `Collection` is a multi-pass `Sequence`.
   for _ in 0..<3 {
     checkSequence(
@@ -449,15 +442,15 @@ public func check${Traversal}Collection<
 
 public func check${Traversal}Collection<
   ${genericParam}, C : ${TraversalCollection}
-  where
-  C.Iterator.Element == ${Element},
-  C.Indices.Iterator.Element == C.Index,
-  ${Element} : Equatable
 >(
   _ expected: ${Expected}, _ collection: C,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
-) {
+) where
+  C.Iterator.Element == ${Element},
+  C.Indices.Iterator.Element == C.Index,
+  ${Element} : Equatable {
+
   check${Traversal}Collection(
     expected, collection, ${trace},
     resiliencyChecks: resiliencyChecks) { $0 == $1 }
@@ -468,16 +461,16 @@ public func check${Traversal}Collection<
 // FIXME: merge into checkCollection()
 public func checkSliceableWithBidirectionalIndex<
   ${genericParam}, S : BidirectionalCollection
-  where
+>(
+  _ expected: ${Expected}, _ sliceable: S, ${TRACE}
+) where
   S.Iterator.Element == ${Element},
   S.Indices.Iterator.Element == S.Index,
   S.SubSequence : BidirectionalCollection,
   S.SubSequence.Iterator.Element == ${Element},
   S.SubSequence.Indices.Iterator.Element == S.SubSequence.Index,
-  ${Element} : Equatable
->(
-  _ expected: ${Expected}, _ sliceable: S, ${TRACE}
-) {
+  ${Element} : Equatable {
+
   // A `Sliceable` is a `Collection`.
   checkBidirectionalCollection(expected, sliceable, ${trace})
 
@@ -520,17 +513,16 @@ public func checkSliceableWithBidirectionalIndex<
 % end
 
 
-public func checkRangeReplaceable<
-  C : RangeReplaceableCollection,
-  N : Collection
-  where
-  C.Iterator.Element : Equatable,
-  C.Iterator.Element == N.Iterator.Element,
-  C.Indices.Iterator.Element == C.Index
->(
+public func checkRangeReplaceable<C, N>(
   _ makeCollection: () -> C,
   _ makeNewValues: (Int) -> N
-) {
+) where
+  C : RangeReplaceableCollection,
+  N : Collection,
+  C.Iterator.Element : Equatable,
+  C.Iterator.Element == N.Iterator.Element,
+  C.Indices.Iterator.Element == C.Index {
+
   typealias A = C
 
   // First make an independent copy of the array that we can use for
@@ -583,17 +575,12 @@ public func checkRangeReplaceable<
   }
 }
 
-public func checkCollection<
-  C : Collection,
-  Expected : Collection
-  where
-  C.Iterator.Element == Expected.Iterator.Element
->(
+public func checkCollection<C : Collection, Expected : Collection>(
   _ subject: C,
   expected: Expected,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool
-) {
+) where C.Iterator.Element == Expected.Iterator.Element {
 }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -451,8 +451,7 @@ internal func _product<C1 : Collection, C2 : Collection>(
   def testConstraints(protocol):
     return '''    
     C : %(protocol)s,
-    CollectionWithEquatableElement : %(protocol)s
-  where
+    CollectionWithEquatableElement : %(protocol)s,
     C.SubSequence : %(protocol)s,
     C.SubSequence.Iterator.Element == C.Iterator.Element,
     C.SubSequence.Index == C.Index,
@@ -495,8 +494,12 @@ internal func _product<C1 : Collection, C2 : Collection>(
 }% 
 extension TestSuite {
   public func addCollectionTests<
-    ${testConstraints('Collection')}
-  >(${testParams} = false) {
+    C, CollectionWithEquatableElement
+  >(
+    ${testParams} = false
+  ) where
+    ${testConstraints('Collection')} {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {
@@ -1161,8 +1164,12 @@ extension TestSuite {
   } // addCollectionTests
 
   public func addBidirectionalCollectionTests<
-    ${testConstraints('BidirectionalCollection')}
-  >(${testParams} = true) {
+    C, CollectionWithEquatableElement
+  >(
+    ${testParams} = true
+  ) where
+    ${testConstraints('BidirectionalCollection')} {
+
     var testNamePrefix = testNamePrefix
     if checksAdded.contains(#function) {
       return
@@ -1473,8 +1480,12 @@ extension TestSuite {
   } // addBidirectionalCollectionTests
 
   public func addRandomAccessCollectionTests<
-    ${testConstraints('RandomAccessCollection')}
-  >(${testParams} = true) {
+    C, CollectionWithEquatableElement
+  >(
+    ${testParams} = true
+  ) where
+    ${testConstraints('RandomAccessCollection')} {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {
@@ -1524,8 +1535,12 @@ extension TestSuite {
 
 % for Traversal in ['Forward', 'Bidirectional', 'RandomAccess']:
   func addCommonTests<
-    ${testConstraints(collectionForTraversal(Traversal))}
-  >(${testParams}) {
+    C, CollectionWithEquatableElement
+  >(
+    ${testParams}
+  ) where
+    ${testConstraints(collectionForTraversal(Traversal))} {
+
     if checksAdded.contains(#function) {
       return
     }

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -58,14 +58,10 @@ public func withInvalidOrderings(_ body: ((Int, Int) -> Bool) -> Void) {
   body { (_,_) in defer {i += 1}; return i % 5 == 0 }
 }
 
-internal func _mapInPlace<
-  C : MutableCollection
-  where
-  C.Indices.Iterator.Element == C.Index
->(
+internal func _mapInPlace<C : MutableCollection>(
   _ elements: inout C,
   _ transform: @noescape (C.Iterator.Element) -> C.Iterator.Element
-) {
+) where C.Indices.Iterator.Element == C.Index {
   for i in elements.indices {
     elements[i] = transform(elements[i])
   }
@@ -76,18 +72,6 @@ extension TestSuite {
     C : MutableCollection,
     CollectionWithEquatableElement : MutableCollection,
     CollectionWithComparableElement : MutableCollection
-    where
-    C.SubSequence : MutableCollection,
-    C.SubSequence.Iterator.Element == C.Iterator.Element,
-    C.SubSequence.Index == C.Index,
-    C.SubSequence.Indices.Iterator.Element == C.Index,
-    C.SubSequence.SubSequence == C.SubSequence,
-    C.Indices : Collection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithComparableElement.Iterator.Element : Comparable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -108,7 +92,19 @@ extension TestSuite {
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool,
     collectionIsBidirectional: Bool = false
-  ) {
+  ) where
+    C.SubSequence : MutableCollection,
+    C.SubSequence.Iterator.Element == C.Iterator.Element,
+    C.SubSequence.Index == C.Index,
+    C.SubSequence.Indices.Iterator.Element == C.Index,
+    C.SubSequence.SubSequence == C.SubSequence,
+    C.Indices : Collection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.Iterator.Element : Equatable,
+    CollectionWithComparableElement.Iterator.Element : Comparable {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {
@@ -586,18 +582,6 @@ self.test("\(testNamePrefix).sorted/${'Predicate' if predicate else 'WhereElemen
     C : protocol<BidirectionalCollection, MutableCollection>,
     CollectionWithEquatableElement : protocol<BidirectionalCollection, MutableCollection>,
     CollectionWithComparableElement : protocol<BidirectionalCollection, MutableCollection>
-    where
-    C.SubSequence : protocol<BidirectionalCollection, MutableCollection>,
-    C.SubSequence.Iterator.Element == C.Iterator.Element,
-    C.SubSequence.Index == C.Index,
-    C.SubSequence.Indices.Iterator.Element == C.Index,
-    C.SubSequence.SubSequence == C.SubSequence,
-    C.Indices : BidirectionalCollection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithComparableElement.Iterator.Element : Comparable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -617,7 +601,19 @@ self.test("\(testNamePrefix).sorted/${'Predicate' if predicate else 'WhereElemen
     outOfBoundsSubscriptOffset: Int = 1,
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
-  ) {
+  ) where
+    C.SubSequence : protocol<BidirectionalCollection, MutableCollection>,
+    C.SubSequence.Iterator.Element == C.Iterator.Element,
+    C.SubSequence.Index == C.Index,
+    C.SubSequence.Indices.Iterator.Element == C.Index,
+    C.SubSequence.SubSequence == C.SubSequence,
+    C.Indices : BidirectionalCollection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.Iterator.Element : Equatable,
+    CollectionWithComparableElement.Iterator.Element : Comparable {
+    
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {
@@ -707,19 +703,6 @@ self.test("\(testNamePrefix).reverse()") {
     C : protocol<RandomAccessCollection, MutableCollection>,
     CollectionWithEquatableElement : protocol<RandomAccessCollection, MutableCollection>,
     CollectionWithComparableElement : protocol<RandomAccessCollection, MutableCollection>
-    where
-    C.SubSequence : protocol<RandomAccessCollection, MutableCollection>,
-    C.SubSequence.Iterator.Element == C.Iterator.Element,
-    C.SubSequence.Index == C.Index,
-    C.SubSequence.Indices.Iterator.Element == C.Index,
-    C.SubSequence.SubSequence == C.SubSequence,
-    C.Indices : RandomAccessCollection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithComparableElement.Iterator.Element : Comparable,
-    CollectionWithComparableElement.SubSequence.Indices.Iterator.Element == CollectionWithComparableElement.Index
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -739,7 +722,20 @@ self.test("\(testNamePrefix).reverse()") {
     outOfBoundsSubscriptOffset: Int = 1,
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
-  ) {
+  ) where
+    C.SubSequence : protocol<RandomAccessCollection, MutableCollection>,
+    C.SubSequence.Iterator.Element == C.Iterator.Element,
+    C.SubSequence.Index == C.Index,
+    C.SubSequence.Indices.Iterator.Element == C.Index,
+    C.SubSequence.SubSequence == C.SubSequence,
+    C.Indices : RandomAccessCollection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.Iterator.Element : Equatable,
+    CollectionWithComparableElement.Iterator.Element : Comparable,
+    CollectionWithComparableElement.SubSequence.Indices.Iterator.Element == CollectionWithComparableElement.Index {
+    
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -421,17 +421,6 @@ extension TestSuite {
   public func addRangeReplaceableCollectionTests<
     C : RangeReplaceableCollection,
     CollectionWithEquatableElement : RangeReplaceableCollection
-    where
-    C.SubSequence : Collection,
-    C.SubSequence.Iterator.Element == C.Iterator.Element,
-    C.SubSequence.Index == C.Index,
-    C.SubSequence.Indices.Iterator.Element == C.Index,
-    C.SubSequence.SubSequence == C.SubSequence,
-    C.Indices : Collection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.Iterator.Element : Equatable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -445,7 +434,18 @@ extension TestSuite {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     collectionIsBidirectional: Bool = false
-  ) {
+  ) where
+    C.SubSequence : Collection,
+    C.SubSequence.Iterator.Element == C.Iterator.Element,
+    C.SubSequence.Index == C.Index,
+    C.SubSequence.Indices.Iterator.Element == C.Index,
+    C.SubSequence.SubSequence == C.SubSequence,
+    C.Indices : Collection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {
@@ -1148,17 +1148,6 @@ self.test("\(testNamePrefix).OperatorPlus") {
   public func addRangeReplaceableBidirectionalCollectionTests<
     C : protocol<BidirectionalCollection, RangeReplaceableCollection>,
     CollectionWithEquatableElement : protocol<BidirectionalCollection, RangeReplaceableCollection>
-    where
-    C.SubSequence : protocol<BidirectionalCollection, RangeReplaceableCollection>,
-    C.SubSequence.Iterator.Element == C.Iterator.Element,
-    C.SubSequence.Index == C.Index,
-    C.SubSequence.Indices.Iterator.Element == C.Index,
-    C.SubSequence.SubSequence == C.SubSequence,
-    C.Indices : BidirectionalCollection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.Iterator.Element : Equatable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -1171,7 +1160,18 @@ self.test("\(testNamePrefix).OperatorPlus") {
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
-  ) {
+  ) where
+    C.SubSequence : protocol<BidirectionalCollection, RangeReplaceableCollection>,
+    C.SubSequence.Iterator.Element == C.Iterator.Element,
+    C.SubSequence.Index == C.Index,
+    C.SubSequence.Indices.Iterator.Element == C.Index,
+    C.SubSequence.SubSequence == C.SubSequence,
+    C.Indices : BidirectionalCollection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {
@@ -1276,17 +1276,6 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
   public func addRangeReplaceableRandomAccessCollectionTests<
     C : protocol<RandomAccessCollection, RangeReplaceableCollection>,
     CollectionWithEquatableElement : protocol<RandomAccessCollection, RangeReplaceableCollection>
-    where
-    C.SubSequence : protocol<RandomAccessCollection, RangeReplaceableCollection>,
-    C.SubSequence.Iterator.Element == C.Iterator.Element,
-    C.SubSequence.Index == C.Index,
-    C.SubSequence.Indices.Iterator.Element == C.Index,
-    C.SubSequence.SubSequence == C.SubSequence,
-    C.Indices : RandomAccessCollection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.Iterator.Element : Equatable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -1299,7 +1288,18 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
-  ) {
+  ) where
+    C.SubSequence : protocol<RandomAccessCollection, RangeReplaceableCollection>,
+    C.SubSequence.Iterator.Element == C.Iterator.Element,
+    C.SubSequence.Index == C.Index,
+    C.SubSequence.Indices.Iterator.Element == C.Index,
+    C.SubSequence.SubSequence == C.SubSequence,
+    C.Indices : RandomAccessCollection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -18,14 +18,6 @@ extension TestSuite {
   public func addRangeReplaceableSliceTests<
     C : RangeReplaceableCollection,
     CollectionWithEquatableElement : RangeReplaceableCollection
-    where
-    C.SubSequence == C,
-    C.Indices : Collection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
-    CollectionWithEquatableElement.Iterator.Element : Equatable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -39,7 +31,15 @@ extension TestSuite {
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     collectionIsBidirectional: Bool = false
-  ) {
+  ) where
+    C.SubSequence == C,
+    C.Indices : Collection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
+
     var testNamePrefix = testNamePrefix
 
     // Don't run the same tests twice.
@@ -153,14 +153,6 @@ extension TestSuite {
   public func addRangeReplaceableBidirectionalSliceTests<
     C : protocol<BidirectionalCollection, RangeReplaceableCollection>,
     CollectionWithEquatableElement : protocol<BidirectionalCollection, RangeReplaceableCollection>
-    where
-    C.SubSequence == C,
-    C.Indices : BidirectionalCollection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
-    CollectionWithEquatableElement.Iterator.Element : Equatable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -173,7 +165,15 @@ extension TestSuite {
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
-  ) {
+  ) where
+    C.SubSequence == C,
+    C.Indices : BidirectionalCollection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
+
     var testNamePrefix = testNamePrefix
 
     // Don't run the same tests twice.
@@ -300,14 +300,6 @@ extension TestSuite {
   public func addRangeReplaceableRandomAccessSliceTests<
     C : protocol<RandomAccessCollection, RangeReplaceableCollection>,
     CollectionWithEquatableElement : protocol<RandomAccessCollection, RangeReplaceableCollection>
-    where
-    C.SubSequence == C,
-    C.Indices : RandomAccessCollection,
-    C.Indices.Iterator.Element == C.Index,
-    C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices,
-    CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
-    CollectionWithEquatableElement.Iterator.Element : Equatable
   >(
     _ testNamePrefix: String = "",
     makeCollection: ([C.Iterator.Element]) -> C,
@@ -320,7 +312,15 @@ extension TestSuite {
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
-  ) {
+  ) where
+    C.SubSequence == C,
+    C.Indices : RandomAccessCollection,
+    C.Indices.Iterator.Element == C.Index,
+    C.Indices.Index == C.Index,
+    C.Indices.SubSequence == C.Indices,
+    CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
+    CollectionWithEquatableElement.Iterator.Element : Equatable {
+
     var testNamePrefix = testNamePrefix
 
     // Don't run the same tests twice.

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift.gyb
@@ -26,14 +26,13 @@ import StdlibUnittest
 
 public func checkIterator<
   ${genericParam}, I : IteratorProtocol
-  where I.Element == ${Element}
 >(
   _ expected: ${Expected},
   _ iterator: I,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) {
+) where I.Element == ${Element} {
   // Copying a `IteratorProtocol` is allowed.
   var mutableGen = iterator
   var actual: [${Element}] = []
@@ -52,13 +51,12 @@ public func checkIterator<
 
 public func checkIterator<
   ${genericParam}, I : IteratorProtocol
-  where I.Element == ${Element}, ${Element} : Equatable
 >(
   _ expected: ${Expected},
   _ iterator: I,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
-) {
+) where I.Element == ${Element}, ${Element} : Equatable {
   checkIterator(
     expected, iterator, ${trace},
     resiliencyChecks: resiliencyChecks, showFrame: false
@@ -67,15 +65,13 @@ public func checkIterator<
 
 public func checkSequence<
   ${genericParam}, S : Sequence
-  where
-  S.Iterator.Element == ${Element}
 >(
   _ expected: ${Expected},
   _ sequence: S,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (${Element}, ${Element}) -> Bool
-) {
+) where S.Iterator.Element == ${Element} {
   let expectedCount: Int = numericCast(expected.count)
   checkIterator(
     expected, sequence.makeIterator(), ${trace},
@@ -105,15 +101,15 @@ public func checkSequence<
 
 public func checkSequence<
   ${genericParam}, S : Sequence
-  where
-  S.Iterator.Element == ${Element},
-  S.Iterator.Element : Equatable
 >(
   _ expected: ${Expected},
   _ sequence: S,
   ${TRACE},
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
-) {
+) where
+  S.Iterator.Element == ${Element},
+  S.Iterator.Element : Equatable {
+
   checkSequence(
     expected, sequence, ${trace},
     resiliencyChecks: resiliencyChecks, showFrame: false

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1450,11 +1450,6 @@ extension TestSuite {
   public func addSequenceTests<
     S : Sequence,
     SequenceWithEquatableElement : Sequence
-    where
-    SequenceWithEquatableElement.Iterator.Element : Equatable,
-    S.SubSequence : Sequence,
-    S.SubSequence.Iterator.Element == S.Iterator.Element,
-    S.SubSequence.SubSequence == S.SubSequence
   >(
     _ testNamePrefix: String = "",
     makeSequence: ([S.Iterator.Element]) -> S,
@@ -1466,7 +1461,12 @@ extension TestSuite {
     extractValueFromEquatable: ((SequenceWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all
-  ) {
+  ) where
+    SequenceWithEquatableElement.Iterator.Element : Equatable,
+    S.SubSequence : Sequence,
+    S.SubSequence.Iterator.Element == S.Iterator.Element,
+    S.SubSequence.SubSequence == S.SubSequence {
+
     var testNamePrefix = testNamePrefix
 
     if checksAdded.contains(#function) {

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -463,9 +463,8 @@ public struct ${Self}<
     Log.initRepeating[selfType] += 1
   }
 
-  public init<
-    S : Sequence where S.Iterator.Element == Iterator.Element
-  >(_ elements: S) {
+  public init<S : Sequence>(_ elements: S)
+    where S.Iterator.Element == Iterator.Element {
     self.base = Base(elements)
     Log.initWithSequence[selfType] += 1
   }
@@ -485,9 +484,9 @@ public struct ${Self}<
     base.append(newElement)
   }
 
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == Base.Iterator.Element
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(
+    contentsOf newElements: S
+  ) where S.Iterator.Element == Base.Iterator.Element {
     Log.appendContentsOf[selfType] += 1
     base.append(contentsOf: newElements)
   }
@@ -499,9 +498,9 @@ public struct ${Self}<
     base.insert(newElement, at: i)
   }
 
-  public mutating func insert<
-    C : Collection where C.Iterator.Element == Base.Iterator.Element
-  >(contentsOf newElements: C, at i: Index) {
+  public mutating func insert<C : Collection>(
+    contentsOf newElements: C, at i: Index
+  ) where C.Iterator.Element == Base.Iterator.Element {
     Log.insertContentsOf[selfType] += 1
     base.insert(contentsOf: newElements, at: i)
   }
@@ -534,11 +533,9 @@ public struct ${Self}<
     base.removeSubrange(bounds)
   }
 
-  public mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == Base.Iterator.Element
-  >(
+  public mutating func replaceSubrange<C : Collection>(
     _ bounds: Range<Index>, with newElements: C
-  ) {
+  ) where C.Iterator.Element == Base.Iterator.Element {
     Log.replaceSubrange[selfType] += 1
     base.replaceSubrange(bounds, with: newElements)
   }
@@ -572,36 +569,34 @@ public struct ${Self}<
 // Custom assertions
 //===----------------------------------------------------------------------===//
 
-public func expectCustomizable<
-  T : Wrapper where
-  T : LoggingType,
-  T.Base : Wrapper, T.Base : LoggingType,
-  T.Log == T.Base.Log
->(_: T, _ counters: TypeIndexed<Int>,
+public func expectCustomizable<T : Wrapper>(
+  _: T, _ counters: TypeIndexed<Int>,
   //===--- TRACE boilerplate ----------------------------------------------===//
   _ message: @autoclosure () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = #file, line: UInt = #line
-) {
+) where
+  T : LoggingType,
+  T.Base : Wrapper, T.Base : LoggingType,
+  T.Log == T.Base.Log {
   let newTrace = stackTrace.pushIf(showFrame, file: file, line: line)
   expectNotEqual(0, counters[T.self], message(), stackTrace: newTrace)
   expectEqual(
     counters[T.self], counters[T.Base.self], message(), stackTrace: newTrace)
 }
 
-public func expectNotCustomizable<
-  T : Wrapper where
-  T : LoggingType,
-  T.Base : Wrapper, T.Base : LoggingType,
-  T.Log == T.Base.Log
->(_: T, _ counters: TypeIndexed<Int>,
+public func expectNotCustomizable<T : Wrapper>(
+  _: T, _ counters: TypeIndexed<Int>,
   //===--- TRACE boilerplate ----------------------------------------------===//
   _ message: @autoclosure () -> String = "",
   showFrame: Bool = true,
   stackTrace: SourceLocStack = SourceLocStack(),  
   file: String = #file, line: UInt = #line
-) {
+) where
+  T : LoggingType,
+  T.Base : Wrapper, T.Base : LoggingType,
+  T.Log == T.Base.Log {
   let newTrace = stackTrace.pushIf(showFrame, file: file, line: line)
   expectNotEqual(0, counters[T.self], message(), stackTrace: newTrace)
   expectEqual(0, counters[T.Base.self], message(), stackTrace: newTrace)

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift.gyb
@@ -42,7 +42,7 @@ internal class _MinimalIteratorSharedState<T> {
 ///
 /// This generator will return `nil` only once.
 public struct MinimalIterator<T> : IteratorProtocol {
-  public init<S : Sequence where S.Iterator.Element == T>(_ s: S) {
+  public init<S : Sequence>(_ s: S) where S.Iterator.Element == T {
     self._sharedState = _MinimalIteratorSharedState(Array(s))
   }
 
@@ -93,10 +93,10 @@ public enum UnderestimatedCountBehavior {
 ///
 /// This sequence is consumed when its generator is advanced.
 public struct MinimalSequence<T> : Sequence, CustomDebugStringConvertible {
-  public init<S : Sequence where S.Iterator.Element == T>(
+  public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) {
+  ) where S.Iterator.Element == T {
     let data = Array(elements)
     self._sharedState = _MinimalIteratorSharedState(data)
 
@@ -522,10 +522,10 @@ Int64 distances.
 public struct ${Self}<T> : ${SelfProtocols} {
   /// Creates a collection with given contents, but a unique modification
   /// history.  No other instance has the same modification history.
-  public init<S : Sequence where S.Iterator.Element == T>(
+  public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) {
+  ) where S.Iterator.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -558,9 +558,7 @@ public struct ${Self}<T> : ${SelfProtocols} {
       _CollectionState(name: "\(self.dynamicType)", elementCount: 0)
   }
 
-  public init<
-    S : Sequence where S.Iterator.Element == T
-  >(_ elements: S) {
+  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -728,20 +726,18 @@ public struct ${Self}<T> : ${SelfProtocols} {
     _elements.append(x)
   }
 
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == T
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
     _willMutate(.appendContentsOf(count: newCount - oldCount))
   }
 
-  public mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == T
-  >(
-    _ subRange: Range<${Index}>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ subRange: Range<${Index}>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -759,9 +755,9 @@ public struct ${Self}<T> : ${SelfProtocols} {
     _elements.insert(newElement, at: i.position)
   }
 
-  public mutating func insert<
-    S : Collection where S.Iterator.Element == T
-  >(contentsOf newElements: S, at i: ${Index}) {
+  public mutating func insert<S : Collection>(
+    contentsOf newElements: S, at i: ${Index}
+  ) where S.Iterator.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -836,10 +832,10 @@ public struct DefaultedSequence<Element> : Sequence {
     self.base = base
   }
 
-  public init<S : Sequence where S.Iterator.Element == Element>(
+  public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) {
+  ) where S.Iterator.Element == Element {
     self.init(base: MinimalSequence(
       elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -899,10 +895,10 @@ public struct ${Self}<Element> : ${SelfProtocols} {
     self.base = Base(elements: elements)
   }
 
-  public init<S : Sequence where S.Iterator.Element == Element>(
+  public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) {
+  ) where S.Iterator.Element == Element {
     self.init(base:
       ${Base}(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -994,12 +990,10 @@ public struct ${Self}<Element> : ${SelfProtocols} {
     base = Base()
   }
 
-  public mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == Element
-  >(
+  public mutating func replaceSubrange<C>(
     _ subRange: Range<${Self}<Element>.Index>,
     with newElements: C
-  ) {
+  ) where C : Collection, C.Iterator.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 %   end

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -321,19 +321,18 @@ public func expectTrapping<Bound>(
 public func expectType<T>(_: T.Type, _ x: inout T) {}
 public func expectEqualType<T>(_: T.Type, _: T.Type) {}
 
-public func expectSequenceType<
-  X : Sequence
+public func expectSequenceType<X : Sequence>(_ x: X) -> X
   where
   X.SubSequence : Sequence,
   X.SubSequence.Iterator.Element == X.Iterator.Element,
-  X.SubSequence.SubSequence == X.SubSequence
->(_ x: X) -> X { return x }
+  X.SubSequence.SubSequence == X.SubSequence {
+  return x
+}
 
 % for Mutable in ['', 'Mutable']:
-public func expect${Mutable}CollectionType<
-  X : ${Mutable}Collection
-  where
-
+public func expect${Mutable}CollectionType<X : ${Mutable}Collection>(
+  _ x: X.Type
+) where
   // FIXME(ABI)(compiler limitation): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
   X.SubSequence : Collection,
@@ -344,50 +343,45 @@ public func expect${Mutable}CollectionType<
   X.Indices : Collection,
   X.Indices.Iterator.Element == X.Index,
   X.Indices.Index == X.Index,
-  X.Indices.SubSequence == X.Indices
->(_ x: X.Type) {}
+  X.Indices.SubSequence == X.Indices {}
 % end
 
 /// A slice is a `Collection` that when sliced returns an instance of
 /// itself.
-public func expectSliceType<
-  X : Collection
-  where
-  X.SubSequence == X
->(_ sliceType: X.Type) {}
+public func expectSliceType<X : Collection>(
+  _ sliceType: X.Type
+) where X.SubSequence == X {}
 
 /// A mutable slice is a `MutableCollection` that when sliced returns an
 /// instance of itself.
-public func expectMutableSliceType<
-  X : MutableCollection
-  where
-  X.SubSequence == X
->(_ mutableSliceType: X.Type) {}
+public func expectMutableSliceType<X : MutableCollection>(
+  _ mutableSliceType: X.Type
+) where X.SubSequence == X {}
 
 /// Check that all associated types of a `Sequence` are what we expect them
 /// to be.
-public func expectSequenceAssociatedTypes<
-  X : Sequence
-  where
-
+public func expectSequenceAssociatedTypes<X : Sequence>(
+  sequenceType: X.Type,
+  iteratorType: X.Iterator.Type,
+  subSequenceType: X.SubSequence.Type
+) where
   // FIXME(ABI)(compiler limitation): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
   X.SubSequence : Sequence,
   X.SubSequence.Iterator.Element == X.Iterator.Element,
   // X.SubSequence.Indices == X.Indices, // FIXME(ABI): can't have this constraint now.
-  X.SubSequence.SubSequence == X.SubSequence
->(
-  sequenceType: X.Type,
-  iteratorType: X.Iterator.Type,
-  subSequenceType: X.SubSequence.Type
-) {}
+  X.SubSequence.SubSequence == X.SubSequence {}
 
 /// Check that all associated types of a `Collection` are what we expect them
 /// to be.
-public func expectCollectionAssociatedTypes<
-  X : Collection
-  where
-
+public func expectCollectionAssociatedTypes<X : Collection>(
+  collectionType: X.Type,
+  iteratorType: X.Iterator.Type,
+  subSequenceType: X.SubSequence.Type,
+  indexType: X.Index.Type,
+  indexDistanceType: X.IndexDistance.Type,
+  indicesType: X.Indices.Type
+) where
   // FIXME(ABI)(compiler limitation): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
   X._Element == X.Iterator.Element,
@@ -399,22 +393,18 @@ public func expectCollectionAssociatedTypes<
   X.Indices : Collection,
   X.Indices.Iterator.Element == X.Index,
   X.Indices.Index == X.Index,
-  X.Indices.SubSequence == X.Indices
->(
+  X.Indices.SubSequence == X.Indices {}
+
+/// Check that all associated types of a `BidirectionalCollection` are what we
+/// expect them to be.
+public func expectBidirectionalCollectionAssociatedTypes<X : BidirectionalCollection>(
   collectionType: X.Type,
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type,
   indexType: X.Index.Type,
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
-) {}
-
-/// Check that all associated types of a `BidirectionalCollection` are what we
-/// expect them to be.
-public func expectBidirectionalCollectionAssociatedTypes<
-  X : BidirectionalCollection
-  where
-
+) where
   // FIXME(ABI)(compiler limitation): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
   X._Element == X.Iterator.Element,
@@ -426,22 +416,18 @@ public func expectBidirectionalCollectionAssociatedTypes<
   X.Indices : BidirectionalCollection,
   X.Indices.Iterator.Element == X.Index,
   X.Indices.Index == X.Index,
-  X.Indices.SubSequence == X.Indices
->(
+  X.Indices.SubSequence == X.Indices {}
+
+/// Check that all associated types of a `RandomAccessCollection` are what we
+/// expect them to be.
+public func expectRandomAccessCollectionAssociatedTypes<X : RandomAccessCollection>(
   collectionType: X.Type,
   iteratorType: X.Iterator.Type,
   subSequenceType: X.SubSequence.Type,
   indexType: X.Index.Type,
   indexDistanceType: X.IndexDistance.Type,
   indicesType: X.Indices.Type
-) {}
-
-/// Check that all associated types of a `RandomAccessCollection` are what we
-/// expect them to be.
-public func expectRandomAccessCollectionAssociatedTypes<
-  X : RandomAccessCollection
-  where
-
+) where
   // FIXME(ABI)(compiler limitation): there should be no constraints in
   // the 'where' clause, all of these should be required by the protocol.
   X._Element == X.Iterator.Element,
@@ -453,16 +439,8 @@ public func expectRandomAccessCollectionAssociatedTypes<
   X.Indices : RandomAccessCollection,
   X.Indices.Iterator.Element == X.Index,
   X.Indices.Index == X.Index,
-  X.Indices.SubSequence == X.Indices
->(
-  collectionType: X.Type,
-  iteratorType: X.Iterator.Type,
-  subSequenceType: X.SubSequence.Type,
-  indexType: X.Index.Type,
-  indexDistanceType: X.IndexDistance.Type,
-  indicesType: X.Indices.Type
-) {}
-
+  X.Indices.SubSequence == X.Indices {}
+  
 public func expectIsBooleanType<X : Boolean>(_ x: inout X) -> X { return x }
 
 public struct AssertionResult : CustomStringConvertible, Boolean {
@@ -1891,19 +1869,16 @@ public enum TestRunPredicate : CustomStringConvertible {
 ///
 /// - Note: `oracle` is also checked for conformance to the
 ///   laws.
-public func checkEquatable<
-  Instances : Collection
-  where
-  Instances.Iterator.Element : Equatable,
-
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+public func checkEquatable<Instances : Collection>(
   _ instances: Instances,
   oracle: (Instances.Index, Instances.Index) -> Bool,
   ${TRACE}
-) {
+) where
+  Instances.Iterator.Element : Equatable,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
+
   // TODO: swift-3-indexing-model: add tests for this function.
   for i in instances.indices {
     expectTrue(oracle(i, i), "bad oracle: broken reflexivity at index \(i)")
@@ -1954,19 +1929,16 @@ public func checkEquatable<T : Equatable>(
 /// Test that the elements of `instances` satisfy the semantic
 /// requirements of `Hashable`, using `equalityOracle` to generate
 /// equality expectations from pairs of positions in `instances`.
-public func checkHashable<
-  Instances : Collection
-  where
-  Instances.Iterator.Element : Hashable,
-
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+public func checkHashable<Instances : Collection>(
   _ instances: Instances,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
   ${TRACE}
-) {
+) where
+  Instances.Iterator.Element : Hashable,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
+  
   checkEquatable(instances, oracle: equalityOracle, ${trace})
   
   for x in instances {
@@ -2043,19 +2015,16 @@ extension ExpectedComparisonResult : CustomStringConvertible {
 ///
 /// - Note: `oracle` is also checked for conformance to the
 ///   laws.
-public func checkComparable<
-  Instances : Collection
-  where
-  Instances.Iterator.Element : Comparable,
-
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index
->(
+public func checkComparable<Instances : Collection>(
   _ instances: Instances,
   oracle: (Instances.Index, Instances.Index) -> ExpectedComparisonResult,
   ${TRACE}
-) {
+) where
+  Instances.Iterator.Element : Comparable,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index {
+  
   // Also checks that equality is consistent with comparison and that
   // the oracle obeys the equality laws
   checkEquatable(instances, oracle: { oracle($0, $1).isEQ() }, ${trace})
@@ -2116,25 +2085,21 @@ public func checkComparable<T : Comparable>(
 ///
 /// - Note: `oracle` is also checked for conformance to the
 ///   laws.
-public func checkStrideable<
-  Instances : Collection,
-  Strides : Collection
-  where
-  Instances.Iterator.Element : Strideable,
-  Instances.Iterator.Element.Stride == Strides.Iterator.Element,
-
-  // FIXME(compiler limitation): these constraints should be applied to
-  // associated types of Collection.
-  Instances.Indices.Iterator.Element == Instances.Index,
-  Strides.Indices.Iterator.Element == Strides.Index
->(
+public func checkStrideable<Instances : Collection, Strides : Collection>(
   _ instances: Instances, strides: Strides,
   distanceOracle:
     (Instances.Index, Instances.Index) -> Strides.Iterator.Element,
   advanceOracle:
     (Instances.Index, Strides.Index) -> Instances.Iterator.Element,
   ${TRACE}
-) {
+) where
+  Instances.Iterator.Element : Strideable,
+  Instances.Iterator.Element.Stride == Strides.Iterator.Element,
+  // FIXME(compiler limitation): these constraints should be applied to
+  // associated types of Collection.
+  Instances.Indices.Iterator.Element == Instances.Index,
+  Strides.Indices.Iterator.Element == Strides.Index {
+
   checkComparable(
     instances,
     oracle: {
@@ -2170,10 +2135,12 @@ public func nth<C: Collection>(_ x: C, _ n: Int) -> C.Iterator.Element {
 public func expectEqualSequence<
   Expected: Sequence,
   Actual: Sequence
-  where
+>(
+  _ expected: Expected, _ actual: Actual, ${TRACE}
+) where
   Expected.Iterator.Element == Actual.Iterator.Element,
-  Expected.Iterator.Element : Equatable
->(_ expected: Expected, _ actual: Actual, ${TRACE}) {
+  Expected.Iterator.Element : Equatable {
+  
   expectEqualSequence(expected, actual, ${trace}) { $0 == $1 }
 }
 
@@ -2182,10 +2149,12 @@ public func expectEqualSequence<
   Actual : Sequence,
   T : Equatable,
   U : Equatable
-  where
+>(
+  _ expected: Expected, _ actual: Actual, ${TRACE}
+) where
   Expected.Iterator.Element == Actual.Iterator.Element,
-  Expected.Iterator.Element == (T, U)
->(_ expected: Expected, _ actual: Actual, ${TRACE}) {
+  Expected.Iterator.Element == (T, U) {
+
   expectEqualSequence(
     expected, actual, ${trace}) {
     (lhs: (T, U), rhs: (T, U)) -> Bool in
@@ -2196,10 +2165,11 @@ public func expectEqualSequence<
 public func expectEqualSequence<
   Expected: Sequence,
   Actual: Sequence
-  where
-  Expected.Iterator.Element == Actual.Iterator.Element
->(_ expected: Expected, _ actual: Actual, ${TRACE},
-  sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool) {
+>(
+  _ expected: Expected, _ actual: Actual, ${TRACE},
+  sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool
+) where
+  Expected.Iterator.Element == Actual.Iterator.Element {
 
   if !expected.elementsEqual(actual, isEquivalent: sameValue) {
     expectationFailure("expected elements: \"\(expected)\"\n"
@@ -2211,13 +2181,13 @@ public func expectEqualSequence<
 public func expectEqualsUnordered<
   Expected : Sequence,
   Actual : Sequence
-  where
-  Expected.Iterator.Element == Actual.Iterator.Element
 >(
   _ expected: Expected, _ actual: Actual, ${TRACE},
   compare: (Expected.Iterator.Element, Expected.Iterator.Element)
     -> ExpectedComparisonResult
-) {
+) where
+  Expected.Iterator.Element == Actual.Iterator.Element {
+  
   let x: [Expected.Iterator.Element] =
     expected.sorted(isOrderedBefore: compose(compare, { $0.isLT() }))
   let y: [Actual.Iterator.Element] =
@@ -2229,12 +2199,12 @@ public func expectEqualsUnordered<
 public func expectEqualsUnordered<
   Expected : Sequence,
   Actual : Sequence
-  where
-  Expected.Iterator.Element == Actual.Iterator.Element,
-  Expected.Iterator.Element : Comparable
 >(
   _ expected: Expected, _ actual: Actual, ${TRACE}
-) {
+) where
+  Expected.Iterator.Element == Actual.Iterator.Element,
+  Expected.Iterator.Element : Comparable {
+
   expectEqualsUnordered(expected, actual, ${trace}) {
     $0 < $1 ? .lt : $0 == $1 ? .eq : .gt
   }
@@ -2249,10 +2219,10 @@ public func expectEqualsUnordered<T : Comparable>(
 }
 
 public func expectEqualsUnordered<
-  T : Strideable where T.Stride : SignedInteger
+  T : Strideable
 >(
   _ expected: Range<T>, _ actual: [T], ${TRACE}
-) {
+) where T.Stride : SignedInteger {
   expectEqualsUnordered(
     CountableRange(uncheckedBounds:
       (lower: expected.lowerBound, upper: expected.upperBound)),
@@ -2304,15 +2274,15 @@ func < <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
 }
 
 public func expectEqualsUnordered<
-    Expected : Sequence,
-    Actual : Sequence,
-    T : Comparable
-    where
-    Actual.Iterator.Element == (key: T, value: T),
-    Expected.Iterator.Element == (T, T)
+  Expected : Sequence,
+  Actual : Sequence,
+  T : Comparable
 >(
   _ expected: Expected, _ actual: Actual, ${TRACE}
-) {
+) where
+  Actual.Iterator.Element == (key: T, value: T),
+  Expected.Iterator.Element == (T, T) {
+
   func comparePairLess(_ lhs: (T, T), rhs: (T, T)) -> Bool {
     return [lhs.0, lhs.1].lexicographicallyPrecedes([rhs.0, rhs.1])
   }

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -19,11 +19,8 @@ public func asHex<T : Integer>(_ x: T) -> String {
 
 /// Convert the given sequence of numeric values to a string representing
 /// their hexadecimal values.
-public func asHex<
-  S: Sequence
-where
-  S.Iterator.Element : Integer
->(_ x: S) -> String {
+public func asHex<S: Sequence>(_ x: S) -> String
+  where S.Iterator.Element : Integer {
   return "[ " + x.lazy.map { asHex($0) }.joined(separator: ", ") + " ]"
 }
 
@@ -53,14 +50,10 @@ public func randomShuffle<T>(_ a: [T]) -> [T] {
   return result
 }
 
-public func gather<
-  C : Collection,
-  IndicesSequence : Sequence
-  where
-  IndicesSequence.Iterator.Element == C.Index
->(
+public func gather<C : Collection, IndicesSequence : Sequence>(
   _ collection: C, _ indices: IndicesSequence
-) -> [C.Iterator.Element] {
+) -> [C.Iterator.Element]
+  where IndicesSequence.Iterator.Element == C.Index {
   return Array(indices.map { collection[$0] })
 }
 

--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -1239,7 +1239,10 @@ internal func resolveError(_ error: NSError?) throws {
 }
 
 extension NSCoder {
-  public func decodeObjectOfClass<DecodedObjectType: NSCoding where DecodedObjectType: NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) -> DecodedObjectType? {
+  public func decodeObjectOfClass<DecodedObjectType>(
+    _ cls: DecodedObjectType.Type, forKey key: String
+  ) -> DecodedObjectType?
+    where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
     let result = NS_Swift_NSCoder_decodeObjectOfClassForKey(self as AnyObject, cls as AnyObject, key as AnyObject, nil)
     return result as! DecodedObjectType?
   }
@@ -1273,7 +1276,10 @@ extension NSCoder {
   }
 
   @available(OSX 10.11, iOS 9.0, *)
-  public func decodeTopLevelObjectOfClass<DecodedObjectType: NSCoding where DecodedObjectType: NSObject>(_ cls: DecodedObjectType.Type, forKey key: String) throws -> DecodedObjectType? {
+  public func decodeTopLevelObjectOfClass<DecodedObjectType>(
+    _ cls: DecodedObjectType.Type, forKey key: String
+  ) throws -> DecodedObjectType?
+    where DecodedObjectType : NSCoding, DecodedObjectType : NSObject {
     var error: NSError?
     let result = NS_Swift_NSCoder_decodeObjectOfClassForKey(self as AnyObject, cls as AnyObject, key as AnyObject, &error)
     try resolveError(error)

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -59,10 +59,8 @@ public protocol __BridgedNSError : RawRepresentable, ErrorProtocol {
 }
 
 // Allow two bridged NSError types to be compared.
-public func ==<T: __BridgedNSError where T.RawValue: SignedInteger>(
-  lhs: T,
-  rhs: T
-) -> Bool {
+public func ==<T: __BridgedNSError>(lhs: T, rhs: T ) -> Bool
+  where T.RawValue: SignedInteger {
   return lhs.rawValue.toIntMax() == rhs.rawValue.toIntMax()
 }
 
@@ -86,10 +84,8 @@ public extension __BridgedNSError where RawValue: SignedInteger {
 }
 
 // Allow two bridged NSError types to be compared.
-public func ==<T: __BridgedNSError where T.RawValue: UnsignedInteger>(
-  lhs: T,
-  rhs: T
-) -> Bool {
+public func ==<T: __BridgedNSError>(lhs: T, rhs: T) -> Bool
+  where T.RawValue: UnsignedInteger {
   return lhs.rawValue.toUIntMax() == rhs.rawValue.toUIntMax()
 }
 

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -753,11 +753,9 @@ extension String {
 
   /// Produces an initialized `NSString` object equivalent to the given
   /// `bytes` interpreted in the given `encoding`.
-  public init? <
-    S: Sequence where S.Iterator.Element == UInt8
-  >(
-    bytes: S, encoding: NSStringEncoding
-  ) {
+  public init? <S: Sequence>(bytes: S, encoding: NSStringEncoding)
+    where S.Iterator.Element == UInt8 {
+
     let byteArray = Array(bytes)
     if let ns = NSString(
       bytes: byteArray, length: byteArray.count, encoding: encoding) {

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -71,11 +71,11 @@ public protocol _ArrayBufferProtocol
   ///
   /// - Precondition: This buffer is backed by a uniquely-referenced
   /// `_ContiguousArrayBuffer`.
-  mutating func replace<C : Collection where C.Iterator.Element == Element>(
+  mutating func replace<C>(
     subRange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: C
-  )
+  ) where C : Collection, C.Iterator.Element == Element
 
   /// Returns a `_SliceBuffer` containing the elements in `bounds`.
   subscript(bounds: Range<Int>) -> _SliceBuffer<Element> { get }
@@ -131,13 +131,11 @@ extension _ArrayBufferProtocol where Index == Int {
     return firstElementAddress
   }
 
-  public mutating func replace<
-    C : Collection where C.Iterator.Element == Element
-  >(
+  public mutating func replace<C>(
     subRange: Range<Int>,
     with newCount: Int,
     elementsOf newValues: C
-  ) {
+  ) where C : Collection, C.Iterator.Element == Element {
     _sanityCheck(startIndex == 0, "_SliceBuffer should override this function.")
     let oldCount = self.count
     let eraseCount = subRange.count

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -45,9 +45,8 @@ protocol _ArrayProtocol
   mutating func reserveCapacity(_ minimumCapacity: Int)
 
   /// Operator form of `append(contentsOf:)`.
-  func += <
-    S : Sequence where S.Iterator.Element == Iterator.Element
-  >(lhs: inout Self, rhs: S)
+  func += <S : Sequence>(lhs: inout Self, rhs: S)
+    where S.Iterator.Element == Iterator.Element
 
   /// Insert `newElement` at index `i`.
   ///

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1024,9 +1024,9 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   ///     // Prints "["Gold", "Cerise", "Magenta", "Vermillion"]"
   ///
   /// - Parameter s: The sequence of elements to turn into an array.
-  public init<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ s: S) {
+  public init<S : Sequence>(_ s: S)
+    where S.Iterator.Element == Element {
+
     self = ${Self}(_Buffer(s._copyToNativeArrayBuffer(),
       shiftedToStartIndex: 0))
   }
@@ -1275,11 +1275,8 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// - Parameter newElements: The elements to append to the array.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting array.
-  public mutating func append<
-    S : Sequence
-    where
-    S.Iterator.Element == Element
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == Element {
     let oldCount = self.count
     let capacity = self.capacity
     let newCount = oldCount + newElements.underestimatedCount
@@ -1309,11 +1306,9 @@ extension ${Self} : RangeReplaceableCollection, _ArrayProtocol {
   /// - Parameter newElements: The elements to append to the array.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting array.
-  public mutating func append<
-    C : Collection
-    where
-    C.Iterator.Element == Element
-  >(contentsOf newElements: C) {
+  public mutating func append<C : Collection>(contentsOf newElements: C)
+    where C.Iterator.Element == Element {
+
     let newElementsCount = numericCast(newElements.count) as Int
 
     let oldCount = self.count
@@ -1624,14 +1619,17 @@ internal struct _InitializeMemoryFromCollection<
 
 // FIXME(ABI): add argument labels.
 @inline(never)
-internal func _arrayOutOfPlaceReplace<
-  B : _ArrayBufferProtocol, C : Collection
-  where
+internal func _arrayOutOfPlaceReplace<B, C>(
+  _ source: inout B,
+  _ bounds: Range<Int>,
+  _ newValues: C,
+  _ insertCount: Int
+) where
+  B : _ArrayBufferProtocol,
+  C : Collection,
   C.Iterator.Element == B.Element,
-  B.Index == Int
->(
-  _ source: inout B, _ bounds: Range<Int>, _ newValues: C, _ insertCount: Int
-) {
+  B.Index == Int {
+
   let growth = insertCount - bounds.count
   let newCount = source.count + growth
   var newBuffer = _forceCreateUniqueMutableBuffer(
@@ -1694,11 +1692,10 @@ extension ${Self} {
   ///   array with an empty collection; otherwise, O(*n*), where *n* is the
   ///   length of the array.
   @_semantics("array.mutate_unknown")
-  public mutating func replaceSubrange<
-    C: Collection where C.Iterator.Element == _Buffer.Element
-  >(
-    _ subrange: Range<Int>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ subrange: Range<Int>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == _Buffer.Element {
     _precondition(subrange.lowerBound >= self._buffer.startIndex,
       "${Self} replace: subrange start is negative")
 
@@ -1839,17 +1836,18 @@ internal protocol _PointerFunction {
 /// As an optimization, may move elements out of source rather than
 /// copying when it isUniquelyReferenced.
 @inline(never)
-internal func _arrayOutOfPlaceUpdate<
-  _Buffer : _ArrayBufferProtocol, Initializer : _PointerFunction
-  where Initializer.Element == _Buffer.Element,
-  _Buffer.Index == Int
->(
+internal func _arrayOutOfPlaceUpdate<_Buffer, Initializer>(
   _ source: inout _Buffer,
   _ dest: inout _ContiguousArrayBuffer<_Buffer.Element>,
   _ headCount: Int, // Count of initial source elements to copy/move
   _ newCount: Int,  // Number of new elements to insert
   _ initializeNewElements: Initializer
-) {
+) where
+  _Buffer : _ArrayBufferProtocol,
+  Initializer : _PointerFunction,
+  Initializer.Element == _Buffer.Element,
+  _Buffer.Index == Int {
+
   _sanityCheck(headCount >= 0)
   _sanityCheck(newCount >= 0)
 
@@ -1931,11 +1929,12 @@ internal struct _IgnorePointer<T> : _PointerFunction {
 
 @_versioned
 @inline(never)
-internal func _outlinedMakeUniqueBuffer<
-  _Buffer : _ArrayBufferProtocol where _Buffer.Index == Int
->(
+internal func _outlinedMakeUniqueBuffer<_Buffer>(
   _ buffer: inout _Buffer, bufferCount: Int
-) {
+) where
+  _Buffer : _ArrayBufferProtocol,
+  _Buffer.Index == Int {
+
   if _fastPath(
       buffer.requestUniqueMutableBackingBuffer(minimumCapacity: bufferCount) != nil) {
     return
@@ -1946,11 +1945,12 @@ internal func _outlinedMakeUniqueBuffer<
   _arrayOutOfPlaceUpdate(&buffer, &newBuffer, bufferCount, 0, _IgnorePointer())
 }
 
-internal func _arrayReserve<
-  _Buffer : _ArrayBufferProtocol where _Buffer.Index == Int
->(
+internal func _arrayReserve<_Buffer>(
   _ buffer: inout _Buffer, _ minimumCapacity: Int
-) {
+) where
+  _Buffer : _ArrayBufferProtocol,
+  _Buffer.Index == Int {
+
   let count = buffer.count
   let requiredCapacity = max(count, minimumCapacity)
 
@@ -1967,13 +1967,13 @@ internal func _arrayReserve<
 }
 
 public // SPI(Foundation)
-func _extractOrCopyToNativeArrayBuffer<
-  Buffer : _ArrayBufferProtocol
+func _extractOrCopyToNativeArrayBuffer<Buffer>(
+  _ source: Buffer
+) -> _ContiguousArrayBuffer<Buffer.Iterator.Element>
   where
-  Buffer.Iterator.Element == Buffer.Element
->(_ source: Buffer)
-  -> _ContiguousArrayBuffer<Buffer.Iterator.Element>
-{
+  Buffer : _ArrayBufferProtocol,
+  Buffer.Iterator.Element == Buffer.Element {
+
   if let n = source.requestNativeBuffer() {
     return n
   }
@@ -1981,15 +1981,14 @@ func _extractOrCopyToNativeArrayBuffer<
 }
 
 /// Append items from `newItems` to `buffer`.
-internal func _arrayAppendSequence<
-  Buffer : _ArrayBufferProtocol,
-  S : Sequence
-  where
-  S.Iterator.Element == Buffer.Element,
-  Buffer.Index == Int
->(
+internal func _arrayAppendSequence<Buffer, S>(
   _ buffer: inout Buffer, _ newItems: S
-) {
+) where
+  Buffer : _ArrayBufferProtocol,
+  S : Sequence,
+  S.Iterator.Element == Buffer.Element,
+  Buffer.Index == Int {
+
   var stream = newItems.makeIterator()
   var nextItem = stream.next()
 
@@ -2161,18 +2160,16 @@ extension ${Self} {
   }
 
   @available(*, unavailable, renamed: "replaceSubrange")
-  public mutating func replaceRange<
-    C : Collection where C.Iterator.Element == _Buffer.Element
-  >(_ subRange: Range<Int>, with newElements: C) {
+  public mutating func replaceRange<C>(
+    _ subRange: Range<Int>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == _Buffer.Element {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, renamed: "append(contentsOf:)")
-  public mutating func appendContentsOf<
-    S : Sequence
-    where
-    S.Iterator.Element == Element
-  >(_ newElements: S) {
+  public mutating func appendContentsOf<S : Sequence>(_ newElements: S)
+    where S.Iterator.Element == Element {
     Builtin.unreachable()
   }
 }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -13,10 +13,11 @@
 // FIXME: swift-3-indexing-model: Generalize all tests to check both
 // [Closed]Range and [Closed]CountableRange.
 
-// WORKAROUND rdar://25214598 - should be Bound : Strideable
-internal enum _ClosedRangeIndexRepresentation<
-  Bound : Comparable where Bound : _Strideable, Bound.Stride : Integer
-> {
+internal enum _ClosedRangeIndexRepresentation<Bound>
+  where
+  // WORKAROUND rdar://25214598 - should be Bound : Strideable
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : Integer {
   case pastEnd
   case inRange(Bound)
 }
@@ -24,13 +25,14 @@ internal enum _ClosedRangeIndexRepresentation<
 // FIXME(ABI)(compiler limitation): should be a nested type in
 // `ClosedRange`.
 /// A position in a `CountableClosedRange` instance.
-public struct ClosedRangeIndex<
+public struct ClosedRangeIndex<Bound> : Comparable
+  where
   // WORKAROUND rdar://25214598 - should be Bound : Strideable
-  Bound : Comparable where Bound : _Strideable, Bound.Stride : Integer
   // swift-3-indexing-model: should conform to _Strideable, otherwise
   // CountableClosedRange is not interchangeable with CountableRange in all
   // contexts.
-> : Comparable {
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : Integer {
   /// Creates the "past the end" position.
   internal init() { _value = .pastEnd }
 
@@ -101,11 +103,11 @@ public func < <B>(lhs: ClosedRangeIndex<B>, rhs: ClosedRangeIndex<B>) -> Bool {
 
 // WORKAROUND: needed because of rdar://25584401
 /// An iterator over the elements of a `CountableClosedRange` instance.
-public struct ClosedRangeIterator<
-  Bound : protocol<_Strideable, Comparable>
+public struct ClosedRangeIterator<Bound> : IteratorProtocol, Sequence
   where
-  Bound.Stride : SignedInteger
-> : IteratorProtocol, Sequence {
+  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : SignedInteger {
 
   internal init(_range r: CountableClosedRange<Bound>) {
     _nextResult = r.lowerBound
@@ -175,12 +177,11 @@ public struct ClosedRangeIterator<
 /// `stride(from:through:by:)` function.
 ///
 /// - SeeAlso: `CountableRange`, `ClosedRange`, `Range`
-public struct CountableClosedRange<
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : protocol<_Strideable, Comparable>
+public struct CountableClosedRange<Bound> : RandomAccessCollection
   where
-  Bound.Stride : SignedInteger
-> : RandomAccessCollection {
+  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : SignedInteger {
 
   /// The range's lower bound.
   public let lowerBound: Bound
@@ -387,14 +388,13 @@ public func ... <Bound : Comparable> (minimum: Bound, maximum: Bound)
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-public func ... <
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : protocol<_Strideable, Comparable>
-  where
-  Bound.Stride : SignedInteger
-> (
+public func ... <Bound> (
   minimum: Bound, maximum: Bound
-) -> CountableClosedRange<Bound> {
+) -> CountableClosedRange<Bound>
+  where
+  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : SignedInteger {
   // FIXME: swift-3-indexing-model: tests for traps.
   _precondition(
     minimum <= maximum, "Can't form Range with upperBound < lowerBound")

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -195,9 +195,8 @@ public protocol RawRepresentable {
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
-public func == <
-  T : RawRepresentable where T.RawValue : Equatable
->(lhs: T, rhs: T) -> Bool {
+public func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
+  where T.RawValue : Equatable {
   return lhs.rawValue == rhs.rawValue
 }
 
@@ -206,9 +205,8 @@ public func == <
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
-public func != <
-  T : RawRepresentable where T.RawValue : Equatable
->(lhs: T, rhs: T) -> Bool {
+public func != <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
+  where T.RawValue : Equatable {
   return lhs.rawValue != rhs.rawValue
 }
 
@@ -219,9 +217,8 @@ public func != <
 /// - Parameters:
 ///   - lhs: A raw-representable instance.
 ///   - rhs: A second raw-representable instance.
-public func != <
-  T : Equatable where T : RawRepresentable, T.RawValue : Equatable
->(lhs: T, rhs: T) -> Bool {
+public func != <T : Equatable>(lhs: T, rhs: T) -> Bool
+  where T : RawRepresentable, T.RawValue : Equatable {
   return lhs.rawValue != rhs.rawValue
 }
 

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -495,9 +495,10 @@ public struct _ContiguousArrayBuffer<Element> : _ArrayBufferProtocol {
 }
 
 /// Append the elements of `rhs` to `lhs`.
-public func += <
-  Element, C : Collection where C.Iterator.Element == Element
-> (lhs: inout _ContiguousArrayBuffer<Element>, rhs: C) {
+public func += <Element, C : Collection>(
+  lhs: inout _ContiguousArrayBuffer<Element>, rhs: C
+) where C.Iterator.Element == Element {
+
   let oldCount = lhs.count
   let newCount = oldCount + numericCast(rhs.count)
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -54,7 +54,7 @@ public struct AnyIterator<Element> : IteratorProtocol {
   ///         = lazyStrings.makeIterator()
   ///       return AnyIterator(iterator)
   ///     }
-  public init<I : IteratorProtocol where I.Element == Element>(_ base: I) {
+  public init<I : IteratorProtocol>(_ base: I) where I.Element == Element {
     self._box = _IteratorBox(base)
   }
 
@@ -307,8 +307,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %     assert False, 'Unknown kind'
 %   end
 
-internal final class _${Kind}Box<
-  S : ${Kind}
+internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
   where
   S.SubSequence : ${Kind},
   S.SubSequence.Iterator.Element == S.Iterator.Element,
@@ -325,7 +324,7 @@ internal final class _${Kind}Box<
   S.Indices.Index == S.Index,
   S.Indices.SubSequence == S.Indices
 %   end
-> : _Any${Kind}Box<S.Iterator.Element> {
+{
   internal typealias Element = S.Iterator.Element
 
   internal override func _makeIterator() -> AnyIterator<Element> {
@@ -536,22 +535,20 @@ internal struct _ClosureBasedSequence<Iterator : IteratorProtocol>
 /// - SeeAlso: `AnyIterator`
 public struct AnySequence<Element> : Sequence {
   /// Creates a new sequence that wraps and forwards operations to `base`.
-  public init<
-    S : Sequence
+  public init<S : Sequence>(_ base: S)
     where
     S.Iterator.Element == Element,
     S.SubSequence : Sequence,
     S.SubSequence.Iterator.Element == Element,
-    S.SubSequence.SubSequence == S.SubSequence
-  >(_ base: S) {
+    S.SubSequence.SubSequence == S.SubSequence {
     self._box = _SequenceBox(_base: base)
   }
 
   /// Creates a sequence whose `makeIterator()` method forwards to
   /// `makeUnderlyingIterator`.
-  public init<I : IteratorProtocol where I.Element == Element>(
+  public init<I : IteratorProtocol>(
     _ makeUnderlyingIterator: () -> I
-  ) {
+  ) where I.Element == Element {
     self.init(_ClosureBasedSequence(makeUnderlyingIterator))
   }
 
@@ -816,8 +813,7 @@ public struct ${Self}<Element>
   /// stores `base` as its underlying collection.
   ///
   /// - Complexity: O(1).
-  public init<
-    C : ${SubProtocol}
+  public init<C : ${SubProtocol}>(_ base: C)
     where
     C.Iterator.Element == Element,
 
@@ -834,8 +830,7 @@ public struct ${Self}<Element>
     C.Indices : ${SubProtocol},
     C.Indices.Iterator.Element == C.Index,
     C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices
-  >(_ base: C) {
+    C.Indices.SubSequence == C.Indices {
     // Traversal: ${Traversal}
     // SubTraversal: ${SubTraversal}
     self._box = _${SubProtocol}Box<C>(

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -89,15 +89,12 @@ extension LazyCollectionProtocol
   ///     self.map(transform).flatten()
   ///
   /// - Complexity: O(1)
-  public func flatMap<
-    SegmentOfResult : Collection
-    where SegmentOfResult : BidirectionalCollection
-  >(
+  public func flatMap<SegmentOfResult : Collection>(
     _ transform: (Elements.Iterator.Element) -> SegmentOfResult
   ) -> LazyCollection<
     FlattenBidirectionalCollection<
-      LazyMapBidirectionalCollection<Elements, SegmentOfResult>
-  >> {
+      LazyMapBidirectionalCollection<Elements, SegmentOfResult>>>
+    where SegmentOfResult : BidirectionalCollection {
     return self.map(transform).flatten()
   }
   

--- a/stdlib/public/core/Flatten.swift.gyb
+++ b/stdlib/public/core/Flatten.swift.gyb
@@ -26,9 +26,8 @@ from gyb_stdlib_support import (
 ///
 /// - Note: This is the `IteratorProtocol` used by `FlattenSequence`,
 ///   `FlattenCollection`, and `BidirectionalFlattenCollection`.
-public struct FlattenIterator<
-  Base : IteratorProtocol where Base.Element : Sequence
-> : IteratorProtocol, Sequence {
+public struct FlattenIterator<Base : IteratorProtocol> : IteratorProtocol, Sequence
+  where Base.Element : Sequence {
 
   /// Construct around a `base` iterator.
   internal init(_base: Base) {
@@ -78,9 +77,8 @@ public struct FlattenIterator<
 /// * `s.lazy.flatten().map(f)` maps lazily and returns a `LazyMapSequence`
 ///
 /// - See also: `FlattenCollection`
-public struct FlattenSequence<
-  Base : Sequence where Base.Iterator.Element : Sequence
-> : Sequence {
+public struct FlattenSequence<Base : Sequence> : Sequence
+  where Base.Iterator.Element : Sequence {
 
   /// Creates a concatenation of the elements of the elements of `base`.
   ///
@@ -152,11 +150,10 @@ extension LazySequenceProtocol
 %   Index = Collection + 'Index'
 %   Slice = sliceTypeName(traversal=traversal, mutable=False, rangeReplaceable=False)
 /// A position in a `${Collection}`.
-public struct ${Index}<
-  BaseElements : ${collectionForTraversal(traversal)}
+public struct ${Index}<BaseElements> : Comparable
   where
-  ${constraints % {'Base': 'BaseElements.'}}
-> : Comparable {
+  BaseElements : ${collectionForTraversal(traversal)},
+  ${constraints % {'Base': 'BaseElements.'}} {
 
   internal init(
     _ _outer: BaseElements.Index,
@@ -227,11 +224,10 @@ public func < <BaseElements> (
 ///   documented complexity.
 ///
 /// - See also: `FlattenSequence`
-public struct ${Collection}<
-  Base : ${collectionForTraversal(traversal)}
+public struct ${Collection}<Base> : ${collectionForTraversal(traversal)}
   where
-  ${constraints % {'Base': 'Base.'}}
-> : ${collectionForTraversal(traversal)} {
+  Base : ${collectionForTraversal(traversal)},
+  ${constraints % {'Base': 'Base.'}} {
   // FIXME: swift-3-indexing-model: check test coverage for collection.
 
   /// A type that represents a valid position in the collection.

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -747,9 +747,8 @@ public struct Set<Element : Hashable> :
   ///     // Prints "[17, 19, 23, 11, 13]"
   ///
   /// - Parameter sequence: The elements to use as members of the new set.
-  public init<
-    Source : Sequence where Source.Iterator.Element == Element
-  >(_ sequence: Source) {
+  public init<Source : Sequence>(_ sequence: Source)
+    where Source.Iterator.Element == Element {
     self.init()
     if let s = sequence as? Set<Element> {
       // If this sequence is actually a native `Set`, then we can quickly
@@ -783,9 +782,8 @@ public struct Set<Element : Hashable> :
   ///   must be finite.
   /// - Returns: `true` if the set is a subset of `possibleSuperset`;
   ///   otherwise, `false`.
-  public func isSubset<
-    S : Sequence where S.Iterator.Element == Element
-  >(of possibleSuperset: S) -> Bool {
+  public func isSubset<S : Sequence>(of possibleSuperset: S) -> Bool
+    where S.Iterator.Element == Element {
     // FIXME(performance): isEmpty fast path, here and elsewhere.
     let other = Set(possibleSuperset)
     return isSubset(of: other)
@@ -811,9 +809,8 @@ public struct Set<Element : Hashable> :
   ///   `possibleStrictSuperset` must be finite.
   /// - Returns: `true` is the set is strict subset of
   ///   `possibleStrictSuperset`; otherwise, `false`.
-  public func isStrictSubset<
-    S : Sequence where S.Iterator.Element == Element
-  >(of possibleStrictSuperset: S) -> Bool {
+  public func isStrictSubset<S : Sequence>(of possibleStrictSuperset: S) -> Bool
+    where S.Iterator.Element == Element {
     // FIXME: code duplication.
     let other = Set(possibleStrictSuperset)
     return isStrictSubset(of: other)
@@ -834,9 +831,8 @@ public struct Set<Element : Hashable> :
   ///   be finite.
   /// - Returns: `true` if the set is a superset of `possibleSubset`;
   ///   otherwise, `false`.
-  public func isSuperset<
-    S : Sequence where S.Iterator.Element == Element
-  >(of possibleSubset: S) -> Bool {
+  public func isSuperset<S : Sequence>(of possibleSubset: S) -> Bool
+    where S.Iterator.Element == Element {
     // FIXME(performance): Don't build a set; just ask if every element is in
     // `self`.
     let other = Set(possibleSubset)
@@ -861,9 +857,8 @@ public struct Set<Element : Hashable> :
   ///   `possibleStrictSubset` must be finite.
   /// - Returns: `true` if the set is a strict superset of
   ///   `possibleStrictSubset`; otherwise, `false`.
-  public func isStrictSuperset<
-    S : Sequence where S.Iterator.Element == Element
-  >(of possibleStrictSubset: S) -> Bool {
+  public func isStrictSuperset<S : Sequence>(of possibleStrictSubset: S) -> Bool
+    where S.Iterator.Element == Element {
     let other = Set(possibleStrictSubset)
     return other.isStrictSubset(of: self)
   }
@@ -881,9 +876,8 @@ public struct Set<Element : Hashable> :
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: `true` if the set has no elements in common with `other`;
   ///   otherwise, `false`.
-  public func isDisjoint<
-    S : Sequence where S.Iterator.Element == Element
-  >(with other: S) -> Bool {
+  public func isDisjoint<S : Sequence>(with other: S) -> Bool
+    where S.Iterator.Element == Element {
     // FIXME(performance): Don't need to build a set.
     let otherSet = Set(other)
     return isDisjoint(with: otherSet)
@@ -912,9 +906,8 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set with the unique elements of this set and `other`.
-  public func union<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) -> Set<Element> {
+  public func union<S : Sequence>(_ other: S) -> Set<Element>
+    where S.Iterator.Element == Element {
     var newSet = self
     newSet.formUnion(other)
     return newSet
@@ -933,9 +926,8 @@ public struct Set<Element : Hashable> :
   ///     // Prints "["Diana", "Nathaniel", "Bethany", "Alicia", "Marcia"]"
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
-  public mutating func formUnion<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) {
+  public mutating func formUnion<S : Sequence>(_ other: S)
+    where S.Iterator.Element == Element {
     for item in other {
       insert(item)
     }
@@ -954,15 +946,13 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set.
-  public func subtracting<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) -> Set<Element> {
+  public func subtracting<S : Sequence>(_ other: S) -> Set<Element>
+    where S.Iterator.Element == Element {
     return self._subtracting(other)
   }
 
-  internal func _subtracting<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) -> Set<Element> {
+  internal func _subtracting<S : Sequence>(_ other: S) -> Set<Element>
+    where S.Iterator.Element == Element {
     var newSet = self
     newSet.subtract(other)
     return newSet
@@ -979,15 +969,13 @@ public struct Set<Element : Hashable> :
   ///     // Prints "["Chris", "Diana", "Alicia"]"
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
-  public mutating func subtract<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) {
+  public mutating func subtract<S : Sequence>(_ other: S)
+    where S.Iterator.Element == Element {
     _subtract(other)
   }
 
-  internal mutating func _subtract<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) {
+  internal mutating func _subtract<S : Sequence>(_ other: S)
+    where S.Iterator.Element == Element {
     for item in other {
       remove(item)
     }
@@ -1006,9 +994,8 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set.
-  public func intersection<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) -> Set<Element> {
+  public func intersection<S : Sequence>(_ other: S) -> Set<Element>
+    where S.Iterator.Element == Element {
     let otherSet = Set(other)
     return intersection(otherSet)
   }
@@ -1024,9 +1011,8 @@ public struct Set<Element : Hashable> :
   ///     // Prints "["Bethany", "Eric"]"
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
-  public mutating func formIntersection<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) {
+  public mutating func formIntersection<S : Sequence>(_ other: S)
+    where S.Iterator.Element == Element {
     // Because `intersect` needs to both modify and iterate over
     // the left-hand side, the index may become invalidated during
     // traversal so an intermediate set must be created.
@@ -1056,9 +1042,8 @@ public struct Set<Element : Hashable> :
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
   /// - Returns: A new set.
-  public func symmetricDifference<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) -> Set<Element> {
+  public func symmetricDifference<S : Sequence>(_ other: S) -> Set<Element>
+    where S.Iterator.Element == Element {
     var newSet = self
     newSet.formSymmetricDifference(other)
     return newSet
@@ -1076,9 +1061,8 @@ public struct Set<Element : Hashable> :
   ///     // Prints "["Diana", "Forlani", "Alicia"]"
   ///
   /// - Parameter other: A sequence of elements. `other` must be finite.
-  public mutating func formSymmetricDifference<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ other: S) {
+  public mutating func formSymmetricDifference<S : Sequence>(_ other: S)
+    where S.Iterator.Element == Element {
     let otherSet = Set(other)
     formSymmetricDifference(otherSet)
   }

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -19,19 +19,15 @@ internal enum _JoinIteratorState {
 
 /// An iterator that presents the elements of the sequences traversed
 /// by `Base`, concatenated using a given separator.
-public struct JoinedIterator<
-  Base : IteratorProtocol where Base.Element : Sequence
-> : IteratorProtocol {
+public struct JoinedIterator<Base : IteratorProtocol> : IteratorProtocol
+  where Base.Element : Sequence {
 
   /// Creates an iterator that presents the elements of the sequences
   /// traversed by `base`, concatenated using `separator`.
   ///
   /// - Complexity: O(`separator.count`).
-  public init<
-    Separator : Sequence
-    where
-    Separator.Iterator.Element == Base.Element.Iterator.Element
-  >(base: Base, separator: Separator) {
+  public init<Separator : Sequence>(base: Base, separator: Separator)
+    where Separator.Iterator.Element == Base.Element.Iterator.Element {
     self._base = base
     self._separatorData = ContiguousArray(separator)
   }
@@ -92,19 +88,15 @@ public struct JoinedIterator<
 
 /// A sequence that presents the elements of the `Base` sequences
 /// concatenated using a given separator.
-public struct JoinedSequence<
-  Base : Sequence where Base.Iterator.Element : Sequence
-> : Sequence {
+public struct JoinedSequence<Base : Sequence> : Sequence
+  where Base.Iterator.Element : Sequence {
 
   /// Creates a sequence that presents the elements of `base` sequences
   /// concatenated using `separator`.
   ///
   /// - Complexity: O(`separator.count`).
-  public init<
-    Separator : Sequence
-    where
-    Separator.Iterator.Element == Base.Iterator.Element.Iterator.Element
-  >(base: Base, separator: Separator) {
+  public init<Separator : Sequence>(base: Base, separator: Separator)
+    where Separator.Iterator.Element == Base.Iterator.Element.Iterator.Element {
     self._base = base
     self._separator = ContiguousArray(separator)
   }
@@ -177,19 +169,17 @@ extension Sequence where Iterator.Element : Sequence {
   /// - Returns: The joined sequence of elements.
   ///
   /// - SeeAlso: `flatten()`
-  public func joined<
-    Separator : Sequence
-    where
-    Separator.Iterator.Element == Iterator.Element.Iterator.Element
-  >(separator: Separator) -> JoinedSequence<Self> {
+  public func joined<Separator : Sequence>(
+    separator: Separator
+  ) -> JoinedSequence<Self>
+    where Separator.Iterator.Element == Iterator.Element.Iterator.Element {
     return JoinedSequence(base: self, separator: separator)
   }
 }
 
 @available(*, unavailable, renamed: "JoinedIterator")
-public struct JoinGenerator<
-  Base : IteratorProtocol where Base.Element : Sequence
-> {}
+public struct JoinGenerator<Base : IteratorProtocol>
+  where Base.Element : Sequence {}
 
 extension JoinedSequence {
   @available(*, unavailable, renamed: "makeIterator")
@@ -200,11 +190,10 @@ extension JoinedSequence {
 
 extension Sequence where Iterator.Element : Sequence {
   @available(*, unavailable, renamed: "joined")
-  public func joinWithSeparator<
-    Separator : Sequence
-    where
-    Separator.Iterator.Element == Iterator.Element.Iterator.Element
-  >(_ separator: Separator) -> JoinedSequence<Self> {
+  public func joinWithSeparator<Separator : Sequence>(
+    _ separator: Separator
+  ) -> JoinedSequence<Self>
+    where Separator.Iterator.Element == Iterator.Element.Iterator.Element {
     Builtin.unreachable()
   }
 }

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -208,12 +208,13 @@ public struct Mirror {
   /// `Mirror`'s `children` may be upgraded later.  See the failable
   /// initializers of `AnyBidirectionalCollection` and
   /// `AnyRandomAccessCollection` for details.
-  public init<
-    Subject,
-    C : Collection
-    where
+  public init<Subject, C : Collection>(
+    _ subject: Subject,
+    children: C,
+    displayStyle: DisplayStyle? = nil,
+    ancestorRepresentation: AncestorRepresentation = .generated
+  ) where
     C.Iterator.Element == Child,
-
     // FIXME(ABI)(compiler limitation): these constraints should be applied to
     // associated types of Collection.
     C.SubSequence : Collection,
@@ -227,13 +228,8 @@ public struct Mirror {
     C.Indices : Collection,
     C.Indices.Iterator.Element == C.Index,
     C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices
-  >(
-    _ subject: Subject,
-    children: C,
-    displayStyle: DisplayStyle? = nil,
-    ancestorRepresentation: AncestorRepresentation = .generated
-  ) {
+    C.Indices.SubSequence == C.Indices {
+
     self.subjectType = Subject.self
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)
@@ -274,11 +270,12 @@ public struct Mirror {
   /// `Mirror`'s `children` may be upgraded later.  See the failable
   /// initializers of `AnyBidirectionalCollection` and
   /// `AnyRandomAccessCollection` for details.
-  public init<
-    Subject,
-    C : Collection
-    where
-
+  public init<Subject, C : Collection>(
+    _ subject: Subject,
+    unlabeledChildren: C,
+    displayStyle: DisplayStyle? = nil,
+    ancestorRepresentation: AncestorRepresentation = .generated
+  ) where
     // FIXME(ABI)(compiler limitation): these constraints should be applied to
     // associated types of Collection.
     C.SubSequence : Collection,
@@ -286,13 +283,8 @@ public struct Mirror {
     C.Indices : Collection,
     C.Indices.Iterator.Element == C.Index,
     C.Indices.Index == C.Index,
-    C.Indices.SubSequence == C.Indices
-  >(
-    _ subject: Subject,
-    unlabeledChildren: C,
-    displayStyle: DisplayStyle? = nil,
-    ancestorRepresentation: AncestorRepresentation = .generated
-  ) {
+    C.Indices.SubSequence == C.Indices {
+
     self.subjectType = Subject.self
     self._makeSuperclassMirror = Mirror._superclassIterator(
       subject, ancestorRepresentation)

--- a/stdlib/public/core/NewtypeWrapper.swift.gyb
+++ b/stdlib/public/core/NewtypeWrapper.swift.gyb
@@ -22,9 +22,8 @@ extension _SwiftNewtypeWrapper where Self.RawValue : Hashable {
 }
 
 % for op in ['<', '>', '<=', '>=']:
-public func ${op} <
-  T : _SwiftNewtypeWrapper where T.RawValue : Comparable
->(lhs: T, rhs: T) -> Bool {
+public func ${op} <T: _SwiftNewtypeWrapper>(lhs: T, rhs: T) -> Bool
+  where T.RawValue : Comparable {
   return lhs.rawValue ${op} rhs.rawValue
 }
 % end

--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -78,12 +78,11 @@ public enum _DisabledRangeIndex_ {}
 ///     // Prints "0"
 ///
 /// - SeeAlso: `CountableClosedRange`, `Range`, `ClosedRange`
-public struct CountableRange<
-  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
-  Bound : protocol<_Strideable, Comparable>
+public struct CountableRange<Bound> : RandomAccessCollection
   where
-  Bound.Stride : SignedInteger
-> : RandomAccessCollection {
+  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : SignedInteger {
 
   /// The range's lower bound.
   ///
@@ -574,12 +573,14 @@ public func ..< <Bound : Comparable> (minimum: Bound, maximum: Bound)
 ///   - minimum: The lower bound for the range.
 ///   - maximum: The upper bound for the range.
 @_transparent
-// WORKAROUND rdar://25214598 - should be just Bound : Strideable
-public func ..< <
-  Bound : _Strideable where Bound : Comparable, Bound.Stride : Integer
-> (
+public func ..< <Bound>(
   minimum: Bound, maximum: Bound
-) -> CountableRange<Bound> {
+) -> CountableRange<Bound>
+  where
+  // WORKAROUND rdar://25214598 - should be just Bound : Strideable
+  Bound : protocol<_Strideable, Comparable>,
+  Bound.Stride : Integer {
+
   // FIXME: swift-3-indexing-model: tests for traps.
   _precondition(minimum <= maximum,
     "Can't form Range with upperBound < lowerBound")

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -53,9 +53,7 @@ public protocol RangeReplaceableIndexable : Indexable {
   ///
   /// - Parameter elements: The sequence of elements for the new collection.
   ///   `elements` must be finite.
-  init<
-    S : Sequence where S.Iterator.Element == _Element
-  >(_ elements: S)
+  init<S : Sequence>(_ elements: S) where S.Iterator.Element == _Element
 
   /// Replaces the specified subrange of elements with the given collection.
   ///
@@ -93,11 +91,10 @@ public protocol RangeReplaceableIndexable : Indexable {
   ///   and `newElements`. If the call to `replaceSubrange` simply appends the
   ///   contents of `newElements` to the collection, the complexity is O(*n*),
   ///   where *n* is the length of `newElements`.
-  mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == _Element
-  >(
-    _ subrange: Range<Index>, with newElements: C
-  )
+  mutating func replaceSubrange<C>(
+    _ subrange: Range<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == _Element
 
   /// Inserts a new element into the collection at the specified position.
   ///
@@ -149,9 +146,9 @@ public protocol RangeReplaceableIndexable : Indexable {
   ///   and `newElements`. If `i` is equal to the collection's `endIndex`
   ///   property, the complexity is O(*n*), where *n* is the length of
   ///   `newElements`.
-  mutating func insert<
-    S : Collection where S.Iterator.Element == _Element
-  >(contentsOf newElements: S, at i: Index)
+  mutating func insert<S : Collection>(
+    contentsOf newElements: S, at i: Index
+  ) where S.Iterator.Element == _Element
 
   /// Removes and returns the element at the specified position.
   ///
@@ -284,11 +281,10 @@ public protocol RangeReplaceableCollection
   ///   and `newElements`. If the call to `replaceSubrange` simply appends the
   ///   contents of `newElements` to the collection, the complexity is O(*n*),
   ///   where *n* is the length of `newElements`.
-  mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == Iterator.Element
-  >(
-    _ subrange: Range<Index>, with newElements: C
-  )
+  mutating func replaceSubrange<C>(
+    _ subrange: Range<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Iterator.Element
 
   /*
   We could have these operators with default implementations, but the compiler
@@ -297,26 +293,18 @@ public protocol RangeReplaceableCollection
   <rdar://problem/16566712> Dependent type should have been substituted by Sema
   or SILGen
 
-  func +<
-    S : Sequence
+  func +<S : Sequence>(_: Self, _: S) -> Self
     where S.Iterator.Element == Iterator.Element
-  >(_: Self, _: S) -> Self
 
-  func +<
-    S : Sequence
+  func +<S : Sequence>(_: S, _: Self) -> Self
     where S.Iterator.Element == Iterator.Element
-  >(_: S, _: Self) -> Self
 
-  func +<
-    S : Collection
+  func +<S : Collection>(_: Self, _: S) -> Self
     where S.Iterator.Element == Iterator.Element
-  >(_: Self, _: S) -> Self
 
-  func +<
-    RC : RangeReplaceableCollection
+  func +<RC : RangeReplaceableCollection>(_: Self, _: S) -> Self
     where RC.Iterator.Element == Iterator.Element
-  >(_: Self, _: S) -> Self
-*/
+  */
 
   /// Prepares the collection to store the specified number of elements, when
   /// doing so is appropriate for the underlying type.
@@ -353,9 +341,8 @@ public protocol RangeReplaceableCollection
   ///
   /// - Parameter elements: The sequence of elements for the new collection.
   ///   `elements` must be finite.
-  init<
-    S : Sequence where S.Iterator.Element == Iterator.Element
-  >(_ elements: S)
+  init<S : Sequence>(_ elements: S)
+    where S.Iterator.Element == Iterator.Element
 
   /// Adds an element to the end of the collection.
   ///
@@ -379,10 +366,8 @@ public protocol RangeReplaceableCollection
   <rdar://problem/16566712> Dependent type should have been substituted by Sema
   or SILGen
 
-  func +=<
-    S : Sequence
+  func +=<S : Sequence>(inout _: Self, _: S)
     where S.Iterator.Element == Iterator.Element
-  >(inout _: Self, _: S)
   */
 
   /// Adds the elements of a sequence to the end of the collection.
@@ -399,11 +384,8 @@ public protocol RangeReplaceableCollection
   /// - Parameter newElements: The elements to append to the collection.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting collection.
-  mutating func append<
-    S : Sequence
-    where
-    S.Iterator.Element == Iterator.Element
-  >(contentsOf newElements: S)
+  mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == Iterator.Element
 
   /// Inserts a new element into the collection at the specified position.
   ///
@@ -455,9 +437,8 @@ public protocol RangeReplaceableCollection
   ///   and `newElements`. If `i` is equal to the collection's `endIndex`
   ///   property, the complexity is O(*n*), where *n* is the length of
   ///   `newElements`.
-  mutating func insert<
-    S : Collection where S.Iterator.Element == Iterator.Element
-  >(contentsOf newElements: S, at i: Index)
+  mutating func insert<S : Collection>(contentsOf newElements: S, at i: Index)
+    where S.Iterator.Element == Iterator.Element
 
   /// Removes and returns the element at the specified position.
   ///
@@ -576,9 +557,8 @@ extension RangeReplaceableCollection {
   /// sequence.
   ///
   /// - Parameter elements: The sequence of elements for the new collection.
-  public init<
-    S : Sequence where S.Iterator.Element == Iterator.Element
-  >(_ elements: S) {
+  public init<S : Sequence>(_ elements: S)
+    where S.Iterator.Element == Iterator.Element {
     self.init()
     append(contentsOf: elements)
   }
@@ -615,9 +595,9 @@ extension RangeReplaceableCollection {
   /// - Parameter newElements: The elements to append to the collection.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting collection.
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == Iterator.Element
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == Iterator.Element {
+
     let approximateCapacity = self.count +
       numericCast(newElements.underestimatedCount)
     self.reserveCapacity(approximateCapacity)
@@ -680,9 +660,9 @@ extension RangeReplaceableCollection {
   ///   and `newElements`. If `i` is equal to the collection's `endIndex`
   ///   property, the complexity is O(*n*), where *n* is the length of
   ///   `newElements`.
-  public mutating func insert<
-    C : Collection where C.Iterator.Element == Iterator.Element
-  >(contentsOf newElements: C, at i: Index) {
+  public mutating func insert<C : Collection>(
+    contentsOf newElements: C, at i: Index
+  ) where C.Iterator.Element == Iterator.Element {
     replaceSubrange(i..<i, with: newElements)
   }
 
@@ -919,11 +899,10 @@ extension RangeReplaceableCollection
   ///   and `newElements`. If the call to `replaceSubrange` simply appends the
   ///   contents of `newElements` to the collection, the complexity is O(*n*),
   ///   where *n* is the length of `newElements`.
-  public mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == Iterator.Element
-  >(
-    _ subrange: ${Range}<Index>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ subrange: ${Range}<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Iterator.Element {
     // FIXME: swift-3-indexing-model: tests.
     self.replaceSubrange(_makeHalfOpen(subrange), with: newElements)
   }
@@ -1101,11 +1080,9 @@ extension RangeReplaceableCollection
 /// - Parameters:
 ///   - lhs: A range-replaceable collection.
 ///   - rhs: A collection or finite sequence.
-public func +<
-    C : RangeReplaceableCollection,
-    S : Sequence
-    where S.Iterator.Element == C.Iterator.Element
->(lhs: C, rhs: S) -> C {
+public func +<C : RangeReplaceableCollection, S : Sequence>(lhs: C, rhs: S) -> C
+  where S.Iterator.Element == C.Iterator.Element {
+
   var lhs = lhs
   // FIXME: what if lhs is a reference type?  This will mutate it.
   lhs.reserveCapacity(lhs.count + numericCast(rhs.underestimatedCount))
@@ -1131,11 +1108,9 @@ public func +<
 /// - Parameters:
 ///   - lhs: A collection or finite sequence.
 ///   - rhs: A range-replaceable collection.
-public func +<
-  C : RangeReplaceableCollection,
-  S : Sequence
-  where S.Iterator.Element == C.Iterator.Element
->(lhs: S, rhs: C) -> C {
+public func +<C : RangeReplaceableCollection, S : Sequence>(lhs: S, rhs: C) -> C
+  where S.Iterator.Element == C.Iterator.Element {
+
   var result = C()
   result.reserveCapacity(rhs.count + numericCast(lhs.underestimatedCount))
   result.append(contentsOf: lhs)
@@ -1164,8 +1139,9 @@ public func +<
 public func +<
   RRC1 : RangeReplaceableCollection,
   RRC2 : RangeReplaceableCollection
-  where RRC1.Iterator.Element == RRC2.Iterator.Element
->(lhs: RRC1, rhs: RRC2) -> RRC1 {
+>(lhs: RRC1, rhs: RRC2) -> RRC1
+  where RRC1.Iterator.Element == RRC2.Iterator.Element {
+
   var lhs = lhs
   // FIXME: what if lhs is a reference type?  This will mutate it.
   lhs.reserveCapacity(lhs.count + numericCast(rhs.count))
@@ -1178,11 +1154,10 @@ public typealias RangeReplaceableCollectionType = RangeReplaceableCollection
 
 extension RangeReplaceableCollection {
   @available(*, unavailable, renamed: "replaceSubrange")
-  public mutating func replaceRange<
-    C : Collection where C.Iterator.Element == Iterator.Element
-  >(
-    _ subrange: Range<Index>, with newElements: C
-  ) {
+  public mutating func replaceRange<C>(
+    _ subrange: Range<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Iterator.Element {
     Builtin.unreachable()
   }
   
@@ -1196,18 +1171,15 @@ extension RangeReplaceableCollection {
   }
 
   @available(*, unavailable, renamed: "append(contentsOf:)")
-  public mutating func appendContentsOf<
-    S : Sequence
-    where
-    S.Iterator.Element == Iterator.Element
-  >(_ newElements: S) {
+  public mutating func appendContentsOf<S : Sequence>(_ newElements: S)
+    where S.Iterator.Element == Iterator.Element {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, renamed: "insert(contentsOf:at:)")
-  public mutating func insertContentsOf<
-    C : Collection where C.Iterator.Element == Iterator.Element
-  >(_ newElements: C, at i: Index) {
+  public mutating func insertContentsOf<C : Collection>(
+    _ newElements: C, at i: Index
+  ) where C.Iterator.Element == Iterator.Element {
     Builtin.unreachable()
   }
 }

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -236,14 +236,16 @@ ${equivalenceExplanation}
   ///
   /// - SeeAlso: `starts(with:isEquivalent:)`
 %   end
-  public func starts<
-    PossiblePrefix : Sequence where PossiblePrefix.${GElement} == ${GElement}
-  >(
+  public func starts<PossiblePrefix>(
     with possiblePrefix: PossiblePrefix${"," if preds else ""}
 %   if preds:
     isEquivalent: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
-  ) ${rethrows_}-> Bool {
+  ) ${rethrows_}-> Bool
+    where
+    PossiblePrefix : Sequence,
+    PossiblePrefix.${GElement} == ${GElement} {
+
     var possiblePrefixIterator = possiblePrefix.makeIterator()
     for e0 in self {
       if let e1 = possiblePrefixIterator.next() {
@@ -310,14 +312,16 @@ ${equivalenceExplanation}
   ///
   /// - SeeAlso: `elementsEqual(_:isEquivalent:)`
 %   end
-  public func elementsEqual<
-    OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
-  >(
+  public func elementsEqual<OtherSequence>(
     _ other: OtherSequence${"," if preds else ""}
 %   if preds:
     isEquivalent: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
-  ) ${rethrows_}-> Bool {
+  ) ${rethrows_}-> Bool
+    where
+    OtherSequence: Sequence,
+    OtherSequence.${GElement} == ${GElement} {
+
     var iter1 = self.makeIterator()
     var iter2 = other.makeIterator()
     while true {
@@ -393,14 +397,16 @@ ${orderingExplanation}
   ///   perform localized comparison.
   /// - SeeAlso: `lexicographicallyPrecedes(_:isOrderedBefore:)`
 %   end
-  public func lexicographicallyPrecedes<
-    OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
-  >(
+  public func lexicographicallyPrecedes<OtherSequence>(
     _ other: OtherSequence${"," if preds else ""}
 %   if preds:
     isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
-  ) ${rethrows_}-> Bool {
+  ) ${rethrows_}-> Bool
+    where
+    OtherSequence : Sequence,
+    OtherSequence.${GElement} == ${GElement} {
+
     var iter1 = self.makeIterator()
     var iter2 = other.makeIterator()
     while true {
@@ -685,22 +691,26 @@ extension Sequence {
   }
 
   @available(*, unavailable, renamed: "starts")
-  public func startsWith<
-    PossiblePrefix : Sequence where PossiblePrefix.Iterator.Element == Iterator.Element
-  >(
+  public func startsWith<PossiblePrefix>(
     with possiblePrefix: PossiblePrefix,
     isEquivalent: @noescape (Iterator.Element, Iterator.Element) throws -> Bool
-  ) rethrows-> Bool {
+  ) rethrows-> Bool
+    where
+    PossiblePrefix : Sequence,
+    PossiblePrefix.Iterator.Element == Iterator.Element {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, renamed: "lexicographicallyPrecedes")
   public func lexicographicalCompare<
-    OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
+    OtherSequence
   >(
     _ other: OtherSequence,
     isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
-  ) rethrows -> Bool {
+  ) rethrows -> Bool
+    where
+    OtherSequence : Sequence,
+    OtherSequence.${GElement} == ${GElement} {
     Builtin.unreachable()
   }
 }
@@ -717,20 +727,22 @@ extension Sequence where Iterator.Element : Comparable {
   }
 
   @available(*, unavailable, renamed: "starts")
-  public func startsWith<
-    PossiblePrefix : Sequence where PossiblePrefix.${GElement} == ${GElement}
-  >(
+  public func startsWith<PossiblePrefix>(
     with possiblePrefix: PossiblePrefix
-  ) -> Bool {
+  ) -> Bool
+    where
+    PossiblePrefix : Sequence,
+    PossiblePrefix.${GElement} == ${GElement} {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, renamed: "lexicographicallyPrecedes")
-  public func lexicographicalCompare<
-    OtherSequence : Sequence where OtherSequence.${GElement} == ${GElement}
-  >(
+  public func lexicographicalCompare<OtherSequence>(
     _ other: OtherSequence
-  ) -> Bool {
+  ) -> Bool
+    where
+    OtherSequence : Sequence,
+    OtherSequence.${GElement} == ${GElement} {
     Builtin.unreachable()
   }
 }

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -350,7 +350,7 @@ public protocol SetAlgebra : Equatable, ArrayLiteralConvertible {
   ///     // Prints "[6, 0, 1, 3]"
   ///
   /// - Parameter sequence: The elements to use as members of the new set.
-  init<S : Sequence where S.Iterator.Element == Element>(_ sequence: S)
+  init<S : Sequence>(_ sequence: S) where S.Iterator.Element == Element
 
   /// Removes the elements of the given set from this set.
   ///
@@ -383,9 +383,8 @@ extension SetAlgebra {
   ///     // Prints "[6, 0, 1, 3]"
   ///
   /// - Parameter sequence: The elements to use as members of the new set.
-  public init<
-    S : Sequence where S.Iterator.Element == Element
-  >(_ sequence: S) {
+  public init<S : Sequence>(_ sequence: S)
+    where S.Iterator.Element == Element {
     self.init()
     for e in sequence { insert(e) }
   }

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -228,19 +228,22 @@ public struct ${Self}<Base : ${BaseRequirements}>
     self._endIndex = _base.endIndex
   }
 
-  public init<
-    S : Sequence where S.Iterator.Element == Base._Element
-  >(_ elements: S) {
+  public init<S>(_ elements: S)
+    where
+    S : Sequence,
+    S.Iterator.Element == Base._Element {
+
     self._base = Base(elements)
     self._startIndex = _base.startIndex
     self._endIndex = _base.endIndex
   }
 
-  public mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == Base._Element
-  >(
+  public mutating func replaceSubrange<C>(
     _ subRange: Range<Index>, with newElements: C
-  ) {
+  ) where
+    C : Collection,
+    C.Iterator.Element == Base._Element {
+
     // FIXME: swift-3-indexing-model: range check.
 %     if Traversal == 'Forward':
     let sliceOffset: IndexDistance =
@@ -304,9 +307,11 @@ public struct ${Self}<Base : ${BaseRequirements}>
 %     end
   }
 
-  public mutating func insert<
-    S : Collection where S.Iterator.Element == Base._Element
-  >(contentsOf newElements: S, at i: Index) {
+  public mutating func insert<S>(contentsOf newElements: S, at i: Index)
+    where
+    S : Collection,
+    S.Iterator.Element == Base._Element {
+
     // FIXME: swift-3-indexing-model: range check.
 %     if Traversal == 'Forward':
     let sliceOffset: IndexDistance =

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -76,13 +76,12 @@ struct _SliceBuffer<Element> : _ArrayBufferProtocol, RandomAccessCollection {
   /// - Precondition: This buffer is backed by a uniquely-referenced
   ///   `_ContiguousArrayBuffer` and
   ///   `insertCount <= numericCast(newValues.count)`.
-  public mutating func replace<
-    C : Collection where C.Iterator.Element == Element
-  >(
+  public mutating func replace<C>(
     subRange: Range<Int>,
     with insertCount: Int,
     elementsOf newValues: C
-  ) {
+  ) where C : Collection, C.Iterator.Element == Element {
+
     _invariantCheck()
     _sanityCheck(insertCount <= numericCast(newValues.count))
 

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -25,14 +25,14 @@ def cmp(a, b, p):
 % preds = [True, False]
 % for p in preds:
 
-func _insertionSort<
-  C : protocol<MutableCollection, BidirectionalCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _insertionSort<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
-) {
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+) where
+  C : protocol<MutableCollection, BidirectionalCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
+
   if !range.isEmpty {
     let start = range.lowerBound
 
@@ -72,14 +72,15 @@ func _insertionSort<
   }
 }
 
-func _partition<
-  C : protocol<MutableCollection, RandomAccessCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _partition<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
-) -> C.Index {
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+) -> C.Index
+  where
+  C : protocol<MutableCollection, RandomAccessCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
+
   var lo = range.lowerBound
   var hi = range.upperBound
 
@@ -127,14 +128,14 @@ Loop: while true {
 }
 
 public // @testable
-func _introSort<
-  C : protocol<MutableCollection, RandomAccessCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _introSort<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
-) {
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+) where
+  C : protocol<MutableCollection, RandomAccessCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
+
 %   if p:
   var isOrderedBeforeVar = isOrderedBefore
 %   end
@@ -153,15 +154,15 @@ func _introSort<
     depthLimit: depthLimit)
 }
 
-func _introSortImpl<
-  C : protocol<MutableCollection, RandomAccessCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _introSortImpl<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""},
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""},
   depthLimit: Int
-) {
+) where
+  C : protocol<MutableCollection, RandomAccessCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
+
   // Insertion sort is better at handling smaller regions.
   if elements.distance(from: range.lowerBound, to: range.upperBound) < 20 {
     _insertionSort(
@@ -197,15 +198,15 @@ func _introSortImpl<
     depthLimit: depthLimit &- 1)
 }
 
-func _siftDown<
-  C : protocol<MutableCollection, RandomAccessCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _siftDown<C>(
   _ elements: inout C,
   index: C.Index,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
-) {
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+) where
+  C : protocol<MutableCollection, RandomAccessCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
+
   let countToIndex = elements.distance(from: range.lowerBound, to: index)
   let countFromIndex = elements.distance(from: index, to: range.upperBound)
   // Check if left child is within bounds. If not, return, because there are
@@ -236,14 +237,13 @@ func _siftDown<
       ${", isOrderedBefore: &isOrderedBefore" if p else ""})
   }
 }
-func _heapify<
-  C : protocol<MutableCollection, RandomAccessCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _heapify<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
-) {
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+) where
+  C : protocol<MutableCollection, RandomAccessCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
   // Here we build a heap starting from the lowest nodes and moving to the root.
   // On every step we sift down the current node to obey the max-heap property:
   //   parent >= max(leftChild, rightChild)
@@ -265,14 +265,13 @@ func _heapify<
       ${", isOrderedBefore: &isOrderedBefore" if p else ""})
   }
 }
-func _heapSort<
-  C : protocol<MutableCollection, RandomAccessCollection>
-  ${"" if p else "where C.Iterator.Element : Comparable"}
->(
+func _heapSort<C>(
   _ elements: inout C,
-  subRange range: Range<C.Index> ${"," if p else ""}
-  ${"isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
-) {
+  subRange range: Range<C.Index>
+  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+) where
+  C : protocol<MutableCollection, RandomAccessCollection>
+  ${"" if p else ", C.Iterator.Element : Comparable"} {
   var hi = range.upperBound
   let lo = range.lowerBound
   _heapify(

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -300,22 +300,24 @@ public struct String {
 
 extension String {
   public // @testable
-  static func _fromWellFormedCodeUnitSequence<
-    Encoding: UnicodeCodec, Input: Collection
-    where Input.Iterator.Element == Encoding.CodeUnit
-  >(
+  static func _fromWellFormedCodeUnitSequence<Encoding, Input>(
     _ encoding: Encoding.Type, input: Input
-  ) -> String {
+  ) -> String
+    where
+    Encoding: UnicodeCodec,
+    Input: Collection,
+    Input.Iterator.Element == Encoding.CodeUnit {
     return String._fromCodeUnitSequence(encoding, input: input)!
   }
 
   public // @testable
-  static func _fromCodeUnitSequence<
-    Encoding: UnicodeCodec, Input: Collection
-    where Input.Iterator.Element == Encoding.CodeUnit
-  >(
+  static func _fromCodeUnitSequence<Encoding, Input>(
     _ encoding: Encoding.Type, input: Input
-  ) -> String? {
+  ) -> String?
+    where
+    Encoding: UnicodeCodec,
+    Input: Collection,
+    Input.Iterator.Element == Encoding.CodeUnit {
     let (stringBufferOptional, _) =
         _StringBuffer.fromCodeUnits(input, encoding: encoding,
             repairIllFormedSequences: false)
@@ -327,12 +329,14 @@ extension String {
   }
 
   public // @testable
-  static func _fromCodeUnitSequenceWithRepair<
-    Encoding: UnicodeCodec, Input: Collection
-    where Input.Iterator.Element == Encoding.CodeUnit
-  >(
+  static func _fromCodeUnitSequenceWithRepair<Encoding, Input>(
     _ encoding: Encoding.Type, input: Input
-  ) -> (String, hadError: Bool) {
+  ) -> (String, hadError: Bool)
+    where
+    Encoding: UnicodeCodec,
+    Input: Collection,
+    Input.Iterator.Element == Encoding.CodeUnit {
+
     let (stringBuffer, hadError) =
         _StringBuffer.fromCodeUnits(input, encoding: encoding,
             repairIllFormedSequences: true)
@@ -978,25 +982,22 @@ extension String {
   }
 
   @available(*, unavailable, renamed: "append(contentsOf:)")
-  public mutating func appendContentsOf<
-    S : Sequence where S.Iterator.Element == Character
-  >(_ newElements: S) {
+  public mutating func appendContentsOf<S : Sequence>(_ newElements: S)
+    where S.Iterator.Element == Character {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, renamed: "insert(contentsOf:at:)")
-  public mutating func insertContentsOf<
-    S : Collection where S.Iterator.Element == Character
-  >(_ newElements: S, at i: Index) {
+  public mutating func insertContentsOf<S : Collection>(
+    _ newElements: S, at i: Index
+  ) where S.Iterator.Element == Character {
     Builtin.unreachable()
   }
 
   @available(*, unavailable, renamed: "replaceSubrange")
-  public mutating func replaceRange<
-    C : Collection where C.Iterator.Element == Character
-  >(
+  public mutating func replaceRange<C : Collection>(
     _ subRange: Range<Index>, with newElements: C
-  ) {
+  ) where C.Iterator.Element == Character {
     Builtin.unreachable()
   }
     

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -83,14 +83,14 @@ public struct _StringBuffer {
       = ((_storage._capacity() - capacityBump) << 1) + elementShift
   }
 
-  static func fromCodeUnits<
-    Input : Collection, // Sequence?
-    Encoding : UnicodeCodec
-    where Input.Iterator.Element == Encoding.CodeUnit
-  >(
+  static func fromCodeUnits<Input, Encoding>(
     _ input: Input, encoding: Encoding.Type, repairIllFormedSequences: Bool,
     minimumCapacity: Int = 0
-  ) -> (_StringBuffer?, hadError: Bool) {
+  ) -> (_StringBuffer?, hadError: Bool)
+    where
+    Input : Collection, // Sequence?
+    Encoding : UnicodeCodec,
+    Input.Iterator.Element == Encoding.CodeUnit {
     // Determine how many UTF-16 code units we'll need
     let inputStream = input.makeIterator()
     guard let (utf16Count, isAscii) = UTF16.transcodedLength(

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -347,11 +347,10 @@ extension String.CharacterView : RangeReplaceableCollection {
   ///   view and `newElements`. If the call to `replaceSubrange(_:with:)`
   ///   simply removes characters at the end of the view, the complexity is
   ///   O(*n*), where *n* is equal to `bounds.count`.
-  public mutating func replaceSubrange<
-    C: Collection where C.Iterator.Element == Character
-  >(
-    _ bounds: Range<Index>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ bounds: Range<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Character {
     let rawSubRange: Range<Int> =
       bounds.lowerBound._base._position
       ..< bounds.upperBound._base._position
@@ -391,9 +390,8 @@ extension String.CharacterView : RangeReplaceableCollection {
   /// Appends the characters in the given sequence to the character view.
   /// 
   /// - Parameter newElements: A sequence of characters.
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == Character
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == Character {
     reserveCapacity(_core.count + newElements.underestimatedCount)
     for c in newElements {
       self.append(c)
@@ -404,9 +402,8 @@ extension String.CharacterView : RangeReplaceableCollection {
   /// sequence.
   ///
   /// - Parameter characters: A sequence of characters.
-  public init<
-    S : Sequence where S.Iterator.Element == Character
-  >(_ characters: S) {
+  public init<S : Sequence>(_ characters: S)
+    where S.Iterator.Element == Character {
     self = String.CharacterView()
     self.append(contentsOf: characters)
   }
@@ -437,18 +434,16 @@ extension String.CharacterView {
 
 extension String.CharacterView {
   @available(*, unavailable, renamed: "replaceSubrange")
-  public mutating func replaceRange<
-    C : Collection where C.Iterator.Element == Character
-  >(
-    _ subRange: Range<Index>, with newElements: C
-  ) {
+  public mutating func replaceRange<C>(
+    _ subRange: Range<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Character {
     Builtin.unreachable()
   }
     
   @available(*, unavailable, renamed: "append(contentsOf:)")
-  public mutating func appendContentsOf<
-    S : Sequence where S.Iterator.Element == Character
-  >(_ newElements: S) {
+  public mutating func appendContentsOf<S : Sequence>(_ newElements: S)
+    where S.Iterator.Element == Character {
     Builtin.unreachable()
   }
 }

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -587,11 +587,10 @@ extension _StringCore : RangeReplaceableCollection {
   ///
   /// - Complexity: O(`bounds.count`) if `bounds.upperBound
   ///   == self.endIndex` and `newElements.isEmpty`, O(N) otherwise.
-  public mutating func replaceSubrange<
-    C: Collection where C.Iterator.Element == UTF16.CodeUnit
-  >(
-    _ bounds: Range<Int>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ bounds: Range<Int>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == UTF16.CodeUnit {
     _precondition(
       bounds.lowerBound >= 0,
       "replaceSubrange: subrange start precedes String start")
@@ -683,9 +682,8 @@ extension _StringCore : RangeReplaceableCollection {
       minElementWidth: 1)
   }
 
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == UTF16.CodeUnit
-  >(contentsOf s: S) {
+  public mutating func append<S : Sequence>(contentsOf s: S)
+    where S.Iterator.Element == UTF16.CodeUnit {
     var width = elementWidth
     if width == 1 {
       if let hasNonAscii = s._preprocessingPass({

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -117,9 +117,8 @@ extension String {
   ///     // Prints "Th rn n Spn stys mnly n th pln."
   ///
   /// - Parameter characters: A sequence of characters.
-  public init<
-    S : Sequence where S.Iterator.Element == Character
-  >(_ characters: S) {
+  public init<S : Sequence>(_ characters: S)
+    where S.Iterator.Element == Character {
     self._core = CharacterView(characters)._core
   }
 
@@ -160,9 +159,8 @@ extension String {
   /// Appends the characters in the given sequence to the string.
   /// 
   /// - Parameter newElements: A sequence of characters.
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == Character
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == Character {
     withMutableCharacters {
       (v: inout CharacterView) in v.append(contentsOf: newElements)
     }
@@ -183,11 +181,10 @@ extension String {
   ///   `newElements`. If the call to `replaceSubrange(_:with:)` simply
   ///   removes text at the end of the string, the complexity is O(*n*), where
   ///   *n* is equal to `bounds.count`.
-  public mutating func replaceSubrange<
-    C : Collection where C.Iterator.Element == Character
-  >(
-    _ bounds: ${Range}<Index>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ bounds: ${Range}<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == Character {
     // FIXME: swift-3-indexing-model: tests.
     withMutableCharacters {
       (v: inout CharacterView)
@@ -248,9 +245,9 @@ extension String {
   ///
   /// - Complexity: O(*n*), where *n* is the combined length of the string and
   ///   `newElements`.
-  public mutating func insert<
-    S : Collection where S.Iterator.Element == Character
-  >(contentsOf newElements: S, at i: Index) {
+  public mutating func insert<S : Collection>(
+    contentsOf newElements: S, at i: Index
+  ) where S.Iterator.Element == Character {
     withMutableCharacters {
       (v: inout CharacterView) in v.insert(contentsOf: newElements, at: i)
     }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -374,9 +374,8 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
   /// - Parameter newElements: A sequence of Unicode scalar values.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the resulting view.
-  public mutating func append<
-    S : Sequence where S.Iterator.Element == UnicodeScalar
-  >(contentsOf newElements: S) {
+  public mutating func append<S : Sequence>(contentsOf newElements: S)
+    where S.Iterator.Element == UnicodeScalar {
     _core.append(contentsOf: newElements.lazy.flatMap { $0.utf16 })
   }
   
@@ -395,11 +394,10 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
   ///   `newElements`. If the call to `replaceSubrange(_:with:)` simply
   ///   removes elements at the end of the string, the complexity is O(*n*),
   ///   where *n* is equal to `bounds.count`.
-  public mutating func replaceSubrange<
-    C: Collection where C.Iterator.Element == UnicodeScalar
-  >(
-    _ bounds: Range<Index>, with newElements: C
-  ) {
+  public mutating func replaceSubrange<C>(
+    _ bounds: Range<Index>,
+    with newElements: C
+  ) where C : Collection, C.Iterator.Element == UnicodeScalar {
     let rawSubRange: Range<Int> =
       bounds.lowerBound._position
       ..< bounds.upperBound._position

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -346,9 +346,8 @@ public struct ${Self}<Pointee>
   ///
   /// - Postcondition: The `Pointee`s at `self..<self + count` are
   ///   initialized.
-  public func initializeFrom<
-    C : Collection where C.Iterator.Element == Pointee
-  >(_ source: C) {
+  public func initializeFrom<C : Collection>(_ source: C)
+    where C.Iterator.Element == Pointee {
     source._copyContents(initializing: self)
   }
 

--- a/stdlib/public/core/WriteBackMutableSlice.swift
+++ b/stdlib/public/core/WriteBackMutableSlice.swift
@@ -10,13 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal func _writeBackMutableSlice<
+internal func _writeBackMutableSlice<C, Slice_>(
+  _ self_: inout C, bounds: Range<C.Index>, slice: Slice_
+) where
   C : MutableCollection,
-  Slice_ : Collection
-  where
+  Slice_ : Collection,
   C._Element == Slice_.Iterator.Element,
-  C.Index == Slice_.Index
->(_ self_: inout C, bounds: Range<C.Index>, slice: Slice_) {
+  C.Index == Slice_.Index {
 
   self_._failEarlyRangeCheck(bounds, bounds: self_.startIndex..<self_.endIndex)
 


### PR DESCRIPTION
#### What's in this pull request?

Follow-up on [SE-0081](https://github.com/apple/swift-evolution/blob/master/proposals/0081-move-where-expression.md) c5bf433490f4fe471584550b431695498a6adc0e
Migrate stdlib core to tail style `where` clause.
#### Resolved bug number: (Related [SR-1561](https://bugs.swift.org/browse/SR-1561))

---

Before merging this pull request to apple/swift repository:
- [x] Fix consistent code style
- [ ] Test pull request on Swift continuous integration.
