### PR TITLE
Limit inlining for stdlibunittest. This saves a lot of compilation time

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -1192,6 +1192,12 @@ public final class TestSuite {
     PersistentState.complainIfNothingRuns()
   }
 
+  // This method is prohibited from inlining because inlining the test harness
+  // into the test is not interesting from the runtime performance perspective.
+  // And it does not really make the test cases more effectively at testing the
+  // optimizer from a correctness prospective. On the contrary, it sometimes
+  // severely affects the compile time of the test code.
+  @inline(never)
   public func test(
     _ name: String,
     file: String = #file, line: UInt = #line,
@@ -1201,6 +1207,12 @@ public final class TestSuite {
     .code(testFunction)
   }
 
+  // This method is prohibited from inlining because inlining the test harness
+  // into the test is not interesting from the runtime performance perspective.
+  // And it does not really make the test cases more effectively at testing the
+  // optimizer from a correctness prospective. On the contrary, it sometimes
+  // severely affects the compile time of the test code.
+  @inline(never)
   public func test(
     _ name: String, file: String = #file, line: UInt = #line
   ) -> _TestBuilder {


### PR DESCRIPTION
Limit inlining for stdlibunittest. This saves a lot of compilation time for some of the stdlibunittests.

i.e. For the FixPoint benchmark, from 256s on my machine to 27s.
