### PR TITLE
SE-0093 - Add public base property to slices

### DIFF
--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -435,6 +435,11 @@ public struct ${Self}<Base : ${BaseRequirements}>
 %     else:
   internal let _base: Base
 %     end
+
+  /// The underlying collection of the slice.
+  public var base: Base {
+    return _base
+  }
 }
 
 %     end

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -18,6 +18,32 @@ import StdlibCollectionUnittest
 import SwiftPrivate
 
 
+/// Reference-type collection for testing the `base` property.
+class ReferenceCollection : RandomAccessCollection {
+    typealias Index = Int
+    
+    var startIndex: Int {
+        return 0
+    }
+    
+    var endIndex: Int {
+        return 1
+    }
+
+    subscript(index: Int) -> String {
+        return ""
+    }
+    
+    func index(after i: Int) -> Int {
+        return 1
+    }
+    
+    func index(before i: Int) -> Int {
+        return 0
+    }
+}
+
+
 var SliceTests = TestSuite("Collection")
 
 //===----------------------------------------------------------------------===//
@@ -68,6 +94,14 @@ SliceTests.test("${Slice}/init(base:bounds:)") {
       { $0.value == $1.value }
   }
 }
+
+% if RangeReplaceable == False and Mutable == False:
+SliceTests.test("${Slice}/baseProperty") {
+  let referenceCollection = ReferenceCollection()
+  let testSlice = ${Slice}(base: referenceCollection, bounds: 0..<1)
+  expectTrue(testSlice.base === referenceCollection)
+}
+% end
 
 SliceTests.test("${Slice}.{startIndex,endIndex}") {
   for test in subscriptRangeTests {


### PR DESCRIPTION
#### What's in this pull request?

Implement SE-0093 with a readonly property on Slice that returns the internal value `_base`.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
