### PR TITLE
[gardening] Adding note clarifying status of Concurrency.rst

### DIFF
--- a/docs/proposals/Concurrency.rst
+++ b/docs/proposals/Concurrency.rst
@@ -3,6 +3,8 @@
 .. @raise litre.TestsAreMissing
 .. ConcurrencyModel:
 
+*Note*: This document is **not an accepted Swift proposal**. It does not describe Swift's concurrency mechanisms as they currently exist, nor is it a roadmap for the addition of concurrency mechanisms in future versions of Swift.
+
 Swift Thread Safety
 ===================
 


### PR DESCRIPTION
@lattner 

Given that this document keeps on showing up on the evolution list and blog posts, maybe a brief disclaimer at the top might be in order?
