### PR TITLE
[build-script-impl] Optimize setting -> variable name lookups.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -646,26 +646,58 @@ function set_build_options_for_host() {
     )
 }
 
-# Set up an "associative array" of settings for error checking, and set
-# (or unset) each corresponding variable to its default value
-# If the Mac's bash were not stuck in the past, we could "declare -A" an
-# associative array, but instead we have to hack it by defining variables
-# declare -A IS_KNOWN_SETTING
-for ((i = 0; i < ${#KNOWN_SETTINGS[@]}; i += 3)); do
-    setting="${KNOWN_SETTINGS[i]}"
+# get_setting_varname(setting-name) -> variable-name
+#
+# Converts a known setting name, like "install-prefix" to an internal variable
+# name, like "INSTALL_PREFIX".
+#
+# \returns Empty if the setting is not a known one.
+function get_setting_varname() {
+    local setting="$1"
+    # Look up in the associative array built by configure_default_options().
+    local setting_varname_var="${setting//-/_}_VARNAME"
+    echo ${!setting_varname_var}
+}
 
-    default_value="${KNOWN_SETTINGS[$((i+1))]}"
+function configure_default_options() {
+    # Build a table of all of the known setting variables names.
+    #
+    # This is an optimization to do the argument to variable conversion (which is
+    # slow) in a single pass.
+    local all_settings=()
+    for ((i = 0; i < ${#KNOWN_SETTINGS[@]}; i += 3)); do
+        all_settings+=("${KNOWN_SETTINGS[i]}")
+    done
+    local known_setting_varnames=($(to_varname "${all_settings[*]}"))
 
-    varname="$(to_varname "${setting}")"    # upcase the setting name to get the variable
-    eval "${varname}_IS_KNOWN_SETTING=1"
+    # Build up an "associative array" mapping setting names to variable names
+    # (we use this for error checking to identify "known options", and as a fast
+    # way to map the setting name to a variable name). See get_setting_varname().
+    #
+    # This loop also sets (or unsets) each corresponding variable to its default
+    # value.
+    #
+    # NOTE: If the Mac's bash were not stuck in the past, we could "declare -A"
+    # an associative array, but instead we have to hack it by defining variables.
+    for ((i = 0; i < ${#KNOWN_SETTINGS[@]}; i += 3)); do
+        local setting="${KNOWN_SETTINGS[i]}"
+        local default_value="${KNOWN_SETTINGS[$((i+1))]}"
 
-    if [[ "${default_value}" ]] ; then
-        # For an explanation of the backslash see http://stackoverflow.com/a/9715377
-        eval ${varname}=$\default_value
-    else
-        unset ${varname}
-    fi
-done
+        # Find the variable name in our lookup table.
+        local varname="${known_setting_varnames[$((i/3))]]}"
+
+        # Establish the associative array mapping.
+        eval "${setting//-/_}_VARNAME=${varname}"
+
+        if [[ "${default_value}" ]] ; then
+            # For an explanation of the backslash see http://stackoverflow.com/a/9715377
+            eval ${varname}=$\default_value
+        else
+            unset ${varname}
+        fi
+    done
+}
+configure_default_options
 
 COMMAND_NAME="$(basename "$0")"
 
@@ -728,12 +760,11 @@ while [[ "$1" ]] ; do
             setting="${dashless%%=*}"
 
             # compute the variable to set
-            varname="$(to_varname "${setting}")"
+            varname=$(get_setting_varname $setting)
 
             # check to see if this is a known option
-            known_var_name="${varname}_IS_KNOWN_SETTING"
-            if [[ ! "${!known_var_name}" ]] ; then
-                echo "Error: Unknown setting: ${setting}" 1>&2
+            if [[ "${varname}" = "" ]] ; then
+                echo "error: unknown setting: ${setting}" 1>&2
                 usage 1>&2
                 exit 1
             fi


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This optimizes `build-script-impl`'s setting processing code (which was adding about 1s to each invocation, on my machine). See commit for details.

Related to SR-237.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- The current behavior of mapping via `tr` was very slow when called over and
  over for each option. This matters for SR-237 where I would like
  `build-script` to take over the top-level build process control loop, which
  involves executing `build-script-impl` multiple times.
- This patch optimizes the lookup in two ways:
  1. It does the setting to variable conversion in a single pass, for all
     options at once.
  2. It builds a cache of the setting to variable name conversion (as an
     exploded associate array), and uses that when doing variable assignment.
- This patch speeds up `build-script-impl --dry-run` by 2x on one test case.
