### PR TITLE
[gardening] PEP-8: First argument of a classmethod should be named 'cls'. Fix typo.

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -200,8 +200,8 @@ class StdlibDeploymentTarget(object):
             return [host_target]
 
     @classmethod
-    def get_target_for_name(klass, name):
-        return klass._targets_by_name.get(name)
+    def get_target_for_name(cls, name):
+        return cls._targets_by_name.get(name)
 
 
 def install_prefix():

--- a/utils/swift_build_support/tests/test_toolchain.py
+++ b/utils/swift_build_support/tests/test_toolchain.py
@@ -113,7 +113,7 @@ class ToolchainTestCase(unittest.TestCase):
 
     def test_toolchain_instances(self):
         # Check that we can instantiate every toolchain, even if it isn't the
-        # current patform.
+        # current platform.
         toolchain.MacOSX()
         toolchain.Linux()
         toolchain.FreeBSD()


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

PEP-8: First argument of a classmethod should be named `cls`. Fix typo.
#### Resolved bug number: –

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
