### PR TITLE
Exporting ioctl

### DIFF
--- a/stdlib/public/Platform/Misc.c
+++ b/stdlib/public/Platform/Misc.c
@@ -14,6 +14,7 @@
 #include <semaphore.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 
 #include "swift/Runtime/Config.h"
 
@@ -49,6 +50,18 @@ extern int _swift_Platform_fcntlPtr(int fd, int cmd, void* ptr) {
   return fcntl(fd, cmd, ptr);
 }
 
+SWIFT_CC(swift)
+extern int
+_swift_Platform_ioctl(int fd, unsigned long int request, int value) {
+  return ioctl(fd, request, value);
+}
+
+SWIFT_CC(swift)
+extern int
+_swift_Platform_ioctlPtr(int fd, unsigned long int request, void* ptr) {
+  return ioctl(fd, request, ptr);
+}
+ 
 #if defined(__APPLE__)
 #define _REENTRANT
 #include <math.h>

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -278,6 +278,48 @@ public var S_IEXEC: mode_t  { return S_IXUSR }
 #endif
 
 //===----------------------------------------------------------------------===//
+// ioctl.h
+//===----------------------------------------------------------------------===//
+
+@_silgen_name("_swift_Platform_ioctl")
+internal func _swift_Platform_ioctl(
+  _ fd: CInt,
+  _ request: UInt,
+  _ value: CInt
+) -> CInt
+
+@_silgen_name("_swift_Platform_ioctlPtr")
+internal func _swift_Platform_ioctlPtr(
+  _ fd: CInt,
+  _ request: UInt,
+  _ ptr: UnsafeMutablePointer<Void>
+) -> CInt
+
+public func ioctl(
+  _ fd: CInt,
+  _ request: UInt,
+  _ value: CInt
+) -> CInt {
+  return _swift_Platform_ioctl(fd, request, value)
+}
+
+public func ioctl(
+  _ fd: CInt,
+  _ request: UInt,
+  _ ptr: UnsafeMutablePointer<Void>
+) -> CInt {
+  return _swift_Platform_ioctlPtr(fd, request, ptr)
+}
+
+public func ioctl(
+  _ fd: CInt,
+  _ request: UInt
+) -> CInt {
+  return _swift_Platform_ioctl(fd, request, 0)
+}
+ 
+ 
+//===----------------------------------------------------------------------===//
 // unistd.h
 //===----------------------------------------------------------------------===//
 

--- a/test/1_stdlib/POSIX.swift
+++ b/test/1_stdlib/POSIX.swift
@@ -82,7 +82,36 @@ POSIXTests.test("sem_open existing O_EXCL fail") {
   let res2 = sem_unlink(semaphoreName)
   expectEqual(0, res2)
 }
+
+// Fail because the file descriptor is invalid.
+POSIXTests.test("ioctl(CInt, UInt, CInt): fail") {
+  let fd = open(fn, 0)
+  expectEqual(-1, fd)
+  expectEqual(ENOENT, errno)
 	
+  // A simple check to verify that ioctl is available
+  let _ = ioctl(fd, 0, 0)
+  expectEqual(EBADF, errno)
+}   
+
+#if os(Linux)
+// Successful creation of a socket and listing interfaces
+POSIXTests.test("ioctl(CInt, UInt, UnsafeMutablePointer<Void>): listing interfaces success") {
+  // Create a socket
+  let sock = socket(PF_INET, 1, 0)
+  expectGT(Int(sock), 0)
+
+  // List interfaces
+  var ic = ifconf()
+  let io = ioctl(sock, UInt(SIOCGIFCONF), &ic);
+  expectGE(io, 0)
+
+  //Cleanup
+  let res = close(sock)
+  expectEqual(0, res)
+}
+#endif
+
 // Fail because file doesn't exist.
 POSIXTests.test("fcntl(CInt, CInt): fail") {
   let fd = open(fn, 0)


### PR DESCRIPTION
#### What's in this pull request?

This pull request exports the variadic `ioctl` system call, needed to interact with device files on Linux and other Unix-like systems. At the moment, Linux Swift libraries that interact with a device driver need to implement a c wrapper for `ioctl` in a separate clang/llvm module (essentially the same c module is duplicated in every library that does something with devices). 

Having `ioctl` available in Swift would allow the creation of pure-Swift device libraries (more portable, easier to compile).

The two new functions contained in this PR follow the same approach of the already exported `fcntl`, one function with an int parameter and one with a pointer. But unlike `fcntl` i don't expect `ioctl` to be used internally in Foundation any time soon.

On the testing side, the only thing that can be tested across platforms is the presence of the function, since aside from a few obscure commands related to tty devices, ioctl requests are heavily platform-dependent. I'm including a single test that tries an ioctl on a non-existing file (failure is expected).   

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [x] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
