### PR TITLE
[build-script-impl] Inline get_setting_varname().

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -646,19 +646,6 @@ function set_build_options_for_host() {
     )
 }
 
-# get_setting_varname(setting-name) -> variable-name
-#
-# Converts a known setting name, like "install-prefix" to an internal variable
-# name, like "INSTALL_PREFIX".
-#
-# \returns Empty if the setting is not a known one.
-function get_setting_varname() {
-    local setting="$1"
-    # Look up in the associative array built by configure_default_options().
-    local setting_varname_var="${setting//-/_}_VARNAME"
-    echo ${!setting_varname_var}
-}
-
 function configure_default_options() {
     # Build a table of all of the known setting variables names.
     #
@@ -672,7 +659,8 @@ function configure_default_options() {
 
     # Build up an "associative array" mapping setting names to variable names
     # (we use this for error checking to identify "known options", and as a fast
-    # way to map the setting name to a variable name). See get_setting_varname().
+    # way to map the setting name to a variable name). See the code for scanning
+    # command line arguments.
     #
     # This loop also sets (or unsets) each corresponding variable to its default
     # value.
@@ -759,8 +747,10 @@ while [[ "$1" ]] ; do
             # drop suffix beginning with the first "="
             setting="${dashless%%=*}"
 
-            # compute the variable to set
-            varname=$(get_setting_varname $setting)
+            # compute the variable to set, using the cached map set up by
+            # configure_default_options().
+            varname_var="${setting//-/_}_VARNAME"
+            varname=${!varname_var}
 
             # check to see if this is a known option
             if [[ "${varname}" = "" ]] ; then


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- It turns out that just this function by itself has a significant impact on
  the runtime of the `build-script-impl` when it is being invoked many times by
  the `build-script` (as I intend to do as part of SR-237).
