### PR TITLE
Python 3 removes the reduce builtin

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -16,6 +16,8 @@ import json
 import os
 import sys
 
+from functools import reduce
+
 sys.path.append(os.path.dirname(__file__))
 
 from SwiftBuildSupport import (


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

Python 3 removes the `reduce` builtin. This fix is merely the result of the [suggestion in the Python 3 docs](https://docs.python.org/3.0/whatsnew/3.0.html#builtins).

Perhaps the solution is a refactoring to use a `for` loop as suggested in the docs. That's not really for me to say though as I understand next to nothing about Python or "preferred" methods. This was the smallest change I could make to get it back to working.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
