### PR TITLE
[build-script] Eliminate swift build support subprocess functions

### DIFF
--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -18,7 +18,6 @@ except ImportError:
     import configparser as ConfigParser
 
 import os
-import subprocess
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
@@ -67,22 +66,6 @@ SWIFT_SOURCE_ROOT = os.environ.get(
 # for each build configuration
 SWIFT_BUILD_ROOT = os.environ.get(
     "SWIFT_BUILD_ROOT", os.path.join(SWIFT_SOURCE_ROOT, "build"))
-
-
-def check_output(args, print_command=False, verbose=False):
-    if print_command:
-        print(os.getcwd() + "$ " + shell.quote_command(args))
-        sys.stdout.flush()
-    try:
-        return subprocess.check_output(args)
-    except subprocess.CalledProcessError as e:
-        diagnostics.fatal(
-            "command terminated with a non-zero exit status " +
-            str(e.returncode) + ", aborting")
-    except OSError as e:
-        diagnostics.fatal(
-            "could not execute '" + shell.quote_command(args) +
-            "': " + e.strerror)
 
 
 def _load_preset_files_impl(preset_file_names, substitutions={}):

--- a/utils/SwiftBuildSupport.py
+++ b/utils/SwiftBuildSupport.py
@@ -18,7 +18,6 @@ except ImportError:
     import configparser as ConfigParser
 
 import os
-import platform
 import subprocess
 import sys
 
@@ -68,28 +67,6 @@ SWIFT_SOURCE_ROOT = os.environ.get(
 # for each build configuration
 SWIFT_BUILD_ROOT = os.environ.get(
     "SWIFT_BUILD_ROOT", os.path.join(SWIFT_SOURCE_ROOT, "build"))
-
-
-def check_call(args, print_command=False, verbose=False, disable_sleep=False):
-    if disable_sleep:
-        if platform.system() == 'Darwin':
-            # Don't mutate the caller's copy of the arguments.
-            args = list(args)
-            args.insert(0, "caffeinate")
-
-    if print_command:
-        print(os.getcwd() + "$ " + shell.quote_command(args))
-        sys.stdout.flush()
-    try:
-        return subprocess.check_call(args)
-    except subprocess.CalledProcessError as e:
-        diagnostics.fatal(
-            "command terminated with a non-zero exit status " +
-            str(e.returncode) + ", aborting")
-    except OSError as e:
-        diagnostics.fatal(
-            "could not execute '" + shell.quote_command(args) +
-            "': " + e.strerror)
 
 
 def check_output(args, print_command=False, verbose=False):

--- a/utils/build-script
+++ b/utils/build-script
@@ -28,7 +28,6 @@ from SwiftBuildSupport import (
     HOME,
     SWIFT_BUILD_ROOT,
     SWIFT_SOURCE_ROOT,
-    check_call,
     get_all_preset_names,
     get_preset_options,
 )  # noqa (E402 module level import not at top of file)
@@ -49,6 +48,21 @@ from swift_build_support.targets import StdlibDeploymentTarget  # noqa (E402)
 from swift_build_support.cmake import CMake  # noqa (E402)
 from swift_build_support.workspace import Workspace  # noqa(E402)
 from swift_build_support.workspace import compute_build_subdir  # noqa(E402)
+
+
+def call_without_sleeping(command, dry_run=False):
+    """
+    Execute a command during which system sleep is disabled.
+
+    By default, this ignores the state of the `shell.dry_run` flag.
+    """
+
+    # Disable system sleep, if possible.
+    if platform.system() == 'Darwin':
+        # Don't mutate the caller's copy of the arguments.
+        command = ["caffeinate"] + list(command)
+
+    shell.call(command, dry_run=dry_run, print_command=False)
 
 
 # Main entry point for the preset mode.
@@ -124,7 +138,7 @@ def main_preset():
         "using preset '" + args.preset + "', which expands to \n\n" +
         shell.quote_command(build_script_args) + "\n")
 
-    check_call(build_script_args, disable_sleep=True)
+    call_without_sleeping(build_script_args)
 
     return 0
 
@@ -1429,8 +1443,7 @@ details of the setups of other systems or automated environments.""")
     if args.dry_run:
         build_script_impl_args += ["--dry-run"]
 
-    check_call([build_script_impl] + build_script_impl_args,
-               disable_sleep=True)
+    call_without_sleeping([build_script_impl] + build_script_impl_args)
 
     if args.symbols_package:
         print('--- Creating symbols package ---')

--- a/utils/profdata_merge/process.py
+++ b/utils/profdata_merge/process.py
@@ -19,18 +19,16 @@ import sys
 from multiprocessing import Process
 
 
-# hack to import SwiftBuildSupport and swift_build_support
-parent_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
-sys.path.append(parent_dir)
-support_dir = os.path.join(parent_dir, 'swift_build_support')
-sys.path.append(support_dir)
+# Allow importing swift_build_support.
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..',
+                             'swift_build_support'))
 from swift_build_support import shell  # noqa (E402)
 from swift_build_support.toolchain import host_toolchain  # noqa (E402)
-from SwiftBuildSupport import check_output  # noqa (E402)
 
 toolchain = host_toolchain()
 LLVM_PROFDATA_PATH = toolchain.llvm_profdata
-_profdata_help = check_output([LLVM_PROFDATA_PATH, 'merge', '-help'])
+_profdata_help = shell.capture([LLVM_PROFDATA_PATH, 'merge', '-help'],
+                               print_command=False)
 LLVM_PROFDATA_SUPPORTS_SPARSE = 'sparse' in _profdata_help
 
 

--- a/utils/profdata_merge/process.py
+++ b/utils/profdata_merge/process.py
@@ -24,8 +24,9 @@ parent_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
 sys.path.append(parent_dir)
 support_dir = os.path.join(parent_dir, 'swift_build_support')
 sys.path.append(support_dir)
+from swift_build_support import shell  # noqa (E402)
 from swift_build_support.toolchain import host_toolchain  # noqa (E402)
-from SwiftBuildSupport import check_output, check_call  # noqa (E402)
+from SwiftBuildSupport import check_output  # noqa (E402)
 
 toolchain = host_toolchain()
 LLVM_PROFDATA_PATH = toolchain.llvm_profdata
@@ -65,7 +66,7 @@ class ProfdataMergerProcess(Process):
             llvm_cmd.append("-sparse")
         llvm_cmd += cleaned_files
         self.report(llvm_cmd)
-        ret = check_call(llvm_cmd)
+        ret = shell.call(llvm_cmd, print_command=False)
         if ret != 0:
             self.report("llvm profdata command failed -- Exited with code %d"
                         % ret, level=logging.ERROR)

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -7,8 +7,11 @@ import filecmp
 import os
 import os.path
 import shutil
+import sys
 
-from SwiftBuildSupport import check_call
+sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
+
+from swift_build_support import shell  # noqa (E402)
 
 
 def merge_file_lists(src_root_dirs, skip_files, skip_subpaths):
@@ -89,8 +92,8 @@ def merge_lipo_files(src_root_dirs, file_list, copy_verbatim_subpaths,
                     print("-- Running lipo %s to %s" % (file_paths, dest_path))
                 else:
                     print("-- Running lipo %s" % dest_path)
-                check_call(lipo_cmd + ["-output", dest_path] + file_paths,
-                           print_command=verbose, verbose=verbose)
+                shell.call(lipo_cmd + ["-output", dest_path] + file_paths,
+                           print_command=verbose)
             else:
                 # Multiple instances are different, and they're not executable.
                 print(

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -60,6 +60,13 @@ def _print_command(dry_run, command, env=None, prompt="+ "):
 
 
 def call(command, stderr=None, env=None, dry_run=None, print_command=True):
+    """
+    call(command, ...) -> str
+
+    Execute the given command.
+
+    This function will raise an exception on any command failure.
+    """
     dry_run = _coerce_dry_run(dry_run)
     if dry_run or print_command:
         _print_command(dry_run, command, env=env)
@@ -71,6 +78,35 @@ def call(command, stderr=None, env=None, dry_run=None, print_command=True):
         _env.update(env)
     try:
         subprocess.check_call(command, env=_env, stderr=stderr)
+    except subprocess.CalledProcessError as e:
+        diagnostics.fatal(
+            "command terminated with a non-zero exit status " +
+            str(e.returncode) + ", aborting")
+    except OSError as e:
+        diagnostics.fatal(
+            "could not execute '" + quote_command(command) +
+            "': " + e.strerror)
+
+
+def capture(command, stderr=None, env=None, dry_run=None, print_command=True):
+    """
+    capture(command, ...) -> str
+
+    Execute the given command and return the standard output.
+
+    This function will raise an exception on any command failure.
+    """
+    dry_run = _coerce_dry_run(dry_run)
+    if dry_run or print_command:
+        _print_command(dry_run, command, env=env)
+    if dry_run:
+        return
+    _env = None
+    if env is not None:
+        _env = dict(os.environ)
+        _env.update(env)
+    try:
+        return subprocess.check_output(command, env=_env, stderr=stderr)
     except subprocess.CalledProcessError as e:
         diagnostics.fatal(
             "command terminated with a non-zero exit status " +

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -59,9 +59,10 @@ def _print_command(dry_run, command, env=None, prompt="+ "):
     file.flush()
 
 
-def call(command, stderr=None, env=None, dry_run=None):
+def call(command, stderr=None, env=None, dry_run=None, print_command=True):
     dry_run = _coerce_dry_run(dry_run)
-    _print_command(dry_run, command, env=env)
+    if dry_run or print_command:
+        _print_command(dry_run, command, env=env)
     if dry_run:
         return
     _env = None
@@ -81,39 +82,44 @@ def call(command, stderr=None, env=None, dry_run=None):
 
 
 @contextmanager
-def pushd(path, dry_run=None):
+def pushd(path, dry_run=None, print_command=True):
     dry_run = _coerce_dry_run(dry_run)
     old_dir = os.getcwd()
-    _print_command(dry_run, ["pushd", path])
+    if dry_run or print_command:
+        _print_command(dry_run, ["pushd", path])
     if not dry_run:
         os.chdir(path)
     yield
-    _print_command(dry_run, ["popd"])
+    if dry_run or print_command:
+        _print_command(dry_run, ["popd"])
     if not dry_run:
         os.chdir(old_dir)
 
 
-def makedirs(path, dry_run=None):
+def makedirs(path, dry_run=None, print_command=True):
     dry_run = _coerce_dry_run(dry_run)
-    _print_command(dry_run, ['mkdir', '-p', path])
+    if dry_run or print_command:
+        _print_command(dry_run, ['mkdir', '-p', path])
     if dry_run:
         return
     if not os.path.isdir(path):
         os.makedirs(path)
 
 
-def rmtree(path, dry_run=None):
+def rmtree(path, dry_run=None, print_command=True):
     dry_run = _coerce_dry_run(dry_run)
-    _print_command(dry_run, ['rm', '-rf', path])
+    if dry_run or print_command:
+        _print_command(dry_run, ['rm', '-rf', path])
     if dry_run:
         return
     if os.path.exists(path):
         shutil.rmtree(path)
 
 
-def copytree(src, dest, dry_run=None):
+def copytree(src, dest, dry_run=None, print_command=True):
     dry_run = _coerce_dry_run(dry_run)
-    _print_command(dry_run, ['cp', '-r', src, dest])
+    if dry_run or print_command:
+        _print_command(dry_run, ['cp', '-r', src, dest])
     if dry_run:
         return
     shutil.copytree(src, dest)

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -63,6 +63,12 @@ class ShellTestCase(unittest.TestCase):
 + cp {foo_file} {bar_file}
 '''.format(foo_file=foo_file, bar_file=bar_file))
 
+    def test_capture(self):
+        self.assertEqual(shell.capture(["echo", "hi"]), "hi\n")
+
+        with self.assertRaises(SystemExit):
+            shell.capture(["false"])
+
     def test_rmtree(self):
         shell.dry_run = False
         path = os.path.join(self.tmpdir, 'foo', 'bar')

--- a/utils/swift_build_support/tests/test_tar.py
+++ b/utils/swift_build_support/tests/test_tar.py
@@ -10,7 +10,6 @@
 
 import os
 import platform
-import subprocess
 import sys
 import tempfile
 import unittest

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -94,7 +94,7 @@ def update_working_copy(repo_path, branch):
         return
 
     print("--- Updating '" + repo_path + "' ---")
-    with shell.pushd(repo_path, dry_run=False):
+    with shell.pushd(repo_path, dry_run=False, print_command=False):
         if branch:
             status = check_output(['git', 'status', '--porcelain'])
             if status:
@@ -117,7 +117,7 @@ def obtain_additional_swift_sources(
         if dir_name in skip_repositories:
             print("--- Skipping '" + dir_name + "' ---")
             continue
-        with shell.pushd(SWIFT_SOURCE_ROOT, dry_run=False):
+        with shell.pushd(SWIFT_SOURCE_ROOT, dry_run=False, print_command=False):
             if not os.path.isdir(os.path.join(dir_name, ".git")):
                 print("--- Cloning '" + dir_name + "' ---")
                 if with_ssh is True:

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -19,7 +19,6 @@ sys.path.append(os.path.dirname(__file__))
 
 from SwiftBuildSupport import (
     SWIFT_SOURCE_ROOT,
-    check_output,
 )  # noqa (E402 module level import not at top of file)
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'swift_build_support'))
@@ -95,7 +94,8 @@ def update_working_copy(repo_path, branch):
     print("--- Updating '" + repo_path + "' ---")
     with shell.pushd(repo_path, dry_run=False, print_command=False):
         if branch:
-            status = check_output(['git', 'status', '--porcelain'])
+            status = shell.capture(['git', 'status', '--porcelain'],
+                                   print_command=False)
             if status:
                 print("Please, commit your changes.")
                 print(status)

--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -19,7 +19,6 @@ sys.path.append(os.path.dirname(__file__))
 
 from SwiftBuildSupport import (
     SWIFT_SOURCE_ROOT,
-    check_call,
     check_output,
 )  # noqa (E402 module level import not at top of file)
 
@@ -101,14 +100,15 @@ def update_working_copy(repo_path, branch):
                 print("Please, commit your changes.")
                 print(status)
                 exit(1)
-            check_call(['git', 'checkout', branch])
+            shell.call(['git', 'checkout', branch], print_command=False)
 
         # Prior to Git 2.6, this is the way to do a "git pull
         # --rebase" that respects rebase.autostash.  See
         # http://stackoverflow.com/a/30209750/125349
-        check_call(["git", "fetch"])
-        check_call(["git", "rebase", "FETCH_HEAD"])
-        check_call(["git", "submodule", "update", "--recursive"])
+        shell.call(["git", "fetch"], print_command=False)
+        shell.call(["git", "rebase", "FETCH_HEAD"], print_command=False)
+        shell.call(["git", "submodule", "update", "--recursive"],
+                   print_command=False)
 
 
 def obtain_additional_swift_sources(
@@ -117,7 +117,8 @@ def obtain_additional_swift_sources(
         if dir_name in skip_repositories:
             print("--- Skipping '" + dir_name + "' ---")
             continue
-        with shell.pushd(SWIFT_SOURCE_ROOT, dry_run=False, print_command=False):
+        with shell.pushd(SWIFT_SOURCE_ROOT, dry_run=False,
+                         print_command=False):
             if not os.path.isdir(os.path.join(dir_name, ".git")):
                 print("--- Cloning '" + dir_name + "' ---")
                 if with_ssh is True:
@@ -125,11 +126,11 @@ def obtain_additional_swift_sources(
                 else:
                     remote = "https://github.com/" + repo + '.git'
                 if skip_history:
-                    check_call(['git', 'clone', '--recursive', '--depth', '1',
-                                remote, dir_name])
+                    shell.call(['git', 'clone', '--recursive', '--depth', '1',
+                                remote, dir_name], print_command=False)
                 else:
-                    check_call(['git', 'clone', '--recursive', remote,
-                                dir_name])
+                    shell.call(['git', 'clone', '--recursive', remote,
+                                dir_name], print_command=False)
                 if branch:
                     if branch == "master" or branch == "stable":
                         repo_branch = MASTER_BRANCHES[dir_name]
@@ -142,9 +143,9 @@ def obtain_additional_swift_sources(
                         repo_branch = branch
                     src_path = SWIFT_SOURCE_ROOT + "/" + dir_name + "/" + \
                         ".git"
-                    check_call(['git', '--git-dir', src_path, '--work-tree',
+                    shell.call(['git', '--git-dir', src_path, '--work-tree',
                                 os.path.join(SWIFT_SOURCE_ROOT, dir_name),
-                                'checkout', repo_branch])
+                                'checkout', repo_branch], print_command=False)
 
 
 def main():


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This PR eliminates the subprocess-related functions in SwiftBuildSupport in favor of using the newer `swift_build_support.shell` module. It adds a `print_command` option to the functions in the shell module (to match the behavior of existing code), adds a `swift_build_support.shell.capture` function which is analogous to `subprocess.check_output`, and migrates clients to them.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
