### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::addImplicitConstructors(…)

### DIFF
--- a/validation-test/compiler_crashers/28309-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers/28309-swift-typechecker-addimplicitconstructors.swift
@@ -1,0 +1,14 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class a
+class A:a{
+class d:a
+let a=D
+let f:d


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
swift: /path/to/swift/lib/AST/DiagnosticEngine.cpp:549: void swift::DiagnosticEngine::flushActiveDiagnostic(): Assertion `ActiveDiagnostic && "No active diagnostic to flush"' failed.
10 swift           0x0000000000ea7db9 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1593
11 swift           0x00000000010b8197 swift::ClassDecl::inheritsSuperclassInitializers(swift::LazyResolver*) + 231
14 swift           0x00000000010d6016 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1174
15 swift           0x0000000000edeaa4 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
16 swift           0x0000000000e88998 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3864
18 swift           0x00000000010538e3 swift::Expr::walk(swift::ASTWalker&) + 19
19 swift           0x0000000000e89220 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
20 swift           0x0000000000e8fbf2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
21 swift           0x0000000000e90d47 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
22 swift           0x0000000000e90f5b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
24 swift           0x0000000000e9d819 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 4153
25 swift           0x00000000010f636c swift::DeclContext::lookupQualified(swift::Type, swift::DeclName, swift::NLOptions, swift::LazyResolver*, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 2652
26 swift           0x00000000010f4c05 swift::UnqualifiedLookup::UnqualifiedLookup(swift::DeclName, swift::DeclContext*, swift::LazyResolver*, bool, swift::SourceLoc, bool, bool) + 2469
27 swift           0x0000000000edd69b swift::TypeChecker::lookupUnqualified(swift::DeclContext*, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>) + 187
30 swift           0x0000000000f0e8ae swift::TypeChecker::resolveIdentifierType(swift::DeclContext*, swift::IdentTypeRepr*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, bool, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 158
32 swift           0x0000000000f0f8b4 swift::TypeChecker::resolveType(swift::TypeRepr*, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 164
33 swift           0x0000000000f0e7a0 swift::TypeChecker::validateType(swift::TypeLoc&, swift::DeclContext*, swift::OptionSet<swift::TypeResolutionFlags, unsigned int>, swift::GenericTypeResolver*, llvm::function_ref<bool (swift::TypeCheckRequest)>*) + 192
34 swift           0x0000000000e9aa1a swift::TypeChecker::checkInheritanceClause(swift::Decl*, swift::GenericTypeResolver*) + 5370
35 swift           0x0000000000e9c9ef swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 527
40 swift           0x0000000000ea2166 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
41 swift           0x0000000000ec4ac2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
42 swift           0x0000000000c58d39 swift::CompilerInstance::performSema() + 3289
44 swift           0x00000000007d73bf swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
45 swift           0x00000000007a33d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28309-swift-typechecker-addimplicitconstructors.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28309-swift-typechecker-addimplicitconstructors-da3b4e.o
1.  While type-checking 'A' at validation-test/compiler_crashers/28309-swift-typechecker-addimplicitconstructors.swift:11:1
2.  While resolving type a at [validation-test/compiler_crashers/28309-swift-typechecker-addimplicitconstructors.swift:12:9 - line:12:9] RangeText="a"
3.  While type-checking expression at [validation-test/compiler_crashers/28309-swift-typechecker-addimplicitconstructors.swift:13:7 - line:13:7] RangeText="D"
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
