### PR TITLE
Fix FloatingPoint nextUp/Down on armv7.

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -464,6 +464,15 @@ extension ${Self}: BinaryFloatingPoint {
   public var nextUp: ${Self} {
     if isNaN { return self }
     if sign == .minus {
+#if arch(arm)
+      // On arm, subnormals are flushed to zero.
+      if (exponentBitPattern == 1 && significandBitPattern == 0) ||
+         (exponentBitPattern == 0 && significandBitPattern != 0) {
+        return ${Self}(sign: .minus,
+          exponentBitPattern: 0,
+          significandBitPattern: 0)
+      }
+#endif
       if significandBitPattern == 0 {
         if exponentBitPattern == 0 {
           return .leastNonzeroMagnitude
@@ -485,7 +494,6 @@ extension ${Self}: BinaryFloatingPoint {
 #if arch(arm)
     // On arm, subnormals are skipped.
     if exponentBitPattern == 0 {
-      _sanityCheck(self < .leastNonzeroMagnitude, "subnormal out of range")
       return .leastNonzeroMagnitude
     }
 #endif

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -107,7 +107,9 @@ FloatingPoint.test("Float/staticProperties") {
   expectBitwiseEqual(0x1.921f_b6__p1, Ty.pi)
   expectBitwiseEqual(0x1.0p-23, Ty.ulpOfOne)
   expectBitwiseEqual(0x1.0p-126, Ty.leastNormalMagnitude)
-#if !arch(arm)
+#if arch(arm)
+  expectBitwiseEqual(0x1.0p-126, Ty.leastNonzeroMagnitude)
+#else
   expectBitwiseEqual(0x1.0p-149, Ty.leastNonzeroMagnitude)
 #endif
 
@@ -182,7 +184,9 @@ FloatingPoint.test("Double/staticProperties") {
   expectBitwiseEqual(0x1.921f_b544_42d1_8__p1, Ty.pi)
   expectBitwiseEqual(0x1.0p-52, Ty.ulpOfOne)
   expectBitwiseEqual(0x1.0p-1022, Ty.leastNormalMagnitude)
-#if !arch(arm)
+#if arch(arm)
+  expectBitwiseEqual(0x1.0p-1022, Ty.leastNonzeroMagnitude)
+#else
   expectBitwiseEqual(0x1.0p-1074, Ty.leastNonzeroMagnitude)
 #endif
 

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -107,7 +107,9 @@ FloatingPoint.test("Float/staticProperties") {
   expectBitwiseEqual(0x1.921f_b6__p1, Ty.pi)
   expectBitwiseEqual(0x1.0p-23, Ty.ulpOfOne)
   expectBitwiseEqual(0x1.0p-126, Ty.leastNormalMagnitude)
+#if !arch(arm)
   expectBitwiseEqual(0x1.0p-149, Ty.leastNonzeroMagnitude)
+#endif
 
   // From the BinaryFloatingPoint protocol.
   expectEqual(8, Ty.exponentBitCount)
@@ -180,7 +182,9 @@ FloatingPoint.test("Double/staticProperties") {
   expectBitwiseEqual(0x1.921f_b544_42d1_8__p1, Ty.pi)
   expectBitwiseEqual(0x1.0p-52, Ty.ulpOfOne)
   expectBitwiseEqual(0x1.0p-1022, Ty.leastNormalMagnitude)
+#if !arch(arm)
   expectBitwiseEqual(0x1.0p-1074, Ty.leastNonzeroMagnitude)
+#endif
 
   // From the BinaryFloatingPoint protocol.
   expectEqual(11, Ty.exponentBitCount)
@@ -243,6 +247,24 @@ FloatingPoint.test("Double/HashValueZero") {
   expectEqual(zero.hashValue, negativeZero.hashValue)
 }
 
+#if arch(arm)
+% for FloatSelf in ['Float32', 'Float64']:
+func testSubNormalFlush(_ f: ${FloatSelf}) {
+  if !f.isSubnormal {
+    return
+  }
+  switch f.sign {
+  case .plus:
+    expectBitwiseEqual(.leastNonzeroMagnitude, f.nextUp)
+    expectBitwiseEqual(0.0, f.nextDown)
+  case .minus:
+    expectBitwiseEqual(-0.0, f.nextUp)
+    expectBitwiseEqual(-.leastNonzeroMagnitude, f.nextDown)
+  }
+}
+% end
+#endif
+
 let floatNextUpDownTests: [(Float, Float)] = [
   (.nan, .nan),
   (.greatestFiniteMagnitude, .infinity),
@@ -254,6 +276,13 @@ let floatNextUpDownTests: [(Float, Float)] = [
 FloatingPoint.test("Float.nextUp, .nextDown")
   .forEach(in: floatNextUpDownTests) {
   (prev, succ) in
+#if arch(arm)
+  if prev.isSubnormal || succ.isSubnormal {
+    testSubNormalFlush(prev)
+    testSubNormalFlush(succ)
+    return
+  }
+#endif
   expectBitwiseEqual(succ, prev.nextUp)
   expectBitwiseEqual(prev, succ.nextDown)
   expectBitwiseEqual(-succ, (-prev).nextDown)
@@ -271,6 +300,13 @@ let doubleNextUpDownTests: [(Double, Double)] = [
 FloatingPoint.test("Double.nextUp, .nextDown")
   .forEach(in: doubleNextUpDownTests) {
   (prev, succ) in
+#if arch(arm)
+  if prev.isSubnormal || succ.isSubnormal {
+    testSubNormalFlush(prev)
+    testSubNormalFlush(succ)
+    return
+  }
+#endif
   expectBitwiseEqual(succ, prev.nextUp)
   expectBitwiseEqual(prev, succ.nextDown)
   expectBitwiseEqual(-succ, (-prev).nextDown)


### PR DESCRIPTION
Rigorously implement flush-to-zero behavior.

This fixes several recent unit test failures on armv7 hardware.
