### PR TITLE
[swift-3.0-preview-1-branch][stdlib] Fix the definition of nextUp and nextDown for floating point

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -238,25 +238,25 @@ public func expectOptionalEqual${Generic}(
 
 %end
 
-public func expectLT(_ lhs: Int, _ rhs: Int, ${TRACE}) {
+public func expectLT<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
   if !(lhs < rhs) {
     expectationFailure("\(lhs) < \(rhs)", trace: ${trace})
   }
 }
 
-public func expectLE(_ lhs: Int, _ rhs: Int, ${TRACE}) {
+public func expectLE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
   if !(lhs <= rhs) {
     expectationFailure("\(lhs) <= \(rhs)", trace: ${trace})
   }
 }
 
-public func expectGT(_ lhs: Int, _ rhs: Int, ${TRACE}) {
+public func expectGT<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
   if !(lhs > rhs) {
     expectationFailure("\(lhs) > \(rhs)", trace: ${trace})
   }
 }
 
-public func expectGE(_ lhs: Int, _ rhs: Int, ${TRACE}) {
+public func expectGE<T : Comparable>(_ lhs: T, _ rhs: T, ${TRACE}) {
   if !(lhs >= rhs) {
     expectationFailure("\(lhs) >= \(rhs)", trace: ${trace})
   }

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -480,6 +480,9 @@ extension ${Self}: BinaryFloatingPoint {
           exponentBitPattern: exponentBitPattern - 1,
           significandBitPattern: ${Self}._significandMask)
       }
+      return ${Self}(sign: .minus,
+        exponentBitPattern: exponentBitPattern,
+        significandBitPattern: significandBitPattern - 1)
     }
     if isInfinite { return self }
     if significandBitPattern == ${Self}._significandMask {

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -171,6 +171,42 @@ FloatingPoint.test("Double/HashValueZero") {
   expectEqual(zero.hashValue, negativeZero.hashValue)
 }
 
+let floatNextUpDownTests: [(Float, Float)] = [
+  (.nan, .nan),
+  (.greatestFiniteMagnitude, .infinity),
+  (-.infinity, -.greatestFiniteMagnitude),
+  (0x1.fffffep-1, 1.0), (1.0, 0x1.000002p+0),
+  (-0x1p-149, -0.0), (0.0, 0x1p-149),
+  (0x1.effffep-1, 0.96875), (0.96875, 0x1.f00002p-1),
+]
+
+FloatingPoint.test("Float.nextUp, .nextDown")
+  .forEach(in: floatNextUpDownTests) {
+  (prev, succ) in
+  expectEqual(succ.bitPattern, prev.nextUp.bitPattern)
+  expectEqual(prev.bitPattern, succ.nextDown.bitPattern)
+  expectEqual((-succ).bitPattern, (-prev).nextDown.bitPattern)
+  expectEqual((-prev).bitPattern, (-succ).nextUp.bitPattern)  
+}
+
+let doubleNextUpDownTests: [(Double, Double)] = [
+  (.nan, .nan),
+  (.greatestFiniteMagnitude, .infinity),
+  (-.infinity, -.greatestFiniteMagnitude),
+  (0x1.fffffffffffffp-1, 1.0), (1.0, 0x1.0000000000001p+0),
+  (-0x1p-1074, -0.0), (0.0, 0x1p-1074),
+  (0x1.effffffffffffp-1, 0.96875), (0.96875, 0x1.f000000000001p-1),
+]
+
+FloatingPoint.test("Double.nextUp, .nextDown")
+  .forEach(in: doubleNextUpDownTests) {
+  (prev, succ) in
+  expectEqual(succ.bitPattern, prev.nextUp.bitPattern)
+  expectEqual(prev.bitPattern, succ.nextDown.bitPattern)
+  expectEqual((-succ).bitPattern, (-prev).nextDown.bitPattern)
+  expectEqual((-prev).bitPattern, (-succ).nextUp.bitPattern)  
+}
+
 #if arch(i386) || arch(x86_64)
 
 FloatingPoint.test("Float80/IntegerLiteralConvertible") {


### PR DESCRIPTION
- Explanation: fix a bug in `nextUp` and `nextDown` on floating point types.
- Scope of the issue: advanced uses of floating point.
- Risk: low.
- Reviewed by: @gribozavr.
- Testing: new regression tests.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
