### PR TITLE
[utils] Improve swift_build_support.shell failure messages.

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 from contextlib import contextmanager
 
+from . import diagnostics
+
 dry_run = False
 
 
@@ -66,7 +68,16 @@ def call(command, stderr=None, env=None, dry_run=None):
     if env is not None:
         _env = dict(os.environ)
         _env.update(env)
-    subprocess.check_call(command, env=_env, stderr=stderr)
+    try:
+        subprocess.check_call(command, env=_env, stderr=stderr)
+    except subprocess.CalledProcessError as e:
+        diagnostics.fatal(
+            "command terminated with a non-zero exit status " +
+            str(e.returncode) + ", aborting")
+    except OSError as e:
+        diagnostics.fatal(
+            "could not execute '" + quote_command(command) +
+            "': " + e.strerror)
 
 
 @contextmanager

--- a/utils/swift_build_support/tests/test_tar.py
+++ b/utils/swift_build_support/tests/test_tar.py
@@ -51,7 +51,7 @@ class TarTestCase(unittest.TestCase):
                          expect.format(dest=destination, source=source))
 
     def test_tar_nonexistent_file_raises(self):
-        with self.assertRaises(subprocess.CalledProcessError):
+        with self.assertRaises(SystemExit):
             tar(source='/path/to/something/that/surely/doesnt/exist',
                 destination='/another/path/that/shouldnt/exist')
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

```
[utils] Improve swift_build_support.shell failure messages.

 - This improves the error messages when commands fail (or don't exist) to show
   a one-line summary of the issue instead of the Python backtrace, and matches
   what was being done by the matching function in `SwiftBuildSupport`.
```

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
