### PR TITLE
IRGen: Handle protocol inheritance in witness_method lowering.

### DIFF
--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -82,6 +82,11 @@ public:
 
   /// Return the protocol requirement.
   ProtocolDecl *getRequirement() const;
+  
+  /// Get the inherited conformance corresponding to the given protocol.
+  /// Returns `this` if `parent` is already the same as the protocol this
+  /// conformance represents.
+  ProtocolConformanceRef getInherited(ProtocolDecl *parent) const;
 
   void dump() const;
   void dump(llvm::raw_ostream &out, unsigned indent = 0) const;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -49,6 +49,30 @@ ProtocolDecl *ProtocolConformanceRef::getRequirement() const {
   }
 }
 
+ProtocolConformanceRef
+ProtocolConformanceRef::getInherited(ProtocolDecl *parent) const {
+  assert((getRequirement() == parent ||
+          getRequirement()->inheritsFrom(parent)) &&
+         "not a parent of this protocol");
+  
+  if (parent == getRequirement())
+    return *this;
+  
+  // For an abstract requirement, simply produce a new abstract requirement
+  // for the parent.
+  if (isAbstract()) {
+    return ProtocolConformanceRef(parent);
+  }
+  
+  // Navigate concrete conformances.
+  if (isConcrete()) {
+    return ProtocolConformanceRef(
+      getConcrete()->getInheritedConformance(parent));
+  }
+  
+  llvm_unreachable("unhandled ProtocolConformanceRef");
+}
+
 void *ProtocolConformance::operator new(size_t bytes, ASTContext &context,
                                         AllocationArena arena,
                                         unsigned alignment) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2621,9 +2621,9 @@ irgen::emitWitnessMethodValue(IRGenFunction &IGF,
                               ProtocolConformanceRef conformance,
                               Explosion &out) {
   auto fn = cast<AbstractFunctionDecl>(member.getDecl());
-
-  assert(cast<ProtocolDecl>(fn->getDeclContext())
-           == conformance.getRequirement());
+  auto fnProto = cast<ProtocolDecl>(fn->getDeclContext());
+  
+  conformance = conformance.getInherited(fnProto);
 
   // Find the witness table.
   // FIXME conformance for concrete type

--- a/test/IRGen/witness_method_after_devirt.swift
+++ b/test/IRGen/witness_method_after_devirt.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-ir -verify %s 
+
+protocol BaseProtocol {
+    static func run()
+}
+
+protocol DerivedProtocol: BaseProtocol {
+}
+
+struct Foo: DerivedProtocol {
+    static func run() { }
+}
+
+@inline(never)
+func test() {
+    let t: DerivedProtocol.Type = Foo.self
+    t.run()
+}


### PR DESCRIPTION
If the conformance in a witness_method instruction represented a derived protocol instead of the exact protocol of the desired method, we would crash. Handle this by drilling down to the exact conformance needed before forming a witness ref. Fixes rdar://problem/26633668.
