### PR TITLE
Follow-up on the raw-representable casting fixits, produce the fixit for optional destination types as well.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3158,6 +3158,9 @@ static void tryRawRepresentableFixIts(InFlightDiagnostic &diag,
                                       Type toType,
                                       KnownProtocolKind kind,
                                       Expr *expr) {
+  // The following fixes apply for optional destination types as well.
+  toType = toType->lookThroughAllAnyOptionalTypes();
+
   if (isLiteralConvertibleType(fromType, kind, CS)) {
     if (auto rawTy = isRawRepresentable(toType, kind, CS)) {
       // Produce before/after strings like 'Result(rawValue: RawType(<expr>))'
@@ -3821,9 +3824,7 @@ static bool diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI,
       candidate.getDecl() && isa<ConstructorDecl>(candidate.getDecl()) &&
       candidate.level == 1) {
     CallArgParam &arg = args[0];
-    auto resTy = candidate.getResultType();
-    if (auto unwrappedOpt = resTy->getOptionalObjectType())
-      resTy = unwrappedOpt;
+    auto resTy = candidate.getResultType()->lookThroughAllAnyOptionalTypes();
     auto rawTy = isRawRepresentable(resTy, CCI.CS);
     if (rawTy && resTy->getCanonicalType() == arg.Ty.getCanonicalTypeOrNull()) {
       auto getInnerExpr = [](Expr *E) -> Expr* {

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -36,6 +36,7 @@ struct MyEventMask2 : OptionSet {
   var rawValue: UInt64 { return 0 }
 }
 func sendIt(_: MyEventMask2) {}
+func sendItOpt(_: MyEventMask2?) {}
 func testMask1(a: Int) {
   sendIt(a)
 }
@@ -47,6 +48,9 @@ func testMask3(a: MyEventMask2) {
 }
 func testMask4(a: MyEventMask2) {
   testMask2(a: a)
+}
+func testMask5(a: Int) {
+  sendItOpt(a)
 }
 
 enum MyEnumType : UInt32 {

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -37,6 +37,7 @@ struct MyEventMask2 : OptionSet {
 }
 func sendIt(_: MyEventMask2) {}
 func sendItOpt(_: MyEventMask2?) {}
+func sendItOpt3(_: MyEventMask2???) {}
 func testMask1(a: Int) {
   sendIt(a)
 }
@@ -50,6 +51,9 @@ func testMask4(a: MyEventMask2) {
   testMask2(a: a)
 }
 func testMask5(a: Int) {
+  sendItOpt(a)
+}
+func testMask6(a: Int) {
   sendItOpt(a)
 }
 

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -36,6 +36,7 @@ struct MyEventMask2 : OptionSet {
   var rawValue: UInt64 { return 0 }
 }
 func sendIt(_: MyEventMask2) {}
+func sendItOpt(_: MyEventMask2?) {}
 func testMask1(a: Int) {
   sendIt(MyEventMask2(rawValue: UInt64(a)))
 }
@@ -47,6 +48,9 @@ func testMask3(a: MyEventMask2) {
 }
 func testMask4(a: MyEventMask2) {
   testMask2(a: a.rawValue)
+}
+func testMask5(a: Int) {
+  sendItOpt(MyEventMask2(rawValue: UInt64(a)))
 }
 
 enum MyEnumType : UInt32 {

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -37,6 +37,7 @@ struct MyEventMask2 : OptionSet {
 }
 func sendIt(_: MyEventMask2) {}
 func sendItOpt(_: MyEventMask2?) {}
+func sendItOpt3(_: MyEventMask2???) {}
 func testMask1(a: Int) {
   sendIt(MyEventMask2(rawValue: UInt64(a)))
 }
@@ -50,6 +51,9 @@ func testMask4(a: MyEventMask2) {
   testMask2(a: a.rawValue)
 }
 func testMask5(a: Int) {
+  sendItOpt(MyEventMask2(rawValue: UInt64(a)))
+}
+func testMask6(a: Int) {
   sendItOpt(MyEventMask2(rawValue: UInt64(a)))
 }
 


### PR DESCRIPTION
#### What's in this pull request?

Enhancement on the compiler fixits for adding casts to raw-representable types (from their raw values) to enable the fixits when the destination type is optional as well.

It was reviewed by Ben Langmuir
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26639218

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
