### PR TITLE
[stdlib] Better testing for floating point types

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -143,6 +143,13 @@ public func expectEqual<T : Equatable, U : Equatable>(
   expectEqual(expected.1, actual.1, ${trace}, showFrame: false) {$0 == $1}
 }
 
+public func expectEqual<T : Equatable, U : Equatable, V : Equatable>(
+  _ expected: (T, U, V), _ actual: (T, U, V), ${TRACE}) {
+  expectEqual(expected.0, actual.0, ${trace}, showFrame: false) {$0 == $1}
+  expectEqual(expected.1, actual.1, ${trace}, showFrame: false) {$0 == $1}
+  expectEqual(expected.2, actual.2, ${trace}, showFrame: false) {$0 == $1}
+}
+
 public func expectationFailure(
   _ reason: String,
   trace message: String,

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -34,8 +34,6 @@ builtinIntLiteralBits = 2048
 # Mapping from float bits to significand bits
 explicitSignificandBits = { 32:24, 64:53, 80:64 }
 
-cFunctionSuffix = { 32:'f', 64:'', 80:'l' }
-
 def allInts():
     for bits in allIntBits:
         for signed in False, True:

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -19,7 +19,7 @@ struct Float80Bits : Equatable, CustomStringConvertible {
   }
 
   var description: String {
-    return "(\(String(signAndExponent, radix: 16)) \(String(significand, radix: 16))))"
+    return "(\(String(signAndExponent, radix: 16)) \(String(significand, radix: 16)))"
   }
 }
 

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -209,10 +209,10 @@ let floatNextUpDownTests: [(Float, Float)] = [
 FloatingPoint.test("Float.nextUp, .nextDown")
   .forEach(in: floatNextUpDownTests) {
   (prev, succ) in
-  expectEqual(succ.bitPattern, prev.nextUp.bitPattern)
-  expectEqual(prev.bitPattern, succ.nextDown.bitPattern)
-  expectEqual((-succ).bitPattern, (-prev).nextDown.bitPattern)
-  expectEqual((-prev).bitPattern, (-succ).nextUp.bitPattern)  
+  expectBitwiseEqual(succ, prev.nextUp)
+  expectBitwiseEqual(prev, succ.nextDown)
+  expectBitwiseEqual(-succ, (-prev).nextDown)
+  expectBitwiseEqual(-prev, (-succ).nextUp)
 }
 
 let doubleNextUpDownTests: [(Double, Double)] = [
@@ -227,10 +227,10 @@ let doubleNextUpDownTests: [(Double, Double)] = [
 FloatingPoint.test("Double.nextUp, .nextDown")
   .forEach(in: doubleNextUpDownTests) {
   (prev, succ) in
-  expectEqual(succ.bitPattern, prev.nextUp.bitPattern)
-  expectEqual(prev.bitPattern, succ.nextDown.bitPattern)
-  expectEqual((-succ).bitPattern, (-prev).nextDown.bitPattern)
-  expectEqual((-prev).bitPattern, (-succ).nextUp.bitPattern)  
+  expectBitwiseEqual(succ, prev.nextUp)
+  expectBitwiseEqual(prev, succ.nextDown)
+  expectBitwiseEqual(-succ, (-prev).nextDown)
+  expectBitwiseEqual(-prev, (-succ).nextUp)
 }
 
 #if arch(i386) || arch(x86_64)

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -3,9 +3,12 @@
 // RUN: %S/../../utils/line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
+%{
+from gyb_stdlib_unittest_support import TRACE, stackTrace, trace
+}%
+
 import Swift
 import StdlibUnittest
-
 
 #if arch(i386) || arch(x86_64)
 
@@ -50,6 +53,29 @@ extension Float80 {
 }
 
 #endif
+
+% for (FloatTy, BitPatternTy) in [
+%   ('Float', 'UInt32'),
+%   ('Double', 'UInt64'),
+%   ('Float80', 'Float80Bits')
+% ]:
+%   if FloatTy == 'Float80':
+#if arch(i386) || arch(x86_64)
+%   end
+func expectBitwiseEqual(
+  _ expected: ${FloatTy}, _ actual: ${FloatTy}, ${TRACE}
+) {
+  expectEqual(expected.bitPattern, actual.bitPattern, ${trace})
+}
+func expectBitwiseEqual(
+  bitPattern expected: ${BitPatternTy}, _ actual: ${FloatTy}, ${TRACE}
+) {
+  expectBitwiseEqual(${FloatTy}(bitPattern: expected), actual, ${trace})
+}
+%   if FloatTy == 'Float80':
+#endif
+%   end
+% end
 
 var FloatingPoint = TestSuite("FloatingPoint")
 

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -200,10 +200,9 @@ FloatingPoint.test("Double/HashValueZero") {
 let floatNextUpDownTests: [(Float, Float)] = [
   (.nan, .nan),
   (.greatestFiniteMagnitude, .infinity),
-  (-.infinity, -.greatestFiniteMagnitude),
-  (0x1.fffffep-1, 1.0), (1.0, 0x1.000002p+0),
-  (-0x1p-149, -0.0), (0.0, 0x1p-149),
-  (0x1.effffep-1, 0.96875), (0.96875, 0x1.f00002p-1),
+  (0x1.ffff_fe__p-1, 1.0), (1.0, 0x1.0000_02__p+0),
+  (0.0, .leastNonzeroMagnitude),
+  (0x1.efff_fe__p-1, 0x1.fp-1), (0x1.fp-1, 0x1.f000_02__p-1),
 ]
 
 FloatingPoint.test("Float.nextUp, .nextDown")
@@ -218,10 +217,9 @@ FloatingPoint.test("Float.nextUp, .nextDown")
 let doubleNextUpDownTests: [(Double, Double)] = [
   (.nan, .nan),
   (.greatestFiniteMagnitude, .infinity),
-  (-.infinity, -.greatestFiniteMagnitude),
-  (0x1.fffffffffffffp-1, 1.0), (1.0, 0x1.0000000000001p+0),
-  (-0x1p-1074, -0.0), (0.0, 0x1p-1074),
-  (0x1.effffffffffffp-1, 0.96875), (0.96875, 0x1.f000000000001p-1),
+  (0x1.ffff_ffff_ffff_fp-1, 1.0), (1.0, 0x1.0000_0000_0000_1p+0),
+  (0.0, .leastNonzeroMagnitude),
+  (0x1.efff_ffff_ffff_fp-1, 0x1.fp-1), (0x1.fp-1, 0x1.f000_0000_0000_1p-1),
 ]
 
 FloatingPoint.test("Double.nextUp, .nextDown")

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -91,6 +91,29 @@ FloatingPoint.test("Float/IntegerLiteralConvertible") {
   expectEqual(negativeOne(), -1.0 as Float)
 }
 
+FloatingPoint.test("Float/FloatLiteralConvertible") {
+  let x: Float = -0.0
+  expectBitwiseEqual(bitPattern: 0x8000_0000, x)
+}
+
+FloatingPoint.test("Float/staticProperties") {
+  typealias Ty = Float
+  // From the FloatingPoint protocol.
+  expectEqual(2, Ty.radix)
+  expectBitwiseEqual(bitPattern: 0x7fc0_0000, Ty.nan)
+  expectBitwiseEqual(bitPattern: 0x7fa0_0000, Ty.signalingNaN)
+  expectBitwiseEqual(bitPattern: 0x7f80_0000, Ty.infinity)
+  expectBitwiseEqual(0x1.ffff_fe__p127, Ty.greatestFiniteMagnitude)
+  expectBitwiseEqual(0x1.921f_b6__p1, Ty.pi)
+  expectBitwiseEqual(0x1.0p-23, Ty.ulpOfOne)
+  expectBitwiseEqual(0x1.0p-126, Ty.leastNormalMagnitude)
+  expectBitwiseEqual(0x1.0p-149, Ty.leastNonzeroMagnitude)
+
+  // From the BinaryFloatingPoint protocol.
+  expectEqual(8, Ty.exponentBitCount)
+  expectEqual(23, Ty.significandBitCount)
+}
+
 // Tests the float and int conversions work correctly. Each case is special.
 FloatingPoint.test("Float/UInt8") {
   expectEqual(UInt8.min, UInt8(Float(UInt8.min)))
@@ -139,6 +162,29 @@ FloatingPoint.test("Float/Int64") {
 FloatingPoint.test("Double/IntegerLiteralConvertible") {
   expectEqual(positiveOne(),  1.0 as Double)
   expectEqual(negativeOne(), -1.0 as Double)
+}
+
+FloatingPoint.test("Double/FloatLiteralConvertible") {
+  let x: Double = -0.0
+  expectBitwiseEqual(bitPattern: 0x8000_0000_0000_0000, x)
+}
+
+FloatingPoint.test("Double/staticProperties") {
+  typealias Ty = Double
+  // From the FloatingPoint protocol.
+  expectEqual(2, Ty.radix)
+  expectBitwiseEqual(bitPattern: 0x7ff8_0000_0000_0000, Ty.nan)
+  expectBitwiseEqual(bitPattern: 0x7ff4_0000_0000_0000, Ty.signalingNaN)
+  expectBitwiseEqual(bitPattern: 0x7ff0_0000_0000_0000, Ty.infinity)
+  expectBitwiseEqual(0x1.ffff_ffff_ffff_f__p1023, Ty.greatestFiniteMagnitude)
+  expectBitwiseEqual(0x1.921f_b544_42d1_8__p1, Ty.pi)
+  expectBitwiseEqual(0x1.0p-52, Ty.ulpOfOne)
+  expectBitwiseEqual(0x1.0p-1022, Ty.leastNormalMagnitude)
+  expectBitwiseEqual(0x1.0p-1074, Ty.leastNonzeroMagnitude)
+
+  // From the BinaryFloatingPoint protocol.
+  expectEqual(11, Ty.exponentBitCount)
+  expectEqual(52, Ty.significandBitCount)
 }
 
 FloatingPoint.test("Double/UInt8") {
@@ -236,6 +282,29 @@ FloatingPoint.test("Double.nextUp, .nextDown")
 FloatingPoint.test("Float80/IntegerLiteralConvertible") {
   expectEqual(positiveOne(),  1.0 as Float80)
   expectEqual(negativeOne(), -1.0 as Float80)
+}
+
+FloatingPoint.test("Float80/FloatLiteralConvertible") {
+  let x: Float80 = -0.0
+  expectBitwiseEqual(bitPattern: Float80Bits(0x8000, 0), x)
+}
+
+FloatingPoint.test("Float80/staticProperties") {
+  typealias Ty = Double
+  // From the FloatingPoint protocol.
+  expectEqual(2, Ty.radix)
+  expectBitwiseEqual(bitPattern: 0x7ff8_0000_0000_0000, Ty.nan)
+  expectBitwiseEqual(bitPattern: 0x7ff4_0000_0000_0000, Ty.signalingNaN)
+  expectBitwiseEqual(bitPattern: 0x7ff0_0000_0000_0000, Ty.infinity)
+  expectBitwiseEqual(0x1.ffff_ffff_ffff_f__p1023, Ty.greatestFiniteMagnitude)
+  expectBitwiseEqual(0x1.921f_b544_42d1_8__p1, Ty.pi)
+  expectBitwiseEqual(0x1.0p-52, Ty.ulpOfOne)
+  expectBitwiseEqual(0x1.0p-1022, Ty.leastNormalMagnitude)
+  expectBitwiseEqual(0x1.0p-1074, Ty.leastNonzeroMagnitude)
+
+  // From the BinaryFloatingPoint protocol.
+  expectEqual(11, Ty.exponentBitCount)
+  expectEqual(52, Ty.significandBitCount)
 }
 
 FloatingPoint.test("Float80/HashValueZero") {

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -314,6 +314,25 @@ FloatingPoint.test("Float80/HashValueZero") {
   expectEqual(zero.hashValue, negativeZero.hashValue)
 }
 
+let float80NextUpDownTests: [(Float80, Float80)] = [
+  (.nan, .nan),
+  (.greatestFiniteMagnitude, .infinity),
+  (0x1.ffff_ffff_ffff_fffep-1, 1.0), (1.0, 0x1.0000_0000_0000_0002p+0),
+  (0.0, .leastNonzeroMagnitude),
+  (0x1.efff_ffff_ffff_fffep-1, 0x1.fp-1),
+  (0x1.fp-1, 0x1.f000_0000_0000_0002p-1),
+]
+
+FloatingPoint.test("Float80.nextUp, .nextDown")
+  .forEach(in: float80NextUpDownTests) {
+  (prev, succ) in
+
+  expectBitwiseEqual(succ, prev.nextUp)
+  expectBitwiseEqual(prev, succ.nextDown)
+  expectBitwiseEqual(-succ, (-prev).nextDown)
+  expectBitwiseEqual(-prev, (-succ).nextUp)
+}
+
 #endif
 
 % for FloatSelf in ['Float32', 'Float64']:

--- a/validation-test/StdlibUnittest/Assertions.swift.gyb
+++ b/validation-test/StdlibUnittest/Assertions.swift.gyb
@@ -162,5 +162,67 @@ AssertionsTestSuite.test("expectEqualsUnordered(Range<T>, [T])") {
 % end
 }
 
+AssertionsTestSuite.test("expectEqual<T : Equatable>") {
+  let _0 = MinimalEquatableValue(0)
+  let _1 = MinimalEquatableValue(1)
+
+  expectEqual(_0, _0)
+  expectEqual(_1, _1)
+  expectFailure {
+    expectEqual(_0, _1)
+    expectEqual(_1, _0)
+  }
+}
+
+AssertionsTestSuite.test("expectEqual<T : Equatable, U : Equatable>") {
+  let _0 = MinimalEquatableValue(0)
+  let _1 = MinimalEquatableValue(1)
+
+  for a in [_0, _1] {
+    for b in [_0, _1] {
+      for c in [_0, _1] {
+        for d in [_0, _1] {
+          let lhs = (a, b)
+          let rhs = (c, d)
+          if lhs == rhs {
+            expectEqual(lhs, rhs)
+          } else {
+            expectFailure {
+              expectEqual(lhs, rhs)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+AssertionsTestSuite.test("expectEqual<T : Equatable, U : Equatable, V : Equatable>") {
+  let _0 = MinimalEquatableValue(0)
+  let _1 = MinimalEquatableValue(1)
+
+  for a in [_0, _1] {
+    for b in [_0, _1] {
+      for c in [_0, _1] {
+        for d in [_0, _1] {
+          for e in [_0, _1] {
+            for f in [_0, _1] {
+              let lhs = (a, b, c)
+              let rhs = (d, e, f)
+              if lhs == rhs {
+                expectEqual(lhs, rhs)
+              } else {
+                expectFailure {
+                  expectEqual(lhs, rhs)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 runAllTests()
 


### PR DESCRIPTION
This change improves the tests for floating point types.  We still have a long way to go though.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
