### PR TITLE
[stdlib] Adding tests for removeSubrange overloads for range types

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -159,11 +159,11 @@ internal struct RemoveLastNTest {
   }
 }
 
-internal struct RemoveSubrangeTest {
-  let collection: [OpaqueValue<Int>]
-  let rangeSelection: RangeSelection
-  let expected: [Int]
-  let loc: SourceLoc
+public struct RemoveSubrangeTest {
+  public let collection: [OpaqueValue<Int>]
+  public let rangeSelection: RangeSelection
+  public let expected: [Int]
+  public let loc: SourceLoc
 
   internal init(
     collection: [Int], rangeSelection: RangeSelection, expected: [Int],
@@ -392,6 +392,48 @@ public let replaceRangeTests: [ReplaceSubrangeTest] = [
     rangeSelection: .offsets(1, 2),
     expected: [1010, 8080, 9090, 3030],
     closedExpected: [1010, 8080, 9090]),
+]
+
+public let removeRangeTests: [RemoveSubrangeTest] = [
+  RemoveSubrangeTest(
+    collection: [],
+    rangeSelection: .emptyRange,
+    expected: []),
+
+  RemoveSubrangeTest(
+    collection: [1010],
+    rangeSelection: .middle,
+    expected: []),
+
+  RemoveSubrangeTest(
+    collection: [1010, 2020, 3030, 4040],
+    rangeSelection: .leftHalf,
+    expected: [3030, 4040]),
+
+  RemoveSubrangeTest(
+    collection: [1010, 2020, 3030, 4040],
+    rangeSelection: .rightHalf,
+    expected: [1010, 2020]),
+
+  RemoveSubrangeTest(
+    collection: [1010, 2020, 3030, 4040, 5050],
+    rangeSelection: .middle,
+    expected: [1010, 5050]),
+
+  RemoveSubrangeTest(
+    collection: [1010, 2020, 3030, 4040, 5050, 6060],
+    rangeSelection: .leftHalf,
+    expected: [4040, 5050, 6060]),
+
+  RemoveSubrangeTest(
+    collection: [1010, 2020, 3030, 4040, 5050, 6060],
+    rangeSelection: .rightHalf,
+    expected: [1010, 2020, 3030]),
+
+  RemoveSubrangeTest(
+    collection: [1010, 2020, 3030, 4040, 5050, 6060],
+    rangeSelection: .middle,
+    expected: [1010, 6060]),
 ]
 
 extension TestSuite {
@@ -808,52 +850,22 @@ self.test("\(testNamePrefix).removeFirst(n: Int)/removeTooMany/semantics") {
 // removeSubrange()
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).removeSubrange()/semantics") {
-  let tests: [RemoveSubrangeTest] = [
-    RemoveSubrangeTest(
-      collection: [],
-      rangeSelection: .emptyRange,
-      expected: []),
-
-    RemoveSubrangeTest(
-      collection: [1010],
-      rangeSelection: .middle,
-      expected: []),
-
-    RemoveSubrangeTest(
-      collection: [1010, 2020, 3030, 4040],
-      rangeSelection: .leftHalf,
-      expected: [3030, 4040]),
-
-    RemoveSubrangeTest(
-      collection: [1010, 2020, 3030, 4040],
-      rangeSelection: .rightHalf,
-      expected: [1010, 2020]),
-
-    RemoveSubrangeTest(
-      collection: [1010, 2020, 3030, 4040, 5050],
-      rangeSelection: .middle,
-      expected: [1010, 5050]),
-
-    RemoveSubrangeTest(
-      collection: [1010, 2020, 3030, 4040, 5050, 6060],
-      rangeSelection: .leftHalf,
-      expected: [4040, 5050, 6060]),
-
-    RemoveSubrangeTest(
-      collection: [1010, 2020, 3030, 4040, 5050, 6060],
-      rangeSelection: .rightHalf,
-      expected: [1010, 2020, 3030]),
-
-    RemoveSubrangeTest(
-      collection: [1010, 2020, 3030, 4040, 5050, 6060],
-      rangeSelection: .middle,
-      expected: [1010, 6060]),
-  ]
-
-  for test in tests {
+self.test("\(testNamePrefix).removeSubrange()/range/semantics") {
+  for test in removeRangeTests {
     var c = makeWrappedCollection(test.collection)
     let rangeToRemove = test.rangeSelection.range(in: c)
+    c.removeSubrange(rangeToRemove)
+    expectEqualSequence(
+      test.expected,
+      c.map { extractValue($0).value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+self.test("\(testNamePrefix).replaceSubrange()/closedRange/semantics") {
+  for test in removeRangeTests.filter({ !$0.rangeSelection.isEmpty }) {
+    var c = makeWrappedCollection(test.collection)
+    let rangeToRemove = test.rangeSelection.closedRange(in: c)
     c.removeSubrange(rangeToRemove)
     expectEqualSequence(
       test.expected,

--- a/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
+++ b/stdlib/private/StdlibCollectionUnittest/RangeSelection.swift
@@ -21,6 +21,13 @@ public enum RangeSelection {
   case rightHalf
   case offsets(Int, Int)
 
+  public var isEmpty: Bool {
+    switch self {
+    case .emptyRange: return true
+    default: return false
+    }
+  }
+
   public func range<C : Collection>(in c: C) -> Range<C.Index> {
     switch self {
       case .emptyRange: return c.endIndex..<c.endIndex

--- a/stdlib/public/core/RangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/RangeReplaceableCollection.swift.gyb
@@ -925,7 +925,6 @@ extension RangeReplaceableCollection
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   public mutating func removeSubrange(_ bounds: ${Range}<Index>) {
-    // FIXME: swift-3-indexing-model: tests.
     removeSubrange(_makeHalfOpen(bounds))
   }
 }

--- a/validation-test/stdlib/RangeReplaceable.swift.gyb
+++ b/validation-test/stdlib/RangeReplaceable.swift.gyb
@@ -109,6 +109,26 @@ RangeReplaceableTestSuite.test("replaceSubrange/countableClosedRange") {
   }
 }
 
+% withRangeTypes = ["countableRange", "countableClosedRange"]
+% for rangeType in withRangeTypes:
+RangeReplaceableTestSuite.test("removeSubrange/${rangeType}") {
+%   if rangeType is "countableClosedRange":
+  for test in removeRangeTests.filter({ !$0.rangeSelection.isEmpty }) {
+%   else:
+  for test in removeRangeTests {
+%   end
+    var c = 
+      MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex(elements: test.collection)
+    let rangeToRemove = test.rangeSelection.${rangeType}(in: c)
+    c.removeSubrange(rangeToRemove)
+    expectEqualSequence(
+      test.expected,
+      c.map { $0.value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+% end
+
 RangeReplaceableTestSuite.test("reserveCapacity/dispatch") {
   var tester = RangeReplaceableCollectionLog.dispatchTester(Array<Int>())
   tester.reserveCapacity(10)


### PR DESCRIPTION
#### What's in this pull request?

@gribozavr 

Tests for `removeSubrange` overloads on range replaceable collections. The test suite passes and the PR can be merged whenever you are ready.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
