### PR TITLE
[index] Add finish() hook to the index consumer API

### DIFF
--- a/include/swift/Index/IndexDataConsumer.h
+++ b/include/swift/Index/IndexDataConsumer.h
@@ -36,6 +36,8 @@ public:
   virtual bool recordRelatedEntity(const IndexSymbol &symbol) = 0;
   virtual bool finishSourceEntity(SymbolKind kind, SymbolSubKindSet subKinds,
                                   SymbolRoleSet roles) = 0;
+
+  virtual void finish() {}
 };
 
 } // end namespace index

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1069,6 +1069,7 @@ void index::indexSourceFile(SourceFile *SF, StringRef hash,
   unsigned bufferID = SF->getBufferID().getValue();
   IndexSwiftASTWalker walker(consumer, SF->getASTContext(), bufferID);
   walker.visitModule(*SF->getParentModule(), hash);
+  consumer.finish();
 }
 
 void index::indexModule(ModuleDecl *module, StringRef hash,
@@ -1077,4 +1078,5 @@ void index::indexModule(ModuleDecl *module, StringRef hash,
   IndexSwiftASTWalker walker(consumer, module->getASTContext(),
                              /*bufferID*/ -1);
   walker.visitModule(*module, hash);
+  consumer.finish();
 }


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Since the memory underlying returned USRs is guaranteed to last until
the indexing action completes, add a finish() hook so that clients can
trigger an action at the end of indexing but before the memory goes
away.
