### PR TITLE
[SwiftRemoteMirror] Consider ObjCClass field descriptors when convert…

### DIFF
--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -1013,7 +1013,8 @@ const TypeInfo *TypeConverter::getClassInstanceTypeInfo(const TypeRef *TR,
     return nullptr;
 
   switch (FD->Kind) {
-  case FieldDescriptorKind::Class: {
+  case FieldDescriptorKind::Class:
+  case FieldDescriptorKind::ObjCClass: {
     // Lower the class's fields using substitutions from the
     // TypeRef to make field types concrete.
     RecordTypeInfoBuilder builder(*this, RecordKind::ClassInstance);
@@ -1030,7 +1031,6 @@ const TypeInfo *TypeConverter::getClassInstanceTypeInfo(const TypeRef *TR,
   case FieldDescriptorKind::ObjCProtocol:
   case FieldDescriptorKind::ClassProtocol:
   case FieldDescriptorKind::Protocol:
-  case FieldDescriptorKind::ObjCClass:
     // Invalid field descriptor.
     return nullptr;
   }

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -2,6 +2,9 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_NSObject
 // RUN: %target-run %target-swift-reflection-test %t/inherits_NSObject | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
 import Foundation
 
 import SwiftReflectionTest
@@ -37,7 +40,7 @@ reflect(object: inheritsNSObject)
 // CHECK-32: (class inherits_NSObject.InheritsNSObject)
 
 // CHECK-32: Type info:
-// CHECK-32: (class_instance size=4 alignment=8 stride=8 num_extra_inhabitants=0)
+// CHECK-32: (class_instance size=4 alignment=16 stride=16 num_extra_inhabitants=0)
 
 let sc = ContainsInheritsNSObject()
 reflect(object: sc)
@@ -58,7 +61,7 @@ reflect(object: sc)
 // CHECK-32: (class inherits_NSObject.ContainsInheritsNSObject)
 
 // CHECK-32:        Type info:
-// CHECK-32:        (class_instance size=12 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-32:        (class_instance size=12 alignment=16 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:   (field name=a offset=4
 // CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:   (field name=_b offset=8

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_NSObject
+// RUN: %target-run %target-swift-reflection-test %t/inherits_NSObject | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+import Foundation
+
+import SwiftReflectionTest
+
+class InheritsNSObject : NSObject {}
+class ContainsInheritsNSObject : NSObject {
+    var a: InheritsNSObject
+    var _b: InheritsNSObject
+
+    var b: InheritsNSObject {
+        get { return _b }
+        set (newVal) { _b = newVal }
+    }
+
+    override init() {
+        a = InheritsNSObject()
+        _b = InheritsNSObject()
+    }
+}
+
+let inheritsNSObject = InheritsNSObject()
+reflect(object: inheritsNSObject)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_NSObject.InheritsNSObject)
+
+// CHECK-64: Type info:
+// CHECK-64: (class_instance size=8 alignment=16 stride=16 num_extra_inhabitants=0)
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_NSObject.InheritsNSObject)
+
+// CHECK-32: Type info:
+// CHECK-32: (class_instance size=4 alignment=8 stride=8 num_extra_inhabitants=0)
+
+let sc = ContainsInheritsNSObject()
+reflect(object: sc)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Type reference:
+// CHECK-64: (class inherits_NSObject.ContainsInheritsNSObject)
+
+// CHECK-64:        Type info:
+// CHECK-64:        (class_instance size=24 alignment=16 stride=32 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=a offset=8
+// CHECK-64-NEXT:     (reference kind=strong refcounting=unknown))
+// CHECK-64-NEXT:   (field name=_b offset=16
+// CHECK-64-NEXT:     (reference kind=strong refcounting=unknown)))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Type reference:
+// CHECK-32: (class inherits_NSObject.ContainsInheritsNSObject)
+
+// CHECK-32:        Type info:
+// CHECK-32:        (class_instance size=12 alignment=8 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=a offset=4
+// CHECK-32-NEXT:     (reference kind=strong refcounting=unknown))
+// CHECK-32-NEXT:   (field name=_b offset=8
+// CHECK-32-NEXT:     (reference kind=strong refcounting=unknown)))
+
+doneReflecting()


### PR DESCRIPTION
@slavapestov recently folded in @objc classes when building class field
descriptors - we just need to update the switch when considering records
for converting TypeRefs to TypeInfos.

rdar://problem/26594130
