### PR TITLE
IRGen: address a TODO in the type metadata emission

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1989,11 +1989,16 @@ llvm::Value *IRGenFunction::emitTypeLayoutRef(SILType type) {
 
 void IRGenModule::setTrueConstGlobal(llvm::GlobalVariable *var) {
   switch (TargetInfo.OutputObjectFormat) {
+  case llvm::Triple::UnknownObjectFormat:
+    llvm_unreachable("unknown object format");
   case llvm::Triple::MachO:
-    var->setSection("__TEXT, __const");
+    var->setSection("__TEXT,__const");
     break;
-  // TODO: ELF?
-  default:
+  case llvm::Triple::ELF:
+    var->setSection(".rodata");
+    break;
+  case llvm::Triple::COFF:
+    var->setSection(".rdata");
     break;
   }
 }

--- a/test/IRGen/nominal-type-section.swift
+++ b/test/IRGen/nominal-type-section.swift
@@ -1,0 +1,11 @@
+// RUN: %swift -target x86_64-apple-macosx10.10 -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | FileCheck %s -check-prefix CHECK-MACHO
+// RUN: %swift -target x86_64-unknown-linux-gnu -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | FileCheck %s -check-prefix CHECK-ELF
+// RUN: %swift -target x86_64-unknown-windows-itanium -emit-ir -parse-stdlib -primary-file %s -module-name main -o - | FileCheck %s -check-prefix CHECK-COFF
+
+// CHECK-MACHO: @_TMnV4main1s = constant {{.*}}, section "__TEXT,__const"
+// CHECK-ELF: @_TMnV4main1s = {{.*}}constant {{.*}}, section ".rodata"
+// CHECK-COFF: @_TMnV4main1s = {{.*}}constant {{.*}}, section ".rdata"
+
+public struct s {
+}
+


### PR DESCRIPTION
Mark the explicit section for the nominal type metadata being emitted.  This is
constant data (post-relocation).  Map this to __TEXT,__const on MachO, .rodata
on ELF and .rdata on COFF.  Add the cases for COFF and ELF, and change the
switch to be covered.

Try this again, hopefully all the buildbots are now using gold after the last great build script refactoring.  Gold is now the default linker (on ELFish targets).
