### PR TITLE
[gyb] Add gyb doctest to validation-test

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -38,8 +38,6 @@ function(handle_gyb_source_single dependency_out_var_name)
       "${options}" "${single_value_args}" "${multi_value_args}" ${ARGN})
 
   set(gyb_flags
-      "--test" # Run gyb's self-tests whenever we use it.  They're cheap
-               # enough and it keeps us honest.
       ${SWIFT_GYB_FLAGS}
       ${GYB_SINGLE_FLAGS})
 

--- a/validation-test/Python/gyb.swift
+++ b/validation-test/Python/gyb.swift
@@ -1,0 +1,4 @@
+// RUN: %{python} -m doctest %S/../../utils/gyb.py
+// RUN: echo 'Hello ${ME}' | %S/../../utils/gyb --test -DME=Swift | FileCheck %s
+// RUN: echo 'Hello ${ME}' | %S/../../utils/gyb --verbose-test -DME=Swift | FileCheck %s
+// CHECK: Hello Swift


### PR DESCRIPTION
**WARNING: DO NOT MERGE BEFORE #2978**
#### What's in this pull request?
- Added `gyb` doctest to validation test as `validation-test/Python/gyb.swift`
- Removed `--test` option from normal `gyb` invocation in `CMakeLists.txt`.
  While I agree with the [comment](https://github.com/apple/swift/blob/fc9c1f6a/cmake/modules/SwiftHandleGybSources.cmake#L41-L42): 
  
  > Run gyb's self-tests whenever we use it.  They're cheap enough and it keeps us honest.
  
  Do we really need it?
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
