### PR TITLE
[build-script] Consistent use of shell.capture in swift_build_support

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -14,9 +14,11 @@
 #
 # ----------------------------------------------------------------------------
 
-import subprocess
+from __future__ import absolute_import
 
 from numbers import Number
+
+from . import shell
 
 
 class CMakeOptions(object):
@@ -125,8 +127,8 @@ class CMake(object):
         toolchain = self.toolchain
         jobs = args.build_jobs
         if args.distcc:
-            jobs = str(subprocess.check_output(
-                [toolchain.distcc, '-j']).decode()).rstrip()
+            jobs = shell.capture([toolchain.distcc, '-j'],
+                                 dry_run=False, echo=False).rstrip()
 
         build_args = list(args.build_args)
 

--- a/utils/swift_build_support/swift_build_support/debug.py
+++ b/utils/swift_build_support/swift_build_support/debug.py
@@ -28,11 +28,9 @@ def print_xcodebuild_versions(file=sys.stdout):
     information for all available SDKs.
     """
     version = shell.capture(
-        ['xcodebuild', '-version'],
-        dry_run=False, echo=False, optional=True).rstrip()
+        ['xcodebuild', '-version'], dry_run=False, echo=False).rstrip()
     sdks = shell.capture(
-        ['xcodebuild', '-version', '-sdk'],
-        dry_run=False, echo=False, optional=True).rstrip()
+        ['xcodebuild', '-version', '-sdk'], dry_run=False, echo=False).rstrip()
     fmt = """\
 {version}
 

--- a/utils/swift_build_support/swift_build_support/debug.py
+++ b/utils/swift_build_support/swift_build_support/debug.py
@@ -14,18 +14,12 @@
 #
 # ----------------------------------------------------------------------------
 
+from __future__ import absolute_import
 from __future__ import print_function
 
-import subprocess
 import sys
 
-
-def _output(args):
-    try:
-        out = subprocess.check_output(args, stderr=subprocess.PIPE)
-        return out.rstrip().decode()
-    except subprocess.CalledProcessError:
-        return None
+from . import shell
 
 
 def print_xcodebuild_versions(file=sys.stdout):
@@ -33,10 +27,18 @@ def print_xcodebuild_versions(file=sys.stdout):
     Print the host machine's `xcodebuild` version, as well as version
     information for all available SDKs.
     """
-    print(u'{}\n'.format(_output(['xcodebuild', '-version'])), file=file)
-    print(u'--- SDK versions ---', file=file)
-    print(u'{}\n'.format(_output(['xcodebuild', '-version', '-sdk'])),
-          file=file)
+    version = shell.capture(
+        ['xcodebuild', '-version'],
+        dry_run=False, echo=False, optional=True).rstrip()
+    sdks = shell.capture(
+        ['xcodebuild', '-version', '-sdk'],
+        dry_run=False, echo=False, optional=True).rstrip()
+    fmt = """\
+{version}
+
+--- SDK versions ---
+{sdks}
+
+"""
+    print(fmt.format(version=version, sdks=sdks), file=file)
     file.flush()
-    # You can't test beyond this because each developer's machines may have
-    # a different set of SDKs installed.

--- a/utils/swift_build_support/swift_build_support/tar.py
+++ b/utils/swift_build_support/swift_build_support/tar.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 import platform
-import subprocess
 
 from . import shell
 
@@ -29,7 +28,7 @@ def tar(source, destination):
     if platform.system() != 'Darwin':
         args += ['--owner=0', '--group=0']
 
-    # Capture stderr output such as 'tar: Failed to open ...'. We'll detect
-    # these cases using the exit code, which should cause 'check_call' to
+    # Discard stderr output such as 'tar: Failed to open ...'. We'll detect
+    # these cases using the exit code, which should cause 'shell.call' to
     # raise.
-    shell.call(args + [source], stderr=subprocess.PIPE)
+    shell.call(args + [source], stderr=shell.DEVNULL)

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -17,9 +17,9 @@ Represent toolchain - the versioned executables.
 from __future__ import absolute_import
 
 import platform
-import subprocess
 
 from . import cache_util
+from . import shell
 from . import xcrun
 from .which import which
 
@@ -151,13 +151,13 @@ class FreeBSD(GenericUnix):
         """Return the release date for FreeBSD operating system on this host.
         If the release date cannot be ascertained, return None.
         """
-        try:
-            # For details on `sysctl`, see:
-            # http://www.freebsd.org/cgi/man.cgi?sysctl(8)
-            out = subprocess.check_output(['sysctl', '-n', 'kern.osreldate'])
-            return int(out)
-        except subprocess.CalledProcessError:
+        # For details on `sysctl`, see:
+        # http://www.freebsd.org/cgi/man.cgi?sysctl(8)
+        out = shell.capture(['sysctl', '-n', 'kern.osreldate'],
+                            dry_run=False, echo=False, optional=True)
+        if out is None:
             return None
+        return int(out)
 
 
 class Cygwin(Linux):

--- a/utils/swift_build_support/swift_build_support/which.py
+++ b/utils/swift_build_support/swift_build_support/which.py
@@ -18,9 +18,8 @@
 
 from __future__ import absolute_import
 
-import subprocess
-
 from . import cache_util
+from . import shell
 
 
 @cache_util.cached
@@ -35,8 +34,8 @@ def which(cmd):
     We provide our own implementation because shutil.which() has not
     been backported to Python 2.7, which we support.
     """
-    try:
-        ret = subprocess.check_output(['which', cmd])
-        return str(ret.rstrip().decode())
-    except subprocess.CalledProcessError:
+    out = shell.capture(['which', cmd],
+                        dry_run=False, echo=False, optional=True)
+    if out is None:
         return None
+    return out.rstrip()

--- a/utils/swift_build_support/swift_build_support/xcrun.py
+++ b/utils/swift_build_support/swift_build_support/xcrun.py
@@ -16,9 +16,8 @@
 
 from __future__ import absolute_import
 
-import subprocess
-
 from . import cache_util
+from . import shell
 
 
 @cache_util.cached
@@ -35,14 +34,14 @@ def find(tool, sdk=None, toolchain=None):
     if toolchain is not None:
         command += ['--toolchain', toolchain]
 
-    try:
-        # `xcrun --find` prints to stderr when it fails to find the
-        # given tool. We swallow that output with a pipe.
-        out = subprocess.check_output(command,
-                                      stderr=subprocess.PIPE)
-        return str(out.rstrip().decode())
-    except subprocess.CalledProcessError:
+    # `xcrun --find` prints to stderr when it fails to find the
+    # given tool. We swallow that output with a pipe.
+    out = shell.capture(
+        command,
+        stderr=shell.DEVNULL, dry_run=False, echo=False, optional=True)
+    if out is None:
         return None
+    return out.rstrip()
 
 
 @cache_util.cached
@@ -53,8 +52,7 @@ def sdk_path(sdk):
     If `xcrun --show-sdk-path` cannot find the SDK, return None.
     """
     command = ['xcrun', '--sdk', sdk, '--show-sdk-path']
-    try:
-        out = subprocess.check_output(command)
-        return str(out.rstrip().decode())
-    except subprocess.CalledProcessError:
+    out = shell.capture(command, dry_run=False, echo=False, optional=True)
+    if out is None:
         return None
+    return out.rstrip()

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -22,8 +22,8 @@ except ImportError:
     from io import StringIO
 
 from swift_build_support.arguments import (
-    type as argtype,
     action as argaction,
+    type as argtype,
 )
 
 

--- a/utils/swift_build_support/tests/test_debug.py
+++ b/utils/swift_build_support/tests/test_debug.py
@@ -10,12 +10,12 @@
 
 import platform
 import unittest
-
-# StringIO import path differs across Python 2 and 3.
 try:
-    from io import StringIO
+    # py2
+    from StringIO import StringIO
 except ImportError:
-    from cStringIO import StringIO
+    # py3
+    from io import StringIO
 
 from swift_build_support import debug
 
@@ -33,6 +33,8 @@ class PrintXcodebuildVersionsTestCase(unittest.TestCase):
         self.assertTrue(actual[0].startswith('Xcode '))
         self.assertTrue(actual[1].startswith('Build version '))
         self.assertEqual(actual[3], '--- SDK versions ---')
+        # You can't test beyond this because each developer's machines may have
+        # a different set of SDKs installed.
 
 
 if __name__ == '__main__':

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -69,6 +69,11 @@ class ShellTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit):
             shell.capture(["false"])
 
+        self.assertIsNone(shell.capture(["false"], optional=True))
+
+        with self.assertRaises(SystemExit):
+            shell.capture(["**not-a-command**"], optional=True)
+
     def test_rmtree(self):
         shell.dry_run = False
         path = os.path.join(self.tmpdir, 'foo', 'bar')


### PR DESCRIPTION
#### What's in this pull request?

Replace `subprocess.check_call` with `shell.capture` in `swift_build_support` package.
This eliminates direct `subprocess` import. Currently, except for [`migration` module](https://github.com/apple/swift/blob/c9cd33bb0aee05c2d19cdf37f16f4f88f2c8cca2/utils/swift_build_support/swift_build_support/migration.py).

Introduced `optional` parameter to `shell.capture`.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
