### PR TITLE
[lto][cmake] While chopping up patches, I lost an update to AddSwiftU…

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -118,8 +118,8 @@ function(_add_variant_c_compile_link_flags)
     endif()
   endif()
 
-  if(CFLAGS_ENABLE_LTO)
-    _compute_lto_flag(${CFLAGS_ENABLE_LTO} _lto_flag_out)
+  _compute_lto_flag("${CFLAGS_ENABLE_LTO}" _lto_flag_out)
+  if (_lto_flag_out)
     list(APPEND result "${_lto_flag_out}")
   endif()
 

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -15,9 +15,10 @@ function(add_swift_unittest test_dirname)
   #
   # *NOTE* The unittests are never built for the target, so we always enable LTO
   # *if we are asked to.
-  if (SWIFT_TOOLS_ENABLE_LTO)
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY COMPILE_FLAGS " -flto ")
-    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY LINK_FLAGS " -flto ")
+  _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
+  if (_lto_flag_out)
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY COMPILE_FLAGS " ${_lto_flag_out} ")
+    set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY LINK_FLAGS " ${_lto_flag_out} ")
   endif()
 
   if(SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

<!-- Description about pull request. -->

I lost this while chopping patches into logical chunks. Without this fix, unittests will not be built with LTO.
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

<!-- If this pull request resolves any bugs from Swift bug tracker -->

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…nittests to use _compute_lto_flag.

rdar://24717107
