### PR TITLE
[utils] Switch update-checkout over to `shell.pushd`.

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -233,20 +233,3 @@ def get_all_preset_names(preset_file_names):
     config = _load_preset_files_impl(preset_file_names)
     return [name[len(_PRESET_PREFIX):] for name in config.sections()
             if name.startswith(_PRESET_PREFIX)]
-
-
-# A context manager for changing the current working directory.
-#
-#     with WorkingDirectory('/tmp'):
-#         ... do work in /tmp...
-class WorkingDirectory(object):
-
-    def __init__(self, new_cwd):
-        self.new_cwd = new_cwd
-
-    def __enter__(self):
-        self.old_cwd = os.getcwd()
-        os.chdir(self.new_cwd)
-
-    def __exit__(self, type, value, traceback):
-        os.chdir(self.old_cwd)

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -19,10 +19,13 @@ sys.path.append(os.path.dirname(__file__))
 
 from SwiftBuildSupport import (
     SWIFT_SOURCE_ROOT,
-    WorkingDirectory,
     check_call,
     check_output,
 )  # noqa (E402 module level import not at top of file)
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
+
+from swift_build_support import shell  # noqa (E402)
 
 REPOSITORIES = {
     'llvm': 'apple/swift-llvm',
@@ -91,7 +94,7 @@ def update_working_copy(repo_path, branch):
         return
 
     print("--- Updating '" + repo_path + "' ---")
-    with WorkingDirectory(repo_path):
+    with shell.pushd(repo_path, dry_run=False):
         if branch:
             status = check_output(['git', 'status', '--porcelain'])
             if status:
@@ -114,7 +117,7 @@ def obtain_additional_swift_sources(
         if dir_name in skip_repositories:
             print("--- Skipping '" + dir_name + "' ---")
             continue
-        with WorkingDirectory(SWIFT_SOURCE_ROOT):
+        with shell.pushd(SWIFT_SOURCE_ROOT, dry_run=False):
             if not os.path.isdir(os.path.join(dir_name, ".git")):
                 print("--- Cloning '" + dir_name + "' ---")
                 if with_ssh is True:


### PR DESCRIPTION
#### What's in this pull request?

This removes a redundant context manager for managing the current working directory, switching to the one used by the build script.

One side effect of this change is that we will now log information on the directory changes to stdout; if that is undesirable I can add options to the swift_build_support's `shell` module to allow suppressing this when used in this context.

Related to SR-237.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- Related to SR-237.
