### PR TITLE
[Sema] Make typealiases in protocols available for nested type lookup.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1340,6 +1340,9 @@ NOTE(optional_req_near_match_accessibility,none,
 // Protocols and existentials
 ERROR(assoc_type_outside_of_protocol,none,
       "cannot use associated type %0 outside of its protocol", (Identifier))
+ERROR(typealias_to_assoc_type_outside_of_protocol,none,
+      "cannot use typealias %0 of associated type %1 outside of its protocol",
+      (Identifier, TypeLoc))
 
 ERROR(circular_protocol_def,none,
       "circular protocol inheritance %0", (StringRef))

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -362,17 +362,22 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       }
     }
 
-    // Ignore typealiases found in protocol members.
-    if (auto alias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-      auto aliasParent = alias->getParent();
-      if (aliasParent != dc && isa<ProtocolDecl>(aliasParent))
-        continue;
-    }
-
     // Substitute the base into the member's type.
     if (Type memberType = substMemberTypeWithBase(dc->getParentModule(),
                                                   typeDecl, type,
                                                   /*isTypeReference=*/true)) {
+
+      // Similar to the associated type case, ignore typealiases containing
+      // associated types when looking into a non-protocol.
+      if (auto alias = dyn_cast<TypeAliasDecl>(typeDecl)) {
+        auto parentProtocol = alias->getDeclContext()->
+          getAsProtocolOrProtocolExtensionContext();
+        if (parentProtocol && memberType->hasTypeParameter() &&
+            !type->is<ArchetypeType>() && !type->isExistentialType()) {
+          continue;
+        }
+      }
+
       // If we haven't seen this type result yet, add it to the result set.
       if (types.insert(memberType->getCanonicalType()).second)
         result.Results.push_back({typeDecl, memberType});

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1110,12 +1110,21 @@ static Type resolveNestedIdentTypeComponent(
     member = memberTypes.back().first;
   }
 
-  if (parentTy->isExistentialType()) {
+  if (parentTy->isExistentialType() && isa<AssociatedTypeDecl>(member)) {
     if (diagnoseErrors)
       TC.diagnose(comp->getIdLoc(), diag::assoc_type_outside_of_protocol,
                   comp->getIdentifier());
 
     return ErrorType::get(TC.Context);
+  }
+  if (auto alias = dyn_cast<TypeAliasDecl>(member)) {
+    if (parentTy->isExistentialType() && memberType->hasTypeParameter()) {
+      if (diagnoseErrors)
+        TC.diagnose(comp->getIdLoc(), diag::typealias_to_assoc_type_outside_of_protocol,
+                    comp->getIdentifier(), alias->getUnderlyingTypeLoc());
+
+      return ErrorType::get(TC.Context);
+    }
   }
 
   // If there are generic arguments, apply them now.
@@ -3208,10 +3217,18 @@ public:
   }
 
   bool walkToTypeReprPre(TypeRepr *T) {
+    if (T->isInvalid())
+      return false;
+    if (auto compound = dyn_cast<CompoundIdentTypeRepr>(T)) {
+      // Only visit the last component to check, because nested typealiases in
+      // existentials are okay.
+      visit(compound->getComponentRange().back());
+      return false;
+    }
     visit(T);
     return true;
   }
-    
+
   std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) {
     if (recurseIntoSubstatements) {
       return { true, S };

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -246,4 +246,17 @@ protocol P4 {
   func getSelf() -> X
 }
 
+// Availability of typealiases in protocols for nested type lookup
+protocol P5 {
+  associatedtype A
+  typealias T1 = Int
+  typealias T2 = A
+  var a: T2 { get }
+}
+
+struct T5 : P5 {
+  var a: P5.T1 // OK
+  var v2: P5.T2 // expected-error {{cannot use typealias 'T2' of associated type 'A' outside of its protocol}}
+}
+
 


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

```
protocol TestProto {
  typealias X = Int
}

struct Foo : TestProto {
  let a : X
}
```

This involved a couple complications, mostly making the distinction between typealiases whose definitions contain associated types and those which don't:
- Only check final component of compound idents for existential-typeness, so that it is legal to refer to a nested typealias inside the existential.
- New diagnosis for trying to use typealias which is an alias for an associated type outside of the defining protocol.
- Add check on member lookup to omit typealiases to assoc types, similar to existing treatment of assoc types.
- Added test.

This PR arises out of the conversation in this pull https://github.com/apple/swift-evolution/pull/321 where @lattner was surprised that this didn't already work (I was surprised too - oops.). 

Also note that all of this is currently disabled by default and enabled by the -enable-protocol-typealiases flag (done in https://github.com/apple/swift/pull/2803).
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
