### PR TITLE
[swiftc] Add test case for crash triggered in swift::lookupVisibleDecls(…)

### DIFF
--- a/validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift
+++ b/validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift
@@ -1,0 +1,12 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+{
+var:A.a
+class A:A{let a=T


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/LookupVisibleDecls.cpp:525: void lookupVisibleMemberDeclsImpl(swift::Type, swift::VisibleDeclConsumer &, const swift::DeclContext *, (anonymous namespace)::LookupState, swift::DeclVisibilityKind, swift::LazyResolver *, VisitedSet &): Assertion `BaseTy.getPointer() != CurClass->getSuperclass().getPointer() && "type is its own superclass"' failed.
10 swift           0x00000000010d5466 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1174
11 swift           0x0000000000ede784 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
12 swift           0x0000000000e88878 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3864
14 swift           0x0000000001052c13 swift::Expr::walk(swift::ASTWalker&) + 19
15 swift           0x0000000000e89097 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 119
16 swift           0x0000000000e8fa52 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
17 swift           0x0000000000e90ba7 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
18 swift           0x0000000000e90dbb swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
20 swift           0x0000000000e9d4f9 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 4153
21 swift           0x00000000010f57bc swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2652
22 swift           0x0000000000ede077 swift::TypeChecker::lookupMemberType(swift::DeclContext*, swift::Type, swift::Identifier, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 295
24 swift           0x0000000000f0e50e swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
26 swift           0x0000000000f0f514 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
27 swift           0x0000000000f0e400 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
28 swift           0x0000000000ee1167 swift::TypeChecker::typeCheckPattern(swift::Pattern*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*) + 967
31 swift           0x0000000000ea1e46 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
34 swift           0x0000000000f08504 swift::TypeChecker::typeCheckClosureBody(swift::ClosureExpr*) + 244
35 swift           0x0000000000f3336c swift::constraints::ConstraintSystem::applySolution(swift::constraints::Solution&, swift::Expr*, swift::Type, bool, bool, bool) + 876
36 swift           0x0000000000e8faf1 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 769
38 swift           0x0000000000f08646 swift::TypeChecker::typeCheckTopLevelCodeDecl(swift::TopLevelCodeDecl*) + 134
39 swift           0x0000000000ec480d swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1133
40 swift           0x0000000000c58ed9 swift::CompilerInstance::performSema() + 3289
42 swift           0x00000000007d739f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
43 swift           0x00000000007a33b8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28306-swift-lookupvisibledecls-4e975d.o
1.  While type-checking expression at [validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift:10:1 - line:12:17] RangeText="{
2.  While type-checking declaration 0x5b54828 at validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift:11:1
3.  While resolving type A.a at [validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift:11:5 - line:11:7] RangeText="A.a"
4.  While type-checking expression at [validation-test/compiler_crashers/28306-swift-lookupvisibledecls.swift:12:17 - line:12:17] RangeText="T"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
