### PR TITLE
IRGen: Fix TypeInfo for witness_method SIL values.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -274,6 +274,10 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     FunctionPtrTy,
     RefCountedPtrTy,
   });
+  WitnessFunctionPairTy = createStructType(*this, "swift.function", {
+    FunctionPtrTy,
+    WitnessTablePtrTy,
+  });
   
   OpaquePtrTy = llvm::StructType::create(LLVMContext, "swift.opaque")
                   ->getPointerTo(DefaultAS);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -405,6 +405,7 @@ public:
   llvm::PointerType *UnownedReferencePtrTy;/// %swift.unowned_reference*
   llvm::Constant *RefCountedNull;      /// %swift.refcounted* null
   llvm::StructType *FunctionPairTy;    /// { i8*, %swift.refcounted* }
+  llvm::StructType *WitnessFunctionPairTy;    /// { i8*, %witness.table* }
   llvm::FunctionType *DeallocatingDtorTy; /// void (%swift.refcounted*)
   llvm::StructType *TypeMetadataStructTy; /// %swift.type = type { ... }
   llvm::PointerType *TypeMetadataPtrTy;/// %swift.type*

--- a/lib/IRGen/ReferenceTypeInfo.h
+++ b/lib/IRGen/ReferenceTypeInfo.h
@@ -33,8 +33,8 @@ class ReferenceTypeInfo : public LoadableTypeInfo {
 protected:
   // FIXME: Get spare bits for pointers from a TargetInfo-like structure.
   ReferenceTypeInfo(llvm::Type *type, Size size, SpareBitVector spareBits,
-                    Alignment align)
-    : LoadableTypeInfo(type, size, spareBits, align, IsNotPOD,
+                    Alignment align, IsPOD_t pod = IsNotPOD)
+    : LoadableTypeInfo(type, size, spareBits, align, pod,
                        IsFixedSize, STIK_Reference)
   {}
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2700,9 +2700,7 @@ public:
     // NOTE: IRGen currently does not support the following method_inst
     // variants as branch arguments.
     // Once this is supported, the check can be removed.
-    require(
-        !isa<WitnessMethodInst>(branchArg) &&
-            !(isa<MethodInst>(branchArg) &&
+    require(!(isa<MethodInst>(branchArg) &&
               cast<MethodInst>(branchArg)->getMember().isForeign),
         "branch argument cannot be a witness_method or an objc method_inst");
     return branchArg->getType() == bbArg->getType();

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -36,9 +36,11 @@ entry(%x : $() -> ()):
   return %x : $() -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} i8* @thin_witness_value(i8*) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} { i8*, i8** } @thin_witness_value(i8*, i8**) {{.*}} {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    ret i8* %0
+// CHECK-NEXT:    [[T0:%.*]] = insertvalue { i8*, i8** } undef, i8* %0, 0
+// CHECK-NEXT:    [[T1:%.*]] = insertvalue { i8*, i8** } [[T0]], i8** %1, 1
+// CHECK-NEXT:    ret { i8*, i8** } [[T1]]
 // CHECK-NEXT:  }
 sil @thin_witness_value : $@convention(thin) (@convention(witness_method) () -> ()) -> @convention(witness_method) () -> () {
 entry(%x : $@convention(witness_method) () -> ()):

--- a/test/IRGen/witness_method_phi.sil
+++ b/test/IRGen/witness_method_phi.sil
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir %s | FileCheck %s
+
+sil_stage canonical
+
+protocol P { func foo() }
+// CHECK-LABEL: define{{( protected)?}} void @phi_witness_method(%swift.type* %T, i8** %T.P) #0 {
+sil @phi_witness_method : $@convention(thin) <T: P> () -> () {
+entry:
+  %1 = witness_method $T, #P.foo!1 : $@convention(witness_method) <T: P> (@in P) -> ()
+  br bb1(%1 : $@convention(witness_method) <T: P> (@in P) -> ())
+
+// CHECK:         phi i8* [ %0, %entry ]
+// CHECK-NEXT:    phi i8** [ %T.P, %entry ]
+bb1(%2 : $@convention(witness_method) <T: P> (@in P) -> ()):
+  unreachable
+}


### PR DESCRIPTION
`@convention(witness_method)` values were changed to carry a pointer to their source witness table, but the type info wasn't changed to match. Fixing this fixes rdar://problem/26268544.
