### PR TITLE
[IDE, SourceKit] Pass in clang as arg[0] in initInvocationByClangArguments

### DIFF
--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -238,9 +238,15 @@ bool ide::initInvocationByClangArguments(ArrayRef<const char *> ArgList,
                                                &DiagBuf,
                                                /*ShouldOwnClient=*/false);
 
+  // Clang expects this to be like an actual command line. So we need to pass in
+  // "clang" for argv[0].
+  std::vector<const char *> ClangArgList;
+  ClangArgList.push_back("clang");
+  ClangArgList.insert(ClangArgList.end(), ArgList.begin(), ArgList.end());
+
   // Create a new Clang compiler invocation.
   llvm::IntrusiveRefCntPtr<clang::CompilerInvocation> ClangInvok{
-    clang::createInvocationFromCommandLine(ArgList, ClangDiags)
+    clang::createInvocationFromCommandLine(ClangArgList, ClangDiags)
   };
   if (!ClangInvok || ClangDiags->hasErrorOccurred()) {
     for (auto I = DiagBuf.err_begin(), E = DiagBuf.err_end(); I != E; ++I) {

--- a/test/IDE/print_clang_header.swift
+++ b/test/IDE/print_clang_header.swift
@@ -1,6 +1,5 @@
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
 // XFAIL: linux
-// REQUIRES: OS=macosx
 
 // RUN: echo '#include "header-to-print.h"' > %t.m
 // RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -4,7 +4,6 @@
 // RUN:     -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs | FileCheck %s
 
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
 
 // CHECK: enum Normal : Int {
 // CHECK-NOT: {{^}}}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

This applies the same fix as cfdb8ac2e61, but this time to libIDE so
that SourceKit and swift-ide-test will also pass in an appropriate
argv[0]. Re-enable the tests that broke.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

rdar://problem/24431137

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
