### PR TITLE
Canonicalize the components of a GenericFunctionType in the context o…

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -232,6 +232,11 @@ public:
   /// The type parameters must be known to not be concrete within the context.
   bool areSameTypeParameterInContext(Type type1, Type type2, ModuleDecl &mod);
 
+  /// Return the canonical version of the given type under this generic
+  /// signature.
+  CanType getCanonicalTypeInContext(Type type, ModuleDecl &mod);
+  bool isCanonicalTypeInContext(Type type, ModuleDecl &mod);
+
   static void Profile(llvm::FoldingSetNodeID &ID,
                       ArrayRef<GenericTypeParamType *> genericParams,
                       ArrayRef<Requirement> requirements);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2494,8 +2494,10 @@ BEGIN_CAN_TYPE_WRAPPER(GenericFunctionType, AnyFunctionType)
   static CanGenericFunctionType get(CanGenericSignature sig,
                                     CanType input, CanType result,
                                     const ExtInfo &info) {
-    return CanGenericFunctionType(
-              GenericFunctionType::get(sig, input, result, info));
+    // Knowing that the argument types are independently canonical is
+    // not suffiicient to guarantee that the function type will be canonical.
+    auto fnType = GenericFunctionType::get(sig, input, result, info);
+    return cast<GenericFunctionType>(fnType->getCanonicalType());
   }
   
   CanGenericSignature getGenericSignature() const {

--- a/test/IDE/complete_override_access_control.swift
+++ b/test/IDE/complete_override_access_control.swift
@@ -196,11 +196,9 @@ public class TestPublicED : ProtocolEPublic, ProtocolDPrivate {
   #^TEST_PUBLIC_ED^#
 }
 
-// FIXME: there should be no duplicates in the results below.
-
 // TEST_PRIVATE_ED: Begin completions, 2 items
-// TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func colliding() {|}{{; name=.+$}}
+// TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
 // TEST_INTERNAL_ED: Begin completions, 2 items
 // TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}

--- a/test/SILGen/generic_tuples.swift
+++ b/test/SILGen/generic_tuples.swift
@@ -19,3 +19,20 @@ struct Blub {}
 func foo<T>(_ x: T) {}
 // CHECK-LABEL: sil hidden @_TF14generic_tuples3bar
 func bar(_ x: (Blub, Blub)) { foo(x) }
+
+
+// rdar://26279628
+//   A type parameter constrained to be a concrete type must be handled
+//   as that concrete type throughout SILGen.  That's especially true
+//   if it's constrained to be a tuple.
+
+protocol HasAssoc {
+  associatedtype A
+}
+extension HasAssoc where A == (Int, Int) {
+  func returnTupleAlias() -> A {
+    return (0, 0)
+  }
+}
+// CHECK-LABEL: sil hidden @_TFe14generic_tuplesRxS_8HasAssocwx1AzTSiSi_rS0_16returnTupleAliasfT_wxS1_ : $@convention(method) <Self where Self : HasAssoc, Self.A == (Int, Int)> (@in_guaranteed Self) -> (Int, Int) {
+// CHECK:       return {{.*}} : $(Int, Int)


### PR DESCRIPTION
#### What's in this pull request?

Canonicalizes the components of a GenericFunctionType in the context of the generic signature for general correctness and to eliminate of some persistent and frustrating corner cases in SIL generic function type lowering.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

…f the generic signature.

This is obviously the right thing to do in terms of ensuring
that two different expressions of the same signature always result
in the same type.  It also has the pleasant side-effect of causing
the canonical function type to never be expressed in terms of type
parameters which have been equated with concrete types, which means
that various consumers that work primarily with canonical types
(such as SILGen and IRGen) no longer have to worry about such types,
at least when decomposing a generic function signature.
