### PR TITLE
Protocol typealias fixes

### DIFF
--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -62,6 +62,9 @@ enum NLOptions : unsigned {
   /// \see NL_KnownDependencyMask
   NL_KnownCascadingDependency = 0x80,
 
+  /// This lookup should only return type declarations.
+  NL_OnlyTypes = 0x100,
+
   /// This lookup is known to not add any additional dependencies to the
   /// primary source file.
   ///

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -194,11 +194,18 @@ class NamedDeclConsumer : public VisibleDeclConsumer {
 public:
   DeclName name;
   SmallVectorImpl<UnqualifiedLookupResult> &results;
+  bool isTypeLookup;
+
   NamedDeclConsumer(DeclName name,
-                    SmallVectorImpl<UnqualifiedLookupResult> &results)
-    : name(name), results(results) {}
+                    SmallVectorImpl<UnqualifiedLookupResult> &results,
+                    bool isTypeLookup)
+    : name(name), results(results), isTypeLookup(isTypeLookup) {}
 
   virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
+    // Give clients an opportunity to filter out non-type declarations early,
+    // to avoid circular validation.
+    if (isTypeLookup && !isa<TypeDecl>(VD))
+      return;
     if (VD->getFullName().matchesRef(name))
       results.push_back(UnqualifiedLookupResult(VD));
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -286,8 +286,8 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
 DeclContext *Decl::getInnermostDeclContext() const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))
     return const_cast<AbstractFunctionDecl*>(func);
-  if (auto nominal = dyn_cast<NominalTypeDecl>(this))
-    return const_cast<NominalTypeDecl*>(nominal);
+  if (auto nominal = dyn_cast<GenericTypeDecl>(this))
+    return const_cast<GenericTypeDecl*>(nominal);
   if (auto ext = dyn_cast<ExtensionDecl>(this))
     return const_cast<ExtensionDecl*>(ext);
   if (auto topLevel = dyn_cast<TopLevelCodeDecl>(this))

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -385,7 +385,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
   const SourceManager &SM = Ctx.SourceMgr;
   DebuggerClient *DebugClient = M.getDebugClient();
 
-  NamedDeclConsumer Consumer(Name, Results);
+  NamedDeclConsumer Consumer(Name, Results, IsTypeLookup);
 
   Optional<bool> isCascadingUse;
   if (IsKnownNonCascading)
@@ -530,6 +530,8 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
 
         if (AllowProtocolMembers)
           options |= NL_ProtocolMembers;
+        if (IsTypeLookup)
+          options |= NL_OnlyTypes;
 
         if (!ExtendedType)
           ExtendedType = ErrorType::get(Ctx);
@@ -1262,6 +1264,11 @@ bool DeclContext::lookupQualified(Type type,
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);
     for (auto decl : current->lookupDirect(member)) {
+      // If we're performing a type lookup, don't even attempt to validate
+      // the decl if its not a type.
+      if ((options & NL_OnlyTypes) && !isa<TypeDecl>(decl))
+        continue;
+
       // Resolve the declaration signature when we find the
       // declaration.
       if (typeResolver && !decl->isBeingTypeChecked()) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2917,15 +2917,8 @@ TypeSubstitutionMap TypeBase::getMemberSubstitutions(const DeclContext *dc) {
   // If the member is part of a protocol or extension thereof, we need
   // to substitute in the type of Self.
   if (dc->getAsProtocolOrProtocolExtensionContext()) {
-    // We only substitute into archetypes for now for protocols.
-    // FIXME: This seems like an odd restriction. Whatever is depending on
-    // this, shouldn't.
-    if (!baseTy->is<ArchetypeType>() && isa<ProtocolDecl>(dc))
-      return substitutions;
-
     // FIXME: This feels painfully inefficient. We're creating a dense map
     // for a single substitution.
-    substitutions[dc->getProtocolSelf()->getArchetype()] = baseTy;
     substitutions[dc->getProtocolSelf()->getDeclaredType()
                     ->getCanonicalType()->castTo<GenericTypeParamType>()]
       = baseTy;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1846,11 +1846,11 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       cs.addConstraint(ConstraintKind::ConformsTo, SequenceType,
                        sequenceProto->getDeclaredType(), Locator);
 
-      auto generatorLocator =
+      auto iteratorLocator =
         cs.getConstraintLocator(Locator,
                                 ConstraintLocator::SequenceIteratorProtocol);
       auto elementLocator =
-        cs.getConstraintLocator(generatorLocator,
+        cs.getConstraintLocator(iteratorLocator,
                                 ConstraintLocator::GeneratorElementType);
 
       // Collect constraints from the element pattern.
@@ -1859,48 +1859,58 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       if (!InitType)
         return true;
       
-      // Manually search for the generator witness. If no generator/element pair
+      // Manually search for the iterator witness. If no iterator/element pair
       // exists, solve for them.
-      // FIXME: rename generatorType to iteratorType due to the protocol
-      // renaming
-      Type generatorType;
+      Type iteratorType;
       Type elementType;
       
       NameLookupOptions lookupOptions = defaultMemberTypeLookupOptions;
       if (isa<AbstractFunctionDecl>(cs.DC))
         lookupOptions |= NameLookupFlags::KnownPrivate;
-      auto member = cs.TC.lookupMemberType(cs.DC,
-                                           expr->getType()->getRValueType(),
-                                           tc.Context.Id_Iterator,
-                                           lookupOptions);
+
+      auto sequenceType = expr->getType()->getRValueType();
+
+      // If the sequence type is an existential, we should not attempt to
+      // look up the member type at all, since we cannot represent associated
+      // types of existentials.
+      //
+      // We will diagnose it later.
+      if (!sequenceType->isExistentialType()) {
+        auto member = cs.TC.lookupMemberType(cs.DC,
+                                             sequenceType,
+                                             tc.Context.Id_Iterator,
+                                             lookupOptions);
       
-      if (member) {
-        generatorType = member.front().second;
-        
-        member = cs.TC.lookupMemberType(cs.DC,
-                                        generatorType,
-                                        tc.Context.Id_Element,
-                                        lookupOptions);
-        
-        if (member)
-          elementType = member.front().second;
+        if (member) {
+          iteratorType = member.front().second;
+
+          member = cs.TC.lookupMemberType(cs.DC,
+                                          iteratorType,
+                                          tc.Context.Id_Element,
+                                          lookupOptions);
+
+          if (member)
+            elementType = member.front().second;
+        }
       }
-      
+
+      // If the type lookup failed, just add some constraints we can
+      // try to solve later.
       if (elementType.isNull()) {
       
-        // Determine the generator type of the sequence.
-        generatorType = cs.createTypeVariable(Locator, /*options=*/0);
+        // Determine the iterator type of the sequence.
+        iteratorType = cs.createTypeVariable(Locator, /*options=*/0);
         cs.addConstraint(Constraint::create(
                            cs, ConstraintKind::TypeMember,
-                           SequenceType, generatorType,
-                           tc.Context.Id_Iterator, generatorLocator));
+                           SequenceType, iteratorType,
+                           tc.Context.Id_Iterator, iteratorLocator));
 
-        // Determine the element type of the generator.
+        // Determine the element type of the iterator.
         // FIXME: Should look up the type witness.
         elementType = cs.createTypeVariable(Locator, /*options=*/0);
         cs.addConstraint(Constraint::create(
                            cs, ConstraintKind::TypeMember,
-                           generatorType, elementType,
+                           iteratorType, elementType,
                            tc.Context.Id_Element, elementLocator));
       }
       

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -104,9 +104,9 @@ namespace {
     /// \param foundInType The type through which we found the
     /// declaration.
     void add(ValueDecl *found, ValueDecl *base, Type foundInType) {
-      // If we only want types and we didn't get one, bail out.
-      if (Options.contains(NameLookupFlags::OnlyTypes) && !isa<TypeDecl>(found))
-        return;
+      // If we only want types, AST name lookup should not yield anything else.
+      assert(!Options.contains(NameLookupFlags::OnlyTypes) ||
+             isa<TypeDecl>(found));
 
       ConformanceCheckOptions conformanceOptions;
       if (Options.contains(NameLookupFlags::KnownPrivate))
@@ -245,6 +245,8 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
     subOptions |= NL_DynamicLookup;
   if (options.contains(NameLookupFlags::IgnoreAccessibility))
     subOptions |= NL_IgnoreAccessibility;
+  if (options.contains(NameLookupFlags::OnlyTypes))
+    subOptions |= NL_OnlyTypes;
 
   // Dig out the type that we'll actually be looking into, and determine
   // whether it is a nominal type.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -351,37 +351,54 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     validateDecl(typeDecl);
     if (!typeDecl->hasType()) // FIXME: recursion-breaking hack
       continue;
-    
-    // If we found a member of a protocol type when looking into a non-protocol,
-    // non-archetype type, only include this member in the result set if
-    // this member was used as the default definition or otherwise inferred.
-    if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
-      if (!type->is<ArchetypeType>() && !type->isExistentialType()) {
-        inferredAssociatedTypes.push_back(assocType);
-        continue;
-      }
-    }
 
-    // Substitute the base into the member's type.
-    if (Type memberType = substMemberTypeWithBase(dc->getParentModule(),
-                                                  typeDecl, type,
-                                                  /*isTypeReference=*/true)) {
+    // If we're looking up a member of a protocol, we must take special care.
+    if (typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+      // We don't allow lookups of an associated type or typealias of an
+      // existential type, because we have no way to represent such types.
+      //
+      // This is diagnosed further on down in resolveNestedIdentTypeComponent().
+      if (type->isExistentialType()) {
+        auto memberType = typeDecl->getInterfaceType()->getRValueInstanceType();
 
-      // Similar to the associated type case, ignore typealiases containing
-      // associated types when looking into a non-protocol.
-      if (auto alias = dyn_cast<TypeAliasDecl>(typeDecl)) {
-        auto parentProtocol = alias->getDeclContext()->
-          getAsProtocolOrProtocolExtensionContext();
-        if (parentProtocol && memberType->hasTypeParameter() &&
-            !type->is<ArchetypeType>() && !type->isExistentialType()) {
+        if (memberType->hasTypeParameter()) {
+          // If we haven't seen this type result yet, add it to the result set.
+          if (types.insert(memberType->getCanonicalType()).second)
+            result.Results.push_back({typeDecl, memberType});
+
           continue;
         }
       }
 
-      // If we haven't seen this type result yet, add it to the result set.
-      if (types.insert(memberType->getCanonicalType()).second)
-        result.Results.push_back({typeDecl, memberType});
+      // If we're looking up an associated type of a concrete type,
+      // record it later for conformance checking; we might find a more
+      // direct typealias with the same name later.
+      if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
+        if (!type->is<ArchetypeType>()) {
+          inferredAssociatedTypes.push_back(assocType);
+          continue;
+        }
+      }
+
+      // We are looking up an associated type of an archetype, or a
+      // protocol typealias or an archetype or concrete type.
+      //
+      // Proceed with the usual path below.
     }
+
+    // Substitute the base into the member's type.
+    auto memberType = substMemberTypeWithBase(dc->getParentModule(),
+                                              typeDecl, type,
+                                              /*isTypeReference=*/true);
+
+    // FIXME: It is not clear why this substitution can fail, but the
+    // standard library won't build without this check.
+    if (!memberType)
+      continue;
+
+    // If we haven't seen this type result yet, add it to the result set.
+    if (types.insert(memberType->getCanonicalType()).second)
+      result.Results.push_back({typeDecl, memberType});
   }
 
   if (result.Results.empty()) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -193,23 +193,6 @@ void TypeChecker::forceExternalDeclMembers(NominalTypeDecl *nominalDecl) {
   }
 }
 
-static Optional<Type>
-resolveAssociatedTypeInContext(TypeChecker &TC, AssociatedTypeDecl *assocType,
-                               DeclContext *DC, GenericTypeResolver *resolver) {
-  auto protoSelf = DC->getProtocolSelf();
-  auto selfTy = protoSelf->getDeclaredType()->castTo<GenericTypeParamType>();
-  auto baseTy = resolver->resolveGenericTypeParamType(selfTy);
-
-  if (baseTy->isTypeParameter())
-    return resolver->resolveSelfAssociatedType(baseTy, DC, assocType);
-
-  if (assocType->getDeclContext() != DC)
-    return TC.substMemberTypeWithBase(DC->getParentModule(), assocType,
-                                      protoSelf->getArchetype(),
-                                      /*isTypeReference=*/true);
-  return None;
-}
-
 Type TypeChecker::resolveTypeInContext(
        TypeDecl *typeDecl,
        DeclContext *fromDC,
@@ -239,15 +222,12 @@ Type TypeChecker::resolveTypeInContext(
     nominalType = nullptr;
   }
 
-  // Walk up through the type scopes to find the context where the type
-  // declaration was found. When we find it, substitute the appropriate base
-  // type.
+  // Walk up through the type scopes to find the context containing the type
+  // being resolved.
   auto ownerDC = typeDecl->getDeclContext();
   bool nonTypeOwner = !ownerDC->isTypeContext();
   auto ownerNominal = ownerDC->getAsNominalTypeOrNominalTypeExtensionContext();
   auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl);
-  auto alias = dyn_cast<TypeAliasDecl>(typeDecl);
-  DeclContext *typeParent = nullptr;
   assert((ownerNominal || nonTypeOwner) &&
          "Owner must be a nominal type or a non type context");
 
@@ -273,140 +253,126 @@ Type TypeChecker::resolveTypeInContext(
       return typeDecl->getDeclaredType();
 
     // For the next steps we need our parentDC to be a type context
-    if (!parentDC->isTypeContext()) {
+    if (!parentDC->isTypeContext())
       continue;
-    } else if (!typeParent) {
-      // Remember the first type decl context in the hierarchy for later use
-      typeParent = parentDC;
-    }
 
-    // If we found an associated type in an inherited protocol, the base for our
-    // reference to this associated type is our own `Self`. If we can't resolve
-    // the associated type during this iteration, try again on the next.
-    if (assocType) {
-      if (auto proto = parentDC->getAsProtocolOrProtocolExtensionContext()) {
-        auto assocProto = assocType->getProtocol();
-        if (proto == assocProto || proto->inheritsFrom(assocProto)) {
-          // If the associated type is from our own protocol or we inherit from
-          // the associated type's protocol, resolve it
-          if (auto resolved = resolveAssociatedTypeInContext(
-                  *this, assocType, parentDC, resolver))
-            return *resolved;
+    // Search the type of this context and its supertypes (if its a
+    // class) or refined protocols (if its a protocol).
+    llvm::SmallPtrSet<const NominalTypeDecl *, 8> visited;
+    llvm::SmallVector<Type, 8> stack;
 
-        } else if (auto ED = dyn_cast<ExtensionDecl>(parentDC)) {
-          // Otherwise, if we are in an extension there might be other
-          // associated types brought into the context through
-          // `extension ... where Self : SomeProtocol`
-          for (auto req : ED->getGenericParams()->getTrailingRequirements()) {
-            // Reject requirements other than constraints with an subject other
-            // than `Self`
-            if (req.getKind() != RequirementReprKind::TypeConstraint ||
-                !req.getSubject()->castTo<ArchetypeType>()->isSelfDerived())
+    // Start with the type of the current context.
+    if (auto fromType = resolver->resolveTypeOfContext(parentDC))
+      stack.push_back(fromType);
+
+    // If we are in a protocol extension there might be other type aliases and
+    // nominal types brought into the context through requirements on Self,
+    // for example:
+    //
+    // extension MyProtocol where Self : YourProtocol { ... }
+    if (parentDC->getAsProtocolExtensionContext()) {
+      auto ED = cast<ExtensionDecl>(parentDC);
+      if (auto genericParams = ED->getGenericParams()) {
+        for (auto req : genericParams->getTrailingRequirements()) {
+          // We might be resolving 'req.getSubject()' itself.
+          // This whole case feels like a hack -- there should be a
+          // more principled way to represent extensions of protocol
+          // compositions.
+          if (req.getKind() == RequirementReprKind::TypeConstraint) {
+            if (!req.getSubject() ||
+                !req.getSubject()->is<ArchetypeType>() ||
+                !req.getSubject()->castTo<ArchetypeType>()->getSelfProtocol())
               continue;
 
-            // If the associated type is defined in the same protocol which is
-            // required for this extension, or if the required protocol inherits
-            // from the protocol the associated type is declared in, we can
-            // resolve the associated type with our `Self` as the reference
-            // point.
-            auto reqProto =
-                req.getConstraint()->castTo<ProtocolType>()->getDecl();
-            if (reqProto == assocProto || reqProto->inheritsFrom(assocProto)) {
-              if (auto resolved = resolveAssociatedTypeInContext(
-                      *this, assocType, parentDC, resolver))
-                return *resolved;
-              break;
-            }
+            stack.push_back(req.getConstraint());
           }
         }
       }
     }
-    
-    // If we found an alias type in an inherited protocol, resolve it based on our
-    // own `Self`.
-    if (alias && alias->hasInterfaceType()) {
-      auto metaType = alias->getInterfaceType()->getAs<MetatypeType>();
-      auto memberType = metaType ? metaType->getInstanceType()->getAs<DependentMemberType>() :
-                        nullptr;
 
-      if (memberType && parentDC->getAsProtocolOrProtocolExtensionContext()) {
-        auto protoSelf = parentDC->getProtocolSelf();
-        auto selfTy = protoSelf->getDeclaredType()->castTo<GenericTypeParamType>();
-        auto baseTy = resolver->resolveGenericTypeParamType(selfTy);
+    while (!stack.empty()) {
+      auto fromType = stack.back();
+      auto *fromProto = parentDC->getAsProtocolOrProtocolExtensionContext();
 
-        SmallVector<DependentMemberType *, 4> memberTypes;
-        do {
-          memberTypes.push_back(memberType);
-          memberType = memberType->getBase()->getAs<DependentMemberType>();
-        } while (memberType);
+      stack.pop_back();
 
-        auto module = parentDC->getParentModule();
-        while (memberTypes.size()) {
-          baseTy = memberTypes.back()->substBaseType(module, baseTy, nullptr);
-          memberTypes.pop_back();
-        }
-        return baseTy;
-      }
-    }
-
-    // Search the type of this context and its supertypes.
-    llvm::SmallPtrSet<const NominalTypeDecl *, 8> visited;
-    for (auto fromType = resolver->resolveTypeOfContext(parentDC);
-         fromType;
-         fromType = getSuperClassOf(fromType)) {
       // If we hit circularity, we will diagnose at some point in typeCheckDecl().
       // However we have to explicitly guard against that here because we get
       // called as part of validateDecl().
       if (!visited.insert(fromType->getAnyNominal()).second)
-        break;
+        continue;
 
-      // If the nominal type declaration of the context type we're looking at
-      // matches the owner's nominal type declaration, this is how we found
-      // the member type declaration. Substitute the type we're coming from as
-      // the base of the member type to produce the projected type result.
+      // Handle this case:
+      // - Current context: concrete type
+      // - Nested type: associated type
+      // - Nested type's context: protocol or protocol extension
+      //
+      if (assocType && fromProto == nullptr) {
+        ProtocolConformance *conformance = nullptr;
+
+        // If the conformance check failed, the associated type is for a
+        // conformance of an outer context.
+        if (!options.contains(TR_InheritanceClause) &&
+            conformsToProtocol(fromType,
+                               cast<ProtocolDecl>(ownerNominal),
+                               parentDC, ConformanceCheckFlags::Used,
+                               &conformance) &&
+            conformance) {
+          return conformance->getTypeWitness(assocType, this).getReplacement();
+        }
+      }
+
+      // Handle these cases:
+      // - Current context: concrete type
+      // - Nested type: concrete type or type alias
+      // - Nested type's context: concrete type
+      //
+      // - Current context: protocol or protocol extension
+      // - Nested type: type alias
+      // - Nested type's context: protocol or protocol extension
+      //
+      // Note: this is not supported yet, FIXME:
+      // - Current context: concrete type
+      // - Nested type: type alias
+      // - Nested type's context: protocol or protocol extension
+      //
       if (fromType->getAnyNominal() == ownerNominal) {
-        // If we are referring into a protocol or extension thereof,
-        // the base type is the 'Self'.
-        if (ownerDC->getAsProtocolOrProtocolExtensionContext()) {
-          auto selfTy = ownerDC->getProtocolSelf()->getDeclaredType()
-                          ->castTo<GenericTypeParamType>();
-          fromType = resolver->resolveGenericTypeParamType(selfTy);
+        if (fromProto &&
+            ownerNominal->getAsProtocolOrProtocolExtensionContext()) {
+          // If we are looking up an associated type or a protocol's type alias
+          // from a protocol or protocol extension, use the archetype for 'Self'
+          // instead of the existential type.
+          assert(fromType->is<ProtocolType>());
+
+          auto protoSelf = parentDC->getProtocolSelf();
+          auto selfType = protoSelf
+              ->getDeclaredType()
+              ->castTo<GenericTypeParamType>();
+          fromType = resolver->resolveGenericTypeParamType(selfType);
+
+          if (assocType) {
+            // Odd special case, ask Doug to explain it over pizza one day
+            if (fromType->isTypeParameter())
+              return resolver->resolveSelfAssociatedType(
+                  fromType, parentDC, assocType);
+          }
         }
 
-        // Perform the substitution.
         return substMemberTypeWithBase(parentDC->getParentModule(), typeDecl,
                                        fromType, /*isTypeReference=*/true);
       }
 
-      ProtocolConformance *conformance = nullptr;
-      if (assocType &&
-          !options.contains(TR_InheritanceClause) &&
-          conformsToProtocol(fromType,
-                             cast<ProtocolDecl>(assocType->getDeclContext()),
-                             parentDC, ConformanceCheckFlags::Used,
-                             &conformance) &&
-          conformance) {
-        return conformance->getTypeWitness(assocType, this).getReplacement();
+      if (auto superclassTy = getSuperClassOf(fromType))
+        stack.push_back(superclassTy);
+      else if (auto protoTy = fromType->getAs<ProtocolType>()) {
+        for (auto *proto : protoTy->getDecl()->getInheritedProtocols(this))
+          if (auto refinedTy = proto->getDeclaredTypeInContext())
+            stack.push_back(refinedTy);
       }
     }
   }
 
-  // At this point by iterating through the decl context hierarchy we should
-  // have encountered the first type context in the stack.
-  assert(typeParent && "incomplete iteration");
-  assert(!typeParent->isModuleContext());
-
-  // Substitute in the appropriate type for 'Self'.
-  // FIXME: We shouldn't have to guess here; the caller should tell us.
-  Type fromType;
-  if (typeParent->getAsProtocolOrProtocolExtensionContext())
-    fromType = typeParent->getProtocolSelf()->getArchetype();
-  else
-    fromType = resolver->resolveTypeOfContext(typeParent);
-
-  // Perform the substitution.
-  return substMemberTypeWithBase(typeParent->getParentModule(), typeDecl,
-                                 fromType, /*isTypeReference=*/true);
+  llvm_unreachable("Cannot resolve type");
 }
 
 Type TypeChecker::applyGenericArguments(Type type, SourceLoc loc,
@@ -537,7 +503,8 @@ Type TypeChecker::applyUnboundGenericArguments(
 
     // Check the generic arguments against the generic signature.
     auto genericSig = unbound->getDecl()->getGenericSignature();
-    if (unbound->getDecl()->isValidatingGenericSignature()) {
+    if (!unbound->getDecl()->hasType() ||
+        unbound->getDecl()->isValidatingGenericSignature()) {
       diagnose(loc, diag::recursive_requirement_reference);
       return nullptr;
     }
@@ -995,7 +962,7 @@ static Type resolveNestedIdentTypeComponent(
   // Short-circuiting.
   if (comp->isInvalid()) return ErrorType::get(TC.Context);
 
-  // If a declaration has already been bound, use it.
+  // Phase 2: If a declaration has already been bound, use it.
   if (ValueDecl *decl = comp->getBoundDecl()) {
     // Make sure we have a type declaration.
     auto typeDecl = dyn_cast<TypeDecl>(decl);
@@ -1026,9 +993,13 @@ static Type resolveNestedIdentTypeComponent(
       memberType = resolver->resolveDependentMemberType(parentTy, DC,
                                                         parentRange, comp);
       assert(memberType && "Received null dependent member type");
-    } else if (isa<AssociatedTypeDecl>(typeDecl) &&
-               !parentTy->is<ArchetypeType>() &&
-               !parentTy->isExistentialType()) {
+      return memberType;
+    }
+
+    if (isa<AssociatedTypeDecl>(typeDecl) &&
+        !parentTy->is<ArchetypeType>()) {
+      assert(!parentTy->isExistentialType());
+
       auto assocType = cast<AssociatedTypeDecl>(typeDecl);
 
       // Find the conformance and dig out the type witness.
@@ -1046,12 +1017,12 @@ static Type resolveNestedIdentTypeComponent(
 
       // FIXME: Establish that we need a type witness.
       return conformance->getTypeWitness(assocType, &TC).getReplacement();
-    } else {
-      // Otherwise, simply substitute the parent type into the member.
-      memberType = TC.substMemberTypeWithBase(DC->getParentModule(), typeDecl,
-                                              parentTy,
-                                              /*isTypeReference=*/true);
     }
+
+    // Otherwise, simply substitute the parent type into the member.
+    memberType = TC.substMemberTypeWithBase(DC->getParentModule(), typeDecl,
+                                            parentTy,
+                                            /*isTypeReference=*/true);
 
     // Propagate failure.
     if (!memberType || memberType->is<ErrorType>()) return memberType;
@@ -1069,6 +1040,8 @@ static Type resolveNestedIdentTypeComponent(
     // We're done.
     return memberType;
   }
+
+  // Phase 1: Find and bind the component decl.
 
   // If the parent is a dependent type, the member is a dependent member.
   if (parentTy->isTypeParameter()) {
@@ -2474,7 +2447,6 @@ Type TypeChecker::substMemberTypeWithBase(Module *module,
   Type memberType = isTypeReference
                       ? cast<TypeDecl>(member)->getDeclaredInterfaceType()
                       : member->getInterfaceType();
-
   if (isTypeReference) {
     // The declared interface type for a generic type will have the type
     // arguments; strip them off.

--- a/test/IDE/complete_override_access_control.swift
+++ b/test/IDE/complete_override_access_control.swift
@@ -174,25 +174,17 @@ public class TestPublicDE : ProtocolDPrivate, ProtocolEPublic {
   #^TEST_PUBLIC_DE^#
 }
 
-// FIXME: there should be no duplicates in the results below.
-
-// TEST_PRIVATE_DE: Begin completions, 4 items
+// TEST_PRIVATE_DE: Begin completions, 2 items
 // TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: private func colliding() {|}{{; name=.+$}}
 // TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_INTERNAL_DE: Begin completions, 4 items
+// TEST_INTERNAL_DE: Begin completions, 2 items
 // TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_PUBLIC_DE: Begin completions, 4 items
+// TEST_PUBLIC_DE: Begin completions, 2 items
 // TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: public func colliding() {|}{{; name=.+$}}
 // TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
 private class TestPrivateED : ProtocolEPublic, ProtocolDPrivate {
   #^TEST_PRIVATE_ED^#
@@ -206,23 +198,17 @@ public class TestPublicED : ProtocolEPublic, ProtocolDPrivate {
 
 // FIXME: there should be no duplicates in the results below.
 
-// TEST_PRIVATE_ED: Begin completions, 4 items
+// TEST_PRIVATE_ED: Begin completions, 2 items
 // TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func colliding() {|}{{; name=.+$}}
-// TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_INTERNAL_ED: Begin completions, 4 items
-// TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_INTERNAL_ED: Begin completions, 2 items
+// TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
-// TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_PUBLIC_ED: Begin completions, 4 items
-// TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_PUBLIC_ED: Begin completions, 2 items
+// TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: public func colliding() {|}{{; name=.+$}}
-// TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
 private class TestPrivateEF : ProtocolEPublic, ProtocolFPublic {
   #^TEST_PRIVATE_EF^#
@@ -234,22 +220,14 @@ public class TestPublicEF : ProtocolEPublic, ProtocolFPublic {
   #^TEST_PUBLIC_EF^#
 }
 
-// FIXME: there should be no duplicates in the results below.
-
-// TEST_PRIVATE_EF: Begin completions, 4 items
+// TEST_PRIVATE_EF: Begin completions, 2 items
 // TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: private func colliding() {|}{{; name=.+$}}
 // TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: private func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_INTERNAL_EF: Begin completions, 4 items
+// TEST_INTERNAL_EF: Begin completions, 2 items
 // TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_PUBLIC_EF: Begin completions, 4 items
+// TEST_PUBLIC_EF: Begin completions, 2 items
 // TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func colliding() {|}{{; name=.+$}}
-// TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
-// TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1742,7 +1742,7 @@ func testUnusableProtExt(_ x: PWithT) {
   x.#^PROTOCOL_EXT_UNUSABLE_EXISTENTIAL^#
 }
 // PROTOCOL_EXT_UNUSABLE_EXISTENTIAL: Begin completions
-// PROTOCOL_EXT_UNUSABLE_EXISTENTIAL: Decl[InstanceMethod]/CurrNominal:   foo({#(x): Self.T#})[#Self.T#]{{; name=.+}}
+// PROTOCOL_EXT_UNUSABLE_EXISTENTIAL: Decl[InstanceMethod]/CurrNominal:   foo({#(x): T#})[#T#]{{; name=.+}}
 // PROTOCOL_EXT_UNUSABLE_EXISTENTIAL: Decl[InstanceMethod]/CurrNominal:   bar({#(x): T#})[#T#]{{; name=.+}}
 // PROTOCOL_EXT_UNUSABLE_EXISTENTIAL: End completions
 

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -1,9 +1,9 @@
 // RUN: %target-parse-verify-swift
 
 class HasFunc {
-  func HasFunc(_: HasFunc) { // expected-error {{use of undeclared type 'HasFunc'}}
+  func HasFunc(_: HasFunc) {
   }
-  func HasFunc() -> HasFunc { // expected-error {{use of undeclared type 'HasFunc'}}
+  func HasFunc() -> HasFunc {
     return HasFunc()
   }
   func SomethingElse(_: SomethingElse) { // expected-error {{use of undeclared type 'SomethingElse'}}
@@ -24,17 +24,17 @@ class HasGenericFunc {
 }
 
 class HasProp {
-  var HasProp: HasProp { // expected-error {{'HasProp' used within its own type}} expected-error 2 {{use of undeclared type 'HasProp'}}
-    return HasProp()
+  var HasProp: HasProp {
+    return HasProp() // expected-error {{cannot call value of non-function type 'HasProp'}}
   }
-  var SomethingElse: SomethingElse? { // expected-error {{'SomethingElse' used within its own type}} expected-error 2 {{use of undeclared type 'SomethingElse'}}
+  var SomethingElse: SomethingElse? { // expected-error 2 {{use of undeclared type 'SomethingElse'}}
     return nil
   }
 }
 
 protocol SomeProtocol {}
 protocol ReferenceSomeProtocol {
-  var SomeProtocol: SomeProtocol { get }  // expected-error {{'SomeProtocol' used within its own type}} expected-error 2 {{use of undeclared type 'SomeProtocol'}}
+  var SomeProtocol: SomeProtocol { get } 
 }
 
 func TopLevelFunc(x: TopLevelFunc) -> TopLevelFunc { return x } // expected-error {{use of undeclared type 'TopLevelFunc'}}'

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -5,7 +5,7 @@ class Foo {
 }
 
 class C {
-	var triangle : triangle  // expected-error {{'triangle' used within its own type}} expected-error{{use of undeclared type 'triangle'}}
+	var triangle : triangle  // expected-error{{use of undeclared type 'triangle'}}
 
 	init() {}
 }

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -1,0 +1,120 @@
+// RUN: %target-parse-verify-swift
+
+struct MyType<TyA, TyB> {
+  var a : TyA, b : TyB
+}
+
+typealias DS<T> = MyType<String, T>
+
+typealias BadA<T : Int> = MyType<String, T>  // expected-error {{inheritance from non-protocol, non-class type 'Int'}}
+
+typealias BadB<T where T == Int> = MyType<String, T>  // expected-error {{associated types may not have a generic parameter list}}
+// expected-error @-1 {{same-type requirement makes generic parameter 'T' non-generic}}
+
+typealias BadC<T,T> = MyType<String, T>  // expected-error {{definition conflicts with previous value}}
+// expected-note @-1 {{previous definition of 'T' is here}}
+
+typealias Tuple2<T1, T2> = (T1, T2)
+
+typealias Tuple3<T1> = (T1, T1) where T1 : Hashable
+
+
+let _ : Tuple2<Int, String> = (1, "foo")
+let _ : Tuple2 = (1, "foo")
+let _ : Tuple2<Int, String> = ("bar",  // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
+                               "foo")
+
+func f() {
+  typealias Tuple2b<T1, T2> = (T1, T2)
+  let _ : Tuple2b = (1, "foo")
+  
+}
+
+
+typealias A<T1, T2> = MyType<T2, T1>  // expected-note {{generic type 'A' declared here}}
+
+typealias B<T1> = MyType<T1, T1>  // expected-note {{'T1' declared as parameter to type 'B'}}
+
+typealias C<T> = MyType<String, T>
+
+// Type aliases with unused generic params.
+typealias D<T1, T2, T3> = MyType<T2, T1>  // expected-note {{'T3' declared as parameter to type 'D'}}
+
+typealias E<T1, T2> = Int  // expected-note {{generic type 'E' declared here}}
+
+typealias F<T1, T2> = (T1) -> T2
+
+// Type alias of type alias.
+typealias G<S1, S2> = A<S1, S2>
+
+let _ : E<Int, Float> = 42
+let _ : E<Float> = 42   // expected-error {{generic type 'E' specialized with too few type parameters (got 1, but expected 2)}}
+let _ : E = 42   // expected-error {{cannot convert value of type 'Int' to specified type 'E'}}
+let _ : D = D(a: 1, b: 2)  // expected-error {{cannot convert value of type 'MyType<Int, Int>' to specified type 'D'}}
+
+let _ : D<Int, Int, Float> = D<Int, Int, Float>(a: 1, b: 2)
+
+// expected-error @+1 {{cannot convert value of type 'MyType<Int, Int>' to specified type 'D'}}
+let _ : D = D<Int, Int, Float>(a: 1, b: 2)
+
+
+// expected-error @+1 {{generic parameter 'T3' could not be inferred}}
+let _ : D<Int, Int, Float> = D(a: 1, b: 2)
+
+let _ : F = { (a : Int) -> Int in a }  // Infer the types of F
+
+// TODO QoI: Cannot infer T1/T2.
+let _ : F = { a in a }  // expected-error {{cannot convert value of type '(_) -> _' to specified type 'F'}}
+
+_ = MyType(a: "foo", b: 42)
+_ = A(a: "foo", b: 42)
+_ = A<Int, String>(a: "foo", b: 42)
+_ = A<String, Int>(a: "foo", // expected-error {{'String' is not convertible to 'Int'}}
+  b: 42)
+_ = B(a: 12, b: 42)
+_ = B(a: 12, b: 42 as Float)
+_ = B(a: "foo", b: 42)     // expected-error {{generic parameter 'T1' could not be inferred}}
+_ = C(a: "foo", b: 42)
+_ = C(a: 42,        // expected-error {{'Int' is not convertible to 'String'}}
+  b: 42)
+
+_ = G(a: "foo", b: 42)
+_ = G<Int, String>(a: "foo", b: 42)
+
+
+struct MyTypeWithHashable<TyA, TyB : Hashable> {
+}
+
+typealias MTWHInt<HT : Hashable> = MyTypeWithHashable<Int, HT>
+typealias MTWHInt2<HT> = MyTypeWithHashable<Int, HT> // expected-error {{type 'HT' does not conform to protocol 'Hashable'}}
+
+func f(a : MyTypeWithHashable<Int, Int>) {
+  f(a: MyTypeWithHashable<Int, Int>())
+  f(a: MTWHInt<Int>())
+}
+
+
+
+
+// FIXME: Nested generic typealiases aren't working yet.
+struct GenericStruct<T> {
+  typealias TA<U> = MyType<T, U>
+  
+  func testCapture<S>(s : S, t : T) -> TA<S> {  // expected-error {{cannot specialize non-generic type 'MyType<T, U>'}}
+    return TA<S>(a: t, b : s)
+  }
+}
+
+let _ = GenericStruct<Int>.TA<Float>(a: 4.0, b: 1)  // expected-error {{'Int' is not convertible to 'Float'}}
+
+let _ : GenericStruct<Int>.TA<Float>  // expected-error {{cannot specialize non-generic type 'MyType<Int, U>'}}
+
+
+
+extension A {}  // expected-error {{non-nominal type 'A' cannot be extended}}
+extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
+extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension C<T> {}  // expected-error {{use of undeclared type 'T'}}
+extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+
+

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -1,0 +1,154 @@
+// RUN: %target-parse-verify-swift -enable-protocol-typealiases
+
+// Tests for typealias inside protocols
+
+protocol Bad {
+  associatedtype X<T>  // expected-error {{associated types may not have a generic parameter list}}
+  typealias Y<T>       // expected-error {{expected '=' in typealias declaration}}
+}
+
+protocol Col {
+  associatedtype Elem
+  typealias E = Elem?
+  var elem: Elem { get }
+}
+
+protocol CB {
+  associatedtype C : Col
+
+  // Self at top level
+  typealias S = Self
+  func cloneDefinitely() -> S
+
+  // Self in bound generic position
+  typealias OS = Self?
+  func cloneMaybe() -> OS
+
+  // Associated type of archetype
+  typealias E = C.Elem
+  func setIt(_ element: E)
+
+  // Typealias of archetype
+  typealias EE = C.E
+  func setItSometimes(_ element: EE)
+
+  // Associated type in bound generic position
+  typealias OE = C.Elem?
+  func setItMaybe(_ element: OE)
+
+  // Complex type expression
+  typealias FE = (C) -> (C.Elem) -> Self
+  func teleport(_ fn: FE)
+}
+
+// Generic signature requirement involving protocol typealias
+func go1<T : CB, U : Col where U.Elem == T.E>(_ col: U, builder: T) { // OK
+  builder.setIt(col.elem)
+}
+func go2<T : CB, U : Col where U.Elem == T.C.Elem>(_ col: U, builder: T) { // OK
+  builder.setIt(col.elem)
+}
+
+// Test for same type requirement with typealias == concrete
+func go3<T : CB where T.E == Int>(_ builder: T) {
+  builder.setIt(1)
+}
+
+// Test for conformance to protocol with associatedtype and another with
+// typealias with same name
+protocol MyIterator {
+  associatedtype Elem
+
+  func next() -> Elem?
+}
+
+protocol MySeq {
+  associatedtype I : MyIterator
+  typealias Elem = Self.I.Elem
+
+  func makeIterator() -> I
+  func getIndex(_ i: Int) -> Elem
+  func first() -> Elem
+}
+
+extension MySeq where Self : MyIterator {
+  func makeIterator() -> Self {
+    return self
+  }
+}
+
+func plusOne<S: MySeq where S.Elem == Int>(_ s: S, i: Int) -> Int {
+  return s.getIndex(i) + 1
+}
+
+struct OneIntSeq: MySeq, MyIterator {
+  let e : Float
+
+  func next() -> Float? {
+    return e
+  }
+
+  func getIndex(_ i: Int) -> Float {
+    return e
+  }
+}
+
+// test for conformance correctness using typealias in extension
+extension MySeq {
+  func first() -> Elem {
+    return getIndex(0)
+  }
+}
+
+// Specific diagnosis for trying to use complex typealiases in generic constraints
+protocol P1 {
+    associatedtype A
+    typealias F = (A) -> ()
+}
+
+protocol P2 {
+    associatedtype B
+}
+
+func go3<T : P1, U : P2 where T.F == U.B>(_ x: T) -> U { // expected-error {{typealias 'F' is too complex to be used as a generic constraint; use an associatedtype instead}} expected-error {{'F' is not a member type of 'T'}}
+}
+
+// Specific diagnosis for things that look like Swift 2.x typealiases
+protocol P3 {
+  typealias T // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
+  typealias U : P2 // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
+
+  associatedtype V : P2 = // expected-error {{expected type in associatedtype declaration}}
+}
+
+// Test for not crashing on recursive aliases
+protocol Circular {
+  typealias Y = Self.Y // expected-error {{type alias 'Y' circularly references itself}}
+}
+
+// Qualified and unqualified references to protocol typealiases from concrete type
+protocol P5 {
+  associatedtype A
+  typealias X = Self
+  typealias T1 = Int
+  typealias T2 = A
+  var a: T2 { get }
+}
+
+struct T5 : P5 {
+  // This is OK -- the typealias is fully concrete
+  var a: P5.T1 // OK
+
+  // Invalid -- cannot represent associated type of existential
+  var v2: P5.T2 // expected-error {{cannot use typealias 'T2' of associated type 'A' outside of its protocol}}
+  var v3: P5.X // expected-error {{cannot use typealias 'X' of associated type 'Self' outside of its protocol}}
+
+  // FIXME: Unqualified reference to typealias from a protocol conformance
+  var v4: T1 // expected-error {{use of undeclared type 'T1'}}
+  var v5: T2 // expected-error {{use of undeclared type 'T2'}}
+
+  // Qualified reference
+  var v6: T5.T1 // OK
+  var v7: T5.T2 // OK
+}
+

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -3,6 +3,9 @@
 typealias rgb = Int32 // expected-note {{declared here}}
 var rgb : rgb? // expected-error {{invalid redeclaration of 'rgb'}}
 
+// This used to produce a diagnostic about 'rgba' being used in its own
+// type, but arguably that is incorrect, since we are referencing a
+// different 'rgba'.
 struct Color {
     var rgba : rgba? { // expected-error {{'rgba' used within its own type}}
         return nil
@@ -12,7 +15,7 @@ struct Color {
 }
 
 struct Color2 {
-    let rgba : rgba? // expected-error {{'rgba' used within its own type}}
+    let rgba : rgba?
 
     struct rgba {}
 }

--- a/test/decl/typealias/typealias.swift
+++ b/test/decl/typealias/typealias.swift
@@ -1,8 +1,7 @@
-// RUN: %target-parse-verify-swift -enable-protocol-typealiases
+// RUN: %target-parse-verify-swift
 
 typealias rgb = Int32 // expected-note {{declared here}}
 var rgb : rgb? // expected-error {{invalid redeclaration of 'rgb'}}
-
 
 struct Color {
     var rgba : rgba? { // expected-error {{'rgba' used within its own type}}
@@ -18,247 +17,18 @@ struct Color2 {
     struct rgba {}
 }
 
+typealias Integer = Int
 
+var i: Integer
 
+struct Hair<Style> {
+  typealias Hairdo = Style
+  typealias MorningHair = Style?
 
-
-
-struct MyType<TyA, TyB> {
-  var a : TyA, b : TyB
+  func fancy() -> Hairdo {}
+  func wakeUp() -> MorningHair {}
 }
 
-protocol P {
-  associatedtype X<T>  // expected-error {{associated types may not have a generic parameter list}}
-  typealias Y<T>       // expected-error {{expected '=' in typealias declaration}}
-}
+typealias FunnyHair = Hair<Color>
 
-typealias basicTypealias = Int
-
-typealias DSI = MyType<String, Int>
-typealias DS<T> = MyType<String, T>
-
-typealias BadA<T : Int> = MyType<String, T>  // expected-error {{inheritance from non-protocol, non-class type 'Int'}}
-
-typealias BadB<T where T == Int> = MyType<String, T>  // expected-error {{associated types may not have a generic parameter list}}
-// expected-error @-1 {{same-type requirement makes generic parameter 'T' non-generic}}
-
-typealias BadC<T,T> = MyType<String, T>  // expected-error {{definition conflicts with previous value}}
-// expected-note @-1 {{previous definition of 'T' is here}}
-
-typealias Tuple2<T1, T2> = (T1, T2)
-
-typealias Tuple3<T1> = (T1, T1) where T1 : Hashable
-
-
-let _ : Tuple2<Int, String> = (1, "foo")
-let _ : Tuple2 = (1, "foo")
-let _ : Tuple2<Int, String> = ("bar",  // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
-                               "foo")
-
-func f() {
-  typealias Tuple2b<T1, T2> = (T1, T2)
-  let _ : Tuple2b = (1, "foo")
-  
-}
-
-
-typealias A<T1, T2> = MyType<T2, T1>  // expected-note {{generic type 'A' declared here}}
-
-typealias B<T1> = MyType<T1, T1>  // expected-note {{'T1' declared as parameter to type 'B'}}
-
-typealias C<T> = MyType<String, T>
-
-// Type aliases with unused generic params.
-typealias D<T1, T2, T3> = MyType<T2, T1>  // expected-note {{'T3' declared as parameter to type 'D'}}
-
-typealias E<T1, T2> = Int  // expected-note {{generic type 'E' declared here}}
-
-typealias F<T1, T2> = (T1) -> T2
-
-// Type alias of type alias.
-typealias G<S1, S2> = A<S1, S2>
-
-let _ : E<Int, Float> = 42
-let _ : E<Float> = 42   // expected-error {{generic type 'E' specialized with too few type parameters (got 1, but expected 2)}}
-let _ : E = 42   // expected-error {{cannot convert value of type 'Int' to specified type 'E'}}
-let _ : D = D(a: 1, b: 2)  // expected-error {{cannot convert value of type 'MyType<Int, Int>' to specified type 'D'}}
-
-let _ : D<Int, Int, Float> = D<Int, Int, Float>(a: 1, b: 2)
-
-// expected-error @+1 {{cannot convert value of type 'MyType<Int, Int>' to specified type 'D'}}
-let _ : D = D<Int, Int, Float>(a: 1, b: 2)
-
-
-// expected-error @+1 {{generic parameter 'T3' could not be inferred}}
-let _ : D<Int, Int, Float> = D(a: 1, b: 2)
-
-let _ : F = { (a : Int) -> Int in a }  // Infer the types of F
-
-// TODO QoI: Cannot infer T1/T2.
-let _ : F = { a in a }  // expected-error {{cannot convert value of type '(_) -> _' to specified type 'F'}}
-
-_ = MyType(a: "foo", b: 42)
-_ = A(a: "foo", b: 42)
-_ = A<Int, String>(a: "foo", b: 42)
-_ = A<String, Int>(a: "foo", // expected-error {{'String' is not convertible to 'Int'}}
-  b: 42)
-_ = B(a: 12, b: 42)
-_ = B(a: 12, b: 42 as Float)
-_ = B(a: "foo", b: 42)     // expected-error {{generic parameter 'T1' could not be inferred}}
-_ = C(a: "foo", b: 42)
-_ = C(a: 42,        // expected-error {{'Int' is not convertible to 'String'}}
-  b: 42)
-
-_ = G(a: "foo", b: 42)
-_ = G<Int, String>(a: "foo", b: 42)
-
-
-struct MyTypeWithHashable<TyA, TyB : Hashable> {
-}
-
-typealias MTWHInt<HT : Hashable> = MyTypeWithHashable<Int, HT>
-typealias MTWHInt2<HT> = MyTypeWithHashable<Int, HT> // expected-error {{type 'HT' does not conform to protocol 'Hashable'}}
-
-func f(a : MyTypeWithHashable<Int, Int>) {
-  f(a: MyTypeWithHashable<Int, Int>())
-  f(a: MTWHInt<Int>())
-}
-
-
-
-
-// FIXME: Nested generic typealiases aren't working yet.
-struct GenericStruct<T> {
-  typealias TA<U> = MyType<T, U>
-  
-  func testCapture<S>(s : S, t : T) -> TA<S> {  // expected-error {{cannot specialize non-generic type 'MyType<T, U>'}}
-    return TA<S>(a: t, b : s)
-  }
-}
-
-let _ = GenericStruct<Int>.TA<Float>(a: 4.0, b: 1)  // expected-error {{'Int' is not convertible to 'Float'}}
-
-let _ : GenericStruct<Int>.TA<Float>  // expected-error {{cannot specialize non-generic type 'MyType<Int, U>'}}
-
-
-
-extension A {}  // expected-error {{non-nominal type 'A' cannot be extended}}
-extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
-extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
-extension C<T> {}  // expected-error {{use of undeclared type 'T'}}
-extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
-
-
-// Allow typealias inside protocol
-protocol Col {
-  associatedtype Elem
-  var elem: Elem { get }
-}
-
-protocol CB {
-  associatedtype C : Col
-  typealias E = C.Elem
-  
-  func setIt(_ element: E)
-}
-
-func go1<T : CB, U : Col where U.Elem == T.E>(_ col: U, builder: T) { // OK
-  builder.setIt(col.elem)
-}
-func go2<T : CB, U : Col where U.Elem == T.C.Elem>(_ col: U, builder: T) { // OK
-  builder.setIt(col.elem)
-}
-
-// Test for same type requirement with typealias == concrete
-func go3<T : CB where T.E == Int>(_ builder: T) {
-  builder.setIt(1)
-}
-
-// Test for conformance to protocol with associatedtype and another with typealias with same name.
-protocol MyIterator {
-  associatedtype Elem
-  
-  func next() -> Elem?
-}
-
-protocol MySeq {
-  associatedtype I : MyIterator
-  typealias Elem = Self.I.Elem
-  
-  func makeIterator() -> I
-  func getIndex(_ i: Int) -> Elem
-  func first() -> Elem
-}
-
-extension MySeq where Self : MyIterator {
-  func makeIterator() -> Self {
-    return self
-  }
-}
-
-func plusOne<S: MySeq where S.Elem == Int>(_ s: S, i: Int) -> Int {
-  return s.getIndex(i) + 1
-}
-
-struct OneIntSeq: MySeq, MyIterator {
-  let e : Float
-  
-  func next() -> Float? {
-    return e
-  }
-  
-  func getIndex(_ i: Int) -> Float {
-    return e
-  }
-}
-
-// test for conformance correctness using typealias in extension
-extension MySeq {
-  func first() -> Elem {
-    return getIndex(0)
-  }
-}
-
-// Specific diagnosis for trying to use complex typealiases in generic constraints
-protocol P1 {
-    associatedtype A
-    typealias F = (A) -> ()
-}
-
-protocol P2 {
-    associatedtype B
-}
-
-func go3<T : P1, U : P2 where T.F == U.B>(_ x: T) -> U { // expected-error {{typealias 'F' is too complex to be used as a generic constraint; use an associatedtype instead}} expected-error {{'F' is not a member type of 'T'}}
-}
-
-// Specific diagnosis for things that look like Swift 2.x typealiases
-protocol P3 {
-  typealias T // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
-  typealias U : P2 // expected-error {{typealias is missing an assigned type; use 'associatedtype' to define an associated type requirement}}
-  
-  associatedtype V : P2 = // expected-error {{expected type in associatedtype declaration}}
-}
-
-// Test for not crashing on self and recursive aliases
-protocol P4 {
-  typealias X = Self
-  typealias Y = Self.Y // expected-error {{type alias 'Y' circularly references itself}}
-  
-  func getSelf() -> X
-}
-
-// Availability of typealiases in protocols for nested type lookup
-protocol P5 {
-  associatedtype A
-  typealias T1 = Int
-  typealias T2 = A
-  var a: T2 { get }
-}
-
-struct T5 : P5 {
-  var a: P5.T1 // OK
-  var v2: P5.T2 // expected-error {{cannot use typealias 'T2' of associated type 'A' outside of its protocol}}
-}
-
-
+var f: FunnyHair

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -172,3 +172,9 @@ func testOptionalSequence() {
   }
 }
 
+// Crash with (invalid) for each over an existential
+func testExistentialSequence(s: Sequence) { // expected-error {{protocol 'Sequence' can only be used as a generic constraint because it has Self or associated type requirements}}
+  for x in s { // expected-error {{using 'Sequence' as a concrete type conforming to protocol 'Sequence' is not supported}}
+    _ = x
+  }
+}

--- a/validation-test/IDE/crashers/015-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/IDE/crashers/015-swift-typechecker-lookupunqualified.swift
@@ -1,3 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-T{struct B{let h=protocol P{struct B<T where h:e{var f=B#^A^#

--- a/validation-test/IDE/crashers/021-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/IDE/crashers/021-swift-typechecker-resolveidentifiertype.swift
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-{class T{protocol b{#^A^#associatedtype b:B<T>struct B<b

--- a/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-protocol c{func a:P
-protocol P{#^A^#func a:b
-associatedtype b:a

--- a/validation-test/IDE/crashers/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/IDE/crashers/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,5 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-protocol A{protocol A{
-associatedtype e:a
-func a<T:e
-enum b{func a{#^A^#

--- a/validation-test/IDE/crashers/067-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/IDE/crashers/067-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-struct d{func b
-let g=b<a let a=enum b<j where g:p:#^A^#

--- a/validation-test/IDE/crashers_fixed/015-swift-typechecker-lookupunqualified.swift
+++ b/validation-test/IDE/crashers_fixed/015-swift-typechecker-lookupunqualified.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+T{struct B{let h=protocol P{struct B<T where h:e{var f=B#^A^#

--- a/validation-test/IDE/crashers_fixed/021-swift-typechecker-resolveidentifiertype.swift
+++ b/validation-test/IDE/crashers_fixed/021-swift-typechecker-resolveidentifiertype.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+{class T{protocol b{#^A^#associatedtype b:B<T>struct B<b

--- a/validation-test/IDE/crashers_fixed/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
+++ b/validation-test/IDE/crashers_fixed/024-swift-archetypebuilder-potentialarchetype-getrepresentative.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol c{func a:P
+protocol P{#^A^#func a:b
+associatedtype b:a

--- a/validation-test/IDE/crashers_fixed/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
+++ b/validation-test/IDE/crashers_fixed/044-swift-dependentgenerictyperesolver-resolveselfassociatedtype.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+protocol A{protocol A{
+associatedtype e:a
+func a<T:e
+enum b{func a{#^A^#

--- a/validation-test/IDE/crashers_fixed/067-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/IDE/crashers_fixed/067-swift-constraints-constraintsystem-resolveoverload.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+struct d{func b
+let g=b<a let a=enum b<j where g:p:#^A^#

--- a/validation-test/compiler_crashers_fixed/00429-vtable.swift
+++ b/validation-test/compiler_crashers_fixed/00429-vtable.swift
@@ -7,10 +7,6 @@
 
 // RUN: not %target-swift-frontend %s -parse
 
-// REQUIRES: asserts
-// SR-1584
-// XFAIL: objc_interop
-
 }
 struct S {
 static let i: B<Q<T where A"""

--- a/validation-test/compiler_crashers_fixed/01766-swift-typechecker-validatedecl.swift
+++ b/validation-test/compiler_crashers_fixed/01766-swift-typechecker-validatedecl.swift
@@ -5,6 +5,13 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-var d:Collection{for c d in
+// RUN: not %target-swift-frontend %s -parse
+protocol a {
+protocol A {
+}
+}
+protocol b : a {
+protocol c : A {
+}
+}
+for b

--- a/validation-test/compiler_crashers_fixed/26083-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/26083-std-function-func-swift-type-subst.swift
@@ -5,13 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-protocol a {
-protocol A {
-}
-}
-protocol b : a {
-protocol c : A {
-}
-}
-for b
+// DUPLICATE-OF: 01766-swift-typechecker-validatedecl.swift
+// RUN: not %target-swift-frontend %s -parse
+protocol e:A{protocol e:A class A}protocol A{enum A}protocol B:e

--- a/validation-test/compiler_crashers_fixed/27131-isvalidoverload.swift
+++ b/validation-test/compiler_crashers_fixed/27131-isvalidoverload.swift
@@ -5,10 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-class a
-class A:a{
-class d:a
-let a=D
-let f:d
+// RUN: not %target-swift-frontend %s -parse
+struct A{class d:a{protocol a{func<}}let a=S<

--- a/validation-test/compiler_crashers_fixed/27156-swift-typechecker-applygenericarguments.swift
+++ b/validation-test/compiler_crashers_fixed/27156-swift-typechecker-applygenericarguments.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// DUPLICATE-OF: 01766-swift-typechecker-validatedecl.swift
-// RUN: not --crash %target-swift-frontend %s -parse
-protocol e:A{protocol e:A class A}protocol A{enum A}protocol B:e
+// RUN: not %target-swift-frontend %s -parse
+struct B<T{protocol A{
+class B<T
+associatedtype e:B<T>

--- a/validation-test/compiler_crashers_fixed/27636-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27636-swift-typechecker-resolvetypeincontext.swift
@@ -5,8 +5,9 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-enum w{class d:a
-var d=[[]a
-class a:d
+// RUN: not %target-swift-frontend %s -parse
+// ASAN Output: stack-overflow on address 0x7ffdcd2b1fd0 (pc 0x0000008ecf9e bp 0x7ffdcd2b2810 sp 0x7ffdcd2b1fc0 T0)
+enum A
+protocol A{
+associatedtype f:a
+func a<T where f:d

--- a/validation-test/compiler_crashers_fixed/27832-swift-typechecker-resolvetypeincontext.swift
+++ b/validation-test/compiler_crashers_fixed/27832-swift-typechecker-resolvetypeincontext.swift
@@ -5,9 +5,9 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-enum a{
-func b
-var h=b
-enum b<T where h=a
+// RUN: not %target-swift-frontend %s -parse
+// ASAN Output: stack-overflow on address 0x7ffd2c334fb0 (pc 0x0000008ecf9e bp 0x7ffd2c3357f0 sp 0x7ffd2c334fa0 T0)
+enum A
+protocol A{
+associatedtype f:a
+func a<T where f:d

--- a/validation-test/compiler_crashers_fixed/28193-swift-typechecker-lookupmembertype.swift
+++ b/validation-test/compiler_crashers_fixed/28193-swift-typechecker-lookupmembertype.swift
@@ -5,7 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-struct B<T{protocol A{
-class B<T
-associatedtype e:B<T>
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+var d:Collection{for c d in

--- a/validation-test/compiler_crashers_fixed/28195-swift-constraints-constraintsystem-resolveoverload.swift
+++ b/validation-test/compiler_crashers_fixed/28195-swift-constraints-constraintsystem-resolveoverload.swift
@@ -5,11 +5,9 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-class S<T{
-class A{
-func g:d
-var d={
-class B:A class e:B{
-func g
+enum a{
+func b
+var h=b
+enum b<T where h=a

--- a/validation-test/compiler_crashers_fixed/28227-swift-typechecker-gettypeofrvalue.swift
+++ b/validation-test/compiler_crashers_fixed/28227-swift-typechecker-gettypeofrvalue.swift
@@ -5,9 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// ASAN Output: stack-overflow on address 0x7ffd2c334fb0 (pc 0x0000008ecf9e bp 0x7ffd2c3357f0 sp 0x7ffd2c334fa0 T0)
-enum A
-protocol A{
-associatedtype f:a
-func a<T where f:d
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+struct c{struct A:a{var d}let a=A{}protocol A

--- a/validation-test/compiler_crashers_fixed/28233-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28233-swift-typebase-getmembersubstitutions.swift
@@ -5,5 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-class n{var d={}class A typealias d<T>:A let a=d{
+// DUPLICATE-OF: 01766-swift-typechecker-validatedecl.swift
+// RUN: not %target-swift-frontend %s -parse
+protocol A{class A}protocol a:A{protocol P{associatedtype e:A}}a

--- a/validation-test/compiler_crashers_fixed/28251-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28251-swift-typechecker-addimplicitconstructors.swift
@@ -5,7 +5,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-class A{typealias e:a
-let a=c
+enum w{class d:a
+var d=[[]a
+class a:d

--- a/validation-test/compiler_crashers_fixed/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
+++ b/validation-test/compiler_crashers_fixed/28253-swift-constraints-constraintsystem-matchdeepequalitytypes.swift
@@ -5,5 +5,12 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-struct A{class d:a{protocol a{func<}}let a=S<
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class A{let h=B<
+protocol A{
+extension{
+struct A{
+var b={}
+class A:b{
+protocol C{func<

--- a/validation-test/compiler_crashers_fixed/28298-swift-namealiastype-getsinglydesugaredtype.swift
+++ b/validation-test/compiler_crashers_fixed/28298-swift-namealiastype-getsinglydesugaredtype.swift
@@ -5,6 +5,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-struct c{struct A:a{var d}let a=A{}protocol A
+class A{typealias e:a
+let a=c

--- a/validation-test/compiler_crashers_fixed/28300-swift-type-transform.swift
+++ b/validation-test/compiler_crashers_fixed/28300-swift-type-transform.swift
@@ -5,9 +5,11 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// ASAN Output: stack-overflow on address 0x7ffdcd2b1fd0 (pc 0x0000008ecf9e bp 0x7ffdcd2b2810 sp 0x7ffdcd2b1fc0 T0)
-enum A
-protocol A{
-associatedtype f:a
-func a<T where f:d
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+class S<T{
+class A{
+func g:d
+var d={
+class B:A class e:B{
+func g

--- a/validation-test/compiler_crashers_fixed/28301-swift-constraints-constraintsystem-simplifyconstructionconstraint.swift
+++ b/validation-test/compiler_crashers_fixed/28301-swift-constraints-constraintsystem-simplifyconstructionconstraint.swift
@@ -5,6 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// DUPLICATE-OF: 01766-swift-typechecker-validatedecl.swift
-// RUN: not --crash %target-swift-frontend %s -parse
-protocol A{class A}protocol a:A{protocol P{associatedtype e:A}}a
+// RUN: not %target-swift-frontend %s -parse
+class n{var d={}class A typealias d<T>:A let a=d{

--- a/validation-test/compiler_crashers_fixed/28309-swift-typechecker-addimplicitconstructors.swift
+++ b/validation-test/compiler_crashers_fixed/28309-swift-typechecker-addimplicitconstructors.swift
@@ -5,12 +5,10 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
+// RUN: not %target-swift-frontend %s -parse
 // REQUIRES: asserts
-class A{let h=B<
-protocol A{
-extension{
-struct A{
-var b={}
-class A:b{
-protocol C{func<
+class a
+class A:a{
+class d:a
+let a=D
+let f:d


### PR DESCRIPTION
Finally this fixes my earlier patch that got reverted:

https://github.com/apple/swift/commit/14d0be209969c5431ae0823f90fd7d7c0a421f1b
