### PR TITLE
[swift_build_support] Change shell `env` to be a mapping.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -44,15 +44,15 @@ class Ninja(object):
             sysroot = xcrun.sdk_path("macosx")
             osx_version_min = self.args.darwin_deployment_version_osx
             assert sysroot is not None
-            env = [
-                ("CXX", self.toolchain.cxx),
-                ("CFLAGS", (
+            env = {
+                "CXX": self.toolchain.cxx,
+                "CFLAGS": (
                     "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
-                ).format(sysroot=sysroot, osx_version=osx_version_min)),
-                ("LDFLAGS", (
+                ).format(sysroot=sysroot, osx_version=osx_version_min),
+                "LDFLAGS": (
                     "-mmacosx-version-min={osx_version}"
-                ).format(osx_version=osx_version_min)),
-            ]
+                ).format(osx_version=osx_version_min),
+            }
 
         # Ninja can only be built in-tree.  Copy the source tree to the build
         # directory.

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -53,7 +53,8 @@ def _coerce_dry_run(dry_run_override):
 def _echo_command(dry_run, command, env=None, prompt="+ "):
     output = []
     if env is not None:
-        output += ['env'] + [_quote("%s=%s" % (k, v)) for k, v in env]
+        output += ['env'] + [_quote("%s=%s" % (k, v))
+                             for (k, v) in sorted(env.items())]
     output += [_quote(arg) for arg in command]
     file = sys.stderr
     if dry_run:

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -92,8 +92,8 @@ class NinjaTestCase(unittest.TestCase):
         if platform.system() == "Darwin":
             expect_env = (
                 "env "
-                "CXX={cxx} "
                 "'CFLAGS=-isysroot {sysroot} -mmacosx-version-min=10.9' "
+                "CXX={cxx} "
                 "LDFLAGS=-mmacosx-version-min=10.9 "
             ).format(
                 cxx=self.toolchain.cxx,


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

This changes the `env` parameter in the swift_build_support.shell module to be more `subprocess` like.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
- This is consistent with the `subprocess` API, which this module is otherwise
  closely related to, so I think this makes more sense than taking a list of
  key-value pairs.
