### PR TITLE
Fixed a single '$' being accepted as a valid identifier by the lexer.

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -806,7 +806,7 @@ void Lexer::lexOperatorIdentifier() {
   return formToken(leftBound ? tok::oper_postfix : tok::oper_prefix, TokStart);
 }
 
-/// lexDollarIdent - Match $[0-9a-zA-Z_$]*
+/// lexDollarIdent - Match $[0-9a-zA-Z_$]+
 void Lexer::lexDollarIdent() {
   const char *tokStart = CurPtr-1;
   assert(*tokStart == '$');
@@ -827,10 +827,15 @@ void Lexer::lexDollarIdent() {
     }
   }
 
-  // It's always an error to see a standalone $, and we reserve
-  // $nonNumeric for persistent bindings in the debugger.
-  if (CurPtr == tokStart + 1 || !isAllDigits) {
-    if (!isAllDigits && !LangOpts.EnableDollarIdentifiers)
+  // It's always an error to see a standalone $
+  if (CurPtr == tokStart + 1) {
+    diagnose(tokStart, diag::expected_dollar_numeric);
+    return formToken(tok::unknown, TokStart);
+  }
+
+  // We reserve $nonNumeric for persistent bindings in the debugger.
+  if(!isAllDigits) {
+    if (!LangOpts.EnableDollarIdentifiers)
       diagnose(tokStart, diag::expected_dollar_numeric);
 
     // Even if we diagnose, we go ahead and form an identifier token,

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -830,7 +830,7 @@ void Lexer::lexDollarIdent() {
   // It's always an error to see a standalone $
   if (CurPtr == tokStart + 1) {
     diagnose(tokStart, diag::expected_dollar_numeric);
-    return formToken(tok::unknown, TokStart);
+    return formToken(tok::unknown, tokStart);
   }
 
   // We reserve $nonNumeric for persistent bindings in the debugger.

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -1,0 +1,13 @@
+// RUN: %target-parse-verify-swift
+
+var $ : Int // expected-error {{expected numeric value following '$'}}
+let $ = 42 // expected-error {{expected numeric value following '$'}}
+class $ : {} // expected-error {{expected numeric value following '$'}}
+enum $ : {} // expected-error {{expected numeric value following '$'}}
+struct $ : {} // expected-error {{expected numeric value following '$'}}
+
+var $a : Int // expected-error {{expected numeric value following '$'}}
+let $b = 42 // expected-error {{expected numeric value following '$'}}
+class $c : {} // expected-error {{expected numeric value following '$'}}
+enum $d : {} // expected-error {{expected numeric value following '$'}}
+struct $e : {} // expected-error {{expected numeric value following '$'}}


### PR DESCRIPTION
<!-- Please complete this template before creating pull request. -->
#### What's in this pull request?

A fix for the bug where the lexer accepts "$" as a valid identifier in violation of the language specification. Now it becomes an unknown token instead.

<!-- Description about pull request. -->
#### Resolved bug number: ([SR-1661](https://bugs.swift.org/browse/SR-1661))

<!-- If this pull request resolves any bugs from Swift bug tracker -->
