### PR TITLE
Hide stdlib underscored api names from interface and code-completion

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -425,6 +425,9 @@ bool Decl::isPrivateStdlibDecl(bool whitelistProtocols) const {
     for (auto param : *params) {
       if (param->hasName() && param->getNameStr().startswith("_"))
         return true;
+      auto argName = param->getArgumentName();
+      if (!argName.empty() && argName.str().startswith("_"))
+        return true;
     }
     return false;
   };

--- a/stdlib/public/core/FixedPoint.swift.gyb
+++ b/stdlib/public/core/FixedPoint.swift.gyb
@@ -243,11 +243,11 @@ public struct ${Self}
 % if self_ty.is_word:
   @_transparent
   public // @testable
-  init(_ v: Builtin.Word) {
+  init(_ _v: Builtin.Word) {
 % if BuiltinName == 'Int32':
-    self._value = Builtin.truncOrBitCast_Word_Int32(v)
+    self._value = Builtin.truncOrBitCast_Word_Int32(_v)
 % elif BuiltinName == 'Int64':
-    self._value = Builtin.zextOrBitCast_Word_Int64(v)
+    self._value = Builtin.zextOrBitCast_Word_Int64(_v)
 % end
   }
 

--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -33,8 +33,8 @@
 // DONT_CHECK-NOT: {{([^I]|$)([^n]|$)([^d]|$)([^e]|$)([^x]|$)([^a]|$)([^b]|$)([^l]|$)([^e]|$)}}
 // CHECK-NOT: buffer: _ArrayBuffer
 // CHECK-NOT: func ~>
-// FIXME: Builtin.
-// FIXME: RawPointer
+// CHECK-NOT: Builtin.
+// CHECK-NOT: RawPointer
 // CHECK-NOT: extension [
 // CHECK-NOT: extension {{.*}}?
 // CHECK-NOT: extension {{.*}}!


### PR DESCRIPTION
#### What's in this pull request?

APIs from Swift stdlib like `String.init(_builtinExtendedGraphemeClusterLiteral …)` should be hidden as private from interface and code-completion.

This commit, and the changes in Swift stdlib interface that results in, have been reviewed and approved by Dmitri.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26595224

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
