### PR TITLE
Adding tests for String's replaceSubrange overloads for closed ranges

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -185,7 +185,6 @@ extension String {
     _ bounds: ${Range}<Index>,
     with newElements: C
   ) where C : Collection, C.Iterator.Element == Character {
-    // FIXME: swift-3-indexing-model: tests.
     withMutableCharacters {
       (v: inout CharacterView)
       in v.replaceSubrange(bounds, with: newElements)
@@ -209,7 +208,6 @@ extension String {
   public mutating func replaceSubrange(
     _ bounds: ${Range}<Index>, with newElements: String
   ) {
-    // FIXME: swift-3-indexing-model: tests.
     replaceSubrange(bounds, with: newElements.characters)
   }
 % end

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1285,10 +1285,9 @@ StringTests.test("String.decodeCString/UTF32") {
 internal struct ReplaceSubrangeTest {
   let original: String
   let newElements: String
-  // RangeSelection is defined in CheckRangeReplaceableCollectionType
   let rangeSelection: RangeSelection
   let expected: String
-  let closedExpected: String?  // Expected array for closed ranges
+  let closedExpected: String?
   let loc: SourceLoc
 
   internal init(
@@ -1322,49 +1321,57 @@ let replaceSubrangeTests = [
     original: "eela",
     newElements: "m",
     rangeSelection: .leftEdge,
-    expected: "meela"
+    expected: "meela",
+    closedExpected: "mela"
   ),
   ReplaceSubrangeTest(
     original: "meel",
     newElements: "a",
     rangeSelection: .rightEdge,
-    expected: "meela"
+    expected: "meela",
+    closedExpected: "meea"
   ),
   ReplaceSubrangeTest(
     original: "a",
     newElements: "meel",
     rangeSelection: .leftEdge,
-    expected: "meela"
+    expected: "meela",
+    closedExpected: "meel"
   ),
   ReplaceSubrangeTest(
     original: "m",
     newElements: "eela",
     rangeSelection: .rightEdge,
-    expected: "meela"
+    expected: "meela",
+    closedExpected: "eela"
   ),
   ReplaceSubrangeTest(
     original: "alice",
     newElements: "bob",
     rangeSelection: .offsets(1, 1),
-    expected: "aboblice"
+    expected: "aboblice",
+    closedExpected: "abobice"
   ),
   ReplaceSubrangeTest(
     original: "alice",
     newElements: "bob",
     rangeSelection: .offsets(1, 2),
-    expected: "abobice"
+    expected: "abobice",
+    closedExpected: "abobce"
   ),
   ReplaceSubrangeTest(
     original: "alice",
     newElements: "bob",
     rangeSelection: .offsets(1, 3),
-    expected: "abobce"
+    expected: "abobce",
+    closedExpected: "abobe"
   ),
   ReplaceSubrangeTest(
     original: "alice",
     newElements: "bob",
     rangeSelection: .offsets(1, 4),
-    expected: "abobe"
+    expected: "abobe",
+    closedExpected: "abob"
   ),
   ReplaceSubrangeTest(
     original: "alice",
@@ -1376,7 +1383,8 @@ let replaceSubrangeTests = [
     original: "bob",
     newElements: "meela",
     rangeSelection: .offsets(1, 2),
-    expected: "bmeelab"
+    expected: "bmeelab",
+    closedExpected: "bmeela"
   ),
 ]
 
@@ -1403,6 +1411,39 @@ StringTests.test("String.replaceSubrange()/string/range") {
     expectEqual(
       theString,
       test.expected,
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+StringTests.test("String.replaceSubrange()/characters/closedRange") {
+  for test in replaceSubrangeTests {
+    guard let closedExpected = test.closedExpected else {
+      continue
+    }
+    var theString = test.original
+    let c = test.original.characters
+    let rangeToReplace = test.rangeSelection.closedRange(in: c)
+    let newCharacters = Array(test.newElements.characters)
+    theString.replaceSubrange(rangeToReplace, with: newCharacters)
+    expectEqual(
+      theString,
+      closedExpected,
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+StringTests.test("String.replaceSubrange()/string/closedRange") {
+  for test in replaceSubrangeTests {
+    guard let closedExpected = test.closedExpected else {
+      continue
+    }
+    var theString = test.original
+    let c = test.original.characters
+    let rangeToReplace = test.rangeSelection.closedRange(in: c)
+    theString.replaceSubrange(rangeToReplace, with: test.newElements)
+    expectEqual(
+      theString,
+      closedExpected,
       stackTrace: SourceLocStack().with(test.loc))
   }
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Tests for `replaceSubrange` overloads on `String` for closed ranges. @gribozavr 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
