### PR TITLE
When converting potential IUO bindings to optional

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -880,8 +880,9 @@ static PotentialBindings getPotentialBindings(ConstraintSystem &cs,
     if (kind == AllowedBindingKind::Supertypes &&
         constraint->getKind() >= ConstraintKind::Conversion &&
         constraint->getKind() <= ConstraintKind::OperatorArgumentConversion) {
+      auto innerType = type->getLValueOrInOutObjectType();
       if (auto objectType =
-          cs.lookThroughImplicitlyUnwrappedOptionalType(type)) {
+          cs.lookThroughImplicitlyUnwrappedOptionalType(innerType)) {
         type = OptionalType::get(objectType);
         alternateType = objectType;
       }

--- a/test/ClangModules/cvars_parse.swift
+++ b/test/ClangModules/cvars_parse.swift
@@ -8,7 +8,7 @@ func getPI() -> Float {
 
 func testPointers() {
   let cp = globalConstPointer
-  cp.abcde() // expected-error {{value of type 'UnsafePointer<Void>' (aka 'UnsafePointer<()>') has no member 'abcde'}}
+  cp.abcde() // expected-error {{value of type 'UnsafePointer<Void>?' has no member 'abcde'}}
   let mp = globalPointer
-  mp.abcde() // expected-error {{value of type 'UnsafeMutablePointer<Void>' (aka 'UnsafeMutablePointer<()>') has no member 'abcde'}}
+  mp.abcde() // expected-error {{value of type 'UnsafeMutablePointer<Void>?' has no member 'abcde'}}
 }


### PR DESCRIPTION
This PR cherry-picks change 778a4ee13650 (rdar://problem/26360502) from master to swift-3.0-preview-1-branch.

Details:
When converting potential IUO bindings to optional ones, look through any lvalue types. 
Doing so can prevent improper double-optional binds, which can cause unexpected runtime behavior.
