### PR TITLE
SILGen: Evaluate loaded lvalues in a writeback scope.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1514,6 +1514,11 @@ void LValue::print(raw_ostream &OS) const {
 }
 
 LValue SILGenFunction::emitLValue(Expr *e, AccessKind accessKind) {
+  // Some lvalue nodes (namely BindOptionalExprs) require immediate evaluation
+  // of their subexpression, so we must have a writeback scope open while
+  // building an lvalue.
+  assert(InWritebackScope && "must be in a writeback scope");
+
   LValue r = SILGenLValue(*this).visit(e, accessKind);
   // If the final component has an abstraction change, introduce a
   // reabstraction component.

--- a/test/SILGen/optional_chain_addressor.swift
+++ b/test/SILGen/optional_chain_addressor.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-silgen -verify -parse-as-library %s
+
+func foo(x: UnsafeMutablePointer<UnsafeMutablePointer<()>?>) {
+  _ = x.pointee?.pointee
+  _ = x.pointee?.dynamicType
+}


### PR DESCRIPTION
emitLValue always has to occur in a writeback scope, even if the lvalue isn't formally accessed until later, because some lvalue productions immediately access their parent lvalue expression (namely optional chaining expressions). Fixes rdar://problem/26642478.
