### PR TITLE
[CMake] Include ICU for stubs

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -160,8 +160,6 @@ else()
   find_package(ICU REQUIRED COMPONENTS uc i18n)
   list(APPEND swift_core_private_link_libraries
       ${ICU_UC_LIBRARY} ${ICU_I18N_LIBRARY})
-  include_directories(
-      ${ICU_UC_INCLUDE_DIR} ${ICU_I18N_INCLUDE_DIR})
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -9,8 +9,11 @@ if(SWIFT_HOST_VARIANT MATCHES "${SWIFT_DARWIN_VARIANTS}")
   set(LLVM_OPTIONAL_SOURCES
       UnicodeNormalization.cpp)
 else()
+  find_package(ICU REQUIRED COMPONENTS uc i18n)
   set(swift_stubs_unicode_normalization_sources
       UnicodeNormalization.cpp)
+  include_directories(
+      ${ICU_UC_INCLUDE_DIR} ${ICU_I18N_INCLUDE_DIR})
 endif()
 
 add_swift_library(swiftStdlibStubs OBJECT_LIBRARY TARGET_LIBRARY


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

`stdlib/public/stubs` includes `unicode/ustring.h`, `unicode/ucol.h`, `unicode/ucoleitr.h`, and `unicode/uiter.h`.

Also, `stubs` comes before `core` in the CMake configuration order. As a result, ICU includes are not configured in time for `stubs`. This causes an error when building Swift for Android.

This behavior was introduced in d227aeb. This commit reverts the include order change.

/cc @gribozavr 
#### Resolved bug number: None

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
