### PR TITLE
Fix a bug where 'indices' property from Collections doesn't show up for code-completion.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3302,6 +3302,8 @@ bool swift::isExtensionApplied(DeclContext &DC, Type BaseTy,
     CreatedTC.reset(new TypeChecker(DC.getASTContext()));
     TC = CreatedTC.get();
   }
+  if (ED->getAsProtocolExtensionContext())
+    return TC->isProtocolExtensionUsable(&DC, BaseTy, const_cast<ExtensionDecl*>(ED));
   ConstraintSystem CS(*TC, &DC, Options);
   auto Loc = CS.getConstraintLocator(nullptr);
   std::vector<Identifier> Scratch;

--- a/test/IDE/complete_from_constraint_extensions.swift
+++ b/test/IDE/complete_from_constraint_extensions.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONSTRAINT1 | FileCheck %s -check-prefix=CONSTRAINT1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONSTRAINT2 | FileCheck %s -check-prefix=CONSTRAINT2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONSTRAINT3 | FileCheck %s -check-prefix=CONSTRAINT3
 
 public protocol P1 {}
 public protocol P2 {}
@@ -33,3 +34,20 @@ func foo2() {
 // CONSTRAINT2:      Begin completions, 1 items
 // CONSTRAINT2-NEXT: Decl[InstanceMethod]/CurrNominal:   P2Method()[#Void#]; name=P2Method()
 // CONSTRAINT2-NEXT: End completions
+
+protocol MyIndexable {}
+protocol MyCollection : MyIndexable {
+  associatedtype Indices = MyDefaultIndices<Self>
+  var indices: Indices { get }
+}
+struct MyDefaultIndices<Elements : MyIndexable> : MyCollection {}
+extension MyCollection where Indices == MyDefaultIndices<Self> {
+    var indices: MyDefaultIndices<Self> { return MyDefaultIndices() }
+}
+struct ConcreteCollection<Element> : MyCollection {}
+func foo3() {
+  ConcreteCollection<Int>().#^CONSTRAINT3^#
+}
+// CONSTRAINT3:      Begin completions, 1 items
+// CONSTRAINT3-NEXT: Decl[InstanceVar]/Super:            indices[#MyDefaultIndices<ConcreteCollection<Int>>#]; name=indices
+// CONSTRAINT3-NEXT: End completions


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Fixes a bug where, when code-completing, 'indices' property is missing from Set/Dictionary and 'indices' and 'makeIterator()' is missing from Array.

Suggestion on how to fix and final review was done by Doug Gregor.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

rdar://26642818

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
