### PR TITLE
Ask SILFunction link entities' clang nodes for weakness when applicable

### DIFF
--- a/lib/IRGen/Linking.h
+++ b/lib/IRGen/Linking.h
@@ -574,6 +574,10 @@ public:
         getSILGlobalVariable()->getDecl())
       return getSILGlobalVariable()->getDecl()->isWeakImported(module);
 
+    if (getKind() == Kind::SILFunction)
+      if (auto clangOwner = getSILFunction()->getClangNodeOwner())
+        return clangOwner->isWeakImported(module);
+
     if (!isDeclKind(getKind()))
       return false;
 

--- a/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -50,6 +50,9 @@ __attribute__((availability(macosx,introduced=10.51)))
 @interface NSUserNotificationAction : NSObject
 @end
 
+__attribute__((availability(macosx,introduced=10.51)))
+void future_function_should_be_weak();
+
 extern int weak_variable __attribute__((weak_import));
 
 @interface NSError : NSObject

--- a/test/IRGen/weak_import.swift
+++ b/test/IRGen/weak_import.swift
@@ -30,3 +30,11 @@ func testObjCClass() {
 func testGlobalVariable() {
   let i = weak_variable
 }
+
+
+@available(OSX 10.51, *)
+func wrapWeakFunction() {
+  // CHECK-10_50: declare extern_weak void @future_function_should_be_weak()
+  // CHECK-10_51: declare void @future_function_should_be_weak()
+  future_function_should_be_weak()
+}

--- a/test/Interpreter/Inputs/FakeUnavailableObjCFramework.framework/Headers/FakeUnavailableObjCFramework.h
+++ b/test/Interpreter/Inputs/FakeUnavailableObjCFramework.framework/Headers/FakeUnavailableObjCFramework.h
@@ -16,3 +16,6 @@ __attribute__((availability(macosx,introduced=1066.0)))  __attribute__((availabi
 @interface UnavailableObjCClass : NSObject
 - (void)someMethod;
 @end
+
+__attribute__((availability(macosx,introduced=1066.0)))  __attribute__((availability(ios,introduced=1066.0)))
+void someFunction();

--- a/test/Interpreter/Inputs/FakeUnavailableObjCFramework.m
+++ b/test/Interpreter/Inputs/FakeUnavailableObjCFramework.m
@@ -5,3 +5,6 @@ int UnavailableObjCGlobalVariable = 20300;
 @implementation UnavailableObjCClass
 - (void)someMethod { }
 @end
+
+void someFunction() {}
+

--- a/test/Interpreter/availability_weak_linking.swift
+++ b/test/Interpreter/availability_weak_linking.swift
@@ -140,6 +140,11 @@ func useUnavailableObjCClass() {
   }
 }
 
+@available(OSX 1066.0, iOS 1066.0, watchOS 1066.0, tvOS 1066.0, *)
+func wrapUnavailableFunction() {
+  someFunction()
+}
+
 useUnavailableObjCClass()
 
 // Allow extending a weakly-linked class to conform to a protocol.


### PR DESCRIPTION
When importing C functions with availability attributes, we don't
properly use that information to decide whether a symbol should be
weak_extern, causing load failures in dylibs that reference these
symbols when deployed to an older OS.

This is a very targeted fix and we need a better architecture for
deciding this.

rdar://problem/26359452
