### PR TITLE
build-script: allow non-zero exit codes from 'xcodebuild -version -sdk'

### DIFF
--- a/utils/swift_build_support/swift_build_support/debug.py
+++ b/utils/swift_build_support/swift_build_support/debug.py
@@ -29,8 +29,12 @@ def print_xcodebuild_versions(file=sys.stdout):
     """
     version = shell.capture(
         ['xcodebuild', '-version'], dry_run=False, echo=False).rstrip()
+    # Allow non-zero exit codes.  Under certain obscure circumstances
+    # xcodebuild can exit with an non-zero exit code even when the SDK is
+    # usable.
     sdks = shell.capture(
-        ['xcodebuild', '-version', '-sdk'], dry_run=False, echo=False).rstrip()
+        ['xcodebuild', '-version', '-sdk'], dry_run=False, echo=False,
+        allow_non_zero_exit=True).rstrip()
     fmt = """\
 {version}
 

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -92,7 +92,7 @@ def call(command, stderr=None, env=None, dry_run=None, echo=True):
 
 
 def capture(command, stderr=None, env=None, dry_run=None, echo=True,
-            optional=False):
+            optional=False, allow_non_zero_exit=False):
     """
     capture(command, ...) -> str
 
@@ -114,6 +114,8 @@ def capture(command, stderr=None, env=None, dry_run=None, echo=True,
         # Coerce to `str` hack. not py3 `byte`, not py2 `unicode`.
         return str(out.decode())
     except subprocess.CalledProcessError as e:
+        if allow_non_zero_exit:
+            return e.output
         if optional:
             return None
         diagnostics.fatal(

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -71,6 +71,10 @@ class ShellTestCase(unittest.TestCase):
 
         self.assertIsNone(shell.capture(["false"], optional=True))
 
+        self.assertEqual(
+            shell.capture(["sh", "-c", "echo foo && false"],
+                          allow_non_zero_exit=True), "foo\n")
+
         with self.assertRaises(SystemExit):
             shell.capture(["**not-a-command**"], optional=True)
 


### PR DESCRIPTION
Under certain obscure circumstances (incomplete SDKs), xcodebuild can
successfully work with the SDK and print its version number, but will
still exit with a non-zero code.  This change works around the issue by
ignoring the exit code.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
