### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::checkGenericParamList(…)

### DIFF
--- a/validation-test/compiler_crashers/28305-swift-typechecker-checkgenericparamlist.swift
+++ b/validation-test/compiler_crashers/28305-swift-typechecker-checkgenericparamlist.swift
@@ -1,0 +1,9 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+protocol b{let:e{}func e where h:e


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
4  swift           0x0000000000ed9afd swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 93
6  swift           0x0000000000eda21e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
9  swift           0x0000000000e9c901 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
10 swift           0x00000000010f57bc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2652
11 swift           0x00000000010f4055 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2469
12 swift           0x0000000000edd37b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
15 swift           0x0000000000f0e50e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
17 swift           0x0000000000f0f514 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
18 swift           0x0000000000f0e400 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
19 swift           0x0000000000ee1167 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 967
24 swift           0x0000000000ea1e46 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
25 swift           0x0000000000ec47a2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
26 swift           0x0000000000c58ed9 swift::CompilerInstance::performSema() + 3289
28 swift           0x00000000007d739f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
29 swift           0x00000000007a33b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28305-swift-typechecker-checkgenericparamlist.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28305-swift-typechecker-checkgenericparamlist-6620b8.o
1.  While type-checking 'b' at validation-test/compiler_crashers/28305-swift-typechecker-checkgenericparamlist.swift:9:1
2.  While resolving type e at [validation-test/compiler_crashers/28305-swift-typechecker-checkgenericparamlist.swift:9:16 - line:9:16] RangeText="e"
3.  While type-checking 'e' at validation-test/compiler_crashers/28305-swift-typechecker-checkgenericparamlist.swift:9:19
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
