### PR TITLE
[stdlib] Implementing O(1) methods on `CountableClosedRange`

### DIFF
--- a/stdlib/public/core/Range.swift.gyb
+++ b/stdlib/public/core/Range.swift.gyb
@@ -115,26 +115,26 @@ public struct CountableRange<Bound> : RandomAccessCollection
   }
 
   public func index(after i: Index) -> Index {
-    // FIXME: swift-3-indexing-model: tests.
     _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
 
     return i.advanced(by: 1)
   }
 
   public func index(before i: Index) -> Index {
-    // FIXME: swift-3-indexing-model: range check i: should allow `endIndex`.
-    //_failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
+    _precondition(i > lowerBound)
+    _precondition(i <= upperBound)
 
     return i.advanced(by: -1)
   }
 
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    // FIXME: swift-3-indexing-model: tests.
-    return i.advanced(by: n)
+    let r = i.advanced(by: n)
+    _precondition(r >= lowerBound)
+    _precondition(r <= upperBound)
+    return r
   }
 
   public func distance(from start: Index, to end: Index) -> IndexDistance {
-    // FIXME: swift-3-indexing-model: tests.
     return start.distance(to: end)
   }
 

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -185,6 +185,136 @@ let clampedTests: [ClampedTest] = [
   ClampedTest(expected: 10..<10, subject: 13..<15, limits: 5..<10),
 ]
 
+struct AdvanceIndexTest {
+  static let start: Int = 10
+  static let end: Int = 20
+  let advanceBy: Int
+  /// Instead of advancing from `startIndex`, advance from `endIndex`.
+  let advanceFromEnd: Bool
+  // `nil` if the test should fail for open ranges
+  let newOpenIndex: Int?
+  // `nil` if the test should fail for closed ranges
+  let newClosedIndex: Int?
+  let loc: SourceLoc
+
+  init(
+    advanceBy: Int, newOpenIndex: Int? = nil, newClosedIndex: Int? = nil,
+    advanceFromEnd: Bool = false, file: String = #file, line: UInt = #line
+  ) {
+    self.advanceBy = advanceBy
+    self.newOpenIndex = newOpenIndex
+    self.newClosedIndex = newClosedIndex
+    self.advanceFromEnd = advanceFromEnd
+    self.loc = SourceLoc(file, line, comment: "index(_:offsetBy:) tests for countable ranges")
+  }
+}
+
+let advanceIndexTests: [AdvanceIndexTest] = [
+  // Move forward, good
+  AdvanceIndexTest(advanceBy: 4, newOpenIndex: 14, newClosedIndex: 14),
+  AdvanceIndexTest(advanceBy: 0, newOpenIndex: 10, newClosedIndex: 10),
+  AdvanceIndexTest(advanceBy: 10, newOpenIndex: 20, newClosedIndex: 20),
+  AdvanceIndexTest(advanceBy: 11, newClosedIndex: 21),
+
+  // Move forward, bad
+  AdvanceIndexTest(advanceBy: 12),
+  AdvanceIndexTest(advanceBy: 25600),
+
+  // Move backward, good
+  AdvanceIndexTest(advanceBy: -9, newOpenIndex: 11, newClosedIndex: 12,
+    advanceFromEnd: true),
+  AdvanceIndexTest(advanceBy: -10, newOpenIndex: 10, newClosedIndex: 11,
+    advanceFromEnd: true),
+  AdvanceIndexTest(advanceBy: -11, newClosedIndex: 11, 
+    advanceFromEnd: true),
+  AdvanceIndexTest(advanceBy: 0, newOpenIndex: 20, newClosedIndex: 21,
+    advanceFromEnd: true),
+
+  // Move backward, bad
+  AdvanceIndexTest(advanceBy: -12, advanceFromEnd: true),
+  AdvanceIndexTest(advanceBy: -2885, advanceFromEnd: true),
+]
+
+struct IndexDistanceTest {
+  static let start: Int = 10
+  static let end: Int = 30
+
+  // Leave either of these `nil` to use the 'right edge index', which differs
+  // between open and closed ranges.
+  let leftIndex: Int?
+  let rightIndex: Int?
+  
+  let loc: SourceLoc
+  let openDistance: Int
+  let closedDistance: Int
+
+  /// Return the index `leftIndex` steps away from `start`, or the collection's
+  /// `endIndex` if `leftIndex` is `nil`.
+  func leftIndex<C: RandomAccessCollection>(forCollection c: C) -> C.Index {
+    guard let leftIndex = leftIndex else {
+      return c.endIndex
+    }
+    let iterations = leftIndex - IndexDistanceTest.start
+    _precondition(iterations >= 0)
+    var idx = c.startIndex
+    for _ in 0..<iterations {
+      idx = c.index(after: idx)
+    }
+    return idx
+  }
+
+  /// Return the index `rightIndex` steps away from `start`, or the
+  /// collection's `endIndex` if `rightIndex` is `nil`.
+  func rightIndex<C: RandomAccessCollection>(forCollection c: C) -> C.Index {
+    guard let rightIndex = rightIndex else {
+      return c.endIndex
+    }
+    let iterations = rightIndex - IndexDistanceTest.start
+    _precondition(iterations >= 0)
+    var idx = c.startIndex
+    for _ in 0..<iterations {
+      idx = c.index(after: idx)
+    }
+    return idx
+  }
+
+  init(
+    leftIndex: Int? = nil, rightIndex: Int? = nil,
+    distance: Int, closedDistance: Int? = nil,
+    file: String = #file, line: UInt = #line
+  ) {
+    self.leftIndex = leftIndex
+    self.rightIndex = rightIndex
+    self.openDistance = distance
+    // Only set closedDistance if testing against someRange.endIndex!
+    if closedDistance != nil {
+      _precondition(leftIndex == nil || rightIndex == nil)
+    }
+    self.closedDistance = closedDistance ?? distance
+    self.loc = SourceLoc(file, line, comment: "distance(from:to:) tests for countable ranges")
+  }
+}
+
+let indexDistanceTests: [IndexDistanceTest] = [
+  // Forward, inside bounds
+  IndexDistanceTest(leftIndex: 10, rightIndex: 29, distance: 19),
+  IndexDistanceTest(leftIndex: 15, rightIndex: 15, distance: 0),
+  IndexDistanceTest(leftIndex: 16, rightIndex: 29, distance: 13),
+  // Forward, at edge
+  IndexDistanceTest(leftIndex: 10, distance: 20, closedDistance: 21),
+  IndexDistanceTest(leftIndex: 21, distance: 9, closedDistance: 10),
+  IndexDistanceTest(leftIndex: IndexDistanceTest.end, distance: 0, closedDistance: 1),
+  // Backwards, inside bounds
+  IndexDistanceTest(leftIndex: 27, rightIndex: 16, distance: -11),
+  IndexDistanceTest(leftIndex: 15, rightIndex: 14, distance: -1),
+  // Backwards, at edge
+  IndexDistanceTest(rightIndex: 18, distance: -12, closedDistance: -13),
+  IndexDistanceTest(rightIndex: 10, distance: -20, closedDistance: -21),
+  IndexDistanceTest(rightIndex: IndexDistanceTest.end, distance: 0, closedDistance: -1),
+  // Completely at edge
+  IndexDistanceTest(distance: 0),
+]
+
 %{
 all_range_types = [
    ('Range',                '..<', 'MinimalComparableValue'),
@@ -410,20 +540,179 @@ ${TestSuite}.test("count/whereBoundIsStrideable") {
   expectEqual(0, Bound.timesAdvancedWasCalled.value)
   expectEqual( 0 + (${Self}<Bound>._isHalfOpen ? 0 : 1), range1.count)
   expectEqual(10 + (${Self}<Bound>._isHalfOpen ? 0 : 1), range2.count)
-%   if Self == 'CountableClosedRange':
-  // FIXME: swift-3-indexing-model: implement an O(1) `distance()` on
-  // CountableClosedRange.
-  expectEqual(12, Bound.timesEqualEqualWasCalled.value)
-  expectEqual(2, Bound.timesLessWasCalled.value)
-  expectEqual(0, Bound.timesDistanceWasCalled.value)
-  expectEqual(10, Bound.timesAdvancedWasCalled.value)
-%   else:
   expectEqual(0, Bound.timesEqualEqualWasCalled.value)
   expectEqual(2, Bound.timesLessWasCalled.value)
   expectEqual(2, Bound.timesDistanceWasCalled.value)
   expectEqual(0, Bound.timesAdvancedWasCalled.value)
-%   end
 }
+
+%   if 'Countable' in Self:
+${TestSuite}.test("index(after:)/semantics") {
+  let rangeSizes = [3, 5, 10, 12, 86]
+
+  for endValue in rangeSizes {
+    let start = ${Bound}(0)
+    let end = ${Bound}(endValue)
+    let range: ${Self}<${Bound}> = start${op}end
+    var idx = range.startIndex
+    var previousValue : Int? = nil
+
+    for _ in 0${op}(endValue - 1) {
+      // Advance the index
+      idx = range.index(after: idx)
+      if let previousValue = previousValue {
+        expectEqual(range[idx].value, previousValue + 1)
+      }
+      previousValue = range[idx].value
+    }
+    // Iterate once more to get to the 'after end' position
+    idx = range.index(after: idx)
+    // Now, iterate once more and expect a crash
+    expectCrashLater()
+    _ = range.index(after: idx)
+  }
+}
+
+${TestSuite}.test("index(after:)/semantics/smallestRange") {
+  let range: ${Self}<${Bound}> = ${Bound}(0)${op}${Bound}(0)
+  var idx = range.startIndex
+
+%     if 'Closed' in Self:
+  // Should be able to advance the range once
+  idx = range.index(after: idx)
+%     end
+
+  expectCrashLater()
+    _ = range.index(after: idx)
+}
+
+${TestSuite}.test("index(before:)/semantics") {
+  let rangeSizes = [3, 5, 10, 12, 86]
+
+  for endValue in rangeSizes {
+    let start = ${Bound}(0)
+    let end = ${Bound}(endValue)
+    let range: ${Self}<${Bound}> = start${op}end
+    var idx = range.endIndex
+    var previousValue : Int? = nil
+
+    for _ in 0${op}(endValue - 1) {
+      // Advance the index
+      idx = range.index(before: idx)
+      if let previousValue = previousValue {
+        expectEqual(range[idx].value, previousValue - 1)
+      }
+      previousValue = range[idx].value
+    }
+    // Iterate once more to get to the 'before start' position
+    idx = range.index(before: idx)
+    // Now, iterate once more and expect a crash
+    expectCrashLater()
+    _ = range.index(before: idx)
+  }
+}
+
+${TestSuite}.test("index(before:)/semantics/smallestRange") {
+  let range: ${Self}<${Bound}> = ${Bound}(0)${op}${Bound}(0)
+  var idx = range.endIndex
+
+%     if 'Closed' in Self:
+  // Should be able to advance the range once
+  idx = range.index(before: idx)
+%     end
+
+  expectCrashLater()
+  _ = range.index(before: idx)
+}
+
+${TestSuite}.test("index(offsetBy:)/semantics") {
+  for test in advanceIndexTests {
+    let start = ${Bound}(AdvanceIndexTest.start)
+    let end = ${Bound}(AdvanceIndexTest.end)
+    let range: ${Self}<${Bound}> = start${op}end
+    let initialIdx = test.advanceFromEnd ? range.endIndex : range.startIndex
+
+%     if 'Closed' in Self:
+    if let newIndex = test.newClosedIndex {
+%     else:
+    if let newIndex = test.newOpenIndex {
+%     end
+      let idx = range.index(initialIdx, offsetBy: test.advanceBy)
+      if idx != range.endIndex {
+        expectEqual(newIndex, range[idx].value, stackTrace: SourceLocStack().with(test.loc))
+      }
+    } else {
+      expectCrashLater()
+      _ = range.index(initialIdx, offsetBy: test.advanceBy)
+    }
+  }
+}
+
+${TestSuite}.test("index(offsetBy:)/semantics/smallestRange/forward") {
+  let range: ${Self}<${Bound}> = ${Bound}(0)${op}${Bound}(0)
+  var idx = range.startIndex
+
+  // This should work
+  _ = range.index(idx, offsetBy: 0)
+
+%     if 'Closed' in Self:
+  // Can advance one more
+  _ = range.index(idx, offsetBy: 1)
+  expectCrashLater()
+  _ = range.index(idx, offsetBy: 2)
+%     else:
+  expectCrashLater()
+  _ = range.index(idx, offsetBy: 1)
+%     end
+}
+
+${TestSuite}.test("index(offsetBy:)/semantics/smallestRange/backward") {
+  let range: ${Self}<${Bound}> = ${Bound}(0)${op}${Bound}(0)
+  var idx = range.endIndex
+
+  // This should work
+  _ = range.index(idx, offsetBy: 0)
+
+%     if 'Closed' in Self:
+  // Can advance one more
+  _ = range.index(idx, offsetBy: -1)
+  expectCrashLater()
+  _ = range.index(idx, offsetBy: -2)
+%     else:
+  expectCrashLater()
+  _ = range.index(idx, offsetBy: -1)
+%     end
+}
+
+${TestSuite}.test("distance(from:to:)/semantics") {
+  for test in indexDistanceTests {
+    let start = ${Bound}(IndexDistanceTest.start)
+    let end = ${Bound}(IndexDistanceTest.end)
+    let range: ${Self}<${Bound}> = start${op}end
+    let leftIdx = test.leftIndex(forCollection: range)
+    let rightIdx = test.rightIndex(forCollection: range)
+
+    let distance = range.distance(from: leftIdx, to: rightIdx)
+%     if 'Closed' in Self:
+    expectEqual(test.closedDistance, distance, stackTrace: SourceLocStack().with(test.loc))
+%     else:
+    expectEqual(test.openDistance, distance, stackTrace: SourceLocStack().with(test.loc))
+%     end
+  }
+}
+
+${TestSuite}.test("distance(from:to:)/semantics/smallestRange") {
+  let range: ${Self}<${Bound}> = ${Bound}(0)${op}${Bound}(0)
+  var idx = range.endIndex
+
+%     if 'Closed' in Self:
+  expectEqual(1, range.distance(from: range.startIndex, to: range.endIndex))
+%     else:
+  expectEqual(0, range.distance(from: range.startIndex, to: range.endIndex))
+%     end
+}
+
+%   end
 
 ${TestSuite}.test("isEmpty") {
   let start = ${Bound}(10)

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -558,7 +558,7 @@ ${TestSuite}.test("index(after:)/semantics") {
     var previousValue : Int? = nil
 
     for _ in 0${op}(endValue - 1) {
-      // Advance the index
+      // Advance the index to the last in-range position
       idx = range.index(after: idx)
       if let previousValue = previousValue {
         expectEqual(range[idx].value, previousValue + 1)
@@ -567,6 +567,7 @@ ${TestSuite}.test("index(after:)/semantics") {
     }
     // Iterate once more to get to the 'after end' position
     idx = range.index(after: idx)
+    expectEqual(idx, range.endIndex)
     // Now, iterate once more and expect a crash
     expectCrashLater()
     _ = range.index(after: idx)
@@ -596,16 +597,18 @@ ${TestSuite}.test("index(before:)/semantics") {
     var idx = range.endIndex
     var previousValue : Int? = nil
 
-    for _ in 0${op}(endValue - 1) {
-      // Advance the index
+    for _ in 0${op}(endValue) {
+      // Advance the index backwards until we reach `startIndex`
+      // Precondition: for a..<b, advance endIndex (b - a) times to reach startIndex
+      // Precondition: for a...b, advance endIndex (b - a) + 1 times to reach startIndex
       idx = range.index(before: idx)
       if let previousValue = previousValue {
         expectEqual(range[idx].value, previousValue - 1)
       }
       previousValue = range[idx].value
     }
-    // Iterate once more to get to the 'before start' position
-    idx = range.index(before: idx)
+    // At this point, we should be at `startIndex`
+    expectEqual(idx, range.startIndex)
     // Now, iterate once more and expect a crash
     expectCrashLater()
     _ = range.index(before: idx)


### PR DESCRIPTION
#### What's in this pull request?

Functional changes and additional unit test coverage for `CountableRange` and `CountableClosedRange`.

All tests pass on OS X.

@gribozavr 

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->

Changes:
- Implemented O(1) `index(_:offsetBy:)` and `distance(from:to:)` methods on `CountableClosedRange`
- Fixed some unit tests
- Added many more unit tests for Countable*Range index APIs
