### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::checkGenericParamList(…)

### DIFF
--- a/validation-test/compiler_crashers/28307-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/compiler_crashers/28307-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,81 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct D:d< : < :Int {class T: T: a {
+class T class A S : P {case,
+func a {{ }typealias d A enum S{
+class A {
+}
+class A
+class T: T {func a{
+func f: a typealias d
+class
+struct c {letct c {class
+class
+var d
+clafunc a class A enum S{
+{class B h d T : a {class
+let a{
+func a class B
+}
+class d S : a typealias b {case
+}}
+case c d e B T wc d where g: d : d where c func f: d T{
+class A {
+var d
+struct c {
+}} } } "
+{
+}typealias b b class A func g Int ( ( ( ) >{
+var d T where h A func d
+var _= g: d A
+}
+struct D a{
+var d
+{
+class A {
+protocol A{
+protocol A
+class T: P {
+var d
+}
+func f: a {
+struct B T where g: d
+{ {{ } "
+}
+}
+var d e d e d
+class B
+}
+class T let a T {
+class B S : a {
+case,
+func a S : a {
+class A func a{
+}
+struct c {
+protocol A func a
+struct c {let a e
+protocol a { class A func g: d A
+let end = A } }} }}}protocol A{class A func a b c,
+class A {class A
+[]
+class
+class A
+protocol A T{
+protocol a {class B S : T
+struct c {
+}
+}"
+}
+class c{
+class B
+struct D A Int } typealias b
+func d where h:
+c


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
4  swift           0x0000000000ed9ded swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 93
6  swift           0x0000000000eda50e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
11 swift           0x0000000000ea2136 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
12 swift           0x0000000000ec4a92 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
13 swift           0x0000000000c58d09 swift::CompilerInstance::performSema() + 3289
15 swift           0x00000000007d735f swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
16 swift           0x00000000007a3378 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28307-swift-typechecker-resolveidentifiertype.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28307-swift-typechecker-resolveidentifiertype-687f0c.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28307-swift-typechecker-resolveidentifiertype.swift:66:21
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
