### PR TITLE
[swift-3.0-preview-1-branch][stdlib] add an unavailable ClosedRange.clamp() function

### DIFF
--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -614,6 +614,24 @@ extension Range {
   }
 }
 
+extension ClosedRange {
+  @available(*, unavailable, message: "Call clamped(to:) and swap the argument and the receiver.  For example, x.clamp(y) becomes y.clamped(to: x) in Swift 3.")
+  public func clamp(
+    _ intervalToClamp: ClosedRange<Bound>
+  ) -> ClosedRange<Bound> {
+    Builtin.unreachable()
+  }
+}
+
+extension CountableClosedRange {
+  @available(*, unavailable, message: "Call clamped(to:) and swap the argument and the receiver.  For example, x.clamp(y) becomes y.clamped(to: x) in Swift 3.")
+  public func clamp(
+    _ intervalToClamp: CountableClosedRange<Bound>
+  ) -> CountableClosedRange<Bound> {
+    Builtin.unreachable()
+  }
+}
+
 @available(*, unavailable, message: "IntervalType has been removed in Swift 3. Use ranges instead.")
 public typealias IntervalType = Void
 


### PR DESCRIPTION
Explanation: add an unavailable ClosedRange.clamp() function to help users with a non-trivial migration that involves swapping the argument and the receiver.

Scope of the issue: migration of ClosedInterval code.

Risk: low.

Reviewed by: @benlangmuir.

Testing: manual.

rdar://problem/26642124

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
