### PR TITLE
[build-script] Reject user-supplied '--common-cmake-options' argument

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -962,6 +962,12 @@ details of the setups of other systems or automated environments.""")
         default=False,
         const=True)
 
+    parser.add_argument(
+        # Explicitly unavailable options here.
+        "--build-jobs",
+        "--common-cmake-options",
+        action=arguments.action.unavailable)
+
     args = migration.parse_args(parser, sys.argv[1:])
 
     build_script_impl = os.path.join(

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -22,7 +22,8 @@ import re
 import shlex
 
 __all__ = [
-    "type"
+    "action",
+    "type",
 ]
 
 
@@ -34,6 +35,7 @@ def _register(registry, name, value):
     setattr(registry, name, value)
 
 
+# Types ----------------------------------------------------------------------
 type = _Registry()
 
 
@@ -99,3 +101,30 @@ def type_executable(string):
         "%r is not executable" % string)
 
 _register(type, 'executable', type_executable)
+
+# Actions --------------------------------------------------------------------
+action = _Registry()
+
+
+class _UnavailableAction(argparse.Action):
+    def __init__(self,
+                 option_strings,
+                 dest=argparse.SUPPRESS,
+                 default=argparse.SUPPRESS,
+                 nargs='?',
+                 help=None):
+        super(_UnavailableAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=nargs,
+            help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string is not None:
+            arg = option_string
+        else:
+            arg = str(values)
+        parser.error('unknown argument: %s' % arg)
+
+_register(action, 'unavailable', _UnavailableAction)


### PR DESCRIPTION
#### What's in this pull request?

The build system doesn't support user-supplied `--common-cmake-options` argument.
This PR catches it in `build-script`, then exit with error:

```
$ utils/build-script -Rt --common-cmake-options="-DFOO=BAR"
usage: 
  build-script [-h | --help] [OPTION ...]
  build-script --preset=NAME [SUBSTITUTION ...]
build-script: error: unknown argument: --common-cmake-options
```

Introduced `swift_build_support.arguments.action` namespace for custom actions.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
