### PR TITLE
[fixits] Don't fixit-remove generic arguments on ModuleType

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -417,9 +417,14 @@ Type TypeChecker::applyGenericArguments(Type type, SourceLoc loc,
 
   auto unbound = type->getAs<UnboundGenericType>();
   if (!unbound) {
-    if (!type->is<ErrorType>())
-      diagnose(loc, diag::not_a_generic_type, type)
-          .fixItRemove(generic->getAngleBrackets());
+    if (!type->is<ErrorType>()) {
+      auto diag = diagnose(loc, diag::not_a_generic_type, type);
+
+      // Don't add fixit on module type; that isn't the right type regardless
+      // of whether it had generic arguments.
+      if (!type->is<ModuleType>())
+        diag.fixItRemove(generic->getAngleBrackets());
+    }
     generic->setInvalid();
     return type;
   }

--- a/test/FixCode/Inputs/module.modulemap
+++ b/test/FixCode/Inputs/module.modulemap
@@ -1,0 +1,1 @@
+module Empty {}

--- a/test/FixCode/fixits-apply.swift
+++ b/test/FixCode/fixits-apply.swift
@@ -1,4 +1,4 @@
-// RUN: not %swift -parse -target %target-triple %s -emit-fixits-path %t.remap
+// RUN: not %swift -parse -target %target-triple %s -emit-fixits-path %t.remap -I %S/Inputs
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 class Base {}
@@ -156,3 +156,6 @@ func evilCommas(s: String) {
   _ = true ? s[s.startIndex..<<#editorplaceholder#>] : ""
   _ = [s.startIndex..<<#editorplaceholder#>]
 }
+
+import Empty
+func testGenericSig(x: Empty<Int>) -> Empty<String> {}

--- a/test/FixCode/fixits-apply.swift.result
+++ b/test/FixCode/fixits-apply.swift.result
@@ -1,4 +1,4 @@
-// RUN: not %swift -parse -target %target-triple %s -emit-fixits-path %t.remap
+// RUN: not %swift -parse -target %target-triple %s -emit-fixits-path %t.remap -I %S/Inputs
 // RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
 
 class Base {}
@@ -159,3 +159,6 @@ func evilCommas(s: String) {
   _ = true ? s[s.startIndex..<<#editorplaceholder#>] : ""
   _ = [s.startIndex..<<#editorplaceholder#>]
 }
+
+import Empty
+func testGenericSig(x: Empty<Int>) -> Empty<String> {}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

Seeing Module<Args> is more likely to indicate some catastrophic
failure, for instance a missing type with the same name as the module,
than that we should remove the generic arguments.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/26639477

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
