### PR TITLE
[gardening] Add `.self` to suppress compiler warnings

### DIFF
--- a/benchmark/single-source/BitCount.swift
+++ b/benchmark/single-source/BitCount.swift
@@ -17,7 +17,7 @@ import Foundation
 import TestsUtils
 
 func countBitSet(_ num: Int) -> Int {
-  let bits = sizeof(Int) * 8
+  let bits = sizeof(Int.self) * 8
   var cnt : Int = 0
   var mask: Int = 1
   for _ in 0...bits {

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift.gyb
@@ -527,7 +527,7 @@ extension TestSuite {
       return makeCollectionOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     //===------------------------------------------------------------------===//
     // generate()
@@ -1182,7 +1182,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     // FIXME: swift-3-indexing-model - add tests for the follow?
     //          index(before: of i: Index) -> Index
@@ -1495,7 +1495,7 @@ extension TestSuite {
 
     addBidirectionalCollectionTests(${forwardTestArgs})
     
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     func makeWrappedCollection(_ elements: [OpaqueValue<Int>]) -> C {
       return makeCollection(elements.map(wrapValue))

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -136,7 +136,7 @@ extension TestSuite {
       return makeCollectionOfComparable(elements.map(wrapValueIntoComparable))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // subscript(_: Index)
@@ -657,7 +657,7 @@ self.test("\(testNamePrefix).sorted/${'Predicate' if predicate else 'WhereElemen
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // subscript(_: Index)
@@ -783,7 +783,7 @@ self.test("\(testNamePrefix).reverse()") {
       return makeCollectionOfComparable(elements.map(wrapValueIntoComparable))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // sort()

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -455,7 +455,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // init()
@@ -1206,7 +1206,7 @@ self.test("\(testNamePrefix).OperatorPlus") {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
 //===----------------------------------------------------------------------===//
 // removeLast()
@@ -1328,7 +1328,7 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
       resiliencyChecks: resiliencyChecks,
       outOfBoundsIndexOffset: outOfBoundsIndexOffset)
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     // No extra checks for collections with random access traversal so far.
   } // addRangeReplaceableRandomAccessCollectionTests

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -65,7 +65,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     //===------------------------------------------------------------------===//
     // removeFirst()
@@ -210,7 +210,7 @@ extension TestSuite {
       return makeCollection(elements.map(wrapValue))
     }
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     //===------------------------------------------------------------------===//
     // removeLast()
@@ -351,7 +351,7 @@ extension TestSuite {
       resiliencyChecks: resiliencyChecks,
       outOfBoundsIndexOffset: outOfBoundsIndexOffset)
 
-    testNamePrefix += String(C.Type)
+    testNamePrefix += String(C.Type.self)
 
     // No tests yet.
   } // addRangeReplaceableRandomAccessSliceTests

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1484,7 +1484,7 @@ extension TestSuite {
       return makeSequenceOfEquatable(elements.map(wrapValueIntoEquatable))
     }
 
-    testNamePrefix += String(S.Type)
+    testNamePrefix += String(S.Type.self)
 
     let isMultiPass = makeSequence([])
       ._preprocessingPass { true } ?? false

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -298,7 +298,7 @@ final internal class _VaListBuilder {
     // differs from ABI alignment on some architectures.
 #if arch(arm) && !os(iOS)
     if let arg = arg as? _CVarArgAligned {
-      let alignmentInWords = arg._cVarArgAlignment / sizeof(Int)
+      let alignmentInWords = arg._cVarArgAlignment / sizeof(Int.self)
       let misalignmentInWords = count % alignmentInWords
       if misalignmentInWords != 0 {
         let paddingInWords = alignmentInWords - misalignmentInWords

--- a/test/SILOptimizer/peephole_trunc_and_ext.sil
+++ b/test/SILOptimizer/peephole_trunc_and_ext.sil
@@ -259,7 +259,7 @@ bb0(%0 : $BuiltinWord):
 
 
 // sizeof is known to return strictly positive values
-// peephole: UWord(UInt64(sizeof(Int))) -> sizeof(Int)
+// peephole: UWord(UInt64(sizeof(Int.self))) -> sizeof(Int.self)
 // CHECK-LABEL: sil @_TF4test29test_trunc_s_to_u_zext_sizeofFT_Su : $@convention(thin) () -> BuiltinUWord
 // CHECK: builtin "sizeof"
 // CHECK-NOT: builtin "zextOrBitCast_Word_Int64"
@@ -289,7 +289,7 @@ bb0:
 
 // sizeof is known to return strictly positive values
 // But Word ->Int64 is not a safe conversion
-// No peephole for UInt16(UInt32(sizeof(Int)))
+// No peephole for UInt16(UInt32(sizeof(Int.self)))
 // CHECK-LABEL: sil @_TF4test35test_int16_trunc_s_to_u_zext_sizeofFT_Vs6UInt16 : $@convention(thin) () -> UInt16
 // CHECK: builtin "zextOrBitCast_Word_Int64"
 // CHECK: builtin "s_to_u_checked_trunc_Int64_Int32"


### PR DESCRIPTION
#### What's in this pull request?

Adding `.self` to all places where a bare type (or metatype) name was used as the value of the argument to a single-argument function. This quiets a number of warnings caused by Doug Gregor's recent patch to fix the original (unintended) behavior. All tests pass on OS X.

_NOTE_: since there is a general sentiment that `.self` should be removed in the future, feel free to close this PR if you don't think the benefits outweigh the costs.

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| All supported platforms | @swift-ci Please smoke test and merge |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

**Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| All supported platforms | @swift-ci Please test and merge |
| OS X platform | @swift-ci Please test OS X platform |
| OS X platform | @swift-ci Please benchmark |
| Linux platform | @swift-ci Please test Linux platform |

**Lint Testing**

| Language | Comment |
| --- | --- |
| Python | @swift-ci Please Python lint |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
