### PR TITLE
Track dependencies of SIL instructions on opened archetypes which they use.

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SIL_SILCLONER_H
 #define SWIFT_SIL_SILCLONER_H
 
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILVisitor.h"
@@ -39,9 +40,19 @@ class SILCloner : protected SILVisitor<ImplClass> {
 public:
   using SILVisitor<ImplClass>::asImpl;
 
+  explicit SILCloner(SILFunction &F,
+                     SILOpenedArchetypesTracker &OpenedArchetypesTracker)
+      : Builder(F), InsertBeforeBB(nullptr),
+        OpenedArchetypesTracker(OpenedArchetypesTracker) {
+    Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+  }
+
   explicit SILCloner(SILFunction &F)
-    : Builder(F), InsertBeforeBB(nullptr) { }
-  
+      : Builder(F), InsertBeforeBB(nullptr),
+        OpenedArchetypesTracker(F) {
+    Builder.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+  }
+
   /// Clients of SILCloner who want to know about any newly created
   /// instructions can install a SmallVector into the builder to collect them.
   void setTrackingList(SmallVectorImpl<SILInstruction*> *II) {
@@ -199,6 +210,14 @@ protected:
   void cleanUp(SILFunction *F);
 
 public:
+  void doPreProcess(SILInstruction *Orig) {
+    // Extend the set of available opened archetypes by the opened archetypes
+    // used by the instruction being cloned.
+    auto OpenedArchetypeOperands = Orig->getOpenedArchetypeOperands();
+    Builder.getOpenedArchetypes().addOpenedArchetypeOperands(
+        OpenedArchetypeOperands);
+  }
+
   void doPostProcess(SILInstruction *Orig, SILInstruction *Cloned) {
     asImpl().postProcess(Orig, Cloned);
     assert((Orig->getDebugScope() ? Cloned->getDebugScope()!=nullptr : true) &&
@@ -217,6 +236,8 @@ protected:
   llvm::MapVector<SILBasicBlock*, SILBasicBlock*> BBMap;
 
   TypeSubstitutionMap OpenedExistentialSubs;
+  SILOpenedArchetypesTracker OpenedArchetypesTracker;
+
   /// Set of basic blocks where unreachable was inserted.
   SmallPtrSet<SILBasicBlock *, 32> BlocksWithUnreachables;
 };
@@ -253,8 +274,10 @@ template<typename ImplClass>
 class SILClonerWithScopes : public SILCloner<ImplClass> {
   friend class SILCloner<ImplClass>;
 public:
-  SILClonerWithScopes(SILFunction &To, bool Disable = false)
-    : SILCloner<ImplClass>(To) {
+  SILClonerWithScopes(SILFunction &To,
+                      SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+                      bool Disable = false)
+      : SILCloner<ImplClass>(To, OpenedArchetypesTracker) {
 
     // We only want to do this when we generate cloned functions, not
     // when we inline.
@@ -268,6 +291,24 @@ public:
 
     scopeCloner.reset(new ScopeCloner(To));
   }
+
+  SILClonerWithScopes(SILFunction &To,
+                      bool Disable = false)
+      : SILCloner<ImplClass>(To) {
+
+    // We only want to do this when we generate cloned functions, not
+    // when we inline.
+
+    // FIXME: This is due to having TypeSubstCloner inherit from
+    //        SILClonerWithScopes, and having TypeSubstCloner be used
+    //        both by passes that clone whole functions and ones that
+    //        inline functions.
+    if (Disable)
+      return;
+
+    scopeCloner.reset(new ScopeCloner(To));
+  }
+
 
 private:
   std::unique_ptr<ScopeCloner> scopeCloner;
@@ -333,8 +374,12 @@ void
 SILCloner<ImplClass>::visitSILBasicBlock(SILBasicBlock* BB) {
   SILFunction &F = getBuilder().getFunction();
   // Iterate over and visit all instructions other than the terminator to clone.
-  for (auto I = BB->begin(), E = --BB->end(); I != E; ++I)
+  for (auto I = BB->begin(), E = --BB->end(); I != E; ++I) {
+    // Update the set of available opened archetypes with the opned archetypes
+    // used by the current instruction.
+    doPreProcess(&*I);
     asImpl().visit(&*I);
+  }
   // Iterate over successors to do the depth-first search.
   for (auto &Succ : BB->getSuccessors()) {
     auto BBI = BBMap.find(Succ);
@@ -1251,16 +1296,17 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitWitnessMethodInst(WitnessMethodInst *Inst) {
   auto conformance =
-    getOpConformance(Inst->getLookupType(), Inst->getConformance());
+      getOpConformance(Inst->getLookupType(), Inst->getConformance());
+  auto lookupType = Inst->getLookupType();
+  auto newLookupType = getOpASTType(lookupType);
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(
       Inst,
       getBuilder()
           .createWitnessMethod(
               getOpLocation(Inst->getLoc()),
-              getOpASTType(Inst->getLookupType()), conformance,
+              newLookupType, conformance,
               Inst->getMember(), getOpType(Inst->getType()),
-              Inst->hasOperand() ? getOpValue(Inst->getOperand()) : SILValue(),
               Inst->isVolatile()));
 }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -43,6 +43,7 @@ class SILDebugLocation;
 class SILDebugScope;
 class SILFunction;
 class SILGlobalVariable;
+class SILOpenedArchetypesState;
 class SILType;
 class SILArgument;
 class Stmt;
@@ -168,11 +169,34 @@ public:
   /// Return the array of operands for this instruction.
   ArrayRef<Operand> getAllOperands() const;
 
+  /// Return the array of opened archetype operands for this instruction.
+  ArrayRef<Operand> getOpenedArchetypeOperands() const;
+
   /// Return the array of mutable operands for this instruction.
   MutableArrayRef<Operand> getAllOperands();
 
+  /// Return the array of opened archetypes operands for this instruction.
+  MutableArrayRef<Operand> getOpenedArchetypeOperands();
+
   unsigned getNumOperands() const { return getAllOperands().size(); }
-  SILValue getOperand(unsigned Num) const { return getAllOperands()[Num].get();}
+
+  unsigned getNumOpenedArchetypeOperands() const {
+    return getOpenedArchetypeOperands().size();
+  }
+
+  bool isOpenedArchetypeOperand(unsigned i) const {
+    return i >= getNumOperands() - getNumOpenedArchetypeOperands();
+  }
+
+  bool isOpenedArchetypeOperand(Operand &O) const {
+    assert(O.getUser() == this &&
+           "Operand does not belong to a SILInstruction");
+    return isOpenedArchetypeOperand(O.getOperandNumber());
+  }
+
+  SILValue getOperand(unsigned Num) const {
+    return getAllOperands()[Num].get();
+  }
   void setOperand(unsigned Num, SILValue V) { getAllOperands()[Num].set(V); }
   void swapOperands(unsigned Num1, unsigned Num2) {
     getAllOperands()[Num1].swap(getAllOperands()[Num2]);
@@ -306,6 +330,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
 /// and has no result or a single value result.
 template<ValueKind KIND, typename BASE = SILInstruction, bool HAS_RESULT = true>
 class UnaryInstructionBase : public BASE {
+  // Space for 1 operand.
   FixedOperandList<1> Operands;
 
   /// Check HAS_RESULT in enable_if predicates by injecting a dependency on
@@ -345,6 +370,137 @@ public:
 
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
+
+  bool hasOpenedArchetypeOperands() const {
+    return false;
+  }
+
+  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+    return {};
+  }
+
+  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+    return {};
+  }
+
+  static bool classof(const ValueBase *V) {
+    return V->getKind() == KIND;
+  }
+};
+
+/// A template base class for instructions that take a single regular SILValue
+/// operand, a set of opened archetypes operands and has no result
+/// or a single value result. The operands are tail allocated after the
+/// instruction. Further trailing data can be allocated as well if
+/// TRAILING_TYPES are provided.
+template<ValueKind KIND, typename DERIVED,
+         typename BASE, bool HAS_RESULT,
+         typename... TRAILING_TYPES>
+class UnaryInstructionWithOpenArchetypesBase :
+  public BASE,
+  protected llvm::TrailingObjects<DERIVED, Operand, TRAILING_TYPES...> {
+
+  /// Check HAS_RESULT in enable_if predicates by injecting a dependency on
+  /// a template argument.
+  template<typename X>
+  struct has_result {
+    enum { value = HAS_RESULT };
+  };
+
+protected:
+  friend class llvm::TrailingObjects<DERIVED, Operand, TRAILING_TYPES...>;
+
+  typedef llvm::TrailingObjects<DERIVED, Operand, TRAILING_TYPES...>
+      TrailingBase;
+
+  using TrailingBase::totalSizeToAlloc;
+
+  // Total number of operands of this instruction.
+  // It is number of opened archetype operands + 1.
+  unsigned NumOperands;
+
+public:
+  // Destruct tail allocated objects.
+  ~UnaryInstructionWithOpenArchetypesBase() {
+    Operand *Operands = &getAllOperands()[0];
+    for (unsigned i = 0, end = NumOperands; i < end; ++i) {
+      Operands[i].~Operand();
+    }
+  }
+
+  size_t numTrailingObjects(
+      typename TrailingBase::template OverloadToken<Operand>) const {
+    return NumOperands;
+  }
+
+  UnaryInstructionWithOpenArchetypesBase(
+      SILDebugLocation DebugLoc, SILValue Operand,
+      ArrayRef<SILValue> OpenedArchetypeOperands)
+      : BASE(KIND, DebugLoc), NumOperands(1 + OpenedArchetypeOperands.size()) {
+    TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                           Operand, OpenedArchetypeOperands);
+  }
+
+  template <typename X = void>
+  UnaryInstructionWithOpenArchetypesBase(
+      SILDebugLocation DebugLoc, SILValue Operand,
+      ArrayRef<SILValue> OpenedArchetypeOperands,
+      typename std::enable_if<has_result<X>::value, SILType>::type Ty)
+      : BASE(KIND, DebugLoc, Ty),
+        NumOperands(1 + OpenedArchetypeOperands.size())
+  {
+    TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                           Operand, OpenedArchetypeOperands);
+  }
+
+  template <typename X = void, typename... A>
+  UnaryInstructionWithOpenArchetypesBase(
+      SILDebugLocation DebugLoc, SILValue Operand,
+      ArrayRef<SILValue> OpenedArchetypeOperands,
+      typename std::enable_if<has_result<X>::value, SILType>::type Ty,
+      A &&... args)
+      : BASE(KIND, DebugLoc, Ty, std::forward<A>(args)...),
+        NumOperands(1 + OpenedArchetypeOperands.size())
+  {
+    TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                           Operand, OpenedArchetypeOperands);
+  }
+
+  unsigned getNumOpenedArchetypeOperands() const {
+    return NumOperands - 1;
+  }
+
+  SILValue getOperand() const { return getAllOperands()[0].get(); }
+  void setOperand(SILValue V) { getAllOperands()[0].set(V); }
+
+  Operand &getOperandRef() { return getAllOperands()[0]; }
+
+  /// getType() is ok if this is known to only have one type.
+  template<typename X = void>
+  typename std::enable_if<has_result<X>::value, SILType>::type
+  getType() const { return ValueBase::getType(); }
+
+  ArrayRef<Operand> getAllOperands() const {
+    return {TrailingBase::template getTrailingObjects<Operand>(),
+            static_cast<size_t>(NumOperands)};
+  }
+
+  MutableArrayRef<Operand> getAllOperands() {
+    return {TrailingBase::template getTrailingObjects<Operand>(),
+            static_cast<size_t>(NumOperands)};
+  }
+
+  bool hasOpenedArchetypeOperands() const {
+    return NumOperands > 1;
+  }
+
+  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+    return getAllOperands().slice(1);
+  }
+
+  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+    return getAllOperands().slice(1);
+  }
 
   static bool classof(const ValueBase *V) {
     return V->getKind() == KIND;
@@ -635,11 +791,14 @@ class ApplyInstBase<Impl, Base, false> : public Base {
 
   /// The number of tail-allocated substitutions, allocated after the operand
   /// list's tail allocation.
-  unsigned NumSubstitutions;
+  unsigned NumSubstitutions: 31;
 
   /// Used for apply_inst instructions: true if the called function has an
   /// error result but is not actually throwing.
-  bool NonThrowing;
+  bool NonThrowing: 1;
+
+  /// The number of call arguments as required by the callee.
+  unsigned NumCallArguments;
 
   /// The fixed operand is the callee;  the rest are arguments.
   TailAllocatedOperandList<1> Operands;
@@ -656,10 +815,13 @@ protected:
   template <class... As>
   ApplyInstBase(ValueKind kind, SILDebugLocation DebugLoc, SILValue callee,
                 SILType substCalleeType, ArrayRef<Substitution> substitutions,
-                ArrayRef<SILValue> args, As... baseArgs)
+                ArrayRef<SILValue> args,
+                ArrayRef<SILValue> openedArchetypesOperands,
+                As... baseArgs)
       : Base(kind, DebugLoc, baseArgs...), SubstCalleeType(substCalleeType),
         NumSubstitutions(substitutions.size()), NonThrowing(false),
-        Operands(this, args, callee) {
+        NumCallArguments(args.size()),
+        Operands(this, args, openedArchetypesOperands, callee) {
     static_assert(sizeof(Impl) == sizeof(*this),
         "subclass has extra storage, cannot use TailAllocatedOperandList");
     memcpy(getSubstitutionsStorage(), substitutions.begin(),
@@ -668,12 +830,13 @@ protected:
 
   static void *allocate(SILFunction &F,
                         ArrayRef<Substitution> substitutions,
+                        ArrayRef<SILValue> openedArchetypesOperands,
                         ArrayRef<SILValue> args) {
-    return allocateApplyInst(F,
-                    sizeof(Impl) +
-                    decltype(Operands)::getExtraSize(args.size()) +
-                    sizeof(substitutions[0]) * substitutions.size(),
-                             alignof(Impl));
+    return allocateApplyInst(
+        F, sizeof(Impl) + decltype(Operands)::getExtraSize(
+                              args.size() + openedArchetypesOperands.size()) +
+               sizeof(substitutions[0]) * substitutions.size(),
+        alignof(Impl));
   }
 
   void setNonThrowing(bool isNonThrowing) { NonThrowing = isNonThrowing; }
@@ -742,23 +905,24 @@ public:
 
   /// The arguments passed to this instruction.
   MutableArrayRef<Operand> getArgumentOperands() {
-    return Operands.getDynamicAsArray();
+    return Operands.getDynamicAsArray().slice(0, getNumCallArguments());
   }
 
   ArrayRef<Operand> getArgumentOperands() const {
-    return Operands.getDynamicAsArray();
+    return Operands.getDynamicAsArray().slice(0, getNumCallArguments());
   }
 
   /// The arguments passed to this instruction.
   OperandValueArrayRef getArguments() const {
-    return Operands.getDynamicValuesAsArray();
+    return OperandValueArrayRef(
+        Operands.getDynamicAsArray().slice(0, getNumCallArguments()));
   }
 
   /// Returns the number of arguments for this partial apply.
   unsigned getNumArguments() const { return getArguments().size(); }
 
   Operand &getArgumentRef(unsigned i) {
-    return Operands.getDynamicAsArray()[i];
+    return getArgumentOperands()[i];
   }
 
   /// Return the ith argument passed to this instruction.
@@ -772,6 +936,22 @@ public:
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
 
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
+
+  unsigned getNumCallArguments() const {
+    return NumCallArguments;
+  }
+
+  bool hasOpenedArchetypeOperands() const {
+    return getAllOperands().size() - 1 - getNumCallArguments() != 0;
+  }
+
+  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+    return Operands.getDynamicAsArray().slice(NumCallArguments);
+  }
+
+  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+    return Operands.getDynamicAsArray().slice(NumCallArguments);
+  }
 };
 
 /// Given the callee operand of an apply or try_apply instruction,
@@ -900,14 +1080,17 @@ class ApplyInst : public ApplyInstBase<ApplyInst, SILInstruction> {
 
   ApplyInst(SILDebugLocation DebugLoc, SILValue Callee,
             SILType SubstCalleeType, SILType ReturnType,
-            ArrayRef<Substitution> Substitutions, ArrayRef<SILValue> Args,
+            ArrayRef<Substitution> Substitutions,
+            ArrayRef<SILValue> Args,
+            ArrayRef<SILValue> OpenedArchetypeOperands,
             bool isNonThrowing);
 
   static ApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
                            SILType SubstCalleeType, SILType ReturnType,
                            ArrayRef<Substitution> Substitutions,
                            ArrayRef<SILValue> Args, bool isNonThrowing,
-                           SILFunction &F);
+                           SILFunction &F,
+                           SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   static bool classof(const ValueBase *V) {
@@ -930,13 +1113,16 @@ class PartialApplyInst
   PartialApplyInst(SILDebugLocation DebugLoc, SILValue Callee,
                    SILType SubstCalleeType,
                    ArrayRef<Substitution> Substitutions,
-                   ArrayRef<SILValue> Args, SILType ClosureType);
+                   ArrayRef<SILValue> Args,
+                   ArrayRef<SILValue> OpenedArchetypeOperands,
+                   SILType ClosureType);
 
   static PartialApplyInst *create(SILDebugLocation DebugLoc, SILValue Callee,
                                   SILType SubstCalleeType,
                                   ArrayRef<Substitution> Substitutions,
                                   ArrayRef<SILValue> Args, SILType ClosureType,
-                                  SILFunction &F);
+                                  SILFunction &F,
+                                  SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   /// Return the ast level function type of this partial apply.
@@ -1529,6 +1715,8 @@ class DebugValueInst final
   static DebugValueInst *create(SILDebugLocation DebugLoc, SILValue Operand,
                                 SILModule &M, SILDebugVariable Var);
 
+  size_t numTrailingObjects(OverloadToken<char>) const { return 1; }
+
 public:
   /// Return the underlying variable declaration that this denotes,
   /// or null if we don't have one.
@@ -1541,9 +1729,9 @@ public:
 
 /// Define the start or update to a symbolic variable value (for address-only
 /// types) .
-class DebugValueAddrInst
+class DebugValueAddrInst final
   : public UnaryInstructionBase<ValueKind::DebugValueAddrInst>,
-    private llvm::TrailingObjects<DebugValueInst, char> {
+    private llvm::TrailingObjects<DebugValueAddrInst, char> {
   friend TrailingObjects;
   friend class SILBuilder;
   TailAllocatedDebugVariable VarInfo;
@@ -1802,8 +1990,7 @@ class UpcastInst
 
 /// AddressToPointerInst - Convert a SIL address to a Builtin.RawPointer value.
 class AddressToPointerInst
-  : public UnaryInstructionBase<ValueKind::AddressToPointerInst,
-                                ConversionInst>
+  : public UnaryInstructionBase<ValueKind::AddressToPointerInst, ConversionInst>
 {
   friend class SILBuilder;
 
@@ -1823,14 +2010,22 @@ class PointerToAddressInst
 
 /// Convert a heap object reference to a different type without any runtime
 /// checks.
-class UncheckedRefCastInst
-  : public UnaryInstructionBase<ValueKind::UncheckedRefCastInst,
-                                ConversionInst>
+class UncheckedRefCastInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::UncheckedRefCastInst,
+                                UncheckedRefCastInst,
+                                ConversionInst,
+                                /* HAS_RESULT */ true>
 {
   friend class SILBuilder;
 
-  UncheckedRefCastInst(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+  UncheckedRefCastInst(SILDebugLocation DebugLoc, SILValue Operand,
+                       ArrayRef<SILValue> OpenedArchetypeOperands, SILType Ty)
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
+                                               OpenedArchetypeOperands, Ty) {}
+  static UncheckedRefCastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// Converts a heap object reference to a different type without any runtime
@@ -1875,39 +2070,63 @@ public:
   }
 };
 
-class UncheckedAddrCastInst
-  : public UnaryInstructionBase<ValueKind::UncheckedAddrCastInst,
-                                ConversionInst>
+class UncheckedAddrCastInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::UncheckedAddrCastInst,
+                                UncheckedAddrCastInst,
+                                ConversionInst,
+                                true>
 {
   friend class SILBuilder;
 
   UncheckedAddrCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                        SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+                        ArrayRef<SILValue> OpenedArchetypeOperands, SILType Ty)
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
+                                               OpenedArchetypeOperands, Ty) {}
+  static UncheckedAddrCastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// Convert a value's binary representation to a trivial type of the same size.
-class UncheckedTrivialBitCastInst
-  : public UnaryInstructionBase<ValueKind::UncheckedTrivialBitCastInst,
-                                ConversionInst>
+class UncheckedTrivialBitCastInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::UncheckedTrivialBitCastInst,
+                                UncheckedTrivialBitCastInst,
+                                ConversionInst,
+                                true>
 {
   friend class SILBuilder;
 
   UncheckedTrivialBitCastInst(SILDebugLocation DebugLoc, SILValue Operand,
+                              ArrayRef<SILValue> OpenedArchetypeOperands,
                               SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
+                                               OpenedArchetypeOperands, Ty) {}
+
+  static UncheckedTrivialBitCastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
   
 /// Bitwise copy a value into another value of the same size or smaller.
-class UncheckedBitwiseCastInst
-  : public UnaryInstructionBase<ValueKind::UncheckedBitwiseCastInst,
-                                ConversionInst>
+class UncheckedBitwiseCastInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::UncheckedBitwiseCastInst,
+                                UncheckedBitwiseCastInst,
+                                ConversionInst,
+                                true>
 {
   friend class SILBuilder;
 
   UncheckedBitwiseCastInst(SILDebugLocation DebugLoc, SILValue Operand,
+                           ArrayRef<SILValue> OpenedArchetypeOperands,
                            SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
+                                               OpenedArchetypeOperands, Ty) {}
+  static UncheckedBitwiseCastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// Build a Builtin.BridgeObject from a heap object reference by bitwise-or-ing
@@ -2133,15 +2352,25 @@ class IsNonnullInst : public UnaryInstructionBase<ValueKind::IsNonnullInst> {
   
 
 /// Perform an unconditional checked cast that aborts if the cast fails.
-class UnconditionalCheckedCastInst
-  : public UnaryInstructionBase<ValueKind::UnconditionalCheckedCastInst,
-                                ConversionInst>
+class UnconditionalCheckedCastInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::UnconditionalCheckedCastInst,
+                                UnconditionalCheckedCastInst,
+                                ConversionInst,
+                                true>
 {
   friend class SILBuilder;
 
   UnconditionalCheckedCastInst(SILDebugLocation DebugLoc, SILValue Operand,
+                               ArrayRef<SILValue> OpenedArchetypeOperands,
                                SILType DestTy)
-      : UnaryInstructionBase(DebugLoc, Operand, DestTy) {}
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
+                                               OpenedArchetypeOperands,
+                                               DestTy) {}
+
+  static UnconditionalCheckedCastInst *
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType DestTy,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 };
 
 /// Perform an unconditional checked cast that aborts if the cast fails.
@@ -2812,16 +3041,45 @@ public:
 
 /// MetatypeInst - Represents the production of an instance of a given metatype
 /// named statically.
-class MetatypeInst : public SILInstruction {
+class MetatypeInst final
+    : public SILInstruction,
+      private llvm::TrailingObjects<MetatypeInst, Operand> {
+  friend class TrailingObjects;
   friend class SILBuilder;
 
+  unsigned NumOperands;
+
   /// Constructs a MetatypeInst
-  MetatypeInst(SILDebugLocation DebugLoc, SILType Metatype);
+  MetatypeInst(SILDebugLocation DebugLoc, SILType Metatype,
+               ArrayRef<SILValue> OpenedArchetypeOperands);
+
+  static MetatypeInst *create(SILDebugLocation DebugLoc, SILType Metatype,
+                              SILFunction *F,
+                              SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
+  ~MetatypeInst() {
+    Operand *Operands = getTrailingObjects<Operand>();
+    for (unsigned i = 0, end = NumOperands; i < end; ++i) {
+      Operands[i].~Operand();
+    }
+  }
 
-  ArrayRef<Operand> getAllOperands() const { return {}; }
-  MutableArrayRef<Operand> getAllOperands() { return {}; }
+  ArrayRef<Operand> getAllOperands() const {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  MutableArrayRef<Operand> getAllOperands() {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
 
   static bool classof(const ValueBase *V) {
     return V->getKind() == ValueKind::MetatypeInst;
@@ -3060,39 +3318,48 @@ class SuperMethodInst
 /// WitnessMethodInst - Given a type, a protocol conformance,
 /// and a protocol method constant, extracts the implementation of that method
 /// for the type.
-/// If this witness_method is on an opened existential type it needs the opened
-/// value as operand.
-class WitnessMethodInst : public MethodInst {
+class WitnessMethodInst final
+    : public MethodInst,
+      llvm::TrailingObjects<WitnessMethodInst, Operand> {
+  friend class TrailingObjects;
   friend class SILBuilder;
 
   CanType LookupType;
   ProtocolConformanceRef Conformance;
-  Optional<FixedOperandList<1>> OptionalOperand;
+  unsigned NumOperands;
 
   WitnessMethodInst(SILDebugLocation DebugLoc, CanType LookupType,
                     ProtocolConformanceRef Conformance, SILDeclRef Member,
-                    SILType Ty, SILValue OpenedExistential,
+                    SILType Ty, ArrayRef<SILValue> OpenedArchetypeOperands,
                     bool Volatile = false)
       : MethodInst(ValueKind::WitnessMethodInst, DebugLoc, Ty, Member,
                    Volatile),
-        LookupType(LookupType), Conformance(Conformance) {
-    if (OpenedExistential)
-      OptionalOperand.emplace(this, OpenedExistential);
+        LookupType(LookupType), Conformance(Conformance),
+        NumOperands(OpenedArchetypeOperands.size()) {
+    TrailingOperandsList::InitOperandsList(getAllOperands().begin(), this,
+                                           OpenedArchetypeOperands);
   }
 
   static WitnessMethodInst *
   create(SILDebugLocation DebugLoc, CanType LookupType,
          ProtocolConformanceRef Conformance, SILDeclRef Member, SILType Ty,
-         SILFunction *Parent, SILValue OpenedExistential,
+         SILFunction *Parent, SILOpenedArchetypesState &OpenedArchetypes,
          bool Volatile = false);
 
 public:
+  ~WitnessMethodInst() {
+    Operand *Operands = getTrailingObjects<Operand>();
+    for (unsigned i = 0, end = NumOperands; i < end; ++i) {
+      Operands[i].~Operand();
+    }
+  }
 
   CanType getLookupType() const { return LookupType; }
   ProtocolDecl *getLookupProtocol() const {
     return getMember().getDecl()->getDeclContext()
              ->getAsProtocolOrProtocolExtensionContext();
   }
+
   ProtocolConformanceRef getConformance() const { return Conformance; }
 
   /// Get a representation of the lookup type as a substitution of the
@@ -3101,19 +3368,20 @@ public:
     return Substitution{getLookupType(), Conformance};
   }
 
-  bool hasOperand() const { return OptionalOperand.hasValue(); }
-  SILValue getOperand() const {
-    assert(hasOperand() && "Missing operand");
-    return OptionalOperand->asValueArray()[0];
-  }
-
   ArrayRef<Operand> getAllOperands() const {
-    return OptionalOperand ? OptionalOperand->asArray() : ArrayRef<Operand>{};
+    return { getTrailingObjects<Operand>(), NumOperands };
   }
 
   MutableArrayRef<Operand> getAllOperands() {
-    return OptionalOperand ? OptionalOperand->asArray()
-                           : MutableArrayRef<Operand>{};
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  ArrayRef<Operand> getOpenedArchetypeOperands() const {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  MutableArrayRef<Operand> getOpenedArchetypeOperands() {
+    return { getTrailingObjects<Operand>(), NumOperands };
   }
 
   static bool classof(const ValueBase *V) {
@@ -3144,8 +3412,7 @@ class OpenExistentialAddrInst
   friend class SILBuilder;
 
   OpenExistentialAddrInst(SILDebugLocation DebugLoc, SILValue Operand,
-                          SILType SelfTy)
-      : UnaryInstructionBase(DebugLoc, Operand, SelfTy) {}
+                          SILType SelfTy);
 };
 
 /// Given a class existential, "opens" the
@@ -3157,8 +3424,7 @@ class OpenExistentialRefInst
   friend class SILBuilder;
 
   OpenExistentialRefInst(SILDebugLocation DebugLoc, SILValue Operand,
-                         SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty) {}
+                         SILType Ty);
 };
 
 /// Given an existential metatype,
@@ -3171,8 +3437,7 @@ class OpenExistentialMetatypeInst
   friend class SILBuilder;
 
   OpenExistentialMetatypeInst(SILDebugLocation DebugLoc, SILValue operand,
-                              SILType ty)
-      : UnaryInstructionBase(DebugLoc, operand, ty) {}
+                              SILType ty);
 };
 
 /// Given a boxed existential container,
@@ -3184,16 +3449,19 @@ class OpenExistentialBoxInst
   friend class SILBuilder;
 
   OpenExistentialBoxInst(SILDebugLocation DebugLoc, SILValue operand,
-                         SILType ty)
-      : UnaryInstructionBase(DebugLoc, operand, ty) {}
+                         SILType ty);
 };
 
 /// Given an address to an uninitialized buffer of
 /// a protocol type, initializes its existential container to contain a concrete
 /// value of the given type, and returns the address of the uninitialized
 /// concrete value inside the existential container.
-class InitExistentialAddrInst
-  : public UnaryInstructionBase<ValueKind::InitExistentialAddrInst>
+class InitExistentialAddrInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::InitExistentialAddrInst,
+                                InitExistentialAddrInst,
+                                SILInstruction,
+                                true>
 {
   friend class SILBuilder;
 
@@ -3201,16 +3469,19 @@ class InitExistentialAddrInst
   ArrayRef<ProtocolConformanceRef> Conformances;
 
   InitExistentialAddrInst(SILDebugLocation DebugLoc, SILValue Existential,
+                          ArrayRef<SILValue> OpenedArchetypeOperands,
                           CanType ConcreteType, SILType ConcreteLoweredType,
                           ArrayRef<ProtocolConformanceRef> Conformances)
-      : UnaryInstructionBase(DebugLoc, Existential,
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Existential,
+                             OpenedArchetypeOperands,
                              ConcreteLoweredType.getAddressType()),
         ConcreteType(ConcreteType), Conformances(Conformances) {}
 
   static InitExistentialAddrInst *
   create(SILDebugLocation DebugLoc, SILValue Existential, CanType ConcreteType,
          SILType ConcreteLoweredType,
-         ArrayRef<ProtocolConformanceRef> Conformances, SILFunction *Parent);
+         ArrayRef<ProtocolConformanceRef> Conformances, SILFunction *Parent,
+         SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   ArrayRef<ProtocolConformanceRef> getConformances() const {
@@ -3229,8 +3500,12 @@ public:
 /// InitExistentialRefInst - Given a class instance reference and a set of
 /// conformances, creates a class existential value referencing the
 /// class instance.
-class InitExistentialRefInst
-  : public UnaryInstructionBase<ValueKind::InitExistentialRefInst>
+class InitExistentialRefInst final
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                ValueKind::InitExistentialRefInst,
+                                InitExistentialRefInst,
+                                SILInstruction,
+                                true>
 {
   friend class SILBuilder;
 
@@ -3239,14 +3514,20 @@ class InitExistentialRefInst
 
   InitExistentialRefInst(SILDebugLocation DebugLoc, SILType ExistentialType,
                          CanType FormalConcreteType, SILValue Instance,
+                         ArrayRef<SILValue> OpenedArchetypeOperands,
                          ArrayRef<ProtocolConformanceRef> Conformances)
-      : UnaryInstructionBase(DebugLoc, Instance, ExistentialType),
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Instance,
+                                               OpenedArchetypeOperands,
+                                               ExistentialType),
         ConcreteType(FormalConcreteType), Conformances(Conformances) {}
 
   static InitExistentialRefInst *
   create(SILDebugLocation DebugLoc, SILType ExistentialType,
          CanType ConcreteType, SILValue Instance,
-         ArrayRef<ProtocolConformanceRef> Conformances, SILFunction *Parent);
+         ArrayRef<ProtocolConformanceRef> Conformances, SILFunction *Parent,
+         SILOpenedArchetypesState &OpenedArchetypes);
+
+  //size_t numTrailingObjects(OverloadToken<Operand>) const { return NumOperands; }
 
 public:
   CanType getFormalConcreteType() const {
@@ -3262,11 +3543,13 @@ public:
 /// of conformances, creates an existential metatype value referencing
 /// the metatype.
 class InitExistentialMetatypeInst final
-  : public UnaryInstructionBase<ValueKind::InitExistentialMetatypeInst>,
-    private llvm::TrailingObjects<InitExistentialMetatypeInst,
+  : public UnaryInstructionWithOpenArchetypesBase<
+                                  ValueKind::InitExistentialMetatypeInst,
+                                  InitExistentialMetatypeInst,
+                                  SILInstruction,
+                                  true,
                                   ProtocolConformanceRef>
 {
-  friend TrailingObjects;
   friend class SILBuilder;
 
   unsigned NumConformances;
@@ -3274,12 +3557,13 @@ class InitExistentialMetatypeInst final
   InitExistentialMetatypeInst(SILDebugLocation DebugLoc,
                               SILType existentialMetatypeType,
                               SILValue metatype,
+                              ArrayRef<SILValue> OpenedArchetypeOperands,
                               ArrayRef<ProtocolConformanceRef> conformances);
 
   static InitExistentialMetatypeInst *
   create(SILDebugLocation DebugLoc, SILType existentialMetatypeType,
          SILValue metatype, ArrayRef<ProtocolConformanceRef> conformances,
-         SILFunction *parent);
+         SILFunction *parent, SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   /// Return the object type which was erased.  That is, if this
@@ -3328,7 +3612,6 @@ class ProjectBlockStorageInst
       : UnaryInstructionBase(DebugLoc, Operand, DestTy) {}
 };
 
-///
 
 /// Initializes a block header, creating a block that
 /// invokes a given thin cdecl function.
@@ -4331,27 +4614,35 @@ public:
 /// Perform a checked cast operation and branch on whether the cast succeeds.
 /// The success branch destination block receives the cast result as a BB
 /// argument.
-class CheckedCastBranchInst : public TermInst {
+class CheckedCastBranchInst final:
+  public UnaryInstructionWithOpenArchetypesBase<
+                              ValueKind::CheckedCastBranchInst,
+                              CheckedCastBranchInst,
+                              TermInst,
+                              false> {
   friend class SILBuilder;
 
   SILType DestTy;
   bool IsExact;
 
-  FixedOperandList<1> Operands;
   SILSuccessor DestBBs[2];
 
   CheckedCastBranchInst(SILDebugLocation DebugLoc, bool IsExact,
-                        SILValue Operand, SILType DestTy,
+                        SILValue Operand,
+                        ArrayRef<SILValue> OpenedArchetypeOperands,
+                        SILType DestTy,
                         SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB)
-      : TermInst(ValueKind::CheckedCastBranchInst, DebugLoc), DestTy(DestTy),
-        IsExact(IsExact), Operands{this, Operand},
+      : UnaryInstructionWithOpenArchetypesBase(DebugLoc, Operand,
+                                               OpenedArchetypeOperands),
+        DestTy(DestTy), IsExact(IsExact),
         DestBBs{{this, SuccessBB}, {this, FailureBB}} {}
 
-public:
-  ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
-  MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
+  static CheckedCastBranchInst *
+  create(SILDebugLocation DebugLoc, bool IsExact, SILValue Operand,
+         SILType DestTy, SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB,
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
 
-  SILValue getOperand() const { return Operands[0].get(); }
+public:
   bool isExact() const { return IsExact; }
 
   SuccessorListTy getSuccessors() {
@@ -4470,14 +4761,16 @@ class TryApplyInst
 
   TryApplyInst(SILDebugLocation DebugLoc, SILValue callee,
                SILType substCalleeType, ArrayRef<Substitution> substitutions,
-               ArrayRef<SILValue> args, SILBasicBlock *normalBB,
-               SILBasicBlock *errorBB);
+               ArrayRef<SILValue> args,
+               ArrayRef<SILValue> openedArchetypesOperands,
+               SILBasicBlock *normalBB, SILBasicBlock *errorBB);
 
   static TryApplyInst *create(SILDebugLocation DebugLoc, SILValue callee,
                               SILType substCalleeType,
                               ArrayRef<Substitution> substitutions,
                               ArrayRef<SILValue> args, SILBasicBlock *normalBB,
-                              SILBasicBlock *errorBB, SILFunction &F);
+                              SILBasicBlock *errorBB, SILFunction &F,
+                              SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   static bool classof(const ValueBase *V) {
@@ -4613,6 +4906,11 @@ public:
   /// The arguments passed to this instruction.
   OperandValueArrayRef getArguments() const {
     FOREACH_IMPL_RETURN(getArguments());
+  }
+
+  /// The number of call arguments.
+  unsigned getNumCallArguments() const {
+    FOREACH_IMPL_RETURN(getNumCallArguments());
   }
 
   /// The arguments passed to this instruction, without self.

--- a/include/swift/SIL/SILOpenedArchetypesTracker.h
+++ b/include/swift/SIL/SILOpenedArchetypesTracker.h
@@ -1,0 +1,165 @@
+//===- SILOpenedArchetypeTracker.h - Track opened archetypes  ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
+#define SWIFT_SIL_SILOPENEDARCHETYPESTRACKER_H
+
+#include "swift/SIL/Notifications.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILUndef.h"
+
+namespace swift {
+
+/// SILOpenedArchetypesTracker is a helper class that can be used to create
+/// and maintain a mapping from opened archetypes to instructions
+/// defining them, e.g. open_existential_ref, open_existential_addr,
+/// open_existential_metatype.
+///
+/// This information is useful for representing and maintaining the
+/// dependencies of instructions on opened archetypes they are using.
+///
+/// The intended clients of this class are SILGen, SIL deserializers, etc.
+class SILOpenedArchetypesTracker : public DeleteNotificationHandler {
+public:
+  typedef llvm::DenseMap<Type, SILValue> OpenedArchetypeDefsMap;
+  // Re-use pre-populated map if available.
+  SILOpenedArchetypesTracker(const SILFunction &F,
+                             SILOpenedArchetypesTracker &Tracker)
+      : F(F), OpenedArchetypeDefs(Tracker.OpenedArchetypeDefs) { }
+
+  // Re-use pre-populated map if available.
+  SILOpenedArchetypesTracker(const SILFunction &F,
+                             OpenedArchetypeDefsMap &OpenedArchetypeDefs)
+      : F(F), OpenedArchetypeDefs(OpenedArchetypeDefs) { }
+
+  // Use its own local map if no pre-populated map is provided.
+  SILOpenedArchetypesTracker(const SILFunction &F)
+      : F(F), OpenedArchetypeDefs(LocalOpenedArchetypeDefs) { }
+
+
+  const SILFunction &getFunction() const { return F; }
+
+  void addOpenedArchetypeDef(Type archetype, SILValue Def) {
+    assert(!getOpenedArchetypeDef(archetype) &&
+           "There can be only one definition of an opened archetype");
+    OpenedArchetypeDefs[archetype] = Def;
+  }
+
+  void removeOpenedArchetypeDef(Type archetype, SILValue Def) {
+    auto FoundDef = getOpenedArchetypeDef(archetype);
+    assert(FoundDef &&
+           "Opened archetype definition is not registered in SILFunction");
+    if (FoundDef == Def)
+      OpenedArchetypeDefs.erase(archetype);
+  }
+
+  // Return the SILValue defining a given archetype.
+  // If the defining value is not known, return an empty SILValue.
+  SILValue getOpenedArchetypeDef(Type archetype) const {
+    return OpenedArchetypeDefs.lookup(archetype);
+  }
+
+  const OpenedArchetypeDefsMap &getOpenedArchetypeDefs() const {
+    return OpenedArchetypeDefs;
+  }
+
+  // Register archetypes opened by a given instruction.
+  // Can be used to incrementally populate the mapping, e.g.
+  // if it is done when performing a scan of all instructions
+  // inside a function.
+  void registerOpenedArchetypes(const SILInstruction *I);
+
+  // Register opened archetypes whose definitions are referenced by
+  // the typedef operands of this instruction.
+  void registerUsedOpenedArchetypes(const SILInstruction *I);
+
+  // Unregister archetypes opened by a given instruction.
+  // Should be only called when this instruction is to be removed.
+  void unregisterOpenedArchetypes(const SILInstruction *I);
+
+  // Handling of instruction removal notifications.
+  bool needsNotifications() { return true; }
+
+  // Handle notifications about removals of instructions.
+  void handleDeleteNotification(swift::ValueBase *Value);
+
+  virtual ~SILOpenedArchetypesTracker() {
+    // Unregister the handler.
+    F.getModule().removeDeleteNotificationHandler(this);
+  }
+
+private:
+  /// The function whose opened archetypes are being tracked.
+  /// Used only for verification purposes.
+  const SILFunction &F;
+  /// Mapping from opened archetypes to their definitions.
+  OpenedArchetypeDefsMap &OpenedArchetypeDefs;
+  /// Local map to be used if no other map was provided in the
+  /// constructor.
+  OpenedArchetypeDefsMap LocalOpenedArchetypeDefs;
+};
+
+// A state object containing information about opened archetypes.
+// This information can be used by constructors of SILInstructions,
+// their create methods, etc.
+// The object can be configured to use different sources for providing
+// archetypes, but none of those archetype sets can be modified through
+// this object, which makes it essentially immutable.
+class SILOpenedArchetypesState {
+  // A set of opened archetypes operands for quick lookup.
+  // It usually provides opened archetypes operands of the
+  // instruction being currently processed.
+  ArrayRef<Operand> OpenedArchetypeOperands;
+  // A non-modifiable mapping provided by the tracker.
+  const SILOpenedArchetypesTracker *OpenedArchetypesTracker;
+public:
+  SILOpenedArchetypesState(const SILOpenedArchetypesTracker *Tracker = nullptr)
+      : OpenedArchetypesTracker(Tracker) {}
+
+  SILOpenedArchetypesState(const SILOpenedArchetypesTracker &Tracker)
+      : OpenedArchetypesTracker(&Tracker) { }
+
+  void setOpenedArchetypesTracker(const SILOpenedArchetypesTracker *Tracker) {
+    OpenedArchetypesTracker = Tracker;
+  }
+
+  void addOpenedArchetypeOperands(ArrayRef<Operand> Operands) {
+    OpenedArchetypeOperands = Operands;
+  }
+
+  const SILOpenedArchetypesTracker *getOpenedArchetypesTracker() const {
+    return OpenedArchetypesTracker;
+  }
+
+  /// Lookup the instruction defining an opened archetype by first 
+  /// performing a quick lookup in the opened archetypes operands
+  /// and then in the opened archetypes tracker.
+  SILValue getOpenedArchetypeDef(Type Ty) const;
+};
+
+/// Find an opened archetype defined by an instruction.
+/// \returns The found archetype or empty type otherwise.
+CanType getOpenedArchetypeOf(const SILInstruction *I);
+
+/// Find an opened archetype represented by this type.
+/// It is assumed by this method that the type contains
+/// at most one opened archetype.
+/// Typically, it would be called from a type visitor.
+/// It checks only the type itself, but does not try to
+/// recursively check any children of this type, because
+/// this is the task of the type visitor invoking it.
+/// \returns The found archetype or empty type otherwise.
+CanType getOpenedArchetypeOf(CanType Ty);
+
+} // end swift namespace
+#endif

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -277,6 +277,7 @@ private:
   friend class ValueUseIterator;
   template <unsigned N> friend class FixedOperandList;
   template <unsigned N> friend class TailAllocatedOperandList;
+  friend class TrailingOperandsList;
 };
 
 /// A class which adapts an array of Operands into an array of Values.
@@ -464,6 +465,31 @@ public:
     }
   }
 
+  /// Initialize this operand list.
+  ///
+  /// The dynamic operands are actually out of order: logically they
+  /// will placed after the fixed operands, not before them.  But
+  /// the variadic arguments have to come last.
+  template <class... T>
+  TailAllocatedOperandList(SILInstruction *user,
+                           ArrayRef<SILValue> dynamicArgs,
+                           ArrayRef<SILValue> additionalDynamicArgs,
+                           T&&... fixedArgs)
+      : NumExtra(dynamicArgs.size() + additionalDynamicArgs.size()),
+        Buffer{ { user, std::forward<T>(fixedArgs) }... } {
+    static_assert(sizeof...(fixedArgs) == N, "wrong number of initializers");
+
+    Operand *dynamicSlot = Buffer + N;
+    for (auto value : dynamicArgs) {
+      new (dynamicSlot++) Operand(user, value);
+    }
+
+    for (auto value : additionalDynamicArgs) {
+      new (dynamicSlot++) Operand(user, value);
+    }
+ }
+
+
   ~TailAllocatedOperandList() {
     for (auto &op : getDynamicAsArray()) {
       op.~Operand();
@@ -564,6 +590,27 @@ public:
   /// Indexes into the full list of operands.
   Operand &operator[](unsigned i) { return asArray()[i]; }
   const Operand &operator[](unsigned i) const { return asArray()[i]; }
+};
+
+/// A helper class for initializing the list of trailing operands.
+class TrailingOperandsList {
+public:
+  static void InitOperandsList(Operand *p, SILInstruction *user,
+                               SILValue operand, ArrayRef<SILValue> operands) {
+    assert(p && "Trying to initialize operands using a nullptr");
+    new (p++) Operand(user, operand);
+    for (auto op : operands) {
+      new (p++) Operand(user, op);
+    }
+  }
+
+  static void InitOperandsList(Operand *p, SILInstruction *user,
+                               ArrayRef<SILValue> operands) {
+    assert(p && "Trying to initialize operands using a nullptr");
+    for (auto op : operands) {
+      new (p++) Operand(user, op);
+    }
+  }
 };
 
 /// SILValue hashes just like a pointer.

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -51,6 +51,20 @@ public:
   using SILClonerWithScopes<ImplClass>::doPostProcess;
   using SILClonerWithScopes<ImplClass>::ValueMap;
   using SILClonerWithScopes<ImplClass>::addBlockWithUnreachable;
+  using SILClonerWithScopes<ImplClass>::OpenedArchetypesTracker;
+
+  TypeSubstCloner(SILFunction &To,
+                  SILFunction &From,
+                  TypeSubstitutionMap &ContextSubs,
+                  ArrayRef<Substitution> ApplySubs,
+                  SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+                  bool Inlining = false)
+    : SILClonerWithScopes<ImplClass>(To, OpenedArchetypesTracker, Inlining),
+      SwiftMod(From.getModule().getSwiftModule()),
+      SubsMap(ContextSubs),
+      Original(From),
+      ApplySubs(ApplySubs),
+      Inlining(Inlining) { }
 
   TypeSubstCloner(SILFunction &To,
                   SILFunction &From,
@@ -63,6 +77,7 @@ public:
       Original(From),
       ApplySubs(ApplySubs),
       Inlining(Inlining) { }
+
 
 protected:
   SILType remapType(SILType Ty) {
@@ -223,7 +238,6 @@ protected:
         getBuilder().createWitnessMethod(
             getOpLocation(Inst->getLoc()), newLookupType, Conformance,
             Inst->getMember(), getOpType(Inst->getType()),
-            Inst->hasOperand() ? getOpValue(Inst->getOperand()) : SILValue(),
             Inst->isVolatile()));
   }
 

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -47,10 +47,12 @@ public:
 
   SILInliner(SILFunction &To, SILFunction &From, InlineKind IKind,
              TypeSubstitutionMap &ContextSubs, ArrayRef<Substitution> ApplySubs,
-             CloneCollector::CallbackType Callback =nullptr)
-    : TypeSubstCloner<SILInliner>(To, From, ContextSubs, ApplySubs, true),
-    IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
-    Callback(Callback) {
+             SILOpenedArchetypesTracker &OpenedArchetypesTracker,
+             CloneCollector::CallbackType Callback = nullptr)
+      : TypeSubstCloner<SILInliner>(To, From, ContextSubs, ApplySubs,
+                                    OpenedArchetypesTracker, true),
+        IKind(IKind), CalleeEntryBB(nullptr), CallSiteScope(nullptr),
+        Callback(Callback) {
   }
 
   /// inlineFunction - This method inlines a callee function, assuming that it

--- a/lib/Parse/ParseSIL.cpp
+++ b/lib/Parse/ParseSIL.cpp
@@ -269,14 +269,14 @@ namespace {
     bool parseScopeRef(SILDebugScope *&DS);
     bool parseSILDebugLocation(SILLocation &L, SILBuilder &B,
                                bool parsedComma = false);
-    bool parseSILInstruction(SILBasicBlock *BB);
+    bool parseSILInstruction(SILBasicBlock *BB, SILBuilder &B);
     bool parseCallInstruction(SILLocation InstLoc,
                               ValueKind Opcode, SILBuilder &B,
                               ValueBase *&ResultVal);
     bool parseSILFunctionRef(SILLocation InstLoc,
                              SILBuilder &B, ValueBase *&ResultVal);
 
-    bool parseSILBasicBlock();
+    bool parseSILBasicBlock(SILBuilder &B);
     
     bool isStartOfSILInstruction();
 
@@ -1539,7 +1539,7 @@ bool SILParser::parseSILDebugLocation(SILLocation &L, SILBuilder &B,
 
 /// sil-instruction-def ::= (sil-value-name '=')? sil-instruction
 ///                         (',' sil-scope-ref)? (',' sil-loc)?
-bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
+bool SILParser::parseSILInstruction(SILBasicBlock *BB, SILBuilder &B) {
   // We require SIL instructions to be at the start of a line to assist
   // recovery.
   if (!P.Tok.isAtStartOfLine()) {
@@ -1567,7 +1567,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
   if (parseSILOpcode(Opcode, OpcodeLoc, OpcodeName))
     return true;
 
-  SILBuilder B(BB);
+  B.setInsertionPoint(BB);
   SmallVector<SILValue, 4> OpList;
   SILValue Val;
 
@@ -2909,7 +2909,7 @@ bool SILParser::parseSILInstruction(SILBasicBlock *BB) {
     }
     
     ResultVal = B.createWitnessMethod(InstLoc, LookupTy, Conformance, Member,
-                                        MethodTy, Operand, IsVolatile);
+                                      MethodTy, IsVolatile);
     break;
   }
   case ValueKind::CopyAddrInst: {
@@ -3736,7 +3736,7 @@ bool SILParser::isStartOfSILInstruction() {
 ///     identifier sil-bb-argument-list? ':' sil-instruction+
 ///   sil-bb-argument-list:
 ///     '(' sil-typed-valueref (',' sil-typed-valueref)+ ')'
-bool SILParser::parseSILBasicBlock() {
+bool SILParser::parseSILBasicBlock(SILBuilder &B) {
   SILBasicBlock *BB;
 
   // The basic block name is optional.
@@ -3779,7 +3779,7 @@ bool SILParser::parseSILBasicBlock() {
   F->getBlocks().push_back(BB);
 
   do {
-    if (parseSILInstruction(BB))
+    if (parseSILInstruction(BB, B))
       return true;
   } while (isStartOfSILInstruction());
 
@@ -3871,8 +3871,14 @@ bool Parser::parseDeclSIL() {
       }
       
       // Parse the basic block list.
+      SILOpenedArchetypesTracker OpenedArchetypesTracker(*FunctionState.F);
+      SILBuilder B(*FunctionState.F);
+      // Track the archetypes just like SILGen. This
+      // is required for adding typedef operands to instrucitons.
+      B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
+
       do {
-        if (FunctionState.parseSILBasicBlock())
+        if (FunctionState.parseSILBasicBlock(B))
           return true;
       } while (Tok.isNot(tok::r_brace) && Tok.isNot(tok::eof));
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -23,6 +23,7 @@ add_swift_library(swiftSIL
   SILInstructions.cpp
   SILLocation.cpp
   SILModule.cpp
+  SILOpenedArchetypesTracker.cpp
   SILPrinter.cpp
   SILSuccessor.cpp
   SILType.cpp

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -79,8 +79,8 @@ SILInstruction *SILBuilder::tryCreateUncheckedRefCast(SILLocation Loc,
   if (!SILType::canRefCast(Op->getType(), ResultTy, M))
     return nullptr;
 
-  return insert(
-      new (M) UncheckedRefCastInst(getSILDebugLocation(Loc), Op, ResultTy));
+  return insert(UncheckedRefCastInst::create(getSILDebugLocation(Loc), Op,
+                                             ResultTy, F, OpenedArchetypes));
 }
 
 // Create the appropriate cast instruction based on result type.
@@ -89,16 +89,16 @@ SILInstruction *SILBuilder::createUncheckedBitCast(SILLocation Loc,
                                                    SILType Ty) {
   auto &M = F.getModule();
   if (Ty.isTrivial(M))
-    return insert(
-        new (M) UncheckedTrivialBitCastInst(getSILDebugLocation(Loc), Op, Ty));
+    return insert(UncheckedTrivialBitCastInst::create(
+        getSILDebugLocation(Loc), Op, Ty, F, OpenedArchetypes));
 
   if (auto refCast = tryCreateUncheckedRefCast(Loc, Op, Ty))
-    return refCast;  
+    return refCast;
 
   // The destination type is nontrivial, and may be smaller than the source
   // type, so RC identity cannot be assumed.
-  return insert(
-      new (M) UncheckedBitwiseCastInst(getSILDebugLocation(Loc), Op, Ty));
+  return insert(UncheckedBitwiseCastInst::create(getSILDebugLocation(Loc), Op,
+                                                 Ty, F, OpenedArchetypes));
 }
 
 BranchInst *SILBuilder::createBranch(SILLocation Loc,

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -662,14 +662,63 @@ namespace {
     }
 #include "swift/SIL/SILNodes.def"
   };
+
+#define IMPLEMENTS_METHOD(DerivedClass, BaseClass, MemberName, ExpectedType)  \
+  (!::std::is_same<BaseClass, GET_IMPLEMENTING_CLASS(DerivedClass, MemberName,\
+                                                     ExpectedType)>::value)
+
+  class OpenedArchetypeOperandsAccessor
+      : public SILVisitor<OpenedArchetypeOperandsAccessor,
+                          ArrayRef<Operand>> {
+  public:
+#define VALUE(CLASS, PARENT) \
+    ArrayRef<Operand> visit##CLASS(const CLASS *I) {                    \
+      llvm_unreachable("accessing non-instruction " #CLASS);            \
+    }
+#define INST(CLASS, PARENT, MEMBEHAVIOR, RELEASINGBEHAVIOR)                    \
+    ArrayRef<Operand> visit##CLASS(const CLASS *I) {                           \
+      if (!IMPLEMENTS_METHOD(CLASS, SILInstruction, getOpenedArchetypeOperands, \
+                             ArrayRef<Operand>() const))                       \
+        return {};                                                             \
+      return I->getOpenedArchetypeOperands();                                 \
+    }
+#include "swift/SIL/SILNodes.def"
+  };
+
+  class OpenedArchetypeOperandsMutableAccessor
+    : public SILVisitor<OpenedArchetypeOperandsMutableAccessor,
+                        MutableArrayRef<Operand> > {
+  public:
+#define VALUE(CLASS, PARENT) \
+    MutableArrayRef<Operand> visit##CLASS(const CLASS *I) {             \
+      llvm_unreachable("accessing non-instruction " #CLASS);            \
+    }
+#define INST(CLASS, PARENT, MEMBEHAVIOR, RELEASINGBEHAVIOR)                    \
+    MutableArrayRef<Operand> visit##CLASS(CLASS *I) {                          \
+      if (!IMPLEMENTS_METHOD(CLASS, SILInstruction, getOpenedArchetypeOperands, \
+                             MutableArrayRef<Operand>()))                      \
+        return {};                                                             \
+      return I->getOpenedArchetypeOperands();                                 \
+    }
+#include "swift/SIL/SILNodes.def"
+  };
 } // end anonymous namespace
 
 ArrayRef<Operand> SILInstruction::getAllOperands() const {
-  return AllOperandsAccessor().visit(const_cast<SILInstruction*>(this));
+  return AllOperandsAccessor().visit(const_cast<SILInstruction *>(this));
 }
 
 MutableArrayRef<Operand> SILInstruction::getAllOperands() {
   return AllOperandsMutableAccessor().visit(this);
+}
+
+ArrayRef<Operand> SILInstruction::getOpenedArchetypeOperands() const {
+  return OpenedArchetypeOperandsAccessor().visit(
+      const_cast<SILInstruction *>(this));
+}
+
+MutableArrayRef<Operand> SILInstruction::getOpenedArchetypeOperands() {
+  return OpenedArchetypeOperandsMutableAccessor().visit(this);
 }
 
 /// getOperandNumber - Return which operand this is in the operand list of the

--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -1,0 +1,124 @@
+//==- SILOpenedArchetypeTracker.cpp - Track opened archetypes  ---*- C++ -*-==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
+
+using namespace swift;
+
+// Register archetypes opened by a given instruction.
+// Can be used to incrementally populate the mapping, e.g.
+// if it is done when performing a scan of all instructions
+// inside a function.
+void SILOpenedArchetypesTracker::registerOpenedArchetypes(
+    const SILInstruction *I) {
+  assert((!I->getParent() || I->getFunction() == &F) &&
+         "Instruction does not belong to a proper SILFunction");
+  auto Archetype = getOpenedArchetypeOf(I);
+  if (Archetype)
+    addOpenedArchetypeDef(Archetype, I);
+}
+
+// Register opened archetypes whose definitions are referenced by
+// the typedef operands of this instruction.
+void SILOpenedArchetypesTracker::registerUsedOpenedArchetypes(
+    const SILInstruction *I) {
+  assert((!I->getParent() || I->getFunction() == &F) &&
+         "Instruction does not belong to a proper SILFunction");
+  for (auto &Op : I->getOpenedArchetypeOperands()) {
+    auto OpenedArchetypeDef = Op.get();
+    assert(isa<SILInstruction>(OpenedArchetypeDef) &&
+           "typedef operand should refer to a SILInstruction");
+    addOpenedArchetypeDef(
+        getOpenedArchetypeOf(cast<SILInstruction>(OpenedArchetypeDef)),
+        OpenedArchetypeDef);
+  }
+}
+
+// Unregister archetypes opened by a given instruction.
+// Should be only called when this instruction is to be removed.
+void SILOpenedArchetypesTracker::unregisterOpenedArchetypes(
+    const SILInstruction *I) {
+  assert(I->getFunction() == &F &&
+         "Instruction does not belong to a proper SILFunction");
+  auto Archetype = getOpenedArchetypeOf(I);
+  if (Archetype)
+    removeOpenedArchetypeDef(Archetype, I);
+}
+
+void SILOpenedArchetypesTracker::handleDeleteNotification(
+    swift::ValueBase *Value) {
+  if (auto I = dyn_cast<SILInstruction>(Value))
+    if (I->getFunction() == &F)
+      unregisterOpenedArchetypes(I);
+}
+
+/// Find an opened archetype defined by an instruction.
+/// \returns The found archetype or empty type otherwise.
+CanType swift::getOpenedArchetypeOf(const SILInstruction *I) {
+  if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
+      isa<OpenExistentialBoxInst>(I) || isa<OpenExistentialMetatypeInst>(I)) {
+    auto Ty = getOpenedArchetypeOf(I->getType().getSwiftRValueType());
+    assert(Ty->isOpenedExistential() && "Type should be an opened archetype");
+    return Ty;
+  }
+
+  return CanType();
+}
+
+
+bool hasAtMostOneOpenedArchetype(CanType Ty) {
+  int NumOpenedArchetypes = 0;
+  Ty.visit([&](Type t) {
+    if (t->isOpenedExistential()) {
+      NumOpenedArchetypes++;
+    }
+    return;
+  });
+  return NumOpenedArchetypes <= 1;
+}
+
+/// Find an opened archetype represented by this type.
+/// It is assumed by this method that the type contains
+/// at most one opened archetype.
+/// Typically, it would be called from a type visitor.
+/// It checks only the type itself, but does not try to
+/// recursively check any children of this type, because
+/// this is the task of the type visitor invoking it.
+/// \returns The found archetype or empty type otherwise.
+CanType swift::getOpenedArchetypeOf(CanType Ty) {
+  if (!Ty)
+    return CanType();
+  assert(hasAtMostOneOpenedArchetype(Ty) &&
+         "Type should contain at most one opened archetype");
+  while (auto MetaTy = dyn_cast<AnyMetatypeType>(Ty)) {
+    Ty = MetaTy->getInstanceType().getCanonicalTypeOrNull();
+  }
+  if (Ty->isOpenedExistential())
+    return Ty;
+  return CanType();
+}
+
+SILValue SILOpenedArchetypesState::getOpenedArchetypeDef(Type Ty) const {
+  if (!Ty)
+    return SILValue();
+  auto CanTy = Ty.getCanonicalTypeOrNull();
+  // First perform a quick check.
+  for (auto &Op : OpenedArchetypeOperands) {
+    auto Def = Op.get();
+    if (getOpenedArchetypeOf(cast<SILInstruction>(Def)) == CanTy)
+      return Def;
+  }
+  // Then use a regular lookup.
+  if (OpenedArchetypesTracker)
+    return OpenedArchetypesTracker->getOpenedArchetypeDef(Ty);
+  return SILValue();
+}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1291,9 +1291,9 @@ public:
     if (WMI->isVolatile())
       *this << "[volatile] ";
     *this << "$" << WMI->getLookupType() << ", " << WMI->getMember();
-    if (WMI->hasOperand()) {
+    if (!WMI->getOpenedArchetypeOperands().empty()) {
       *this << ", ";
-      *this << getIDAndType(WMI->getOperand());
+      *this << getIDAndType(WMI->getOpenedArchetypeOperands()[0].get());
     }
     *this << " : " << WMI->getType();
   }

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -14,6 +14,7 @@
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILOpenedArchetypesTracker.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/SILVTable.h"
 #include "swift/SIL/Dominance.h"
@@ -100,6 +101,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   Module *M;
   const SILFunction &F;
   Lowering::TypeConverter &TC;
+  SILOpenedArchetypesTracker OpenedArchetypes;
   const SILInstruction *CurInstruction = nullptr;
   DominanceInfo *Dominance = nullptr;
   bool SingleFunction = true;
@@ -414,7 +416,7 @@ public:
 
   SILVerifier(const SILFunction &F, bool SingleFunction=true)
     : M(F.getModule().getSwiftModule()), F(F), TC(F.getModule().Types),
-      Dominance(nullptr), SingleFunction(SingleFunction) {
+      OpenedArchetypes(F), Dominance(nullptr), SingleFunction(SingleFunction) {
     if (F.isExternalDeclaration())
       return;
       
@@ -440,17 +442,18 @@ public:
   }
 
   void visitSILArgument(SILArgument *arg) {
-    checkLegalType(arg->getFunction(), arg);
+    checkLegalType(arg->getFunction(), arg, nullptr);
   }
 
   void visitSILInstruction(SILInstruction *I) {
     CurInstruction = I;
+    OpenedArchetypes.registerOpenedArchetypes(I);
     checkSILInstruction(I);
 
     // Check the SILLLocation attached to the instruction.
     checkInstructionsSILLocation(I);
 
-    checkLegalType(I->getFunction(), I);
+    checkLegalType(I->getFunction(), I, I);
   }
 
   void checkSILInstruction(SILInstruction *I) {
@@ -513,10 +516,18 @@ public:
               "instruction's operand's owner isn't the instruction");
       require(isInValueUses(&operand), "operand value isn't used by operand");
 
+      if (I->isOpenedArchetypeOperand(operand)) {
+        require(isa<SILInstruction>(I),
+               "opened archetype operand should refer to a SILInstruction");
+      }
+
       // Make sure that if operand is generic that its primary archetypes match
       // the function context.
-      checkLegalType(I->getFunction(), operand.get());
+      checkLegalType(I->getFunction(), operand.get(), I);
     }
+
+    // TODO: There should be a use of an opened archetype inside the instruction for
+    // each opened archetype operand of the instruction.
   }
 
   void checkInstructionsSILLocation(SILInstruction *I) {
@@ -562,14 +573,14 @@ public:
 
   /// Check that the types of this value producer are all legal in the function
   /// context in which it exists.
-  void checkLegalType(SILFunction *F, ValueBase *value) {
+  void checkLegalType(SILFunction *F, ValueBase *value, SILInstruction *I) {
     if (SILType type = value->getType()) {
-      checkLegalType(F, type);
+      checkLegalType(F, type, I);
     }
   }
 
   /// Check that the given type is a legal SIL value.
-  void checkLegalType(SILFunction *F, SILType type) {
+  void checkLegalType(SILFunction *F, SILType type, SILInstruction *I) {
     auto rvalueType = type.getSwiftRValueType();
     require(!isa<LValueType>(rvalueType),
             "l-value types are not legal in SIL");
@@ -583,6 +594,14 @@ public:
       require(isArchetypeValidInFunction(A, F),
               "Operand is of an ArchetypeType that does not exist in the "
               "Caller's generic param list.");
+      if (auto OpenedA = getOpenedArchetype(t.getCanonicalTypeOrNull())) {
+        auto Def = OpenedArchetypes.getOpenedArchetypeDef(OpenedA);
+        require (Def, "Opened archetype should be registered in SILFunction");
+        require(I == nullptr || Def == I ||
+                Dominance->properlyDominates(cast<SILInstruction>(Def), I),
+                "Use of an opened archetype should be dominated by a "
+                "definition of this opened archetype");
+      }
     });
   }
 
@@ -674,21 +693,55 @@ public:
     return fnTy->substGenericArgs(F.getModule(), M, subs);
   }
 
-  void checkFullApplySite(FullApplySite site) {
+  /// Check that for each opened archetype in substitutions, there is an
+  /// opened archetype operand.
+  void checkApplySubstitutionsOpenedArchetypes(SILInstruction *AI,
+                                               ArrayRef<Substitution> Subs) {
     // If we have a substitution whose replacement type is an archetype, make
     // sure that the replacement archetype is in the context generic params of
     // the caller function.
-    // For each substitution Sub in AI...
-    for (auto &Sub : site.getSubstitutions()) {
-      // If Sub's replacement is not an archetype type or is from an opened
-      // existential type, skip it...
-      auto *A = Sub.getReplacement()->getAs<ArchetypeType>();
-      if (!A)
-        continue;
-      require(isArchetypeValidInFunction(A, site.getInstruction()->getFunction()),
-              "Archetype to be substituted must be valid in function.");
+    llvm::DenseSet<CanType> FoundOpenedArchetypes;
+    for (auto &Sub : Subs) {
+      Sub.getReplacement().visit([&](Type Ty) {
+        if (!Ty->isOpenedExistential())
+          return;
+        auto *A = Ty->getAs<ArchetypeType>();
+        require(isArchetypeValidInFunction(A, AI->getFunction()),
+                "Archetype to be substituted must be valid in function.");
+        // Collect all opened archetypes used in the substitutions list.
+        FoundOpenedArchetypes.insert(Ty.getCanonicalTypeOrNull());
+        // Also check that they are properly tracked inside the current
+        // function.
+        auto Def =
+            OpenedArchetypes.getOpenedArchetypeDef(Ty.getCanonicalTypeOrNull());
+        require(Def, "Opened archetype should be registered in SILFunction");
+        require(Def == AI ||
+                    Dominance->properlyDominates(cast<SILInstruction>(Def), AI),
+                "Use of an opened archetype should be dominated by a "
+                "definition of this opened archetype");
+      });
     }
 
+    require(FoundOpenedArchetypes.size() ==
+                AI->getOpenedArchetypeOperands().size(),
+            "Number of opened archetypes in the substitutions list should "
+            "match the number of opened archetype operands");
+
+    for (auto &Op : AI->getOpenedArchetypeOperands()) {
+      auto V = Op.get();
+      require(isa<SILInstruction>(V),
+             "opened archetype operand should refer to a SIL instruction");
+      auto Archetype = getOpenedArchetypeOf(cast<SILInstruction>(V));
+      require(Archetype, "opened archetype operand should define an opened archetype");
+      require(FoundOpenedArchetypes.count(Archetype),
+              "opened archetype operand does not correspond to any opened archetype from "
+              "the substitutions list");
+    }
+  }
+
+  void checkFullApplySite(FullApplySite site) {
+    checkApplySubstitutionsOpenedArchetypes(site.getInstruction(),
+                                            site.getSubstitutions());
     // Then make sure that we have a type that can be substituted for the
     // callee.
     auto substTy = checkApplySubstitutions(site.getSubstitutions(),
@@ -705,10 +758,11 @@ public:
             "substituted callee type does not match substitutions");
 
     // Check that the arguments and result match.
-    require(site.getArguments().size() == substTy->getNumSILArguments(),
+    //require(site.getArguments().size() == substTy->getNumSILArguments(),
+    require(site.getNumCallArguments() == substTy->getNumSILArguments(),
             "apply doesn't have right number of arguments for function");
     auto numIndirects = substTy->getNumIndirectResults();
-    for (size_t i = 0, size = site.getArguments().size(); i < size; ++i) {
+    for (size_t i = 0, size = site.getNumCallArguments(); i < size; ++i) {
       if (i < numIndirects) {
         requireSameType(site.getArguments()[i]->getType(),
                         substTy->getIndirectResults()[i].getSILType(),
@@ -807,21 +861,7 @@ public:
     require(resultInfo->getExtInfo().hasContext(),
             "result of closure cannot have a thin function type");
 
-    // If we have a substitution whose replacement type is an archetype, make
-    // sure that the replacement archetype is in the context generic params of
-    // the caller function.
-    // For each substitution Sub in AI...
-    for (auto &Sub : PAI->getSubstitutions()) {
-      // If Sub's replacement is not an archetype type or is from an opened
-      // existential type, skip it...
-      Sub.getReplacement().visit([&](Type t) {
-        auto *A = t->getAs<ArchetypeType>();
-        if (!A)
-          return;
-        require(isArchetypeValidInFunction(A, PAI->getFunction()),
-                "Archetype to be substituted must be valid in function.");
-      });
-    }
+    checkApplySubstitutionsOpenedArchetypes(PAI, PAI->getSubstitutions());
 
     auto substTy = checkApplySubstitutions(PAI->getSubstitutions(),
                                         PAI->getCallee()->getType());
@@ -1388,6 +1428,7 @@ public:
             "metatype instruction must be of metatype type");
     require(MI->getType().castTo<MetatypeType>()->hasRepresentation(),
             "metatype instruction must have a metatype representation");
+    verifyOpenedArchetype(MI, MI->getType().getSwiftRValueType());
   }
   void checkValueMetatypeInst(ValueMetatypeInst *MI) {
     require(MI->getType().is<MetatypeType>(),
@@ -1646,8 +1687,14 @@ public:
             "method's Self parameter should be constrained by protocol");
 
     auto lookupType = AMI->getLookupType();
-    if (isOpenedArchetype(lookupType))
-      require(AMI->hasOperand(), "Must have an opened existential operand");
+    if (getOpenedArchetype(lookupType)) {
+      require(AMI->getOpenedArchetypeOperands().size() == 1,
+              "Must have an opened existential operand");
+      verifyOpenedArchetype(AMI, lookupType);
+    } else {
+      require(AMI->getOpenedArchetypeOperands().empty(),
+              "Should not have an operand for the opened existential");
+    }
     if (isa<ArchetypeType>(lookupType) || lookupType->isAnyExistentialType()) {
       require(AMI->getConformance().isAbstract(),
               "archetype or existential lookup should have abstract conformance");
@@ -1662,12 +1709,8 @@ public:
     }
   }
 
-  bool isOpenedArchetype(CanType t) {
-    ArchetypeType *archetype = dyn_cast<ArchetypeType>(t);
-    if (!archetype)
-      return false;
-
-    return !archetype->getOpenedExistentialType().isNull();
+  CanType getOpenedArchetype(CanType t) {
+    return getOpenedArchetypeOf(t);
   }
 
   // Get the expected type of a dynamic method reference.
@@ -1809,8 +1852,12 @@ public:
     require(OEI->getType().isAddress(),
             "open_existential_addr result must be an address");
 
-    require(isOpenedArchetype(OEI->getType().getSwiftRValueType()),
+    auto archetype = getOpenedArchetype(OEI->getType().getSwiftRValueType());
+    require(archetype,
         "open_existential_addr result must be an opened existential archetype");
+    require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
+            "Archetype opened by open_existential_addr should be registered in "
+            "SILFunction");
   }
 
   void checkOpenExistentialRefInst(OpenExistentialRefInst *OEI) {
@@ -1827,8 +1874,12 @@ public:
     require(OEI->getType().isObject(),
             "open_existential_ref result must be an address");
 
-    require(isOpenedArchetype(resultInstanceTy),
-            "open_existential_ref result must be an opened existential");
+    auto archetype = getOpenedArchetype(resultInstanceTy);
+    require(archetype,
+        "open_existential_ref result must be an opened existential archetype");
+    require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
+            "Archetype opened by open_existential_ref should be registered in "
+            "SILFunction");
   }
 
   void checkOpenExistentialBoxInst(OpenExistentialBoxInst *OEI) {
@@ -1845,8 +1896,12 @@ public:
     require(OEI->getType().isAddress(),
             "open_existential_box result must be an address");
 
-    require(isOpenedArchetype(resultInstanceTy),
-            "open_existential_box result must be an opened existential");
+    auto archetype = getOpenedArchetype(resultInstanceTy);
+    require(archetype,
+        "open_existential_box result must be an opened existential archetype");
+    require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
+            "Archetype opened by open_existential_box should be registered in "
+            "SILFunction");
   }
 
   void checkOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *I) {
@@ -1886,11 +1941,15 @@ public:
     require(operandInstTy.isExistentialType(),
             "ill-formed existential metatype in open_existential_metatype "
             "operand");
-    require(isOpenedArchetype(resultInstTy),
-            "open_existential_metatype result must be an opened existential "
-            "metatype");
+    auto archetype = getOpenedArchetype(resultInstTy);
+    require(archetype, "open_existential_metatype result must be an opened "
+                       "existential metatype");
+    require(
+        OpenedArchetypes.getOpenedArchetypeDef(archetype) == I,
+        "Archetype opened by open_existential_metatype should be registered in "
+        "SILFunction");
   }
-  
+
   void checkAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {
     SILType exType = AEBI->getExistentialType();
     require(exType.isObject(),
@@ -1932,6 +1991,7 @@ public:
             "concrete type");
     
     checkExistentialProtocolConformances(exType, AEI->getConformances());
+    verifyOpenedArchetype(AEI, AEI->getFormalConcreteType());
   }
 
   void checkInitExistentialRefInst(InitExistentialRefInst *IEI) {
@@ -1961,6 +2021,7 @@ public:
             "concrete type");
     
     checkExistentialProtocolConformances(exType, IEI->getConformances());
+    verifyOpenedArchetype(IEI, IEI->getFormalConcreteType());
   }
 
   void checkDeinitExistentialAddrInst(DeinitExistentialAddrInst *DEI) {
@@ -2005,6 +2066,8 @@ public:
             "operand");
 
     checkExistentialProtocolConformances(resultType, I->getConformances());
+    verifyOpenedArchetype(
+        I, getOpenedArchetypeOf(I->getType().getSwiftRValueType()));
   }
 
   void checkExistentialProtocolConformances(SILType resultType,
@@ -2081,12 +2144,41 @@ public:
     verifyCheckedCast(/*exact*/ false,
                       CI->getOperand()->getType(),
                       CI->getType());
+    verifyOpenedArchetype(CI, CI->getType().getSwiftRValueType());
+  }
+
+  /// Verify if a given type is an opened archetype.
+  /// If this is the case, verify that the provided instruction has an
+  /// opened archetype parameter for it.
+  void verifyOpenedArchetype(SILInstruction *I, CanType Ty) {
+    if (!Ty)
+      return;
+    // Check for each referenced opened archetype from Ty
+    // that the instruction contains an opened archetype operand
+    // for it.
+    Ty.visit([&](Type t) {
+      if (!t->isOpenedExistential())
+        return;
+      auto Def = OpenedArchetypes.getOpenedArchetypeDef(t);
+      require(Def, "Opened archetype should be registered in SILFunction");
+      bool found = false;
+      for (auto &TypeDefOp : I->getOpenedArchetypeOperands()) {
+        if (TypeDefOp.get() == Def) {
+          found = true;
+          break;
+        }
+      }
+      require(found,
+              "Instruction should contain an opened archetype operand for "
+              "every used open archetype");
+    });
   }
 
   void checkCheckedCastBranchInst(CheckedCastBranchInst *CBI) {
     verifyCheckedCast(CBI->isExact(),
                       CBI->getOperand()->getType(),
                       CBI->getCastType());
+    verifyOpenedArchetype(CBI, CBI->getCastType().getSwiftRValueType());
 
     require(CBI->getSuccessBB()->bbarg_size() == 1,
             "success dest of checked_cast_br must take one argument");
@@ -2288,6 +2380,7 @@ public:
   }
   
   void checkUncheckedRefCastInst(UncheckedRefCastInst *AI) {
+    verifyOpenedArchetype(AI, AI->getType().getSwiftRValueType());
     require(AI->getOperand()->getType().isObject(),
             "unchecked_ref_cast operand must be a value");
     require(AI->getType().isObject(),
@@ -2311,6 +2404,8 @@ public:
   }
   
   void checkUncheckedAddrCastInst(UncheckedAddrCastInst *AI) {
+    verifyOpenedArchetype(AI, AI->getType().getSwiftRValueType());
+
     require(AI->getOperand()->getType().isAddress(),
             "unchecked_addr_cast operand must be an address");
     require(AI->getType().isAddress(),
@@ -2318,6 +2413,7 @@ public:
   }
   
   void checkUncheckedTrivialBitCastInst(UncheckedTrivialBitCastInst *BI) {
+    verifyOpenedArchetype(BI, BI->getType().getSwiftRValueType());
     require(BI->getOperand()->getType().isObject(),
             "unchecked_trivial_bit_cast must operate on a value");
     require(BI->getType().isObject(),
@@ -2327,6 +2423,7 @@ public:
   }
 
   void checkUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *BI) {
+    verifyOpenedArchetype(BI, BI->getType().getSwiftRValueType());
     require(BI->getOperand()->getType().isObject(),
             "unchecked_bitwise_cast must operate on a value");
     require(BI->getType().isObject(),
@@ -2344,6 +2441,7 @@ public:
   }
 
   void checkRawPointerToRefInst(RawPointerToRefInst *AI) {
+    verifyOpenedArchetype(AI, AI->getType().getSwiftRValueType());
     require(AI->getType()
               .getSwiftType()->isBridgeableObjectType()
             || AI->getType().getSwiftType()->isEqual(
@@ -2370,6 +2468,7 @@ public:
   }
   
   void checkBridgeObjectToRefInst(BridgeObjectToRefInst *RI) {
+    verifyOpenedArchetype(RI, RI->getType().getSwiftRValueType());
     require(RI->getConverted()->getType()
                == SILType::getBridgeObjectType(F.getASTContext()),
             "bridge_object_to_ref must take a BridgeObject");
@@ -3071,6 +3170,22 @@ public:
     }
   }
 
+  void verifyOpenedArchetypes(SILFunction *F) {
+    require(&OpenedArchetypes.getFunction() == F,
+           "Wrong SILFunction provided to verifyOpenedArchetypes");
+    // Check that definitions of all opened archetypes from
+    // OpenedArchetypesDefs are existing instructions
+    // belonging to the function F.
+    for (auto KV: OpenedArchetypes.getOpenedArchetypeDefs()) {
+      require(getOpenedArchetype(KV.first.getCanonicalTypeOrNull()),
+              "Only opened archetypes should be registered in SILFunction");
+      auto Def = cast<SILInstruction>(KV.second);
+      require(Def->getFunction() == F, 
+              "Definition of every registered opened archetype should be an"
+              " existing instruction in a current SILFunction");
+    }
+  }
+
   void visitSILBasicBlock(SILBasicBlock *BB) {
     // Make sure that each of the successors/predecessors of this basic block
     // have this basic block in its predecessor/successor list.
@@ -3145,6 +3260,7 @@ public:
     verifyEpilogBlocks(F);
     verifyStackHeight(F);
     verifyBranches(F);
+    verifyOpenedArchetypes(F);
     SILVisitor::visitSILFunction(F);
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -547,18 +547,12 @@ public:
       auto proto = Constant.getDecl()->getDeclContext()
                                      ->getAsProtocolOrProtocolExtensionContext();
       auto archetype = getWitnessMethodSelfType();
-      // Get the openend existential value if the archetype is an opened
-      // existential type.
-      SILValue OpenedExistential;
-      if (!archetype->getOpenedExistentialType().isNull())
-        OpenedExistential = SelfValue;
 
       SILValue fn = gen.B.createWitnessMethod(Loc,
                                   archetype,
                                   ProtocolConformanceRef(proto),
                                   *constant,
                                   constantInfo.getSILType(),
-                                  OpenedExistential,
                                   constant->isForeign);
       mv = ManagedValue::forUnmanaged(fn);
       break;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -35,10 +35,12 @@ using namespace Lowering;
 SILGenFunction::SILGenFunction(SILGenModule &SGM, SILFunction &F)
   : SGM(SGM), F(F),
     B(*this, createBasicBlock()),
+    OpenedArchetypesTracker(F),
     CurrentSILLoc(F.getLocation()),
     Cleanups(*this)
 {
   B.setCurrentDebugScope(F.getDebugScope());
+  B.setOpenedArchetypesTracker(&OpenedArchetypesTracker);
 }
 
 /// SILGenFunction destructor - called after the entire function's AST has been

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -353,6 +353,8 @@ public:
   /// into.
   SILGenBuilder B;
 
+  SILOpenedArchetypesTracker OpenedArchetypesTracker;
+
   struct BreakContinueDest {
     LabeledStmt *Target;
     JumpDest BreakDest;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -650,6 +650,8 @@ isNonmutatingCapture(SILArgument *BoxArg) {
 static bool
 isNonescapingUse(Operand *O, SmallVectorImpl<SILInstruction*> &Mutations) {
   auto *U = O->getUser();
+  if (U->isOpenedArchetypeOperand(*O))
+    return true;
   // Marking the boxed value as escaping is OK. It's just a DI annotation.
   if (isa<MarkFunctionEscapeInst>(U))
     return true;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -305,6 +305,7 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
 
   SmallVector<SILValue, 16> CaptureArgs;
   SmallVector<SILValue, 32> FullArgs;
+
   for (auto FI = F->begin(), FE = F->end(); FI != FE; ++FI) {
     for (auto I = FI->begin(), E = FI->end(); I != E; ++I) {
       FullApplySite InnerAI = FullApplySite::isa(&*I);
@@ -397,9 +398,16 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
       ContextSubs.copyFrom(CalleeFunction->getContextGenericParams()
                                          ->getSubstitutionMap(ApplySubs));
 
+      SILOpenedArchetypesTracker OpenedArchetypesTracker(*F);
+      F->getModule().registerDeleteNotificationHandler(
+          &OpenedArchetypesTracker);
+      // The callee only needs to know about opened archetypes used in
+      // the substitution list.
+      OpenedArchetypesTracker.registerUsedOpenedArchetypes(InnerAI.getInstruction());
+
       SILInliner Inliner(*F, *CalleeFunction,
-                         SILInliner::InlineKind::MandatoryInline,
-                         ContextSubs, ApplySubs);
+                         SILInliner::InlineKind::MandatoryInline, ContextSubs,
+                         ApplySubs, OpenedArchetypesTracker);
       if (!Inliner.inlineFunction(InnerAI, FullArgs)) {
         I = InnerAI.getInstruction()->getIterator();
         continue;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -252,6 +252,7 @@ private:
                                                SILValue NewSelf,
                                                SILValue Self,
                                                CanType ConcreteType,
+                                               SILValue ConcreteTypeDef,
                                                ProtocolConformanceRef Conformance,
                                                CanType OpenedArchetype);
   SILInstruction *

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -1468,12 +1468,19 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
           Caller->size() << "] " << Callee->getName() << "\n";
     );
 
+    SILOpenedArchetypesTracker OpenedArchetypesTracker(*Caller);
+    Caller->getModule().registerDeleteNotificationHandler(&OpenedArchetypesTracker);
+    // The callee only needs to know about opened archetypes used in
+    // the substitution list.
+    OpenedArchetypesTracker.registerUsedOpenedArchetypes(AI.getInstruction());
+
     // Notice that we will skip all of the newly inlined ApplyInsts. That's
     // okay because we will visit them in our next invocation of the inliner.
     TypeSubstitutionMap ContextSubs;
     SILInliner Inliner(*Caller, *Callee,
                        SILInliner::InlineKind::PerformanceInline, ContextSubs,
-                       AI.getSubstitutions());
+                       AI.getSubstitutions(),
+                       OpenedArchetypesTracker);
 
     auto Success = Inliner.inlineFunction(AI, Args);
     (void) Success;

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -82,6 +82,7 @@ namespace swift {
                                      SmallVectorImpl<uint64_t> &scratch);
     /// Read a SIL instruction within a given SIL basic block.
     bool readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
+                            SILBuilder &Builder,
                             unsigned RecordKind,
                             SmallVectorImpl<uint64_t> &scratch);
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -507,7 +507,7 @@ void SILSerializer::writeOneTypeOneOperandLayout(ValueKind valueKind,
 /// Write an instruction that looks exactly like a conversion: all
 /// important information is encoded in the operand and the result type.
 void SILSerializer::writeConversionLikeInstruction(const SILInstruction *I) {
-  assert(I->getNumOperands() == 1);
+  assert(I->getNumOperands() - I->getOpenedArchetypeOperands().size() == 1);
   writeOneTypeOneOperandLayout(I->getKind(), 0, I->getType(),
                                I->getOperand(0));
 }
@@ -1395,15 +1395,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     handleSILDeclRef(S, AMI->getMember(), ListOfValues);
 
     // Add an optional operand.
-    TypeID OperandTy =
-        AMI->hasOperand()
-            ? S.addTypeRef(AMI->getOperand()->getType().getSwiftRValueType())
-            : TypeID();
-    unsigned OperandTyCategory =
-        AMI->hasOperand() ? (unsigned)AMI->getOperand()->getType().getCategory()
-                          : 0;
-    SILValue OptionalOpenedExistential =
-        AMI->hasOperand() ? AMI->getOperand() : SILValue();
+    TypeID OperandTy = TypeID();
+    unsigned OperandTyCategory = 0;
+    SILValue OptionalOpenedExistential = SILValue();
     auto OperandValueId = addValueRef(OptionalOpenedExistential);
 
     SILInstWitnessMethodLayout::emitRecord(

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -7,6 +7,20 @@ protocol CP : class {
   func f() -> Self
 }
 
+protocol P2 {
+  var c: Int32 { get }
+}
+
+extension P2 {
+  func s() -> Int32
+}
+
+struct L {
+  var start: Int32 { get }
+  @sil_stored let o: P2
+  init(o: P2)
+}
+
 sil @plus : $@convention(thin) (Int64, Int64) -> Int64
 sil @fromLiteral : $@convention(thin) (Builtin.Int128, @thin Int64.Type) -> Int64
 
@@ -845,3 +859,47 @@ sil shared [transparent] @identity_closure : $@convention(thin) (Builtin.Int8) -
 bb0(%0 : $Builtin.Int8):
   return %0 : $Builtin.Int8
 }
+
+sil [transparent] @P2_s : $@convention(method) <Self where Self : P2> (@in_guaranteed Self) -> Int32 {
+bb0(%0 : $*Self):
+  %2 = alloc_stack $Self
+  copy_addr %0 to [initialization] %2 : $*Self
+  %4 = witness_method $Self, #P2.c!getter.1 : $@convention(witness_method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  %5 = apply %4<Self>(%2) : $@convention(witness_method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  destroy_addr %2 : $*Self
+  %7 = integer_literal $Builtin.Int32, 1
+  %8 = struct_extract %5 : $Int32, #Int32._value
+  %9 = integer_literal $Builtin.Int1, -1
+  %10 = builtin "sadd_with_overflow_Int32"(%8 : $Builtin.Int32, %7 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %11 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 0
+  %12 = tuple_extract %10 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %12 : $Builtin.Int1
+  %14 = struct $Int32 (%11 : $Builtin.Int32)
+  dealloc_stack %2 : $*Self
+  return %14 : $Int32
+}
+
+// Check that P2_s call can be properly inlined and the resulting witness_method instruction
+// uses the opned archetype from the caller.
+// CHECK-LABEL: sil hidden @L_start
+// CHECK: open_existential_addr{{.*}}$*@[[OPENED_ARCHETYPE:opened\("[A-Z0-9-]+"\) P2]]
+// CHECK: witness_method $@[[OPENED_ARCHETYPE]], #P2.c!getter.1, %{{[0-9]+}} : $*@[[OPENED_ARCHETYPE]]
+// CHECK: return
+sil hidden @L_start : $@convention(method) (@in_guaranteed L) -> Int32 {
+bb0(%0 : $*L):
+  %2 = struct_element_addr %0 : $*L, #L.o
+  %3 = alloc_stack $P2
+  copy_addr %2 to [initialization] %3 : $*P2
+  %5 = open_existential_addr %3 : $*P2 to $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2
+  %6 = function_ref @P2_s : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  %7 = apply %6<@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2>(%5) : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
+  destroy_addr %5 : $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60") P2
+  deinit_existential_addr %3 : $*P2
+  dealloc_stack %3 : $*P2
+  return %7 : $Int32
+}
+
+sil_default_witness_table hidden P2 {
+  no_default
+}
+

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -142,8 +142,8 @@ lookup2:
   %23 = alloc_box $Optional<() -> ()>
   %24 = load %21a : $*AnyObject
   strong_retain %24 : $AnyObject
-  %26 = open_existential_ref %24 : $AnyObject to $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject
-  %27 = unchecked_ref_cast %26 : $@opened("01234567-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
+  %26 = open_existential_ref %24 : $AnyObject to $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject
+  %27 = unchecked_ref_cast %26 : $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
   dynamic_method_br %27 : $Builtin.UnknownObject, #X.f!1.foreign, bb1, bb2
 
 bb1(%8 : $@convention(objc_method) (Builtin.UnknownObject) -> ()):


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Till now there was no way in SIL to explicitly express a dependency of an instruction on any opened archetypes used by it. This was a cause of many errors and correctness issues. In many cases the code was moved around without taking into account these dependencies, which resulted in breaking the invariant that any uses of an opened archetype should be dominated by the definition of this archetype.

This patch does the following:
- Map opened archetypes to the instructions defining them, i.e. to open_existential instructions.
- Introduce a helper class SILOpenedArchetypesTracker for creating and maintaining such mappingss.
- Each SIL instruction which uses an opened archetype as a type gets an additional "typedef" operand representing a dependency of the instruction on this archetype. These typedef operands are an in-memory representation. They are not serialized. Instead, they are re-constructed when reading binary or textual SIL files.
- SILVerifier was extended to conduct more thorough checks related to the usage of opened archetypes.
