### PR TITLE
Adding tests for String's removeSubrange overloads

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -291,7 +291,6 @@ extension String {
   ///   lower bounds of `bounds` must be valid indices of the string.
 % end
   public mutating func removeSubrange(_ bounds: ${Range}<Index>) {
-    // FIXME: swift-3-indexing-model: tests.
     withMutableCharacters {
       (v: inout CharacterView) in v.removeSubrange(bounds)
     }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1304,6 +1304,26 @@ internal struct ReplaceSubrangeTest {
   }
 }
 
+internal struct RemoveSubrangeTest {
+  let original: String
+  let rangeSelection: RangeSelection
+  let expected: String
+  let closedExpected: String
+  let loc: SourceLoc
+
+  internal init(
+    original: String, rangeSelection: RangeSelection, expected: String,
+    closedExpected: String? = nil,
+    file: String = #file, line: UInt = #line
+  ) {
+    self.original = original
+    self.rangeSelection = rangeSelection
+    self.expected = expected
+    self.closedExpected = closedExpected ?? expected
+    self.loc = SourceLoc(file, line, comment: "replaceSubrange() test data")
+  }
+}
+
 let replaceSubrangeTests = [
   ReplaceSubrangeTest(
     original: "",
@@ -1388,6 +1408,51 @@ let replaceSubrangeTests = [
   ),
 ]
 
+let removeSubrangeTests = [
+  RemoveSubrangeTest(
+    original: "",
+    rangeSelection: .emptyRange,
+    expected: ""
+  ),
+  RemoveSubrangeTest(
+    original: "a",
+    rangeSelection: .middle,
+    expected: ""
+  ),
+  RemoveSubrangeTest(
+    original: "perdicus",
+    rangeSelection: .leftHalf,
+    expected: "icus"
+  ),
+  RemoveSubrangeTest(
+    original: "perdicus",
+    rangeSelection: .rightHalf,
+    expected: "perd"
+  ),
+  RemoveSubrangeTest(
+    original: "alice",
+    rangeSelection: .middle,
+    expected: "ae"
+  ),
+  RemoveSubrangeTest(
+    original: "perdicus",
+    rangeSelection: .middle,
+    expected: "pes"
+  ),
+  RemoveSubrangeTest(
+    original: "perdicus",
+    rangeSelection: .offsets(1, 2),
+    expected: "prdicus",
+    closedExpected: "pdicus"
+  ),
+  RemoveSubrangeTest(
+    original: "perdicus",
+    rangeSelection: .offsets(3, 6),
+    expected: "perus",
+    closedExpected: "pers"
+  )
+]
+
 StringTests.test("String.replaceSubrange()/characters/range") {
   for test in replaceSubrangeTests {
     var theString = test.original
@@ -1396,8 +1461,8 @@ StringTests.test("String.replaceSubrange()/characters/range") {
     let newCharacters : [Character] = test.newElements.characters.map { $0 }
     theString.replaceSubrange(rangeToReplace, with: newCharacters)
     expectEqual(
-      theString,
       test.expected,
+      theString,
       stackTrace: SourceLocStack().with(test.loc))
   }
 }
@@ -1409,8 +1474,8 @@ StringTests.test("String.replaceSubrange()/string/range") {
     let rangeToReplace = test.rangeSelection.range(in: c)
     theString.replaceSubrange(rangeToReplace, with: test.newElements)
     expectEqual(
-      theString,
       test.expected,
+      theString,
       stackTrace: SourceLocStack().with(test.loc))
   }
 }
@@ -1426,8 +1491,8 @@ StringTests.test("String.replaceSubrange()/characters/closedRange") {
     let newCharacters = Array(test.newElements.characters)
     theString.replaceSubrange(rangeToReplace, with: newCharacters)
     expectEqual(
-      theString,
       closedExpected,
+      theString,
       stackTrace: SourceLocStack().with(test.loc))
   }
 }
@@ -1442,8 +1507,38 @@ StringTests.test("String.replaceSubrange()/string/closedRange") {
     let rangeToReplace = test.rangeSelection.closedRange(in: c)
     theString.replaceSubrange(rangeToReplace, with: test.newElements)
     expectEqual(
-      theString,
       closedExpected,
+      theString,
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+StringTests.test("String.removeSubrange()/range") {
+  for test in removeSubrangeTests {
+    var theString = test.original
+    let c = test.original.characters
+    let rangeToRemove = test.rangeSelection.range(in: c)
+    theString.removeSubrange(rangeToRemove)
+    expectEqual(
+      test.expected,
+      theString,
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+StringTests.test("String.removeSubrange()/closedRange") {
+  for test in removeSubrangeTests {
+    switch test.rangeSelection {
+      case .emptyRange: continue
+      default: break
+    }
+    var theString = test.original
+    let c = test.original.characters
+    let rangeToRemove = test.rangeSelection.closedRange(in: c)
+    theString.removeSubrange(rangeToRemove)
+    expectEqual(
+      test.closedExpected,
+      theString,
       stackTrace: SourceLocStack().with(test.loc))
   }
 }


### PR DESCRIPTION
#### What's in this pull request?

Tests for `String`'s `removeSubrange` overloads. Also swapped "expected" and "actual" arguments for a few of the functions so error messages would make more sense. @gribozavr 

Tests ran fine for me last night; this can be merged whenever you're ready.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
