### PR TITLE
CMake: work around an issue with CMake Xcode generator and the Swift driver

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -370,6 +370,27 @@ function(_compile_swift_files dependency_target_out_var_name)
     set(swift_compiler_tool "${SWIFT_SOURCE_DIR}/utils/check-incremental" "${swift_compiler_tool}")
   endif()
 
+  set(outputs
+    ${SWIFTFILE_OUTPUT} "${module_file}" "${module_doc_file}"
+    ${apinote_files})
+
+  if(XCODE)
+    # HACK: work around an issue with CMake Xcode generator and the Swift
+    # driver.
+    #
+    # The Swift driver does not update the mtime of the output files if the
+    # existing output files on disk are identical to the ones that are about
+    # to be written.  This behavior confuses the makefiles used in CMake Xcode
+    # projects: the makefiles will not consider everything up to date after
+    # invoking the compiler.  As a result, the standard library gets rebuilt
+    # multiple times during a single build.
+    #
+    # To work around this issue we touch the output files so that their mtime
+    # always gets updated.
+    set(command_touch_outputs
+      COMMAND "${CMAKE_COMMAND}" -E touch ${outputs})
+  endif()
+
   add_custom_command_target(
       dependency_target
       ${command_create_dirs}
@@ -380,9 +401,8 @@ function(_compile_swift_files dependency_target_out_var_name)
         "${line_directive_tool}" "${source_files}" --
         "${swift_compiler_tool}" "${main_command}" ${swift_flags}
         ${output_option} "${source_files}"
-      OUTPUT
-        ${SWIFTFILE_OUTPUT} "${module_file}" "${module_doc_file}"
-        ${apinote_files}
+      ${command_touch_outputs}
+      OUTPUT ${outputs}
       DEPENDS
         ${swift_compiler_tool_dep}
         ${source_files} ${SWIFTFILE_DEPENDS}


### PR DESCRIPTION
The Swift driver does not update the mtime of the output files if the
existing output files on disk are identical to the ones that are about
to be written.  This behavior confuses the makefiles used in CMake Xcode
projects: the makefiles will not consider everything up to date after
invoking the compiler.  As a result, the standard library gets rebuilt
multiple times during a single build.

To work around this issue we touch the output files so that their mtime
always gets updated.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
