### PR TITLE
[swiftc] Add test case for crash triggered in swift::ParamDecl::createUnboundSelf(…)

### DIFF
--- a/validation-test/compiler_crashers/28302-swift-paramdecl-createunboundself.swift
+++ b/validation-test/compiler_crashers/28302-swift-paramdecl-createunboundself.swift
@@ -1,0 +1,10 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct g where g:t{protocol A{func b


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/llvm/include/llvm/ADT/ArrayRef.h:265: T &llvm::MutableArrayRef<swift::GenericTypeParamDecl *>::front() const [T = swift::GenericTypeParamDecl *]: Assertion `!this->empty()' failed.
9  swift           0x00000000010b835b swift::ParamDecl::createUnboundSelf(swift::SourceLoc, swift::DeclContext*, bool, bool) + 75
10 swift           0x00000000010f6ff3 swift::ParameterList::createUnboundSelf(swift::SourceLoc, swift::DeclContext*, bool, bool) + 19
11 swift           0x0000000000e606b6 swift::Parser::parseDeclFunc(swift::SourceLoc, swift::StaticSpellingKind, swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 3798
12 swift           0x0000000000e562e0 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3760
14 swift           0x0000000000e0a4a9 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 377
15 swift           0x0000000000e5e188 swift::Parser::parseDeclProtocol(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1656
16 swift           0x0000000000e56373 swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3907
18 swift           0x0000000000e0a4a9 swift::Parser::parseList(swift::tok, swift::SourceLoc, swift::SourceLoc&, swift::tok, bool, bool, swift::Diag<>, std::function<swift::ParserStatus ()>) + 377
19 swift           0x0000000000e5c458 swift::Parser::parseDeclStruct(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, swift::DeclAttributes&) + 1848
20 swift           0x0000000000e5638c swift::Parser::parseDecl(swift::OptionSet<swift::Parser::ParseDeclFlags, unsigned int>, llvm::function_ref<void (swift::Decl*)>) + 3932
21 swift           0x0000000000e386b2 swift::Parser::parseBraceItems(llvm::SmallVectorImpl<swift::ASTNode>&, swift::BraceItemListKind, swift::BraceItemListKind) + 850
22 swift           0x0000000000e4a8ac swift::Parser::parseTopLevel() + 156
23 swift           0x0000000000e06920 swift::parseIntoSourceFile(swift::SourceFile&, unsigned int, bool*, swift::SILParserState*, swift::PersistentParserState*, swift::DelayedParsingCallbacks*) + 208
24 swift           0x0000000000c585c6 swift::CompilerInstance::performSema() + 3254
26 swift           0x00000000007d6f4f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
27 swift           0x00000000007a2f58 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28302-swift-paramdecl-createunboundself.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28302-swift-paramdecl-createunboundself-53086d.o
1.  With parser at source location: validation-test/compiler_crashers/28302-swift-paramdecl-createunboundself.swift:11:1
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
