### PR TITLE
Name and label changes for closure parameters (SE-0118)

### DIFF
--- a/benchmark/single-source/CaptureProp.swift
+++ b/benchmark/single-source/CaptureProp.swift
@@ -21,7 +21,7 @@ func benchCaptureProp<S : Sequence
 
   var it = s.makeIterator()
   let initial = it.next()!
-  return IteratorSequence(it).reduce(initial, combine: f)
+  return IteratorSequence(it).reduce(initial, f)
 }
 
 public func run_CaptureProp(_ N: Int) {

--- a/benchmark/single-source/MapReduce.swift
+++ b/benchmark/single-source/MapReduce.swift
@@ -20,7 +20,7 @@ public func run_MapReduce(_ N: Int) {
   var c = 0
   for _ in 1...N*100 {
     numbers = numbers.map({$0 &+ 5})
-    c += numbers.reduce(0, combine: &+)
+    c += numbers.reduce(0, &+)
   }
   CheckResults(c != 0, "IncorrectResults in MapReduce")
 }

--- a/benchmark/single-source/SortStrings.swift
+++ b/benchmark/single-source/SortStrings.swift
@@ -1021,7 +1021,7 @@ func benchSortStrings(_ words: [String]) {
   // Notice that we _copy_ the array of words before we sort it.
   // Pass an explicit '<' predicate to benchmark reabstraction thunks.
   var tempwords = words
-  tempwords.sort(isOrderedBefore: <)
+  tempwords.sort(by: <)
 }
 
 public func run_SortStrings(_ N: Int) {

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -274,13 +274,13 @@ public struct ${Self}<
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
-    isSeparator: @noescape (Base.Iterator.Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Base.Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence] {
     Log.split[selfType] += 1
     return try base.split(
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences,
-      isSeparator: isSeparator)
+      whereSeparator: isSeparator)
   }
 
   public func _customContainsEquatableElement(

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -229,10 +229,10 @@ public struct ${Self}<
   }
 
   public func filter(
-    _ includeElement: @noescape (Base.Iterator.Element) throws -> Bool
+    _ isIncluded: @noescape (Base.Iterator.Element) throws -> Bool
   ) rethrows -> [Base.Iterator.Element] {
     Log.filter[selfType] += 1
-    return try base.filter(includeElement)
+    return try base.filter(isIncluded)
   }
 
   public func forEach(

--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -596,7 +596,9 @@ internal struct ClosureBasedRaceTest : RaceTestWithPerTrialData {
   ) {}
 }
 
-public func runRaceTest(trials: Int, threads: Int? = nil, body: () -> ()) {
+public func runRaceTest(
+  trials: Int, threads: Int? = nil, invoking body: () -> ()
+) {
   ClosureBasedRaceTest.thread = body
   runRaceTest(ClosureBasedRaceTest.self, trials: trials, threads: threads)
 }

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -214,7 +214,7 @@ extension MutableCollection
 }
 
 /// Generate all permutations.
-public func forAllPermutations(_ size: Int, body: ([Int]) -> Void) {
+public func forAllPermutations(_ size: Int, _ body: ([Int]) -> Void) {
   var data = Array(0..<size)
   repeat {
     body(data)
@@ -223,7 +223,7 @@ public func forAllPermutations(_ size: Int, body: ([Int]) -> Void) {
 
 /// Generate all permutations.
 public func forAllPermutations<S : Sequence>(
-  _ sequence: S, body: ([S.Iterator.Element]) -> Void
+  _ sequence: S, _ body: ([S.Iterator.Element]) -> Void
 ) {
   let data = Array(sequence)
   forAllPermutations(data.count) {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -107,7 +107,7 @@ var _seenExpectCrash = false
 /// Run `body` and expect a failure to happen.
 ///
 /// The check passes iff `body` triggers one or more failures.
-public func expectFailure(${TRACE}, body: () -> Void) {
+public func expectFailure(${TRACE}, invoking body: () -> Void) {
   let startAnyExpectFailed = _anyExpectFailed
   _anyExpectFailed = false
   body()

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2246,9 +2246,9 @@ public func expectEqualsUnordered<
   Expected.Iterator.Element == Actual.Iterator.Element {
   
   let x: [Expected.Iterator.Element] =
-    expected.sorted(isOrderedBefore: compose(compare, { $0.isLT() }))
+    expected.sorted(by: compose(compare, { $0.isLT() }))
   let y: [Actual.Iterator.Element] =
-    actual.sorted(isOrderedBefore: compose(compare, { $0.isLT() }))
+    actual.sorted(by: compose(compare, { $0.isLT() }))
   expectEqualSequence(
     x, y, ${trace}, sameValue: compose(compare, { $0.isEQ() }))
 }
@@ -2345,10 +2345,10 @@ public func expectEqualsUnordered<
   }
 
   let x: [(T, T)] =
-    expected.sorted(isOrderedBefore: comparePairLess)
+    expected.sorted(by: comparePairLess)
   let y: [(T, T)] =
     actual.map { ($0.0, $0.1) }
-      .sorted(isOrderedBefore: comparePairLess)
+      .sorted(by: comparePairLess)
 
   func comparePairEquals(_ lhs: (T, T), rhs: (key: T, value: T)) -> Bool {
     return lhs.0 == rhs.0 && lhs.1 == rhs.1

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -2228,7 +2228,7 @@ public func expectEqualSequence<
 ) where
   Expected.Iterator.Element == Actual.Iterator.Element {
 
-  if !expected.elementsEqual(actual, isEquivalent: sameValue) {
+  if !expected.elementsEqual(actual, by: sameValue) {
     expectationFailure("expected elements: \"\(expected)\"\n"
       + "actual: \"\(actual)\" (of type \(String(reflecting: actual.dynamicType)))",
       trace: ${trace})

--- a/stdlib/private/StdlibUnittest/TypeIndexed.swift
+++ b/stdlib/private/StdlibUnittest/TypeIndexed.swift
@@ -59,7 +59,7 @@ extension TypeIndexed where Value : Strideable {
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = #file, line: UInt = #line,
-    body: () -> R
+    invoking body: () -> R
   ) -> R {
     let expected = self[t].advanced(by: 1)
     let r = body()
@@ -77,7 +77,7 @@ extension TypeIndexed where Value : Equatable {
     showFrame: Bool = true,
     stackTrace: SourceLocStack = SourceLocStack(),  
     file: String = #file, line: UInt = #line,
-    body: () -> R
+    invoking body: () -> R
   ) -> R {
     let expected = self[t]
     let r = body()

--- a/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
+++ b/stdlib/private/StdlibUnittestFoundationExtras/StdlibUnittestFoundationExtras.swift
@@ -65,7 +65,7 @@ public func withOverriddenLocaleCurrentLocale<Result>(
 /// return-autoreleased optimization.)
 @inline(never)
 public func autoreleasepoolIfUnoptimizedReturnAutoreleased(
-  _ body: @noescape () -> Void
+  invoking body: @noescape () -> Void
 ) {
 #if arch(i386) && (os(iOS) || os(watchOS))
   autoreleasepool(body)

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -76,7 +76,8 @@ extension Optional {
   /// `body` is complicated than that results in unnecessarily repeated code.
   internal func _withNilOrAddress<NSType : AnyObject, ResultType>(
     of object: inout NSType?,
-    body: @noescape (AutoreleasingUnsafeMutablePointer<NSType?>?) -> ResultType
+    _ body:
+      @noescape (AutoreleasingUnsafeMutablePointer<NSType?>?) -> ResultType
   ) -> ResultType {
     return self == nil ? body(nil) : body(&object)
   }
@@ -495,7 +496,9 @@ extension String {
   //     enumerateLinesUsing:(void (^)(NSString *line, BOOL *stop))block
 
   /// Enumerates all the lines in a string.
-  public func enumerateLines(_ body: (line: String, stop: inout Bool) -> ()) {
+  public func enumerateLines(
+    invoking body: (line: String, stop: inout Bool) -> ()
+  ) {
     _ns.enumerateLines {
       (line: String, stop: UnsafeMutablePointer<ObjCBool>)
     in
@@ -526,7 +529,7 @@ extension String {
     scheme tagScheme: String,
     options opts: NSLinguisticTagger.Options = [],
     orthography: NSOrthography? = nil,
-    _ body:
+    invoking body:
       (String, Range<Index>, Range<Index>, inout Bool) -> ()
   ) {
     _ns.enumerateLinguisticTags(

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -188,7 +188,7 @@ func __pushAutoreleasePool() -> OpaquePointer
 func __popAutoreleasePool(_ pool: OpaquePointer)
 
 public func autoreleasepool<Result>(
-  _ body: @noescape () throws -> Result
+  invoking body: @noescape () throws -> Result
 ) rethrows -> Result {
   let pool = __pushAutoreleasePool()
   defer {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -99,10 +99,10 @@ if True:
 ///
 /// You can call any method on the slices that you might have called on the
 /// `absences` array. To learn which half had more absences, use the
-/// `reduce(_:combine:)` method to calculate each sum.
+/// `reduce(_:)` method to calculate each sum.
 ///
-///     let firstHalfSum = firstHalf.reduce(0, combine: +)
-///     let secondHalfSum = secondHalf.reduce(0, combine: +)
+///     let firstHalfSum = firstHalf.reduce(0, +)
+///     let secondHalfSum = secondHalf.reduce(0, +)
 ///
 ///     if firstHalfSum > secondHalfSum {
 ///         print("More absences in the first half.")

--- a/stdlib/public/core/Boolean.swift
+++ b/stdlib/public/core/Boolean.swift
@@ -42,7 +42,7 @@ public prefix func !<T : Boolean>(a: T) -> Bool {
 /// `lhs` evaluates to `true`. For example:
 ///
 ///     let measurements = [7.44, 6.51, 4.74, 5.88, 6.27, 6.12, 7.76]
-///     let sum = measurements.reduce(0, combine: +)
+///     let sum = measurements.reduce(0, +)
 ///
 ///     if measurements.count > 0 && sum / Double(measurements.count) < 6.5 {
 ///         print("Average measurement is less than 6.5")
@@ -121,7 +121,7 @@ public func || <T : Boolean, U : Boolean>(
 /// `lhs` evaluates to `true`. For example:
 ///
 ///     let measurements = [7.44, 6.51, 4.74, 5.88, 6.27, 6.12, 7.76]
-///     let sum = measurements.reduce(0, combine: +)
+///     let sum = measurements.reduce(0, +)
 ///
 ///     if measurements.count > 0 && sum / Double(measurements.count) < 6.5 {
 ///         print("Average measurement is less than 6.5")

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -92,7 +92,7 @@ public struct Character :
       shift += 8
     }
 
-    UTF8.encode(scalar, sendingOutputTo: output)
+    UTF8.encode(scalar, into: output)
     asInt |= (~0) << shift
     _representation = .small(Builtin.trunc_Int64_Int63(asInt._value))
   }
@@ -297,7 +297,7 @@ public struct Character :
         _SmallUTF8(u8).makeIterator(),
         from: UTF8.self, to: UTF16.self,
         stoppingOnError: false,
-        sendingOutputTo: output)
+        into: output)
       self.data = u16
     }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1484,15 +1484,17 @@ extension Collection {
   /// that was originally separated by one or more spaces.
   ///
   ///     let line = "BLANCHE:   I don't want realism. I want magic!"
-  ///     print(line.characters.split(isSeparator: { $0 == " " })
+  ///     print(line.characters.split(whereSeparator: { $0 == " " })
   ///                          .map(String.init))
   ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
   ///
   /// The second example passes `1` for the `maxSplits` parameter, so the
   /// original string is split just once, into two new strings.
   ///
-  ///     print(line.characters.split(maxSplits: 1, isSeparator: { $0 == " " })
-  ///                           .map(String.init))
+  ///     print(
+  ///         line.characters.split(
+  ///             maxSplits: 1, whereSeparator: { $0 == " " }
+  ///             ).map(String.init))
   ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
   ///
   /// The final example passes `false` for the `omittingEmptySubsequences`
@@ -1523,7 +1525,7 @@ extension Collection {
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
-    isSeparator: @noescape (Iterator.Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence] {
     // TODO: swift-3-indexing-model - review the following
     _precondition(maxSplits >= 0, "Must take zero or more splits")
@@ -1624,7 +1626,7 @@ extension Collection where Iterator.Element : Equatable {
     return split(
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences,
-      isSeparator: { $0 == separator })
+      whereSeparator: { $0 == separator })
   }
 }
 
@@ -1719,11 +1721,11 @@ extension Collection {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, message: "Please use split(maxSplits:omittingEmptySubsequences:isSeparator:) instead")
+  @available(*, unavailable, message: "Please use split(maxSplits:omittingEmptySubsequences:whereSeparator:) instead")
   public func split(
     _ maxSplit: Int = Int.max,
     allowEmptySlices: Bool = false,
-    isSeparator: @noescape (Iterator.Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence] {
     Builtin.unreachable()
   }

--- a/stdlib/public/core/CollectionAlgorithms.swift.gyb
+++ b/stdlib/public/core/CollectionAlgorithms.swift.gyb
@@ -126,9 +126,9 @@ orderingExplanation = """\
   /// is, for any elements `a`, `b`, and `c`, the following conditions must
   /// hold:
   ///
-  /// - `isOrderedBefore(a, a)` is always `false`. (Irreflexivity)
-  /// - If `isOrderedBefore(a, b)` and `isOrderedBefore(b, c)` are both `true`,
-  ///   then `isOrderedBefore(a, c)` is also `true`. (Transitive
+  /// - `areInIncreasingOrder(a, a)` is always `false`. (Irreflexivity)
+  /// - If `areInIncreasingOrder(a, b)` and `areInIncreasingOrder(b, c)` are both `true`,
+  ///   then `areInIncreasingOrder(a, c)` is also `true`. (Transitive
   ///   comparability)
   /// - Two elements are *incomparable* if neither is ordered before the other
   ///   according to the predicate. If `a` and `b` are incomparable, and `b`
@@ -165,7 +165,7 @@ extension MutableCollection
   /// This method is typically one step of a sorting algorithm. A collection is
   /// partitioned around a pivot index when each of the elements before the
   /// pivot is correctly ordered before each of the elements at or after the
-  /// pivot. The `partition(isOrderedBefore:)` method reorders the elements of
+  /// pivot. The `partition(by:)` method reorders the elements of
   /// the collection and returns a pivot index that satisfies this condition,
   /// using the given predicate to determine the relative order of any two
   /// elements.
@@ -197,18 +197,18 @@ ${orderingExplanation}
   /// argument is greater than its second argument, larger elements are
   /// ordered before smaller elements.
   ///
-  /// - Parameter isOrderedBefore: A predicate that returns `true` if its first
+  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its first
   ///   argument should be ordered before its second argument; otherwise,
   ///   `false`.
   /// - Returns: A pivot index, such that every element before the pivot is
   ///   ordered before every element at or above the pivot, using
-  ///   `isOrderedBefore` to determine the relative order of any two elements.
+  ///   `areInIncreasingOrder` to determine the relative order of any two elements.
   ///   The returned pivot is equal to the collection's end index only if the
   ///   collection is empty.
   ///
   /// - SeeAlso: `partition()`
   public mutating func partition(
-    isOrderedBefore: @noescape (${IElement}, ${IElement}) -> Bool
+    by areInIncreasingOrder: @noescape (${IElement}, ${IElement}) -> Bool
   ) -> Index
 
 %   else:
@@ -248,7 +248,7 @@ ${orderingExplanation}
   ///   less than every element at or above the pivot. The returned pivot is
   ///   equal to the collection's end index only if the collection is empty.
   ///
-  /// - SeeAlso: `partition(isOrderedBefore:)`
+  /// - SeeAlso: `partition(by:)`
   public mutating func partition() -> Index
 
 %   end
@@ -259,7 +259,7 @@ ${orderingExplanation}
         UnsafeMutableBufferPointer(start: baseAddress, count: count)
       let unsafeBufferPivot = bufferPointer.partition(
 %   if preds:
-        isOrderedBefore: isOrderedBefore
+        by: areInIncreasingOrder
 %   end
         )
       return unsafeBufferPivot - bufferPointer.startIndex
@@ -272,11 +272,11 @@ ${orderingExplanation}
     typealias EscapingBinaryPredicate =
       (${IElement}, ${IElement}) -> Bool
     var escapableIsOrderedBefore =
-      unsafeBitCast(isOrderedBefore, to: EscapingBinaryPredicate.self)
+      unsafeBitCast(areInIncreasingOrder, to: EscapingBinaryPredicate.self)
     return _partition(
       &self,
       subRange: startIndex..<endIndex,
-      isOrderedBefore: &escapableIsOrderedBefore)
+      by: &escapableIsOrderedBefore)
 %   else:
     return _partition(&self, subRange: startIndex..<endIndex)
 %   end
@@ -313,15 +313,15 @@ extension ${Self} where Self.Iterator.Element : Comparable {
   ///     // Prints "["Abena", "Akosua", "Kofi", "Kweku", "Peter"]"
   ///
   /// To sort the elements of your ${sequenceKind} in descending order, pass the
-  /// greater-than operator (`>`) to the `sorted(isOrderedBefore:)` method.
+  /// greater-than operator (`>`) to the `sorted(by:)` method.
   ///
-  ///     let descendingStudents = students.sorted(isOrderedBefore: >)
+  ///     let descendingStudents = students.sorted(by: >)
   ///     print(descendingStudents)
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   ///
   /// - Returns: A sorted array of the ${sequenceKind}'s elements.
   ///
-  /// - SeeAlso: `sorted(isOrderedBefore:)`
+  /// - SeeAlso: `sorted(by:)`
   /// ${'- MutatingVariant: sort' if Self == 'MutableCollection' else ''}
   public func sorted() -> [Iterator.Element] {
     var result = ContiguousArray(self)
@@ -342,7 +342,7 @@ extension ${Self} {
   ///
 ${orderingExplanation}
   /// The sorting algorithm is not stable. A nonstable sort may change the
-  /// relative order of elements for which `isOrderedBefore` does not
+  /// relative order of elements for which `areInIncreasingOrder` does not
   /// establish an order.
   ///
   /// In the following example, the predicate provides an ordering for an array
@@ -375,10 +375,10 @@ ${orderingExplanation}
   /// You also use this method to sort elements that conform to the
   /// `Comparable` protocol in descending order. To sort your ${sequenceKind}
   /// in descending order, pass the greater-than operator (`>`) as the
-  /// `isOrderedBefore` parameter.
+  /// `areInIncreasingOrder` parameter.
   ///
   ///     let students: Set = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
-  ///     let descendingStudents = students.sorted(isOrderedBefore: >)
+  ///     let descendingStudents = students.sorted(by: >)
   ///     print(descendingStudents)
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   ///
@@ -387,10 +387,10 @@ ${orderingExplanation}
   ///
   ///     print(students.sorted())
   ///     // Prints "["Abena", "Akosua", "Kofi", "Kweku", "Peter"]"
-  ///     print(students.sorted(isOrderedBefore: <))
+  ///     print(students.sorted(by: <))
   ///     // Prints "["Abena", "Akosua", "Kofi", "Kweku", "Peter"]"
   ///
-  /// - Parameter isOrderedBefore: A predicate that returns `true` if its first
+  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its first
   ///   argument should be ordered before its second argument; otherwise,
   ///   `false`.
   /// - Returns: A sorted array of the ${sequenceKind}'s elements.
@@ -398,11 +398,11 @@ ${orderingExplanation}
   /// - SeeAlso: `sorted()`
   /// ${'- MutatingVariant: sort' if Self == 'MutableCollection' else ''}
   public func sorted(
-    isOrderedBefore:
+    by areInIncreasingOrder:
       @noescape (${IElement}, ${IElement}) -> Bool
   ) -> [Iterator.Element] {
     var result = ContiguousArray(self)
-    result.sort(isOrderedBefore: isOrderedBefore)
+    result.sort(by: areInIncreasingOrder)
     return Array(result)
   }
 }
@@ -433,9 +433,9 @@ extension MutableCollection
   ///     // Prints "["Abena", "Akosua", "Kofi", "Kweku", "Peter"]"
   ///
   /// To sort the elements of your collection in descending order, pass the
-  /// greater-than operator (`>`) to the `sort(isOrderedBefore:)` method.
+  /// greater-than operator (`>`) to the `sort(by:)` method.
   ///
-  ///     students.sort(isOrderedBefore: >)
+  ///     students.sort(by: >)
   ///     print(students)
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   public mutating func sort() {
@@ -464,7 +464,7 @@ extension MutableCollection where Self : RandomAccessCollection {
   ///
 ${orderingExplanation}
   /// The sorting algorithm is not stable. A nonstable sort may change the
-  /// relative order of elements for which `isOrderedBefore` does not
+  /// relative order of elements for which `areInIncreasingOrder` does not
   /// establish an order.
   ///
   /// In the following example, the closure provides an ordering for an array
@@ -501,35 +501,35 @@ ${orderingExplanation}
   /// predicate.
   ///
   ///     var students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
-  ///     students.sort(isOrderedBefore: >)
+  ///     students.sort(by: >)
   ///     print(students)
   ///     // Prints "["Peter", "Kweku", "Kofi", "Akosua", "Abena"]"
   ///
-  /// - Parameter isOrderedBefore: A predicate that returns `true` if its first
+  /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its first
   ///   argument should be ordered before its second argument; otherwise,
   ///   `false`.
   public mutating func sort(
-    isOrderedBefore:
+    by areInIncreasingOrder:
       @noescape (${IElement}, ${IElement}) -> Bool
   ) {
     typealias EscapingBinaryPredicate =
       (Iterator.Element, Iterator.Element) -> Bool
     let escapableIsOrderedBefore =
-      unsafeBitCast(isOrderedBefore, to: EscapingBinaryPredicate.self)
+      unsafeBitCast(areInIncreasingOrder, to: EscapingBinaryPredicate.self)
 
     let didSortUnsafeBuffer: Void? =
       _withUnsafeMutableBufferPointerIfSupported {
       (baseAddress, count) -> Void in
       var bufferPointer =
         UnsafeMutableBufferPointer(start: baseAddress, count: count)
-      bufferPointer.sort(isOrderedBefore: escapableIsOrderedBefore)
+      bufferPointer.sort(by: escapableIsOrderedBefore)
       return ()
     }
     if didSortUnsafeBuffer == nil {
       _introSort(
         &self,
         subRange: startIndex..<endIndex,
-        isOrderedBefore: escapableIsOrderedBefore)
+        by: escapableIsOrderedBefore)
     }
   }
 }
@@ -633,7 +633,7 @@ ${subscriptCommentPost}
     
 extension MutableCollection where Self : RandomAccessCollection {
 
-  @available(*, unavailable, message: "slice the collection using the range, and call partition(isOrderedBefore:)")
+  @available(*, unavailable, message: "slice the collection using the range, and call partition(by:)")
   public mutating func partition(
     _ range: Range<Index>,
     isOrderedBefore: (${IElement}, ${IElement}) -> Bool
@@ -663,7 +663,7 @@ extension MutableCollection
 }
 
 extension MutableCollection where Self : RandomAccessCollection {
-  @available(*, unavailable, renamed: "sort(isOrderedBefore:)")
+  @available(*, unavailable, renamed: "sort(by:)")
   public mutating func sortInPlace(
     _ isOrderedBefore: @noescape (Iterator.Element, Iterator.Element) -> Bool
   ) {

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -476,7 +476,7 @@ public protocol ExpressibleByStringLiteral
 /// array as a parameter:
 ///
 ///     func sum(values: [Int]) -> Int {
-///         return values.reduce(0, combine: +)
+///         return values.reduce(0, +)
 ///     }
 ///
 ///     let sumOfFour = sum([5, 10, 15, 20])

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -147,7 +147,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   }
 
   internal func _filter(
-    _ includeElement: @noescape (Element) throws -> Bool
+    _ isIncluded: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
     _abstract()
   }
@@ -335,9 +335,9 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     return try _base.map(transform)
   }
   internal override func _filter(
-    _ includeElement: @noescape (Element) throws -> Bool
+    _ isIncluded: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
-    return try _base.filter(includeElement)
+    return try _base.filter(isIncluded)
   }
   internal override func _forEach(
     _ body: @noescape (Element) throws -> Void
@@ -579,9 +579,9 @@ extension Any${Kind} {
   }
 
   public func filter(
-    _ includeElement: @noescape (Element) throws -> Bool
+    _ isIncluded: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
-    return try _box._filter(includeElement)
+    return try _box._filter(isIncluded)
   }
 
   public func forEach(

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -200,7 +200,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
   internal func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
-    isSeparator: @noescape (Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Element) throws -> Bool
   ) rethrows -> [Any${Kind}<Element>] {
     _abstract()
   }
@@ -376,12 +376,12 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
 %   for ResultKind in EqualAndWeakerKinds:
   internal override func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
-    isSeparator: @noescape (Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Element) throws -> Bool
   ) rethrows -> [Any${ResultKind}<Element>] {
     return try _base.split(
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences,
-      isSeparator: isSeparator)
+      whereSeparator: isSeparator)
       .map {
         Any${ResultKind}(_box: _${Kind}Box<S.SubSequence>(_base: $0))
       }
@@ -609,12 +609,12 @@ extension Any${Kind} {
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
-    isSeparator: @noescape (Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Element) throws -> Bool
   ) rethrows -> [Any${Kind}<Element>] {
     return try _box._split(
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences,
-      isSeparator: isSeparator)
+      whereSeparator: isSeparator)
   }
 
   public func _preprocessingPass<R>(

--- a/stdlib/public/core/Filter.swift.gyb
+++ b/stdlib/public/core/Filter.swift.gyb
@@ -43,13 +43,13 @@ public struct LazyFilterIterator<
   }
 
   /// Creates an instance that produces the elements `x` of `base`
-  /// for which `predicate(x) == true`.
+  /// for which `isIncluded(x) == true`.
   internal init(
     _base: Base,
-    whereElementsSatisfy predicate: (Base.Element) -> Bool
+    _ isIncluded: (Base.Element) -> Bool
   ) {
     self._base = _base
-    self._predicate = predicate
+    self._predicate = isIncluded
   }
 
   /// The underlying iterator whose elements are being filtered.
@@ -75,18 +75,18 @@ public struct LazyFilterSequence<Base : Sequence>
   /// - Complexity: O(1).
   public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
     return LazyFilterIterator(
-      _base: base.makeIterator(), whereElementsSatisfy: _include)
+      _base: base.makeIterator(), _include)
   }
 
   /// Creates an instance consisting of the elements `x` of `base` for
-  /// which `predicate(x) == true`.
+  /// which `isIncluded(x) == true`.
   public // @testable
   init(
     _base base: Base,
-    whereElementsSatisfy predicate: (Base.Iterator.Element) -> Bool
+    _ isIncluded: (Base.Iterator.Element) -> Bool
   ) {
     self.base = base
-    self._include = predicate
+    self._include = isIncluded
   }
 
   /// The underlying sequence whose elements are being filtered
@@ -186,14 +186,14 @@ public struct ${Self}<
   public typealias IndexDistance = Base.IndexDistance
 
   /// Construct an instance containing the elements of `base` that
-  /// satisfy `predicate`.
+  /// satisfy `isIncluded`.
   public // @testable
   init(
     _base: Base,
-    whereElementsSatisfy predicate: (Base.Iterator.Element) -> Bool
+    _ isIncluded: (Base.Iterator.Element) -> Bool
   ) {
     self._base = _base
-    self._predicate = predicate
+    self._predicate = isIncluded
   }
 
   /// The position of the first element in a non-empty collection.
@@ -281,7 +281,7 @@ public struct ${Self}<
   /// - Complexity: O(1).
   public func makeIterator() -> LazyFilterIterator<Base.Iterator> {
     return LazyFilterIterator(
-      _base: _base.makeIterator(), whereElementsSatisfy: _predicate)
+      _base: _base.makeIterator(), _predicate)
   }
 
   var _base: Base
@@ -291,17 +291,17 @@ public struct ${Self}<
 % end
 
 extension LazySequenceProtocol {
-  /// Returns the elements of `self` that satisfy `predicate`.
+  /// Returns the elements of `self` that satisfy `isIncluded`.
   ///
   /// - Note: The elements of the result are computed on-demand, as
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
   public func filter(
-    _ predicate: (Elements.Iterator.Element) -> Bool
+    _ isIncluded: (Elements.Iterator.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
     return LazyFilterSequence(
-      _base: self.elements, whereElementsSatisfy: predicate)
+      _base: self.elements, isIncluded)
   }
 }
 
@@ -319,10 +319,10 @@ extension LazyCollectionProtocol
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
   public func filter(
-    _ predicate: (Elements.Iterator.Element) -> Bool
+    _ isIncluded: (Elements.Iterator.Element) -> Bool
   ) -> LazyFilter${collectionForTraversal(Traversal)}<Self.Elements> {
     return LazyFilter${collectionForTraversal(Traversal)}(
-      _base: self.elements, whereElementsSatisfy: predicate)
+      _base: self.elements, isIncluded)
   }
 }
 

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -66,7 +66,7 @@ extension ${Self} {
     let (result, n) = text.withCString(parseNTBS)
 
     if n == 0 || n != u16.count
-      || u16.contains({ $0 > 127 || _isspace_clocale($0) }) {
+    || u16.contains(where: { $0 > 127 || _isspace_clocale($0) }) {
       return nil
     }
     self = result

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1501,7 +1501,7 @@ public func _setBridgeFromObjectiveCConditional<
 ///                               "triangular": [1, 3, 6, 10, 15, 21, 28],
 ///                               "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 ///     for key in interestingNumbers.keys {
-///         interestingNumbers[key]?.sort(isOrderedBefore: >)
+///         interestingNumbers[key]?.sort(by: >)
 ///     }
 ///
 ///     print(interestingNumbers["primes"]!)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -376,7 +376,7 @@ internal struct _UnmanagedAnyObjectArray {
 ///     }
 ///     // Prints "We have 4 primes."
 ///
-///     let primesSum = primes.reduce(0, combine: +)
+///     let primesSum = primes.reduce(0, +)
 ///     // 'primesSum' == 17
 ///
 ///     let primeStrings = primes.sorted().map(String.init)

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -37,21 +37,21 @@
 ///     extension Sequence {
 ///       /// Returns an array containing the results of
 ///       ///
-///       ///   p.reduce(initial, combine: combine)
+///       ///   p.reduce(initial, nextPartialResult)
 ///       ///
 ///       /// for each prefix `p` of `self`, in order from shortest to
 ///       /// longest.  For example:
 ///       ///
-///       ///     (1..<6).scan(0, combine: +) // [0, 1, 3, 6, 10, 15]
+///       ///     (1..<6).scan(0, +) // [0, 1, 3, 6, 10, 15]
 ///       ///
 ///       /// - Complexity: O(N)
 ///       func scan<ResultElement>(
 ///         _ initial: ResultElement,
-///         combine: @noescape (ResultElement, Iterator.Element) -> ResultElement
+///         _ nextPartialResult: @noescape (ResultElement, Iterator.Element) -> ResultElement
 ///       ) -> [ResultElement] {
 ///         var result = [initial]
 ///         for x in self {
-///           result.append(combine(result.last!, x))
+///           result.append(nextPartialResult(result.last!, x))
 ///         }
 ///         return result
 ///       }
@@ -64,13 +64,13 @@
 ///       : IteratorProtocol {
 ///       mutating func next() -> ResultElement? {
 ///         return nextElement.map { result in
-///           nextElement = base.next().map { combine(result, $0) }
+///           nextElement = base.next().map { nextPartialResult(result, $0) }
 ///           return result
 ///         }
 ///       }
 ///       private var nextElement: ResultElement? // The next result of next().
 ///       private var base: Base                  // The underlying iterator.
-///       private let combine: (ResultElement, Base.Element) -> ResultElement
+///       private let nextPartialResult: (ResultElement, Base.Element) -> ResultElement
 ///     }
 ///     
 ///     struct LazyScanSequence<Base: Sequence, ResultElement>
@@ -78,11 +78,11 @@
 ///     {
 ///       func makeIterator() -> LazyScanIterator<Base.Iterator, ResultElement> {
 ///         return LazyScanIterator(
-///           nextElement: initial, base: base.makeIterator(), combine: combine)
+///           nextElement: initial, base: base.makeIterator(), nextPartialResult)
 ///       }
 ///       private let initial: ResultElement
 ///       private let base: Base
-///       private let combine:
+///       private let nextPartialResult:
 ///         (ResultElement, Base.Iterator.Element) -> ResultElement
 ///     }
 ///
@@ -91,20 +91,20 @@
 ///     extension LazySequenceProtocol {
 ///       /// Returns a sequence containing the results of
 ///       ///
-///       ///   p.reduce(initial, combine: combine)
+///       ///   p.reduce(initial, nextPartialResult)
 ///       ///
 ///       /// for each prefix `p` of `self`, in order from shortest to
 ///       /// longest.  For example:
 ///       ///
-///       ///     Array((1..<6).lazy.scan(0, combine: +)) // [0, 1, 3, 6, 10, 15]
+///       ///     Array((1..<6).lazy.scan(0, +)) // [0, 1, 3, 6, 10, 15]
 ///       ///
 ///       /// - Complexity: O(1)
 ///       func scan<ResultElement>(
 ///         _ initial: ResultElement,
-///         combine: (ResultElement, Iterator.Element) -> ResultElement
+///         _ nextPartialResult: (ResultElement, Iterator.Element) -> ResultElement
 ///       ) -> LazyScanSequence<Self, ResultElement> {
 ///         return LazyScanSequence(
-///           initial: initial, base: self, combine: combine)
+///           initial: initial, base: self, nextPartialResult)
 ///       }
 ///     }
 ///

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -13,19 +13,19 @@
 /// Evaluate `f()` and return its result, ensuring that `x` is not
 /// destroyed before f returns.
 public func withExtendedLifetime<T, Result>(
-  _ x: T, _ f: @noescape () throws -> Result
+  _ x: T, _ body: @noescape () throws -> Result
 ) rethrows -> Result {
   defer { _fixLifetime(x) }
-  return try f()
+  return try body()
 }
 
 /// Evaluate `f(x)` and return its result, ensuring that `x` is not
 /// destroyed before f returns.
 public func withExtendedLifetime<T, Result>(
-  _ x: T, _ f: @noescape (T) throws -> Result
+  _ x: T, _ body: @noescape (T) throws -> Result
 ) rethrows -> Result {
   defer { _fixLifetime(x) }
-  return try f(x)
+  return try body(x)
 }
 
 extension String {
@@ -41,10 +41,10 @@ extension String {
   ///   it is used as the return value of the `withCString(_:)` method.
   /// - Returns: The return value of the `f` closure, if any.
   public func withCString<Result>(
-    _ f: @noescape (UnsafePointer<Int8>) throws -> Result
+    _ body: @noescape (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
     return try self.nulTerminatedUTF8.withUnsafeBufferPointer {
-      try f(UnsafePointer($0.baseAddress!))
+      try body(UnsafePointer($0.baseAddress!))
     }
   }
 }

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -95,18 +95,19 @@ public class ManagedBuffer<Header, Element>
   : ManagedProtoBuffer<Header, Element> {
 
   /// Create a new instance of the most-derived class, calling
-  /// `initialHeader` on the partially-constructed object to
-  /// generate an initial `Header`.
+  /// `factory` on the partially-constructed object to generate
+  /// an initial `Header`.
   public final class func create(
     minimumCapacity: Int,
-    initialHeader: @noescape (ManagedProtoBuffer<Header, Element>) throws -> Header
+    makingHeaderWith factory: (
+      ManagedProtoBuffer<Header, Element>) throws -> Header
   ) rethrows -> ManagedBuffer<Header, Element> {
 
     let p = try ManagedBufferPointer<Header, Element>(
       bufferClass: self,
       minimumCapacity: minimumCapacity,
-      initialHeader: { buffer, _ in
-        try initialHeader(
+      makingHeaderWith: { buffer, _ in
+        try factory(
           unsafeDowncast(buffer, to: ManagedProtoBuffer<Header, Element>.self))
       })
 
@@ -115,14 +116,18 @@ public class ManagedBuffer<Header, Element>
 
   /// Destroy the stored Header.
   deinit {
-    ManagedBufferPointer(self).withUnsafeMutablePointerToHeader { $0.deinitialize() }
+    ManagedBufferPointer(self).withUnsafeMutablePointerToHeader {
+      $0.deinitialize()
+    }
   }
 
   /// The stored `Header` instance.
   public final var header: Header {
     addressWithNativeOwner {
       return (
-        ManagedBufferPointer(self).withUnsafeMutablePointerToHeader { UnsafePointer($0) },
+        ManagedBufferPointer(self).withUnsafeMutablePointerToHeader {
+          UnsafePointer($0)
+        },
         Builtin.castToNativeObject(self))
     }
     mutableAddressWithNativeOwner {
@@ -177,7 +182,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   /// - parameter bufferClass: The class of the object used for storage.
   /// - parameter minimumCapacity: The minimum number of `Element`s that
   ///   must be able to be stored in the new buffer.
-  /// - parameter initialHeader: A function that produces the initial
+  /// - parameter factory: A function that produces the initial
   ///   `Header` instance stored in the buffer, given the `buffer`
   ///   object and a function that can be called on it to get the actual
   ///   number of allocated elements.
@@ -189,14 +194,16 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
   public init(
     bufferClass: AnyClass,
     minimumCapacity: Int,
-    initialHeader: @noescape (buffer: AnyObject, capacity: @noescape (AnyObject) -> Int) throws -> Header
+    makingHeaderWith factory:
+      (buffer: AnyObject, capacity: (AnyObject) -> Int) throws -> Header
   ) rethrows {
-    self = ManagedBufferPointer(bufferClass: bufferClass, minimumCapacity: minimumCapacity)
+    self = ManagedBufferPointer(
+      bufferClass: bufferClass, minimumCapacity: minimumCapacity)
 
     // initialize the header field
     try withUnsafeMutablePointerToHeader {
       $0.initialize(with: 
-        try initialHeader(
+        try factory(
           buffer: self.buffer,
           capacity: {
             ManagedBufferPointer(unsafeBufferObject: $0).capacity

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -61,9 +61,10 @@
 /// algorithms, however, may call for direct iterator use.
 ///
 /// One example is the `reduce1(_:)` method. Similar to the
-/// `reduce(_:combine:)` method defined in the standard library, which takes
-/// an initial value and a combining closure, `reduce1(_:)` uses the first
-/// element of the sequence as the initial value.
+/// `reduce(_:)` method defined in the standard
+/// library, which takes an initial value and a combining closure,
+/// `reduce1(_:)` uses the first element of the sequence as the
+/// initial value.
 ///
 /// Here's an implementation of the `reduce1(_:)` method. The sequence's
 /// iterator is used directly to retrieve the initial value before looping
@@ -71,7 +72,7 @@
 ///
 ///     extension Sequence {
 ///         func reduce1(
-///           combine: (Iterator.Element, Iterator.Element) -> Iterator.Element
+///           _ nextPartialResult: (Iterator.Element, Iterator.Element) -> Iterator.Element
 ///         ) -> Iterator.Element?
 ///         {
 ///             var i = makeIterator()
@@ -80,7 +81,7 @@
 ///             }
 ///
 ///             while let element = i.next() {
-///                 accumulated = combine(accumulated, element)
+///                 accumulated = nextPartialResult(accumulated, element)
 ///             }
 ///             return accumulated
 ///         }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -558,7 +558,7 @@ public protocol Sequence {
   /// - Returns: An array of subsequences, split from this sequence's elements.
   func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
-    isSeparator: @noescape (Iterator.Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [SubSequence]
 
   /// Returns the first element of the sequence that satisfies the given
@@ -859,7 +859,7 @@ extension Sequence {
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
-    isSeparator: @noescape (Iterator.Element) throws -> Bool
+    whereSeparator isSeparator: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [AnySequence<Iterator.Element>] {
     _precondition(maxSplits >= 0, "Must take zero or more splits")
     var result: [AnySequence<Iterator.Element>] = []
@@ -1043,7 +1043,7 @@ extension Sequence where Iterator.Element : Equatable {
     return split(
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences,
-      isSeparator: { $0 == separator })
+      whereSeparator: { $0 == separator })
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -387,12 +387,12 @@ public protocol Sequence {
   ///     print(shortNames)
   ///     // Prints "["Kim", "Karl"]"
   ///
-  /// - Parameter includeElement: A closure that takes an element of the
+  /// - Parameter isIncluded: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
   /// - Returns: An array of the elements that `includeElement` allowed.
   func filter(
-    _ includeElement: @noescape (Iterator.Element) throws -> Bool
+    _ isIncluded: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [Iterator.Element]
 
   /// Calls the given closure on each element in the sequence in the same order
@@ -747,12 +747,12 @@ extension Sequence {
   ///     print(shortNames)
   ///     // Prints "["Kim", "Karl"]"
   ///
-  /// - Parameter includeElement: A closure that takes an element of the
+  /// - Parameter shouldInclude: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
   /// - Returns: An array of the elements that `includeElement` allowed.
   public func filter(
-    _ includeElement: @noescape (Iterator.Element) throws -> Bool
+    _ isIncluded: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> [Iterator.Element] {
 
     var result = ContiguousArray<Iterator.Element>()
@@ -760,7 +760,7 @@ extension Sequence {
     var iterator = self.makeIterator()
 
     while let element = iterator.next() {
-      if try includeElement(element) {
+      if try isIncluded(element) {
         result.append(element)
       }
     }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -564,12 +564,12 @@ public protocol Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate or nil if no such element is found.
   ///
-  /// - Parameter where: A closure that takes an element of the
+  /// - Parameter predicate: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element is a match.
   /// - Returns: The first match or `nil` if there was no match.
   func first(
-    where: @noescape (Iterator.Element) throws -> Bool
+    where predicate: @noescape (Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element?
 
   func _customContainsEquatableElement(
@@ -969,7 +969,7 @@ extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate or nil if no such element is found.
   ///
-  /// - Parameter where: A closure that takes an element of the
+  /// - Parameter predicate: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element is a match.
   /// - Returns: The first match or `nil` if there was no match.

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -524,40 +524,44 @@ extension Sequence {
   /// Returns the result of calling the given combining closure with each
   /// element of this sequence and an accumulating value.
   ///
-  /// The `combine` closure is called sequentially with an accumulating
-  /// value initialized to `initial` and each element of the sequence. This
-  /// example shows how to find the sum of an array of numbers.
+  /// The `nextPartialResult` closure is called sequentially with an
+  /// accumulating value initialized to `initialResult` and each
+  /// element of the sequence. This example shows how to find the sum
+  /// of an array of numbers.
   ///
   ///     let numbers = [1, 2, 3, 4]
   ///     let addTwo: (Int, Int) -> Int = { x, y in x + y }
-  ///     let numberSum = numbers.reduce(0, combine: addTwo)
+  ///     let numberSum = numbers.reduce(0, addTwo)
   ///     // 'numberSum' == 10
   ///
-  /// When `numbers.reduce(_:combine:)` is called, the following steps
-  /// occur:
+  /// When `numbers.reduce(_:_:)` is called, the
+  /// following steps occur:
   ///
-  /// 1. The `combine` closure is called with the initial value and the
-  ///    first element of `numbers`, returning the sum: `1`.
+  /// 1. The `nextPartialResult` closure is called with the initial
+  ///    result and the first element of `numbers`, returning the sum:
+  ///    `1`.
   /// 2. The closure is called again repeatedly with the previous call's
   ///    return value and each element of the sequence.
   /// 3. When the sequence is exhausted, the last value returned from the
   ///    closure is returned to the caller.
   ///
   /// - Parameters:
-  ///   - initial: A value to use as the initial value for accumulation.
-  ///   - combine: A closure that combines an accumulating value and an
-  ///     element of the sequence into a new accumulating value, to be used
-  ///     in the next call of the `combine` closure or returned to the
-  ///     caller.
-  /// - Returns: The final accumulated value.
-  public func reduce<T>(
-    _ initial: T, combine: @noescape (T, ${GElement}) throws -> T
-  ) rethrows -> T {
-    var result = initial
+  ///   - initialResult: the initial accumulating value.
+  ///   - nextPartialResult: A closure that combines an accumulating
+  ///     value and an element of the sequence into a new accumulating
+  ///     value, to be used in the next call of the
+  ///     `nextPartialResult` closure or returned to the caller.
+    /// - Returns: The final accumulated value.
+  public func reduce<Result>(
+    _ initialResult: Result,
+    _ nextPartialResult:
+      @noescape (partialResult: Result, ${GElement}) throws -> Result
+  ) rethrows -> Result {
+    var accumulator = initialResult
     for element in self {
-      result = try combine(result, element)
+      accumulator = try nextPartialResult(partialResult: accumulator, element)
     }
-    return result
+    return accumulator
   }
 }
 

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -36,10 +36,10 @@ equivalenceExplanation = """\
   /// is, for any elements `a`, `b`, and `c`, the following conditions must
   /// hold:
   ///
-  /// - `isEquivalent(a, a)` is always `true`. (Reflexivity)
-  /// - `isEquivalent(a, b)` implies `isEquivalent(b, a)`. (Symmetry)
-  /// - If `isEquivalent(a, b)` and `isEquivalent(b, c)` are both `true`, then
-  ///   `isEquivalent(a, c)` is also `true`. (Transitivity)
+  /// - `areEquivalent(a, a)` is always `true`. (Reflexivity)
+  /// - `areEquivalent(a, b)` implies `areEquivalent(b, a)`. (Symmetry)
+  /// - If `areEquivalent(a, b)` and `areEquivalent(b, c)` are both `true`, then
+  ///   `areEquivalent(a, c)` is also `true`. (Transitivity)
   ///"""
 
 }%
@@ -211,7 +211,7 @@ extension Sequence ${"" if preds else "where Iterator.Element : Equatable"} {
 ${equivalenceExplanation}
   /// - Parameters:
   ///   - possiblePrefix: A sequence to compare to this sequence.
-  ///   - isEquivalent: A predicate that returns `true` if its two arguments
+  ///   - areEquivalent: A predicate that returns `true` if its two arguments
   ///     are equivalent; otherwise, `false`.
   /// - Returns: `true` if the initial elements of the sequence are equivalent
   ///   to the elements of `possiblePrefix`; otherwise, `false`. Returns
@@ -237,12 +237,12 @@ ${equivalenceExplanation}
   ///   the elements of `possiblePrefix`; otherwise, `false`. Returns `true`
   ///   if `possiblePrefix` has no elements.
   ///
-  /// - SeeAlso: `starts(with:isEquivalent:)`
+  /// - SeeAlso: `starts(with:by:)`
 %   end
   public func starts<PossiblePrefix>(
     with possiblePrefix: PossiblePrefix${"," if preds else ""}
 %   if preds:
-    isEquivalent: @noescape (${GElement}, ${GElement}) throws -> Bool
+    by areEquivalent: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
   ) ${rethrows_}-> Bool
     where
@@ -252,7 +252,7 @@ ${equivalenceExplanation}
     var possiblePrefixIterator = possiblePrefix.makeIterator()
     for e0 in self {
       if let e1 = possiblePrefixIterator.next() {
-        if ${"try !isEquivalent(e0, e1)" if preds else "e0 != e1"} {
+        if ${"try !areEquivalent(e0, e1)" if preds else "e0 != e1"} {
           return false
         }
       }
@@ -287,10 +287,10 @@ extension Sequence ${"" if preds else "where Iterator.Element : Equatable"} {
 ${equivalenceExplanation}
   /// - Parameters:
   ///   - other: A sequence to compare to this sequence.
-  ///   - isEquivalent: A predicate that returns `true` if its two arguments
+  ///   - areEquivalent: A predicate that returns `true` if its two arguments
   ///     are equivalent; otherwise, `false`.
   /// - Returns: `true` if this sequence and `other` contain equivalent items,
-  ///   using `isEquivalent` as the equivalence test; otherwise, `false.`
+  ///   using `areEquivalent` as the equivalence test; otherwise, `false.`
   ///
   /// - SeeAlso: `elementsEqual(_:)`
 %   else:
@@ -313,12 +313,12 @@ ${equivalenceExplanation}
   /// - Returns: `true` if this sequence and `other` contain the same elements
   ///   in the same order.
   ///
-  /// - SeeAlso: `elementsEqual(_:isEquivalent:)`
+  /// - SeeAlso: `elementsEqual(_:by:)`
 %   end
   public func elementsEqual<OtherSequence>(
     _ other: OtherSequence${"," if preds else ""}
 %   if preds:
-    isEquivalent: @noescape (${GElement}, ${GElement}) throws -> Bool
+    by areEquivalent: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
   ) ${rethrows_}-> Bool
     where
@@ -330,7 +330,7 @@ ${equivalenceExplanation}
     while true {
       switch (iter1.next(), iter2.next()) {
       case let (e1?, e2?):
-        if ${'try !isEquivalent(e1, e2)' if preds else 'e1 != e2'} {
+        if ${'try !areEquivalent(e1, e2)' if preds else 'e1 != e2'} {
           return false
         }
       case (_?, nil),
@@ -694,7 +694,7 @@ extension Sequence {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "starts(with:isEquivalent:)")
+  @available(*, unavailable, renamed: "starts(with:by:)")
   public func startsWith<PossiblePrefix>(
     _ possiblePrefix: PossiblePrefix,
     isEquivalent: @noescape (Iterator.Element, Iterator.Element) throws -> Bool

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -505,7 +505,7 @@ extension Sequence {
   /// - Returns: `true` if the sequence contains an element that satisfies
   ///   `predicate`; otherwise, `false`.
   public func contains(
-    _ predicate: @noescape (${GElement}) throws -> Bool
+    where predicate: @noescape (${GElement}) throws -> Bool
   ) rethrows -> Bool {
     for e in self {
       if try predicate(e) {

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -21,10 +21,10 @@ orderingExplanation = """\
   /// is, for any elements `a`, `b`, and `c`, the following conditions must
   /// hold:
   ///
-  /// - `isOrderedBefore(a, a)` is always `false`. (Irreflexivity)
-  /// - If `isOrderedBefore(a, b)` and `isOrderedBefore(b, c)` are both `true`,
-  ///   then `isOrderedBefore(a, c)` is also `true`. (Transitive
-  ///   comparability)
+  /// - `areInIncreasingOrder(a, a)` is always `false`. (Irreflexivity)
+  /// - If `areInIncreasingOrder(a, b)` and `areInIncreasingOrder(b, c)` are
+  ///   both `true`, then `areInIncreasingOrder(a, c)` is also
+  ///   `true`. (Transitive comparability)
   /// - Two elements are *incomparable* if neither is ordered before the other
   ///   according to the predicate. If `a` and `b` are incomparable, and `b`
   ///   and `c` are incomparable, then `a` and `c` are also incomparable.
@@ -87,7 +87,7 @@ extension Sequence ${"" if preds else "where Iterator.Element : Comparable"} {
   /// the comparison between elements.
   ///
 ${orderingExplanation}
-  /// This example shows how to use the `min(isOrderedBefore:)` method on a
+  /// This example shows how to use the `min(by:)` method on a
   /// dictionary to find the key-value pair with the lowest value.
   ///
   ///     let hues = ["Heliotrope": 296, "Coral": 16, "Aquamarine": 156]
@@ -95,11 +95,12 @@ ${orderingExplanation}
   ///     print(leastHue)
   ///     // Prints "Optional(("Coral", 16))"
   ///
-  /// - Parameter isOrderedBefore: A predicate that returns `true` if its first
-  ///   argument should be ordered before its second argument; otherwise,
-  ///   `false`.
+  /// - Parameter areInIncreasingOrder: A predicate that returns `true`
+  ///   if its first argument should be ordered before its second
+  ///   argument; otherwise, `false`.
   /// - Returns: The sequence's minimum element, according to
-  ///   `isOrderedBefore`. If the sequence has no elements, returns `nil`.
+  ///   `areInIncreasingOrder`. If the sequence has no elements, returns
+  ///   `nil`.
   ///
   /// - SeeAlso: `min()`
 %   else:
@@ -115,19 +116,19 @@ ${orderingExplanation}
   /// - Returns: The sequence's minimum element. If the sequence has no
   ///   elements, returns `nil`.
   ///
-  /// - SeeAlso: `min(isOrderedBefore:)`
+  /// - SeeAlso: `min(by:)`
 %   end
   @warn_unqualified_access
   public func min(
 %   if preds:
-    isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
+    by areInIncreasingOrder: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
   ) ${rethrows_}-> ${GElement}? {
     var it = makeIterator()
     guard var result = it.next() else { return nil }
     for e in IteratorSequence(it) {
 %   if preds:
-      if try isOrderedBefore(e, result) { result = e }
+      if try areInIncreasingOrder(e, result) { result = e }
 %   else:
       if e < result { result = e }
 %   end
@@ -140,7 +141,7 @@ ${orderingExplanation}
   /// as the comparison between elements.
   ///
 ${orderingExplanation}
-  /// This example shows how to use the `max(isOrderedBefore:)` method on a
+  /// This example shows how to use the `max(by:)` method on a
   /// dictionary to find the key-value pair with the highest value.
   ///
   ///     let hues = ["Heliotrope": 296, "Coral": 16, "Aquamarine": 156]
@@ -148,7 +149,7 @@ ${orderingExplanation}
   ///     print(greatestHue)
   ///     // Prints "Optional(("Heliotrope", 296))"
   ///
-  /// - Parameter isOrderedBefore:  A predicate that returns `true` if its
+  /// - Parameter areInIncreasingOrder:  A predicate that returns `true` if its
   ///   first argument should be ordered before its second argument;
   ///   otherwise, `false`.
   /// - Returns: The sequence's maximum element if the sequence is not empty;
@@ -168,19 +169,19 @@ ${orderingExplanation}
   /// - Returns: The sequence's maximum element. If the sequence has no
   ///   elements, returns `nil`.
   ///
-  /// - SeeAlso: `max(isOrderedBefore:)`
+  /// - SeeAlso: `max(by:)`
 %   end
   @warn_unqualified_access
   public func max(
 %   if preds:
-    isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
+    by areInIncreasingOrder: @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
   ) ${rethrows_}-> ${GElement}? {
     var it = makeIterator()
     guard var result = it.next() else { return nil }
     for e in IteratorSequence(it) {
 %   if preds:
-      if try isOrderedBefore(result, e) { result = e }
+      if try areInIncreasingOrder(result, e) { result = e }
 %   else:
       if e > result { result = e }
 %   end
@@ -363,11 +364,11 @@ extension Sequence ${"" if preds else "where Iterator.Element : Comparable"} {
 ${orderingExplanation}
   /// - Parameters:
   ///   - other: A sequence to compare to this sequence.
-  ///   - isOrderedBefore:  A predicate that returns `true` if its first
+  ///   - areInIncreasingOrder:  A predicate that returns `true` if its first
   ///     argument should be ordered before its second argument; otherwise,
   ///     `false`.
   /// - Returns: `true` if this sequence precedes `other` in a dictionary
-  ///   ordering as ordered by `isOrderedBefore`; otherwise, `false`.
+  ///   ordering as ordered by `areInIncreasingOrder`; otherwise, `false`.
   ///
   /// - Note: This method implements the mathematical notion of lexicographical
   ///   ordering, which has no connection to Unicode.  If you are sorting
@@ -397,12 +398,13 @@ ${orderingExplanation}
   ///   ordering, which has no connection to Unicode.  If you are sorting
   ///   strings to present to the end user, you should use `String` APIs that
   ///   perform localized comparison.
-  /// - SeeAlso: `lexicographicallyPrecedes(_:isOrderedBefore:)`
+  /// - SeeAlso: `lexicographicallyPrecedes(_:by:)`
 %   end
   public func lexicographicallyPrecedes<OtherSequence>(
     _ other: OtherSequence${"," if preds else ""}
 %   if preds:
-    isOrderedBefore: @noescape (${GElement}, ${GElement}) throws -> Bool
+    by areInIncreasingOrder: 
+      @noescape (${GElement}, ${GElement}) throws -> Bool
 %   end
   ) ${rethrows_}-> Bool
     where
@@ -414,10 +416,10 @@ ${orderingExplanation}
     while true {
       if let e1 = iter1.next() {
         if let e2 = iter2.next() {
-          if ${"try isOrderedBefore(e1, e2)" if preds else "e1 < e2"} {
+          if ${"try areInIncreasingOrder(e1, e2)" if preds else "e1 < e2"} {
             return true
           }
-          if ${"try isOrderedBefore(e2, e1)" if preds else "e2 < e1"} {
+          if ${"try areInIncreasingOrder(e2, e1)" if preds else "e2 < e1"} {
             return false
           }
           continue // Equivalent
@@ -673,14 +675,14 @@ extension Sequence {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "min(isOrderedBefore:)")
+  @available(*, unavailable, renamed: "min(by:)")
   public func minElement(
     _ isOrderedBefore: @noescape (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "max(isOrderedBefore:)")
+  @available(*, unavailable, renamed: "max(by:)")
   public func maxElement(
     _ isOrderedBefore: @noescape (Iterator.Element, Iterator.Element) throws -> Bool
   ) rethrows -> Iterator.Element? {
@@ -703,7 +705,7 @@ extension Sequence {
     Builtin.unreachable()
   }
 
-  @available(*, unavailable, renamed: "lexicographicallyPrecedes(_:isOrderedBefore:)")
+  @available(*, unavailable, renamed: "lexicographicallyPrecedes(_:by:)")
   public func lexicographicalCompare<
     OtherSequence
   >(

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -88,9 +88,9 @@ extension Sequence
   ///   whether the element should be included in the returned array.
   /// - Returns: An array of the elements that `includeElement` allowed.
   public func filter(
-    _ includeElement: @noescape (Base.Iterator.Element) throws -> Bool
+    _ isIncluded: @noescape (Base.Iterator.Element) throws -> Bool
   ) rethrows -> [Base.Iterator.Element] {
-    return try _base.filter(includeElement)
+    return try _base.filter(isIncluded)
   }
   
   public func _customContainsEquatableElement(

--- a/stdlib/public/core/Slice.swift.gyb
+++ b/stdlib/public/core/Slice.swift.gyb
@@ -46,7 +46,7 @@ def get_slice_doc_comment(Self):
 ///
 /// 1) Create a slice of the `absences` array that holds the second half of the
 ///    days.
-/// 2) Use the `max(isOrderedBefore:)` method to determine the index of the day
+/// 2) Use the `max(by:)` method to determine the index of the day
 ///    with the most absences.
 /// 3) Print the result using the index found in step 2 on the original
 ///    `absences` array.
@@ -54,7 +54,7 @@ def get_slice_doc_comment(Self):
 /// Here's an implementation of those steps:
 ///
 ///     let secondHalf = absences.suffix(absences.count / 2)
-///     if let i = secondHalf.indices.max(isOrderedBefore: { secondHalf[$0] < secondHalf[$1] }) {
+///     if let i = secondHalf.indices.max(by: { secondHalf[$0] < secondHalf[$1] }) {
 ///         print("Highest second-half absences: \(absences[i])")
 ///     }
 ///     // Prints "Highest second-half absences: 3"

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -13,14 +13,14 @@
 %{
 def cmp(a, b, p):
   if p:
-    return "isOrderedBefore(" + a + ", " + b + ")"
+    return "areInIncreasingOrder(" + a + ", " + b + ")"
   else:
     return "(" + a + " < " + b + ")"
 
 }%
 
 // Generate two versions of sorting functions: one with an explicitly passed
-// predicate 'isOrderedBefore' and the other for Comparable types that don't
+// predicate 'areInIncreasingOrder' and the other for Comparable types that don't
 // need such a predicate.
 % preds = [True, False]
 % for p in preds:
@@ -28,7 +28,7 @@ def cmp(a, b, p):
 func _insertionSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : protocol<MutableCollection, BidirectionalCollection>
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -75,7 +75,7 @@ func _insertionSort<C>(
 func _partition<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) -> C.Index
   where
   C : protocol<MutableCollection, RandomAccessCollection>
@@ -131,13 +131,13 @@ public // @testable
 func _introSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : protocol<MutableCollection, RandomAccessCollection>
   ${"" if p else ", C.Iterator.Element : Comparable"} {
 
 %   if p:
-  var isOrderedBeforeVar = isOrderedBefore
+  var areIncreasingVar = areInIncreasingOrder
 %   end
   let count =
     elements.distance(from: range.lowerBound, to: range.upperBound).toIntMax()
@@ -150,14 +150,14 @@ func _introSort<C>(
   _introSortImpl(
     &elements,
     subRange: range,
-    ${"isOrderedBefore: &isOrderedBeforeVar," if p else ""}
+    ${"by: &areIncreasingVar," if p else ""}
     depthLimit: depthLimit)
 }
 
 func _introSortImpl<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""},
+  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""},
   depthLimit: Int
 ) where
   C : protocol<MutableCollection, RandomAccessCollection>
@@ -168,14 +168,14 @@ func _introSortImpl<C>(
     _insertionSort(
       &elements,
       subRange: range
-      ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+      ${", by: &areInIncreasingOrder" if p else ""})
     return
   }
   if depthLimit == 0 {
     _heapSort(
       &elements,
       subRange: range
-      ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+      ${", by: &areInIncreasingOrder" if p else ""})
     return
   }
 
@@ -185,16 +185,16 @@ func _introSortImpl<C>(
   let partIdx: C.Index = _partition(
     &elements,
     subRange: range
-    ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+    ${", by: &areInIncreasingOrder" if p else ""})
   _introSortImpl(
     &elements,
     subRange: range.lowerBound..<partIdx,
-    ${"isOrderedBefore: &isOrderedBefore, " if p else ""}
+    ${"by: &areInIncreasingOrder, " if p else ""}
     depthLimit: depthLimit &- 1)
   _introSortImpl(
     &elements,
     subRange: (elements.index(after: partIdx))..<range.upperBound,
-    ${"isOrderedBefore: &isOrderedBefore, " if p else ""}
+    ${"by: &areInIncreasingOrder, " if p else ""}
     depthLimit: depthLimit &- 1)
 }
 
@@ -202,7 +202,7 @@ func _siftDown<C>(
   _ elements: inout C,
   index: C.Index,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : protocol<MutableCollection, RandomAccessCollection>
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -234,13 +234,13 @@ func _siftDown<C>(
       &elements,
       index: largest,
       subRange: range
-      ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+      ${", by: &areInIncreasingOrder" if p else ""})
   }
 }
 func _heapify<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : protocol<MutableCollection, RandomAccessCollection>
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -262,13 +262,13 @@ func _heapify<C>(
       &elements,
       index: node,
       subRange: range
-      ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+      ${", by: &areInIncreasingOrder" if p else ""})
   }
 }
 func _heapSort<C>(
   _ elements: inout C,
   subRange range: Range<C.Index>
-  ${", isOrderedBefore: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
+  ${", by areInIncreasingOrder: inout (C.Iterator.Element, C.Iterator.Element) -> Bool" if p else ""}
 ) where
   C : protocol<MutableCollection, RandomAccessCollection>
   ${"" if p else ", C.Iterator.Element : Comparable"} {
@@ -277,7 +277,7 @@ func _heapSort<C>(
   _heapify(
     &elements,
     subRange: range
-    ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+    ${", by: &areInIncreasingOrder" if p else ""})
   elements.formIndex(before: &hi)
   while hi != lo {
     swap(&elements[lo], &elements[hi])
@@ -285,7 +285,7 @@ func _heapSort<C>(
       &elements,
       index: lo,
       subRange: lo..<hi
-      ${", isOrderedBefore: &isOrderedBefore" if p else ""})
+      ${", by: &areInIncreasingOrder" if p else ""})
     elements.formIndex(before: &hi)
   }
 }

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -124,7 +124,7 @@ public struct StaticString
   ///   `withUTF8Buffer(invoke:)` method.
   /// - Returns: The return value of the `body` closure, if any.
   public func withUTF8Buffer<R>(
-    invoke body: @noescape (UnsafeBufferPointer<UInt8>) -> R) -> R {
+    _ body: @noescape (UnsafeBufferPointer<UInt8>) -> R) -> R {
     if hasPointerRepresentation {
       return body(UnsafeBufferPointer(
         start: utf8Start, count: Int(utf8CodeUnitCount)))

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -135,7 +135,7 @@ public struct StaticString
         buffer = buffer | (UInt64($0) << (UInt64(i) * 8))
         i += 1
       }
-      UTF8.encode(unicodeScalar, sendingOutputTo: sink)
+      UTF8.encode(unicodeScalar, into: sink)
       return body(UnsafeBufferPointer(
         start: UnsafePointer(Builtin.addressof(&buffer)),
         count: i))

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -468,8 +468,7 @@ extension String {
     Encoding: UnicodeCodec
   >(_ encoding: Encoding.Type) -> Int {
     var codeUnitCount = 0
-    let output: (Encoding.CodeUnit) -> Void = { _ in codeUnitCount += 1 }
-    self._encode(encoding, output: output)
+    self._encode(encoding, into: { _ in codeUnitCount += 1 })
     return codeUnitCount
   }
 
@@ -482,9 +481,11 @@ extension String {
   // with unpaired surrogates
   func _encode<
     Encoding: UnicodeCodec
-  >(_ encoding: Encoding.Type, output: @noescape (Encoding.CodeUnit) -> Void)
-  {
-    return _core.encode(encoding, output: output)
+  >(
+    _ encoding: Encoding.Type,
+    into processCodeUnit: @noescape (Encoding.CodeUnit) -> Void
+  ) {
+    return _core.encode(encoding, into: processCodeUnit)
   }
 }
 

--- a/stdlib/public/core/StringBuffer.swift
+++ b/stdlib/public/core/StringBuffer.swift
@@ -116,7 +116,7 @@ public struct _StringBuffer {
         input.makeIterator(),
         from: encoding, to: UTF32.self,
         stoppingOnError: true,
-        sendingOutputTo: sink)
+        into: sink)
       _sanityCheck(!hadError, "string cannot be ASCII if there were decoding errors")
       return (result, hadError)
     }
@@ -130,7 +130,7 @@ public struct _StringBuffer {
         input.makeIterator(),
         from: encoding, to: UTF16.self,
         stoppingOnError: !repairIllFormedSequences,
-        sendingOutputTo: sink)
+        into: sink)
       return (result, hadError)
     }
   }

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -103,7 +103,9 @@ extension String {
   /// - Parameter body: A closure that takes a character view as its argument.
   /// - Returns: The return value of the `body` closure, if any, is the return
   ///   value of this method.
-  public mutating func withMutableCharacters<R>(_ body: (inout CharacterView) -> R) -> R {
+  public mutating func withMutableCharacters<R>(
+    _ body: (inout CharacterView) -> R
+  ) -> R {
     // Naively mutating self.characters forces multiple references to
     // exist at the point of mutation. Instead, temporarily move the
     // core of this string into a CharacterView.

--- a/stdlib/public/core/StringCore.swift
+++ b/stdlib/public/core/StringCore.swift
@@ -329,9 +329,9 @@ public struct _StringCore {
   }
 
   /// Write the string, in the given encoding, to output.
-  func encode<
-    Encoding: UnicodeCodec
-  >(_ encoding: Encoding.Type, output: @noescape (Encoding.CodeUnit) -> Void)
+  func encode<Encoding: UnicodeCodec>(
+    _ encoding: Encoding.Type,
+    into processCodeUnit: @noescape (Encoding.CodeUnit) -> Void)
   {
     if _fastPath(_baseAddress != nil) {
       if _fastPath(elementWidth == 1) {
@@ -339,7 +339,7 @@ public struct _StringCore {
           start: UnsafeMutablePointer<UTF8.CodeUnit>(_baseAddress!),
           count: count
         ) {
-          Encoding.encode(UnicodeScalar(UInt32(x)), sendingOutputTo: output)
+          Encoding.encode(UnicodeScalar(UInt32(x)), into: processCodeUnit)
         }
       }
       else {
@@ -351,7 +351,7 @@ public struct _StringCore {
           from: UTF16.self,
           to: encoding,
           stoppingOnError: true,
-          sendingOutputTo: output
+          into: processCodeUnit
         )
         _sanityCheck(!hadError, "Swift.String with native storage should not have unpaired surrogates")
       }
@@ -361,7 +361,7 @@ public struct _StringCore {
       _StringCore(
         _cocoaStringToContiguous(
           source: cocoaBuffer!, range: 0..<count, minimumCapacity: 0)
-      ).encode(encoding, output: output)
+      ).encode(encoding, into: processCodeUnit)
 #else
       _sanityCheckFailure("encode: non-native string without objc runtime")
 #endif

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -121,7 +121,7 @@ public protocol UnicodeCodec {
   /// fermata in UTF-8:
   ///
   ///     var bytes: [UTF8.CodeUnit] = []
-  ///     UTF8.encode("𝄐", sendingOutputTo: { bytes.append($0) })
+  ///     UTF8.encode("𝄐", into: { bytes.append($0) })
   ///     print(bytes)
   ///     // Prints "[240, 157, 132, 144]"
   ///
@@ -131,7 +131,7 @@ public protocol UnicodeCodec {
   ///     time.
   static func encode(
     _ input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: @noescape (CodeUnit) -> Void
+    into processCodeUnit: @noescape (CodeUnit) -> Void
   )
 
   /// Searches for the first occurrence of a `CodeUnit` that is equal to 0.
@@ -363,7 +363,7 @@ public struct UTF8 : UnicodeCodec {
   /// representation. The following code encodes a fermata in UTF-8:
   ///
   ///     var bytes: [UTF8.CodeUnit] = []
-  ///     UTF8.encode("𝄐", sendingOutputTo: { bytes.append($0) })
+  ///     UTF8.encode("𝄐", into: { bytes.append($0) })
   ///     print(bytes)
   ///     // Prints "[240, 157, 132, 144]"
   ///
@@ -373,7 +373,7 @@ public struct UTF8 : UnicodeCodec {
   ///     time.
   public static func encode(
     _ input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: @noescape (CodeUnit) -> Void
+    into processCodeUnit: @noescape (CodeUnit) -> Void
   ) {
     var c = UInt32(input)
     var buf3 = UInt8(c & 0xFF)
@@ -554,7 +554,7 @@ public struct UTF16 : UnicodeCodec {
   /// representation. The following code encodes a fermata in UTF-16:
   ///
   ///     var codeUnits: [UTF16.CodeUnit] = []
-  ///     UTF16.encode("𝄐", sendingOutputTo: { codeUnits.append($0) })
+  ///     UTF16.encode("𝄐", into: { codeUnits.append($0) })
   ///     print(codeUnits)
   ///     // Prints "[55348, 56592]"
   ///
@@ -564,7 +564,7 @@ public struct UTF16 : UnicodeCodec {
   ///     time.
   public static func encode(
     _ input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: @noescape (CodeUnit) -> Void
+    into processCodeUnit: @noescape (CodeUnit) -> Void
   ) {
     let scalarValue: UInt32 = UInt32(input)
 
@@ -654,7 +654,7 @@ public struct UTF32 : UnicodeCodec {
   /// encodes a fermata in UTF-32:
   ///
   ///     var codeUnit: UTF32.CodeUnit = 0
-  ///     UTF32.encode("𝄐", sendingOutputTo: { codeUnit = $0 })
+  ///     UTF32.encode("𝄐", into: { codeUnit = $0 })
   ///     print(codeUnit)
   ///     // Prints "119056"
   ///
@@ -664,7 +664,7 @@ public struct UTF32 : UnicodeCodec {
   ///     time.
   public static func encode(
     _ input: UnicodeScalar,
-    sendingOutputTo processCodeUnit: @noescape (CodeUnit) -> Void
+    into processCodeUnit: @noescape (CodeUnit) -> Void
   ) {
     processCodeUnit(UInt32(input))
   }
@@ -684,7 +684,7 @@ public struct UTF32 : UnicodeCodec {
 ///     var codeUnits: [UTF32.CodeUnit] = []
 ///     let sink = { codeUnits.append($0) }
 ///     transcode(bytes.makeIterator(), from: UTF8.self, to: UTF32.self,
-///               stoppingOnError: false, sendingOutputTo: sink)
+///               stoppingOnError: false, into: sink)
 ///     print(codeUnits)
 ///     // Prints "[70, 101, 114, 109, 97, 116, 97, 32, 119056]"
 ///
@@ -710,7 +710,7 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
   from inputEncoding: InputEncoding.Type,
   to outputEncoding: OutputEncoding.Type,
   stoppingOnError stopOnError: Bool,
-  sendingOutputTo processCodeUnit: @noescape (OutputEncoding.CodeUnit) -> Void
+  into processCodeUnit: @noescape (OutputEncoding.CodeUnit) -> Void
 ) -> Bool
   where
   Input : IteratorProtocol,
@@ -729,7 +729,7 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
   while true {
     switch inputDecoder.decode(&input) {
     case .scalarValue(let us):
-      OutputEncoding.encode(us, sendingOutputTo: processCodeUnit)
+      OutputEncoding.encode(us, into: processCodeUnit)
     case .emptyInput:
       break loop
     case .error:
@@ -737,7 +737,7 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
       if stopOnError {
         break loop
       }
-      OutputEncoding.encode("\u{fffd}", sendingOutputTo: processCodeUnit)
+      OutputEncoding.encode("\u{fffd}", into: processCodeUnit)
     }
   }
   return hadError
@@ -1132,7 +1132,7 @@ extension UnicodeCodec {
 @available(*, unavailable, renamed: "UnicodeCodec")
 public typealias UnicodeCodecType = UnicodeCodec
 
-@available(*, unavailable, message: "use 'transcode(_:from:to:stoppingOnError:sendingOutputTo:)'")
+@available(*, unavailable, message: "use 'transcode(_:from:to:stoppingOnError:into:)'")
 public func transcode<Input, InputEncoding, OutputEncoding>(
   _ inputEncoding: InputEncoding.Type, _ outputEncoding: OutputEncoding.Type,
   _ input: Input, _ output: (OutputEncoding.CodeUnit) -> Void,

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -183,10 +183,10 @@ public struct Unmanaged<Instance : AnyObject> {
   ///    }
   ///  }
   public func _withUnsafeGuaranteedRef<Result>(
-    _ closure: @noescape (Instance) throws -> Result
+    _ body: @noescape (Instance) throws -> Result
   ) rethrows -> Result {
     let (guaranteedInstance, token) = Builtin.unsafeGuaranteed(_value)
-    let result = try closure(guaranteedInstance)
+    let result = try body(guaranteedInstance)
     Builtin.unsafeGuaranteedEnd(token)
     return result
   }

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -65,18 +65,18 @@ let _x86_64RegisterSaveWords = _x86_64CountGPRegisters + _x86_64CountSSERegister
 
 /// Invoke `body` with a C `va_list` argument derived from `args`.
 public func withVaList<R>(_ args: [CVarArg],
-  invoke body: @noescape (CVaListPointer) -> R) -> R {
+  _ body: @noescape (CVaListPointer) -> R) -> R {
   let builder = _VaListBuilder()
   for a in args {
     builder.append(a)
   }
-  return _withVaList(builder, invoke: body)
+  return _withVaList(builder, body)
 }
 
 /// Invoke `body` with a C `va_list` argument derived from `builder`.
 internal func _withVaList<R>(
   _ builder: _VaListBuilder,
-  invoke body: @noescape (CVaListPointer) -> R
+  _ body: @noescape (CVaListPointer) -> R
 ) -> R {
   let result = body(builder.va_list())
   _fixLifetime(builder)

--- a/test/1_stdlib/ArrayTraps.swift.gyb
+++ b/test/1_stdlib/ArrayTraps.swift.gyb
@@ -138,7 +138,7 @@ ArrayTraps.test("unsafeLength")
 
   expectCrashLater()
 
-  a.withUnsafeBufferPointer {
+  _ = a.withUnsafeBufferPointer {
     UnsafeBufferPointer(start: $0.baseAddress, count: -1)
   }
 }

--- a/test/1_stdlib/ErrorHandling.swift
+++ b/test/1_stdlib/ErrorHandling.swift
@@ -233,7 +233,7 @@ ErrorHandlingTests.test("ErrorHandling/contains") {
 ErrorHandlingTests.test("ErrorHandling/reduce") {
   var loopCount = 0
   do {
-    let x: Int = try [1, 2, 3, 4, 5].reduce(0, combine: {
+    let x: Int = try [1, 2, 3, 4, 5].reduce(0) {
       (x: Int, y: Int) -> Int
     in
       loopCount += 1
@@ -242,7 +242,7 @@ ErrorHandlingTests.test("ErrorHandling/reduce") {
         throw SillyError.JazzHands
       }
       return total
-    })
+    }
     expectUnreachable()
   } catch {}
   expectEqual(loopCount, 3)

--- a/test/1_stdlib/Inputs/DictionaryKeyValueTypes.swift
+++ b/test/1_stdlib/Inputs/DictionaryKeyValueTypes.swift
@@ -11,11 +11,11 @@ func acceptsAnyDictionary<KeyTy : Hashable, ValueTy>(
 func equalsUnordered<T : Comparable>(
   _ lhs: Array<(T, T)>, _ rhs: Array<(T, T)>
 ) -> Bool {
-  func comparePair(_ lhs: (T, T), _ rhs: (T, T)) -> Bool {
+  func areInAscendingOrder(_ lhs: (T, T), _ rhs: (T, T)) -> Bool {
     return [ lhs.0, lhs.1 ].lexicographicallyPrecedes([ rhs.0, rhs.1 ])
   }
-  return lhs.sorted(isOrderedBefore: comparePair)
-    .elementsEqual(rhs.sorted(isOrderedBefore: comparePair)) {
+  return lhs.sorted(by: areInAscendingOrder)
+    .elementsEqual(rhs.sorted(by: areInAscendingOrder)) {
     (lhs: (T, T), rhs: (T, T)) -> Bool in
     lhs.0 == rhs.0 && lhs.1 == rhs.1
   }

--- a/test/1_stdlib/NumericParsing.swift.gyb
+++ b/test/1_stdlib/NumericParsing.swift.gyb
@@ -146,7 +146,7 @@ tests.test("${Self}/Basics") {
   // Check that we can round-trip the string representation of 2^100,
   // which requires an exponent to express...
   let large =
-    repeatElement(1024 as ${Self}, count: 10).reduce(1, combine: *)
+    repeatElement(1024 as ${Self}, count: 10).reduce(1, *)
   let largeText = String(large)
   expectEqual(largeText, String(${Self}(largeText)!))
   

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -61,7 +61,7 @@ func _Collection<C : Collection>(c: C) {
   func fn<T : Collection, U>(_: T, _: U) where T.Generator == U {} // expected-error {{'T' does not have a member type named 'Generator'; did you mean 'Iterator'?}} {{50-59=Iterator}} {{none}} 
   _ = c.generate() // expected-error {{'generate()' has been renamed to 'makeIterator()'}} {{9-17=makeIterator}} {{none}}
   _ = c.underestimateCount() // expected-error {{'underestimateCount()' is unavailable: Removed in Swift 3. Please use underestimatedCount property.}} {{none}}
-  _ = c.split(1) { _ in return true} // expected-error {{'split(_:allowEmptySlices:isSeparator:)' is unavailable: Please use split(maxSplits:omittingEmptySubsequences:isSeparator:) instead}} {{none}}
+  _ = c.split(1) { _ in return true} // expected-error {{split(maxSplits:omittingEmptySubsequences:whereSeparator:) instead}} {{none}}
 }
 
 func _Collection<C : Collection, E>(c: C, e: E) where C.Iterator.Element: Equatable, C.Iterator.Element == E {

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -70,8 +70,8 @@ func _Collection<C : Collection, E>(c: C, e: E) where C.Iterator.Element: Equata
 
 func _CollectionAlgorithms<C : MutableCollection, I>(c: C, i: I) where C : RandomAccessCollection, C.Index == I {
   var c = c
-  _ = c.partition(i..<i) { _, _ in true } // expected-error {{slice the collection using the range, and call partition(isOrderedBefore:)}} {{none}}
-  c.sortInPlace { _, _ in true } // expected-error {{'sortInPlace' has been renamed to 'sort(isOrderedBefore:)'}} {{5-16=sort}} {{none}}
+  _ = c.partition(i..<i) { _, _ in true } // expected-error {{slice the collection using the range, and call partition(by:)}} {{none}}
+  c.sortInPlace { _, _ in true } // expected-error {{'sortInPlace' has been renamed to 'sort(by:)'}} {{5-16=sort}} {{none}}
 }
 
 func _CollectionAlgorithms<C : MutableCollection, I>(c: C, i: I) where C : RandomAccessCollection, C.Iterator.Element : Comparable, C.Index == I {
@@ -392,11 +392,11 @@ func _Sequence<S : Sequence>(s: S, e: S.Iterator.Element) where S.Iterator.Eleme
 
 func _SequenceAlgorithms<S : Sequence>(x: S) {
   _ = x.enumerate() // expected-error {{'enumerate()' has been renamed to 'enumerated()'}} {{9-18=enumerated}} {{none}}
-  _ = x.minElement { _, _ in true } // expected-error {{'minElement' has been renamed to 'min(isOrderedBefore:)'}} {{9-19=min}} {{none}}
-  _ = x.maxElement { _, _ in true } // expected-error {{'maxElement' has been renamed to 'max(isOrderedBefore:)'}} {{9-19=max}} {{none}}
+  _ = x.minElement { _, _ in true } // expected-error {{'minElement' has been renamed to 'min(by:)'}} {{9-19=min}} {{none}}
+  _ = x.maxElement { _, _ in true } // expected-error {{'maxElement' has been renamed to 'max(by:)'}} {{9-19=max}} {{none}}
   _ = x.reverse() // expected-error {{'reverse()' has been renamed to 'reversed()'}} {{9-16=reversed}} {{none}}
-  _ = x.startsWith([]) { _ in true } // expected-error {{'startsWith(_:isEquivalent:)' has been renamed to 'starts(with:isEquivalent:)'}} {{9-19=starts}} {{20-20=with: }} {{none}}
-  _ = x.lexicographicalCompare([]) { _, _ in true } // expected-error {{'lexicographicalCompare(_:isOrderedBefore:)' has been renamed to 'lexicographicallyPrecedes(_:isOrderedBefore:)'}} {{9-31=lexicographicallyPrecedes}}{{none}}
+  _ = x.startsWith([]) { _ in true } // expected-error {{'startsWith(_:isEquivalent:)' has been renamed to 'starts(with:by:)'}} {{9-19=starts}} {{20-20=with: }} {{none}}
+  _ = x.lexicographicalCompare([]) { _, _ in true } // expected-error {{'lexicographicalCompare(_:isOrderedBefore:)' has been renamed to 'lexicographicallyPrecedes(_:by:)'}} {{9-31=lexicographicallyPrecedes}}{{none}}
 }
 func _SequenceAlgorithms<S : Sequence>(x: S) where S.Iterator.Element : Comparable {
   _ = x.minElement() // expected-error {{'minElement()' has been renamed to 'min()'}} {{9-19=min}} {{none}}

--- a/test/1_stdlib/Renames.swift
+++ b/test/1_stdlib/Renames.swift
@@ -469,7 +469,7 @@ func _Unicode() {
   func fn<T : UnicodeCodecType>(_: T) {} // expected-error {{'UnicodeCodecType' has been renamed to 'UnicodeCodec'}} {{15-31=UnicodeCodec}} {{none}}
 }
 func _Unicode<I : IteratorProtocol, E : UnicodeCodec>(i: I, e: E.Type) where I.Element == E.CodeUnit {
-  _ = transcode(e, e, i, { _ in }, stopOnError: true) // expected-error {{'transcode(_:_:_:_:stopOnError:)' is unavailable: use 'transcode(_:from:to:stoppingOnError:sendingOutputTo:)'}} {{none}}
+  _ = transcode(e, e, i, { _ in }, stopOnError: true) // expected-error {{'transcode(_:_:_:_:stopOnError:)' is unavailable: use 'transcode(_:from:to:stoppingOnError:into:)'}} {{none}}
   _ = UTF16.measure(e, input: i, repairIllFormedSequences: true) // expected-error {{'measure(_:input:repairIllFormedSequences:)' is unavailable: use 'transcodedLength(of:decodedAs:repairingIllFormedSequences:)'}} {{none}}
 }
 

--- a/test/1_stdlib/Strideable.swift
+++ b/test/1_stdlib/Strideable.swift
@@ -66,14 +66,14 @@ StrideTestSuite.test("Double") {
     // Work on Doubles
     expectEqual(
       sum,
-      stride(from: start, to: end, by: stepSize).reduce(0.0, combine: +))
+      stride(from: start, to: end, by: stepSize).reduce(0.0, +))
   }
   
   func checkClosed(from start: Double, through end: Double, by stepSize: Double, sum: Double) {
     // Work on Doubles
     expectEqual(
       sum,
-      stride(from: start, through: end, by: stepSize).reduce(0.0, combine: +))
+      stride(from: start, through: end, by: stepSize).reduce(0.0, +))
   }
   
   checkOpen(from: 1.0, to: 15.0, by: 3.0, sum: 35.0)
@@ -104,7 +104,8 @@ StrideTestSuite.test("HalfOpen") {
     // Work on Ints
     expectEqual(
       sum,
-      stride(from: start, to: end, by: stepSize).reduce(0, combine: +))
+      stride(from: start, to: end, by: stepSize).reduce(
+        0, +))
 
     // Work on an arbitrary RandomAccessIndex
     expectEqual(
@@ -129,12 +130,15 @@ StrideTestSuite.test("Closed") {
     // Work on Ints
     expectEqual(
       sum,
-      stride(from: start, through: end, by: stepSize).reduce(0, combine: +))
+      stride(from: start, through: end, by: stepSize).reduce(
+        0, +))
 
     // Work on an arbitrary RandomAccessIndex
     expectEqual(
       sum,
-      stride(from: R(start), through: R(end), by: stepSize).reduce(0) { $0 + $1.x })
+      stride(from: R(start), through: R(end), by: stepSize).reduce(
+        0, { $0 + $1.x })
+    )
   }
   
   check(from: 1, through: 15, by: 3, sum: 35)  // 1 + 4 + 7 + 10 + 13

--- a/test/1_stdlib/StringAPI.swift
+++ b/test/1_stdlib/StringAPI.swift
@@ -240,10 +240,10 @@ func checkHasPrefixHasSuffix(
       Array(String($0).unicodeScalars)
     }
   let expectHasPrefix = lhsNFDGraphemeClusters.starts(
-    with: rhsNFDGraphemeClusters, isEquivalent: (==))
+    with: rhsNFDGraphemeClusters, by: (==))
 
   let expectHasSuffix = lhsNFDGraphemeClusters.lazy.reversed()
-    .starts(with: rhsNFDGraphemeClusters.lazy.reversed(), isEquivalent: (==))
+    .starts(with: rhsNFDGraphemeClusters.lazy.reversed(), by: (==))
 
   expectEqual(expectHasPrefix, lhs.hasPrefix(rhs), stackTrace: stackTrace)
   expectEqual(
@@ -411,7 +411,7 @@ CStringTests.test("String(cString:)") {
 CStringTests.test("String.decodeCString") {
   do {
     let s = getNullCString()
-    let result = String.decodeCString(UnsafePointer(s), `as`: UTF8.self)
+    let result = String.decodeCString(UnsafePointer(s), as: UTF8.self)
     expectEmpty(result)
   }
   do { // repairing

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -554,7 +554,7 @@ func r22020088bar(_ p: r22020088P?) {
 
 // <rdar://problem/22288575> QoI: poor diagnostic involving closure, bad parameter label, and mismatch return type
 func f(_ arguments: [String]) -> [ArraySlice<String>] {
-  return arguments.split(maxSplits: 1, omittingEmptySubsequences: false, isSeparator: { $0 == "--" })
+  return arguments.split(maxSplits: 1, omittingEmptySubsequences: false, whereSeparator: { $0 == "--" })
 }
 
 

--- a/test/DebugInfo/closure-multivalue.swift
+++ b/test/DebugInfo/closure-multivalue.swift
@@ -21,7 +21,7 @@ public func sort(_ a: String, b: String) -> Bool {
 
 public func demo() {
     let names = ["Sean", "Barry", "Kate"]
-    let sortedNames = names.sorted(isOrderedBefore: sort)
+    let sortedNames = names.sorted(by: sort)
     var sortedNamesAsString : String = String()
     for name in sortedNames {
         sortedNamesAsString += ("\(name), ")

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -147,8 +147,8 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst()[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropLast()[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         enumerated()[#EnumeratedSequence<[Equatable]>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         min({#isOrderedBefore: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#isOrderedBefore: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         min({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         reduce({#(initial): T#}, {#combine: (T, Equatable) throws -> T##(T, Equatable) throws -> T#})[' rethrows'][#T#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[SegmentOfResult.Iterator.Element]#]{{; name=.+}}

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -166,7 +166,7 @@ func testArchetypeReplacement3 (_ a : [Int]) {
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         dropLast({#(n): Int#})[#ArraySlice<Int>#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#AnySequence<Int>#]
 // PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         prefix({#(maxLength): Int#})[#AnySequence<Int>#]
-// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         elementsEqual({#(other): Sequence#}, {#isEquivalent: (Int, Int) throws -> Bool##(Int, Int) throws -> Bool#})[' rethrows'][#Bool#]
+// PRIVATE_NOMINAL_MEMBERS_7-DAG: Decl[InstanceMethod]/Super:         elementsEqual({#(other): Sequence#}, {#by: (Int, Int) throws -> Bool##(Int, Int) throws -> Bool#})[' rethrows'][#Bool#]
 
 
 protocol P2 {

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -149,7 +149,7 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         enumerated()[#EnumeratedSequence<[Equatable]>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         min({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         max({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         reduce({#(initial): T#}, {#combine: (T, Equatable) throws -> T##(T, Equatable) throws -> T#})[' rethrows'][#T#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         reduce({#(initialResult): Result#}, {#(nextPartialResult): (partialResult: Result, Equatable) throws -> Result##(partialResult: Result, Equatable) throws -> Result#})[' rethrows'][#Result#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         dropFirst({#(n): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[SegmentOfResult.Iterator.Element]#]{{; name=.+}}
 

--- a/test/IDE/complete_literal.swift
+++ b/test/IDE/complete_literal.swift
@@ -39,7 +39,7 @@
 }
 
 // LITERAL4:         Begin completions
-// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal:   withCString({#(f): (UnsafePointer<Int8>) throws -> Result##(UnsafePointer<Int8>) throws -> Result#})[' rethrows'][#Result#]; name=withCString(f: (UnsafePointer<Int8>) throws -> Result) rethrows{{$}}
+// LITERAL4-DAG:     Decl[InstanceMethod]/CurrNominal:   withCString({#(body): (UnsafePointer<Int8>) throws -> Result##(UnsafePointer<Int8>) throws -> Result#})[' rethrows'][#Result#]; name=withCString(body: (UnsafePointer<Int8>) throws -> Result) rethrows{{$}}
 
 // FIXME: we should show the qualified String.Index type.
 // rdar://problem/20788802

--- a/test/NameBinding/reference-dependencies.swift
+++ b/test/NameBinding/reference-dependencies.swift
@@ -139,7 +139,7 @@ func lookUpManyTopLevelNames() {
 
   // CHECK-DAG: !private "UInt"
   // CHECK-DAG: !private "+"
-  let _: UInt = [1, 2].reduce(0, combine: +)
+  let _: UInt = [1, 2].reduce(0, +)
   
   // CHECK-DAG: !private "-"
   let _: UInt = 3 - 2 - 1

--- a/test/Parse/semicolon.swift
+++ b/test/Parse/semicolon.swift
@@ -44,7 +44,7 @@ for i in 1..<1000 {
     };
 }
 
-let six = (1..<3).reduce(0, combine: +);
+let six = (1..<3).reduce(0, +);
 
 func lessThanTwo(input: UInt) -> Bool {
     switch input {

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -859,7 +859,7 @@ internal class _CollectionTransformerStep<PipelineInputElement_, OutputElement_>
     fatalError("abstract method")
   }
 
-  func filter(_ predicate: (OutputElement) -> Bool)
+  func filter(_ isIncluded: (OutputElement) -> Bool)
     -> _CollectionTransformerStep<PipelineInputElement, OutputElement> {
 
     fatalError("abstract method")
@@ -911,11 +911,11 @@ final internal class _CollectionTransformerStepCollectionSource<
     }
   }
 
-  override func filter(_ predicate: (InputElement) -> Bool)
+  override func filter(_ isIncluded: (InputElement) -> Bool)
     -> _CollectionTransformerStep<PipelineInputElement, InputElement> {
 
     return _CollectionTransformerStepOneToMaybeOne(self) {
-      predicate($0) ? $0 : nil
+      isIncluded($0) ? $0 : nil
     }
   }
 
@@ -990,7 +990,7 @@ final internal class _CollectionTransformerStepOneToMaybeOne<
     }
   }
 
-  override func filter(_ predicate: (OutputElement) -> Bool)
+  override func filter(_ isIncluded: (OutputElement) -> Bool)
     -> _CollectionTransformerStep<PipelineInputElement, OutputElement> {
 
     // Let the closure below capture only one variable, not the whole `self`.
@@ -998,7 +998,7 @@ final internal class _CollectionTransformerStepOneToMaybeOne<
     return _CollectionTransformerStepOneToMaybeOne<PipelineInputElement, OutputElement, InputStep>(_input) {
       (input: InputElement) -> OutputElement? in
       if let e = localTransform(input) {
-        return predicate(e) ? e : nil
+        return isIncluded(e) ? e : nil
       }
       return nil
     }
@@ -1265,12 +1265,12 @@ public struct CollectionTransformerPipeline<
     )
   }
 
-  public func filter(_ predicate: (T) -> Bool)
+  public func filter(_ isIncluded: (T) -> Bool)
     -> CollectionTransformerPipeline<InputCollection, T> {
 
     return CollectionTransformerPipeline<InputCollection, T>(
       _input: _input,
-      _step: _step.filter(predicate)
+      _step: _step.filter(isIncluded)
     )
   }
 

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -1274,7 +1274,9 @@ public struct CollectionTransformerPipeline<
     )
   }
 
-  public func reduce<U>(_ initial: U, _ combine: (U, T) -> U) -> U {
+  public func reduce<U>(
+    _ initial: U, _ combine: (U, T) -> U
+  ) -> U {
     return _runCollectionTransformer(_input, _step.reduce(initial, combine))
   }
 

--- a/test/Prototypes/Result.swift
+++ b/test/Prototypes/Result.swift
@@ -79,7 +79,9 @@ public func ?? <T> (
 }
 
 /// Translate the execution of a throwing closure into a Result
-func catchResult<Success>(body: () throws -> Success) -> Result<Success> {
+func catchResult<Success>(
+  invoking body: () throws -> Success
+) -> Result<Success> {
   do {
     return try .Success(body())
   }

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -12,7 +12,7 @@ func foo1(_ a : inout [Int]) {
 struct S1 {}
 
 func foo2(_ a : inout [S1]) {
-  a = a.sorted(isOrderedBefore: { (a, b) -> Bool in
+  a = a.sorted(by: { (a, b) -> Bool in
     return false
   })
   a.append(S1())
@@ -37,9 +37,9 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-REPLACEMENT1: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT1: <Declaration>func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
 // CHECK-REPLACEMENT1: RELATED BEGIN
-// CHECK-REPLACEMENT1: sorted(isOrderedBefore: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
+// CHECK-REPLACEMENT1: sorted(by: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
 // CHECK-REPLACEMENT1: sorted() -&gt; [Int]</RelatedName>
-// CHECK-REPLACEMENT1: sorted(isOrderedBefore: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
+// CHECK-REPLACEMENT1: sorted(by: @noescape (Int, Int) -&gt; Bool) -&gt; [Int]</RelatedName>
 // CHECK-REPLACEMENT1: RELATED END
 
 // RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
@@ -48,10 +48,10 @@ func foo3(a: Float, b: Bool) {}
 
 // RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
 // CHECK-REPLACEMENT3: <Group>Collection/Array</Group>
-// CHECK-REPLACEMENT3: func sorted(isOrderedBefore: @noescape (<Type usr="s:V13cursor_stdlib2S1">S1</Type>
+// CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: @noescape (<Type usr="s:V13cursor_stdlib2S1">S1</Type>
 // CHECK-REPLACEMENT3: sorted() -&gt; [S1]</RelatedName>
 // CHECK-REPLACEMENT3: sorted() -&gt; [S1]</RelatedName>
-// CHECK-REPLACEMENT3: sorted(isOrderedBefore: @noescape (S1, S1) -&gt; Bool) -&gt; [S1]</RelatedName>
+// CHECK-REPLACEMENT3: sorted(by: @noescape (S1, S1) -&gt; Bool) -&gt; [S1]</RelatedName>
 
 // RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt %clang-importer-sdk | FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>

--- a/validation-test/compiler_crashers_2_fixed/0020-rdar21598514.swift
+++ b/validation-test/compiler_crashers_2_fixed/0020-rdar21598514.swift
@@ -116,10 +116,10 @@ extension LoggingSequenceType {
   }
 
   public func filter(
-    @noescape includeElement: (Base.Iterator.Element) -> Bool
+    @noescape isIncluded: (Base.Iterator.Element) -> Bool
   ) -> [Base.Iterator.Element] {
     ++SequenceLog.filter[selfType]
-    return base.filter(includeElement)
+    return base.filter(isIncluded)
   }
   
   public func _customContainsEquatableElement(

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -24,7 +24,7 @@ public protocol MySequence {
   ) -> [T]
 
   func filter(
-    _ includeElement: @noescape (Iterator.Element) -> Bool
+    _ isIncluded: @noescape (Iterator.Element) -> Bool
   ) -> [Iterator.Element]
 
   func _customContainsEquatableElement(
@@ -54,7 +54,7 @@ extension MySequence {
   }
 
   public func filter(
-    _ includeElement: @noescape (Iterator.Element) -> Bool
+    _ isIncluded: @noescape (Iterator.Element) -> Bool
   ) -> [Iterator.Element] {
     return []
   }
@@ -256,10 +256,10 @@ extension LoggingSequenceType
   }
 
   public func filter(
-    _ includeElement: @noescape (Base.Iterator.Element) -> Bool
+    _ isIncluded: @noescape (Base.Iterator.Element) -> Bool
   ) -> [Base.Iterator.Element] {
     Log.filter[selfType] += 1
-    return base.filter(includeElement)
+    return base.filter(isIncluded)
   }
   
   public func _customContainsEquatableElement(

--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -144,12 +144,12 @@ func randomArray() -> A<Int> {
 Algorithm.test("invalidOrderings") {
   withInvalidOrderings {
     var a = randomArray()
-    _blackHole(a.sorted(isOrderedBefore: $0))
+    _blackHole(a.sorted(by: $0))
   }
   withInvalidOrderings {
     var a: A<Int>
     a = randomArray()
-    _ = a.partition(isOrderedBefore: $0)
+    _ = a.partition(by: $0)
   }
   /*
   // FIXME: Disabled due to <rdar://problem/17734737> Unimplemented:
@@ -188,7 +188,7 @@ func makeQSortKiller(_ len: Int) -> [Int] {
   var ary = [Int](repeating: 0, count: len)
   var ret = [Int](repeating: 0, count: len)
   for i in 0..<len { ary[i] = i }
-  ary = ary.sorted(isOrderedBefore: Compare)
+  ary = ary.sorted(by: Compare)
   for i in 0..<len {
     ret[ary[i]] = i
   }

--- a/validation-test/stdlib/AtomicInt.swift
+++ b/validation-test/stdlib/AtomicInt.swift
@@ -725,7 +725,7 @@ struct AtomicInitializeARCRefRaceTest : RaceTestWithPerTrialData {
     _ raceData: RaceData, _ threadLocalData: inout ThreadLocalData
   ) -> Observation {
     var observation = Observation4UInt(0, 0, 0, 0)
-    var initializerDestroyed = HeapBool(false)
+    let initializerDestroyed = HeapBool(false)
     do {
       let initializer = DummyObject(
         destroyedFlag: initializerDestroyed,
@@ -749,13 +749,13 @@ struct AtomicInitializeARCRefRaceTest : RaceTestWithPerTrialData {
     _ sink: (RaceTestObservationEvaluation) -> Void
   ) {
     let ref = observations[0].data2
-    if observations.contains({ $0.data2 != ref }) {
+    if observations.contains(where: { $0.data2 != ref }) {
       for observation in observations {
         sink(.failureInteresting("mismatched reference, expected \(ref): \(observation)"))
       }
       return
     }
-    if observations.contains({ $0.data3 != 0x12345678 }) {
+    if observations.contains(where: { $0.data3 != 0x12345678 }) {
       for observation in observations {
         sink(.failureInteresting("wrong data: \(observation)"))
       }

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -56,13 +56,13 @@ func sortResultIgnored<
   var array = array // expected-warning {{variable 'array' was never mutated; consider changing to 'let' constant}}
 
   sequence.sorted() // expected-warning {{result of call to 'sorted()' is unused}}
-  sequence.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(isOrderedBefore:)' is unused}}
+  sequence.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(by:)' is unused}}
 
   mutableCollection.sorted() // expected-warning {{result of call to 'sorted()' is unused}}
-  mutableCollection.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(isOrderedBefore:)' is unused}}
+  mutableCollection.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(by:)' is unused}}
 
   array.sorted() // expected-warning {{result of call to 'sorted()' is unused}}
-  array.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(isOrderedBefore:)' is unused}}
+  array.sorted { $0 < $1 } // expected-warning {{result of call to 'sorted(by:)' is unused}}
 }
 
 struct GoodIndexable : Indexable {

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -105,10 +105,10 @@ struct MinimalCollectionWith${Implementation}Filter<Element>
   }
 
   func filter(
-    _ transform: @noescape (Element) throws -> Bool
+    _ isIncluded: @noescape (Element) throws -> Bool
   ) rethrows -> [Element] {
     MinimalCollectionWithCustomFilter.timesFilterWasCalled += 1
-    return try _data.filter(transform)
+    return try _data.filter(isIncluded)
   }
 
 %   end
@@ -119,27 +119,27 @@ struct MinimalCollectionWith${Implementation}Filter<Element>
 
 func callStaticCollectionFilter(
   _ sequence: MinimalCollectionWithDefaultFilter<OpaqueValue<Int>>,
-  includeElement: @noescape (OpaqueValue<Int>) -> Bool
+  _ isIncluded: @noescape (OpaqueValue<Int>) -> Bool
 ) -> [OpaqueValue<Int>] {
-  var result = sequence.filter(includeElement)
+  var result = sequence.filter(isIncluded)
   expectType([OpaqueValue<Int>].self, &result)
   return result
 }
 
 func callStaticCollectionFilter(
   _ sequence: MinimalCollectionWithCustomFilter<OpaqueValue<Int>>,
-  includeElement: @noescape (OpaqueValue<Int>) -> Bool
+  _ isIncluded: @noescape (OpaqueValue<Int>) -> Bool
 ) -> [OpaqueValue<Int>] {
-  var result = sequence.filter(includeElement)
+  var result = sequence.filter(isIncluded)
   expectType([OpaqueValue<Int>].self, &result)
   return result
 }
 
 func callGenericCollectionFilter<S : Collection>(
   _ sequence: S,
-  includeElement: @noescape (S.Iterator.Element) -> Bool
+  _ isIncluded: @noescape (S.Iterator.Element) -> Bool
 ) -> [S.Iterator.Element] {
-  var result = sequence.filter(includeElement)
+  var result = sequence.filter(isIncluded)
   expectType(Array<S.Iterator.Element>.self, &result)
   return result
 }

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -1057,7 +1057,7 @@ tests.test("LazyFilterSequence") {
   // Try again using explicit construction
   filtered = LazyFilterSequence(
     _base: MinimalSequence(elements: base),
-    whereElementsSatisfy: { x in calls += 1; return x.value % 2 == 0})
+    { x in calls += 1; return x.value % 2 == 0})
 
   expectEqual(100, calls)
 

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -246,7 +246,7 @@ testCocoa()
 
 extension ArraySlice {
   mutating func qsort(_ compare: (Element, Element) -> Bool) {
-    _introSort(&self, subRange: Range(self.indices), isOrderedBefore: compare)
+    _introSort(&self, subRange: Range(self.indices), by: compare)
   }
 }
 

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -99,7 +99,7 @@ class OffsetCollection : MutableCollection, RandomAccessCollection {
 %   for p in withPredicateValues:
 // workaround for <rdar://problem/18900352> gyb miscompiles nested loops
 %     comparePredicate = "<" if p else ""
-%     commaComparePredicate = ", isOrderedBefore: <" if p else ""
+%     commaComparePredicate = ", by: <" if p else ""
 %     name = "lessPredicate" if p else "noPredicate"
 
 Algorithm.test("${t}/sorted/${name}") {
@@ -110,7 +110,7 @@ Algorithm.test("${t}/sorted/${name}") {
 
   // Similar test for sorting with predicate
 %       if comparePredicate:
-  sortedAry1 = ary.sorted(isOrderedBefore: ${comparePredicate})
+  sortedAry1 = ary.sorted(by: ${comparePredicate})
 %       else:
   sortedAry1 = ary.sorted()
 %       end

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -101,7 +101,7 @@ func checkDecodeUTF<Codec : UnicodeCodec>(
       from: codec,
       to: UTF32.self,
       stoppingOnError: true,
-      sendingOutputTo: output)
+      into: output)
     if expectedHead != decoded {
       return assertionFailure()
           .withDescription("\n")
@@ -122,7 +122,7 @@ func checkDecodeUTF<Codec : UnicodeCodec>(
       from: codec,
       to: UTF32.self,
       stoppingOnError: false,
-      sendingOutputTo: output)
+      into: output)
     if expected != decoded {
       return assertionFailure()
           .withDescription("\n")
@@ -167,7 +167,7 @@ func checkEncodeUTF8(_ expected: [UInt8],
     from: UTF32.self,
     to: UTF8.self,
     stoppingOnError: true,
-    sendingOutputTo: output)
+    into: output)
   expectFalse(hadError)
   if expected != encoded {
     return assertionFailure()
@@ -2061,7 +2061,7 @@ UnicodeAPIs.test("transcode/MutableArray") {
     from: UTF16.self,
     to: UTF16.self,
     stoppingOnError: true,
-    sendingOutputTo: output)
+    into: output)
   expectEqual(input, transcoded)
 }
 
@@ -2074,7 +2074,7 @@ UnicodeAPIs.test("transcode/ReferenceTypedArray") {
     from: UTF16.self,
     to: UTF16.self,
     stoppingOnError: true,
-    sendingOutputTo: output)
+    into: output)
   expectEqual(input, transcoded)
 }
 
@@ -2102,7 +2102,7 @@ class NonContiguousNSString : NSString {
       from: UTF8.self,
       to: UTF16.self,
       stoppingOnError: true,
-      sendingOutputTo: output)
+      into: output)
     expectFalse(hadError)
     self.init(encoded)
   }
@@ -2121,7 +2121,7 @@ class NonContiguousNSString : NSString {
       from: UTF32.self,
       to: UTF16.self,
       stoppingOnError: true,
-      sendingOutputTo: output)
+      into: output)
     expectFalse(hadError)
     self.init(encoded)
   }
@@ -2182,7 +2182,7 @@ StringCookedViews.test("UTF8ForContiguousUTF16") {
       from: UTF32.self,
       to: UTF16.self,
       stoppingOnError: false,
-      sendingOutputTo: output)
+      into: output)
 
     backingStorage.withUnsafeBufferPointer {
       (ptr) -> Void in
@@ -2208,7 +2208,7 @@ StringCookedViews.test("UTF8ForContiguousUTF16") {
       from: UTF32.self,
       to: UTF8.self,
       stoppingOnError: false,
-      sendingOutputTo: output)
+      into: output)
 
     checkUTF8View(expected, subject, test.loc.withCurrentLoc())
   }
@@ -2259,7 +2259,7 @@ StringCookedViews.test("UTF8ForNonContiguousUTF16") {
         from: UTF32.self,
         to: UTF8.self,
         stoppingOnError: false,
-        sendingOutputTo: output)
+        into: output)
 
       var nss = NonContiguousNSString(test.encoded)
       verifyThatStringIsOpaqueForCoreFoundation(nss)
@@ -2332,7 +2332,7 @@ StringCookedViews.test("UTF16") {
       from: UTF32.self,
       to: UTF16.self,
       stoppingOnError: false,
-      sendingOutputTo: output)
+      into: output)
 
     var nss = NonContiguousNSString(test.scalars)
     checkUTF16View(expected, nss as String, test.loc.withCurrentLoc())
@@ -2349,7 +2349,7 @@ StringCookedViews.test("UTF16") {
       from: UTF32.self,
       to: UTF16.self,
       stoppingOnError: false,
-      sendingOutputTo: output)
+      into: output)
 
     checkUTF16View(expected, subject, test.loc.withCurrentLoc())
   }

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -101,7 +101,7 @@ class NonContiguousNSString : NSString {
       from: UTF32.self,
       to: UTF16.self,
       stoppingOnError: true,
-      sendingOutputTo: output)
+      into: output)
     expectFalse(hadError)
     self.init(encoded)
   }

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -129,7 +129,7 @@ final class CodecTest<Codec : TestableUnicodeCodec> {
     ) { $0 == $1 }
 
     encodeIndex = encodeBuffer.startIndex
-    Codec.encode(scalar, sendingOutputTo: encodeOutput)
+    Codec.encode(scalar, into: encodeOutput)
     expectEqual(
       nsEncoded, encodeBuffer[0..<encodeIndex],
       "Decoding failed: \(asHex(nsEncoded)) => " +


### PR DESCRIPTION
## Motivation

The names and argument labels of the standard library's closure parameters have been chosen haphazardly, resulting in documentation comments that are inconsistent and often read poorly, and in code completion/documentation that is less helpful than it might be.  Because of trailing closure syntax, the choice of argument labels for closures has less impact on use-sites than it might otherwise, but there are many contexts in which labels still do appear, and poorly-chosen labels still hurt readability.
## Overview Of Usage Changes

Note: this summary does not illustrate _parameter name_ changes that have also been made pervasively and have an effect on usability of documentation and code completion.  Please see the diffs for examples of those.

| Before | After |
| --- | --- |
| <br/>`s.withUtf8Buffer(invoke: processBytes)` | <br/>`s.withUtf8Buffer(processBytes)` |
| <br/>`lines.split(`<br/>`  isSeparator: isAllWhitespace)` | <br/>`lines.split(`<br/>`  whereSeparator: isAllWhitespace)` |
| <br/>`words.sort(isOrderedBefore: >)` | <br/>`words.sort(by: >)` |
| <br/>`words.sorted(isOrderedBefore: >)` | <br/>`words.sorted(by: >)` |
| <br/>`smallest = shapes.min(`<br/>`  isOrderedBefore: haveIncreasingSize)` | <br/>`smallest = shapes.min(`<br/>`  by: haveIncreasingSize)` |
| <br/>`largest = shapes.max(`<br/>`  isOrderedBefore: haveIncreasingSize)` | <br/>`largest = shapes.max(`<br/>`  by: haveIncreasingSize)` |
| <br/>`if a.lexicographicallyPrecedes(`<br/>`  b,`<br/>`  isOrderedBefore: haveIncreasingWeight)` | <br/>`if a.lexicographicallyPrecedes(`<br/>`  b, by: haveIncreasingWeight)` |
| <br/>`ManagedBuffer<Header,Element>.create(`<br/>`  minimumCapacity: 10,`<br/>`  initialValue: makeHeader)` | <br/>`ManagedBuffer<Header,Element>.create(`<br/>`  minimumCapacity: 10,`<br/>`  makingValueWith: makeHeader)` |
| <br/>`if roots.contains(isPrime) {` | <br/>`if roots.contains(where: isPrime) {` |
| <br/>`if expected.elementsEqual(`<br/>`  actual, isEquivalent: haveSameValue)` | <br/>`if expected.elementsEqual(`<br/>`  actual, by: haveSameValue)` |
| <br/>`if names.starts(`<br/>`  with: myFamily,`<br/>`  isEquivalent: areSameExceptForCase) {` | <br/>`if names.starts(`<br/>`  with: myFamily,`<br/>`  by: areSameExceptForCase) {` |
| <br/>`let sum = measurements.reduce(0, combine: +)` | <br/>`let sum = measurements.reduce(0, +)` |
| <br/>`UTF8.encode(`<br/>`  scalar, sendingOutputTo: accumulateByte)` | <br/>`UTF8.encode(`<br/>`  scalar, into: accumulateByte)` |
## Future Extensions

The process of making these changes revealed other, very compelling, naming improvements that could be made, e.g. `xs.filter(suchThat: isPrime)` becoming `xs.where(isPrime)`, which, in addition to being much less awkward, fully clarifies the polarity of the argument.  These are considered **out of scope** for this proposal, but should be considered soon afterward. Once we have started down the path of diverging from terms of art for functional algorithms,
- I think we should consider whether to rename `reduce(_ initialResult, accumulatingResultBy nextPartialResult:)` to something like `accumulating(startingFrom initialAccumulator:combiningBy nextAccumulator)` just based on the description in the documentation and on the argument labels.  
- The argument against changing other names to be more consistent with API guidelines is weakened. We should consider `mapping(_ transformation)`, `flatMapping(_ transformation)`, and `flattened()`.
- Perhaps `contains(where: isPrime)` should become `containsAny(where: isPrime)`.  It certainly reads better when trailing closure syntax is used.

<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
