### PR TITLE
CMake: move tricky code from CMake to Python

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -44,6 +44,9 @@ The testsuite is split into three subsets:
 
 * Long tests, which are marked with ``REQUIRES: long_test``.
 
+  Unlike other tests, every long test should also include either
+  ``REQUIRES: nonexecutable_test`` or ``REQUIRES: executable_test``.
+
 Running the LLVM lit-based testsuite
 ------------------------------------
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -203,26 +203,6 @@ if(PYTHONINTERP_FOUND)
         set(LIT_ARGS "${SWIFT_TEST_EXTRA_ARGS} ${LLVM_LIT_ARGS}")
         separate_arguments(LIT_ARGS)
 
-        if(test_mode STREQUAL "optimize_none")
-          # No special arguments required.
-        elseif(test_mode STREQUAL "optimize")
-          list(APPEND LIT_ARGS "--param" "run_only_tests=executable_tests")
-        elseif(test_mode STREQUAL "optimize_unchecked")
-          list(APPEND LIT_ARGS "--param" "run_only_tests=executable_tests")
-        elseif(test_mode STREQUAL "only_executable")
-          list(APPEND LIT_ARGS "--param" "run_only_tests=executable_tests")
-        elseif(test_mode STREQUAL "only_non_executable")
-          list(APPEND LIT_ARGS "--param" "run_only_tests=non_executable_tests")
-        else()
-          message(FATAL_ERROR "Unknown test mode: ${test_mode}")
-        endif()
-
-        set(test_mode_target_suffix "")
-        if(NOT test_mode STREQUAL "optimize_none")
-          list(APPEND LIT_ARGS "--param" "swift_test_mode=${test_mode}")
-          set(test_mode_target_suffix "-${test_mode}")
-        endif()
-
         if(NOT SWIFT_BUILD_STDLIB)
           list(APPEND LIT_ARGS
               "--param" "test_sdk_overlay_dir=${SWIFTLIB_DIR}/${SWIFT_SDK_${SDK}_LIB_SUBDIR}")
@@ -236,23 +216,6 @@ if(PYTHONINTERP_FOUND)
         endif()
 
         foreach(test_subset ${TEST_SUBSETS})
-          # We will add arguments specific for this subset to LIT_ARGS.  Copy
-          # the original value and restore it later.
-          set(LIT_ARGS_COPY "${LIT_ARGS}")
-
-          set(want_this_combination TRUE)
-          if(test_subset STREQUAL "only_long")
-            # Long tests are only run in 'optimize_none' mode.
-            if(NOT test_mode STREQUAL "optimize_none")
-              set(want_this_combination FALSE)
-            endif()
-
-            list(APPEND LIT_ARGS "--param" "run_only_tests=long_tests")
-          endif()
-          if(test_subset STREQUAL "all")
-            list(APPEND LIT_ARGS "--param" "run_only_tests=all")
-          endif()
-
           set(directories)
           set(dependencies ${test_dependencies})
 
@@ -275,18 +238,25 @@ if(PYTHONINTERP_FOUND)
             set(test_subset_target_suffix "")
           endif()
 
-          if(want_this_combination)
-            add_custom_target("check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}"
-                ${command_upload_stdlib}
-                ${command_clean_test_results_dir}
-                ${command_profdata_merge_start}
-                COMMAND ${PYTHON_EXECUTABLE} "${LIT}" ${LIT_ARGS} ${directories}
-                ${command_profdata_merge_stop}
-                DEPENDS ${dependencies}
-                COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
-                ${cmake_3_2_USES_TERMINAL})
+          set(test_mode_target_suffix "")
+          if(NOT test_mode STREQUAL "optimize_none")
+            set(test_mode_target_suffix "-${test_mode}")
           endif()
-          set(LIT_ARGS "${LIT_ARGS_COPY}")
+
+          add_custom_target("check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}"
+              ${command_upload_stdlib}
+              ${command_clean_test_results_dir}
+              ${command_profdata_merge_start}
+              COMMAND
+                ${PYTHON_EXECUTABLE} "${LIT}"
+                ${LIT_ARGS}
+                "--param" "swift_test_subset=${test_subset}"
+                "--param" "swift_test_mode=${test_mode}"
+                ${directories}
+              ${command_profdata_merge_stop}
+              DEPENDS ${dependencies}
+              COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
+              ${cmake_3_2_USES_TERMINAL})
         endforeach()
       endforeach()
     endforeach()

--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -1,6 +1,7 @@
 // Check interface produced for the standard library.
 //
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test
 //
 // RUN: %target-swift-frontend -parse %s
 // RUN: %target-swift-ide-test -print-module -module-to-print=Swift -source-filename %s -print-interface > %t.txt

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -441,49 +441,49 @@ if "optimized_stdlib" in config.available_features:
 swift_test_mode = lit_config.params.get('swift_test_mode', 'optimize_none')
 swift_execution_tests_extra_flags = ''
 if swift_test_mode == 'optimize_none':
+    config.available_features.add("nonexecutable_test")
+    config.available_features.add("executable_test")
     config.available_features.add("swift_test_mode_optimize_none")
     # Add the cpu as a feature so we can selectively disable tests in an
     # optimize mode for a cpu.
     config.available_features.add("swift_test_mode_optimize_none_" + run_cpu)
     swift_execution_tests_extra_flags = ''
 elif swift_test_mode == 'optimize':
+    config.available_features.add("executable_test")
+    config.limit_to_features.add("executable_test")
     config.available_features.add("swift_test_mode_optimize")
     # Add the cpu as a feature so we can selectively disable tests in an
     # optimize mode for a cpu.
     config.available_features.add("swift_test_mode_optimize_" + run_cpu)
     swift_execution_tests_extra_flags = '-O'
 elif swift_test_mode == 'optimize_unchecked':
+    config.available_features.add("executable_test")
+    config.limit_to_features.add("executable_test")
+    config.available_features.add("swift_test_mode_optimize_unchecked")
     # Add the cpu as a feature so we can selectively disable tests in an
     # optimize mode for a cpu.
     config.available_features.add("swift_test_mode_optimize_unchecked_" + run_cpu)
-    config.available_features.add("swift_test_mode_optimize_unchecked")
     swift_execution_tests_extra_flags = '-Ounchecked'
 elif swift_test_mode == 'only_executable':
-    # No extra flags needed.
-    pass
+    config.available_features.add("executable_test")
+    config.limit_to_features.add("executable_test")
 elif swift_test_mode == 'only_non_executable':
-    # No extra flags needed.
-    pass
+    config.available_features.add("nonexecutable_test")
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_mode)
 
-# Only run the subset of tests that require 'executable_test'?
-swift_run_only_tests = lit_config.params.get('run_only_tests', 'all_except_long')
-if swift_run_only_tests == 'all':
-    config.available_features.add("executable_test")
-    config.available_features.add("long_test")
-elif swift_run_only_tests == 'executable_tests':
-    config.available_features.add("executable_test")
-    config.limit_to_features.add("executable_test")
-elif swift_run_only_tests == 'non_executable_tests':
+swift_test_subset = lit_config.params.get('swift_test_subset', 'validation')
+if swift_test_subset in ['primary', 'validation', 'only_validation']:
+    # No extra flags needed.
     pass
-elif swift_run_only_tests == 'long_tests':
+elif swift_test_subset == 'all':
+    config.available_features.add("long_test")
+elif swift_test_subset == 'only_long':
     config.available_features.add("long_test")
     config.limit_to_features.add("long_test")
-elif swift_run_only_tests == 'all_except_long':
-    config.available_features.add("executable_test")
+    config.limit_to_features.discard("executable_test")
 else:
-    lit_config.fatal("Unknown test mode %r" % swift_run_only_tests)
+    lit_config.fatal("Unknown test mode %r" % swift_test_subset)
 
 # Add substitutions for the run target triple, CPU, OS, and pointer size.
 config.substitutions.append(('%target-triple', config.variant_triple))

--- a/validation-test/Driver/many-inputs.swift
+++ b/validation-test/Driver/many-inputs.swift
@@ -17,4 +17,5 @@
 // RUN: nm %t/libMultiFile | FileCheck %t/check.txt
 
 // REQUIRES: long_test
+// REQUIRES: executable_test
 

--- a/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
+++ b/validation-test/SIL/Inputs/gen_parse_stdlib_tests.sh
@@ -15,6 +15,7 @@ for id in $(seq 0 $process_id_max); do
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=$process_count -ast-verifier-process-id=$id > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test
 __EOF__
 
 done

--- a/validation-test/SIL/parse_stdlib_0.sil
+++ b/validation-test/SIL/parse_stdlib_0.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=0 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_1.sil
+++ b/validation-test/SIL/parse_stdlib_1.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=1 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_10.sil
+++ b/validation-test/SIL/parse_stdlib_10.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=10 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_11.sil
+++ b/validation-test/SIL/parse_stdlib_11.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=11 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_12.sil
+++ b/validation-test/SIL/parse_stdlib_12.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=12 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_13.sil
+++ b/validation-test/SIL/parse_stdlib_13.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=13 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_14.sil
+++ b/validation-test/SIL/parse_stdlib_14.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=14 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_15.sil
+++ b/validation-test/SIL/parse_stdlib_15.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=15 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_16.sil
+++ b/validation-test/SIL/parse_stdlib_16.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=16 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_2.sil
+++ b/validation-test/SIL/parse_stdlib_2.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=2 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_3.sil
+++ b/validation-test/SIL/parse_stdlib_3.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=3 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_4.sil
+++ b/validation-test/SIL/parse_stdlib_4.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=4 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_5.sil
+++ b/validation-test/SIL/parse_stdlib_5.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=5 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_6.sil
+++ b/validation-test/SIL/parse_stdlib_6.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=6 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_7.sil
+++ b/validation-test/SIL/parse_stdlib_7.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=7 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_8.sil
+++ b/validation-test/SIL/parse_stdlib_8.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=8 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/parse_stdlib_9.sil
+++ b/validation-test/SIL/parse_stdlib_9.sil
@@ -7,3 +7,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -sil-disable-ast-dump %platform-module-dir/Swift.swiftmodule -module-name=Swift -o %t.sil
 // RUN: %target-sil-opt -enable-sil-verify-all %t.sil -ast-verifier-process-count=17 -ast-verifier-process-id=9 > /dev/null
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test

--- a/validation-test/SIL/verify_all_overlays.sil
+++ b/validation-test/SIL/verify_all_overlays.sil
@@ -3,3 +3,4 @@
 // CHECK-NOT: Unknown
 
 // REQUIRES: long_test
+// REQUIRES: nonexecutable_test


### PR DESCRIPTION
Removing an abstraction boundary also allowed me to fix a bug where we could not run long tests in optimized mode, which prevented us from being able to mark executable tests as long.

I tested this refactoring by running each `check-swift-*-macosx-*` target with `--no-execute --show-unsupported` arguments for lit, and inspected the output to make sure that we execute the right tests in each mode.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
