### PR TITLE
Reduce test runtime

### DIFF
--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -1,5 +1,7 @@
 // Check interface produced for the standard library.
 //
+// REQUIRES: long_test
+//
 // RUN: %target-swift-frontend -parse %s
 // RUN: %target-swift-ide-test -print-module -module-to-print=Swift -source-filename %s -print-interface > %t.txt
 // RUN: FileCheck -check-prefix=CHECK-ARGC %s < %t.txt

--- a/test/Runtime/weak-reference-racetests.swift
+++ b/test/Runtime/weak-reference-racetests.swift
@@ -3,7 +3,7 @@
 
 import StdlibUnittest
 
-let iterations = 1_000
+let iterations = 100
 
 class Thing {}
 

--- a/validation-test/Driver/many-inputs.swift
+++ b/validation-test/Driver/many-inputs.swift
@@ -16,3 +16,5 @@
 // RUN: (cd %t && %target-build-swift -emit-library ./*.swift -o ./libMultiFile)
 // RUN: nm %t/libMultiFile | FileCheck %t/check.txt
 
+// REQUIRES: long_test
+


### PR DESCRIPTION
Marked two expensive tests as long, reduced iteration count for a runtime race test.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
