### PR TITLE
use the toolchain's clang when building libdispatch

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2076,6 +2076,8 @@ for host in "${ALL_HOSTS[@]}"; do
             libdispatch)
                 LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                 SWIFT_BUILD_PATH="$(build_directory ${host} swift)"
+                SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
+                LLVM_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
 
                 if [[ ! -f "${LIBDISPATCH_BUILD_DIR}"/config.status ]]; then
                     # First time building; need to run autotools and configure
@@ -2083,7 +2085,10 @@ for host in "${ALL_HOSTS[@]}"; do
                     with_pushd "${LIBDISPATCH_SOURCE_DIR}" \
                         call autoreconf -fvi
                     with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                        call "${LIBDISPATCH_SOURCE_DIR}"/configure --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})" --with-swift-toolchain="${SWIFT_BUILD_PATH}"
+                               call env CC="${LLVM_BIN}/clang" CCX="${LLVM_BIN}/clang" SWIFTC="${SWIFTC_BIN}" \
+                               "${LIBDISPATCH_SOURCE_DIR}"/configure --with-swift-toolchain="${SWIFT_BUILD_PATH}" \
+                               --prefix="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
+
                 fi
                 with_pushd "${LIBDISPATCH_BUILD_DIR}" \
                     call make


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

As discussed offline with @madcoder, we now want to be sure that we are using the clang from the toolchain that is being built to compile libdispatch.  This pull request changes the invocation of libdispatch's configure script from build-script-impl to pass down the location of clang in the CC and CXX environment variables.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

None.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Use the clang that is part of the toolchain being built
when building libdispatch to ensure getting the appropriate
version of clang.

Also pass through SWIFTC_BIN to the configure command to
prepare for a cleanup of the libdispatch side of the build process.
