### PR TITLE
[lit] Add %utils and %line-directive substitutions. Use %gyb

### DIFF
--- a/test/1_stdlib/ArrayTraps.swift.gyb
+++ b/test/1_stdlib/ArrayTraps.swift.gyb
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/ArrayTraps.swift
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O
+// RUN: %gyb %s -o %t/ArrayTraps.swift
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O
 //
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Release
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Debug
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/1_stdlib/ArrayTrapsObjC.swift.gyb
+++ b/test/1_stdlib/ArrayTrapsObjC.swift.gyb
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/ArrayTraps.swift
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O
+// RUN: %gyb %s -o %t/ArrayTraps.swift
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Debug
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out_Release -O
 //
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Release
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Debug
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 

--- a/test/1_stdlib/BridgeStorage.swift.gyb
+++ b/test/1_stdlib/BridgeStorage.swift.gyb
@@ -15,9 +15,9 @@
 //  distinguish these cases efficiently.
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/out.swift
-// RUN: %S/../../utils/line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/out.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/out.swift
+// RUN: %line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out
+// RUN: %line-directive %t/out.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop

--- a/test/1_stdlib/CastTraps.swift.gyb
+++ b/test/1_stdlib/CastTraps.swift.gyb
@@ -1,8 +1,8 @@
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/CastTraps.swift
-// RUN: %S/../../utils/line-directive %t/CastTraps.swift -- %target-build-swift %t/CastTraps.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/CastTraps.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/CastTraps.swift
+// RUN: %line-directive %t/CastTraps.swift -- %target-build-swift %t/CastTraps.swift -o %t/a.out
+// RUN: %line-directive %t/CastTraps.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 // FIXME: Casting.cpp has dozens of places to fail a cast. This test does not 

--- a/test/1_stdlib/FloatingPoint.swift.gyb
+++ b/test/1_stdlib/FloatingPoint.swift.gyb
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/FloatingPoint.swift
-// RUN: %S/../../utils/line-directive %t/FloatingPoint.swift -- %target-build-swift -parse-stdlib -Xfrontend -disable-access-control %t/FloatingPoint.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/FloatingPoint.swift
+// RUN: %line-directive %t/FloatingPoint.swift -- %target-build-swift -parse-stdlib -Xfrontend -disable-access-control %t/FloatingPoint.swift -o %t/a.out
+// RUN: %line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 %{

--- a/test/1_stdlib/InputStream.swift.gyb
+++ b/test/1_stdlib/InputStream.swift.gyb
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/InputStream.swift
-// RUN: %S/../../utils/line-directive %t/InputStream.swift -- %target-build-swift %t/InputStream.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/InputStream.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/InputStream.swift
+// RUN: %line-directive %t/InputStream.swift -- %target-build-swift %t/InputStream.swift -o %t/a.out
+// RUN: %line-directive %t/InputStream.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/1_stdlib/NumericParsing.swift.gyb
+++ b/test/1_stdlib/NumericParsing.swift.gyb
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/NumericParsing.swift
-// RUN: %S/../../utils/line-directive %t/NumericParsing.swift -- %target-build-swift %t/NumericParsing.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/NumericParsing.swift -- %target-run %t/a.out
+// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/NumericParsing.swift
+// RUN: %line-directive %t/NumericParsing.swift -- %target-build-swift %t/NumericParsing.swift -o %t/a.out
+// RUN: %line-directive %t/NumericParsing.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 %{
 from SwiftIntTypes import all_integer_types

--- a/test/1_stdlib/Tuple.swift.gyb
+++ b/test/1_stdlib/Tuple.swift.gyb
@@ -1,8 +1,8 @@
 // RUN: rm -f %t.swift %t.out
 
-// RUN: %S/../../utils/gyb %s -o %t.swift
-// RUN: %S/../../utils/line-directive %t.swift -- %target-build-swift %t.swift -o %t.out
-// RUN: %S/../../utils/line-directive %t.swift -- %target-run %t.out
+// RUN: %gyb %s -o %t.swift
+// RUN: %line-directive %t.swift -- %target-build-swift %t.swift -o %t.out
+// RUN: %line-directive %t.swift -- %target-run %t.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/1_stdlib/UnsafePointer.swift.gyb
+++ b/test/1_stdlib/UnsafePointer.swift.gyb
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/UnsafePointer.swift
-// RUN: %S/../../utils/line-directive %t/UnsafePointer.swift -- %target-build-swift %t/UnsafePointer.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/UnsafePointer.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/UnsafePointer.swift
+// RUN: %line-directive %t/UnsafePointer.swift -- %target-build-swift %t/UnsafePointer.swift -o %t/a.out
+// RUN: %line-directive %t/UnsafePointer.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/1_stdlib/simd.swift.gyb
+++ b/test/1_stdlib/simd.swift.gyb
@@ -1,8 +1,8 @@
 // RUN: rm -f %t.swift %t.out
 
-// RUN: %S/../../utils/gyb %s -o %t.swift
-// RUN: %S/../../utils/line-directive %t.swift -- %target-build-swift %t.swift -o %t.out
-// RUN: %S/../../utils/line-directive %t.swift -- %target-run %t.out
+// RUN: %gyb %s -o %t.swift
+// RUN: %line-directive %t.swift -- %target-build-swift %t.swift -o %t.out
+// RUN: %line-directive %t.swift -- %target-run %t.out
 // REQUIRES: executable_test
 
 // FIXME: No simd module on linux rdar://problem/20795411

--- a/test/ClangModules/mapped-integers.swift.gyb
+++ b/test/ClangModules/mapped-integers.swift.gyb
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/mapped-integers.swift
+// RUN: %gyb %s -o %t/mapped-integers.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse -verify %t/mapped-integers.swift
 
 import ctypes

--- a/test/InterfaceHash/added_function.swift
+++ b/test/InterfaceHash/added_function.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/added_method.swift
+++ b/test/InterfaceHash/added_method.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/added_private_class_property.swift
+++ b/test/InterfaceHash/added_private_class_property.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/added_private_method.swift
+++ b/test/InterfaceHash/added_private_method.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/added_private_struct_property.swift
+++ b/test/InterfaceHash/added_private_struct_property.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/changed_private_var_type.swift
+++ b/test/InterfaceHash/changed_private_var_type.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/changed_var_name.swift
+++ b/test/InterfaceHash/changed_var_name.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/changed_var_type.swift
+++ b/test/InterfaceHash/changed_var_type.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/edited_function_body.swift
+++ b/test/InterfaceHash/edited_function_body.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/split_file.py -o %t %s
+// RUN: %utils/split_file.py -o %t %s
 // RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
 // RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -1,13 +1,13 @@
 // RUN: rm -rf %t && mkdir -p %t
 
-// RUN: %S/../../utils/gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
-// RUN: %S/../../utils/line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift
+// RUN: %gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
+// RUN: %line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift
 
-// RUN: %S/../../utils/gyb -DOPT_KIND=Optional %s -o %t/pointer_conversion_opt.swift
-// RUN: %S/../../utils/line-directive %t/pointer_conversion_opt.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_opt.swift
+// RUN: %gyb -DOPT_KIND=Optional %s -o %t/pointer_conversion_opt.swift
+// RUN: %line-directive %t/pointer_conversion_opt.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_opt.swift
 
-// RUN: %S/../../utils/gyb -DOPT_KIND=ImplicitlyUnwrappedOptional %s -o %t/pointer_conversion_iuo.swift
-// RUN: %S/../../utils/line-directive %t/pointer_conversion_iuo.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_iuo.swift
+// RUN: %gyb -DOPT_KIND=ImplicitlyUnwrappedOptional %s -o %t/pointer_conversion_iuo.swift
+// RUN: %line-directive %t/pointer_conversion_iuo.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_iuo.swift
 
 %{
 if OPT_KIND == 'Optional':

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -1,13 +1,13 @@
 // RUN: rm -rf %t && mkdir -p %t
 
-// RUN: %S/../../utils/gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
-// RUN: %S/../../utils/line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift
+// RUN: %gyb -DOPT_KIND=None %s -o %t/pointer_conversion.swift
+// RUN: %line-directive %t/pointer_conversion.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion.swift
 
-// RUN: %S/../../utils/gyb -DOPT_KIND=Optional %s -o %t/pointer_conversion_opt.swift
-// RUN: %S/../../utils/line-directive %t/pointer_conversion_opt.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_opt.swift
+// RUN: %gyb -DOPT_KIND=Optional %s -o %t/pointer_conversion_opt.swift
+// RUN: %line-directive %t/pointer_conversion_opt.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_opt.swift
 
-// RUN: %S/../../utils/gyb -DOPT_KIND=ImplicitlyUnwrappedOptional %s -o %t/pointer_conversion_iuo.swift
-// RUN: %S/../../utils/line-directive %t/pointer_conversion_iuo.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_iuo.swift
+// RUN: %gyb -DOPT_KIND=ImplicitlyUnwrappedOptional %s -o %t/pointer_conversion_iuo.swift
+// RUN: %line-directive %t/pointer_conversion_iuo.swift -- %target-swift-frontend -parse -verify %t/pointer_conversion_iuo.swift
 
 // REQUIRES: objc_interop
 

--- a/test/Prototypes/FloatingPoint.swift
+++ b/test/Prototypes/FloatingPoint.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %S/../../utils/line-directive %s -- %target-build-swift -parse-stdlib %s -o %t/a.out
-// RUN: %S/../../utils/line-directive %s -- %target-run %t/a.out
+// RUN: %line-directive %s -- %target-build-swift -parse-stdlib %s -o %t/a.out
+// RUN: %line-directive %s -- %target-run %t/a.out
 // REQUIRES: executable_test
 import Swift
 

--- a/test/Prototypes/Integers.swift.gyb
+++ b/test/Prototypes/Integers.swift.gyb
@@ -9,9 +9,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb -DWORD_BITS=%target-ptrsize %s -o %t/out.swift
-// RUN: %S/../../utils/line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out -Onone
-// RUN: %S/../../utils/line-directive %t/out.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb -DWORD_BITS=%target-ptrsize %s -o %t/out.swift
+// RUN: %line-directive %t/out.swift -- %target-build-swift -parse-stdlib %t/out.swift -o %t/a.out -Onone
+// RUN: %line-directive %t/out.swift -- %target-run %t/a.out
 // --stdlib-unittest-filter DoubleWidth/
 
 // REQUIRES: executable_test

--- a/test/Runtime/backtrace.swift
+++ b/test/Runtime/backtrace.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | %S/../../utils/backtrace-check
+// RUN: not --crash %t/a.out 2>&1 | %utils/backtrace-check
 
 // This is not supported on watchos, ios, or tvos
 // UNSUPPORTED: OS=watchos

--- a/test/expr/unary/selector/fixits.swift
+++ b/test/expr/unary/selector/fixits.swift
@@ -20,7 +20,7 @@
 // RUN: mkdir -p %t.remapping
 // RUN: cp %s %t.sources/fixits.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -parse %t.sources/fixits.swift -fixit-all -emit-fixits-path %t.remapping/fixits.remap
-// RUN: %S/../../../../utils/apply-fixit-edits.py %t.remapping
+// RUN: %utils/apply-fixit-edits.py %t.remapping
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -parse %t.sources/fixits.swift 2> %t.result
 
 // RUN: FileCheck %s < %t.result

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -289,8 +289,10 @@ config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
 config.llvm_profdata = inferSwiftBinary('llvm-profdata')
 config.llvm_cov = inferSwiftBinary('llvm-cov')
 
-config.gyb = os.path.join(config.swift_src_root, 'utils', 'gyb')
-config.rth = os.path.join(config.swift_src_root, 'utils', 'rth') # Resilience test helper
+config.swift_utils = os.path.join(config.swift_src_root, 'utils')
+config.line_directive = os.path.join(config.swift_utils, 'line-directive')
+config.gyb = os.path.join(config.swift_utils, 'gyb')
+config.rth = os.path.join(config.swift_utils, 'rth') # Resilience test helper
 config.swift_lib_dir = os.path.join(os.path.dirname(os.path.dirname(config.swift)), 'lib')
 
 # Find the resource directory.  Assume it's near the swift compiler if not set.
@@ -851,6 +853,8 @@ config.substitutions.append(('%target-ld', config.target_ld))
 if hasattr(config, 'target_cc_options'):
     config.substitutions.append(('%target-cc-options', config.target_cc_options))
 
+config.substitutions.append(('%utils', config.swift_utils))
+config.substitutions.append(('%line-directive', config.line_directive))
 config.substitutions.append(('%gyb', config.gyb))
 config.substitutions.append(('%rth', config.rth))
 

--- a/validation-test/Python/cmpcodesize.swift
+++ b/validation-test/Python/cmpcodesize.swift
@@ -1,1 +1,1 @@
-// RUN: %{python} -m unittest discover -s %S/../../utils/cmpcodesize
+// RUN: %{python} -m unittest discover -s %utils/cmpcodesize

--- a/validation-test/Python/line-directive.swift
+++ b/validation-test/Python/line-directive.swift
@@ -1,1 +1,1 @@
-// RUN: %{python} %S/../../utils/line-directive
+// RUN: %{python} %utils/line-directive

--- a/validation-test/Python/swift_build_support.swift
+++ b/validation-test/Python/swift_build_support.swift
@@ -1,1 +1,1 @@
-// RUN: %{python} -m unittest discover -s %S/../../utils/swift_build_support
+// RUN: %{python} -m unittest discover -s %utils/swift_build_support

--- a/validation-test/StdlibUnittest/Assertions.swift.gyb
+++ b/validation-test/StdlibUnittest/Assertions.swift.gyb
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/Assertions.swift
-// RUN: %S/../../utils/line-directive %t/Assertions.swift -- %target-build-swift %t/Assertions.swift -o %t/a.out
+// RUN: %gyb %s -o %t/Assertions.swift
+// RUN: %line-directive %t/Assertions.swift -- %target-build-swift %t/Assertions.swift -o %t/a.out
 //
-// RUN: %S/../../utils/line-directive %t/Assertions.swift -- %target-run %t/a.out
+// RUN: %line-directive %t/Assertions.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/StdlibUnittest/SequencesCollections.swift.gyb
+++ b/validation-test/StdlibUnittest/SequencesCollections.swift.gyb
@@ -1,8 +1,8 @@
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/StdlibUnittestSequencesCollections.swift
-// RUN: %S/../../utils/line-directive %t/StdlibUnittestSequencesCollections.swift -- %target-build-swift %t/StdlibUnittestSequencesCollections.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/StdlibUnittestSequencesCollections.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/StdlibUnittestSequencesCollections.swift
+// RUN: %line-directive %t/StdlibUnittestSequencesCollections.swift -- %target-build-swift %t/StdlibUnittestSequencesCollections.swift -o %t/a.out
+// RUN: %line-directive %t/StdlibUnittestSequencesCollections.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 %{

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -1,14 +1,14 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 //
-// RUN: %S/../../utils/gyb %s -o %t/main.swift
+// RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Array -Xfrontend -disable-access-control; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Array -Xfrontend -disable-access-control; \
 // RUN: else \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Array -Xfrontend -disable-access-control; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Array -Xfrontend -disable-access-control; \
 // RUN: fi
-// RUN: %S/../../utils/line-directive %t/main.swift -- %target-run %t/Array
+// RUN: %line-directive %t/main.swift -- %target-run %t/Array
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -1,9 +1,9 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/ArrayTraps.swift
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out
+// RUN: %gyb %s -o %t/ArrayTraps.swift
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-build-swift %t/ArrayTraps.swift -o %t/a.out
 //
-// RUN: %S/../../utils/line-directive %t/ArrayTraps.swift -- %target-run %t/a.out
+// RUN: %line-directive %t/ArrayTraps.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedMutableBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedMutableBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedMutableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedMutableCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedMutableCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedMutableRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedMutableRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRangeReplaceableBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedMutableRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedMutableRangeReplaceableBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRangeReplaceableCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedMutableRangeReplaceableCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRangeReplaceableCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedMutableRangeReplaceableCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedMutableRangeReplaceableRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRangeReplaceableRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedMutableRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedMutableRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedMutableRangeReplaceableRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRangeReplaceableBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedRangeReplaceableBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRangeReplaceableCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedRangeReplaceableCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRangeReplaceableCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedRangeReplaceableCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/DefaultedRangeReplaceableRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRangeReplaceableRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/DefaultedRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/DefaultedRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/DefaultedRangeReplaceableRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/Template.swift.gyb
@@ -64,9 +64,9 @@ def test_methods(test):
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/${test.name}.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/${test.name}.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/${test.name}.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/${test.name}.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyFilterCollection.swift.gyb
@@ -2,9 +2,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyFilterCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/LazyFilterCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyFilterCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/LazyFilterCollection.swift.a.out
 // REQUIRES: executable_test
 
 import SwiftPrivate

--- a/validation-test/stdlib/Collection/LazyMapCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/LazyMapCollection.swift.gyb
@@ -2,9 +2,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyMapCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/LazyMapCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/LazyMapCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/LazyMapCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalMutableBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalMutableBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalMutableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalMutableCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalMutableCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalMutableRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalMutableRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRangeReplaceableBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalMutableRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalMutableRangeReplaceableBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRangeReplaceableCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalMutableRangeReplaceableCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRangeReplaceableCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalMutableRangeReplaceableCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalMutableRangeReplaceableRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRangeReplaceableRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalMutableRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalMutableRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalMutableRangeReplaceableRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableBidirectionalCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRangeReplaceableBidirectionalCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRangeReplaceableBidirectionalCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalRangeReplaceableBidirectionalCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRangeReplaceableCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalRangeReplaceableCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRangeReplaceableCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalRangeReplaceableCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollection.swift
+++ b/validation-test/stdlib/Collection/MinimalRangeReplaceableRandomAccessCollection.swift
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRangeReplaceableRandomAccessCollection.swift.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MinimalRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MinimalRangeReplaceableRandomAccessCollection.swift.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MinimalRangeReplaceableRandomAccessCollection.swift.a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -1,8 +1,8 @@
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/Collection.swift -D test_path="%S"
-// RUN: %S/../../utils/line-directive %t/Collection.swift -- %target-build-swift %t/Collection.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/Collection.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/Collection.swift -D test_path="%S"
+// RUN: %line-directive %t/Collection.swift -- %target-build-swift %t/Collection.swift -o %t/a.out
+// RUN: %line-directive %t/Collection.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 // <rdar://problem/24357067> The compiler never finishes compiling validation-test/stdlib/CollectionType.swift.gyb in -O

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1,15 +1,15 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 //
-// RUN: %S/../../utils/gyb %s -o %t/main.swift
+// RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Dictionary -Xfrontend -disable-access-control; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Dictionary -Xfrontend -disable-access-control; \
 // RUN: else \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Dictionary -Xfrontend -disable-access-control; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Dictionary -Xfrontend -disable-access-control; \
 // RUN: fi
 //
-// RUN: %S/../../utils/line-directive %t/main.swift -- %target-run %t/Dictionary
+// RUN: %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
 
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -9,9 +9,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/ExistentialCollection.swift
-// RUN: %S/../../utils/line-directive %t/ExistentialCollection.swift -- %target-build-swift %t/ExistentialCollection.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/ExistentialCollection.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/ExistentialCollection.swift
+// RUN: %line-directive %t/ExistentialCollection.swift -- %target-build-swift %t/ExistentialCollection.swift -o %t/a.out
+// RUN: %line-directive %t/ExistentialCollection.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 %{

--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/FixedPoint.swift
-// RUN: %S/../../utils/line-directive %t/FixedPoint.swift -- %target-build-swift %t/FixedPoint.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/FixedPoint.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/FixedPoint.swift
+// RUN: %line-directive %t/FixedPoint.swift -- %target-build-swift %t/FixedPoint.swift -o %t/a.out
+// RUN: %line-directive %t/FixedPoint.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/FixedPointArithmeticTraps.swift.gyb
+++ b/validation-test/stdlib/FixedPointArithmeticTraps.swift.gyb
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/FixedPointArithmeticTraps.swift
-// RUN: %S/../../utils/line-directive %t/FixedPointArithmeticTraps.swift -- %target-build-swift %t/FixedPointArithmeticTraps.swift -o %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/FixedPointArithmeticTraps.swift -- %target-build-swift %t/FixedPointArithmeticTraps.swift -o %t/a.out_Release -O
+// RUN: %gyb %s -o %t/FixedPointArithmeticTraps.swift
+// RUN: %line-directive %t/FixedPointArithmeticTraps.swift -- %target-build-swift %t/FixedPointArithmeticTraps.swift -o %t/a.out_Debug
+// RUN: %line-directive %t/FixedPointArithmeticTraps.swift -- %target-build-swift %t/FixedPointArithmeticTraps.swift -o %t/a.out_Release -O
 //
-// RUN: %S/../../utils/line-directive %t/FixedPointArithmeticTraps.swift -- %target-run %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/FixedPointArithmeticTraps.swift -- %target-run %t/a.out_Release
+// RUN: %line-directive %t/FixedPointArithmeticTraps.swift -- %target-run %t/a.out_Debug
+// RUN: %line-directive %t/FixedPointArithmeticTraps.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -1,5 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../utils/line-directive %t/main.swift -- %target-swift-frontend -parse -verify %t/main.swift
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-swift-frontend -parse -verify %t/main.swift
 
 func testUnaryMinusInUnsigned() {
   var a: UInt8 = -(1) // expected-error {{}} expected-note * {{}}

--- a/validation-test/stdlib/FloatingPointConversionTraps.swift.gyb
+++ b/validation-test/stdlib/FloatingPointConversionTraps.swift.gyb
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/FloatingPointConversionTraps.swift
-// RUN: %S/../../utils/line-directive %t/FloatingPointConversionTraps.swift -- %target-build-swift %t/FloatingPointConversionTraps.swift -Xfrontend -disable-access-control -o %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/FloatingPointConversionTraps.swift -- %target-build-swift %t/FloatingPointConversionTraps.swift -Xfrontend -disable-access-control -o %t/a.out_Release -O
+// RUN: %gyb %s -o %t/FloatingPointConversionTraps.swift
+// RUN: %line-directive %t/FloatingPointConversionTraps.swift -- %target-build-swift %t/FloatingPointConversionTraps.swift -Xfrontend -disable-access-control -o %t/a.out_Debug
+// RUN: %line-directive %t/FloatingPointConversionTraps.swift -- %target-build-swift %t/FloatingPointConversionTraps.swift -Xfrontend -disable-access-control -o %t/a.out_Release -O
 //
-// RUN: %S/../../utils/line-directive %t/FloatingPointConversionTraps.swift -- %target-run %t/a.out_Debug
-// RUN: %S/../../utils/line-directive %t/FloatingPointConversionTraps.swift -- %target-run %t/a.out_Release
+// RUN: %line-directive %t/FloatingPointConversionTraps.swift -- %target-run %t/a.out_Debug
+// RUN: %line-directive %t/FloatingPointConversionTraps.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Index.swift.gyb
+++ b/validation-test/stdlib/Index.swift.gyb
@@ -12,9 +12,9 @@
 //===----------------------------------------------------------------------===//
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/Index.swift
-// RUN: %S/../../utils/line-directive %t/Index.swift -- %target-build-swift %t/Index.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/Index.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/Index.swift
+// RUN: %line-directive %t/Index.swift -- %target-build-swift %t/Index.swift -o %t/a.out
+// RUN: %line-directive %t/Index.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Join.swift.gyb
+++ b/validation-test/stdlib/Join.swift.gyb
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/Join.swift
-// RUN: %S/../../utils/line-directive %t/Join.swift -- %target-build-swift %t/Join.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/Join.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/Join.swift
+// RUN: %line-directive %t/Join.swift -- %target-build-swift %t/Join.swift -o %t/a.out
+// RUN: %line-directive %t/Join.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/Lazy.swift
-// RUN: %S/../../utils/line-directive %t/Lazy.swift -- %target-build-swift %t/Lazy.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/Lazy.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/Lazy.swift
+// RUN: %line-directive %t/Lazy.swift -- %target-build-swift %t/Lazy.swift -o %t/a.out
+// RUN: %line-directive %t/Lazy.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/NewArray.swift.gyb
+++ b/validation-test/stdlib/NewArray.swift.gyb
@@ -11,9 +11,9 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN-DISABLED: %target-run-simple-swift | FileCheck %s
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/NewArray.swift
-// RUN: %S/../../utils/line-directive %t/NewArray.swift -- %target-build-swift %t/NewArray.swift -o %t/a.out -Xfrontend -disable-access-control
-// RUN: %target-run %t/a.out 2>&1 | %S/../../utils/line-directive %t/NewArray.swift -- FileCheck %t/NewArray.swift --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/NewArray.swift
+// RUN: %line-directive %t/NewArray.swift -- %target-build-swift %t/NewArray.swift -o %t/a.out -Xfrontend -disable-access-control
+// RUN: %target-run %t/a.out 2>&1 | %line-directive %t/NewArray.swift -- FileCheck %t/NewArray.swift --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/NumericDiagnostics.swift.gyb
+++ b/validation-test/stdlib/NumericDiagnostics.swift.gyb
@@ -1,5 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../utils/line-directive %t/main.swift -- %target-build-swift -parse -Xfrontend -verify %t/main.swift
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift -parse -Xfrontend -verify %t/main.swift
 // REQUIRES: executable_test
 
 % from SwiftIntTypes import all_numeric_type_names, numeric_type_names_macintosh_only, \

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/out.swift
-// RUN: %S/../../utils/line-directive %t/out.swift -- %target-build-swift %t/out.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/out.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/out.swift
+// RUN: %line-directive %t/out.swift -- %target-build-swift %t/out.swift -o %t/a.out
+// RUN: %line-directive %t/out.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/RangeReplaceable.swift.gyb
+++ b/validation-test/stdlib/RangeReplaceable.swift.gyb
@@ -1,8 +1,8 @@
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/RangeReplaceable.swift
-// RUN: %S/../../utils/line-directive %t/RangeReplaceable.swift -- %target-build-swift %t/RangeReplaceable.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/RangeReplaceable.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/RangeReplaceable.swift
+// RUN: %line-directive %t/RangeReplaceable.swift -- %target-build-swift %t/RangeReplaceable.swift -o %t/a.out
+// RUN: %line-directive %t/RangeReplaceable.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -1,8 +1,8 @@
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/Sequence.swift -D test_path="%S"
-// RUN: %S/../../utils/line-directive %t/Sequence.swift -- %target-build-swift %t/Sequence.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/Sequence.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/Sequence.swift -D test_path="%S"
+// RUN: %line-directive %t/Sequence.swift -- %target-build-swift %t/Sequence.swift -o %t/a.out
+// RUN: %line-directive %t/Sequence.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 % import gyb

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1,15 +1,15 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 //
-// RUN: %S/../../utils/gyb %s -o %t/main.swift
+// RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Set -Xfrontend -disable-access-control; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Set -Xfrontend -disable-access-control; \
 // RUN: else \
-// RUN:   %S/../../utils/line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Set -Xfrontend -disable-access-control; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Set -Xfrontend -disable-access-control; \
 // RUN: fi
 //
-// RUN: %S/../../utils/line-directive %t/main.swift -- %target-run %t/Set
+// RUN: %line-directive %t/main.swift -- %target-run %t/Set
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Slice.swift.gyb
+++ b/validation-test/stdlib/Slice.swift.gyb
@@ -1,8 +1,8 @@
 // -*- swift -*-
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %S/../../utils/gyb %s -o %t/Slice.swift
-// RUN: %S/../../utils/line-directive %t/Slice.swift -- %target-build-swift %t/Slice.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/Slice.swift -- %target-run %t/a.out
+// RUN: %gyb %s -o %t/Slice.swift
+// RUN: %line-directive %t/Slice.swift -- %target-build-swift %t/Slice.swift -o %t/a.out
+// RUN: %line-directive %t/Slice.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 %{

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_DefaultedBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/BidirectionalSlice_Of_MinimalBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
+++ b/validation-test/stdlib/Slice/Inputs/Template.swift.gyb
@@ -77,9 +77,9 @@ def test_methods(test):
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/${test.name}.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/${test.name}.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/${test.name}.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/${test.name}.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_DefaultedMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableBidirectionalSlice_Of_MinimalMutableBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_DefaultedMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRandomAccessSlice_Of_MinimalMutableRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_DefaultedMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableBidirectionalSlice_Of_MinimalMutableRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_DefaultedMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableRandomAccessSlice_Of_MinimalMutableRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_DefaultedMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableRangeReplaceableSlice_Of_MinimalMutableRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_DefaultedMutableCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/MutableSlice_Of_MinimalMutableCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_DefaultedRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RandomAccessSlice_Of_MinimalRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_DefaultedRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableBidirectionalSlice_Of_MinimalRangeReplaceableBidirectionalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_DefaultedRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableRandomAccessSlice_Of_MinimalRangeReplaceableRandomAccessCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_DefaultedRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/RangeReplaceableSlice_Of_MinimalRangeReplaceableCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_DefaultedCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_DefaultedCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_DefaultedCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_FullWidth.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_FullWidth.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_FullWidth.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_FullWidth.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_FullWidth.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_FullWidth.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_WithPrefix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_WithPrefix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_WithPrefix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_WithPrefixAndSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithSuffix.swift.gyb
+++ b/validation-test/stdlib/Slice/Slice_Of_MinimalCollection_WithSuffix.swift.gyb
@@ -7,9 +7,9 @@
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
-// RUN: %S/../../../utils/gyb %s -o %t/main.swift
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_WithSuffix.swift.gyb.a.out
-// RUN: %S/../../../utils/line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %gyb %s -o %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-build-swift %t/main.swift -o %t/Slice_Of_MinimalCollection_WithSuffix.swift.gyb.a.out
+// RUN: %line-directive %t/main.swift -- %target-run %t/Slice_Of_MinimalCollection_WithSuffix.swift.gyb.a.out
 // REQUIRES: executable_test
 
 // FIXME: the test is too slow when the standard library is not optimized.

--- a/validation-test/stdlib/Sort.swift.gyb
+++ b/validation-test/stdlib/Sort.swift.gyb
@@ -1,8 +1,8 @@
 // RUN: rm -f %t.swift %t.out
 
-// RUN: %S/../../utils/gyb %s -o %t.swift
-// RUN: %S/../../utils/line-directive %t.swift -- %target-build-swift %t.swift -o %t.out
-// RUN: %S/../../utils/line-directive %t.swift -- %target-run %t.out
+// RUN: %gyb %s -o %t.swift
+// RUN: %line-directive %t.swift -- %target-build-swift %t.swift -o %t.out
+// RUN: %line-directive %t.swift -- %target-run %t.out
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/Unicode.swift
-// RUN: %S/../../utils/line-directive %t/Unicode.swift -- %target-build-swift %t/Unicode.swift -o %t/a.out -Xfrontend -disable-objc-attr-requires-foundation-module
-// RUN: %S/../../utils/line-directive %t/Unicode.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/Unicode.swift
+// RUN: %line-directive %t/Unicode.swift -- %target-build-swift %t/Unicode.swift -o %t/a.out -Xfrontend -disable-objc-attr-requires-foundation-module
+// RUN: %line-directive %t/Unicode.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import SwiftPrivate

--- a/validation-test/stdlib/UnicodeTrie.swift.gyb
+++ b/validation-test/stdlib/UnicodeTrie.swift.gyb
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb -DunicodeGraphemeBreakPropertyFile=%S/../../utils/UnicodeData/GraphemeBreakProperty.txt -DunicodeGraphemeBreakTestFile=%S/../../utils/UnicodeData/GraphemeBreakTest.txt %s -o %t/UnicodeTrie.swift
-// RUN: %S/../../utils/line-directive %t/UnicodeTrie.swift -- %target-build-swift %t/UnicodeTrie.swift -o %t/a.out -g -Xfrontend -disable-access-control
-// RUN: %S/../../utils/line-directive %t/UnicodeTrie.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb -DunicodeGraphemeBreakPropertyFile=%S/../../utils/UnicodeData/GraphemeBreakProperty.txt -DunicodeGraphemeBreakTestFile=%S/../../utils/UnicodeData/GraphemeBreakTest.txt %s -o %t/UnicodeTrie.swift
+// RUN: %line-directive %t/UnicodeTrie.swift -- %target-build-swift %t/UnicodeTrie.swift -o %t/a.out -g -Xfrontend -disable-access-control
+// RUN: %line-directive %t/UnicodeTrie.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out

--- a/validation-test/stdlib/UnicodeTrieGenerator.gyb
+++ b/validation-test/stdlib/UnicodeTrieGenerator.gyb
@@ -1,6 +1,6 @@
 %{
 
-# RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s | FileCheck %s
+# RUN: rm -rf %t && mkdir -p %t && %gyb %s | FileCheck %s
 
 from __future__ import print_function
 

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir -p %t && %S/../../utils/gyb %s -o %t/UnsafeBufferPointer.swift
-// RUN: %S/../../utils/line-directive %t/UnsafeBufferPointer.swift -- %target-build-swift %t/UnsafeBufferPointer.swift -o %t/a.out
-// RUN: %S/../../utils/line-directive %t/UnsafeBufferPointer.swift -- %target-run %t/a.out
+// RUN: rm -rf %t && mkdir -p %t && %gyb %s -o %t/UnsafeBufferPointer.swift
+// RUN: %line-directive %t/UnsafeBufferPointer.swift -- %target-build-swift %t/UnsafeBufferPointer.swift -o %t/a.out
+// RUN: %line-directive %t/UnsafeBufferPointer.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
#### What's in this pull request?

Added:
`%utils` => `${SWIFT_SOURCE_DIR}/utils`
`%line-directive` => `${SWIFT_SOURCE_DIR}/utils/line-directive`

Utilize `%gyb` instead of `%S/../../utils/gyb` or `%S/../../../utils/gyb`

---

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>
