### PR TITLE
[update-checkout] Allow untracked files

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -37,7 +37,7 @@ def update_working_copy(repo_path, branch):
     print("--- Updating '" + repo_path + "' ---")
     with shell.pushd(repo_path, dry_run=False, echo=False):
         if branch:
-            status = shell.capture(['git', 'status', '--porcelain'],
+            status = shell.capture(['git', 'status', '--porcelain', '-uno'],
                                    echo=False)
             if status:
                 print("Please, commit your changes.")


### PR DESCRIPTION
#### What's in this pull request?

Allow untracked files when updating.

I have several untracked files in my work tree for personal use.
Moreover, `utils/build-toolchain` creates installed files in the source directory.
It's very annoying to stash them away...

```
$ utils/update-checkout 

... <snip> ...

--- Updating '/Users/rintaro/git/swift-oss/swift' ---
Please, commit your changes.
?? swift-nightly-install/
?? swift-nightly-symroot/
?? utils/my-personal-util

$
```

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.
