### PR TITLE
Fix indentation in Swift 3.0 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ Swift 3.0
 
     class Derived<T> : Base<T> {
       // init(t: T) is now synthesized to call super.init(t: t)
-    }```
+    }
+    ```
 
 * [SE-0081](https://github.com/apple/swift-evolution/blob/master/proposals/0081-move-where-expression.md)
   "Move 'where' clause to end of declaration" is implemented, allowing you to 


### PR DESCRIPTION
#### What's in this pull request?

Three back-ticks closing the code block were on the wrong line. This caused too deep indentation of points following the one containing the wrong syntax (until the point describing `SE-0053`).

This issue was visible in GitHub's Markdown preview.
