### PR TITLE
[swiftc] Add test case for crash triggered in swift::TypeChecker::checkGenericParamList(…)

### DIFF
--- a/validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift
+++ b/validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift
@@ -1,0 +1,81 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+// RUN: not --crash %target-swift-frontend %s -parse
+yObject, x in 0
+class a{
+enum b {
+class A {
+class A {
+let i: c
+struct D{
+enum b {
+struct A : a {
+func f: b
+if true {
+class A {
+func d.j where g: j.j: j: Int = {
+map(x(object1: A? {
+class c
+func b: NSObject {{
+}
+class A : Int = b<T: (x()
+import Foundation
+var d<T
+enum b {
+func c
+if true {
+func f
+class A {
+class A : NSObject {
+class A {
+class A : NSManagedObject {
+if true {class B? {
+func a{
+func d.E
+func f: NSManagedObject {let:("
+func f<T>()?
+var f = c<I : Int = {
+class a {
+class a<T where T
+class A : NSManagedObject {
+var f : A : U : a {
+func f<T where g.E
+{
+va d<T -> {
+let a{
+var}
+var d {
+{
+struct D
+class b: a {{
+clas
+var b<T
+}
+if true {
+struct A {struct d<T where T where T>
+class d.h == compose() -> {
+class A : NSObject {
+let start = b<T where g: NSObject {
+func d
+class b
+class B<T where T>
+class B
+class b<T, j, x in 0
+struct d{
+var _ = c
+fum b {{
+class A {{struct S<T> {
+var f {let(x(
+func e, j.h == b{
+}
+class B? {{
+func e:b<c in 0
+S<T> U)"
+func c>() { p(s("
+func f: j.j where g: A {
+stru


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Crash case with stack trace:

```
4  swift           0x0000000000ed9e1d swift::TypeChecker::checkGenericParamList(swift::ArchetypeBuilder*, swift::GenericParamList*, swift::GenericSignature*, bool, swift::GenericTypeResolver*) + 93
6  swift           0x0000000000eda53e swift::TypeChecker::validateGenericFuncSignature(swift::AbstractFunctionDecl*) + 94
9  swift           0x0000000000e9cc21 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
11 swift           0x0000000000e9cc21 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 1089
16 swift           0x00000000010d6016 swift::lookupVisibleDecls(swift::VisibleDeclConsumer&, swift::DeclContext const*, swift::LazyResolver*, bool, swift::SourceLoc) + 1174
17 swift           0x0000000000edeaa4 swift::TypeChecker::performTypoCorrection(swift::DeclContext*, swift::DeclRefKind, swift::DeclName, swift::SourceLoc, swift::OptionSet<swift::NameLookupFlags, unsigned int>, swift::LookupResult&, unsigned int) + 260
18 swift           0x0000000000e88998 swift::TypeChecker::resolveDeclRefExpr(swift::UnresolvedDeclRefExpr*, swift::DeclContext*) + 3864
21 swift           0x00000000010538fe swift::Expr::walk(swift::ASTWalker&) + 46
22 swift           0x0000000000e89220 swift::TypeChecker::solveForExpression(swift::Expr*&, swift::DeclContext*, swift::Type, swift::FreeTypeVariableBinding, swift::ExprTypeCheckListener*, swift::constraints::ConstraintSystem&, llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>) + 224
23 swift           0x0000000000e8fbf2 swift::TypeChecker::typeCheckExpression(swift::Expr*&, swift::DeclContext*, swift::TypeLoc, swift::ContextualTypePurpose, swift::OptionSet<swift::TypeCheckExprFlags, unsigned int>, swift::ExprTypeCheckListener*) + 610
24 swift           0x0000000000e90d47 swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*) + 343
25 swift           0x0000000000e90f5b swift::TypeChecker::typeCheckPatternBinding(swift::PatternBindingDecl*, unsigned int) + 267
27 swift           0x0000000000e9d819 swift::TypeChecker::validateDecl(swift::ValueDecl*, bool) + 4153
28 swift           0x0000000000f207cd swift::createImplicitConstructor(swift::TypeChecker&, swift::NominalTypeDecl*, swift::ImplicitConstructorKind) + 413
29 swift           0x0000000000ea7d76 swift::TypeChecker::addImplicitConstructors(swift::NominalTypeDecl*) + 1526
44 swift           0x0000000000ea2166 swift::TypeChecker::typeCheckDecl(swift::Decl*, bool) + 150
45 swift           0x0000000000ec4ac2 swift::performTypeChecking(swift::SourceFile&, swift::TopLevelContext&, swift::OptionSet<swift::TypeCheckingFlags, unsigned int>, unsigned int, unsigned int) + 1026
46 swift           0x0000000000c58d39 swift::CompilerInstance::performSema() + 3289
48 swift           0x00000000007d73bf swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 2863
49 swift           0x00000000007a33d8 main + 2872
Stack dump:
0.  Program arguments: /path/to/swift/bin/swift -frontend -c -primary-file validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift -target x86_64-unknown-linux-gnu -disable-objc-interop -module-name main -o /tmp/28310-swift-typechecker-checkgenericparamlist-83e1a2.o
1.  While type-checking 'a' at validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift:10:1
2.  While type-checking expression at [validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift:42:9 - line:42:11] RangeText="c<I"
3.  While type-checking 'f' at validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift:18:1
4.  While type-checking 'f' at validation-test/compiler_crashers/28310-swift-typechecker-checkgenericparamlist.swift:80:1
<unknown>:0: error: unable to execute command: Segmentation fault
<unknown>:0: error: compile command failed due to signal (use -v to see invocation)
```
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
