### PR TITLE
[build-script] Introduce "concat" argument action

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -955,7 +955,7 @@ details of the setups of other systems or automated environments.""")
         help="Pass through extra options to CMake in the form of comma "
              "separated options '-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp'. Can be "
              "called multiple times to add multiple such options.",
-        action="append",
+        action=arguments.action.concat,
         type=arguments.type.shell_split,
         default=[])
 
@@ -1436,13 +1436,10 @@ details of the setups of other systems or automated environments.""")
 
     # If we have extra_cmake_options, combine all of them together and then add
     # them as one command.
-    # Note that args.extra_cmake_options is a list of lists of options.
     if args.extra_cmake_options:
         build_script_impl_args += [
             "--extra-cmake-options=%s" % ' '.join(
-                pipes.quote(opt)
-                for options in args.extra_cmake_options
-                for opt in options)
+                pipes.quote(opt) for opt in args.extra_cmake_options)
         ]
 
     build_script_impl_args += args.build_script_impl_args

--- a/utils/swift_build_support/swift_build_support/arguments.py
+++ b/utils/swift_build_support/swift_build_support/arguments.py
@@ -128,3 +128,16 @@ class _UnavailableAction(argparse.Action):
         parser.error('unknown argument: %s' % arg)
 
 _register(action, 'unavailable', _UnavailableAction)
+
+
+class _ConcatAction(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        old_val = getattr(namespace, self.dest)
+        if old_val is None:
+            val = values
+        else:
+            val = old_val + values
+        setattr(namespace, self.dest, val)
+
+_register(action, 'concat', _ConcatAction)

--- a/utils/swift_build_support/tests/test_arguments.py
+++ b/utils/swift_build_support/tests/test_arguments.py
@@ -134,3 +134,44 @@ class ArgumentsActionTestCase(unittest.TestCase):
         self.assertIn('--never-ever', stderr.getvalue())
 
         sys.stderr = orig_stderr
+
+    def test_concat(self):
+        # Has default
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--str-opt",
+            action=argaction.concat,
+            default="def")
+        parser.add_argument(
+            "--list-opt",
+            action=argaction.concat,
+            type=argtype.shell_split,
+            default=["def"])
+
+        self.assertEqual(
+            parser.parse_args(['--str-opt', '12', '--str-opt=42']),
+            argparse.Namespace(str_opt="def1242", list_opt=["def"]))
+
+        self.assertEqual(
+            parser.parse_args(['--list-opt', 'foo 12', '--list-opt=bar 42']),
+            argparse.Namespace(
+                str_opt="def", list_opt=["def", "foo", "12", "bar", "42"]))
+
+        # Default less
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--str-opt",
+            action=argaction.concat)
+        parser.add_argument(
+            "--list-opt",
+            action=argaction.concat,
+            type=argtype.shell_split)
+
+        self.assertEqual(
+            parser.parse_args(['--str-opt', '12', '--str-opt=42']),
+            argparse.Namespace(str_opt="1242", list_opt=None))
+
+        self.assertEqual(
+            parser.parse_args(['--list-opt', 'foo 12', '--list-opt=bar 42']),
+            argparse.Namespace(
+                str_opt=None, list_opt=["foo", "12", "bar", "42"]))


### PR DESCRIPTION
#### What's in this pull request?

Introduce `concat` in `swift_build_support.arguments.action` module.
This simplifies list like arguments processing: avoid unnecessary "list of list".

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
