### PR TITLE
[gyb] Get doctest to pass

### DIFF
--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -208,7 +208,7 @@ def tokenize_template(template_text):
     ... %% first line
     ...   %% second line
     ... '''):
-    ...     print (kind, text.strip().split('\n',1)[0])
+    ...     print((kind, text.strip().split('\n',1)[0]))
     ('literal', 'This is $some$ literal stuff containing a')
     ('substitutionOpen', '${')
     ('literal', 'followed by a %{...} block:')
@@ -361,7 +361,7 @@ def code_starts_with_dedent_keyword(source_lines):
     >>> code_starts_with_dedent_keyword(split_lines('except ifSomethingElse:'))
     True
     >>> code_starts_with_dedent_keyword(
-            split_lines('\n# comment\nelse: # yes'))
+    ...     split_lines('\n# comment\nelse: # yes'))
     True
     """
     token_text = None
@@ -417,7 +417,7 @@ class ParseContext(object):
         ... literally
         ... ''')
         >>> while ctx.token_kind:
-        ...     print (ctx.token_kind, ctx.code_text or ctx.token_text)
+        ...     print((ctx.token_kind, ctx.code_text or ctx.token_text))
         ...     ignored = ctx.next_token()
         ('literal', '\n')
         ('gybLinesOpen', 'for x in y:\n')
@@ -435,7 +435,7 @@ class ParseContext(object):
         ... THIS SHOULD NOT APPEAR IN THE OUTPUT
         ... ''')
         >>> while ctx.token_kind:
-        ...     print (ctx.token_kind, ctx.code_text or ctx.token_text)
+        ...     print((ctx.token_kind, ctx.code_text or ctx.token_text))
         ...     ignored = ctx.next_token()
         ('literal', 'Nothing\n')
         ('gybLinesOpen', 'if x:\n')
@@ -450,7 +450,7 @@ class ParseContext(object):
         ... '''% for x in [1, 2, 3]:
         ... %   if x == 1:
         ... literal1
-        ... %   elif x > 1:  # add an output line after this line to fix bug
+        ... %   elif x > 1:  # add output line here to fix bug
         ... %     if x == 2:
         ... literal2
         ... %     end
@@ -458,12 +458,12 @@ class ParseContext(object):
         ... % end
         ... ''')
         >>> while ctx.token_kind:
-        ...     print (ctx.token_kind, ctx.code_text or ctx.token_text)
+        ...     print((ctx.token_kind, ctx.code_text or ctx.token_text))
         ...     ignored = ctx.next_token()
         ('gybLinesOpen', 'for x in [1, 2, 3]:\n')
         ('gybLinesOpen', '  if x == 1:\n')
         ('literal', 'literal1\n')
-        ('gybLinesOpen', 'elif x > 1: # add output line here to fix bug\n')
+        ('gybLinesOpen', 'elif x > 1:  # add output line here to fix bug\n')
         ('gybLinesOpen', '  if x == 2:\n')
         ('literal', 'literal2\n')
         ('gybLinesClose', '%     end')
@@ -730,17 +730,17 @@ def parse_template(filename, text=None):
     If text is supplied, it is assumed to be the contents of the file,
     as a string.
 
-    >>> print parse_template('dummy.file', text=
+    >>> print(parse_template('dummy.file', text=
     ... '''% for x in [1, 2, 3]:
     ... %   if x == 1:
     ... literal1
-    ... %   elif x > 1:   # add an output line after this line to fix the bug
+    ... %   elif x > 1:  # add output line after this line to fix bug
     ... %     if x == 2:
     ... literal2
     ... %     end
     ... %   end
     ... % end
-    ... ''')
+    ... '''))
     Block:
     [
         Code:
@@ -755,7 +755,7 @@ def parse_template(filename, text=None):
                 {
                     if x == 1:
                         __children__[0].execute(__context__)
-                    elif x > 1: # add output line after this line to fix bug
+                    elif x > 1:  # add output line after this line to fix bug
                         __children__[1].execute(__context__)
                 }
                 [
@@ -784,8 +784,9 @@ def parse_template(filename, text=None):
         ]
     ]
 
-    >>> print parse_template(
-    >>> 'dummy.file', text='%for x in range(10):\n%  print x\n%end\njuicebox')
+    >>> print(parse_template(
+    ...     'dummy.file',
+    ...     text='%for x in range(10):\n%  print(x)\n%end\njuicebox'))
     Block:
     [
         Code:
@@ -796,14 +797,14 @@ def parse_template(filename, text=None):
         [
             Block:
             [
-                Code: {print x} []
+                Code: {print(x)} []
             ]
         ]
         Literal:
         juicebox
     ]
 
-    >>> print parse_template('/dummy.file', text=
+    >>> print(parse_template('/dummy.file', text=
     ... '''Nothing
     ... % if x:
     ... %    for i in range(3):
@@ -811,7 +812,7 @@ def parse_template(filename, text=None):
     ... %    end
     ... % else:
     ... THIS SHOULD NOT APPEAR IN THE OUTPUT
-    ... ''')
+    ... '''))
     Block:
     [
         Literal:
@@ -848,10 +849,10 @@ def parse_template(filename, text=None):
         ]
     ]
 
-    >>> print parse_template('dummy.file', text='''%
+    >>> print(parse_template('dummy.file', text='''%
     ... %for x in y:
-    ... %    print y
-    ... ''')
+    ... %    print(y)
+    ... '''))
     Block:
     [
         Code:
@@ -862,18 +863,18 @@ def parse_template(filename, text=None):
         [
             Block:
             [
-                Code: {print y} []
+                Code: {print(y)} []
             ]
         ]
     ]
 
-    >>> print parse_template('dummy.file', text='''%
+    >>> print(parse_template('dummy.file', text='''%
     ... %if x:
-    ... %    print y
+    ... %    print(y)
     ... AAAA
     ... %else:
     ... BBBB
-    ... ''')
+    ... '''))
     Block:
     [
         Code:
@@ -886,7 +887,7 @@ def parse_template(filename, text=None):
         [
             Block:
             [
-                Code: {print y} []
+                Code: {print(y)} []
                 Literal:
                 AAAA
             ]
@@ -898,14 +899,14 @@ def parse_template(filename, text=None):
         ]
     ]
 
-    >>> print parse_template('dummy.file', text='''%
+    >>> print(parse_template('dummy.file', text='''%
     ... %if x:
-    ... %    print y
+    ... %    print(y)
     ... AAAA
     ... %# This is a comment
     ... %else:
     ... BBBB
-    ... ''')
+    ... '''))
     Block:
     [
         Code:
@@ -919,7 +920,7 @@ def parse_template(filename, text=None):
         [
             Block:
             [
-                Code: {print y} []
+                Code: {print(y)} []
                 Literal:
                 AAAA
             ]
@@ -931,14 +932,14 @@ def parse_template(filename, text=None):
         ]
     ]
 
-    >>> print parse_template('dummy.file', text='''\
+    >>> print(parse_template('dummy.file', text='''\
     ... %for x in y:
     ... AAAA
     ... %if x:
     ... BBBB
     ... %end
     ... CCCC
-    ... ''')
+    ... '''))
     Block:
     [
         Code:
@@ -986,7 +987,8 @@ def execute_template(ast, line_directive='', **local_bindings):
     ... % else:
     ... THIS SHOULD NOT APPEAR IN THE OUTPUT
     ... ''')
-    >>> print execute_template(ast, line_directive='//#sourceLocation', x=1),
+    >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
+    >>> print(out, end="")
     //#sourceLocation(file: "/dummy.file", line: 1)
     Nothing
     //#sourceLocation(file: "/dummy.file", line: 4)
@@ -1004,7 +1006,8 @@ def execute_template(ast, line_directive='', **local_bindings):
     ... % end
     ... ${a}
     ... ''')
-    >>> print execute_template(ast, line_directive='//#sourceLocation', x=1),
+    >>> out = execute_template(ast, line_directive='//#sourceLocation', x=1)
+    >>> print(out, end="")
     //#sourceLocation(file: "/dummy.file", line: 1)
     Nothing
     //#sourceLocation(file: "/dummy.file", line: 6)

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1115,7 +1115,8 @@ def main():
 
     if args.test or args.verbose_test:
         import doctest
-        if doctest.testmod(verbose=args.verbose_test).failed:
+        selfmod = sys.modules[__name__]
+        if doctest.testmod(selfmod, verbose=args.verbose_test).failed:
             sys.exit(1)
 
     bindings = dict(x.split('=', 1) for x in args.defines)


### PR DESCRIPTION
#### What's in this pull request?

Mainly because of `from __future__ import print_function`, doctest was broken.

```
$ python -m doctest utils/gyb.py
```

In addition, currently, we always invoke `utils/gyb` with `--test` option.
https://github.com/apple/swift/blob/fc9c1f6a/cmake/modules/SwiftHandleGybSources.cmake#L41
This doesn't really work.
It used to test `__main__` module of `utils/gyb`, but not `gyb` module of `utils/gyb.py`.

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
