### PR TITLE
[sema] Add a fixit for missing generic arguments.

### DIFF
--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -122,3 +122,18 @@ func letToVar1() {
   y.append("as")
   y.append("df")
 }
+
+class Node  {}
+class Graph<NodeType : Node> {}
+var graph: Graph
+
+class Node2  {}
+class Graph2<NodeType1 : Node, NodeType2 : Node2> {}
+var graph: Graph2
+
+@objc protocol ObjCProt { }
+class Graph3<NodeType : ObjCProt> {}
+var graph: Graph3
+
+class GraphNoFix<NodeType : SomeProt> {}
+var graph: GraphNoFix

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -125,3 +125,18 @@ func letToVar1() {
   y.append("as")
   y.append("df")
 }
+
+class Node  {}
+class Graph<NodeType : Node> {}
+var graph: Graph<Node>
+
+class Node2  {}
+class Graph2<NodeType1 : Node, NodeType2 : Node2> {}
+var graph: Graph2<Node, Node2>
+
+@objc protocol ObjCProt { }
+class Graph3<NodeType : ObjCProt> {}
+var graph: Graph3<AnyObject>
+
+class GraphNoFix<NodeType : SomeProt> {}
+var graph: GraphNoFix


### PR DESCRIPTION
#### What's in this pull request?

When an unbound generic type is missing type arguments try to add a fixit that infers a generic type list to pass.

For example:

```
class Node  {}
class Graph<NodeType : Node> {}
var graph: Graph
```

fixed as:
`var graph: Graph<Node>`

Feedback and review by Doug Gregor.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26623703

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

When the unbound generic type is missing type arguments try to add a fixit that
infers a generic type list to pass.

rdar://26623703
