### PR TITLE
Relax verifier check for InitBlockStorageHeader instructions.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2809,18 +2809,8 @@ public:
             invokeTy->getExtInfo().isPseudogeneric(),
             "invoke function must not take reified generic parameters");
     
-    if (auto sig = invokeTy->getGenericSignature()) {
-      require(sig->getGenericParams().size() ==
-                IBSHI->getSubstitutions().size(),
-              "instruction must provide substitutions matching invoke "
-              "function");
-      invokeTy = invokeTy->substGenericArgs(F.getModule(), M,
-                                            IBSHI->getSubstitutions());
-    } else {
-      require(IBSHI->getSubstitutions().empty(),
-              "instruction must not provide substitutions for non-polymorphic "
-              "invoke fn");
-    }
+    invokeTy = checkApplySubstitutions(IBSHI->getSubstitutions(),
+                                    SILType::getPrimitiveObjectType(invokeTy));
     
     auto storageParam = invokeTy->getParameters()[0];
     require(storageParam.getConvention() ==

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -41,7 +41,7 @@ public func genericPropertyOnAnyObject(o: AnyObject, b: Bool) -> AnyObject?? {
 // CHECK:         dynamic_method_br %4 : $@opened([[TAG:.*]]) AnyObject, #GenericClass.propertyThing!getter.1.foreign, bb1
 // CHECK:       bb1({{%.*}} : $@convention(objc_method) @pseudogeneric (@opened([[TAG]]) AnyObject) -> @autoreleased Optional<AnyObject>):
 
-protocol ThingHolder {
+public protocol ThingHolder {
   associatedtype Thing
 
   init!(thing: Thing!)
@@ -56,16 +56,20 @@ protocol ThingHolder {
 
 extension GenericClass: ThingHolder {}
 
-public func genericBlockBridging<T: AnyObject>(x: GenericClass<T>) {
+public protocol Ansible: class {
+  associatedtype Anser: ThingHolder
+}
+
+public func genericBlockBridging<T: Ansible>(x: GenericClass<T>) {
   let block = x.blockForPerformingOnThings()
   x.performBlock(onThings: block)
 }
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic20genericBlockBridging
-// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_TTRGRxs9AnyObjectrXFdCb_dx_ax_XFo_ox_ox_
-// CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T>
-// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_TTRGRxs9AnyObjectrXFo_ox_ox_XFdCb_dx_ax_
-// CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T>
+// CHECK:         [[BLOCK_TO_FUNC:%.*]] = function_ref @_TTRGRxs9AnyObjectx21objc_imported_generic7AnsiblerXFdCb_dx_ax_XFo_ox_ox_
+// CHECK:         partial_apply [[BLOCK_TO_FUNC]]<T, {{.*}}>
+// CHECK:         [[FUNC_TO_BLOCK:%.*]] = function_ref @_TTRGRxs9AnyObjectx21objc_imported_generic7AnsiblerXFo_ox_ox_XFdCb_dx_ax_
+// CHECK:         init_block_storage_header {{.*}} invoke [[FUNC_TO_BLOCK]]<T,{{.*}}>
 
 // CHECK-LABEL: sil @_TF21objc_imported_generic20arraysOfGenericParam
 public func arraysOfGenericParam<T: AnyObject>(y: Array<T>) {


### PR DESCRIPTION
Correctly handle secondary substitutions using the existing verification logic for apply instructions. Fixes rdar://problem/26623854.
