### PR TITLE
Correct deployment-target regex for watchos/watchsimulator

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -892,7 +892,7 @@ function make_relative_symlink() {
 CROSS_COMPILE_HOSTS=($CROSS_COMPILE_HOSTS)
 for t in ${CROSS_COMPILE_HOSTS} ; do
     case ${t} in
-        iphone* | appletv* | watchos* | linux-armv6 | linux-armv7 )
+        iphone* | appletv* | watch* | linux-armv6 | linux-armv7 )
             ;;
         *)
             echo "Unknown host to cross-compile for: ${t}"
@@ -980,7 +980,7 @@ function should_include_host_in_lipo() {
     local host="$1"
     if [[ $(has_cross_compile_hosts) ]] && [[ -z "${SKIP_MERGE_LIPO_CROSS_COMPILE_TOOLS}" ]]; then
         case ${host} in 
-            iphone* | appletv* | watchos* )
+            iphone* | appletv* | watch* )
                 echo 1
                 ;;
         esac
@@ -990,7 +990,7 @@ function should_include_host_in_lipo() {
 function host_has_darwin_symbols() {
     local host="$1"
     case ${host} in 
-        macosx* | iphone* | appletv* | watchos* )
+        macosx* | iphone* | appletv* | watch* )
             echo 1
             ;;
     esac


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Correct the regex used to match AppleWatch hosts. It should be `watch*` to match both `watchos-*` and `watchsimulator-*`.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
