### PR TITLE
Fix Float/Double .nextUp/.nextDown on arm(v7).

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -484,6 +484,13 @@ extension ${Self}: BinaryFloatingPoint {
         exponentBitPattern: exponentBitPattern + 1,
         significandBitPattern: 0)
     }
+#if arch(arm)
+    // On arm, subnormals are skipped.
+    if exponentBitPattern == 0 {
+      _sanityCheck(self < .leastNonzeroMagnitude, "subnormal out of range")
+      return .leastNonzeroMagnitude
+    }
+#endif
     return ${Self}(sign: .plus,
       exponentBitPattern: exponentBitPattern,
       significandBitPattern: significandBitPattern + 1)


### PR DESCRIPTION
On armv7, leastNonzeroMagnitude is defined to be leastNormalMagnitude.
This seems wrong to me from a language point of view, because it's
possible to have a nonzero float that compares less than the leastNonzero float.
However, it must have been done to gloss over hardware rounding errors.
This is not a problem on arm64.

As a result, nextUp/Down methods were not self-consistent. I fixed
this by skipping over subnormal representations, following the
precedent set by leastNonZeroMagnitude.

This fixes the FloatingPoint floatNextUpDownTests on armv7.
