### PR TITLE
[build-script] Perform validation after defaults propagation

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -130,7 +130,7 @@ class HostSpecificConfiguration(object):
                deployment_platform.is_embedded and \
                not deployment_platform.is_simulator:
                 if deployment_platform not in \
-                       invocation.platforms_to_skip_test_host:
+                        invocation.platforms_to_skip_test_host:
                     test_host_only = True
                     test = True
                 else:
@@ -142,7 +142,7 @@ class HostSpecificConfiguration(object):
                 # library, whereas the other targets can build a slightly
                 # smaller subset which is faster to build.
                 if args.build_swift_stdlib_unittest_extra or \
-                       args.validation_test or args.long_test:
+                        args.validation_test or args.long_test:
                     self.swift_stdlib_build_targets.append(
                         "swift-stdlib-" + name)
                 else:
@@ -394,6 +394,18 @@ class BuildScriptInvocation(object):
         if args.android:
             args.stdlib_deployment_targets.append(
                 StdlibDeploymentTarget.Android.armv7.name)
+
+        # Infer platform flags from manually-specified configure targets.
+        # This doesn't apply to Darwin platforms, as they are
+        # already configured. No building without the platform flag, though.
+
+        android_tgts = [tgt for tgt in args.stdlib_deployment_targets
+                        if StdlibDeploymentTarget.Android.contains(tgt)]
+        if not args.android and len(android_tgts) > 0:
+            args.android = True
+            args.skip_build_android = True
+
+# ---
 
     def __init__(self, toolchain, args):
         self.toolchain = toolchain

--- a/utils/build-script
+++ b/utils/build-script
@@ -1768,11 +1768,11 @@ details of the setups of other systems or automated environments.""")
     if args.cmake is not None:
         toolchain.cmake = args.cmake
 
-    # Validate the arguments.
-    BuildScriptInvocation.validate_arguments(toolchain, args)
-
     # Preprocess the arguments to apply defaults.
     BuildScriptInvocation.apply_default_arguments(toolchain, args)
+
+    # Validate the arguments.
+    BuildScriptInvocation.validate_arguments(toolchain, args)
 
     # Create the build script invocation.
     invocation = BuildScriptInvocation(toolchain, args)

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -42,6 +42,16 @@ class Platform(object):
         # By default, we don't support benchmarks on most platforms.
         return False
 
+    def contains(self, target_name):
+        """
+        Returns True if the given target name belongs to a one of this
+        platform's targets.
+        """
+        for target in self.targets:
+            if target.name == target_name:
+                return True
+        return False
+
 
 class DarwinPlatform(Platform):
     def __init__(self, name, archs, sdk_name=None, is_simulator=False):

--- a/utils/swift_build_support/tests/test_targets.py
+++ b/utils/swift_build_support/tests/test_targets.py
@@ -18,5 +18,20 @@ class HostTargetTestCase(unittest.TestCase):
         self.assertIsNotNone(StdlibDeploymentTarget.host_target())
 
 
+class PlatformTargetsTestCase(unittest.TestCase):
+    def test_platform_contains(self):
+        """
+        Checks that Platform.contains(target_name)
+        matches all of its targets' names and rejects non-matching names.
+        """
+        # Pick a few platforms with lots of targets
+        for platform in [StdlibDeploymentTarget.Linux,
+                         StdlibDeploymentTarget.iOS,
+                         StdlibDeploymentTarget.iOSSimulator]:
+            for target in platform.targets:
+                self.assertTrue(platform.contains(target.name))
+            self.assertFalse(platform.contains("fakeCPU-MSDOS"))
+            self.assertFalse(platform.contains("singleTransistor-fakeOS"))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Perform build-script arguments validation after defaults propagation. In general, validation should be done at late as possible. For example, if you have an android target in your `--stdlib-deployment-list`, Swift will try to configure android even though you didn't specify the `--android` flag (it won't build it, because lack of `--android` implies `--skip-build-android`, but configuring is bad enough). Because you didn't specify the flag, we didn't validate that you gave an NDK path, etc.

So we should perform validation after propagation, so we can propagate the values in the defaults function.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
