### PR TITLE
Removed last uses of @warn_unused_result

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1831,8 +1831,7 @@ public:
   /// Checks an "ignored" expression to see if it's okay for it to be ignored.
   ///
   /// An ignored expression is one that is not nested within a larger
-  /// expression or statement. The warning from the \@warn_unused_result
-  /// attribute is produced here.
+  /// expression or statement.
   void checkIgnoredExpr(Expr *E);
 
   // Emits a diagnostic, if necessary, for a reference to a declaration

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -322,7 +322,7 @@ extension ${Self} where Self.Iterator.Element : Comparable {
   /// - Returns: A sorted array of the ${sequenceKind}'s elements.
   ///
   /// - SeeAlso: `sorted(isOrderedBefore:)`
-  @warn_unused_result(${'mutable_variant: "sort"' if Self == 'MutableCollection' else ''})
+  /// ${'- MutatingVariant: sort' if Self == 'MutableCollection' else ''}
   public func sorted() -> [Iterator.Element] {
     var result = ContiguousArray(self)
     result.sort()
@@ -396,7 +396,7 @@ ${orderingExplanation}
   /// - Returns: A sorted array of the ${sequenceKind}'s elements.
   ///
   /// - SeeAlso: `sorted()`
-  @warn_unused_result(${'mutable_variant: "sort"' if Self == 'MutableCollection' else ''})
+  /// ${'- MutatingVariant: sort' if Self == 'MutableCollection' else ''}
   public func sorted(
     isOrderedBefore:
       @noescape (${IElement}, ${IElement}) -> Bool

--- a/test/1_stdlib/Runtime.swift
+++ b/test/1_stdlib/Runtime.swift
@@ -9,7 +9,6 @@ import StdlibUnittest
 import SwiftShims
 
 
-@warn_unused_result
 @_silgen_name("swift_demangle")
 public
 func _stdlib_demangleImpl(
@@ -20,7 +19,6 @@ func _stdlib_demangleImpl(
   flags: UInt32
 ) -> UnsafeMutablePointer<CChar>?
 
-@warn_unused_result
 func _stdlib_demangleName(_ mangledName: String) -> String {
   return mangledName.nulTerminatedUTF8.withUnsafeBufferPointer {
     (mangledNameUTF8) in

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1284,33 +1284,6 @@ struct d2900_TypeSugar1 {
 // PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
-// @warn_unused_result attribute
-public struct ArrayThingy {
-    // PASS_PRINT_AST: @warn_unused_result(mutable_variant: "sort")
-    // PASS_PRINT_AST-NEXT: public func sort() -> ArrayThingy
-    @warn_unused_result(mutable_variant: "sort")
-    public func sort() -> ArrayThingy { return self }
-
-    public mutating func sort() { }
-
-    // PASS_PRINT_AST: @warn_unused_result(message: "dummy", mutable_variant: "reverseInPlace")
-    // PASS_PRINT_AST-NEXT: public func reverse() -> ArrayThingy
-    @warn_unused_result(message: "dummy", mutable_variant: "reverseInPlace")
-    public func reverse() -> ArrayThingy { return self }
-
-    public mutating func reverseInPlace() { }
-
-    // PASS_PRINT_AST: @warn_unused_result
-    // PASS_PRINT_AST-NEXT: public func mineGold() -> Int
-    @warn_unused_result
-    public func mineGold() -> Int { return 0 }
-
-    // PASS_PRINT_AST: @warn_unused_result(message: "oops")
-    // PASS_PRINT_AST-NEXT: public func mineCopper() -> Int
-    @warn_unused_result(message: "oops")
-    public func mineCopper() -> Int { return 0 }
-}
-
 // @discardableResult attribute
 public struct DiscardableThingy {
     // PASS_PRINT_AST: @discardableResult

--- a/test/IDE/print_stdlib.swift
+++ b/test/IDE/print_stdlib.swift
@@ -97,5 +97,4 @@ func foo(x: _Pointer) {} // Checks that this protocol actually exists.
 
 // CHECK-FREQUENT-WORD: ///
 // CHECK-FREQUENT-WORD-NOT: where Slice<Dictionary<Key, Value>> == Slice<Self>
-// CHECK-FREQUENT-WORD-NOT: @warn_unused_result
 // CHECK-COLLECTION-GROUP: extension MutableCollection

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -150,7 +150,6 @@ public protocol Arithmetic : Equatable, IntegerLiteralConvertible {
 % for x in binaryArithmetic['Arithmetic']:
   // defaulted using an in-place counterpart, but can be used as an
   // optimization hook
-  @warn_unused_result
   func ${x.name}(${x.firstArg} rhs: Self) -> Self
 
   // implementation hook
@@ -190,7 +189,6 @@ extension SignedArithmetic {
 %   for x in binaryArithmetic[Protocol]:
 %     callLabel = x.firstArg + ': ' if not x.firstArg == '_' else ''
 @_transparent
-@warn_unused_result
 public func ${x.operator} <T: ${Protocol}>(lhs: T, rhs: T) -> T {
   return lhs.${x.name}(${callLabel}rhs)
 }
@@ -203,7 +201,6 @@ public func ${x.operator}= <T: ${Protocol}>(lhs: inout T, rhs: T) {
 % end
 
 @_transparent
-@warn_unused_result
 public prefix func -<T: SignedArithmetic>(x: T) -> T {
   return x.negate()
 }
@@ -263,9 +260,7 @@ public protocol Integer : ${IntegerBase} {
   // Dispatching through these puts less stress on the user reading
   // the interface and error messages (and on the type checker) than
   // does having many operator overloads.
-  @warn_unused_result
   func isEqual(to rhs: Self) -> Bool
-  @warn_unused_result
   func isLess(than rhs: Self) -> Bool
 
   /// Creates an instance of `Self` from the value of any other `Integer`,
@@ -285,7 +280,6 @@ public protocol Integer : ${IntegerBase} {
 
   /// Return n-th word (counting from the right) in the underlying
   /// representation of `self`.
-  @warn_unused_result
   func nthWord(_ n: Word) -> UWord
 
   /// A number of bits in current representation of `self`
@@ -301,7 +295,6 @@ public protocol Integer : ${IntegerBase} {
 % for x in binaryArithmetic['Integer']:
   // defaulted using an in-place counterpart, but can be used as an
   // optimization hook
-  @warn_unused_result
   func ${x.name}(${x.firstArg} rhs: Self) -> Self
 
   // implementation hook
@@ -329,20 +322,17 @@ extension Integer {
 
 //===--- Homogeneous comparison -------------------------------------------===//
 @_transparent
-@warn_unused_result
 public func == <T : Integer>(lhs:T, rhs: T) -> Bool {
   return lhs.isEqual(to: rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func < <T : Integer>(lhs: T, rhs: T) -> Bool {
   return lhs.isLess(than: rhs)
 }
 
 //===--- Heterogeneous comparison -----------------------------------------===//
 @_transparent
-@warn_unused_result
 public func == <T : Integer, U : Integer>(lhs:T, rhs: U) -> Bool {
   return (lhs > 0) == (rhs > 0)
     && T(extendingOrTruncating: rhs) == lhs
@@ -350,13 +340,11 @@ public func == <T : Integer, U : Integer>(lhs:T, rhs: U) -> Bool {
 }
 
 @_transparent
-@warn_unused_result
 public func != <T : Integer, U : Integer>(lhs:T, rhs: U) -> Bool {
   return !(lhs == rhs)
 }
 
 @_transparent
-@warn_unused_result
 public func < <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
   let lhsSign = lhs < 0 ? -1 : lhs > 0 ? 1 : 0
   let rhsSign = rhs < 0 ? -1 : rhs > 0 ? 1 : 0
@@ -381,19 +369,16 @@ public func < <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
 }
 
 @inline(__always)
-@warn_unused_result
 public func <= <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
   return !(rhs < lhs)
 }
 
 @inline(__always)
-@warn_unused_result
 public func >= <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
   return !(lhs < rhs)
 }
 
 @inline(__always)
-@warn_unused_result
 public func > <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
   return rhs < lhs
 }
@@ -410,25 +395,21 @@ public func > <T : Integer, U : Integer>(lhs: T, rhs: U) -> Bool {
 //     <T : Integer>(T, T) -> Bool
 
 @_transparent
-@warn_unused_result
 public func != <T : Integer>(lhs: T, rhs: T) -> Bool {
   return !(lhs == rhs)
 }
 
 @inline(__always)
-@warn_unused_result
 public func <= <T : Integer>(lhs: T, rhs: T) -> Bool {
   return !(rhs < lhs)
 }
 
 @inline(__always)
-@warn_unused_result
 public func >= <T : Integer>(lhs: T, rhs: T) -> Bool {
   return !(lhs < rhs)
 }
 
 @inline(__always)
-@warn_unused_result
 public func > <T : Integer>(lhs: T, rhs: T) -> Bool {
   return rhs < lhs
 }
@@ -474,25 +455,21 @@ comment = '''
   /// - Precondition: `rhs != 0`''' if x.kind == '/' else '')
 }%
 ${comment}
-  @warn_unused_result
   func ${x.name}WithOverflow(
     ${x.firstArg} rhs: Self
   ) -> (partialValue: Self, overflow: ArithmeticOverflow)
 % end
 
 % for x in binaryBitwise + maskingShifts:
-  @warn_unused_result
   func ${x.name}(_ rhs: Self) -> Self
 % end
 
-  @warn_unused_result
   func doubleWidthMultiply(_ other: Self) -> (high: Self, low: AbsoluteValue)
 
   init(_truncatingBits bits: UWord)
 }
 
 % for x in binaryBitwise:
-@warn_unused_result
 @_transparent
 public func ${x.operator} <T: FixedWidthInteger>(lhs: T, rhs: T) -> T {
   return lhs.${x.name}(rhs)
@@ -505,7 +482,6 @@ public func ${x.operator}= <T: FixedWidthInteger>(lhs: inout T, rhs: T) {
 % end
 
 % for x in maskingShifts:
-@warn_unused_result
 @_transparent
 public func ${x.operator} <T: FixedWidthInteger>(lhs: T, rhs: T) -> T {
   return lhs.${x.name}(rhs)
@@ -516,7 +492,6 @@ public func ${x.operator}= <T: FixedWidthInteger>(lhs: inout T, rhs: T) {
   lhs = lhs ${x.operator} rhs
 }
 
-@warn_unused_result
 @_transparent
 public func ${x.operator} <
   T: FixedWidthInteger, U: Integer
@@ -531,7 +506,6 @@ public func ${x.operator}= <
   lhs = lhs ${x.operator} rhs
 }
 
-@warn_unused_result
 @_transparent
 public func ${x.nonMaskingOperator} <
   T: FixedWidthInteger, U: Integer
@@ -544,7 +518,6 @@ public func ${x.nonMaskingOperator} <
 
 // "Smart shift", supporting overshifts and negative shifts
 
-@warn_unused_result
 @_transparent
 public func ${x.nonMaskingOperator} <
   T: FixedWidthInteger
@@ -579,7 +552,6 @@ public func ${x.nonMaskingOperator}= <
 }
 % end
 
-@warn_unused_result
 @inline(__always)
 public prefix func ~ <T: FixedWidthInteger>(x: T) -> T {
   return 0 &- x &- 1
@@ -610,7 +582,6 @@ extension FixedWidthInteger {
   ///
   /// Note: use this function to avoid the cost of overflow checking
   /// when you are sure that the operation won't overflow.
-  @warn_unused_result
   @_transparent
   public func unsafe${capitalize(x.name)}(rhs: Self) -> Self {
     let (result, overflow) = self.${x.name}WithOverflow(${callLabel}rhs)
@@ -664,7 +635,6 @@ extension FixedWidthInteger {
 % for x in allBinaryArithmetic:
 %   callLabel = x.firstArg + ': ' if not x.firstArg == '_' else ''
 %   if x.kind != '/':
-@warn_unused_result
 public func &${x.operator} <T: FixedWidthInteger>(lhs: T, rhs: T) -> T {
   return lhs.${x.name}WithOverflow(${callLabel}rhs).partialValue
 }
@@ -798,12 +768,10 @@ public struct ${Self}
     _storage = x._storage
   }
 
-  @warn_unused_result
   public func isEqual(to rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_eq_Int${bits}(_storage, rhs._storage))
   }
 
-  @warn_unused_result
   public func isLess(than rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_${u}lt_Int${bits}(_storage, rhs._storage))
   }
@@ -813,7 +781,6 @@ public struct ${Self}
   /// Return a pair consisting of `self` ${x.operator} `rhs`,
   /// truncated to fit if necessary, and a flag indicating whether an
   /// arithmetic overflow occurred.
-  @warn_unused_result
   @_transparent
   public func ${x.name}WithOverflow(
     ${x.firstArg} rhs: ${Self}
@@ -852,7 +819,6 @@ public struct ${Self}
   }
 
 % for x in binaryBitwise:
-  @warn_unused_result
   @_transparent
   public func ${x.name}(_ rhs: ${Self}) -> ${Self} {
     return ${Self}(
@@ -861,7 +827,6 @@ public struct ${Self}
 % end
 
 % for x in maskingShifts:
-  @warn_unused_result
   @_transparent
   public func ${x.name}(_ rhs: ${Self}) -> ${Self} {
     let rhs_ = rhs & ${Self}._highBitIndex
@@ -887,7 +852,6 @@ public struct ${Self}
 
 
   @_transparent
-  @warn_unused_result
   public func countLeadingZeros() -> Word {
     return Word(
       ${Self}(
@@ -934,7 +898,6 @@ public struct ${Self}
 % end
 
 %     dbits = bits*2
-  @warn_unused_result
   public func doubleWidthMultiply(_ other: ${Self})
     -> (high: ${Self}, low: ${Self}.AbsoluteValue) {
 %       if bits > 64:
@@ -992,13 +955,11 @@ public struct DoubleWidth<
       _storage.high.absoluteValue, _storage.low.absoluteValue))
   }
 
-  @warn_unused_result
   public func isEqual(to rhs: DoubleWidth<T>) -> Bool {
     return (_storage.high == rhs._storage.high) &&
            (_storage.low == rhs._storage.low)
   }
 
-  @warn_unused_result
   public func isLess(than rhs: DoubleWidth<T>) -> Bool {
     if _storage.high < rhs._storage.high {
       return true
@@ -1017,7 +978,6 @@ public struct DoubleWidth<
     fatalError()
   }
 
-  @warn_unused_result
   public func nthWord(_ n: Word) -> UWord {
     if T.bitWidth < ${word_bits} || T.bitWidth % ${word_bits} != 0 {
       fatalError("nthWord is not supported on this type")
@@ -1073,7 +1033,6 @@ public struct DoubleWidth<
 % end
 
 
-  @warn_unused_result
   public func multipliedWithOverflow(
     by rhs: DoubleWidth<T>
   ) -> (partialValue: DoubleWidth<T>, overflow: ArithmeticOverflow) {
@@ -1135,7 +1094,6 @@ public struct DoubleWidth<
   }
 
 % for x in allBinaryArithmetic[3:]:
-  @warn_unused_result
   public func ${x.name}WithOverflow(
     ${x.firstArg} rhs: DoubleWidth<T>
   ) -> (partialValue: DoubleWidth<T>, overflow: ArithmeticOverflow) {
@@ -1143,14 +1101,12 @@ public struct DoubleWidth<
   }
 % end
 
-  @warn_unused_result
   public func doubleWidthMultiply(_ other: DoubleWidth<T>)
     -> (high: DoubleWidth<T>, low: DoubleWidth<T>.AbsoluteValue) {
       fatalError()
   }
 
 % for x in binaryBitwise + maskingShifts:
-  @warn_unused_result
   public func ${x.name}(_ rhs: DoubleWidth<T>) -> DoubleWidth<T> {
     fatalError()
   }
@@ -1200,12 +1156,10 @@ public struct ${Self}
     fatalError()
   }
 
-  @warn_unused_result
   public func isEqual(to rhs: ${Self}) -> Bool {
     return _storage.isEqual(to: rhs._storage)
   }
 
-  @warn_unused_result
   public func isLess(than rhs: ${Self}) -> Bool {
     return _storage.isLess(than: rhs._storage)
   }
@@ -1215,7 +1169,6 @@ public struct ${Self}
   /// Return a pair consisting of `self` ${x.operator} `rhs`,
   /// truncated to fit if necessary, and a flag indicating whether an
   /// arithmetic overflow occurred.
-  @warn_unused_result
   public func ${x.name}WithOverflow(
     ${x.firstArg} rhs: ${Self}
   ) -> (partialValue: ${Self}, overflow: ArithmeticOverflow) {
@@ -1224,7 +1177,6 @@ public struct ${Self}
 %   end
 
 % for x in binaryBitwise:
-  @warn_unused_result
   @_transparent
   public func ${x.name}(_ rhs: ${Self}) -> ${Self} {
     fatalError()
@@ -1232,7 +1184,6 @@ public struct ${Self}
 % end
 
 % for x in maskingShifts:
-  @warn_unused_result
   @_transparent
   public func ${x.name}(_ rhs: ${Self}) -> ${Self} {
     fatalError()
@@ -1247,7 +1198,6 @@ public struct ${Self}
     return _storage.signBitIndex
   }
 
-  @warn_unused_result
   public func countLeadingZeros() -> Word {
     fatalError()
   }
@@ -1268,7 +1218,6 @@ public struct ${Self}
   }
 % end
 
-  @warn_unused_result
   public func doubleWidthMultiply(_ other: ${Self})
     -> (high: ${Self}, low: ${Self}.AbsoluteValue) {
     let (high: high, low: low) = _storage.doubleWidthMultiply(other._storage)

--- a/test/Serialization/Inputs/def_func.swift
+++ b/test/Serialization/Inputs/def_func.swift
@@ -2,7 +2,7 @@ public func getZero() -> Int {
   return 0
 }
 
-public func getInput(x x: Int) -> Int {
+public func getInput(x: Int) -> Int {
   return x
 }
 
@@ -12,14 +12,14 @@ public func getSecond(_: Int, y: Int) -> Int {
 
 public func useNested(_: (x: Int, y: Int), n: Int) {}
 
-public func variadic(x x: Double, _ y: Int...) {}
+public func variadic(x: Double, _ y: Int...) {}
 public func variadic2(_ y: Int..., x: Double) {}
 
-public func slice(x x: [Int]) {}
-public func optional(x x: Int?) {}
+public func slice(x: [Int]) {}
+public func optional(x: Int?) {}
 
-public func overloaded(x x: Int) {}
-public func overloaded(x x: Bool) {}
+public func overloaded(x: Int) {}
+public func overloaded(x: Bool) {}
 
 // Generic functions.
 public func makePair<A, B>(a: A, b: B) -> (A, B) {
@@ -54,7 +54,7 @@ public func differentWrapped<
 @noreturn @_silgen_name("exit") public func exit () -> ()
 
 @noreturn public func testNoReturnAttr() -> () { exit() }
-@noreturn public func testNoReturnAttrPoly<T>(x x: T) -> () { exit() }
+@noreturn public func testNoReturnAttrPoly<T>(x: T) -> () { exit() }
 
 
 @_silgen_name("primitive") public func primitive()
@@ -65,15 +65,3 @@ public protocol EqualOperator {
 
 public func throws1() throws {}
 public func throws2<T>(_ t: T) throws -> T { return t }
-
-@warn_unused_result(message: "you might want to keep it")
-public func mineGold() -> Int { return 1 }
-
-public struct Foo {
-  public init() { }
-
-  @warn_unused_result(mutable_variant: "reverseInPlace")
-  public func reverse() -> Foo { return self }
-
-  public mutating func reverseInPlace() { }
-}

--- a/test/Serialization/function.swift
+++ b/test/Serialization/function.swift
@@ -63,13 +63,13 @@ var pair : (Int, Double) = makePair(a: 1, b: 2.5)
 // SIL:   [[DIFFERENT_A:%.+]] = function_ref @_TF8def_func9different{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
 // SIL:   [[DIFFERENT_B:%.+]] = function_ref @_TF8def_func9different{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
 
-different(a: 1, b: 2)
-different(a: false, b: false)
+_ = different(a: 1, b: 2)
+_ = different(a: false, b: false)
 
 // SIL:   [[DIFFERENT2_A:%.+]] = function_ref @_TF8def_func10different2{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
 // SIL:   [[DIFFERENT2_B:%.+]] = function_ref @_TF8def_func10different2{{.*}} : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
-different2(a: 1, b: 2)
-different2(a: false, b: false)
+_ = different2(a: 1, b: 2)
+_ = different2(a: false, b: false)
 
 
 struct IntWrapper1 : Wrapped {
@@ -83,7 +83,7 @@ struct IntWrapper2 : Wrapped {
 
 // SIL:   [[DIFFERENT_WRAPPED:%.+]] = function_ref @_TF8def_func16differentWrapped{{.*}} : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Wrapped, τ_0_1 : Wrapped, τ_0_0.Value : Equatable, τ_0_0.Value == τ_0_1.Value> (@in τ_0_0, @in τ_0_1) -> Bool
 
-differentWrapped(a: IntWrapper1(), b: IntWrapper2())
+_ = differentWrapped(a: IntWrapper1(), b: IntWrapper2())
 
 
 // SIL:   {{%.+}} = function_ref @_TF8def_func10overloadedFT1xSi_T_ : $@convention(thin) (Int) -> ()
@@ -110,13 +110,10 @@ if raw == 5 {
 
 do {
   try throws1()
-  try throws2(1)
+  _ = try throws2(1)
 } catch _ {}
 // SIL: sil @_TF8def_func7throws1FzT_T_ : $@convention(thin) () -> @error ErrorProtocol
 // SIL: sil @_TF8def_func7throws2{{.*}} : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error ErrorProtocol)
 
 // LLVM: }
 
-mineGold() // expected-warning{{you might want to keep it}}
-var foo = Foo()
-foo.reverse() // expected-warning{{reverseInPlace}}{{5-12=reverseInPlace}}

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -169,15 +169,6 @@ class C7 {
   func f() -> Self { return self }
 }
 
-public class FooClass1 {
-  @warn_unused_result
-  public func fooFunc1() {}
-}
-
-func goo1(_ f : FooClass1) {
-  f.fooFunc1()
-}
-
 public protocol P4 {
   /// foo1 comment from P4
   func foo1()
@@ -648,33 +639,30 @@ typealias MyVoid = ()
 // CHECK76: <Declaration>func f() -&gt; <Type usr="s:C11cursor_info2C7">Self</Type></Declaration>
 // CHECK76: <decl.function.returntype><ref.class usr="s:C11cursor_info2C7">Self</ref.class></decl.function.returntype>
 
-// RUN: %sourcekitd-test -req=cursor -pos=178:10 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK77 %s
-// CHECK77-NOT: @warn_unused_result
+// RUN: %sourcekitd-test -req=cursor -pos=188:7 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK77 %s
+// RUN: %sourcekitd-test -req=cursor -pos=189:7 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK78 %s
 
-// RUN: %sourcekitd-test -req=cursor -pos=197:7 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK78 %s
-// RUN: %sourcekitd-test -req=cursor -pos=198:7 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK79 %s
+// CHECK77: foo1 comment from P4
+// CHECK78: foo2 comment from C1
 
-// CHECK78: foo1 comment from P4
-// CHECK79: foo2 comment from C1
+// RUN: %sourcekitd-test -req=cursor -pos=192:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK79 %s
+// CHECK79: <decl.var.parameter><decl.var.parameter.argument_label>t</decl.var.parameter.argument_label>:
+// CHECK79-SAME: <decl.var.parameter.type><tuple>(
+// CHECK79-SAME:   <tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>,
+// CHECK79-SAME:   <tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>
+// CHECK79-SAME: )</tuple></decl.var.parameter.type></decl.var.parameter>
 
-// RUN: %sourcekitd-test -req=cursor -pos=201:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK80 %s
-// CHECK80: <decl.var.parameter><decl.var.parameter.argument_label>t</decl.var.parameter.argument_label>: 
-// CHECK80-SAME: <decl.var.parameter.type><tuple>(
-// CHECK80-SAME:   <tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>,
-// CHECK80-SAME:   <tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>
-// CHECK80-SAME: )</tuple></decl.var.parameter.type></decl.var.parameter>
+// RUN: %sourcekitd-test -req=cursor -pos=193:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK80 %s
+// CHECK80: <decl.var.parameter.type><tuple>()</tuple>
 
-// RUN: %sourcekitd-test -req=cursor -pos=202:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK81 %s
-// CHECK81: <decl.var.parameter.type><tuple>()</tuple>
+// RUN: %sourcekitd-test -req=cursor -pos=194:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK81 %s
+// CHECK81: <decl.var.parameter.type>() -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.var.parameter.type>
 
-// RUN: %sourcekitd-test -req=cursor -pos=203:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK82 %s
-// CHECK82: <decl.var.parameter.type>() -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.var.parameter.type>
+// RUN: %sourcekitd-test -req=cursor -pos=195:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK82 %s
+// CHECK82: <decl.function.returntype><tuple>(<tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>)</tuple>
 
-// RUN: %sourcekitd-test -req=cursor -pos=204:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK83 %s
-// CHECK83: <decl.function.returntype><tuple>(<tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element>)</tuple>
+// RUN: %sourcekitd-test -req=cursor -pos=196:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK83 %s
+// CHECK83: <decl.var.parameter.type>() -&gt; <decl.function.returntype><ref.typealias usr="s:s4Void">Void</ref.typealias>
 
-// RUN: %sourcekitd-test -req=cursor -pos=205:6 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK84 %s
-// CHECK84: <decl.var.parameter.type>() -&gt; <decl.function.returntype><ref.typealias usr="s:s4Void">Void</ref.typealias>
-
-// RUN: %sourcekitd-test -req=cursor -pos=206:11 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK85 %s
-// CHECK85: <decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>MyVoid</decl.name> = <tuple>()</tuple></decl.typealias>
+// RUN: %sourcekitd-test -req=cursor -pos=197:11 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | FileCheck -check-prefix=CHECK84 %s
+// CHECK84: <decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>MyVoid</decl.name> = <tuple>()</tuple></decl.typealias>

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -555,7 +555,6 @@ final class EvilSequence : Sequence {
     return _count
   }
 
-  @warn_unused_result
   func makeIterator() -> AnyIterator<LifetimeTracked> {
     var i = 0
     return AnyIterator {

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -44,7 +44,6 @@ struct CollectionWithDefaultUnderestimatedCount : Collection {
       position: _count, startIndex: 0, endIndex: _count)
   }
 
-  @warn_unused_result
   func index(after i: MinimalIndex) -> MinimalIndex {
     return MinimalIndex(
       collectionState: _collectionState,
@@ -88,7 +87,6 @@ struct MinimalCollectionWith${Implementation}Filter<Element>
     return _data.endIndex
   }
 
-  @warn_unused_result
   func index(after i: MinimalIndex) -> MinimalIndex {
     return _data.index(after: i)
   }
@@ -225,7 +223,6 @@ struct MinimalCollectionWith${Implementation}Map<Element>
     return _data.endIndex
   }
 
-  @warn_unused_result
   func index(after i: MinimalIndex) -> MinimalIndex {
     return _data.index(after: i)
   }
@@ -390,7 +387,6 @@ struct CollectionWithCustomUnderestimatedCount : Collection {
       position: 0xffff, startIndex: 0, endIndex: 0xffff)
   }
 
-  @warn_unused_result
   func index(after i: MinimalIndex) -> MinimalIndex {
     return MinimalIndex(
       collectionState: _collectionState,
@@ -444,7 +440,6 @@ struct MinimalCollectionWithDefaultIterator : Collection {
       position: _count, startIndex: 0, endIndex: _count)
   }
 
-  @warn_unused_result
   func index(after i: MinimalIndex) -> MinimalIndex {
     return MinimalIndex(
       collectionState: _collectionState,
@@ -518,7 +513,6 @@ struct MinimalCollectionWithCustomIterator : Collection {
       position: _count, startIndex: 0, endIndex: _count)
   }
 
-  @warn_unused_result
   func index(after i: MinimalIndex) -> MinimalIndex {
     return MinimalIndex(
       collectionState: _collectionState,


### PR DESCRIPTION
#### What's in this pull request?

Removed last uses of `@warn_unused_result` from stdlib and tests, with the exception of IDE code completion tests that depend on other compiler changes.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
