### PR TITLE
No longer pass llvm enable lto into swift cmake invocation

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -10,6 +10,16 @@ function(add_swift_unittest test_dirname)
   # function defined by AddLLVM.cmake.
   add_unittest(SwiftUnitTests ${test_dirname} ${ARGN})
 
+  # TODO: _add_variant_c_compile_link_flags and these tests should share some
+  # sort of logic.
+  #
+  # *NOTE* The unittests are never built for the target, so we always enable LTO
+  # *if we are asked to.
+  if (SWIFT_TOOLS_ENABLE_LTO)
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY COMPILE_FLAGS " -flto ")
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY LINK_FLAGS " -flto ")
+  endif()
+
   if(SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
     # Replace target references with full paths, so that we use LLVM's
     # build configuration rather than Swift's.

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -1,0 +1,45 @@
+
+include(AddSwift)
+
+add_custom_target(SwiftUnitTests)
+
+set_target_properties(SwiftUnitTests PROPERTIES FOLDER "Tests")
+
+function(add_swift_unittest test_dirname)
+  # *NOTE* Even though "add_unittest" does not have llvm in its name, it is a
+  # function defined by AddLLVM.cmake.
+  add_unittest(SwiftUnitTests ${test_dirname} ${ARGN})
+
+  if(SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
+    # Replace target references with full paths, so that we use LLVM's
+    # build configuration rather than Swift's.
+    get_target_property(libnames ${test_dirname} LINK_LIBRARIES)
+
+    set(new_libnames)
+    foreach(dep ${libnames})
+      if("${dep}" MATCHES "^(LLVM|Clang|gtest)")
+        list(APPEND new_libnames "${LLVM_LIBRARY_OUTPUT_INTDIR}/lib${dep}.a")
+      else()
+        list(APPEND new_libnames "${dep}")
+      endif()
+    endforeach()
+
+    set_property(TARGET ${test_dirname} PROPERTY LINK_LIBRARIES ${new_libnames})
+    swift_common_llvm_config(${test_dirname} support)
+  endif()
+
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
+      LINK_FLAGS " -Xlinker -rpath -Xlinker ${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx")
+
+    if(SWIFT_ANALYZE_CODE_COVERAGE)
+      set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
+        LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
+    endif()
+  elseif(${SWIFT_ENABLE_GOLD_LINKER})
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
+      LINK_FLAGS " -fuse-ld=gold")
+  endif()
+endfunction()
+
+

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,41 +1,5 @@
-add_custom_target(SwiftUnitTests)
 
-set_target_properties(SwiftUnitTests PROPERTIES FOLDER "Tests")
-
-function(add_swift_unittest test_dirname)
-  add_unittest(SwiftUnitTests ${test_dirname} ${ARGN})
-
-  if(SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
-    # Replace target references with full paths, so that we use LLVM's
-    # build configuration rather than Swift's.
-    get_target_property(libnames ${test_dirname} LINK_LIBRARIES)
-
-    set(new_libnames)
-    foreach(dep ${libnames})
-      if("${dep}" MATCHES "^(LLVM|Clang|gtest)")
-        list(APPEND new_libnames "${LLVM_LIBRARY_OUTPUT_INTDIR}/lib${dep}.a")
-      else()
-        list(APPEND new_libnames "${dep}")
-      endif()
-    endforeach()
-
-    set_property(TARGET ${test_dirname} PROPERTY LINK_LIBRARIES ${new_libnames})
-    swift_common_llvm_config(${test_dirname} support)
-  endif()
-
-  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
-      LINK_FLAGS " -Xlinker -rpath -Xlinker ${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx")
-
-    if(SWIFT_ANALYZE_CODE_COVERAGE)
-      set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
-        LINK_FLAGS " -fprofile-instr-generate -fcoverage-mapping")
-    endif()
-  elseif(${SWIFT_ENABLE_GOLD_LINKER})
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY
-      LINK_FLAGS " -fuse-ld=gold")
-  endif()
-endfunction()
+include(AddSwiftUnittests)
 
 if(SWIFT_BUILD_TOOLS)
   # We can't link C++ unit tests unless we build the tools.

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -588,14 +588,6 @@ function set_build_options_for_host() {
                     )
                 fi
 
-                # We need to also pass in this flag so that parts of LLVM's
-                # build system that we use (for instance when compiling
-                # unittests) do not use too many threads when we are using lto.
-                if [[ $(true_false "${LLVM_ENABLE_LTO}") == "TRUE" ]]; then
-                    swift_cmake_options+=(
-                        "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_NUM_PARALLEL_LTO_LINK_JOBS}"
-                    )
-                fi
                 swift_cmake_options+=(
                     "-DSWIFT_PARALLEL_LINK_JOBS=${SWIFT_TOOLS_NUM_PARALLEL_LTO_LINK_JOBS}"
                 )
@@ -1864,7 +1856,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_CXX_FLAGS="$(swift_c_flags ${host})"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
-                    -DLLVM_ENABLE_LTO=$(true_false "${LLVM_ENABLE_LTO}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")
                     -DSWIFT_STDLIB_BUILD_TYPE:STRING="${SWIFT_STDLIB_BUILD_TYPE}"
                     -DSWIFT_STDLIB_ASSERTIONS:BOOL=$(true_false "${SWIFT_STDLIB_ENABLE_ASSERTIONS}")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
