### PR TITLE
[stdlib] Adding new indices model tests

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -318,16 +318,16 @@ public struct DistanceFromToTest {
   public let loc: SourceLoc
 
   public init(
-    _ offsets: Range<Int>,
+    start: Int, end: Int,
     file: String = #file, line: UInt = #line
   ) {
-    self.startOffset = offsets.lowerBound
-    self.endOffset = offsets.upperBound
+    self.startOffset = start
+    self.endOffset = end
     self.loc = SourceLoc(file, line, comment: "distance(from:to:) test data")
   }
 }
 
-public struct IndexStepsFromTest {
+public struct IndexOffsetByTest {
   public let startOffset: Int
   public let distance: Int
   public let limit: Int?
@@ -349,37 +349,68 @@ public struct IndexStepsFromTest {
 }
 
 public let distanceFromToTests = [
-  DistanceFromToTest(0..<0),
-  DistanceFromToTest(10..<10),
-  DistanceFromToTest(10..<13),
-  DistanceFromToTest(7..<10),
+  DistanceFromToTest(start: 0, end: 0),
+  DistanceFromToTest(start: 10, end: 10),
+  DistanceFromToTest(start: 10, end: 13),
+  DistanceFromToTest(start: 7, end: 10),
+  DistanceFromToTest(start: 12, end: 4),
+  DistanceFromToTest(start: 8, end: 2),
+  DistanceFromToTest(start: 19, end: 0)
 ]
 
-public let indexStepsFromTests = [
-  IndexStepsFromTest(startOffset: 0, distance: 0, expectedOffset: 0),
-  IndexStepsFromTest(startOffset: 0, distance: -1, expectedOffset: -1),
-  IndexStepsFromTest(
+public let indexOffsetByTests = [
+  IndexOffsetByTest(startOffset: 0, distance: 0, expectedOffset: 0),
+  IndexOffsetByTest(startOffset: 7, distance: 0, expectedOffset: 7),
+  IndexOffsetByTest(startOffset: 0, distance: -1, expectedOffset: -1),
+  IndexOffsetByTest(startOffset: 4, distance: -9, expectedOffset: -5),
+  IndexOffsetByTest(startOffset: 8, distance: -2, expectedOffset: 6),
+  IndexOffsetByTest(startOffset: 4, distance: -4, expectedOffset: 0),
+  IndexOffsetByTest(startOffset: 3, distance: 12, expectedOffset: 15),
+  IndexOffsetByTest(startOffset: 9, distance: 1, expectedOffset: 10),
+  IndexOffsetByTest(startOffset: 2, distance: 4, expectedOffset: 6),
+  IndexOffsetByTest(startOffset: 0, distance: 9, expectedOffset: 9),
+  IndexOffsetByTest(
     startOffset: 0, distance: 0, expectedOffset: 0, limitedBy: 0),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 0, distance: 0, expectedOffset: 0, limitedBy: 10),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 0, distance: 10, expectedOffset: nil, limitedBy: 0),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 0, distance: -10, expectedOffset: nil, limitedBy: 0),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 0, distance: 10, expectedOffset: 10, limitedBy: 10),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 0, distance: 20, expectedOffset: nil, limitedBy: 10),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 10, distance: -20, expectedOffset: nil, limitedBy: 0),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 5, distance: 5, expectedOffset: 10, limitedBy: 2),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 5, distance: 5, expectedOffset: nil, limitedBy: 5),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 5, distance: -5, expectedOffset: 0, limitedBy: 7),
-  IndexStepsFromTest(
+  IndexOffsetByTest(
     startOffset: 5, distance: -5, expectedOffset: nil, limitedBy: 5)
+]
+
+public struct IndexAfterTest {
+  public let start: Int
+  public let end: Int
+  public let loc: SourceLoc
+
+  public init(start: Int, end: Int, file: String = #file, line: UInt = #line) {
+    self.start = start
+    self.end = end
+    self.loc = SourceLoc(file, line, 
+      comment: "index(after:) and formIndex(after:) test data")
+  }
+}
+
+public let indexAfterTests = [
+  IndexAfterTest(start: 0, end: 1),
+  IndexAfterTest(start: 0, end: 10),
+  IndexAfterTest(start: 5, end: 12),
+  IndexAfterTest(start: -58, end: -54),
 ]
 
 internal func _allIndices<C : Collection>(
@@ -788,13 +819,6 @@ extension TestSuite {
     }
 
     // FIXME: swift-3-indexing-model - add tests for the following?
-    //          index(after: i: Index) -> Index
-    //          formIndex(after: i: inout Index)
-    //          index(i: Index, offsetBy n: IndexDistance) -> Index
-    //          index(i: Index, offsetBy n: IndexDistance, limitedBy: Index) -> Index
-    //          formIndex(i: inout Index, offsetBy n: IndexDistance) -> Index
-    //          formIndex(i: inout Index, offsetBy n: IndexDistance, limitedBy: Index) -> Index
-    //          distance(from start: Index, to end: Index) -> IndexDistance
     //          _failEarlyRangeCheck(index: Index, bounds: Range<Index>)
     //          _failEarlyRangeCheck(range: Range<Index>, bounds: Range<Index>)
 
@@ -1549,24 +1573,53 @@ extension TestSuite {
     func toCollection(_ r: CountableRange<Int>) -> C {
       return makeCollection(r.map { wrapValue(OpaqueValue($0)) })
     }
+
+%   for i in ['index', 'formIndex']:
+    self.test("\(testNamePrefix).${i}(after:)/semantics") {
+      for test in indexAfterTests {
+        let c = toCollection(test.start..<test.end)
+        var currentIndex = c.startIndex
+        var counter = test.start
+        repeat {
+          expectEqual(counter, extractValue(c[currentIndex]).value,
+            stackTrace: SourceLocStack().with(test.loc))
+%     if i is 'index':
+          currentIndex = c.index(after: currentIndex)
+%     else:
+          c.formIndex(after: &currentIndex)
+%     end
+          counter += 1
+        } while counter < test.end
+      }
+    }
+%   end
     
     self.test("\(testNamePrefix)/distance(from:to:)/semantics") {
       let c = toCollection(0..<20)
       for test in distanceFromToTests {
         let d = c.distance(
           from: c.nthIndex(test.startOffset), to: c.nthIndex(test.endOffset))
+
+        let backwards = (test.startOffset < test.endOffset)
+        if backwards && !collectionIsBidirectional {
+          expectCrashLater()
+        }
         expectEqual(
           numericCast(test.expectedDistance),
           d, stackTrace: SourceLocStack().with(test.loc))
       }
     }
 
-    self.test("\(testNamePrefix)/index(_:stepsFrom: n)/semantics") {
-      for test in indexStepsFromTests.filter(
+    self.test("\(testNamePrefix)/index(_:offsetBy: n)/semantics") {
+      for test in indexOffsetByTests.filter(
         {$0.limit == nil && $0.distance >= 0}
       ) {
-        let c = toCollection(0..<10)
+        let max = 10
+        let c = toCollection(0..<max)
 
+        if test.expectedOffset! >= max {
+          expectCrashLater()
+        }
         let new = c.index(
           c.nthIndex(test.startOffset),
           offsetBy: numericCast(test.distance))
@@ -1580,54 +1633,143 @@ extension TestSuite {
       }
     }
 
-    if !collectionIsBidirectional {
-      self.test("\(testNamePrefix)/index(_:stepsFrom: -n)/semantics") {
-        for test in indexStepsFromTests.filter(
-          {$0.limit == nil && $0.distance < 0}
-        ) {
-          let c = toCollection(0..<10)
-          let start = c.nthIndex(test.startOffset)
+    self.test("\(testNamePrefix)/formIndex(_:offsetBy: n)/semantics") {
+      for test in indexOffsetByTests.filter(
+        {$0.limit == nil && $0.distance >= 0}
+      ) {
+        let max = 10
+        let c = toCollection(0..<max)
+
+        var new = c.nthIndex(test.startOffset)
+
+        if test.expectedOffset! >= max {
           expectCrashLater()
-          _ = c.index(start, offsetBy: numericCast(test.distance))
         }
-      }
-      self.test("\(testNamePrefix)/advance(by: -n, limitedBy:)/semantics") {
-        for test in indexStepsFromTests.filter(
-          {$0.limit != nil && $0.distance < 0}
-        ) {
-          let c = toCollection(0..<10)
-          let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
-          let start = c.nthIndex(test.startOffset)
-          expectCrashLater()
-          _ = c.index(
-            start, offsetBy: numericCast(test.distance), limitedBy: limit)
-        }
+        c.formIndex(&new, offsetBy: numericCast(test.distance))
+        expectEqual(test.expectedOffset!, extractValue(c[new]).value,
+          stackTrace: SourceLocStack().with(test.loc))
       }
     }
 
-    self.test("\(testNamePrefix)/advance(by: n, limitedBy:)/semantics") {
-      for test in indexStepsFromTests.filter(
+%   for i in ['index', 'formIndex']:
+    self.test("\(testNamePrefix)/${i}(_:offsetBy: -n)/semantics") {
+      for test in indexOffsetByTests.filter(
+        {$0.limit == nil && $0.distance < 0}
+      ) {
+        let c = toCollection(0..<20)
+%     if i is 'index':
+        let start = c.nthIndex(test.startOffset)
+%     else:
+        var new = c.nthIndex(test.startOffset)
+%     end
+
+        if test.expectedOffset! < 0 || !collectionIsBidirectional {
+          expectCrashLater()
+        }
+%     if i is 'index':
+        let new = c.index(start, offsetBy: numericCast(test.distance))
+%     else:
+        c.formIndex(&new, offsetBy: numericCast(test.distance))
+%     end
+        expectEqual(test.expectedOffset!, extractValue(c[new]).value,
+          stackTrace: SourceLocStack().with(test.loc))
+      }
+    }
+%   end
+
+    self.test("\(testNamePrefix)/index(_:offsetBy: n, limitedBy:)/semantics") {
+      for test in indexOffsetByTests.filter(
         {$0.limit != nil && $0.distance >= 0}
       ) {
         let c = toCollection(0..<20)
         let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
-
-        if !collectionIsBidirectional && test.distance < 0 {
-          expectCrashLater()
-        }
-
         let new = c.index(
           c.nthIndex(test.startOffset),
           offsetBy: numericCast(test.distance),
           limitedBy: limit)
-        if test.expectedOffset == nil {
-          expectEmpty(new)
-        } else {
-          expectEqual(c.nthIndex(test.expectedOffset!), new!,
+        if let expectedOffset = test.expectedOffset {
+          expectEqual(c.nthIndex(expectedOffset), new!,
             stackTrace: SourceLocStack().with(test.loc))
+        } else {
+          expectEmpty(new)
         }
       }
     }
+
+    self.test("\(testNamePrefix)/formIndex(_:offsetBy: n, limitedBy:)/semantics") {
+      for test in indexOffsetByTests.filter(
+        {$0.limit != nil && $0.distance >= 0}
+      ) {
+        let c = toCollection(0..<20)
+        let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
+        var new = c.nthIndex(test.startOffset)
+        let exact = c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        if let expectedOffset = test.expectedOffset {
+          expectEqual(c.nthIndex(expectedOffset), new,
+            stackTrace: SourceLocStack().with(test.loc))
+          expectTrue(exact, stackTrace: SourceLocStack().with(test.loc))
+        } else {
+          // Clamped to the limit
+          expectEqual(limit, new, stackTrace: SourceLocStack().with(test.loc))
+          expectFalse(exact, stackTrace: SourceLocStack().with(test.loc))
+        }
+      }
+    }
+
+    self.test("\(testNamePrefix)/index(_:offsetBy: -n, limitedBy:)/semantics") {
+      for test in indexOffsetByTests.filter(
+        {$0.limit != nil && $0.distance < 0}
+      ) {
+        let c = toCollection(0..<20)
+        let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
+        if collectionIsBidirectional {
+          let new = c.index(
+            c.nthIndex(test.startOffset),
+            offsetBy: numericCast(test.distance),
+            limitedBy: limit)
+          if let expectedOffset = test.expectedOffset {
+            expectEqual(c.nthIndex(expectedOffset), new!,
+              stackTrace: SourceLocStack().with(test.loc))
+          } else {
+            expectEmpty(new)
+          }
+        } else {
+          expectCrashLater()
+          _ = c.index(
+            c.nthIndex(test.startOffset),
+            offsetBy: numericCast(test.distance),
+            limitedBy: limit)
+        }
+      }
+    }
+
+    self.test("\(testNamePrefix)/formIndex(_:offsetBy: -n, limitedBy:)/semantics") {
+      for test in indexOffsetByTests.filter(
+        {$0.limit != nil && $0.distance < 0}
+      ) {
+        let c = toCollection(0..<20)
+        let limit = c.nthIndex(test.limit.unsafelyUnwrapped)
+        var new = c.nthIndex(test.startOffset)
+        if collectionIsBidirectional {
+          let exact = c.formIndex(
+            &new, 
+            offsetBy: numericCast(test.distance), 
+            limitedBy: limit)
+          if let expectedOffset = test.expectedOffset {
+            expectEqual(c.nthIndex(expectedOffset), new,
+              stackTrace: SourceLocStack().with(test.loc))
+            expectTrue(exact, stackTrace: SourceLocStack().with(test.loc))
+          } else {
+            expectEqual(limit, new, stackTrace: SourceLocStack().with(test.loc))
+            expectFalse(exact, stackTrace: SourceLocStack().with(test.loc))
+          }
+        } else {
+          expectCrashLater()
+          c.formIndex(&new, offsetBy: numericCast(test.distance), limitedBy: limit)
+        }
+      }
+    }
+
   }
 % end
 }

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -1574,8 +1574,8 @@ extension TestSuite {
       return makeCollection(r.map { wrapValue(OpaqueValue($0)) })
     }
 
-%   for i in ['index', 'formIndex']:
-    self.test("\(testNamePrefix).${i}(after:)/semantics") {
+%   for function_name in ['index', 'formIndex']:
+    self.test("\(testNamePrefix).${function_name}(after:)/semantics") {
       for test in indexAfterTests {
         let c = toCollection(test.start..<test.end)
         var currentIndex = c.startIndex
@@ -1583,7 +1583,7 @@ extension TestSuite {
         repeat {
           expectEqual(counter, extractValue(c[currentIndex]).value,
             stackTrace: SourceLocStack().with(test.loc))
-%     if i is 'index':
+%     if function_name is 'index':
           currentIndex = c.index(after: currentIndex)
 %     else:
           c.formIndex(after: &currentIndex)
@@ -1651,13 +1651,13 @@ extension TestSuite {
       }
     }
 
-%   for i in ['index', 'formIndex']:
-    self.test("\(testNamePrefix)/${i}(_:offsetBy: -n)/semantics") {
+%   for function_name in ['index', 'formIndex']:
+    self.test("\(testNamePrefix)/${function_name}(_:offsetBy: -n)/semantics") {
       for test in indexOffsetByTests.filter(
         {$0.limit == nil && $0.distance < 0}
       ) {
         let c = toCollection(0..<20)
-%     if i is 'index':
+%     if function_name is 'index':
         let start = c.nthIndex(test.startOffset)
 %     else:
         var new = c.nthIndex(test.startOffset)
@@ -1666,7 +1666,7 @@ extension TestSuite {
         if test.expectedOffset! < 0 || !collectionIsBidirectional {
           expectCrashLater()
         }
-%     if i is 'index':
+%     if function_name is 'index':
         let new = c.index(start, offsetBy: numericCast(test.distance))
 %     else:
         c.formIndex(&new, offsetBy: numericCast(test.distance))

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -873,7 +873,6 @@ extension Indexable {
   ///   `endIndex`.
   @inline(__always)
   public func formIndex(after i: inout Index) {
-    // FIXME: swift-3-indexing-model: tests.
     i = index(after: i)
   }
 
@@ -934,7 +933,6 @@ extension Indexable {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the absolute
   ///   value of `n`.
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    // FIXME: swift-3-indexing-model: tests.
     return self._advanceForward(i, by: n)
   }
 
@@ -985,7 +983,6 @@ extension Indexable {
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
-    // FIXME: swift-3-indexing-model: tests.
     return self._advanceForward(i, by: n, limitedBy: limit)
   }
 
@@ -1058,7 +1055,6 @@ extension Indexable {
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the
   ///   resulting distance.
   public func distance(from start: Index, to end: Index) -> IndexDistance {
-    // FIXME: swift-3-indexing-model: tests.
     _precondition(start <= end,
       "Only BidirectionalCollections can have end come before start")
 

--- a/validation-test/stdlib/Index.swift.gyb
+++ b/validation-test/stdlib/Index.swift.gyb
@@ -58,10 +58,11 @@ Index.test(
   "${Collection}/index(_:offsetBy:)/"
   + "avoidsSuccessorAndPredecessor/dispatch"
 ) {
-  for test in indexStepsFromTests.filter(
-    {$0.limit == nil && $0.distance >= 0}
+  let max = 10
+  for test in indexOffsetByTests.filter(
+    { $0.limit == nil && $0.distance >= 0 && $0.expectedOffset! < max }
   ) {
-    let c = ${Collection}(Array(0..<10))
+    let c = ${Collection}(Array(0..<max))
 
     let i = c.nthIndex(test.startOffset)
     let result  = c.index(i, offsetBy: test.distance)
@@ -82,7 +83,7 @@ Index.test(
   "${Collection}/index(_:offsetBy:limitedBy:)/"
   + "avoidsSuccessorAndPredecessor/dispatch"
 ) {
-  for test in indexStepsFromTests.filter(
+  for test in indexOffsetByTests.filter(
     {$0.limit != nil}
   ) {
     let c = ${Collection}(Array(0..<10))

--- a/validation-test/stdlib/Index.swift.gyb
+++ b/validation-test/stdlib/Index.swift.gyb
@@ -60,7 +60,7 @@ Index.test(
 ) {
   let max = 10
   for test in indexOffsetByTests.filter(
-    { $0.limit == nil && $0.distance >= 0 && $0.expectedOffset! < max }
+    { $0.limit == nil && $0.distance >= 0 && ($0.expectedOffset ?? max) < max }
   ) {
     let c = ${Collection}(Array(0..<max))
 


### PR DESCRIPTION
#### What's in this pull request?

More tests for the new Swift 3 indexing model. Tests pass on OS X.

@gribozavr 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes:
- Added tests for 'index(next:)'
- Added tests for all 'formIndex' API variants
- Modified existing tests to better test bidirectional collections
