### PR TITLE
[sema] Add compiler fixit for the case where a raw-representable type is constructed from an argument with the same type.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -752,6 +752,9 @@ ERROR(instance_member_in_initializer,none,
       "cannot use instance member %0 within property initializer; "
       "property initializers run before 'self' is available", (DeclName))
 
+ERROR(invalid_initialization_parameter_same_type,none,
+      "invalid initializer call with same type %0 as parameter", (Type))
+
 ERROR(missing_argument_named,none,
       "missing argument for parameter %0 in call", (Identifier))
 ERROR(missing_argument_positional,none,

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -49,6 +49,11 @@ func testMask4(a: MyEventMask2) {
   testMask2(a: a)
 }
 
+enum MyEnumType : UInt32 {
+  case invalid
+}
+_ = MyEnumType(MyEnumType.invalid)
+
 func goo(var e : ErrorProtocol) {
 }
 func goo2(var e: ErrorProtocol) {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -49,6 +49,11 @@ func testMask4(a: MyEventMask2) {
   testMask2(a: a.rawValue)
 }
 
+enum MyEnumType : UInt32 {
+  case invalid
+}
+_ = MyEnumType.invalid
+
 func goo(e : ErrorProtocol) {
     var e = e
 }


### PR DESCRIPTION
#### What's in this pull request?

Add compiler fixit for the case where a raw-representable type is constructed from an argument with the same type, like this:
      `MyEnumType(MyEnumType.foo)`
    This is missing 'rawValue:' label, but that won't actually fix this. A better fix is to just remove the unnecessary constructor call:
     `MyEnumType(MyEnumType.foo)`
    -->
     `MyEnumType.foo`
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26615638

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

… is constructed from an argument with the same type.

Like this:

  MyEnumType(MyEnumType.foo)

This is missing 'rawValue:' label, but that won't actually fix this. A better fix is to just remove the unnecessary constructor call:

  MyEnumType(MyEnumType.foo)
-->
  MyEnumType.foo
