### PR TITLE
[utils] Move quote_shell_command into swift_build_support.

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -18,10 +18,14 @@ except ImportError:
     import configparser as ConfigParser
 
 import os
-import pipes
 import platform
 import subprocess
 import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
+
+# E402 means module level import not at top of file
+from swift_build_support import shell  # noqa (E402)
 
 
 HOME = os.environ.get("HOME", "/")
@@ -70,10 +74,6 @@ def print_with_argv0(message):
     sys.stdout.flush()
 
 
-def quote_shell_command(args):
-    return " ".join([pipes.quote(a) for a in args])
-
-
 def check_call(args, print_command=False, verbose=False, disable_sleep=False):
     if disable_sleep:
         if platform.system() == 'Darwin':
@@ -82,7 +82,7 @@ def check_call(args, print_command=False, verbose=False, disable_sleep=False):
             args.insert(0, "caffeinate")
 
     if print_command:
-        print(os.getcwd() + "$ " + quote_shell_command(args))
+        print(os.getcwd() + "$ " + shell.quote_command(args))
         sys.stdout.flush()
     try:
         return subprocess.check_call(args)
@@ -94,7 +94,7 @@ def check_call(args, print_command=False, verbose=False, disable_sleep=False):
         sys.exit(1)
     except OSError as e:
         print_with_argv0(
-            "could not execute '" + quote_shell_command(args) +
+            "could not execute '" + shell.quote_command(args) +
             "': " + e.strerror)
         sys.stdout.flush()
         sys.exit(1)
@@ -102,7 +102,7 @@ def check_call(args, print_command=False, verbose=False, disable_sleep=False):
 
 def check_output(args, print_command=False, verbose=False):
     if print_command:
-        print(os.getcwd() + "$ " + quote_shell_command(args))
+        print(os.getcwd() + "$ " + shell.quote_command(args))
         sys.stdout.flush()
     try:
         return subprocess.check_output(args)
@@ -114,7 +114,7 @@ def check_output(args, print_command=False, verbose=False):
         sys.exit(1)
     except OSError as e:
         print_with_argv0(
-            "could not execute '" + quote_shell_command(args) +
+            "could not execute '" + shell.quote_command(args) +
             "': " + e.strerror)
         sys.stdout.flush()
         sys.exit(1)

--- a/utils/build-script
+++ b/utils/build-script
@@ -32,7 +32,6 @@ from SwiftBuildSupport import (
     get_all_preset_names,
     get_preset_options,
     print_with_argv0,
-    quote_shell_command,
 )  # noqa (E402 module level import not at top of file)
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
@@ -124,7 +123,7 @@ def main_preset():
 
     print_with_argv0(
         "using preset '" + args.preset + "', which expands to \n\n" +
-        quote_shell_command(build_script_args) + "\n")
+        shell.quote_command(build_script_args) + "\n")
 
     check_call(build_script_args, disable_sleep=True)
 

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -29,6 +29,15 @@ def _quote(arg):
     return pipes.quote(str(arg))
 
 
+def quote_command(args):
+    """
+    quote_command(args) -> str
+
+    Quote the command for passing to a shell.
+    """
+    return ' '.join([_quote(a) for a in args])
+
+
 def _coerce_dry_run(dry_run_override):
     if dry_run_override is None:
         return dry_run

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -42,6 +42,9 @@ class ShellTestCase(unittest.TestCase):
         if os.path.exists(self.tmpdir):
             shutil.rmtree(self.tmpdir)
 
+    def test_quote_command(self):
+        self.assertEqual(shell.quote_command(["a b", "", "c"]), "'a b' '' c")
+
     def test_call(self):
         shell.dry_run = False
         foo_file = os.path.join(self.tmpdir, 'foo.txt')


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This moves the `quote_shell_command` utility method into the `swift_build_support.shell` module.

Part of SR-237.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
